### PR TITLE
merge: #824 Replication: primary-authoritative TTL expiry + replica read-time filter

### DIFF
--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -864,6 +864,9 @@ fn dispatch_hypertable_retention(db: &RedDB, name: &str, args: &[Value]) -> Opti
     // doesn't need a hypertable name — handle before the per-name
     // dispatch path.
     if name == "HYPERTABLE_SWEEP_ALL_EXPIRED" {
+        if db.is_replica_role() {
+            return Some(Value::Integer(0));
+        }
         let now_ns = args
             .first()
             .and_then(|v| match v {
@@ -894,6 +897,9 @@ fn dispatch_hypertable_retention(db: &RedDB, name: &str, args: &[Value]) -> Opti
                 .collect(),
         )),
         "HYPERTABLE_DROP_CHUNKS_BEFORE" => {
+            if db.is_replica_role() {
+                return Some(Value::Integer(0));
+            }
             let cutoff = match args.get(1)? {
                 Value::Integer(n) | Value::BigInt(n) => *n as u64,
                 Value::UnsignedInteger(n) => *n,
@@ -903,6 +909,9 @@ fn dispatch_hypertable_retention(db: &RedDB, name: &str, args: &[Value]) -> Opti
             Some(Value::Integer(dropped as i64))
         }
         "HYPERTABLE_SWEEP_EXPIRED" => {
+            if db.is_replica_role() {
+                return Some(Value::Integer(0));
+            }
             let now_ns = args
                 .get(1)
                 .and_then(|v| match v {
@@ -920,6 +929,9 @@ fn dispatch_hypertable_retention(db: &RedDB, name: &str, args: &[Value]) -> Opti
             Some(Value::Integer(dropped as i64))
         }
         "HYPERTABLE_SET_TTL" => {
+            if db.is_replica_role() {
+                return Some(Value::Boolean(false));
+            }
             // HYPERTABLE_SET_TTL(name, duration | null)
             let ttl_ns = match args.get(1)? {
                 Value::Null => None,

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3484,7 +3484,7 @@ impl RedDBRuntime {
         // there is no half-finished mutation state to clean up). The
         // tick interval is intentionally longer than the MV scheduler
         // (500ms) because retention is order-of-seconds at minimum.
-        {
+        if !runtime.write_gate().is_read_only() {
             let weak_inner = Arc::downgrade(&runtime.inner);
             std::thread::Builder::new()
                 .name("reddb-retention-sweeper".into())
@@ -9287,7 +9287,12 @@ impl RedDBRuntime {
                 table_name,
                 crate::storage::unified::EntityId::new(entity_id),
             )
-            .filter(entity_visible_under_current_snapshot);
+            .filter(entity_visible_under_current_snapshot)
+            .filter(|entity| {
+                self.inner
+                    .db
+                    .replica_allows_entity_at_read(table_name, entity)
+            });
 
         let count = if entity.is_some() { 1u64 } else { 0 };
 

--- a/crates/reddb-server/src/runtime/impl_physical.rs
+++ b/crates/reddb-server/src/runtime/impl_physical.rs
@@ -273,6 +273,27 @@ impl RedDBRuntime {
     }
 
     pub fn apply_retention_policy(&self) -> RedDBResult<()> {
+        self.check_write(crate::runtime::write_gate::WriteKind::Maintenance)?;
+        let expired = self
+            .inner
+            .db
+            .ttl_expired_entities_now()
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+        let store = self.inner.db.store();
+        for (collection, id) in expired {
+            let deleted = store
+                .delete(&collection, id)
+                .map_err(|err| RedDBError::Internal(err.to_string()))?;
+            if deleted {
+                store.context_index().remove_entity(id);
+                self.cdc_emit(
+                    crate::replication::cdc::ChangeOperation::Delete,
+                    &collection,
+                    id.raw(),
+                    "entity",
+                );
+            }
+        }
         self.inner
             .db
             .enforce_retention_policy()
@@ -309,9 +330,18 @@ impl RedDBRuntime {
                 _ => false,
             });
             for entity in expired {
-                store
+                let deleted = store
                     .delete(&contract.name, entity.id)
                     .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                if deleted {
+                    store.context_index().remove_entity(entity.id);
+                    self.cdc_emit(
+                        crate::replication::cdc::ChangeOperation::Delete,
+                        &contract.name,
+                        entity.id.raw(),
+                        "entity",
+                    );
+                }
             }
         }
 

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -279,6 +279,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     if table_row_resolver.resolve_read_candidate(entity).is_none() {
                         return;
                     }
+                    if !db.replica_allows_entity_at_read(&query.table, entity) {
+                        return;
+                    }
                     if let Some(cf) = compiled_filter.as_ref() {
                         if !cf.evaluate(entity) {
                             return;
@@ -305,6 +308,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     .resolve_read_candidate(&entity_opt)
                     .is_none()
                 {
+                    continue;
+                }
+                if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                     continue;
                 }
                 if let Some(cf) = compiled_filter.as_ref() {
@@ -393,6 +399,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                                     .resolve_read_candidate(&entity_opt)
                                     .is_none()
                                 {
+                                    continue;
+                                }
+                                if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                                     continue;
                                 }
                                 if compiled_filter
@@ -539,6 +548,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 {
                     continue;
                 }
+                if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
+                    continue;
+                }
                 if compiled_filter.evaluate(&entity_opt) {
                     let record_opt = if lean {
                         super::super::record_search::runtime_table_record_lean_in_collection(
@@ -648,6 +660,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                                 .resolve_read_candidate(&entity_opt)
                                 .is_none()
                             {
+                                continue;
+                            }
+                            if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                                 continue;
                             }
                             if compiled_filter
@@ -822,6 +837,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             let table_row_resolver = TableRowMvccReadResolver::captured(snap_ctx);
             let matching = manager.query_all_zoned(&zone_preds, |entity| {
                 table_row_resolver.resolve_read_candidate(entity).is_some()
+                    && db.replica_allows_entity_at_read(&query.table, entity)
                     && compiled.evaluate(entity)
             });
             for entity in &matching {
@@ -883,6 +899,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 }
                 if table_row_resolver.resolve_read_candidate(entity).is_none() {
                     return true; // skip hidden tuple, keep scanning
+                }
+                if !db.replica_allows_entity_at_read(&query.table, entity) {
+                    return true;
                 }
                 if compiled.evaluate(entity) {
                     let record = if !select_cols.is_empty() {
@@ -1066,6 +1085,9 @@ pub(crate) fn execute_runtime_canonical_table_node(
                     EntityId::new(entity_id),
                 );
                 if let Some(entity) = entity {
+                    if !db.replica_allows_entity_at_read(&context.query.table, &entity) {
+                        return Ok(Vec::new());
+                    }
                     return Ok(
                         super::super::record_search::runtime_table_record_lean_in_collection(
                             entity,
@@ -1150,6 +1172,9 @@ pub(crate) fn execute_runtime_canonical_table_node(
                         return false;
                     }
                     if table_row_resolver.resolve_read_candidate(entity).is_none() {
+                        return true;
+                    }
+                    if !db.replica_allows_entity_at_read(&context.query.table, entity) {
                         return true;
                     }
                     if compiled.evaluate(entity) {

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -161,6 +161,9 @@ pub(super) fn scan_runtime_table_source_records_limited(
             .query_all(move |e| table_row_resolver.resolve_read_candidate(e).is_some())
             .into_iter()
             .filter_map(|(collection, entity)| {
+                if !db.replica_allows_entity_at_read(&collection, &entity) {
+                    return None;
+                }
                 let mut record = runtime_any_record_from_entity(entity)?;
                 set_source_collection(&mut record, &collection);
                 Some(record)
@@ -194,7 +197,9 @@ pub(super) fn scan_runtime_table_source_records_limited(
         let mut entities: Vec<crate::storage::unified::entity::UnifiedEntity> =
             Vec::with_capacity(entity_count);
         manager.for_each_entity(|e| {
-            if table_row_resolver.resolve_read_candidate(e).is_some() {
+            if table_row_resolver.resolve_read_candidate(e).is_some()
+                && db.replica_allows_entity_at_read(table, e)
+            {
                 entities.push(e.clone());
             }
             true
@@ -246,6 +251,9 @@ pub(super) fn scan_runtime_table_source_records_limited(
         if table_row_resolver.resolve_read_candidate(entity).is_none() {
             return true;
         }
+        if !db.replica_allows_entity_at_read(table, entity) {
+            return true;
+        }
         if let Some(mut record) = runtime_table_record_from_entity_ref_with_schema(
             entity,
             manager.column_schema().as_ref(),
@@ -292,7 +300,9 @@ pub(crate) fn stream_runtime_table_source_scan(
     let table_row_resolver = TableRowMvccReadResolver::current_statement();
     let mut entities: Vec<crate::storage::unified::entity::UnifiedEntity> = Vec::new();
     manager.for_each_entity(|entity| {
-        if table_row_resolver.resolve_read_candidate(entity).is_some() {
+        if table_row_resolver.resolve_read_candidate(entity).is_some()
+            && db.replica_allows_entity_at_read(table, entity)
+        {
             entities.push(entity.clone());
         }
         true

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
@@ -2,8 +2,15 @@ use super::*;
 use crate::storage::unified::metadata::{MetadataFilter, MetadataValue};
 
 impl RedDB {
+    pub fn is_replica_role(&self) -> bool {
+        matches!(
+            self.options.replication.role,
+            crate::replication::ReplicationRole::Replica { .. }
+        )
+    }
+
     pub fn enforce_retention_policy(&self) -> Result<(), Box<dyn std::error::Error>> {
-        if self.options.read_only {
+        if self.options.read_only || self.is_replica_role() {
             return Ok(());
         }
 
@@ -27,23 +34,25 @@ impl RedDB {
         Ok(())
     }
 
+    pub(crate) fn ttl_expired_entities_now(
+        &self,
+    ) -> Result<Vec<(String, EntityId)>, Box<dyn std::error::Error>> {
+        self.ttl_expired_entities_at(current_unix_ms())
+    }
+
+    pub fn replica_allows_entity_at_read(
+        &self,
+        collection: &str,
+        entity: &crate::storage::UnifiedEntity,
+    ) -> bool {
+        if !self.is_replica_role() {
+            return true;
+        }
+        !self.entity_expired_at(collection, entity, current_unix_ms())
+    }
+
     fn sweep_ttl_expired_entities(&self) -> Result<usize, Box<dyn std::error::Error>> {
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis()
-            .min(u128::from(u64::MAX)) as u64;
-
-        let mut to_delete = Vec::<(String, EntityId)>::new();
-
-        let mut absolute_expired = self.expired_entities_by_expires_at(now_ms)?;
-        to_delete.append(&mut absolute_expired);
-
-        let mut relative_expired = self.expired_entities_by_ttl(now_ms)?;
-        to_delete.append(&mut relative_expired);
-
-        to_delete.sort_unstable();
-        to_delete.dedup();
+        let to_delete = self.ttl_expired_entities_now()?;
 
         let mut deleted = 0usize;
         for (collection, id) in to_delete {
@@ -60,6 +69,61 @@ impl RedDB {
         }
 
         Ok(deleted)
+    }
+
+    fn ttl_expired_entities_at(
+        &self,
+        now_ms: u64,
+    ) -> Result<Vec<(String, EntityId)>, Box<dyn std::error::Error>> {
+        let mut to_delete = Vec::<(String, EntityId)>::new();
+
+        let mut absolute_expired = self.expired_entities_by_expires_at(now_ms)?;
+        to_delete.append(&mut absolute_expired);
+
+        let mut relative_expired = self.expired_entities_by_ttl(now_ms)?;
+        to_delete.append(&mut relative_expired);
+
+        to_delete.sort_unstable();
+        to_delete.dedup();
+
+        Ok(to_delete)
+    }
+
+    fn entity_expired_at(
+        &self,
+        collection: &str,
+        entity: &crate::storage::UnifiedEntity,
+        now_ms: u64,
+    ) -> bool {
+        let Some(metadata) = self.store.get_metadata(collection, entity.id) else {
+            return false;
+        };
+
+        if metadata
+            .get("_expires_at")
+            .and_then(Self::metadata_u64)
+            .is_some_and(|expires_at_ms| expires_at_ms <= now_ms)
+        {
+            return true;
+        }
+
+        let ttl_ms = metadata.get("_ttl_ms").and_then(Self::metadata_u64);
+        let ttl_secs = if ttl_ms.is_none() {
+            metadata.get("_ttl").and_then(|value| {
+                Self::metadata_u64(value).and_then(|value_secs| value_secs.checked_mul(1000))
+            })
+        } else {
+            None
+        };
+
+        let Some(ttl_ms) = ttl_ms.or(ttl_secs) else {
+            return false;
+        };
+        entity
+            .created_at
+            .saturating_mul(1000)
+            .saturating_add(ttl_ms)
+            <= now_ms
     }
 
     fn expired_entities_by_expires_at(
@@ -1288,4 +1352,12 @@ impl RedDB {
             let _ = self.store.delete(QUEUE_META_COLLECTION, row.id);
         }
     }
+}
+
+fn current_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
 }

--- a/tests/e2e_issue_824_replication_ttl.rs
+++ b/tests/e2e_issue_824_replication_ttl.rs
@@ -1,0 +1,221 @@
+//! Issue #824 — primary-authoritative TTL expiry under replication.
+//!
+//! TTL/expiry decisions are owned by the primary. Replicas replay the
+//! primary's delete record, and their read path hides records whose
+//! absolute expiry has already passed while they are still waiting for
+//! that delete to arrive.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use reddb::application::NativeUseCases;
+use reddb::replication::cdc::{ChangeOperation, ChangeRecord};
+use reddb::replication::logical::{ApplyMode, LogicalChangeApplier};
+use reddb::replication::primary::LogicalWalSpool;
+use reddb::replication::ReplicationConfig;
+use reddb::storage::RedDB;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn temp_path(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "reddb-824-{prefix}-{}-{nanos}.rdb",
+        std::process::id()
+    ))
+}
+
+fn cleanup(path: &Path) {
+    let _ = std::fs::remove_file(path);
+    for ext in ["-wal", "-hdr", "-meta", "-dwb", "-uwal", ".logical.wal"] {
+        let mut p = path.to_path_buf().into_os_string();
+        p.push(ext);
+        let _ = std::fs::remove_file(PathBuf::from(p));
+    }
+}
+
+fn read_spool(path: &Path) -> Vec<ChangeRecord> {
+    let spool = LogicalWalSpool::open(path).expect("open logical WAL spool");
+    spool
+        .read_since(0, usize::MAX)
+        .expect("read logical WAL")
+        .into_iter()
+        .map(|(lsn, bytes)| {
+            ChangeRecord::decode(&bytes)
+                .unwrap_or_else(|err| panic!("decode logical record lsn={lsn}: {err}"))
+        })
+        .collect()
+}
+
+fn replay(replica: &RedDB, records: impl IntoIterator<Item = ChangeRecord>) {
+    let applier = LogicalChangeApplier::new(0);
+    for record in records {
+        applier
+            .apply(replica, &record, ApplyMode::Replica)
+            .unwrap_or_else(|err| panic!("apply lsn={} failed: {err}", record.lsn));
+    }
+}
+
+fn physical_count(db: &RedDB, collection: &str) -> usize {
+    db.store()
+        .get_collection(collection)
+        .map(|manager| manager.query_all(|_| true).len())
+        .unwrap_or(0)
+}
+
+#[test]
+fn primary_ttl_sweep_replicates_delete_to_replica() {
+    let primary_path = temp_path("primary-delete");
+    let replica_path = temp_path("replica-delete");
+
+    {
+        let primary = RedDBRuntime::with_options(
+            RedDBOptions::persistent(&primary_path).with_replication(ReplicationConfig::primary()),
+        )
+        .expect("open primary");
+        primary
+            .execute_query("CREATE TABLE sessions (id INT, token TEXT)")
+            .expect("create table");
+        primary
+            .execute_query("INSERT INTO sessions (id, token, _ttl_ms) VALUES (1, 'a', 1)")
+            .expect("insert ttl row");
+
+        NativeUseCases::new(&primary)
+            .apply_retention_policy()
+            .expect("primary retention sweep");
+        primary.db().flush().expect("flush primary");
+    }
+
+    let records = read_spool(&primary_path);
+    assert!(
+        records.iter().any(|record| {
+            record.operation == ChangeOperation::Delete && record.collection == "sessions"
+        }),
+        "primary TTL sweep must materialize expiry as a logical delete: {records:?}"
+    );
+
+    let replica = RedDB::open(&replica_path).expect("open replica");
+    replay(&replica, records);
+    assert_eq!(
+        physical_count(&replica, "sessions"),
+        0,
+        "replica must converge by applying the primary's delete"
+    );
+
+    drop(replica);
+    cleanup(&primary_path);
+    cleanup(&replica_path);
+}
+
+#[test]
+fn lagging_replica_filters_expired_row_before_delete_arrives() {
+    let primary_path = temp_path("primary-filter");
+    let replica_path = temp_path("replica-filter");
+
+    {
+        let primary = RedDBRuntime::with_options(
+            RedDBOptions::persistent(&primary_path).with_replication(ReplicationConfig::primary()),
+        )
+        .expect("open primary");
+        primary
+            .execute_query("CREATE TABLE sessions (id INT, token TEXT)")
+            .expect("create table");
+        primary
+            .execute_query("INSERT INTO sessions (id, token, _expires_at) VALUES (1, 'a', 1)")
+            .expect("insert expired row");
+        primary.db().flush().expect("flush primary");
+    }
+
+    let insert_records = read_spool(&primary_path)
+        .into_iter()
+        .filter(|record| record.operation == ChangeOperation::Insert)
+        .collect::<Vec<_>>();
+    assert_eq!(insert_records.len(), 1, "expected one insert record");
+
+    {
+        let replica = RedDB::open(&replica_path).expect("open replica storage");
+        replay(&replica, insert_records);
+        replica.flush().expect("flush replica");
+    }
+
+    let replica = RedDBRuntime::with_options(
+        RedDBOptions::persistent(&replica_path)
+            .with_replication(ReplicationConfig::replica("http://primary:50051")),
+    )
+    .expect("open replica runtime");
+
+    let read = replica
+        .execute_query("SELECT * FROM sessions")
+        .expect("replica select");
+    assert_eq!(
+        read.result.records.len(),
+        0,
+        "lagging replica must not serve a row past its absolute expiry"
+    );
+    assert_eq!(
+        physical_count(&replica.db(), "sessions"),
+        1,
+        "read-time filtering must not locally delete the lagging row"
+    );
+    assert!(
+        NativeUseCases::new(&replica)
+            .apply_retention_policy()
+            .is_err(),
+        "replica retention sweep must not mutate state from its own clock"
+    );
+
+    drop(replica);
+    cleanup(&primary_path);
+    cleanup(&replica_path);
+}
+
+#[test]
+fn replica_hypertable_expiry_sweep_is_read_only_noop() {
+    let path = temp_path("hypertable-replica");
+
+    {
+        let seed = RedDB::open(&path).expect("seed replica path");
+        seed.flush().expect("flush seed");
+    }
+
+    let replica = RedDBRuntime::with_options(
+        RedDBOptions::persistent(&path)
+            .with_replication(ReplicationConfig::replica("http://primary:50051")),
+    )
+    .expect("open replica");
+    let replica_db = replica.db();
+    let registry = replica_db.hypertables();
+    registry.register(
+        reddb::storage::timeseries::HypertableSpec::new("metrics", "ts", 3_600_000_000_000)
+            .with_ttl_ns(3_600_000_000_000),
+    );
+    registry
+        .route("metrics", 0)
+        .expect("route replica chunk fixture");
+
+    let sweep = replica
+        .execute_query("SELECT HYPERTABLE_SWEEP_EXPIRED('metrics', 7200000000000) AS dropped")
+        .expect("replica sweep scalar");
+    assert_eq!(
+        sweep.result.records[0].get("dropped"),
+        Some(&reddb::storage::schema::Value::Integer(0)),
+        "replica sweep scalar must report no local drops"
+    );
+
+    let chunks = replica
+        .execute_query("SELECT HYPERTABLE_SHOW_CHUNKS('metrics') AS chunks")
+        .expect("show chunks");
+    let chunk_count = match chunks.result.records[0].get("chunks") {
+        Some(reddb::storage::schema::Value::Array(items)) => items.len(),
+        other => panic!("expected chunks array, got {other:?}"),
+    };
+    assert_eq!(
+        chunk_count, 1,
+        "replica hypertable expiry sweep must not drop local chunks"
+    );
+
+    drop(replica);
+    cleanup(&path);
+}


### PR DESCRIPTION
Automated AFK landing for #824. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782747243&installation_id=129708444&pr_number=846&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F846&signature=201ed42915c9a593e1699fff809d05d2ba4298606ed5368f2af0b7bd317d2c18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replica instances now filter expired entities from read queries, preventing expired data from being served to users.

* **Bug Fixes**
  * Fixed replica instances performing TTL retention operations, preventing unintended state mutations on read-only deployments.
  * Replica instances now correctly skip hypertable maintenance and retention sweep operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->