### PR TITLE
merge: #820 Replication: dedicated stream/ack capabilities + ack bound to peer identity

### DIFF
--- a/crates/reddb-server/src/auth/action_catalog.rs
+++ b/crates/reddb-server/src/auth/action_catalog.rs
@@ -694,6 +694,28 @@ pub const ACTIONS: &[ActionEntry] = &[
         lifecycle_state: LifecycleState::Active,
         gates_description: "any operational read verb",
     },
+    // -- Replication control (#820 / PRD #819) ---------------------------
+    // Dedicated replication capabilities. These are intentionally not
+    // covered by generic data reads: WAL streaming exposes the change set,
+    // and replica acks can move synchronous-commit watermarks.
+    ActionEntry {
+        name: "cluster:replication:stream",
+        category: ActionCategory::Other,
+        lifecycle_state: LifecycleState::Active,
+        gates_description: "stream primary WAL records and replication snapshots to a replica",
+    },
+    ActionEntry {
+        name: "cluster:replication:ack",
+        category: ActionCategory::Other,
+        lifecycle_state: LifecycleState::Active,
+        gates_description: "acknowledge replica LSN progress to the primary",
+    },
+    ActionEntry {
+        name: "cluster:*",
+        category: ActionCategory::Wildcard,
+        lifecycle_state: LifecycleState::Active,
+        gates_description: "any cluster-scoped capability",
+    },
     // -- Vector operations (#756 / PRD #735) -----------------------------
     // Red UI needs to grant vector toolbar actions independently —
     // metadata / data reads, similarity / text / hybrid search,

--- a/crates/reddb-server/src/grpc/control_support.rs
+++ b/crates/reddb-server/src/grpc/control_support.rs
@@ -132,6 +132,51 @@ impl GrpcRuntime {
         check_permission(&auth, false, true).map_err(Status::permission_denied)
     }
 
+    pub(crate) fn authorize_replication_stream(
+        &self,
+        metadata: &MetadataMap,
+    ) -> Result<String, Status> {
+        self.authorize_replication_capability(metadata, "cluster:replication:stream")
+    }
+
+    pub(crate) fn authorize_replication_ack(
+        &self,
+        metadata: &MetadataMap,
+    ) -> Result<String, Status> {
+        self.authorize_replication_capability(metadata, "cluster:replication:ack")
+    }
+
+    fn authorize_replication_capability(
+        &self,
+        metadata: &MetadataMap,
+        action: &str,
+    ) -> Result<String, Status> {
+        let auth = self.resolve_auth(metadata);
+        let username = match auth {
+            AuthResult::Authenticated { username, .. } => username,
+            AuthResult::Denied(reason) => return Err(Status::unauthenticated(reason)),
+            AuthResult::Anonymous => {
+                return Err(Status::unauthenticated("authentication required"));
+            }
+        };
+
+        let principal = crate::auth::UserId::platform(username.clone());
+        let resource = crate::auth::policies::ResourceRef::new("cluster", "replication");
+        let outcome = self.auth_store.simulate(
+            &principal,
+            action,
+            &resource,
+            crate::auth::store::SimCtx::default(),
+        );
+        match outcome.decision {
+            crate::auth::policies::Decision::Allow { .. }
+            | crate::auth::policies::Decision::AdminBypass => Ok(username),
+            _ => Err(Status::permission_denied(format!(
+                "policy: principal '{username}' is not allowed to perform '{action}'"
+            ))),
+        }
+    }
+
     /// PLAN.md Phase 11.4 — call after a successful gRPC write to
     /// enforce the configured commit policy. When policy is `Local`
     /// (default) this returns immediately. When policy is

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2876,7 +2876,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<JsonPayloadRequest>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_read(request.metadata())?;
+        self.authorize_replication_stream(request.metadata())?;
         let db = self.runtime.db();
         let repl = db.replication.as_ref().ok_or_else(|| {
             Status::failed_precondition("this instance is not a replication primary")
@@ -2954,7 +2954,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<JsonPayloadRequest>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_read(request.metadata())?;
+        let authenticated_replica_id = self.authorize_replication_ack(request.metadata())?;
         let db = self.runtime.db();
         let repl = db.replication.as_ref().ok_or_else(|| {
             Status::failed_precondition("this instance is not a replication primary")
@@ -2966,6 +2966,11 @@ impl RedDb for GrpcRuntime {
             .and_then(JsonValue::as_str)
             .ok_or_else(|| Status::invalid_argument("missing replica_id"))?
             .to_string();
+        if replica_id != authenticated_replica_id {
+            return Err(Status::permission_denied(
+                "replica_id does not match authenticated identity",
+            ));
+        }
         let applied_lsn = payload
             .get("applied_lsn")
             .and_then(JsonValue::as_u64)
@@ -2975,11 +2980,14 @@ impl RedDb for GrpcRuntime {
             .and_then(JsonValue::as_u64)
             .unwrap_or(applied_lsn);
 
-        repl.ack_replica_lsn(&replica_id, applied_lsn, durable_lsn);
+        repl.ack_replica_lsn(&authenticated_replica_id, applied_lsn, durable_lsn);
 
         let mut reply = crate::json::Map::new();
         reply.insert("ok".into(), JsonValue::Bool(true));
-        reply.insert("replica_id".into(), JsonValue::String(replica_id));
+        reply.insert(
+            "replica_id".into(),
+            JsonValue::String(authenticated_replica_id),
+        );
         reply.insert("applied_lsn".into(), JsonValue::Number(applied_lsn as f64));
         reply.insert("durable_lsn".into(), JsonValue::Number(durable_lsn as f64));
         Ok(Response::new(json_payload_reply(JsonValue::Object(reply))))
@@ -2989,7 +2997,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<Empty>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_read(request.metadata())?;
+        self.authorize_replication_stream(request.metadata())?;
         let db = self.runtime.db();
 
         if db.replication.is_none() {

--- a/tests/e2e_issue_820_replication_auth.rs
+++ b/tests/e2e_issue_820_replication_auth.rs
@@ -1,0 +1,224 @@
+//! Issue #820 — replication stream/ack capabilities and ack identity binding.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::{Empty, JsonPayloadRequest};
+use reddb::replication::ReplicationConfig;
+use reddb::runtime::RedDBRuntime;
+use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions};
+
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+use tonic::Code;
+
+fn pick_port() -> u16 {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let p = l.local_addr().unwrap().port();
+    drop(l);
+    p
+}
+
+async fn wait_for_port(port: u16, max_ms: u64) {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(max_ms);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
+    let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5));
+    let channel = endpoint.connect().await.expect("client connect");
+    RedDbClient::new(channel)
+}
+
+fn install_policy(store: &AuthStore, username: &str, id: &str, actions: &[&str], resource: &str) {
+    let actions_json = actions
+        .iter()
+        .map(|action| format!("\"{action}\""))
+        .collect::<Vec<_>>()
+        .join(",");
+    let policy_json = format!(
+        r#"{{"id":"{id}","version":1,"statements":[{{"effect":"allow","actions":[{actions_json}],"resources":["{resource}"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(PrincipalRef::User(UserId::platform(username)), id)
+        .expect("attach policy");
+}
+
+fn bearer_request<T>(message: T, token: &str) -> tonic::Request<T> {
+    let mut request = tonic::Request::new(message);
+    let value: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+fn pull_request(replica_id: &str, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","since_lsn":0,"max_count":10}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn ack_request(
+    replica_id: &str,
+    applied_lsn: u64,
+    token: &str,
+) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","applied_lsn":{applied_lsn},"durable_lsn":{applied_lsn}}}"#
+            ),
+        },
+        token,
+    )
+}
+
+#[tokio::test]
+async fn replication_stream_and_ack_require_capabilities_and_bind_ack_identity() {
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("runtime");
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("reader", "p", Role::Read).unwrap();
+    store.create_user("replica_a", "p", Role::Read).unwrap();
+    store.create_user("replica_b", "p", Role::Read).unwrap();
+    let reader_key = store
+        .create_api_key("reader", "read-only", Role::Read)
+        .unwrap();
+    let replica_a_key = store
+        .create_api_key("replica_a", "replication-a", Role::Read)
+        .unwrap();
+    let replica_b_key = store
+        .create_api_key("replica_b", "replication-b", Role::Read)
+        .unwrap();
+
+    install_policy(
+        &store,
+        "reader",
+        "p_reader_data_read",
+        &["select"],
+        "table:*",
+    );
+    install_policy(
+        &store,
+        "replica_a",
+        "p_replica_a",
+        &["cluster:replication:stream", "cluster:replication:ack"],
+        "cluster:replication",
+    );
+    install_policy(
+        &store,
+        "replica_b",
+        "p_replica_b",
+        &["cluster:replication:stream", "cluster:replication:ack"],
+        "cluster:replication",
+    );
+
+    let port = pick_port();
+    let bind = format!("127.0.0.1:{port}");
+    let server = RedDBGrpcServer::with_options(
+        runtime.clone(),
+        GrpcServerOptions {
+            bind_addr: bind,
+            tls: None,
+        },
+        store,
+    );
+    let h = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port, 5000).await;
+    let mut client = connect_client(port).await;
+
+    let read_only_pull = client
+        .pull_wal_records(pull_request("reader", &reader_key.key))
+        .await
+        .expect_err("read-only token must not stream WAL records");
+    assert_eq!(read_only_pull.code(), Code::PermissionDenied);
+
+    let read_only_snapshot = client
+        .replication_snapshot(bearer_request(Empty {}, &reader_key.key))
+        .await
+        .expect_err("read-only token must not fetch replication snapshot");
+    assert_eq!(read_only_snapshot.code(), Code::PermissionDenied);
+
+    let read_only_ack = client
+        .ack_replica_lsn(ack_request("reader", 10, &reader_key.key))
+        .await
+        .expect_err("read-only token must not ack replica LSN");
+    assert_eq!(read_only_ack.code(), Code::PermissionDenied);
+
+    client
+        .pull_wal_records(pull_request("replica_a", &replica_a_key.key))
+        .await
+        .expect("replication-capable token can stream WAL records");
+    client
+        .replication_snapshot(bearer_request(Empty {}, &replica_a_key.key))
+        .await
+        .expect("replication-capable token can fetch snapshot");
+
+    client
+        .pull_wal_records(pull_request("replica_b", &replica_b_key.key))
+        .await
+        .expect("second replica self-registers before forged ack attempt");
+
+    let forged = client
+        .ack_replica_lsn(ack_request("replica_b", 100, &replica_a_key.key))
+        .await
+        .expect_err("replica_a token must not ack as replica_b");
+    assert_eq!(forged.code(), Code::PermissionDenied);
+    let replica_b = runtime
+        .primary_replica_snapshots()
+        .into_iter()
+        .find(|replica| replica.id == "replica_b")
+        .expect("replica_b registered");
+    assert_eq!(
+        replica_b.last_acked_lsn, 0,
+        "forged ack must not advance replica_b commit watermark"
+    );
+
+    let ack = client
+        .ack_replica_lsn(ack_request("replica_a", 10, &replica_a_key.key))
+        .await
+        .expect("replica_a can ack as itself")
+        .into_inner();
+    let body: serde_json::Value = serde_json::from_str(&ack.payload).expect("ack reply is JSON");
+    assert_eq!(body["replica_id"], "replica_a");
+    let replica_a = runtime
+        .primary_replica_snapshots()
+        .into_iter()
+        .find(|replica| replica.id == "replica_a")
+        .expect("replica_a registered");
+    assert_eq!(replica_a.last_acked_lsn, 10);
+
+    h.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #820. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782736607&installation_id=129708444&pr_number=842&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F842&signature=bd50a2826c2fff0e2a12fcf39d64e2bbf7d02c2a1efd384f13885336b03bac20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added granular authorization controls for cluster replication operations (`cluster:replication:stream` and `cluster:replication:ack` permissions)
  * Replication operations now require dedicated permissions instead of generic read access
  * Replica acknowledgments validate that authenticated replica identity matches the requested operation

* **Tests**
  * Added end-to-end test coverage for replication authorization enforcement and identity validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->