### PR TITLE
test(regression): column-name persistence (#4) + aggregate casing (#9) guards

### DIFF
--- a/crates/reddb-server/tests/aggregate_column_casing_diag.rs
+++ b/crates/reddb-server/tests/aggregate_column_casing_diag.rs
@@ -1,0 +1,159 @@
+//! THROWAWAY DIAGNOSTIC for reported bug #9 (1.1.2): inconsistent
+//! casing of aggregate result-set column names (COUNT(*) vs count(*),
+//! SUM vs sum). Goal: observe externally-visible column-name keys for
+//! the SAME aggregate across pushdown vs general execution and across
+//! lower/upper user input. Not an assertion of internals — we print the
+//! actual projected column-name strings.
+
+use reddb_server::{RedDBOptions, RedDBRuntime, RuntimeQueryResult};
+
+fn col_names(r: &RuntimeQueryResult) -> Vec<String> {
+    r.result.records[0]
+        .column_names()
+        .iter()
+        .map(|c| c.to_string())
+        .collect()
+}
+
+fn seed(rt: &RedDBRuntime) {
+    rt.execute_query("CREATE TABLE t (id INT, amount INT)")
+        .expect("create t");
+    rt.execute_query("INSERT INTO t (id, amount) VALUES (1, 10), (2, 20), (3, 30)")
+        .expect("insert t");
+}
+
+fn run(rt: &RedDBRuntime, label: &str, sql: &str) -> Vec<String> {
+    let r = rt
+        .execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed [{label}]: {sql}\n  err: {e}"));
+    assert!(
+        !r.result.records.is_empty(),
+        "no rows returned for [{label}]: {sql}"
+    );
+    let names = col_names(&r);
+    println!("[{label:<28}] {sql}\n    -> columns: {names:?}");
+    names
+}
+
+#[test]
+fn aggregate_column_name_casing_diag() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    seed(&rt);
+
+    println!("\n===== AGGREGATE COLUMN-NAME CASING DIAGNOSTIC =====\n");
+
+    // --- COUNT(*), no alias, pushdownable plain form ---
+    let count_lower_plain = run(&rt, "count-lower-plain", "SELECT count(*) FROM t");
+    let count_upper_plain = run(&rt, "COUNT-upper-plain", "SELECT COUNT(*) FROM t");
+
+    // --- SUM(amount), no alias, pushdownable plain form ---
+    let sum_lower_plain = run(&rt, "sum-lower-plain", "SELECT sum(amount) FROM t");
+    let sum_upper_plain = run(&rt, "SUM-upper-plain", "SELECT SUM(amount) FROM t");
+
+    // --- Forms that try to defeat aggregate pushdown / route general ---
+    // GROUP BY with a HAVING-ish / extra column tends to route differently.
+    let count_lower_group = run(
+        &rt,
+        "count-lower-groupby",
+        "SELECT count(*) FROM t GROUP BY id",
+    );
+    let count_upper_group = run(
+        &rt,
+        "COUNT-upper-groupby",
+        "SELECT COUNT(*) FROM t GROUP BY id",
+    );
+    let sum_lower_group = run(
+        &rt,
+        "sum-lower-groupby",
+        "SELECT sum(amount) FROM t GROUP BY id",
+    );
+    let sum_upper_group = run(
+        &rt,
+        "SUM-upper-groupby",
+        "SELECT SUM(amount) FROM t GROUP BY id",
+    );
+
+    // --- Wrapped in subquery (general path, projected out) ---
+    let count_lower_sub = run(
+        &rt,
+        "count-lower-subquery",
+        "SELECT (SELECT count(*) FROM t) AS dummy FROM t LIMIT 1",
+    );
+    let _ = &count_lower_sub; // alias forces 'dummy'; kept for record only
+
+    // --- Aggregate alongside another aggregate (multi-agg can route general) ---
+    let count_lower_mixed = run(
+        &rt,
+        "count-lower-multi",
+        "SELECT count(*), sum(amount) FROM t",
+    );
+    let sum_lower_mixed = run(&rt, "SUM-upper-multi", "SELECT COUNT(*), SUM(amount) FROM t");
+
+    println!("\n===== SUMMARY =====");
+    println!("COUNT plain : lower={count_lower_plain:?}  upper={count_upper_plain:?}");
+    println!("SUM   plain : lower={sum_lower_plain:?}  upper={sum_upper_plain:?}");
+    println!("COUNT group : lower={count_lower_group:?}  upper={count_upper_group:?}");
+    println!("SUM   group : lower={sum_lower_group:?}  upper={sum_upper_group:?}");
+    println!("COUNT mixed : lower={count_lower_mixed:?}");
+    println!("SUM   mixed : lower={sum_lower_mixed:?}");
+    println!("===================\n");
+
+    // Helper: pick the column matching a given aggregate kind prefix.
+    let agg_of = |names: &[String], prefix: &str| -> String {
+        names
+            .iter()
+            .find(|n| n.to_ascii_lowercase().starts_with(prefix))
+            .cloned()
+            .unwrap_or_else(|| format!("<no {prefix} col in {names:?}>"))
+    };
+    let count_of = |n: &[String]| agg_of(n, "count(");
+    let sum_of = |n: &[String]| agg_of(n, "sum(");
+
+    let observed = [
+        ("count-lower-plain", count_of(&count_lower_plain)),
+        ("COUNT-upper-plain", count_of(&count_upper_plain)),
+        ("sum-lower-plain", sum_of(&sum_lower_plain)),
+        ("SUM-upper-plain", sum_of(&sum_upper_plain)),
+        ("count-lower-groupby", count_of(&count_lower_group)),
+        ("COUNT-upper-groupby", count_of(&count_upper_group)),
+        ("sum-lower-groupby", sum_of(&sum_lower_group)),
+        ("SUM-upper-groupby", sum_of(&sum_upper_group)),
+        ("count-lower-multi", count_of(&count_lower_mixed)),
+        ("sum-lower-multi", sum_of(&count_lower_mixed)),
+        ("COUNT-upper-multi", count_of(&sum_lower_mixed)),
+        ("SUM-upper-multi", sum_of(&sum_lower_mixed)),
+    ];
+
+    println!("AGGREGATE COLUMN KEY PER FORM:");
+    for (label, name) in &observed {
+        println!("  {label:<24} -> {name:?}");
+    }
+    println!();
+
+    // VERDICT computation: do all COUNT forms agree, and all SUM forms agree?
+    let count_keys: Vec<&String> = observed
+        .iter()
+        .filter(|(l, _)| l.to_ascii_lowercase().contains("count"))
+        .map(|(_, n)| n)
+        .collect();
+    let sum_keys: Vec<&String> = observed
+        .iter()
+        .filter(|(l, _)| l.to_ascii_lowercase().contains("sum"))
+        .map(|(_, n)| n)
+        .collect();
+
+    let count_consistent = count_keys.windows(2).all(|w| w[0] == w[1]);
+    let sum_consistent = sum_keys.windows(2).all(|w| w[0] == w[1]);
+
+    println!(
+        "COUNT keys consistent across all forms? {count_consistent} ({count_keys:?})"
+    );
+    println!("SUM   keys consistent across all forms? {sum_consistent} ({sum_keys:?})");
+
+    // This assertion encodes the DESIRED behavior (consistent casing).
+    // If the bug reproduces, it FAILS and the printout above shows the divergence.
+    assert!(
+        count_consistent && sum_consistent,
+        "INCONSISTENT aggregate column-name casing reproduced. See per-form keys above."
+    );
+}

--- a/crates/reddb-server/tests/aggregate_column_casing_diag.rs
+++ b/crates/reddb-server/tests/aggregate_column_casing_diag.rs
@@ -87,7 +87,11 @@ fn aggregate_column_name_casing_diag() {
         "count-lower-multi",
         "SELECT count(*), sum(amount) FROM t",
     );
-    let sum_lower_mixed = run(&rt, "SUM-upper-multi", "SELECT COUNT(*), SUM(amount) FROM t");
+    let sum_lower_mixed = run(
+        &rt,
+        "SUM-upper-multi",
+        "SELECT COUNT(*), SUM(amount) FROM t",
+    );
 
     println!("\n===== SUMMARY =====");
     println!("COUNT plain : lower={count_lower_plain:?}  upper={count_upper_plain:?}");
@@ -145,9 +149,7 @@ fn aggregate_column_name_casing_diag() {
     let count_consistent = count_keys.windows(2).all(|w| w[0] == w[1]);
     let sum_consistent = sum_keys.windows(2).all(|w| w[0] == w[1]);
 
-    println!(
-        "COUNT keys consistent across all forms? {count_consistent} ({count_keys:?})"
-    );
+    println!("COUNT keys consistent across all forms? {count_consistent} ({count_keys:?})");
     println!("SUM   keys consistent across all forms? {sum_consistent} ({sum_keys:?})");
 
     // This assertion encodes the DESIRED behavior (consistent casing).

--- a/crates/reddb-server/tests/repro_issue4_column_names_reopen.rs
+++ b/crates/reddb-server/tests/repro_issue4_column_names_reopen.rs
@@ -42,10 +42,8 @@ fn issue4_typed_column_names_survive_persistent_reopen() {
     {
         let rt =
             RedDBRuntime::with_options(RedDBOptions::persistent(&db_path)).expect("runtime boots");
-        rt.execute_query(
-            "CREATE TABLE chapter_words (chapter TEXT, word TEXT, freq INTEGER)",
-        )
-        .expect("create table");
+        rt.execute_query("CREATE TABLE chapter_words (chapter TEXT, word TEXT, freq INTEGER)")
+            .expect("create table");
 
         insert_chunks(&rt);
 
@@ -83,7 +81,10 @@ fn issue4_typed_column_names_survive_persistent_reopen() {
         .expect("reopened select-star executes");
 
     eprintln!("REOPEN projection columns = {:?}", reopened.result.columns);
-    eprintln!("REOPEN projection rows     = {}", reopened.result.records.len());
+    eprintln!(
+        "REOPEN projection rows     = {}",
+        reopened.result.records.len()
+    );
     eprintln!("REOPEN select-* columns    = {:?}", star.result.columns);
 
     // The bug report: after reopen these degrade to c0/c1/c2 and the

--- a/crates/reddb-server/tests/repro_issue4_column_names_reopen.rs
+++ b/crates/reddb-server/tests/repro_issue4_column_names_reopen.rs
@@ -1,0 +1,110 @@
+//! Reproduction for bug #4 ("the big one"): typed table column names not
+//! persisted across a file-backed close + reopen once the row count crosses
+//! a snapshot/WAL boundary (~500 rows).
+//!
+//! Externally observable assertions only — we never touch private internals.
+//! We assert on what `SELECT` actually returns: the projected column names,
+//! the `SELECT *` column set, and the row contents of a filtered query.
+
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+const ROWS: usize = 2500;
+const CHUNK: usize = 300;
+
+fn insert_chunks(rt: &RedDBRuntime) {
+    let mut inserted = 0usize;
+    while inserted < ROWS {
+        let end = (inserted + CHUNK).min(ROWS);
+        let values: Vec<String> = (inserted..end)
+            .map(|i| {
+                // Make exactly one row carry word='ring' so the filtered
+                // SELECT below has a deterministic single-row expectation.
+                let word = if i == 7 { "ring" } else { "other" };
+                format!("('chapter{}', '{}', {})", i % 10, word, i as i64)
+            })
+            .collect();
+        let sql = format!(
+            "INSERT INTO chapter_words (chapter, word, freq) VALUES {}",
+            values.join(", ")
+        );
+        rt.execute_query(&sql)
+            .unwrap_or_else(|e| panic!("insert chunk [{inserted}..{end}) failed: {e}"));
+        inserted = end;
+    }
+}
+
+#[test]
+fn issue4_typed_column_names_survive_persistent_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("chapter_words.rdb");
+
+    // ---- First connection: create + bulk insert ----
+    {
+        let rt =
+            RedDBRuntime::with_options(RedDBOptions::persistent(&db_path)).expect("runtime boots");
+        rt.execute_query(
+            "CREATE TABLE chapter_words (chapter TEXT, word TEXT, freq INTEGER)",
+        )
+        .expect("create table");
+
+        insert_chunks(&rt);
+
+        // Same-connection sanity: named columns must work right after insert.
+        let same = rt
+            .execute_query("SELECT chapter, freq FROM chapter_words WHERE word = 'ring'")
+            .expect("same-connection select");
+        assert_eq!(
+            same.result.columns,
+            vec!["chapter".to_string(), "freq".to_string()],
+            "same-connection projection must carry declared names"
+        );
+        assert_eq!(
+            same.result.records.len(),
+            1,
+            "same-connection filtered query must find the one word='ring' row"
+        );
+
+        // Drop the runtime to release the pager + file lock so the same
+        // process can reopen the persistent file (see impl_core.rs comment
+        // about the maintenance thread holding only a Weak ref).
+        drop(rt);
+    }
+
+    // ---- Second connection: reopen the SAME file ----
+    let rt2 =
+        RedDBRuntime::with_options(RedDBOptions::persistent(&db_path)).expect("runtime reopens");
+
+    let reopened = rt2
+        .execute_query("SELECT chapter, freq FROM chapter_words WHERE word = 'ring'")
+        .expect("reopened select executes");
+
+    let star = rt2
+        .execute_query("SELECT * FROM chapter_words")
+        .expect("reopened select-star executes");
+
+    eprintln!("REOPEN projection columns = {:?}", reopened.result.columns);
+    eprintln!("REOPEN projection rows     = {}", reopened.result.records.len());
+    eprintln!("REOPEN select-* columns    = {:?}", star.result.columns);
+
+    // The bug report: after reopen these degrade to c0/c1/c2 and the
+    // filtered query returns no rows.
+    assert_eq!(
+        reopened.result.columns,
+        vec!["chapter".to_string(), "freq".to_string()],
+        "reopened projection lost declared column names (got {:?})",
+        reopened.result.columns
+    );
+    assert_eq!(
+        reopened.result.records.len(),
+        1,
+        "reopened filtered query lost rows (word='ring' should match exactly one)"
+    );
+
+    assert!(
+        star.result.columns.contains(&"chapter".to_string())
+            && star.result.columns.contains(&"word".to_string())
+            && star.result.columns.contains(&"freq".to_string()),
+        "reopened SELECT * lost declared column names (got {:?})",
+        star.result.columns
+    );
+}


### PR DESCRIPTION
## What

Two regression guards realizing scenarios from the lord-of-the-rings RedDB
friction report. Both reports were 1.1.x-era and are **already fixed** on the
1.2 line — these tests pass green and lock the fix in.

- `repro_issue4_column_names_reopen.rs` — typed table columns survive a
  file-backed close + reopen at 2500 rows (the reporter saw them degrade to
  `c0/c1` on 1.1.2). Realizes the scenario the `impl_core.rs` maintenance-thread
  comment names `finding_1_select_after_bulk_insert_persistent_reopen` but that
  had no test.
- `aggregate_column_casing_diag.rs` — aggregate result columns use a single
  canonical `FUNC(arg)` casing across pushdown / GROUP BY / multi-aggregate
  (the reporter saw inconsistent `COUNT(*)` vs `count(*)` on 1.1.2).

Test-only; no engine source changed. Triage detail in #628/#629/#630.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781962296&installation_id=129708444&pr_number=632&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F632&signature=06b4501bfc7d0bba303ef0d83335e7d10e6d6ffd94a502dd26d4d7e9f202e07a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->