### PR TITLE
ci(bench): cargo target/ on Sticky Disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,13 +100,26 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: rui314/setup-mold@v1
       - uses: mozilla-actions/sccache-action@v0.0.10
+      # Sticky Disk for the cargo target dir — much larger working set
+      # than the 25GB cache cap, and 3s mount vs ~15s on Blacksmith's
+      # colocated cache (per docs). Persistent multimodel layer uses a
+      # separate target dir, also stickied to keep it warm across runs.
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-cargo-target
+          path: target
+      - uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-cargo-target-persistent
+          path: target/persistent-tests
+      # Cargo registry + git index stay on Swatinem (small, fits the
+      # standard cache and benefits from compression).
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
-          workspaces: |
-            . -> target
-            . -> target/persistent-tests
+          # Skip target/ — handled by stickydisk above.
+          cache-targets: "false"
       - name: Build red_client (cross-binary smoke prereq)
         run: cargo build --locked --bin red_client -p reddb-client --no-default-features
       - name: red_client size budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,18 +100,17 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: rui314/setup-mold@v1
       - uses: mozilla-actions/sccache-action@v0.0.10
-      # Sticky Disk for the cargo target dir — much larger working set
-      # than the 25GB cache cap, and 3s mount vs ~15s on Blacksmith's
-      # colocated cache (per docs). Persistent multimodel layer uses a
-      # separate target dir, also stickied to keep it warm across runs.
+      # Sticky Disk for the cargo target dir — 3s mount vs ~15s on
+      # Blacksmith's colocated cache (per docs).
+      #
+      # ONLY the regular target/ is stickied. target/persistent-tests
+      # holds runtime RDB data files for integration tests that assert
+      # on a clean bootstrap — preserving it across runs caused
+      # persistent_native_metadata_and_catalog_stay_consistent to fail.
       - uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-cargo-target
           path: target
-      - uses: useblacksmith/stickydisk@v1
-        with:
-          key: ${{ github.repository }}-cargo-target-persistent
-          path: target/persistent-tests
       # Cargo registry + git index stay on Swatinem (small, fits the
       # standard cache and benefits from compression).
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Test Suite job — replaces Swatinem target caching with useblacksmith/stickydisk. Measuring effect on cold + warm cache.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->