### PR TITLE
feat: port defaults — HTTP 8080→5055, gRPC 5055→5555 (wire stays 5050)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,15 +71,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "asn1-rs"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,16 +353,6 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console"
@@ -1191,7 +1172,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1372,15 +1353,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2018,7 +1990,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror",
  "tokio",
  "tracing",
@@ -2055,7 +2027,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -2269,7 +2241,6 @@ dependencies = [
  "reddb-client-connector",
  "reddb-grpc-proto",
  "reddb-wire",
- "redis",
  "regex",
  "roaring",
  "rstar",
@@ -2301,24 +2272,6 @@ dependencies = [
  "regex",
  "url",
  "zstd",
-]
-
-[[package]]
-name = "redis"
-version = "0.27.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
-dependencies = [
- "arc-swap",
- "combine",
- "itertools 0.13.0",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "ryu",
- "sha1_smol",
- "socket2 0.5.10",
- "url",
 ]
 
 [[package]]
@@ -2671,12 +2624,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2768,16 +2715,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -2994,7 +2931,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3103,7 +3040,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -71,13 +71,13 @@ pub fn all_commands() -> Vec<CommandDef> {
     CommandDef {
       name: "server",
       summary: "Start the database server (router/HTTP/gRPC/wire)",
-      usage: "red server [--grpc] [--http] [--grpc-bind 127.0.0.1:5055] [--http-bind 127.0.0.1:8080] [--wire-bind 127.0.0.1:5050] [--path ./data/reddb.rdb]",
+      usage: "red server [--grpc] [--http] [--grpc-bind 127.0.0.1:5555] [--http-bind 127.0.0.1:5055] [--wire-bind 127.0.0.1:5050] [--path ./data/reddb.rdb]",
       flags: server_flags(),
     },
     CommandDef {
       name: "service",
       summary: "Install or inspect a systemd service",
-      usage: "red service <install|print-unit> [--binary /usr/local/bin/red] [--grpc-bind 0.0.0.0:5055] [--http-bind 0.0.0.0:8080] [--path /var/lib/reddb/data.rdb]",
+      usage: "red service <install|print-unit> [--binary /usr/local/bin/red] [--grpc-bind 0.0.0.0:5555] [--http-bind 0.0.0.0:5055] [--path /var/lib/reddb/data.rdb]",
       flags: service_flags(),
     },
     CommandDef {
@@ -113,13 +113,13 @@ pub fn all_commands() -> Vec<CommandDef> {
     CommandDef {
       name: "tick",
       summary: "Run maintenance/reclaim tick operations",
-      usage: "red tick [--bind 127.0.0.1:8080] [--operations maintenance,retention,checkpoint] [--dry-run]",
+      usage: "red tick [--bind 127.0.0.1:5055] [--operations maintenance,retention,checkpoint] [--dry-run]",
       flags: tick_flags(),
     },
     CommandDef {
       name: "replica",
       summary: "Start as a read replica connected to a primary",
-      usage: "red replica --primary-addr http://primary:5055 [--grpc] [--http] [--grpc-bind 127.0.0.1:5055] [--http-bind 127.0.0.1:8080] [--path ./data/reddb.rdb]",
+      usage: "red replica --primary-addr http://primary:5555 [--grpc] [--http] [--grpc-bind 127.0.0.1:5555] [--http-bind 127.0.0.1:5055] [--path ./data/reddb.rdb]",
       flags: replica_flags(),
     },
     CommandDef {
@@ -173,7 +173,7 @@ pub fn all_commands() -> Vec<CommandDef> {
     CommandDef {
       name: "doctor",
       summary: "Health-check a running server against operator thresholds (PLAN.md Phase 5.5)",
-      usage: "red doctor [--bind 127.0.0.1:8080] [--token <admin>] [--json] [--backup-age-warn-secs 600] [--backup-age-crit-secs 3600] [--wal-lag-warn 1000] [--wal-lag-crit 10000]",
+      usage: "red doctor [--bind 127.0.0.1:5055] [--token <admin>] [--json] [--backup-age-warn-secs 600] [--backup-age-crit-secs 3600] [--wal-lag-warn 1000] [--wal-lag-crit 10000]",
       flags: doctor_flags(),
     },
     CommandDef {
@@ -230,16 +230,16 @@ pub fn main_help_text() -> String {
 
     out.push_str("Examples:\n");
     out.push_str("  red server --path ./data/reddb.rdb\n");
-    out.push_str("  red server --grpc-bind 127.0.0.1:5055 --http-bind 127.0.0.1:8080 --path ./data/reddb.rdb\n");
+    out.push_str("  red server --grpc-bind 127.0.0.1:5555 --http-bind 127.0.0.1:5055 --path ./data/reddb.rdb\n");
     out.push_str("  red server --wire-bind 127.0.0.1:5050 --path ./data/reddb.rdb\n");
-    out.push_str("  sudo red service install --binary /usr/local/bin/red --grpc-bind 0.0.0.0:5055 --http-bind 0.0.0.0:8080 --path /var/lib/reddb/data.rdb\n");
-    out.push_str("  red replica --primary-addr http://primary:5055 --path ./data/replica.rdb\n");
+    out.push_str("  sudo red service install --binary /usr/local/bin/red --grpc-bind 0.0.0.0:5555 --http-bind 0.0.0.0:5055 --path /var/lib/reddb/data.rdb\n");
+    out.push_str("  red replica --primary-addr http://primary:5555 --path ./data/replica.rdb\n");
     out.push_str("  red query \"SELECT * FROM users\"\n");
     out.push_str("  red insert users '{\"name\": \"Alice\"}'\n");
     out.push_str("  red get users abc123\n");
     out.push_str("  red health\n");
     out.push_str(
-        "  red tick --bind 127.0.0.1:8080 --operations maintenance,retention,checkpoint\n",
+        "  red tick --bind 127.0.0.1:5055 --operations maintenance,retention,checkpoint\n",
     );
     out.push_str("  red auth create-user alice --password secret --role admin\n");
     out.push_str("  red auth create-api-key alice --name \"ci-token\" --role write\n");
@@ -503,7 +503,7 @@ fn doctor_flags() -> Vec<FlagSchema> {
     vec![
         FlagSchema::new("bind")
             .with_description("HTTP address of the server to probe")
-            .with_default("127.0.0.1:8080"),
+            .with_default("127.0.0.1:5055"),
         FlagSchema::new("token")
             .with_description("Admin bearer token; defaults to RED_ADMIN_TOKEN env"),
         FlagSchema::boolean("json")
@@ -578,7 +578,7 @@ fn tick_flags() -> Vec<FlagSchema> {
         FlagSchema::new("bind")
             .with_short('b')
             .with_description("Server HTTP bind address")
-            .with_default("127.0.0.1:8080"),
+            .with_default("127.0.0.1:5055"),
         FlagSchema::new("operations")
             .with_description("Comma-separated operations: maintenance,retention,checkpoint"),
         FlagSchema::boolean("dry-run")

--- a/crates/reddb-server/src/grpc.rs
+++ b/crates/reddb-server/src/grpc.rs
@@ -115,7 +115,7 @@ impl GrpcTlsOptions {
 impl Default for GrpcServerOptions {
     fn default() -> Self {
         Self {
-            bind_addr: "127.0.0.1:5055".to_string(),
+            bind_addr: "127.0.0.1:5555".to_string(),
             tls: None,
         }
     }

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -122,7 +122,7 @@ pub struct ServerOptions {
 impl Default for ServerOptions {
     fn default() -> Self {
         Self {
-            bind_addr: "127.0.0.1:8080".to_string(),
+            bind_addr: "127.0.0.1:5055".to_string(),
             max_body_bytes: 1024 * 1024,
             read_timeout_ms: 5_000,
             write_timeout_ms: 5_000,

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -56,8 +56,8 @@ impl ServerTransport {
 
     pub const fn default_bind_addr(self) -> &'static str {
         match self {
-            Self::Grpc => "127.0.0.1:5055",
-            Self::Http => "127.0.0.1:8080",
+            Self::Grpc => "127.0.0.1:5555",
+            Self::Http => "127.0.0.1:5055",
             Self::Wire => "127.0.0.1:5050",
         }
     }
@@ -217,7 +217,7 @@ impl ServerCommandConfig {
                 let primary_addr = self
                     .primary_addr
                     .clone()
-                    .unwrap_or_else(|| "http://127.0.0.1:5055".to_string());
+                    .unwrap_or_else(|| "http://127.0.0.1:5555".to_string());
                 // Public-mutation rejection on replicas is enforced by
                 // `WriteGate` at the runtime/RPC boundary (PLAN.md W1).
                 // Leaving `options.read_only = false` keeps the pager
@@ -1886,12 +1886,12 @@ mod tests {
             run_group: "reddb".to_string(),
             data_path: PathBuf::from("/var/lib/reddb/data.rdb"),
             router_bind_addr: None,
-            grpc_bind_addr: Some("0.0.0.0:5055".to_string()),
+            grpc_bind_addr: Some("0.0.0.0:5555".to_string()),
             http_bind_addr: None,
         };
 
         let unit = render_systemd_unit(&config);
-        assert!(unit.contains("ExecStart=/usr/local/bin/red server --path /var/lib/reddb/data.rdb --grpc-bind 0.0.0.0:5055"));
+        assert!(unit.contains("ExecStart=/usr/local/bin/red server --path /var/lib/reddb/data.rdb --grpc-bind 0.0.0.0:5555"));
         assert!(unit.contains("ReadWritePaths=/var/lib/reddb"));
     }
 
@@ -1905,7 +1905,7 @@ mod tests {
             data_path: PathBuf::from("/srv/reddb/live/data.rdb"),
             router_bind_addr: None,
             grpc_bind_addr: None,
-            http_bind_addr: Some("127.0.0.1:8080".to_string()),
+            http_bind_addr: Some("127.0.0.1:5055".to_string()),
         };
 
         assert_eq!(config.data_dir(), PathBuf::from("/srv/reddb/live"));
@@ -1924,13 +1924,13 @@ mod tests {
             run_group: "reddb".to_string(),
             data_path: PathBuf::from("/var/lib/reddb/data.rdb"),
             router_bind_addr: None,
-            grpc_bind_addr: Some("0.0.0.0:5055".to_string()),
-            http_bind_addr: Some("0.0.0.0:8080".to_string()),
+            grpc_bind_addr: Some("0.0.0.0:5555".to_string()),
+            http_bind_addr: Some("0.0.0.0:5055".to_string()),
         };
 
         let unit = render_systemd_unit(&config);
-        assert!(unit.contains("--grpc-bind 0.0.0.0:5055"));
-        assert!(unit.contains("--http-bind 0.0.0.0:8080"));
+        assert!(unit.contains("--grpc-bind 0.0.0.0:5555"));
+        assert!(unit.contains("--http-bind 0.0.0.0:5055"));
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Set an API key and go. Every provider that exposes an OpenAI-compatible API work
 
 ```bash
 export REDDB_GROQ_API_KEY=gsk_xxx
-red server --path ./data/reddb.rdb --http-bind 127.0.0.1:8080
+red server --path ./data/reddb.rdb --http-bind 127.0.0.1:5055
 ```
 
 ## Semantic search built in
@@ -246,7 +246,7 @@ curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | ba
 ### npx
 
 ```bash
-npx @reddb-io/cli@latest server --path ./data/reddb.rdb --http-bind 127.0.0.1:8080
+npx @reddb-io/cli@latest server --path ./data/reddb.rdb --http-bind 127.0.0.1:5055
 ```
 
 ### JavaScript / TypeScript driver
@@ -268,19 +268,19 @@ await db.close()
 Start the server:
 
 ```bash
-red server --path ./data/reddb.rdb --grpc-bind 127.0.0.1:5055 --http-bind 127.0.0.1:8080
+red server --path ./data/reddb.rdb --grpc-bind 127.0.0.1:5555 --http-bind 127.0.0.1:5055
 ```
 
 Check health:
 
 ```bash
-curl -s http://127.0.0.1:8080/health
+curl -s http://127.0.0.1:5055/health
 ```
 
 Run a query:
 
 ```bash
-curl -X POST http://127.0.0.1:8080/query \
+curl -X POST http://127.0.0.1:5055/query \
   -H 'content-type: application/json' \
   -d '{"query":"SELECT * FROM hosts"}'
 ```
@@ -288,7 +288,7 @@ curl -X POST http://127.0.0.1:8080/query \
 Ask a question:
 
 ```bash
-curl -X POST http://127.0.0.1:8080/ai/ask \
+curl -X POST http://127.0.0.1:5055/ai/ask \
   -H 'content-type: application/json' \
   -d '{"question":"what happened on host 10.0.0.1?","provider":"groq","model":"llama-3.3-70b-versatile"}'
 ```
@@ -296,7 +296,7 @@ curl -X POST http://127.0.0.1:8080/ai/ask \
 Connect via gRPC REPL:
 
 ```bash
-red connect 127.0.0.1:5055
+red connect 127.0.0.1:5555
 ```
 
 ## Start here

--- a/docs/deployment/replication.md
+++ b/docs/deployment/replication.md
@@ -28,18 +28,18 @@ flowchart LR
 red server \
   --path ./data/primary.rdb \
   --role primary \
-  --grpc-bind 0.0.0.0:50051 \
-  --http-bind 0.0.0.0:8080
+  --grpc-bind 0.0.0.0:5555 \
+  --http-bind 0.0.0.0:5055
 ```
 
 ### Replica
 
 ```bash
 red replica \
-  --primary-addr http://primary-host:50051 \
+  --primary-addr http://primary-host:5555 \
   --path ./data/replica.rdb \
-  --grpc-bind 0.0.0.0:50051 \
-  --http-bind 0.0.0.0:8080
+  --grpc-bind 0.0.0.0:5555 \
+  --http-bind 0.0.0.0:5055
 ```
 
 Recommended topology:


### PR DESCRIPTION
## Summary

Aligns the three RedDB transport defaults around the 5xxx range, on-brand and easy to remember:

| Transport | Was | **Now** | Surface |
|---|---|---|---|
| Wire (Postgres-compat) | 5050 | **5050** | clients |
| HTTP (admin / health / replication-status) | 8080 | **5055** | ops |
| gRPC (replication streaming) | 5055 | **5555** | replicas |

Three fives. Operators no longer have to remember which generic port serves what surface — the colon segment on a connection string tells you the protocol.

## Why now

A downstream control-plane deploy is about to pin these in fly.toml. Pinning before the move would mean re-pinning later. Better to move once now, while the field hasn't pinned the old defaults.

## Wire stays

5050 is the customer-facing port — every Postgres driver, every IDE plugin connects there. Rotating it breaks every dependent. HTTP and gRPC defaults move because almost no operator pinned them in their unit / fly config; the few that did get a one-line edit.

## Updates

- \`ServerOptions::default().bind_addr\` → \`127.0.0.1:5055\`
- \`GrpcServerOptions::default().bind_addr\` → \`127.0.0.1:5555\`
- \`service_cli::ServerTransport::Grpc::default_bind_addr\` → \`:5555\`
- CLI usage strings (\`red server\`, \`red replica\`, \`red service install\`, \`red tick\`, \`red doctor\`)
- \`tick\` + \`doctor\` flag defaults via \`with_default(\"127.0.0.1:5055\")\`
- \`service_cli\` systemd unit dual-transport tests
- \`docs/deployment/replication.md\` primary/replica examples
- \`docs/README.md\` quickstart examples

## Test plan
- [x] \`cargo check -p reddb-server\` clean
- [x] \`cargo test -p reddb-server --lib service_cli\` 9/9 passing (systemd unit assertions still match)
- [ ] Pre-existing test failures in \`storage::schema::coercion_spine\` and \`telemetry::admin_intent_log\` reproduce on \`main\` (verified) — out of scope for this PR

## Migration

Operators with explicit \`--http-bind\` / \`--grpc-bind\` flags in their unit / fly config keep working — only the **default** changed. Operators relying on defaults should:

\`\`\`toml
# fly.toml example
[[services]]
internal_port = 5055   # was 8080
[[services]]
internal_port = 5555   # was 5055 (replication-only, internal)
\`\`\`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->