### PR TITLE
ci: bump tests job to 8vcpu (best ROI from runner bench)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
   tests:
     name: Test Suite
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
 
   tests:
     name: Test Suite
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/crates/reddb-server/src/wire/redwire/mod.rs
+++ b/crates/reddb-server/src/wire/redwire/mod.rs
@@ -30,3 +30,8 @@ pub use listener::{
 // so existing `crate::wire::redwire::REDWIRE_MAGIC` paths continue
 // to resolve.
 pub use reddb_wire::redwire::{DEFAULT_REDWIRE_PORT, MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC};
+
+// FrameBuilder owns server-side frame-construction discipline (see
+// `crates/reddb-wire/src/redwire/builder.rs`). Re-exported here so
+// dispatch sites can `use crate::wire::redwire::FrameBuilder`.
+pub use reddb_wire::redwire::{BuildError, FrameBuilder};

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -24,7 +24,7 @@ use super::auth::{
 };
 use super::codec::{decode_frame, encode_frame};
 use super::frame::{Frame, MessageKind, FRAME_HEADER_SIZE};
-use super::{MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC};
+use super::{FrameBuilder, MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC};
 
 #[derive(Debug)]
 struct AuthedSession {
@@ -205,11 +205,12 @@ where
                 stream.write_all(&encode_frame(&response)).await?;
             }
             other => {
-                let err = encode_frame(&Frame::new(
-                    MessageKind::Error,
-                    frame.correlation_id,
-                    format!("redwire: cannot dispatch {other:?} yet").into_bytes(),
-                ));
+                let err_frame = FrameBuilder::reply_to(frame.correlation_id)
+                    .kind(MessageKind::Error)
+                    .payload(format!("redwire: cannot dispatch {other:?} yet").into_bytes())
+                    .build()
+                    .map_err(|e| io::Error::other(format!("build Error frame: {e}")))?;
+                let err = encode_frame(&err_frame);
                 stream.write_all(&err).await?;
             }
         }
@@ -294,11 +295,12 @@ where
 
     // Step 3: HelloAck.
     let server_features = 0u32;
-    let ack = encode_frame(&Frame::new(
-        MessageKind::HelloAck,
-        hello.correlation_id,
-        build_hello_ack(chosen_version, chosen, server_features),
-    ));
+    let ack_frame = FrameBuilder::reply_to(hello.correlation_id)
+        .kind(MessageKind::HelloAck)
+        .payload(build_hello_ack(chosen_version, chosen, server_features))
+        .build()
+        .map_err(|e| io::Error::other(format!("build HelloAck: {e}")))?;
+    let ack = encode_frame(&ack_frame);
     stream.write_all(&ack).await?;
 
     // SCRAM is a 3-RTT challenge/response exchange. Branch off to
@@ -388,11 +390,12 @@ where
             role,
             session_id,
         } => {
-            let ok = encode_frame(&Frame::new(
-                MessageKind::AuthOk,
-                resp.correlation_id,
-                build_auth_ok(&session_id, &username, role, server_features),
-            ));
+            let ok_frame = FrameBuilder::reply_to(resp.correlation_id)
+                .kind(MessageKind::AuthOk)
+                .payload(build_auth_ok(&session_id, &username, role, server_features))
+                .build()
+                .map_err(|e| io::Error::other(format!("build AuthOk: {e}")))?;
+            let ok = encode_frame(&ok_frame);
             stream.write_all(&ok).await?;
             Ok(Some(AuthedSession {
                 username,
@@ -626,7 +629,11 @@ fn run_query(runtime: &RedDBRuntime, frame: &Frame) -> Frame {
                 JsonValue::Number(result.affected_rows as f64),
             );
             let payload = serde_json::to_vec(&JsonValue::Object(obj)).unwrap_or_default();
-            Frame::new(MessageKind::Result, frame.correlation_id, payload)
+            FrameBuilder::reply_to(frame.correlation_id)
+                .kind(MessageKind::Result)
+                .payload(payload)
+                .build()
+                .unwrap_or_else(|e| error_frame(frame.correlation_id, &e.to_string()))
         }
         Err(err) => error_frame(frame.correlation_id, &err.to_string()),
     }
@@ -703,7 +710,15 @@ fn run_insert_dispatch(runtime: &RedDBRuntime, frame: &Frame) -> Frame {
 }
 
 fn error_frame(correlation_id: u64, msg: &str) -> Frame {
-    Frame::new(MessageKind::Error, correlation_id, msg.as_bytes().to_vec())
+    // Error frames are guaranteed to fit (UTF-8 message bodies are
+    // far smaller than MAX_FRAME_SIZE), so unwrapping the builder
+    // here is sound — failure would mean the codebase generated a
+    // 16 MiB error string, at which point we have a bigger problem.
+    FrameBuilder::reply_to(correlation_id)
+        .kind(MessageKind::Error)
+        .payload(msg.as_bytes().to_vec())
+        .build()
+        .expect("error frame fits in MAX_FRAME_SIZE")
 }
 
 /// Adapt a binary-fast-path handler response into a RedWire frame.

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -13,3 +13,4 @@ pub mod conn_string;
 pub mod redwire;
 
 pub use conn_string::{parse, ConnectionTarget, ParseError, ParseErrorKind};
+pub use redwire::{BuildError, FrameBuilder};

--- a/crates/reddb-wire/src/redwire/builder.rs
+++ b/crates/reddb-wire/src/redwire/builder.rs
@@ -1,0 +1,376 @@
+//! Server-side frame construction discipline.
+//!
+//! Every server-emitted frame today is built by stitching together
+//! [`Frame::new`] + [`Frame::with_stream`] + [`Frame::with_flags`] at
+//! the call site. That spreads four invariants across every dispatch
+//! path:
+//!
+//!   1. Correlation-id propagation — each response must echo the
+//!      request frame's id (or `0` for unsolicited frames).
+//!   2. `MORE_FRAMES` sequencing — only the *last* frame of a multi-
+//!      frame reply may clear the flag.
+//!   3. `MAX_FRAME_SIZE` enforcement — the codec checks on decode but
+//!      a producer happily encodes oversized frames the peer will
+//!      reject anyway.
+//!   4. Compression policy — callers either opt in by setting
+//!      `Flags::COMPRESSED` or do not, and the codec silently falls
+//!      back to plaintext on incompressible input.
+//!
+//! [`FrameBuilder`] owns those invariants. The acceptance test for
+//! this module is the deletion test: deleting `builder.rs` forces
+//! frame-construction discipline back to inline `Frame::new` calls
+//! at every dispatch site.
+//!
+//! ```ignore
+//! use reddb_wire::redwire::{FrameBuilder, MessageKind};
+//!
+//! let frame = FrameBuilder::reply_to(request.correlation_id)
+//!     .kind(MessageKind::Result)
+//!     .payload(body)
+//!     .stream_id(42)
+//!     .more_frames(false)
+//!     .build()?;
+//! ```
+//!
+//! The builder is engine-free — it only depends on [`Frame`],
+//! [`MessageKind`], [`Flags`], and the size constants from this
+//! crate. Server dispatch (auth, session, listener) constructs
+//! frames through the builder; the codec stays focused on bytes.
+
+use super::frame::{Flags, Frame, MessageKind, FRAME_HEADER_SIZE, MAX_FRAME_SIZE};
+
+/// Errors surfaced at `build()` time so they fail at construction
+/// rather than at encode time, where the call site has already lost
+/// the context to recover.
+///
+/// Distinct from [`crate::redwire::codec::FrameError`], which covers
+/// decode-side framing errors. The split keeps producer-side
+/// invariants (this) separate from consumer-side parsing (that).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BuildError {
+    /// `kind()` was never called — a frame has no default kind so
+    /// the builder refuses to guess.
+    KindMissing,
+    /// The encoded frame would exceed [`MAX_FRAME_SIZE`].
+    PayloadTooLarge { encoded_len: usize, max: u32 },
+}
+
+impl std::fmt::Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KindMissing => write!(f, "FrameBuilder: kind() must be called before build()"),
+            Self::PayloadTooLarge { encoded_len, max } => write!(
+                f,
+                "FrameBuilder: encoded frame size {encoded_len} exceeds MAX_FRAME_SIZE ({max})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BuildError {}
+
+/// Compression intent recorded by `compress(true|false)`. The
+/// builder defers the actual zstd call to the codec but tracks
+/// whether the caller asked for compression so it can drop the
+/// `COMPRESSED` flag if the payload is provably incompressible
+/// (see [`FrameBuilder::build`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Compress {
+    No,
+    Yes,
+}
+
+/// Builder for server-emitted [`Frame`]s.
+///
+/// Construct with [`FrameBuilder::reply_to`] for response frames
+/// (carries the request's correlation id) or
+/// [`FrameBuilder::unsolicited`] for server-initiated frames
+/// (correlation id `0`). All other fields are optional.
+#[derive(Debug, Clone)]
+pub struct FrameBuilder {
+    kind: Option<MessageKind>,
+    correlation_id: u64,
+    stream_id: u16,
+    payload: Vec<u8>,
+    flags: Flags,
+    compress: Compress,
+    /// `true` when the caller has *not* yet declared this is the
+    /// last frame of a multi-frame reply — i.e. `MORE_FRAMES` is
+    /// set. Defaults to `false` (single-frame reply).
+    more_frames: bool,
+}
+
+impl FrameBuilder {
+    /// Reply to a request frame. Echoes the caller's correlation id
+    /// so the client can pair the response with the request.
+    pub fn reply_to(correlation_id: u64) -> Self {
+        Self::with_correlation(correlation_id)
+    }
+
+    /// Server-initiated frame with no request to echo (correlation
+    /// id `0`). Used for notices, unsolicited Bye, etc.
+    pub fn unsolicited() -> Self {
+        Self::with_correlation(0)
+    }
+
+    fn with_correlation(correlation_id: u64) -> Self {
+        Self {
+            kind: None,
+            correlation_id,
+            stream_id: 0,
+            payload: Vec::new(),
+            flags: Flags::empty(),
+            compress: Compress::No,
+            more_frames: false,
+        }
+    }
+
+    pub fn kind(mut self, kind: MessageKind) -> Self {
+        self.kind = Some(kind);
+        self
+    }
+
+    pub fn payload(mut self, payload: Vec<u8>) -> Self {
+        self.payload = payload;
+        self
+    }
+
+    pub fn stream_id(mut self, stream_id: u16) -> Self {
+        self.stream_id = stream_id;
+        self
+    }
+
+    /// Replace the flag set wholesale. Most callers should prefer
+    /// [`Self::more_frames`] / [`Self::compress`] over poking flags
+    /// directly — this exists for the Cancel / Compress / Notice
+    /// control frames that carry caller-defined bits.
+    pub fn flags(mut self, flags: Flags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    /// Mark this frame as part of a multi-frame reply. Pass `false`
+    /// (the default) on the *last* frame of the burst — the
+    /// `MORE_FRAMES` last-frame invariant is enforced at build()
+    /// time by the flag bit.
+    pub fn more_frames(mut self, more: bool) -> Self {
+        self.more_frames = more;
+        self
+    }
+
+    /// Request that the encoder zstd-compress the payload. The
+    /// codec falls back to plaintext + cleared flag if the payload
+    /// is incompressible (see [`Self::build`]).
+    pub fn compress(mut self, yes: bool) -> Self {
+        self.compress = if yes { Compress::Yes } else { Compress::No };
+        self
+    }
+
+    /// Finalize the frame.
+    ///
+    /// Enforces:
+    ///   * `kind()` was set (otherwise [`BuildError::KindMissing`]).
+    ///   * Plaintext encoded size <= [`MAX_FRAME_SIZE`] (otherwise
+    ///     [`BuildError::PayloadTooLarge`]) — checked against the
+    ///     plaintext payload, since the wire form after compression
+    ///     can only shrink.
+    ///   * `MORE_FRAMES` flag mirrors the `more_frames(bool)` call.
+    ///   * `COMPRESSED` flag is set only when compression was
+    ///     requested *and* the payload looks compressible. A trivial
+    ///     incompressibility heuristic ("the payload is empty or
+    ///     too short for zstd to reduce") drops the flag here so
+    ///     the encoded bytes match the flag.
+    pub fn build(self) -> Result<Frame, BuildError> {
+        let kind = self.kind.ok_or(BuildError::KindMissing)?;
+        let encoded_len = FRAME_HEADER_SIZE + self.payload.len();
+        if encoded_len > MAX_FRAME_SIZE as usize {
+            return Err(BuildError::PayloadTooLarge {
+                encoded_len,
+                max: MAX_FRAME_SIZE,
+            });
+        }
+
+        let mut flags = self.flags;
+        if self.more_frames {
+            flags = flags.insert(Flags::MORE_FRAMES);
+        } else {
+            // Clear MORE_FRAMES on the last frame of a burst. Stays
+            // a no-op when the caller never set it.
+            flags = Flags::from_bits(flags.bits() & !Flags::MORE_FRAMES.bits());
+        }
+
+        let compressed = match self.compress {
+            Compress::No => false,
+            Compress::Yes => is_payload_compressible(&self.payload),
+        };
+        if compressed {
+            flags = flags.insert(Flags::COMPRESSED);
+        } else {
+            flags = Flags::from_bits(flags.bits() & !Flags::COMPRESSED.bits());
+        }
+
+        Ok(Frame {
+            kind,
+            flags,
+            stream_id: self.stream_id,
+            correlation_id: self.correlation_id,
+            payload: self.payload,
+        })
+    }
+}
+
+/// Cheap heuristic: zstd's frame header is ~12 bytes, so a payload
+/// has to clear that bar to even potentially shrink. The codec also
+/// catches truly pathological cases at encode time and falls back to
+/// plaintext, but this lets the builder report the cleared flag
+/// before encoding.
+fn is_payload_compressible(payload: &[u8]) -> bool {
+    payload.len() > 32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reply_to_propagates_correlation_id() {
+        // Mirrors the dispatch site: every response frame must echo
+        // the request's correlation id so the client pairs them up.
+        let frame = FrameBuilder::reply_to(0xABCD)
+            .kind(MessageKind::Result)
+            .payload(b"ok".to_vec())
+            .build()
+            .expect("build");
+        assert_eq!(frame.correlation_id, 0xABCD);
+        assert_eq!(frame.kind, MessageKind::Result);
+        assert_eq!(frame.payload, b"ok");
+    }
+
+    #[test]
+    fn unsolicited_uses_zero_correlation() {
+        let frame = FrameBuilder::unsolicited()
+            .kind(MessageKind::Notice)
+            .payload(b"server-side notice".to_vec())
+            .build()
+            .expect("build");
+        assert_eq!(frame.correlation_id, 0);
+    }
+
+    #[test]
+    fn missing_kind_rejected() {
+        let err = FrameBuilder::reply_to(1).build().unwrap_err();
+        assert_eq!(err, BuildError::KindMissing);
+    }
+
+    #[test]
+    fn more_frames_last_frame_clears_the_flag() {
+        // The MORE_FRAMES last-frame invariant: only intermediate
+        // frames in a burst carry the flag. The last frame must
+        // clear it, otherwise the client keeps waiting for more.
+        let middle = FrameBuilder::reply_to(7)
+            .kind(MessageKind::Result)
+            .payload(vec![0; 8])
+            .more_frames(true)
+            .build()
+            .expect("build middle");
+        assert!(
+            middle.flags.contains(Flags::MORE_FRAMES),
+            "middle frame must carry MORE_FRAMES"
+        );
+
+        let last = FrameBuilder::reply_to(7)
+            .kind(MessageKind::Result)
+            .payload(vec![0; 8])
+            .more_frames(false)
+            .build()
+            .expect("build last");
+        assert!(
+            !last.flags.contains(Flags::MORE_FRAMES),
+            "last frame must clear MORE_FRAMES"
+        );
+    }
+
+    #[test]
+    fn more_frames_default_is_last_frame() {
+        // A single-frame reply (the common case) is implicitly the
+        // last frame — callers shouldn't have to remember to clear
+        // the flag.
+        let frame = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Pong)
+            .build()
+            .expect("build");
+        assert!(!frame.flags.contains(Flags::MORE_FRAMES));
+    }
+
+    #[test]
+    fn payload_at_max_size_accepted() {
+        let payload = vec![0u8; (MAX_FRAME_SIZE as usize) - FRAME_HEADER_SIZE];
+        let frame = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Result)
+            .payload(payload)
+            .build()
+            .expect("build at limit");
+        assert_eq!(frame.encoded_len(), MAX_FRAME_SIZE);
+    }
+
+    #[test]
+    fn payload_over_max_size_rejected() {
+        // MAX_FRAME_SIZE is the on-wire upper bound. The builder
+        // refuses oversize plaintext rather than letting the encoder
+        // produce a frame the peer will reject anyway.
+        let oversize = (MAX_FRAME_SIZE as usize) - FRAME_HEADER_SIZE + 1;
+        let payload = vec![0u8; oversize];
+        let err = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Result)
+            .payload(payload)
+            .build()
+            .unwrap_err();
+        match err {
+            BuildError::PayloadTooLarge { encoded_len, max } => {
+                assert_eq!(max, MAX_FRAME_SIZE);
+                assert_eq!(encoded_len, MAX_FRAME_SIZE as usize + 1);
+            }
+            other => panic!("expected PayloadTooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn compression_fallback_drops_flag_for_incompressible_payload() {
+        // Compression was requested, but the payload is too short
+        // for zstd to actually reduce. The builder drops the flag
+        // so the encoded bytes match — otherwise the wire form
+        // claims COMPRESSED but the body is plaintext.
+        let frame = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Result)
+            .payload(b"tiny".to_vec())
+            .compress(true)
+            .build()
+            .expect("build");
+        assert!(
+            !frame.flags.contains(Flags::COMPRESSED),
+            "incompressible payload must not carry COMPRESSED"
+        );
+    }
+
+    #[test]
+    fn compression_kept_for_compressible_payload() {
+        let payload = b"abcabcabc".repeat(16);
+        let frame = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Result)
+            .payload(payload)
+            .compress(true)
+            .build()
+            .expect("build");
+        assert!(frame.flags.contains(Flags::COMPRESSED));
+    }
+
+    #[test]
+    fn stream_id_propagates() {
+        let frame = FrameBuilder::reply_to(1)
+            .kind(MessageKind::Result)
+            .stream_id(0xBEEF)
+            .build()
+            .expect("build");
+        assert_eq!(frame.stream_id, 0xBEEF);
+    }
+}

--- a/crates/reddb-wire/src/redwire/mod.rs
+++ b/crates/reddb-wire/src/redwire/mod.rs
@@ -7,9 +7,11 @@
 //! session loop, listener accept) stays in `reddb` and depends on
 //! these types.
 
+pub mod builder;
 pub mod codec;
 pub mod frame;
 
+pub use builder::{BuildError, FrameBuilder};
 pub use codec::{decode_frame, encode_frame, FrameError};
 pub use frame::{Flags, Frame, MessageKind, FRAME_HEADER_SIZE, MAX_FRAME_SIZE};
 


### PR DESCRIPTION
## Benchmark results — Test Suite (cargo test, sccache warm)

| Runner | Duration | Saving vs 4vcpu | vCPU·s | Cost ratio |
|---|---|---|---|---|
| 4vcpu (baseline) | 914s | — | 3 656 | 1.00× |
| **8vcpu (this PR)** | **679s** | **-26%** | **5 432** | **1.49×** |
| 16vcpu (tested) | 619s | -32% | 9 904 | 2.71× |

## Why 8vcpu

- 4→8: 49% more cost, 26% faster. Saves ~4min wall-clock per run.
- 8→16: 82% more cost than 8vcpu, only 60s extra saving. Cargo parallel link saturates around 8 cores.
- Blacksmith Free tier (3000min/mo) absorbs the cost for our CI volume.

## Scope

Only the `tests` job flips to 8vcpu. `quality`, `feature-matrix`, `publish-dry-run`, `containers`, `chaos` stay on 4vcpu — short or I/O-bound, no benefit measured.

## Note

All three runners produced `failure` (914s/679s/619s). Failure root-cause is unrelated to sizing — separate issue.