### PR TITLE
merge: #822 Replication: named commit watermark + converge quorum and CommitWaiter onto one ack path

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2812,6 +2812,10 @@ impl RedDb for GrpcRuntime {
                         .unwrap_or_else(|| repl.wal_buffer.current_lsn());
                     map.insert("current_lsn".into(), JsonValue::Number(lsn as f64));
                     map.insert(
+                        "commit_watermark".into(),
+                        JsonValue::Number(self.runtime.commit_watermark() as f64),
+                    );
+                    map.insert(
                         "replica_count".into(),
                         JsonValue::Number(repl.replica_count() as f64),
                     );

--- a/crates/reddb-server/src/replication/commit_policy.rs
+++ b/crates/reddb-server/src/replication/commit_policy.rs
@@ -13,16 +13,11 @@
 //! `Local`. The primary blocks the commit response until the count
 //! is met or `RED_REPLICATION_ACK_TIMEOUT_MS` elapses.
 //!
-//! `Quorum` — future policy backed by `QuorumConfig` once quorum
-//! coordination is wired into the commit path. For now this is a
-//! marker enum value; the runtime falls back to `Local` semantics
-//! and emits a warning at boot when set.
+//! `Quorum` — commit returns after the configured `QuorumConfig`
+//! reaches its durable commit watermark.
 //!
-//! In this sprint only the enum + parsing + observability are wired.
-//! Actually blocking commits on `RemoteWal` / `AckN` / `Quorum` is
-//! out of scope; the write path still returns after local durability
-//! regardless of the configured policy. See PLAN.md 11.4 "default v1
-//! behavior remains `local`".
+//! `RemoteWal` is parsed for observability but does not block the
+//! write path yet. The default remains `Local`.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CommitPolicy {

--- a/crates/reddb-server/src/replication/commit_waiter.rs
+++ b/crates/reddb-server/src/replication/commit_waiter.rs
@@ -126,6 +126,18 @@ impl CommitWaiter {
         v
     }
 
+    /// Highest LSN durable on `required` replicas.
+    ///
+    /// For `ack_n=2`, this is the second-highest durable LSN in the
+    /// ack table. If fewer than `required` replicas have acked, the
+    /// watermark is 0. `required == 0` is not a quorum requirement, so
+    /// observability reports 0 rather than fabricating an infinite
+    /// watermark.
+    pub fn commit_watermark(&self, required: u32) -> u64 {
+        let state = self.state.lock().expect("commit waiter mutex");
+        commit_watermark(&state.durable_lsn, required)
+    }
+
     /// Block until at least `required` replicas have durable LSN
     /// `>= target_lsn`, or `timeout` expires. `required == 0` is a
     /// no-op (returns `NotRequired` instantly).
@@ -145,17 +157,81 @@ impl CommitWaiter {
         let deadline = started + timeout;
         let mut state = self.state.lock().expect("commit waiter mutex");
         loop {
-            let observed = count_at_or_past(&state.durable_lsn, target_lsn);
-            if observed >= required {
+            let watermark = commit_watermark(&state.durable_lsn, required);
+            if watermark >= target_lsn {
                 self.record_outcome_metrics(true, started);
+                let observed = count_at_or_past(&state.durable_lsn, target_lsn);
                 return AwaitOutcome::Reached(observed);
             }
             let now = Instant::now();
             if now >= deadline {
                 self.record_outcome_metrics(false, started);
+                let observed = count_at_or_past(&state.durable_lsn, target_lsn);
                 return AwaitOutcome::TimedOut { observed, required };
             }
             let remaining = deadline - now;
+            let (next_state, _wait_result) = self
+                .cond
+                .wait_timeout(state, remaining)
+                .expect("commit waiter condvar");
+            state = next_state;
+        }
+    }
+
+    /// Wait until `is_satisfied` returns true, waking on replica ack
+    /// notifications instead of a caller-side polling sleep.
+    pub fn wait_for_change_until<F>(&self, timeout: Option<Duration>, mut is_satisfied: F) -> bool
+    where
+        F: FnMut() -> bool,
+    {
+        let started = Instant::now();
+        let mut state = self.state.lock().expect("commit waiter mutex");
+        loop {
+            if is_satisfied() {
+                return true;
+            }
+            let Some(limit) = timeout else {
+                state = self.cond.wait(state).expect("commit waiter condvar");
+                continue;
+            };
+            let elapsed = started.elapsed();
+            if elapsed >= limit {
+                return false;
+            }
+            let remaining = limit - elapsed;
+            let (next_state, _wait_result) = self
+                .cond
+                .wait_timeout(state, remaining)
+                .expect("commit waiter condvar");
+            state = next_state;
+        }
+    }
+
+    /// Wait until the named commit watermark reaches `target_lsn`.
+    pub fn wait_for_commit_watermark(
+        &self,
+        target_lsn: u64,
+        required: u32,
+        timeout: Option<Duration>,
+    ) -> bool {
+        if required == 0 {
+            return true;
+        }
+        let started = Instant::now();
+        let mut state = self.state.lock().expect("commit waiter mutex");
+        loop {
+            if commit_watermark(&state.durable_lsn, required) >= target_lsn {
+                return true;
+            }
+            let Some(limit) = timeout else {
+                state = self.cond.wait(state).expect("commit waiter condvar");
+                continue;
+            };
+            let elapsed = started.elapsed();
+            if elapsed >= limit {
+                return false;
+            }
+            let remaining = limit - elapsed;
             let (next_state, _wait_result) = self
                 .cond
                 .wait_timeout(state, remaining)
@@ -191,6 +267,15 @@ fn count_at_or_past(map: &HashMap<String, u64>, target_lsn: u64) -> u32 {
     map.values().filter(|lsn| **lsn >= target_lsn).count() as u32
 }
 
+fn commit_watermark(map: &HashMap<String, u64>, required: u32) -> u64 {
+    if required == 0 || map.len() < required as usize {
+        return 0;
+    }
+    let mut durable: Vec<u64> = map.values().copied().collect();
+    durable.sort_unstable_by(|a, b| b.cmp(a));
+    durable[(required as usize) - 1]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +296,22 @@ mod tests {
         w.record_replica_ack("b", 200);
         let r = w.await_acks(150, 2, Duration::from_millis(10));
         assert_eq!(r, AwaitOutcome::Reached(2));
+    }
+
+    #[test]
+    fn commit_watermark_is_nth_highest_durable_lsn() {
+        let w = CommitWaiter::new();
+        w.record_replica_ack("a", 10);
+        w.record_replica_ack("b", 30);
+        w.record_replica_ack("c", 20);
+
+        assert_eq!(w.commit_watermark(1), 30);
+        assert_eq!(w.commit_watermark(2), 20);
+        assert_eq!(w.commit_watermark(3), 10);
+        assert_eq!(w.commit_watermark(4), 0);
+
+        w.record_replica_ack("b", 15);
+        assert_eq!(w.commit_watermark(2), 20);
     }
 
     #[test]

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -641,6 +641,7 @@ impl PrimaryReplication {
         let removed = replicas.len() != before;
         drop(replicas);
         if removed {
+            self.commit_waiter.drop_replica(id);
             self.bump_topology_epoch();
         }
         removed
@@ -670,8 +671,11 @@ impl PrimaryReplication {
         let mut replicas = self.replicas.write().unwrap_or_else(|e| e.into_inner());
         if let Some(r) = replicas.iter_mut().find(|r| r.id == id) {
             r.last_acked_lsn = r.last_acked_lsn.max(lsn);
+            r.last_durable_lsn = r.last_durable_lsn.max(lsn);
             r.last_seen_at_unix_ms = now_ms;
         }
+        drop(replicas);
+        self.commit_waiter.record_replica_ack(id, lsn);
     }
 
     /// PLAN.md Phase 11.4 — replica reports applied + durable LSN

--- a/crates/reddb-server/src/replication/quorum.rs
+++ b/crates/reddb-server/src/replication/quorum.rs
@@ -7,7 +7,8 @@
 //! after ack but before replication would drop the write.
 //!
 //! `QuorumCoordinator` sits between the write path and the client ack.
-//! It watches `ReplicaState::last_acked_lsn` on the underlying primary
+//! It watches durable replica ACKs on the underlying primary's
+//! `CommitWaiter`
 //! and blocks the caller until the configured quorum of replicas has
 //! durably received the record. Three quorum shapes are supported:
 //!
@@ -24,7 +25,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use super::primary::PrimaryReplication;
 
@@ -218,27 +219,27 @@ impl QuorumCoordinator {
         // Early validation: can we ever satisfy this quorum?
         self.validate_preconditions()?;
 
-        let start = Instant::now();
         let timeout = self.config.timeout;
-        loop {
-            if self.has_quorum(target_lsn) {
-                return Ok(());
-            }
-            if let Some(limit) = timeout {
-                if start.elapsed() >= limit {
-                    return Err(QuorumError::Timeout {
-                        target_lsn,
-                        elapsed_ms: start.elapsed().as_millis(),
-                        acked_regions: self.acked_regions(target_lsn),
-                    });
-                }
-            }
-            // Poll interval matches ReplicationConfig::poll_interval_ms
-            // default (100ms). The coordinator doesn't get woken by
-            // ack_replica directly today — a future revision adds a
-            // condvar on ReplicaState. For Phase 2.6 polling is fine.
-            std::thread::sleep(Duration::from_millis(25));
+        let start = std::time::Instant::now();
+        let reached = match &self.config.mode {
+            QuorumMode::Async => true,
+            QuorumMode::Sync { min_replicas } => self
+                .primary
+                .commit_waiter
+                .wait_for_commit_watermark(target_lsn, *min_replicas as u32, timeout),
+            QuorumMode::Regions { .. } => self
+                .primary
+                .commit_waiter
+                .wait_for_change_until(timeout, || self.has_quorum(target_lsn)),
+        };
+        if reached {
+            return Ok(());
         }
+        Err(QuorumError::Timeout {
+            target_lsn,
+            elapsed_ms: start.elapsed().as_millis(),
+            acked_regions: self.acked_regions(target_lsn),
+        })
     }
 
     /// Fast-check the quorum predicate without waiting. Returns true
@@ -247,7 +248,12 @@ impl QuorumCoordinator {
     pub fn has_quorum(&self, target_lsn: u64) -> bool {
         match &self.config.mode {
             QuorumMode::Async => true,
-            QuorumMode::Sync { min_replicas } => self.count_acked(target_lsn) >= *min_replicas,
+            QuorumMode::Sync { min_replicas } => {
+                self.primary
+                    .commit_waiter
+                    .commit_watermark(*min_replicas as u32)
+                    >= target_lsn
+            }
             QuorumMode::Regions { required } => {
                 let acked = self.acked_regions(target_lsn);
                 required.iter().all(|r| acked.contains(r))
@@ -284,18 +290,6 @@ impl QuorumCoordinator {
         }
     }
 
-    fn count_acked(&self, target_lsn: u64) -> usize {
-        let replicas = self
-            .primary
-            .replicas
-            .read()
-            .unwrap_or_else(|e| e.into_inner());
-        replicas
-            .iter()
-            .filter(|r| r.last_acked_lsn >= target_lsn)
-            .count()
-    }
-
     fn acked_regions(&self, target_lsn: u64) -> HashSet<String> {
         let replicas = self
             .primary
@@ -305,9 +299,46 @@ impl QuorumCoordinator {
         let regions = self.regions.read();
         replicas
             .iter()
-            .filter(|r| r.last_acked_lsn >= target_lsn)
+            .filter(|r| r.last_durable_lsn >= target_lsn)
             .filter_map(|r| regions.get(&r.id).cloned())
             .collect()
+    }
+
+    /// Highest LSN durable on the configured quorum shape.
+    pub fn commit_watermark(&self) -> u64 {
+        match &self.config.mode {
+            QuorumMode::Async => 0,
+            QuorumMode::Sync { min_replicas } => self
+                .primary
+                .commit_waiter
+                .commit_watermark(*min_replicas as u32),
+            QuorumMode::Regions { required } => self.region_commit_watermark(required),
+        }
+    }
+
+    fn region_commit_watermark(&self, required: &HashSet<String>) -> u64 {
+        if required.is_empty() {
+            return 0;
+        }
+        let replicas = self
+            .primary
+            .replicas
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        let regions = self.regions.read();
+        let mut watermark = u64::MAX;
+        for required_region in required {
+            let Some(region_lsn) = replicas
+                .iter()
+                .filter(|r| regions.get(&r.id) == Some(required_region))
+                .map(|r| r.last_durable_lsn)
+                .max()
+            else {
+                return 0;
+            };
+            watermark = watermark.min(region_lsn);
+        }
+        watermark
     }
 
     /// Minimum LSN across all connected replicas — the "safe replay"
@@ -320,7 +351,7 @@ impl QuorumCoordinator {
             .replicas
             .read()
             .unwrap_or_else(|e| e.into_inner());
-        replicas.iter().map(|r| r.last_acked_lsn).min()
+        replicas.iter().map(|r| r.last_durable_lsn).min()
     }
 
     /// Config accessor.
@@ -394,6 +425,52 @@ mod tests {
         // Both acked → quorum satisfied.
         p.ack_replica("eu_a", 50);
         assert!(q.has_quorum(50));
+    }
+
+    #[test]
+    fn region_mode_requires_durable_lsn_for_watermark() {
+        let p = primary();
+        p.register_replica("us_a".to_string());
+        p.register_replica("eu_a".to_string());
+        let q = QuorumCoordinator::new(
+            Arc::clone(&p),
+            QuorumConfig::regions(["us", "eu"]).with_timeout(Duration::from_millis(50)),
+        );
+        q.bind_replica_region("us_a", "us");
+        q.bind_replica_region("eu_a", "eu");
+
+        p.ack_replica_lsn("us_a", 50, 50);
+        p.ack_replica_lsn("eu_a", 50, 40);
+        assert!(!q.has_quorum(50));
+        assert_eq!(q.commit_watermark(), 40);
+
+        p.ack_replica_lsn("eu_a", 50, 50);
+        assert!(q.has_quorum(50));
+        assert_eq!(q.commit_watermark(), 50);
+    }
+
+    #[test]
+    fn region_mode_wait_wakes_on_durable_ack() {
+        let p = primary();
+        p.register_replica("us_a".to_string());
+        p.register_replica("eu_a".to_string());
+        let q = Arc::new(QuorumCoordinator::new(
+            Arc::clone(&p),
+            QuorumConfig::regions(["us", "eu"]).with_timeout(Duration::from_secs(1)),
+        ));
+        q.bind_replica_region("us_a", "us");
+        q.bind_replica_region("eu_a", "eu");
+
+        let waiter = Arc::clone(&q);
+        let handle = std::thread::spawn(move || waiter.wait_for_quorum(75));
+        std::thread::sleep(Duration::from_millis(20));
+        p.ack_replica_lsn("us_a", 75, 75);
+        p.ack_replica_lsn("eu_a", 75, 75);
+
+        handle
+            .join()
+            .expect("waiter thread")
+            .expect("quorum should release after durable acks");
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -5085,15 +5085,37 @@ impl RedDBRuntime {
             .unwrap_or((0, 0, 0, 0))
     }
 
+    /// Named commit watermark: highest LSN durable on the active
+    /// synchronous commit quorum. Returns 0 when the active policy does
+    /// not require replica durability.
+    pub fn commit_watermark(&self) -> u64 {
+        match self.commit_policy() {
+            crate::replication::CommitPolicy::AckN(n) if n > 0 => self
+                .inner
+                .db
+                .replication
+                .as_ref()
+                .map(|repl| repl.commit_waiter.commit_watermark(n))
+                .unwrap_or(0),
+            crate::replication::CommitPolicy::Quorum => self
+                .inner
+                .db
+                .quorum
+                .as_ref()
+                .map(|q| q.commit_watermark())
+                .unwrap_or(0),
+            _ => 0,
+        }
+    }
+
     /// PLAN.md Phase 11.4 — block until at least `count` replicas
     /// have durably applied through `target_lsn`, or `timeout`
     /// elapses. Returns the `AwaitOutcome` so the caller can decide
     /// whether to surface a timeout error to the client or continue
     /// (the policy mapping lives in the commit dispatcher).
     ///
-    /// Foundation only — the write commit path doesn't yet call
-    /// this. Wiring it is a per-surface task gated on the operator
-    /// flipping `RED_PRIMARY_COMMIT_POLICY` away from `local`.
+    /// Used by the `ack_n` commit policy once the operator flips
+    /// `RED_PRIMARY_COMMIT_POLICY` away from `local`.
     pub fn await_replica_acks(
         &self,
         target_lsn: u64,
@@ -5115,10 +5137,9 @@ impl RedDBRuntime {
     /// against `post_lsn` (the LSN of the just-completed write).
     /// Returns `Ok(AwaitOutcome)` on every successful enforcement
     /// (including `Reached` and `TimedOut` when fail-on-timeout is
-    /// off). Returns `Err(ReadOnly)` only when:
-    ///   * policy is `AckN(n)` with `n > 0`
-    ///   * the wait timed out
-    ///   * `RED_COMMIT_FAIL_ON_TIMEOUT=true` is set
+    /// off). Returns `Err(ReadOnly)` only when a synchronous policy
+    /// misses its threshold and `RED_COMMIT_FAIL_ON_TIMEOUT=true` is
+    /// set.
     ///
     /// The HTTP / gRPC / wire surfaces map the error to 504 / wire
     /// backoff. Default behaviour (env unset) logs warn and returns
@@ -5128,7 +5149,40 @@ impl RedDBRuntime {
         &self,
         post_lsn: u64,
     ) -> RedDBResult<crate::replication::AwaitOutcome> {
-        let n = match self.commit_policy() {
+        let policy = self.commit_policy();
+        if matches!(policy, crate::replication::CommitPolicy::Quorum) {
+            return match self.inner.db.wait_for_replication_quorum(post_lsn) {
+                Ok(()) => Ok(crate::replication::AwaitOutcome::Reached(0)),
+                Err(err) => {
+                    tracing::warn!(
+                        target: "reddb::commit",
+                        post_lsn,
+                        error = %err,
+                        "quorum: timed out waiting for commit watermark"
+                    );
+                    let fail = std::env::var("RED_COMMIT_FAIL_ON_TIMEOUT")
+                        .ok()
+                        .map(|v| {
+                            let t = v.trim();
+                            t.eq_ignore_ascii_case("true")
+                                || t == "1"
+                                || t.eq_ignore_ascii_case("yes")
+                        })
+                        .unwrap_or(false);
+                    if fail {
+                        return Err(RedDBError::ReadOnly(format!(
+                            "commit policy timed out at lsn {post_lsn}: {err} (RED_COMMIT_FAIL_ON_TIMEOUT=true)"
+                        )));
+                    }
+                    Ok(crate::replication::AwaitOutcome::TimedOut {
+                        observed: 0,
+                        required: 1,
+                    })
+                }
+            };
+        }
+
+        let n = match policy {
             crate::replication::CommitPolicy::AckN(n) if n > 0 => n,
             _ => return Ok(crate::replication::AwaitOutcome::NotRequired),
         };

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -1313,6 +1313,16 @@ impl RedDBServer {
             "reddb_commit_wait_last_seconds {}",
             (last_micros as f64) / 1_000_000.0
         );
+        let _ = writeln!(
+            body,
+            "# HELP reddb_commit_watermark_lsn Highest LSN durable on the active synchronous commit quorum."
+        );
+        let _ = writeln!(body, "# TYPE reddb_commit_watermark_lsn gauge");
+        let _ = writeln!(
+            body,
+            "reddb_commit_watermark_lsn {}",
+            self.runtime.commit_watermark()
+        );
 
         // PLAN.md Phase 11.4 — declared commit policy as a labeled
         // gauge so dashboards can confirm what the operator pinned.

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -26,6 +26,10 @@ impl RedDBServer {
                         .map(|spool| spool.current_lsn())
                         .unwrap_or_else(|| primary.wal_buffer.current_lsn());
                     object.insert("wal_lsn".to_string(), JsonValue::Number(wal_lsn as f64));
+                    object.insert(
+                        "commit_watermark".to_string(),
+                        JsonValue::Number(self.runtime.commit_watermark() as f64),
+                    );
                     if let Some(oldest_lsn) = primary
                         .logical_wal_spool
                         .as_ref()


### PR DESCRIPTION
Automated AFK landing for #822. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782742784&installation_id=129708444&pr_number=844&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F844&signature=4a6551586cf93ff4eec1495e04fc3987b01c785802604cb527f949a07265dbe8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit watermark metric (`reddb_commit_watermark_lsn`) to metrics endpoint for improved observability.
  * Added `commit_watermark` field to replication status response.

* **Documentation**
  * Updated Quorum commit policy documentation to clarify observability behavior and current runtime implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/844?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->