### PR TITLE
merge: #816 Replication: replica ACKs applied + durable LSN; primary derives honest lag

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2823,6 +2823,16 @@ impl RedDb for GrpcRuntime {
                         "replica_count".into(),
                         JsonValue::Number(repl.replica_count() as f64),
                     );
+                    if let Some(progress) = repl.replication_progress() {
+                        map.insert(
+                            "replication_lag_lsn".into(),
+                            JsonValue::Number(progress.lag_lsn as f64),
+                        );
+                        map.insert(
+                            "safe_replay_lsn".into(),
+                            JsonValue::Number(progress.safe_replay_lsn as f64),
+                        );
+                    }
                     if let Some(floor) = repl.retention_floor_lsn() {
                         map.insert(
                             "retention_floor_lsn".into(),

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -766,6 +766,32 @@ pub struct ReplicaState {
     pub region: Option<String>,
 }
 
+/// Primary-side replication progress derived from the replica registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReplicationProgress {
+    pub lag_lsn: u64,
+    pub safe_replay_lsn: u64,
+}
+
+impl ReplicationProgress {
+    pub fn from_replicas(replicas: &[ReplicaState]) -> Option<Self> {
+        let max_sent_lsn = replicas.iter().map(|replica| replica.last_sent_lsn).max()?;
+        let min_acked_lsn = replicas
+            .iter()
+            .map(|replica| replica.last_acked_lsn)
+            .min()?;
+        let safe_replay_lsn = replicas
+            .iter()
+            .map(|replica| replica.last_durable_lsn)
+            .min()?;
+
+        Some(Self {
+            lag_lsn: max_sent_lsn.saturating_sub(min_acked_lsn),
+            safe_replay_lsn,
+        })
+    }
+}
+
 /// Primary replication manager.
 pub struct PrimaryReplication {
     pub wal_buffer: Arc<WalBuffer>,
@@ -971,6 +997,11 @@ impl PrimaryReplication {
             .read()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
+    }
+
+    pub fn replication_progress(&self) -> Option<ReplicationProgress> {
+        let replicas = self.replicas.read().unwrap_or_else(|e| e.into_inner());
+        ReplicationProgress::from_replicas(&replicas)
     }
 
     pub fn slot_snapshots(&self) -> Vec<ReplicationSlot> {
@@ -1381,5 +1412,35 @@ mod tests {
             Some(7),
             "no-op registration preserves progress"
         );
+    }
+
+    #[test]
+    fn replication_progress_uses_sent_applied_and_durable_registry_lsns() {
+        let now = crate::utils::now_unix_millis() as u128;
+        let replicas = vec![
+            ReplicaState {
+                id: "fast".to_string(),
+                last_acked_lsn: 90,
+                last_sent_lsn: 120,
+                last_durable_lsn: 80,
+                connected_at_unix_ms: now,
+                last_seen_at_unix_ms: now,
+                region: None,
+            },
+            ReplicaState {
+                id: "slow".to_string(),
+                last_acked_lsn: 70,
+                last_sent_lsn: 100,
+                last_durable_lsn: 60,
+                connected_at_unix_ms: now,
+                last_seen_at_unix_ms: now,
+                region: None,
+            },
+        ];
+
+        let progress = ReplicationProgress::from_replicas(&replicas).expect("registered replicas");
+
+        assert_eq!(progress.lag_lsn, 50);
+        assert_eq!(progress.safe_replay_lsn, 60);
     }
 }

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4805,6 +4805,8 @@ impl RedDBRuntime {
                         if let Some(records) =
                             value.get("records").and_then(crate::json::Value::as_array)
                         {
+                            let mut batch_applied_lsn = None;
+                            let mut ack_failed = false;
                             for record in records {
                                 let Some(data_hex) =
                                     record.get("data").and_then(crate::json::Value::as_str)
@@ -4844,6 +4846,7 @@ impl RedDBRuntime {
                                         self.invalidate_result_cache_for_table(&change.collection);
                                         since_lsn = since_lsn.max(change.lsn);
                                         self.persist_replica_lsn(since_lsn);
+                                        batch_applied_lsn = Some(since_lsn);
                                     }
                                     Ok(_) => {
                                         // Idempotent / Skipped: no advance, no error.
@@ -4900,6 +4903,30 @@ impl RedDBRuntime {
                                         break;
                                     }
                                 }
+                            }
+                            if let Some(applied_lsn) = batch_applied_lsn {
+                                let ack_payload = crate::json!({
+                                    "replica_id": replica_id.clone(),
+                                    "applied_lsn": applied_lsn,
+                                    "durable_lsn": applied_lsn
+                                });
+                                let ack_request = tonic::Request::new(JsonPayloadRequest {
+                                    payload_json: crate::json::to_string(&ack_payload)
+                                        .unwrap_or_else(|_| "{}".to_string()),
+                                });
+                                if client.ack_replica_lsn(ack_request).await.is_err() {
+                                    ack_failed = true;
+                                    self.persist_replication_health(
+                                        "ack_error",
+                                        "primary ack_replica_lsn request failed",
+                                        current_lsn,
+                                        oldest_available_lsn,
+                                    );
+                                }
+                            }
+                            if ack_failed {
+                                std::thread::sleep(std::time::Duration::from_millis(poll_ms));
+                                continue;
                             }
                         }
                         self.persist_replication_health(

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -49,6 +49,16 @@ impl RedDBServer {
                         "replica_count".to_string(),
                         JsonValue::Number(primary.replica_count() as f64),
                     );
+                    if let Some(progress) = primary.replication_progress() {
+                        object.insert(
+                            "replication_lag_lsn".to_string(),
+                            JsonValue::Number(progress.lag_lsn as f64),
+                        );
+                        object.insert(
+                            "safe_replay_lsn".to_string(),
+                            JsonValue::Number(progress.safe_replay_lsn as f64),
+                        );
+                    }
                     if let Some(floor) = primary.retention_floor_lsn() {
                         object.insert(
                             "retention_floor_lsn".to_string(),


### PR DESCRIPTION
Automated AFK landing for #816. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782747263&installation_id=129708444&pr_number=847&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F847&signature=ce340d96002e02056097f12fd27541a2f67f790e7532a19e30fd4777a8a84475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced replication status monitoring: Added new metrics including replication lag and safe replay LSN to better track replication progress and health.

* **Improvements**
  * Improved replica acknowledgment tracking during WAL apply operations for more accurate replication state reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->