### PR TITLE
merge: #825 Replication: bounded slot retention + invalidation with explicit cause codes

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2853,6 +2853,16 @@ impl RedDb for GrpcRuntime {
                                 "confirmed_lsn".into(),
                                 JsonValue::Number(slot.confirmed_lsn as f64),
                             );
+                            slot_json.insert(
+                                "invalidated".into(),
+                                JsonValue::Bool(slot.invalidation_reason.is_some()),
+                            );
+                            if let Some(reason) = slot.invalidation_reason {
+                                slot_json.insert(
+                                    "invalidation_reason".into(),
+                                    JsonValue::String(reason.as_str().to_string()),
+                                );
+                            }
                             JsonValue::Object(slot_json)
                         })
                         .collect();
@@ -2927,6 +2937,16 @@ impl RedDb for GrpcRuntime {
         let payload = parse_json_payload_allow_empty(&request.into_inner().payload_json)?;
         let mut since_lsn = json_usize_field(&payload, "since_lsn").unwrap_or(0) as u64;
         let max_count = json_usize_field(&payload, "max_count").unwrap_or(1000);
+        let current_lsn = repl
+            .logical_wal_spool
+            .as_ref()
+            .map(|spool| spool.current_lsn())
+            .unwrap_or_else(|| repl.wal_buffer.current_lsn());
+        let oldest_available_lsn = repl
+            .logical_wal_spool
+            .as_ref()
+            .and_then(|spool| spool.oldest_lsn().ok().flatten())
+            .or_else(|| repl.wal_buffer.oldest_lsn());
         // PLAN.md Phase 11.4 — caller may identify itself so primary can
         // track per-replica `last_sent_lsn` and `last_seen_at_unix_ms`.
         let replica_id = payload
@@ -2936,6 +2956,24 @@ impl RedDb for GrpcRuntime {
 
         if let Some(id) = &replica_id {
             repl.ensure_replica_registered(id);
+            if let Some(reason) = repl.slot_rebootstrap_reason(id, since_lsn, oldest_available_lsn)
+            {
+                let mut map = crate::json::Map::new();
+                map.insert("records".into(), JsonValue::Array(Vec::new()));
+                map.insert("current_lsn".into(), JsonValue::Number(current_lsn as f64));
+                if let Some(oldest) = oldest_available_lsn {
+                    map.insert(
+                        "oldest_available_lsn".into(),
+                        JsonValue::Number(oldest as f64),
+                    );
+                }
+                map.insert("needs_rebootstrap".into(), JsonValue::Bool(true));
+                map.insert(
+                    "invalidation_reason".into(),
+                    JsonValue::String(reason.as_str().to_string()),
+                );
+                return Ok(Response::new(json_payload_reply(JsonValue::Object(map))));
+            }
             if let Some(slot) = repl.slot_snapshots().into_iter().find(|slot| slot.id == *id) {
                 since_lsn = since_lsn.max(slot.restart_lsn);
             }
@@ -2970,21 +3008,8 @@ impl RedDb for GrpcRuntime {
 
         let mut map = crate::json::Map::new();
         map.insert("records".into(), JsonValue::Array(entries));
-        map.insert(
-            "current_lsn".into(),
-            JsonValue::Number(
-                repl.logical_wal_spool
-                    .as_ref()
-                    .map(|spool| spool.current_lsn())
-                    .unwrap_or_else(|| repl.wal_buffer.current_lsn()) as f64,
-            ),
-        );
-        if let Some(oldest) = repl
-            .logical_wal_spool
-            .as_ref()
-            .and_then(|spool| spool.oldest_lsn().ok().flatten())
-            .or_else(|| repl.wal_buffer.oldest_lsn())
-        {
+        map.insert("current_lsn".into(), JsonValue::Number(current_lsn as f64));
+        if let Some(oldest) = oldest_available_lsn {
             map.insert(
                 "oldest_available_lsn".into(),
                 JsonValue::Number(oldest as f64),

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -41,6 +41,8 @@ pub use topology_advertiser::{
 };
 
 pub const DEFAULT_REPLICATION_TERM: u64 = 1;
+pub const DEFAULT_SLOT_RETENTION_MAX_LAG_LSN: u64 = 100_000;
+pub const DEFAULT_SLOT_IDLE_TIMEOUT_MS: u64 = 86_400_000;
 
 /// Role of this RedDB instance in a replication cluster.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -76,6 +78,11 @@ pub struct ReplicationConfig {
     pub region: String,
     /// Quorum configuration (Phase 2.6 multi-region).
     pub quorum: QuorumConfig,
+    /// Maximum LSN lag a replication slot may pin before the primary
+    /// invalidates it and allows WAL pruning to continue.
+    pub slot_retention_max_lag_lsn: u64,
+    /// Maximum wall-clock idle age for a slot before invalidation.
+    pub slot_idle_timeout_ms: u64,
 }
 
 impl ReplicationConfig {
@@ -87,6 +94,8 @@ impl ReplicationConfig {
             max_batch_size: 1000,
             region: "local".to_string(),
             quorum: QuorumConfig::async_commit(),
+            slot_retention_max_lag_lsn: DEFAULT_SLOT_RETENTION_MAX_LAG_LSN,
+            slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
         }
     }
 
@@ -98,6 +107,8 @@ impl ReplicationConfig {
             max_batch_size: 1000,
             region: "local".to_string(),
             quorum: QuorumConfig::async_commit(),
+            slot_retention_max_lag_lsn: DEFAULT_SLOT_RETENTION_MAX_LAG_LSN,
+            slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
         }
     }
 
@@ -111,6 +122,8 @@ impl ReplicationConfig {
             max_batch_size: 1000,
             region: "local".to_string(),
             quorum: QuorumConfig::async_commit(),
+            slot_retention_max_lag_lsn: DEFAULT_SLOT_RETENTION_MAX_LAG_LSN,
+            slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
         }
     }
 
@@ -129,6 +142,16 @@ impl ReplicationConfig {
     /// Set the replication term stamped into newly produced records.
     pub fn with_term(mut self, term: u64) -> Self {
         self.term = term;
+        self
+    }
+
+    pub fn with_slot_retention_max_lag_lsn(mut self, max_lag_lsn: u64) -> Self {
+        self.slot_retention_max_lag_lsn = max_lag_lsn;
+        self
+    }
+
+    pub fn with_slot_idle_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.slot_idle_timeout_ms = timeout_ms;
         self
     }
 }

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -644,14 +644,43 @@ fn read_one_v1(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SlotInvalidationCause {
+    WalRemoved,
+    Horizon,
+    IdleTimeout,
+}
+
+impl SlotInvalidationCause {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::WalRemoved => "wal-removed",
+            Self::Horizon => "horizon",
+            Self::IdleTimeout => "idle-timeout",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "wal-removed" => Some(Self::WalRemoved),
+            "horizon" => Some(Self::Horizon),
+            "idle-timeout" => Some(Self::IdleTimeout),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ReplicationSlot {
     pub id: String,
     pub restart_lsn: u64,
     pub confirmed_lsn: u64,
+    pub last_seen_at_unix_ms: u128,
+    pub invalidation_reason: Option<SlotInvalidationCause>,
+    pub invalidated_at_unix_ms: Option<u128>,
 }
 
-fn load_replication_slots(path: Option<&Path>) -> BTreeMap<String, ReplicationSlot> {
+fn load_replication_slots(path: Option<&Path>, now_ms: u128) -> BTreeMap<String, ReplicationSlot> {
     let Some(path) = path else {
         return BTreeMap::new();
     };
@@ -679,12 +708,28 @@ fn load_replication_slots(path: Option<&Path>) -> BTreeMap<String, ReplicationSl
                 let id = object.get("id")?.as_str()?.to_string();
                 let restart_lsn = object.get("restart_lsn")?.as_u64()?;
                 let confirmed_lsn = object.get("confirmed_lsn")?.as_u64()?;
+                let last_seen_at_unix_ms = object
+                    .get("last_seen_at_unix_ms")
+                    .and_then(crate::serde_json::Value::as_u64)
+                    .map(u128::from)
+                    .unwrap_or(now_ms);
+                let invalidation_reason = object
+                    .get("invalidation_reason")
+                    .and_then(crate::serde_json::Value::as_str)
+                    .and_then(SlotInvalidationCause::from_str);
+                let invalidated_at_unix_ms = object
+                    .get("invalidated_at_unix_ms")
+                    .and_then(crate::serde_json::Value::as_u64)
+                    .map(u128::from);
                 Some((
                     id.clone(),
                     ReplicationSlot {
                         id,
                         restart_lsn,
                         confirmed_lsn,
+                        last_seen_at_unix_ms,
+                        invalidation_reason,
+                        invalidated_at_unix_ms,
                     },
                 ))
             })
@@ -728,6 +773,22 @@ fn persist_replication_slots(
                 "confirmed_lsn".to_string(),
                 crate::serde_json::Value::Number(slot.confirmed_lsn as f64),
             );
+            object.insert(
+                "last_seen_at_unix_ms".to_string(),
+                crate::serde_json::Value::Number(slot.last_seen_at_unix_ms as f64),
+            );
+            if let Some(reason) = slot.invalidation_reason {
+                object.insert(
+                    "invalidation_reason".to_string(),
+                    crate::serde_json::Value::String(reason.as_str().to_string()),
+                );
+            }
+            if let Some(invalidated_at) = slot.invalidated_at_unix_ms {
+                object.insert(
+                    "invalidated_at_unix_ms".to_string(),
+                    crate::serde_json::Value::Number(invalidated_at as f64),
+                );
+            }
             crate::serde_json::Value::Object(object)
         })
         .collect();
@@ -799,6 +860,8 @@ pub struct PrimaryReplication {
     pub replicas: RwLock<Vec<ReplicaState>>,
     slot_path: Option<PathBuf>,
     slots: RwLock<BTreeMap<String, ReplicationSlot>>,
+    slot_retention_max_lag_lsn: u64,
+    slot_idle_timeout_ms: u64,
     /// PLAN.md Phase 11.4 — ack-driven commit synchronization. Always
     /// allocated so the policy enum can flip from `Local` to
     /// `AckN`/`Quorum` without touching this struct's shape.
@@ -826,8 +889,16 @@ impl PrimaryReplication {
     }
 
     pub fn new(data_path: Option<&Path>) -> Self {
+        Self::new_with_config(data_path, &crate::replication::ReplicationConfig::primary())
+    }
+
+    pub fn new_with_config(
+        data_path: Option<&Path>,
+        config: &crate::replication::ReplicationConfig,
+    ) -> Self {
+        let now_ms = crate::utils::now_unix_millis() as u128;
         let slot_path = data_path.map(Self::slot_path_for);
-        let slots = load_replication_slots(slot_path.as_deref());
+        let slots = load_replication_slots(slot_path.as_deref(), now_ms);
         Self {
             wal_buffer: Arc::new(WalBuffer::new(100_000)),
             logical_wal_spool: data_path
@@ -836,6 +907,8 @@ impl PrimaryReplication {
             replicas: RwLock::new(Vec::new()),
             slot_path,
             slots: RwLock::new(slots),
+            slot_retention_max_lag_lsn: config.slot_retention_max_lag_lsn,
+            slot_idle_timeout_ms: config.slot_idle_timeout_ms,
             commit_waiter: Arc::new(crate::replication::commit_waiter::CommitWaiter::new()),
             topology_epoch: std::sync::atomic::AtomicU64::new(0),
         }
@@ -962,7 +1035,7 @@ impl PrimaryReplication {
     /// `ack_n` / `quorum` can wake and re-check its threshold.
     pub fn ack_replica_lsn(&self, id: &str, applied_lsn: u64, durable_lsn: u64) {
         let now_ms = crate::utils::now_unix_millis() as u128;
-        self.advance_slot(id, applied_lsn, durable_lsn);
+        self.advance_slot(id, applied_lsn, durable_lsn, now_ms);
         let mut replicas = self.replicas.write().unwrap_or_else(|e| e.into_inner());
         if let Some(r) = replicas.iter_mut().find(|r| r.id == id) {
             r.last_acked_lsn = r.last_acked_lsn.max(applied_lsn);
@@ -982,6 +1055,7 @@ impl PrimaryReplication {
     /// from apply-side delay.
     pub fn note_replica_pull(&self, id: &str, last_sent_lsn: u64) {
         let now_ms = crate::utils::now_unix_millis() as u128;
+        self.touch_slot(id, now_ms);
         let mut replicas = self.replicas.write().unwrap_or_else(|e| e.into_inner());
         if let Some(r) = replicas.iter_mut().find(|r| r.id == id) {
             r.last_sent_lsn = r.last_sent_lsn.max(last_sent_lsn);
@@ -1018,11 +1092,13 @@ impl PrimaryReplication {
             .read()
             .unwrap_or_else(|e| e.into_inner())
             .values()
+            .filter(|slot| slot.invalidation_reason.is_none())
             .map(|slot| slot.restart_lsn)
             .min()
     }
 
     pub fn prune_retained_wal_through(&self, archived_lsn: u64) -> io::Result<u64> {
+        self.enforce_retention_limits(crate::utils::now_unix_millis() as u128);
         let prune_lsn = self
             .retention_floor_lsn()
             .map(|floor| floor.min(archived_lsn))
@@ -1051,9 +1127,13 @@ impl PrimaryReplication {
     }
 
     fn ensure_slot(&self, id: &str, initial_lsn: u64) -> u64 {
+        let now_ms = crate::utils::now_unix_millis() as u128;
         let mut slots = self.slots.write().unwrap_or_else(|e| e.into_inner());
-        if let Some(slot) = slots.get(id) {
-            return slot.restart_lsn;
+        if let Some(slot) = slots.get_mut(id) {
+            slot.last_seen_at_unix_ms = now_ms;
+            let restart_lsn = slot.restart_lsn;
+            self.persist_slots_locked(&slots);
+            return restart_lsn;
         }
         slots.insert(
             id.to_string(),
@@ -1061,6 +1141,9 @@ impl PrimaryReplication {
                 id: id.to_string(),
                 restart_lsn: initial_lsn,
                 confirmed_lsn: initial_lsn,
+                last_seen_at_unix_ms: now_ms,
+                invalidation_reason: None,
+                invalidated_at_unix_ms: None,
             },
         );
         let restart_lsn = initial_lsn;
@@ -1068,7 +1151,7 @@ impl PrimaryReplication {
         restart_lsn
     }
 
-    fn advance_slot(&self, id: &str, confirmed_lsn: u64, restart_lsn: u64) {
+    fn advance_slot(&self, id: &str, confirmed_lsn: u64, restart_lsn: u64, now_ms: u128) {
         let mut slots = self.slots.write().unwrap_or_else(|e| e.into_inner());
         let slot = slots
             .entry(id.to_string())
@@ -1076,10 +1159,88 @@ impl PrimaryReplication {
                 id: id.to_string(),
                 restart_lsn: 0,
                 confirmed_lsn: 0,
+                last_seen_at_unix_ms: now_ms,
+                invalidation_reason: None,
+                invalidated_at_unix_ms: None,
             });
+        if slot.invalidation_reason.is_some() {
+            return;
+        }
         slot.confirmed_lsn = slot.confirmed_lsn.max(confirmed_lsn).max(restart_lsn);
         slot.restart_lsn = slot.restart_lsn.max(restart_lsn);
+        slot.last_seen_at_unix_ms = now_ms;
         self.persist_slots_locked(&slots);
+    }
+
+    pub fn touch_slot(&self, id: &str, now_ms: u128) {
+        let mut slots = self.slots.write().unwrap_or_else(|e| e.into_inner());
+        let mut changed = false;
+        if let Some(slot) = slots.get_mut(id) {
+            if slot.invalidation_reason.is_none() {
+                slot.last_seen_at_unix_ms = now_ms;
+                changed = true;
+            }
+        }
+        if changed {
+            self.persist_slots_locked(&slots);
+        }
+    }
+
+    pub fn enforce_retention_limits(&self, now_ms: u128) -> Vec<(String, SlotInvalidationCause)> {
+        let current_lsn = self.current_logical_lsn();
+        let mut invalidated = Vec::new();
+        let mut slots = self.slots.write().unwrap_or_else(|e| e.into_inner());
+        for slot in slots.values_mut() {
+            if slot.invalidation_reason.is_some() {
+                continue;
+            }
+            let reason = if self.slot_retention_max_lag_lsn > 0
+                && current_lsn.saturating_sub(slot.restart_lsn) > self.slot_retention_max_lag_lsn
+            {
+                Some(SlotInvalidationCause::Horizon)
+            } else if self.slot_idle_timeout_ms > 0
+                && now_ms.saturating_sub(slot.last_seen_at_unix_ms)
+                    > u128::from(self.slot_idle_timeout_ms)
+            {
+                Some(SlotInvalidationCause::IdleTimeout)
+            } else {
+                None
+            };
+            if let Some(reason) = reason {
+                slot.invalidation_reason = Some(reason);
+                slot.invalidated_at_unix_ms = Some(now_ms);
+                invalidated.push((slot.id.clone(), reason));
+            }
+        }
+        if !invalidated.is_empty() {
+            self.persist_slots_locked(&slots);
+        }
+        invalidated
+    }
+
+    pub fn slot_rebootstrap_reason(
+        &self,
+        id: &str,
+        requested_since_lsn: u64,
+        oldest_available_lsn: Option<u64>,
+    ) -> Option<SlotInvalidationCause> {
+        let now_ms = crate::utils::now_unix_millis() as u128;
+        let mut slots = self.slots.write().unwrap_or_else(|e| e.into_inner());
+        let slot = slots.get_mut(id)?;
+        if let Some(reason) = slot.invalidation_reason {
+            return Some(reason);
+        }
+        let slot_floor = slot.restart_lsn.max(requested_since_lsn);
+        if oldest_available_lsn
+            .map(|oldest| oldest > slot_floor.saturating_add(1))
+            .unwrap_or(false)
+        {
+            slot.invalidation_reason = Some(SlotInvalidationCause::WalRemoved);
+            slot.invalidated_at_unix_ms = Some(now_ms);
+            self.persist_slots_locked(&slots);
+            return Some(SlotInvalidationCause::WalRemoved);
+        }
+        None
     }
 
     fn persist_slots_locked(&self, slots: &BTreeMap<String, ReplicationSlot>) {
@@ -1366,6 +1527,102 @@ mod tests {
             .map(|(lsn, _)| lsn)
             .collect();
         assert_eq!(retained, vec![6]);
+    }
+
+    #[test]
+    fn default_config_enables_finite_slot_retention_cap() {
+        let config = crate::replication::ReplicationConfig::primary();
+
+        assert!(
+            config.slot_retention_max_lag_lsn > 0,
+            "primary replication must default to a finite slot retention cap"
+        );
+    }
+
+    #[test]
+    fn retention_cap_invalidates_slow_slot_and_releases_wal_floor() {
+        let primary = PrimaryReplication::new_with_config(
+            None,
+            &crate::replication::ReplicationConfig::primary().with_slot_retention_max_lag_lsn(3),
+        );
+        primary.register_replica("fast".to_string());
+        primary.register_replica("slow".to_string());
+
+        for lsn in 1..=6 {
+            primary.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+        primary.ack_replica_lsn("fast", 6, 6);
+
+        assert_eq!(primary.prune_retained_wal_through(6).unwrap(), 6);
+
+        let slow = primary
+            .slot_snapshots()
+            .into_iter()
+            .find(|slot| slot.id == "slow")
+            .expect("slow slot present");
+        assert_eq!(
+            slow.invalidation_reason,
+            Some(SlotInvalidationCause::Horizon)
+        );
+
+        let retained: Vec<_> = primary
+            .wal_buffer
+            .read_since(0, usize::MAX)
+            .into_iter()
+            .map(|(lsn, _)| lsn)
+            .collect();
+        assert!(
+            retained.is_empty(),
+            "invalidated slow slot must not pin WAL"
+        );
+    }
+
+    #[test]
+    fn slot_invalidation_cause_codes_cover_wal_removed_horizon_and_idle_timeout() {
+        let wal_removed = PrimaryReplication::new_with_config(
+            None,
+            &crate::replication::ReplicationConfig::primary()
+                .with_slot_retention_max_lag_lsn(3)
+                .with_slot_idle_timeout_ms(10),
+        );
+        wal_removed.register_replica("wal".to_string());
+        assert_eq!(
+            wal_removed.slot_rebootstrap_reason("wal", 0, Some(2)),
+            Some(SlotInvalidationCause::WalRemoved)
+        );
+
+        let horizon = PrimaryReplication::new_with_config(
+            None,
+            &crate::replication::ReplicationConfig::primary().with_slot_retention_max_lag_lsn(3),
+        );
+        horizon.register_replica("horizon".to_string());
+        for lsn in 1..=4 {
+            horizon.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+        horizon.enforce_retention_limits(0);
+        assert_eq!(
+            horizon
+                .slot_snapshots()
+                .into_iter()
+                .find(|slot| slot.id == "horizon")
+                .and_then(|slot| slot.invalidation_reason),
+            Some(SlotInvalidationCause::Horizon)
+        );
+
+        let idle = PrimaryReplication::new_with_config(
+            None,
+            &crate::replication::ReplicationConfig::primary().with_slot_idle_timeout_ms(10),
+        );
+        idle.register_replica("idle".to_string());
+        idle.touch_slot("idle", 1);
+        idle.enforce_retention_limits(12);
+        assert_eq!(
+            idle.slot_snapshots()
+                .into_iter()
+                .find(|slot| slot.id == "idle")
+                .and_then(|slot| slot.invalidation_reason),
+            Some(SlotInvalidationCause::IdleTimeout)
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4788,13 +4788,31 @@ impl RedDBRuntime {
                         let oldest_available_lsn = value
                             .get("oldest_available_lsn")
                             .and_then(crate::json::Value::as_u64);
+                        if value
+                            .get("needs_rebootstrap")
+                            .and_then(crate::json::Value::as_bool)
+                            .unwrap_or(false)
+                        {
+                            let reason = value
+                                .get("invalidation_reason")
+                                .and_then(crate::json::Value::as_str)
+                                .unwrap_or("unknown");
+                            self.persist_replication_health(
+                                "rebootstrap_required",
+                                &format!("replication slot invalidated ({reason}); re-bootstrap required"),
+                                current_lsn,
+                                oldest_available_lsn,
+                            );
+                            std::thread::sleep(std::time::Duration::from_millis(poll_ms.max(250)));
+                            continue;
+                        }
                         if since_lsn > 0
                             && oldest_available_lsn
                                 .map(|oldest| oldest > since_lsn.saturating_add(1))
                                 .unwrap_or(false)
                         {
                             self.persist_replication_health(
-                                "stalled_gap",
+                                "rebootstrap_required",
                                 "replica is behind the oldest logical WAL available on primary; re-bootstrap required",
                                 current_lsn,
                                 oldest_available_lsn,

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -79,6 +79,16 @@ impl RedDBServer {
                                 "confirmed_lsn".to_string(),
                                 JsonValue::Number(slot.confirmed_lsn as f64),
                             );
+                            slot_json.insert(
+                                "invalidated".to_string(),
+                                JsonValue::Bool(slot.invalidation_reason.is_some()),
+                            );
+                            if let Some(reason) = slot.invalidation_reason {
+                                slot_json.insert(
+                                    "invalidation_reason".to_string(),
+                                    JsonValue::String(reason.as_str().to_string()),
+                                );
+                            }
                             JsonValue::Object(slot_json)
                         })
                         .collect();
@@ -145,5 +155,46 @@ impl RedDBServer {
                 JsonValue::Object(object)
             },
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replication::ReplicationConfig;
+    use crate::runtime::RedDBRuntime;
+    use crate::RedDBOptions;
+
+    #[test]
+    fn replication_status_surfaces_slot_invalidation_reason() {
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory()
+                .with_replication(ReplicationConfig::primary().with_slot_retention_max_lag_lsn(3)),
+        )
+        .expect("runtime");
+        let db = runtime.db();
+        let primary = db.replication.as_ref().expect("primary replication");
+        primary.register_replica("slow".to_string());
+        let spool = primary
+            .logical_wal_spool
+            .as_ref()
+            .expect("logical WAL spool");
+        for lsn in 1..=4 {
+            spool
+                .append_with_term_and_timestamp(1, lsn, lsn, &[lsn as u8])
+                .expect("append logical WAL");
+        }
+        primary.enforce_retention_limits(0);
+
+        let server = RedDBServer::new(runtime);
+        let response = server.handle_replication_status();
+        let body = String::from_utf8(response.body).expect("status body is utf8");
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains(r#""invalidated":true"#), "{body}");
+        assert!(
+            body.contains(r#""invalidation_reason":"horizon""#),
+            "{body}"
+        );
     }
 }

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -320,7 +320,10 @@ impl RedDB {
 
         // Initialize primary replication state if configured as primary.
         let replication = match &options.replication.role {
-            ReplicationRole::Primary => Some(Arc::new(PrimaryReplication::new(path.as_deref()))),
+            ReplicationRole::Primary => Some(Arc::new(PrimaryReplication::new_with_config(
+                path.as_deref(),
+                &options.replication,
+            ))),
             _ => None,
         };
 


### PR DESCRIPTION
Automated AFK landing for #825. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782755964&installation_id=129708444&pr_number=849&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F849&signature=33b44c21f4906a81427b567478bf44ceae7f87daa9f04c416d20b316a484c53b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replication slots now track invalidation status with detailed reasons (WAL removal, horizon limit, idle timeout).
  * Replication status API now reports slot invalidation information.

* **Improvements**
  * Enhanced replica rebootstrap detection with faster signaling when slots become invalid.
  * Added configurable slot retention and idle timeout parameters for better WAL management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->