### PR TITLE
merge: #821 Replication: term/epoch on the WAL (framing v3) and divergence by (term, lsn)

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2797,6 +2797,10 @@ impl RedDb for GrpcRuntime {
         let db = self.runtime.db();
         let role = &db.options().replication.role;
         let mut map = crate::json::Map::new();
+        map.insert(
+            "current_term".into(),
+            JsonValue::Number(db.options().replication.term as f64),
+        );
 
         match role {
             crate::replication::ReplicationRole::Standalone => {

--- a/crates/reddb-server/src/replication/cdc.rs
+++ b/crates/reddb-server/src/replication/cdc.rs
@@ -127,6 +127,7 @@ impl KvWatchEvent {
 /// archived segments.
 #[derive(Debug, Clone)]
 pub struct ChangeRecord {
+    pub term: u64,
     pub lsn: u64,
     pub timestamp: u64,
     pub operation: ChangeOperation,
@@ -162,6 +163,7 @@ impl ChangeRecord {
         };
 
         Self {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn,
             timestamp,
             operation,
@@ -184,6 +186,7 @@ impl ChangeRecord {
         records: Vec<Vec<u8>>,
     ) -> Self {
         Self {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn,
             timestamp,
             operation: ChangeOperation::Refresh,
@@ -198,6 +201,7 @@ impl ChangeRecord {
 
     pub fn to_json_value(&self) -> JsonValue {
         let mut object = Map::new();
+        object.insert("term".to_string(), JsonValue::Number(self.term as f64));
         object.insert("lsn".to_string(), JsonValue::Number(self.lsn as f64));
         object.insert(
             "timestamp".to_string(),
@@ -241,6 +245,11 @@ impl ChangeRecord {
             .into_bytes()
     }
 
+    pub fn with_term(mut self, term: u64) -> Self {
+        self.term = term;
+        self
+    }
+
     pub fn decode(bytes: &[u8]) -> Result<Self, String> {
         let text = std::str::from_utf8(bytes).map_err(|err| err.to_string())?;
         let value = crate::json::from_str::<JsonValue>(text).map_err(|err| err.to_string())?;
@@ -257,6 +266,10 @@ impl ChangeRecord {
             .map_err(|err| err.to_string())?;
 
         Ok(Self {
+            term: value
+                .get("term")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(crate::replication::DEFAULT_REPLICATION_TERM),
             lsn: value.get("lsn").and_then(JsonValue::as_u64).unwrap_or(0),
             timestamp: value
                 .get("timestamp")
@@ -690,6 +703,7 @@ mod tests {
     #[test]
     fn test_change_record_roundtrip() {
         let record = ChangeRecord {
+            term: 3,
             lsn: 7,
             timestamp: 1234,
             operation: ChangeOperation::Update,
@@ -702,6 +716,7 @@ mod tests {
         };
 
         let decoded = ChangeRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded.term, record.term);
         assert_eq!(decoded.lsn, record.lsn);
         assert_eq!(decoded.collection, record.collection);
         assert_eq!(decoded.entity_id, record.entity_id);
@@ -717,11 +732,21 @@ mod tests {
     #[test]
     fn test_change_record_refresh_roundtrip() {
         let records = vec![vec![0x10, 0x20, 0x30], vec![0xAA, 0xBB], Vec::new()];
-        let record = ChangeRecord::for_refresh(11, 99, "mv_orders_summary", records.clone());
+        let record =
+            ChangeRecord::for_refresh(11, 99, "mv_orders_summary", records.clone()).with_term(4);
 
         let decoded = ChangeRecord::decode(&record.encode()).expect("decode");
+        assert_eq!(decoded.term, 4);
         assert_eq!(decoded.operation, ChangeOperation::Refresh);
         assert_eq!(decoded.collection, "mv_orders_summary");
         assert_eq!(decoded.refresh_records.as_deref(), Some(&records[..]));
+    }
+
+    #[test]
+    fn test_change_record_legacy_payload_defaults_term() {
+        let legacy = br#"{"lsn":9,"timestamp":1,"operation":"delete","collection":"users","rid":5,"kind":"row"}"#;
+        let decoded = ChangeRecord::decode(legacy).expect("decode legacy record");
+        assert_eq!(decoded.term, crate::replication::DEFAULT_REPLICATION_TERM);
+        assert_eq!(decoded.lsn, 9);
     }
 }

--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -128,6 +128,8 @@ pub enum LogicalApplyError {
         next: u64,
     },
     Divergence {
+        expected_term: u64,
+        got_term: u64,
         lsn: u64,
         expected: String,
         got: String,
@@ -142,9 +144,15 @@ impl std::fmt::Display for LogicalApplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Gap { last, next } => write!(f, "LSN gap on apply: last={last} next={next}"),
-            Self::Divergence { lsn, expected, got } => write!(
+            Self::Divergence {
+                expected_term,
+                got_term,
+                lsn,
+                expected,
+                got,
+            } => write!(
                 f,
-                "LSN divergence on apply at lsn={lsn}: expected payload hash {expected}, got {got}"
+                "LSN divergence on apply at term/lsn=({got_term},{lsn}): expected term {expected_term} payload hash {expected}, got {got}"
             ),
             Self::Apply { lsn, source } => write!(f, "apply error at lsn={lsn}: {source}"),
         }
@@ -158,6 +166,7 @@ impl std::error::Error for LogicalApplyError {}
 /// LSN + payload hash so duplicates / older LSNs / gaps / divergences are
 /// detected explicitly.
 pub struct LogicalChangeApplier {
+    last_applied_term: AtomicU64,
     last_applied_lsn: AtomicU64,
     last_payload_hash: Mutex<Option<[u8; 32]>>,
     /// Issue #814 — metrics the apply path bumps when a record runs
@@ -185,6 +194,7 @@ impl LogicalChangeApplier {
     /// on `reddb_replica_apply_errors_total{kind="apply_miss"}`.
     pub fn with_metrics(starting_lsn: u64, metrics: std::sync::Arc<ReplicaApplyMetrics>) -> Self {
         Self {
+            last_applied_term: AtomicU64::new(crate::replication::DEFAULT_REPLICATION_TERM),
             last_applied_lsn: AtomicU64::new(starting_lsn),
             last_payload_hash: Mutex::new(None),
             metrics,
@@ -198,6 +208,10 @@ impl LogicalChangeApplier {
 
     pub fn last_applied_lsn(&self) -> u64 {
         self.last_applied_lsn.load(Ordering::Acquire)
+    }
+
+    pub fn last_applied_term(&self) -> u64 {
+        self.last_applied_term.load(Ordering::Acquire)
     }
 
     /// Apply one logical change record. The state machine:
@@ -214,10 +228,12 @@ impl LogicalChangeApplier {
         mode: ApplyMode,
     ) -> Result<ApplyOutcome, LogicalApplyError> {
         let last = self.last_applied_lsn.load(Ordering::Acquire);
+        let last_term = self.last_applied_term.load(Ordering::Acquire);
         let payload_hash = record_payload_hash(record);
 
         if last == 0 && record.lsn > 0 {
             self.do_apply(db, record, mode)?;
+            self.last_applied_term.store(record.term, Ordering::Release);
             self.last_applied_lsn.store(record.lsn, Ordering::Release);
             *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
             return Ok(ApplyOutcome::Applied);
@@ -228,6 +244,8 @@ impl LogicalChangeApplier {
             return match prior {
                 Some(p) if p == payload_hash => Ok(ApplyOutcome::Idempotent),
                 Some(p) => Err(LogicalApplyError::Divergence {
+                    expected_term: last_term,
+                    got_term: record.term,
                     lsn: record.lsn,
                     expected: hex_digest(&p),
                     got: hex_digest(&payload_hash),
@@ -246,6 +264,7 @@ impl LogicalChangeApplier {
         }
 
         self.do_apply(db, record, mode)?;
+        self.last_applied_term.store(record.term, Ordering::Release);
         self.last_applied_lsn.store(record.lsn, Ordering::Release);
         *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
         Ok(ApplyOutcome::Applied)
@@ -426,6 +445,7 @@ impl LogicalChangeApplier {
 
 fn record_payload_hash(record: &ChangeRecord) -> [u8; 32] {
     let mut hasher = crate::crypto::sha256::Sha256::new();
+    hasher.update(&record.term.to_le_bytes());
     hasher.update(&record.lsn.to_le_bytes());
     hasher.update(&[record.operation as u8]);
     hasher.update(record.collection.as_bytes());
@@ -502,6 +522,7 @@ mod tests {
 
     fn delete_record(lsn: u64, collection: &str, entity_id: u64) -> ChangeRecord {
         ChangeRecord {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn,
             timestamp: 100 + lsn,
             operation: ChangeOperation::Delete,
@@ -687,6 +708,33 @@ mod tests {
             matches!(err, LogicalApplyError::Divergence { lsn: 7, .. }),
             "got {err:?}"
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn apply_fails_closed_on_same_lsn_different_term() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+        applier
+            .apply(&db, &record(7, b"same").with_term(1), ApplyMode::Replica)
+            .unwrap();
+        let err = applier
+            .apply(&db, &record(7, b"same").with_term(2), ApplyMode::Replica)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LogicalApplyError::Divergence {
+                    lsn: 7,
+                    expected_term: 1,
+                    got_term: 2,
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(applier.last_applied_term(), 1);
+        assert_eq!(applier.last_applied_lsn(), 7);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -40,6 +40,8 @@ pub use topology_advertiser::{
     TOPOLOGY_READ_CAPABILITY,
 };
 
+pub const DEFAULT_REPLICATION_TERM: u64 = 1;
+
 /// Role of this RedDB instance in a replication cluster.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ReplicationRole {
@@ -59,6 +61,8 @@ pub enum ReplicationRole {
 #[derive(Debug, Clone)]
 pub struct ReplicationConfig {
     pub role: ReplicationRole,
+    /// Current replication term/epoch stamped into WAL-derived records.
+    pub term: u64,
     /// How often replica polls for new WAL records (milliseconds).
     pub poll_interval_ms: u64,
     /// Maximum batch size for WAL record transfer.
@@ -78,6 +82,7 @@ impl ReplicationConfig {
     pub fn standalone() -> Self {
         Self {
             role: ReplicationRole::Standalone,
+            term: DEFAULT_REPLICATION_TERM,
             poll_interval_ms: 100,
             max_batch_size: 1000,
             region: "local".to_string(),
@@ -88,6 +93,7 @@ impl ReplicationConfig {
     pub fn primary() -> Self {
         Self {
             role: ReplicationRole::Primary,
+            term: DEFAULT_REPLICATION_TERM,
             poll_interval_ms: 100,
             max_batch_size: 1000,
             region: "local".to_string(),
@@ -100,6 +106,7 @@ impl ReplicationConfig {
             role: ReplicationRole::Replica {
                 primary_addr: primary_addr.into(),
             },
+            term: DEFAULT_REPLICATION_TERM,
             poll_interval_ms: 100,
             max_batch_size: 1000,
             region: "local".to_string(),
@@ -116,6 +123,12 @@ impl ReplicationConfig {
     /// Set the region identifier (fluent setter).
     pub fn with_region(mut self, region: impl Into<String>) -> Self {
         self.region = region.into();
+        self
+    }
+
+    /// Set the replication term stamped into newly produced records.
+    pub fn with_term(mut self, term: u64) -> Self {
+        self.term = term;
         self
     }
 }

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -2,7 +2,22 @@
 //!
 //! ## Logical WAL spool wire format
 //!
-//! ### Version 2 (current — PLAN.md Phase 2 / W2)
+//! ### Version 3 (current — issue #821)
+//!
+//! ```text
+//! [magic     4 bytes  = b"RDLW"]
+//! [version   1 byte   = 0x03]
+//! [term      8 bytes  little-endian u64]
+//! [lsn       8 bytes  little-endian u64]
+//! [timestamp 8 bytes  little-endian u64 — wall-clock millis since UNIX epoch]
+//! [payload_len 4 bytes little-endian u32]
+//! [payload   payload_len bytes]
+//! [crc32     4 bytes  little-endian u32 — crc32fast of (version || term ||
+//!                                          lsn || timestamp || payload_len ||
+//!                                          payload)]
+//! ```
+//!
+//! ### Version 2 (legacy, read-only — PLAN.md Phase 2 / W2)
 //!
 //! ```text
 //! [magic     4 bytes  = b"RDLW"]
@@ -44,11 +59,12 @@ use tracing::warn;
 const LOGICAL_WAL_SPOOL_MAGIC: &[u8; 4] = b"RDLW";
 const LOGICAL_WAL_SPOOL_VERSION_V1: u8 = 1;
 const LOGICAL_WAL_SPOOL_VERSION_V2: u8 = 2;
-const LOGICAL_WAL_SPOOL_VERSION_CURRENT: u8 = LOGICAL_WAL_SPOOL_VERSION_V2;
-/// Header size in bytes for a v2 record before the payload starts:
-/// magic(4) + version(1) + lsn(8) + timestamp(8) + payload_len(4) = 25.
-const LOGICAL_WAL_V2_HEADER_LEN: u64 = 4 + 1 + 8 + 8 + 4;
-/// CRC32 trailer size in bytes for a v2 record.
+const LOGICAL_WAL_SPOOL_VERSION_V3: u8 = 3;
+const LOGICAL_WAL_SPOOL_VERSION_CURRENT: u8 = LOGICAL_WAL_SPOOL_VERSION_V3;
+/// Header size in bytes for a v3 record before the payload starts:
+/// magic(4) + version(1) + term(8) + lsn(8) + timestamp(8) + payload_len(4) = 33.
+const LOGICAL_WAL_V3_HEADER_LEN: u64 = 4 + 1 + 8 + 8 + 8 + 4;
+/// CRC32 trailer size in bytes for logical spool records.
 const LOGICAL_WAL_V2_CRC_LEN: u64 = 4;
 
 /// Compute CRC32 over the bytes that follow the magic — version,
@@ -67,6 +83,23 @@ fn compute_logical_v2_crc(version: u8, lsn: u64, timestamp: u64, payload: &[u8])
     crc = crc32_update(crc, &(payload.len() as u32).to_le_bytes());
     crc = crc32_update(crc, payload);
     crc
+}
+
+fn compute_logical_v3_crc(version: u8, term: u64, lsn: u64, timestamp: u64, payload: &[u8]) -> u32 {
+    use crate::storage::engine::crc32::crc32_update;
+    let mut crc = crc32_update(0, &[version]);
+    crc = crc32_update(crc, &term.to_le_bytes());
+    crc = crc32_update(crc, &lsn.to_le_bytes());
+    crc = crc32_update(crc, &timestamp.to_le_bytes());
+    crc = crc32_update(crc, &(payload.len() as u32).to_le_bytes());
+    crc = crc32_update(crc, payload);
+    crc
+}
+
+fn term_from_payload(payload: &[u8]) -> u64 {
+    crate::replication::cdc::ChangeRecord::decode(payload)
+        .map(|record| record.term)
+        .unwrap_or(crate::replication::DEFAULT_REPLICATION_TERM)
 }
 
 /// In-memory WAL buffer for replication.
@@ -131,11 +164,24 @@ impl WalBuffer {
 
 #[derive(Debug, Clone)]
 struct LogicalWalEntry {
+    term: u64,
     lsn: u64,
     /// Wall-clock millis at append time. `0` for legacy v1 records that
     /// did not carry a framing timestamp.
     timestamp_ms: u64,
     data: Vec<u8>,
+}
+
+impl LogicalWalEntry {
+    fn data_with_framing_term(&self) -> Vec<u8> {
+        match crate::replication::cdc::ChangeRecord::decode(&self.data) {
+            Ok(mut record) if record.term != self.term => {
+                record.term = self.term;
+                record.encode()
+            }
+            _ => self.data.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -201,6 +247,16 @@ impl LogicalWalSpool {
         timestamp_ms: u64,
         data: &[u8],
     ) -> io::Result<()> {
+        self.append_with_term_and_timestamp(term_from_payload(data), lsn, timestamp_ms, data)
+    }
+
+    pub fn append_with_term_and_timestamp(
+        &self,
+        term: u64,
+        lsn: u64,
+        timestamp_ms: u64,
+        data: &[u8],
+    ) -> io::Result<()> {
         if data.len() > u32::MAX as usize {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -224,16 +280,22 @@ impl LogicalWalSpool {
         //       reader will checksum, with zero risk of header/payload
         //       drift from a partial flush.
         let mut frame = Vec::with_capacity(
-            LOGICAL_WAL_V2_HEADER_LEN as usize + data.len() + LOGICAL_WAL_V2_CRC_LEN as usize,
+            LOGICAL_WAL_V3_HEADER_LEN as usize + data.len() + LOGICAL_WAL_V2_CRC_LEN as usize,
         );
         frame.extend_from_slice(LOGICAL_WAL_SPOOL_MAGIC);
         frame.push(LOGICAL_WAL_SPOOL_VERSION_CURRENT);
+        frame.extend_from_slice(&term.to_le_bytes());
         frame.extend_from_slice(&lsn.to_le_bytes());
         frame.extend_from_slice(&timestamp_ms.to_le_bytes());
         frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
         frame.extend_from_slice(data);
-        let crc =
-            compute_logical_v2_crc(LOGICAL_WAL_SPOOL_VERSION_CURRENT, lsn, timestamp_ms, data);
+        let crc = compute_logical_v3_crc(
+            LOGICAL_WAL_SPOOL_VERSION_CURRENT,
+            term,
+            lsn,
+            timestamp_ms,
+            data,
+        );
         frame.extend_from_slice(&crc.to_le_bytes());
 
         file.write_all(&frame)?;
@@ -254,7 +316,7 @@ impl LogicalWalSpool {
             .into_iter()
             .filter(|entry| entry.lsn > since_lsn)
             .take(max_count)
-            .map(|entry| (entry.lsn, entry.data))
+            .map(|entry| (entry.lsn, entry.data_with_framing_term()))
             .collect())
     }
 
@@ -282,9 +344,9 @@ impl LogicalWalSpool {
         let mut temp = File::create(&temp_path)?;
         let mut current_lsn = 0;
         for entry in retained {
-            // Re-frame as v2 so the spool only ever contains v2 records
+            // Re-frame as v3 so the spool only ever contains current records
             // after a prune. Legacy v1 records are upgraded by carrying
-            // their original LSN forward; the framing timestamp is
+            // their original LSN and default term forward; the framing timestamp is
             // re-stamped to wall-clock-now because the original v1
             // record didn't carry one — downstream consumers that need
             // the operation's logical timestamp continue to use the
@@ -297,14 +359,16 @@ impl LogicalWalSpool {
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0)
             };
-            let crc = compute_logical_v2_crc(
+            let crc = compute_logical_v3_crc(
                 LOGICAL_WAL_SPOOL_VERSION_CURRENT,
+                entry.term,
                 entry.lsn,
                 timestamp_ms,
                 &entry.data,
             );
             temp.write_all(LOGICAL_WAL_SPOOL_MAGIC)?;
             temp.write_all(&[LOGICAL_WAL_SPOOL_VERSION_CURRENT])?;
+            temp.write_all(&entry.term.to_le_bytes())?;
             temp.write_all(&entry.lsn.to_le_bytes())?;
             temp.write_all(&timestamp_ms.to_le_bytes())?;
             temp.write_all(&(entry.data.len() as u32).to_le_bytes())?;
@@ -381,6 +445,7 @@ fn read_and_repair_entries(path: &Path) -> io::Result<Vec<LogicalWalEntry>> {
         }
 
         let entry_result = match version[0] {
+            LOGICAL_WAL_SPOOL_VERSION_V3 => read_one_v3(&mut file, record_start),
             LOGICAL_WAL_SPOOL_VERSION_V2 => read_one_v2(&mut file, record_start),
             LOGICAL_WAL_SPOOL_VERSION_V1 => read_one_v1(&mut file, record_start),
             other => {
@@ -421,6 +486,63 @@ fn read_and_repair_entries(path: &Path) -> io::Result<Vec<LogicalWalEntry>> {
     }
 
     Ok(entries)
+}
+
+/// Read a v3 record assuming the magic + version byte have already
+/// been consumed and the file cursor sits at the term field.
+fn read_one_v3(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, String> {
+    let mut term = [0u8; 8];
+    if let Err(err) = file.read_exact(&mut term) {
+        return Err(format!("torn term at offset {record_start}: {err}"));
+    }
+    let mut lsn = [0u8; 8];
+    if let Err(err) = file.read_exact(&mut lsn) {
+        return Err(format!("torn lsn at offset {record_start}: {err}"));
+    }
+    let mut timestamp = [0u8; 8];
+    if let Err(err) = file.read_exact(&mut timestamp) {
+        return Err(format!("torn timestamp at offset {record_start}: {err}"));
+    }
+    let mut len_bytes = [0u8; 4];
+    if let Err(err) = file.read_exact(&mut len_bytes) {
+        return Err(format!(
+            "torn payload length at offset {record_start}: {err}"
+        ));
+    }
+    let payload_len = u32::from_le_bytes(len_bytes) as usize;
+    const MAX_PLAUSIBLE_PAYLOAD: usize = 256 * 1024 * 1024;
+    if payload_len > MAX_PLAUSIBLE_PAYLOAD {
+        return Err(format!(
+            "implausible payload_len {payload_len} at offset {record_start}"
+        ));
+    }
+    let mut payload = vec![0u8; payload_len];
+    if let Err(err) = file.read_exact(&mut payload) {
+        return Err(format!(
+            "torn payload at offset {record_start} (expected {payload_len} bytes): {err}"
+        ));
+    }
+    let mut crc_bytes = [0u8; 4];
+    if let Err(err) = file.read_exact(&mut crc_bytes) {
+        return Err(format!("torn crc at offset {record_start}: {err}"));
+    }
+    let stored_crc = u32::from_le_bytes(crc_bytes);
+    let term = u64::from_le_bytes(term);
+    let lsn = u64::from_le_bytes(lsn);
+    let timestamp = u64::from_le_bytes(timestamp);
+    let expected_crc =
+        compute_logical_v3_crc(LOGICAL_WAL_SPOOL_VERSION_V3, term, lsn, timestamp, &payload);
+    if stored_crc != expected_crc {
+        return Err(format!(
+            "crc mismatch at offset {record_start}: stored {stored_crc:#010x}, expected {expected_crc:#010x}"
+        ));
+    }
+    Ok(LogicalWalEntry {
+        term,
+        lsn,
+        timestamp_ms: timestamp,
+        data: payload,
+    })
 }
 
 /// Read a v2 record assuming the magic + version byte have already
@@ -474,7 +596,9 @@ fn read_one_v2(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
             "crc mismatch at offset {record_start}: stored {stored_crc:#010x}, expected {expected_crc:#010x}"
         ));
     }
+    let term = term_from_payload(&payload);
     Ok(LogicalWalEntry {
+        term,
         lsn: u64::from_le_bytes(lsn),
         timestamp_ms: u64::from_le_bytes(timestamp),
         data: payload,
@@ -506,7 +630,9 @@ fn read_one_v1(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     if let Err(err) = file.read_exact(&mut payload) {
         return Err(format!("v1 torn payload at offset {record_start}: {err}"));
     }
+    let term = term_from_payload(&payload);
     Ok(LogicalWalEntry {
+        term,
         lsn: u64::from_le_bytes(lsn),
         timestamp_ms: 0,
         data: payload,
@@ -746,6 +872,7 @@ mod tests {
         let spool = LogicalWalSpool::open(&data_path).expect("open spool");
 
         let record1 = ChangeRecord {
+            term: 2,
             lsn: 7,
             timestamp: 1,
             operation: ChangeOperation::Insert,
@@ -757,6 +884,7 @@ mod tests {
             refresh_records: None,
         };
         let record2 = ChangeRecord {
+            term: 2,
             lsn: 8,
             timestamp: 2,
             operation: ChangeOperation::Update,
@@ -769,21 +897,61 @@ mod tests {
         };
 
         spool
-            .append(record1.lsn, &record1.encode())
+            .append_with_term_and_timestamp(record1.term, record1.lsn, 11, &record1.encode())
             .expect("append 1");
         spool
-            .append(record2.lsn, &record2.encode())
+            .append_with_term_and_timestamp(record2.term, record2.lsn, 12, &record2.encode())
             .expect("append 2");
 
         let entries = spool.read_since(0, usize::MAX).expect("read");
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].0, 7);
         assert_eq!(entries[1].0, 8);
+        assert_eq!(ChangeRecord::decode(&entries[0].1).unwrap().term, 2);
+
+        let framed = read_and_repair_entries(&spool_path).expect("read framed entries");
+        assert_eq!(framed[0].term, 2);
+        assert_eq!(framed[0].timestamp_ms, 11);
 
         spool.prune_through(7).expect("prune");
         let retained = spool.read_since(0, usize::MAX).expect("read retained");
         assert_eq!(retained.len(), 1);
         assert_eq!(retained[0].0, 8);
+        assert_eq!(ChangeRecord::decode(&retained[0].1).unwrap().term, 2);
+
+        let _ = fs::remove_file(spool_path);
+    }
+
+    #[test]
+    fn logical_wal_spool_reads_v2_without_term() {
+        let data_path = temp_data_path("logical_spool_v2");
+        let spool_path = LogicalWalSpool::path_for(&data_path);
+        let payload = br#"{"lsn":3,"timestamp":44,"operation":"delete","collection":"users","rid":9,"kind":"row"}"#;
+        let lsn = 3u64;
+        let timestamp = 44u64;
+        let crc = compute_logical_v2_crc(LOGICAL_WAL_SPOOL_VERSION_V2, lsn, timestamp, payload);
+
+        let mut file = File::create(&spool_path).expect("create v2 spool");
+        file.write_all(LOGICAL_WAL_SPOOL_MAGIC).unwrap();
+        file.write_all(&[LOGICAL_WAL_SPOOL_VERSION_V2]).unwrap();
+        file.write_all(&lsn.to_le_bytes()).unwrap();
+        file.write_all(&timestamp.to_le_bytes()).unwrap();
+        file.write_all(&(payload.len() as u32).to_le_bytes())
+            .unwrap();
+        file.write_all(payload).unwrap();
+        file.write_all(&crc.to_le_bytes()).unwrap();
+        file.sync_all().unwrap();
+
+        let spool = LogicalWalSpool::open(&data_path).expect("open v2 spool");
+        let records = spool.read_since(0, usize::MAX).expect("read v2 spool");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, 3);
+        let decoded = ChangeRecord::decode(&records[0].1).expect("decode v2 payload");
+        assert_eq!(decoded.term, crate::replication::DEFAULT_REPLICATION_TERM);
+        assert_eq!(decoded.lsn, 3);
+
+        let framed = read_and_repair_entries(&spool_path).expect("read framed v2 entries");
+        assert_eq!(framed[0].term, crate::replication::DEFAULT_REPLICATION_TERM);
 
         let _ = fs::remove_file(spool_path);
     }

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4437,6 +4437,7 @@ impl RedDBRuntime {
                 store.get(collection, EntityId::new(entity_id))
             };
             let record = ChangeRecord {
+                term: self.current_replication_term(),
                 lsn,
                 timestamp: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -4524,6 +4525,7 @@ impl RedDBRuntime {
                 store.get(collection, EntityId::new(entity_id))
             };
             let record = ChangeRecord {
+                term: self.current_replication_term(),
                 lsn,
                 timestamp: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -4651,6 +4653,7 @@ impl RedDBRuntime {
         if let Some(ref primary) = self.inner.db.replication {
             let store = self.inner.db.store();
             let record = ChangeRecord {
+                term: self.current_replication_term(),
                 lsn,
                 timestamp: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
@@ -4677,6 +4680,10 @@ impl RedDBRuntime {
         }
 
         lsn
+    }
+
+    pub(crate) fn current_replication_term(&self) -> u64 {
+        self.inner.db.options().replication.term
     }
 
     pub(crate) fn cdc_emit_prebuilt_batch<'a, I>(
@@ -4852,7 +4859,7 @@ impl RedDBRuntime {
                                         // diverged" conditions an operator must act
                                         // on out-of-band.
                                         match &err {
-                                            crate::replication::logical::LogicalApplyError::Divergence { lsn, expected: _, got: _ } => {
+                                            crate::replication::logical::LogicalApplyError::Divergence { lsn, expected: _, got: _, .. } => {
                                                 crate::telemetry::operator_event::OperatorEvent::Divergence {
                                                     peer: "primary".to_string(),
                                                     leader_lsn: *lsn,
@@ -7216,7 +7223,8 @@ impl RedDBRuntime {
                                 timestamp,
                                 q.name.clone(),
                                 serialized_records,
-                            );
+                            )
+                            .with_term(self.current_replication_term());
                             let encoded = record.encode();
                             primary.wal_buffer.append(record.lsn, encoded.clone());
                             if let Some(spool) = &primary.logical_wal_spool {

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -10,6 +10,10 @@ impl RedDBServer {
         let mut object = Map::new();
         object.insert("ok".to_string(), JsonValue::Bool(true));
         let db = self.runtime.db();
+        object.insert(
+            "current_term".to_string(),
+            JsonValue::Number(db.options().replication.term as f64),
+        );
         match &db.options().replication.role {
             crate::replication::ReplicationRole::Standalone => {
                 object.insert(

--- a/crates/reddb-server/src/storage/wal/append_coordinator.rs
+++ b/crates/reddb-server/src/storage/wal/append_coordinator.rs
@@ -589,7 +589,7 @@ mod tests {
         let target_a = coord.reserve_and_enqueue(blob_a);
 
         // Writer B: reserve only ("crash" before push).
-        let stuck_len = 13u64;
+        let stuck_len = 21u64;
         let _stuck_lsn = coord.next_lsn.fetch_add(stuck_len, Ordering::AcqRel);
 
         // Writer C: reserve + push.

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -1212,6 +1212,7 @@ mod tests {
         let backend = LocalBackend;
         let prefix = format!("{}/wal/", temp_dir.to_string_lossy());
         let record = ChangeRecord {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn: 7,
             timestamp: 1234,
             operation: crate::replication::cdc::ChangeOperation::Insert,
@@ -1243,6 +1244,7 @@ mod tests {
         let backend = LocalBackend;
         let prefix = format!("{}/wal/", temp_dir.to_string_lossy());
         let record = ChangeRecord {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn: 11,
             timestamp: 99,
             operation: crate::replication::cdc::ChangeOperation::Insert,
@@ -1350,6 +1352,7 @@ mod tests {
         let prefix = format!("{}/wal/", temp_dir.to_string_lossy());
 
         let mk = |lsn: u64| ChangeRecord {
+            term: crate::replication::DEFAULT_REPLICATION_TERM,
             lsn,
             timestamp: lsn * 1000,
             operation: crate::replication::cdc::ChangeOperation::Insert,

--- a/crates/reddb-server/src/storage/wal/group_commit.rs
+++ b/crates/reddb-server/src/storage/wal/group_commit.rs
@@ -351,7 +351,7 @@ mod tests {
 
         let final_durable = wal.lock().unwrap().durable_lsn();
         assert!(gc.flushed_lsn() >= final_durable);
-        // 20 commits worth of 13-byte Begin + 13-byte Commit
+        // 20 commits worth of 21-byte Begin + 21-byte Commit
         // records = 520 bytes minimum on top of the 8-byte header.
         assert!(final_durable >= 8 + 520);
     }

--- a/crates/reddb-server/src/storage/wal/reader.rs
+++ b/crates/reddb-server/src/storage/wal/reader.rs
@@ -1,4 +1,4 @@
-use super::record::{WalRecord, WAL_MAGIC, WAL_VERSION};
+use super::record::{WalRecord, WAL_MAGIC, WAL_VERSION, WAL_VERSION_V2};
 use std::fs::File;
 use std::io::{self, BufReader, Read};
 use std::path::Path;
@@ -7,6 +7,7 @@ use std::path::Path;
 pub struct WalReader {
     reader: BufReader<File>,
     position: u64,
+    format_version: u8,
 }
 
 impl WalReader {
@@ -26,7 +27,7 @@ impl WalReader {
             ));
         }
 
-        if header[4] != WAL_VERSION {
+        if header[4] != WAL_VERSION && header[4] != WAL_VERSION_V2 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("Unsupported WAL version: {}", header[4]),
@@ -36,6 +37,7 @@ impl WalReader {
         Ok(Self {
             reader,
             position: 8,
+            format_version: header[4],
         })
     }
 
@@ -45,6 +47,7 @@ impl WalReader {
         WalIterator {
             reader: self.reader,
             position: self.position,
+            format_version: self.format_version,
         }
     }
 
@@ -79,6 +82,7 @@ impl WalReader {
 pub struct WalIterator {
     reader: BufReader<File>,
     position: u64,
+    format_version: u8,
 }
 
 impl Iterator for WalIterator {
@@ -117,8 +121,8 @@ impl Iterator for WalIterator {
             count: 0,
         };
 
-        match WalRecord::read(&mut counter) {
-            Ok(Some(record)) => {
+        match WalRecord::read_with_format_version(&mut counter, self.format_version) {
+            Ok(Some((_, record))) => {
                 self.position += counter.count;
                 Some(Ok((start_pos, record)))
             }

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -5,7 +5,9 @@ use std::io::{self, Read};
 pub const WAL_MAGIC: &[u8; 4] = b"RDBW";
 
 /// WAL file format version
-pub const WAL_VERSION: u8 = 2;
+pub const WAL_VERSION: u8 = 3;
+pub const WAL_VERSION_V2: u8 = 2;
+pub const WAL_DEFAULT_TERM: u64 = crate::replication::DEFAULT_REPLICATION_TERM;
 
 /// Minimum payload size (bytes) to attempt zstd compression.
 /// Smaller records pay more overhead than benefit from compression.
@@ -134,10 +136,17 @@ impl WalRecord {
     /// compressed with zstd level 3 and emitted as `PageWriteCompressed`.
     /// Smaller payloads use the plain `PageWrite` encoding (no overhead).
     pub fn encode(&self) -> Vec<u8> {
+        self.encode_with_term(WAL_DEFAULT_TERM)
+    }
+
+    /// Serialize record to bytes with the replication term stamped into
+    /// the physical record envelope.
+    pub fn encode_with_term(&self, term: u64) -> Vec<u8> {
         let mut buf = Vec::new();
 
         // Layout (non-PageWrite):
         // [Type: 1]
+        // [Term: 8]
         // [TxID/LSN: 8]
         // [Checksum: 4]
         //
@@ -153,14 +162,17 @@ impl WalRecord {
         match self {
             WalRecord::Begin { tx_id } => {
                 buf.push(RecordType::Begin as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
             }
             WalRecord::Commit { tx_id } => {
                 buf.push(RecordType::Commit as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
             }
             WalRecord::Rollback { tx_id } => {
                 buf.push(RecordType::Rollback as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
             }
             WalRecord::PageWrite {
@@ -176,6 +188,7 @@ impl WalRecord {
                         if compressed.len() < data.len() {
                             // Compressed is smaller — use compressed format.
                             buf.push(RecordType::PageWriteCompressed as u8);
+                            buf.extend_from_slice(&term.to_le_bytes());
                             buf.extend_from_slice(&tx_id.to_le_bytes());
                             buf.extend_from_slice(&page_id.to_le_bytes());
                             buf.push(Compression::Zstd as u8);
@@ -190,6 +203,7 @@ impl WalRecord {
                 }
                 // Uncompressed path (small payload or compression expanded).
                 buf.push(RecordType::PageWrite as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
                 buf.extend_from_slice(&page_id.to_le_bytes());
                 buf.extend_from_slice(&(data.len() as u32).to_le_bytes());
@@ -197,6 +211,7 @@ impl WalRecord {
             }
             WalRecord::TxCommitBatch { tx_id, actions } => {
                 buf.push(RecordType::TxCommitBatch as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
                 buf.extend_from_slice(&(actions.len() as u32).to_le_bytes());
                 for action in actions {
@@ -211,6 +226,7 @@ impl WalRecord {
                 data,
             } => {
                 buf.push(RecordType::FullPageImage as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
                 buf.extend_from_slice(&page_id.to_le_bytes());
                 buf.extend_from_slice(&ckpt_epoch.to_le_bytes());
@@ -223,6 +239,7 @@ impl WalRecord {
                 vector,
             } => {
                 buf.push(RecordType::VectorInsert as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&(collection.len() as u32).to_le_bytes());
                 buf.extend_from_slice(collection.as_bytes());
                 buf.extend_from_slice(&entity_id.to_le_bytes());
@@ -233,6 +250,7 @@ impl WalRecord {
             }
             WalRecord::Checkpoint { lsn } => {
                 buf.push(RecordType::Checkpoint as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&lsn.to_le_bytes());
             }
         }
@@ -249,6 +267,18 @@ impl WalRecord {
     /// Handles both v1 (`PageWrite`) and v2 (`PageWriteCompressed`) record
     /// formats transparently — callers always receive uncompressed data.
     pub fn read<R: Read>(reader: &mut R) -> io::Result<Option<WalRecord>> {
+        Ok(Self::read_with_term(reader)?.map(|(_, record)| record))
+    }
+
+    /// Read a record and return the term stamped into its physical envelope.
+    pub fn read_with_term<R: Read>(reader: &mut R) -> io::Result<Option<(u64, WalRecord)>> {
+        Self::read_with_format_version(reader, WAL_VERSION)
+    }
+
+    pub(crate) fn read_with_format_version<R: Read>(
+        reader: &mut R,
+        format_version: u8,
+    ) -> io::Result<Option<(u64, WalRecord)>> {
         // Read type byte
         let mut type_buf = [0u8; 1];
         match reader.read_exact(&mut type_buf) {
@@ -262,6 +292,21 @@ impl WalRecord {
 
         // Start checksum calculation
         let mut running_crc = crc32_update(0, &type_buf);
+        let term = match format_version {
+            WAL_VERSION => {
+                let mut term_buf = [0u8; 8];
+                reader.read_exact(&mut term_buf)?;
+                running_crc = crc32_update(running_crc, &term_buf);
+                u64::from_le_bytes(term_buf)
+            }
+            WAL_VERSION_V2 => WAL_DEFAULT_TERM,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Unsupported WAL version: {format_version}"),
+                ));
+            }
+        };
 
         let record = match record_type {
             RecordType::Begin | RecordType::Commit | RecordType::Rollback => {
@@ -488,7 +533,7 @@ impl WalRecord {
             ));
         }
 
-        Ok(Some(record))
+        Ok(Some((term, record)))
     }
 }
 
@@ -512,12 +557,13 @@ mod tests {
         );
         assert_eq!(RecordType::from_u8(7), Some(RecordType::TxCommitBatch));
         assert_eq!(RecordType::from_u8(8), Some(RecordType::FullPageImage));
+        assert_eq!(RecordType::from_u8(9), Some(RecordType::VectorInsert));
     }
 
     #[test]
     fn test_record_type_invalid() {
         assert_eq!(RecordType::from_u8(0), None);
-        assert_eq!(RecordType::from_u8(9), None);
+        assert_eq!(RecordType::from_u8(10), None);
         assert_eq!(RecordType::from_u8(255), None);
     }
 
@@ -528,8 +574,8 @@ mod tests {
         let record = WalRecord::Begin { tx_id: 12345 };
         let encoded = record.encode();
 
-        // Type (1) + TxID (8) + Checksum (4) = 13 bytes
-        assert_eq!(encoded.len(), 13);
+        // Type (1) + Term (8) + TxID (8) + Checksum (4) = 21 bytes
+        assert_eq!(encoded.len(), 21);
         assert_eq!(encoded[0], RecordType::Begin as u8);
     }
 
@@ -538,7 +584,7 @@ mod tests {
         let record = WalRecord::Commit { tx_id: 99999 };
         let encoded = record.encode();
 
-        assert_eq!(encoded.len(), 13);
+        assert_eq!(encoded.len(), 21);
         assert_eq!(encoded[0], RecordType::Commit as u8);
     }
 
@@ -547,7 +593,7 @@ mod tests {
         let record = WalRecord::Rollback { tx_id: 54321 };
         let encoded = record.encode();
 
-        assert_eq!(encoded.len(), 13);
+        assert_eq!(encoded.len(), 21);
         assert_eq!(encoded[0], RecordType::Rollback as u8);
     }
 
@@ -556,7 +602,7 @@ mod tests {
         let record = WalRecord::Checkpoint { lsn: 1000000 };
         let encoded = record.encode();
 
-        assert_eq!(encoded.len(), 13);
+        assert_eq!(encoded.len(), 21);
         assert_eq!(encoded[0], RecordType::Checkpoint as u8);
     }
 
@@ -571,8 +617,8 @@ mod tests {
         };
         let encoded = record.encode();
 
-        // Type (1) + TxID (8) + PageID (4) + Len (4) + Data (5) + Checksum (4) = 26 bytes
-        assert_eq!(encoded.len(), 26);
+        // Type (1) + Term (8) + TxID (8) + PageID (4) + Len (4) + Data (5) + Checksum (4) = 34 bytes
+        assert_eq!(encoded.len(), 34);
         assert_eq!(encoded[0], RecordType::PageWrite as u8);
     }
 
@@ -585,8 +631,8 @@ mod tests {
         };
         let encoded = record.encode();
 
-        // Type (1) + TxID (8) + PageID (4) + Len (4) + Checksum (4) = 21 bytes
-        assert_eq!(encoded.len(), 21);
+        // Type (1) + Term (8) + TxID (8) + PageID (4) + Len (4) + Checksum (4) = 29 bytes
+        assert_eq!(encoded.len(), 29);
     }
 
     #[test]
@@ -611,6 +657,36 @@ mod tests {
         let decoded = WalRecord::read(&mut cursor).unwrap().unwrap();
 
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_read_begin_roundtrip_preserves_term() {
+        let original = WalRecord::Begin { tx_id: 42 };
+        let encoded = original.encode_with_term(9);
+
+        let mut cursor = Cursor::new(encoded);
+        let (term, decoded) = WalRecord::read_with_term(&mut cursor).unwrap().unwrap();
+
+        assert_eq!(term, 9);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_read_v2_begin_defaults_term() {
+        let tx_id = 42u64;
+        let mut encoded = Vec::new();
+        encoded.push(RecordType::Begin as u8);
+        encoded.extend_from_slice(&tx_id.to_le_bytes());
+        let checksum = crc32(&encoded);
+        encoded.extend_from_slice(&checksum.to_le_bytes());
+
+        let mut cursor = Cursor::new(encoded);
+        let (term, decoded) = WalRecord::read_with_format_version(&mut cursor, WAL_VERSION_V2)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(term, WAL_DEFAULT_TERM);
+        assert_eq!(decoded, WalRecord::Begin { tx_id });
     }
 
     #[test]
@@ -859,6 +935,6 @@ mod tests {
 
     #[test]
     fn test_wal_version() {
-        assert_eq!(WAL_VERSION, 2);
+        assert_eq!(WAL_VERSION, 3);
     }
 }

--- a/crates/reddb-server/src/storage/wal/writer.rs
+++ b/crates/reddb-server/src/storage/wal/writer.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 /// User-space buffer size for the WAL writer.
 ///
-/// Chosen so that ~5 000 small records (Begin/Commit ≈ 13 bytes,
-/// small PageWrite ≈ 26 bytes) coalesce into a single `write` syscall
+/// Chosen so that ~5 000 small records (Begin/Commit ≈ 21 bytes,
+/// small PageWrite ≈ 34 bytes) coalesce into a single `write` syscall
 /// before the next `sync()` drains the buffer. Tunable; reflects the
 /// postgres XLOG block size (8 KiB) scaled up because we batch
 /// record-level rather than page-level.
@@ -309,8 +309,8 @@ mod tests {
         assert_eq!(lsn, 8);
 
         // Next record should start after encoded size
-        // Begin record: 1 (type) + 8 (tx_id) + 4 (checksum) = 13 bytes
-        assert_eq!(writer.current_lsn(), 8 + 13);
+        // Begin record: 1 (type) + 8 (term) + 8 (tx_id) + 4 (checksum) = 21 bytes
+        assert_eq!(writer.current_lsn(), 8 + 21);
     }
 
     #[test]
@@ -323,8 +323,8 @@ mod tests {
         let lsn3 = writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
 
         assert_eq!(lsn1, 8);
-        assert_eq!(lsn2, 8 + 13);
-        assert_eq!(lsn3, 8 + 13 + 13);
+        assert_eq!(lsn2, 8 + 21);
+        assert_eq!(lsn3, 8 + 21 + 21);
     }
 
     #[test]
@@ -346,10 +346,10 @@ mod tests {
             })
             .unwrap();
 
-        assert_eq!(lsn2, 8 + 13); // after Begin
+        assert_eq!(lsn2, 8 + 21); // after Begin
 
-        // Next LSN = lsn2 + (1 + 8 + 4 + 4 + 5 + 4) = lsn2 + 26
-        assert_eq!(writer.current_lsn(), 8 + 13 + 26);
+        // Next LSN = lsn2 + (1 + 8 + 8 + 4 + 4 + 5 + 4) = lsn2 + 34
+        assert_eq!(writer.current_lsn(), 8 + 21 + 34);
     }
 
     #[test]
@@ -420,12 +420,12 @@ mod tests {
         let (_guard, path) = temp_wal("checkpoint");
         let mut writer = WalWriter::open(&path).unwrap();
 
-        // Checkpoint is same size as Begin (1 + 8 + 4 = 13)
+        // Checkpoint is same size as Begin (1 + 8 + 8 + 4 = 21)
         let lsn = writer
             .append(&WalRecord::Checkpoint { lsn: 12345 })
             .unwrap();
         assert_eq!(lsn, 8);
-        assert_eq!(writer.current_lsn(), 8 + 13);
+        assert_eq!(writer.current_lsn(), 8 + 21);
     }
 
     // -----------------------------------------------------------------
@@ -533,7 +533,7 @@ mod tests {
             writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
         }
         // current_lsn reflects the in-buffer position.
-        assert_eq!(writer.current_lsn(), 8 + 100 * 13);
+        assert_eq!(writer.current_lsn(), 8 + 100 * 21);
         // But the file on disk only has the header.
         let on_disk = std::fs::metadata(&path).unwrap().len();
         assert_eq!(on_disk, 8, "BufWriter leaked bytes to disk before sync");
@@ -597,7 +597,7 @@ mod tests {
         // And we can append again successfully.
         writer.append(&WalRecord::Begin { tx_id: 99 }).unwrap();
         writer.sync().unwrap();
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8 + 13);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8 + 21);
     }
 
     #[test]

--- a/tests/chaos_replica_apply_divergence.rs
+++ b/tests/chaos_replica_apply_divergence.rs
@@ -49,7 +49,9 @@ fn replica_applier_fails_closed_on_lsn_collision_diff_payload() {
         .apply(&db, &record(7, b"forged"), ApplyMode::Replica)
         .expect_err("divergence must fail closed");
     match err {
-        LogicalApplyError::Divergence { lsn, expected, got } => {
+        LogicalApplyError::Divergence {
+            lsn, expected, got, ..
+        } => {
             assert_eq!(lsn, 7);
             assert_ne!(expected, got, "hashes must differ");
         }


### PR DESCRIPTION
Automated AFK landing for #821. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782738607&installation_id=129708444&pr_number=843&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F843&signature=5656aad6cbbc61d9386da9d1b39a08c646d6c400c7a0f270d872d3e2ebb4ae5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replication status endpoint now includes `current_term` field, exposing the active replication epoch to clients.

* **Improvements**
  * Reinforced replication consistency and divergence detection through systematic term-based epoch tracking integrated across change record emission, logical WAL storage, and replica apply validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/843?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->