### PR TITLE
merge: #817 Replication: Prometheus metrics — replica lag, applied/durable LSN, apply errors, divergence

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2996,7 +2996,8 @@ impl RedDb for GrpcRuntime {
 
     /// PLAN.md Phase 11.4 — replica reports applied + durable LSN to the
     /// primary after persisting a WAL batch. JSON payload:
-    /// `{"replica_id": "...", "applied_lsn": <u64>, "durable_lsn": <u64>}`.
+    /// `{"replica_id": "...", "applied_lsn": <u64>, "durable_lsn": <u64>,
+    ///   "apply_errors_total": <u64>, "divergence_total": <u64>}`.
     /// Idempotent — older LSN values are clamped to the existing maximum.
     async fn ack_replica_lsn(
         &self,
@@ -3027,8 +3028,22 @@ impl RedDb for GrpcRuntime {
             .get("durable_lsn")
             .and_then(JsonValue::as_u64)
             .unwrap_or(applied_lsn);
+        let apply_errors_total = payload
+            .get("apply_errors_total")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
+        let divergence_total = payload
+            .get("divergence_total")
+            .and_then(JsonValue::as_u64)
+            .unwrap_or(0);
 
-        repl.ack_replica_lsn(&authenticated_replica_id, applied_lsn, durable_lsn);
+        repl.ack_replica_lsn_with_observability(
+            &authenticated_replica_id,
+            applied_lsn,
+            durable_lsn,
+            apply_errors_total,
+            divergence_total,
+        );
 
         let mut reply = crate::json::Map::new();
         reply.insert("ok".into(), JsonValue::Bool(true));
@@ -3038,6 +3053,14 @@ impl RedDb for GrpcRuntime {
         );
         reply.insert("applied_lsn".into(), JsonValue::Number(applied_lsn as f64));
         reply.insert("durable_lsn".into(), JsonValue::Number(durable_lsn as f64));
+        reply.insert(
+            "apply_errors_total".into(),
+            JsonValue::Number(apply_errors_total as f64),
+        );
+        reply.insert(
+            "divergence_total".into(),
+            JsonValue::Number(divergence_total as f64),
+        );
         Ok(Response::new(json_payload_reply(JsonValue::Object(reply))))
     }
 

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -757,6 +757,8 @@ pub struct ReplicaState {
     pub last_acked_lsn: u64,
     pub last_sent_lsn: u64,
     pub last_durable_lsn: u64,
+    pub apply_error_count: u64,
+    pub divergence_count: u64,
     pub connected_at_unix_ms: u128,
     pub last_seen_at_unix_ms: u128,
     /// Region identifier declared by the replica at handshake time
@@ -877,6 +879,8 @@ impl PrimaryReplication {
             last_acked_lsn: resume_lsn,
             last_sent_lsn: resume_lsn,
             last_durable_lsn: resume_lsn,
+            apply_error_count: 0,
+            divergence_count: 0,
             connected_at_unix_ms: now_ms,
             last_seen_at_unix_ms: now_ms,
             region,
@@ -961,12 +965,25 @@ impl PrimaryReplication {
     /// Also signals `commit_waiter` so any thread blocked on
     /// `ack_n` / `quorum` can wake and re-check its threshold.
     pub fn ack_replica_lsn(&self, id: &str, applied_lsn: u64, durable_lsn: u64) {
+        self.ack_replica_lsn_with_observability(id, applied_lsn, durable_lsn, 0, 0);
+    }
+
+    pub fn ack_replica_lsn_with_observability(
+        &self,
+        id: &str,
+        applied_lsn: u64,
+        durable_lsn: u64,
+        apply_error_count: u64,
+        divergence_count: u64,
+    ) {
         let now_ms = crate::utils::now_unix_millis() as u128;
         self.advance_slot(id, applied_lsn, durable_lsn);
         let mut replicas = self.replicas.write().unwrap_or_else(|e| e.into_inner());
         if let Some(r) = replicas.iter_mut().find(|r| r.id == id) {
             r.last_acked_lsn = r.last_acked_lsn.max(applied_lsn);
             r.last_durable_lsn = r.last_durable_lsn.max(durable_lsn);
+            r.apply_error_count = r.apply_error_count.max(apply_error_count);
+            r.divergence_count = r.divergence_count.max(divergence_count);
             r.last_seen_at_unix_ms = now_ms;
         }
         // Drop the write lock before signaling so a waiter that
@@ -1423,6 +1440,8 @@ mod tests {
                 last_acked_lsn: 90,
                 last_sent_lsn: 120,
                 last_durable_lsn: 80,
+                apply_error_count: 0,
+                divergence_count: 0,
                 connected_at_unix_ms: now,
                 last_seen_at_unix_ms: now,
                 region: None,
@@ -1432,6 +1451,8 @@ mod tests {
                 last_acked_lsn: 70,
                 last_sent_lsn: 100,
                 last_durable_lsn: 60,
+                apply_error_count: 0,
+                divergence_count: 0,
                 connected_at_unix_ms: now,
                 last_seen_at_unix_ms: now,
                 region: None,

--- a/crates/reddb-server/src/replication/topology_advertiser.rs
+++ b/crates/reddb-server/src/replication/topology_advertiser.rs
@@ -285,6 +285,8 @@ mod tests {
             last_acked_lsn: 100,
             last_sent_lsn: 100,
             last_durable_lsn: 100,
+            apply_error_count: 0,
+            divergence_count: 0,
             connected_at_unix_ms: now,
             last_seen_at_unix_ms: last_seen,
             region: region.map(String::from),

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4905,10 +4905,25 @@ impl RedDBRuntime {
                                 }
                             }
                             if let Some(applied_lsn) = batch_applied_lsn {
+                                let apply_errors = self.replica_apply_error_counts();
+                                let apply_errors_total =
+                                    apply_errors.iter().map(|(_, count)| *count).sum::<u64>();
+                                let divergence_total = apply_errors
+                                    .iter()
+                                    .find(|(kind, _)| {
+                                        matches!(
+                                            kind,
+                                            crate::replication::logical::ApplyErrorKind::Divergence
+                                        )
+                                    })
+                                    .map(|(_, count)| *count)
+                                    .unwrap_or(0);
                                 let ack_payload = crate::json!({
                                     "replica_id": replica_id.clone(),
                                     "applied_lsn": applied_lsn,
-                                    "durable_lsn": applied_lsn
+                                    "durable_lsn": applied_lsn,
+                                    "apply_errors_total": apply_errors_total,
+                                    "divergence_total": divergence_total
                                 });
                                 let ack_request = tonic::Request::new(JsonPayloadRequest {
                                     payload_json: crate::json::to_string(&ack_payload)

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -1185,7 +1185,33 @@ impl RedDBServer {
             }
             let _ = writeln!(
                 body,
-                "# HELP reddb_replica_lag_records Distance from primary current LSN to replica acked LSN."
+                "# HELP reddb_replica_applied_lsn Most recent LSN applied by each replica."
+            );
+            let _ = writeln!(body, "# TYPE reddb_replica_applied_lsn gauge");
+            for r in &replicas {
+                let _ = writeln!(
+                    body,
+                    "reddb_replica_applied_lsn{{replica_id=\"{}\"}} {}",
+                    sanitize_label(&r.id),
+                    r.last_acked_lsn
+                );
+            }
+            let _ = writeln!(
+                body,
+                "# HELP reddb_replica_durable_lsn Most recent LSN durably persisted by each replica."
+            );
+            let _ = writeln!(body, "# TYPE reddb_replica_durable_lsn gauge");
+            for r in &replicas {
+                let _ = writeln!(
+                    body,
+                    "reddb_replica_durable_lsn{{replica_id=\"{}\"}} {}",
+                    sanitize_label(&r.id),
+                    r.last_durable_lsn
+                );
+            }
+            let _ = writeln!(
+                body,
+                "# HELP reddb_replica_lag_records Real LSN distance from last sent LSN to applied LSN."
             );
             let _ = writeln!(body, "# TYPE reddb_replica_lag_records gauge");
             for r in &replicas {
@@ -1193,7 +1219,33 @@ impl RedDBServer {
                     body,
                     "reddb_replica_lag_records{{replica_id=\"{}\"}} {}",
                     sanitize_label(&r.id),
-                    current_lsn.saturating_sub(r.last_acked_lsn)
+                    r.last_sent_lsn.saturating_sub(r.last_acked_lsn)
+                );
+            }
+            let _ = writeln!(
+                body,
+                "# HELP reddb_replica_apply_errors_total Replica-reported WAL apply errors since process start."
+            );
+            let _ = writeln!(body, "# TYPE reddb_replica_apply_errors_total counter");
+            for r in &replicas {
+                let _ = writeln!(
+                    body,
+                    "reddb_replica_apply_errors_total{{replica_id=\"{}\"}} {}",
+                    sanitize_label(&r.id),
+                    r.apply_error_count
+                );
+            }
+            let _ = writeln!(
+                body,
+                "# HELP reddb_replica_divergence_total Replica-reported WAL divergence errors since process start."
+            );
+            let _ = writeln!(body, "# TYPE reddb_replica_divergence_total counter");
+            for r in &replicas {
+                let _ = writeln!(
+                    body,
+                    "reddb_replica_divergence_total{{replica_id=\"{}\"}} {}",
+                    sanitize_label(&r.id),
+                    r.divergence_count
                 );
             }
             let _ = writeln!(

--- a/tests/e2e_issue_817_replication_metrics.rs
+++ b/tests/e2e_issue_817_replication_metrics.rs
@@ -1,0 +1,246 @@
+//! Issue #817 — primary /metrics exports per-replica replication progress.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::JsonPayloadRequest;
+use reddb::replication::ReplicationConfig;
+use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions, RedDBRuntime};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+
+use support::prometheus::get;
+
+fn pick_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
+    let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5));
+    RedDbClient::new(endpoint.connect().await.expect("client connect"))
+}
+
+fn install_replication_policy(store: &AuthStore, username: &str) {
+    let policy_id = format!("p_{username}_replication");
+    let policy_json = format!(
+        r#"{{"id":"{policy_id}","version":1,"statements":[{{"effect":"allow","actions":["cluster:replication:stream","cluster:replication:ack"],"resources":["cluster:replication"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(PrincipalRef::User(UserId::platform(username)), &policy_id)
+        .expect("attach policy");
+}
+
+fn bearer_request(message: JsonPayloadRequest, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    let mut request = tonic::Request::new(message);
+    let value: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+fn pull_request(replica_id: &str, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","since_lsn":0,"max_count":10}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn ack_request(
+    replica_id: &str,
+    applied_lsn: u64,
+    durable_lsn: u64,
+    token: &str,
+) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","applied_lsn":{applied_lsn},"durable_lsn":{durable_lsn},"apply_errors_total":4,"divergence_total":2}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn metric_value(body: &str, prefix: &str) -> u64 {
+    for line in body.lines() {
+        if let Some(value) = line.strip_prefix(prefix) {
+            return value
+                .trim()
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("invalid metric value for {prefix:?}: {line}"));
+        }
+    }
+    panic!("metric line not found: {prefix:?}\n{body}");
+}
+
+#[tokio::test]
+async fn metrics_endpoint_exports_registered_replica_progress_and_errors() {
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("runtime");
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("replica_a", "p", Role::Read).unwrap();
+    store.create_user("replica_b", "p", Role::Read).unwrap();
+    let replica_a_key = store
+        .create_api_key("replica_a", "replication-a", Role::Read)
+        .unwrap();
+    let replica_b_key = store
+        .create_api_key("replica_b", "replication-b", Role::Read)
+        .unwrap();
+    install_replication_policy(&store, "replica_a");
+    install_replication_policy(&store, "replica_b");
+
+    let port = pick_port();
+    let server = RedDBGrpcServer::with_options(
+        runtime.clone(),
+        GrpcServerOptions {
+            bind_addr: format!("127.0.0.1:{port}"),
+            tls: None,
+        },
+        store,
+    );
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port).await;
+    let mut client = connect_client(port).await;
+
+    client
+        .pull_wal_records(pull_request("replica_a", &replica_a_key.key))
+        .await
+        .expect("replica_a registers");
+    client
+        .pull_wal_records(pull_request("replica_b", &replica_b_key.key))
+        .await
+        .expect("replica_b registers");
+
+    runtime
+        .execute_query("CREATE TABLE issue_817_replication_metrics (id INTEGER, name TEXT)")
+        .expect("create table");
+    for id in 1..=3 {
+        runtime
+            .execute_query(&format!(
+                "INSERT INTO issue_817_replication_metrics (id, name) VALUES ({id}, 'r{id}')"
+            ))
+            .expect("insert row");
+    }
+
+    let pull = client
+        .pull_wal_records(pull_request("replica_a", &replica_a_key.key))
+        .await
+        .expect("replica_a pulls WAL")
+        .into_inner();
+    let pull_body: serde_json::Value = serde_json::from_str(&pull.payload).expect("pull JSON");
+    let current_lsn = pull_body["current_lsn"].as_u64().expect("current_lsn");
+    assert!(current_lsn >= 2, "test needs nonzero lag; pull={pull_body}");
+    let applied_lsn = current_lsn - 1;
+    let durable_lsn = current_lsn - 2;
+
+    client
+        .ack_replica_lsn(ack_request(
+            "replica_a",
+            applied_lsn,
+            durable_lsn,
+            &replica_a_key.key,
+        ))
+        .await
+        .expect("replica_a acks progress");
+
+    let (status, metrics) = get(runtime.clone(), "/metrics");
+    assert_eq!(status, 200, "unexpected /metrics response: {metrics}");
+
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_lag_records{replica_id=\"replica_a\"} "
+        ),
+        1
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_lag_records{replica_id=\"replica_b\"} "
+        ),
+        0,
+        "registered replicas that have not pulled the new LSNs should not use current_lsn lag"
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_applied_lsn{replica_id=\"replica_a\"} "
+        ),
+        applied_lsn
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_durable_lsn{replica_id=\"replica_a\"} "
+        ),
+        durable_lsn
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_apply_errors_total{replica_id=\"replica_a\"} "
+        ),
+        4
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_divergence_total{replica_id=\"replica_a\"} "
+        ),
+        2
+    );
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_apply_errors_total{replica_id=\"replica_b\"} "
+        ),
+        0
+    );
+    assert!(
+        !metrics.contains("replica_id=\"ghost\""),
+        "metrics must be bounded to the registered-replica set:\n{metrics}"
+    );
+
+    handle.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #817. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782752873&installation_id=129708444&pr_number=848&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F848&signature=679e135d64d82870ae700025cf028456ea8910eea237639e8c97d67527c4a56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced replication observability with new per-replica metrics: applied LSN, durable LSN, apply error counts, and divergence error tracking.
  * Extended replication acknowledgement protocol to include and report observability counters.
  * Updated replica lag metric to measure distance from last sent to applied LSN.

* **Tests**
  * Added end-to-end test validating replication metrics collection and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->