### PR TITLE
merge: #827 Replication: causal bookmarks — token, causal session carry, read-your-writes on one node

### DIFF
--- a/crates/reddb-server/src/grpc.rs
+++ b/crates/reddb-server/src/grpc.rs
@@ -656,6 +656,7 @@ mod grpc_ask_query_reply_tests {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         }
     }
 
@@ -732,6 +733,7 @@ mod grpc_ask_query_reply_tests {
                 result,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             },
             &None,
             &None,

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -75,6 +75,12 @@ pub(crate) fn runtime_query_json(
             JsonValue::String(result.statement_type.to_string()),
         );
     }
+    if let Some(bookmark) = result.bookmark.as_deref() {
+        object.insert(
+            "bookmark".to_string(),
+            JsonValue::String(bookmark.to_string()),
+        );
+    }
     object.insert(
         "result".to_string(),
         unified_result_json_with_records(&result.result, &records),
@@ -1128,6 +1134,7 @@ mod descriptor_tests {
             result: unified,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         };
 
         let json = runtime_query_json(&runtime_result, &None, &None);

--- a/crates/reddb-server/src/replication/bookmark.rs
+++ b/crates/reddb-server/src/replication/bookmark.rs
@@ -1,0 +1,58 @@
+//! Causal bookmark token helpers.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CausalBookmark {
+    term: u64,
+    commit_lsn: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BookmarkDecodeError {
+    InvalidPrefix,
+    InvalidLength,
+    InvalidHex,
+}
+
+impl std::fmt::Display for BookmarkDecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPrefix => write!(f, "invalid causal bookmark prefix"),
+            Self::InvalidLength => write!(f, "invalid causal bookmark length"),
+            Self::InvalidHex => write!(f, "invalid causal bookmark hex payload"),
+        }
+    }
+}
+
+impl std::error::Error for BookmarkDecodeError {}
+
+impl CausalBookmark {
+    pub fn new(term: u64, commit_lsn: u64) -> Self {
+        Self { term, commit_lsn }
+    }
+
+    pub fn term(self) -> u64 {
+        self.term
+    }
+
+    pub fn commit_lsn(self) -> u64 {
+        self.commit_lsn
+    }
+
+    pub fn encode(self) -> String {
+        format!("rbm1.{:016x}{:016x}", self.term, self.commit_lsn)
+    }
+
+    pub fn decode(token: &str) -> Result<Self, BookmarkDecodeError> {
+        let Some(payload) = token.strip_prefix("rbm1.") else {
+            return Err(BookmarkDecodeError::InvalidPrefix);
+        };
+        if payload.len() != 32 {
+            return Err(BookmarkDecodeError::InvalidLength);
+        }
+        let term =
+            u64::from_str_radix(&payload[..16], 16).map_err(|_| BookmarkDecodeError::InvalidHex)?;
+        let commit_lsn =
+            u64::from_str_radix(&payload[16..], 16).map_err(|_| BookmarkDecodeError::InvalidHex)?;
+        Ok(Self { term, commit_lsn })
+    }
+}

--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -1,7 +1,7 @@
 //! Logical replication helpers shared by replica apply and point-in-time restore.
 
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Mutex;
+use std::sync::{Condvar, Mutex};
 
 use crate::api::{RedDBError, RedDBResult};
 use crate::application::entity::metadata_from_json;
@@ -161,6 +161,41 @@ impl std::fmt::Display for LogicalApplyError {
 
 impl std::error::Error for LogicalApplyError {}
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BookmarkWaitError {
+    Timeout { target_lsn: u64, applied_lsn: u64 },
+    TermMismatch { target_term: u64, applied_term: u64 },
+}
+
+impl BookmarkWaitError {
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, Self::Timeout { .. })
+    }
+}
+
+impl std::fmt::Display for BookmarkWaitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout {
+                target_lsn,
+                applied_lsn,
+            } => write!(
+                f,
+                "timed out waiting for causal bookmark lsn {target_lsn}; applied={applied_lsn}"
+            ),
+            Self::TermMismatch {
+                target_term,
+                applied_term,
+            } => write!(
+                f,
+                "causal bookmark term mismatch: target={target_term} applied={applied_term}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for BookmarkWaitError {}
+
 /// Shared logical change applier so replica replay and PITR converge on the
 /// same semantics. Stateful (PLAN.md Phase 11.5): tracks the last applied
 /// LSN + payload hash so duplicates / older LSNs / gaps / divergences are
@@ -168,7 +203,9 @@ impl std::error::Error for LogicalApplyError {}
 pub struct LogicalChangeApplier {
     last_applied_term: AtomicU64,
     last_applied_lsn: AtomicU64,
+    received_frontier_lsn: AtomicU64,
     last_payload_hash: Mutex<Option<[u8; 32]>>,
+    apply_wait: (Mutex<()>, Condvar),
     /// Issue #814 — metrics the apply path bumps when a record runs
     /// against a missing target. The production replica loop shares the
     /// runtime's `ReplicaApplyMetrics` here so `/metrics` surfaces misses;
@@ -196,7 +233,9 @@ impl LogicalChangeApplier {
         Self {
             last_applied_term: AtomicU64::new(crate::replication::DEFAULT_REPLICATION_TERM),
             last_applied_lsn: AtomicU64::new(starting_lsn),
+            received_frontier_lsn: AtomicU64::new(starting_lsn),
             last_payload_hash: Mutex::new(None),
+            apply_wait: (Mutex::new(()), Condvar::new()),
             metrics,
         }
     }
@@ -210,8 +249,58 @@ impl LogicalChangeApplier {
         self.last_applied_lsn.load(Ordering::Acquire)
     }
 
+    pub fn received_frontier_lsn(&self) -> u64 {
+        self.received_frontier_lsn.load(Ordering::Acquire)
+    }
+
     pub fn last_applied_term(&self) -> u64 {
         self.last_applied_term.load(Ordering::Acquire)
+    }
+
+    pub fn wait_for_bookmark(
+        &self,
+        bookmark: &crate::replication::CausalBookmark,
+        timeout: std::time::Duration,
+    ) -> Result<(), BookmarkWaitError> {
+        let deadline = std::time::Instant::now() + timeout;
+        let target_lsn = bookmark.commit_lsn();
+        let target_term = bookmark.term();
+
+        let mut guard = self.apply_wait.0.lock().expect("apply wait mutex");
+        loop {
+            let applied_lsn = self.last_applied_lsn();
+            let applied_term = self.last_applied_term();
+            if applied_lsn >= target_lsn {
+                if applied_term == target_term {
+                    return Ok(());
+                }
+                return Err(BookmarkWaitError::TermMismatch {
+                    target_term,
+                    applied_term,
+                });
+            }
+
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Err(BookmarkWaitError::Timeout {
+                    target_lsn,
+                    applied_lsn,
+                });
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (next_guard, wait_result) = self
+                .apply_wait
+                .1
+                .wait_timeout(guard, remaining)
+                .expect("apply wait condvar");
+            guard = next_guard;
+            if wait_result.timed_out() {
+                return Err(BookmarkWaitError::Timeout {
+                    target_lsn,
+                    applied_lsn: self.last_applied_lsn(),
+                });
+            }
+        }
     }
 
     /// Apply one logical change record. The state machine:
@@ -230,12 +319,15 @@ impl LogicalChangeApplier {
         let last = self.last_applied_lsn.load(Ordering::Acquire);
         let last_term = self.last_applied_term.load(Ordering::Acquire);
         let payload_hash = record_payload_hash(record);
+        self.received_frontier_lsn
+            .fetch_max(record.lsn, Ordering::AcqRel);
 
         if last == 0 && record.lsn > 0 {
             self.do_apply(db, record, mode)?;
             self.last_applied_term.store(record.term, Ordering::Release);
             self.last_applied_lsn.store(record.lsn, Ordering::Release);
             *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
+            self.apply_wait.1.notify_all();
             return Ok(ApplyOutcome::Applied);
         }
 
@@ -267,6 +359,7 @@ impl LogicalChangeApplier {
         self.last_applied_term.store(record.term, Ordering::Release);
         self.last_applied_lsn.store(record.lsn, Ordering::Release);
         *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
+        self.apply_wait.1.notify_all();
         Ok(ApplyOutcome::Applied)
     }
 

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -20,6 +20,7 @@
 //!     .with_replication(ReplicationConfig::replica("http://primary:50051"));
 //! ```
 
+pub mod bookmark;
 pub mod cdc;
 pub mod commit_policy;
 pub mod commit_waiter;
@@ -31,6 +32,7 @@ pub mod replica;
 pub mod scheduler;
 pub mod topology_advertiser;
 
+pub use bookmark::{BookmarkDecodeError, CausalBookmark};
 pub use commit_policy::CommitPolicy;
 pub use commit_waiter::{AwaitOutcome, CommitWaiter};
 pub use lease::{LeaseError, LeaseStore, WriterLease};

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -2354,6 +2354,7 @@ mod tests {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         });
 
         let payload = json
@@ -2539,6 +2540,7 @@ mod tests {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         });
 
         assert_eq!(

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -481,6 +481,7 @@ pub struct RuntimeQueryResult {
     pub affected_rows: u64,
     /// High-level statement type: "select", "insert", "update", "delete", "create", "drop", "alter"
     pub statement_type: &'static str,
+    pub bookmark: Option<String>,
 }
 
 impl RuntimeQueryResult {
@@ -499,6 +500,7 @@ impl RuntimeQueryResult {
             result: UnifiedResult::empty(),
             affected_rows: affected,
             statement_type,
+            bookmark: None,
         }
     }
 
@@ -518,6 +520,7 @@ impl RuntimeQueryResult {
             result,
             affected_rows: 0,
             statement_type,
+            bookmark: None,
         }
     }
 
@@ -548,7 +551,12 @@ impl RuntimeQueryResult {
             result,
             affected_rows: 0,
             statement_type,
+            bookmark: None,
         }
+    }
+
+    pub fn bookmark_token(&self) -> Option<&str> {
+        self.bookmark.as_deref()
     }
 }
 
@@ -1257,6 +1265,46 @@ pub struct RedDBRuntime {
 pub struct RuntimeConnection {
     id: u64,
     inner: Arc<RuntimeInner>,
+}
+
+pub struct CausalSession {
+    runtime: RedDBRuntime,
+    bookmark: Option<crate::replication::CausalBookmark>,
+    wait_timeout: std::time::Duration,
+}
+
+impl CausalSession {
+    pub fn bookmark_token(&self) -> Option<String> {
+        self.bookmark.map(|bookmark| bookmark.encode())
+    }
+
+    pub fn inject_bookmark(&mut self, token: &str) -> RedDBResult<()> {
+        let bookmark = crate::replication::CausalBookmark::decode(token)
+            .map_err(|err| RedDBError::InvalidOperation(err.to_string()))?;
+        self.bookmark = Some(bookmark);
+        Ok(())
+    }
+
+    pub fn execute_query(&mut self, query: &str) -> RedDBResult<RuntimeQueryResult> {
+        if is_select_query_text(query) {
+            if let Some(bookmark) = self.bookmark {
+                self.runtime
+                    .wait_for_bookmark(&bookmark, self.wait_timeout)?;
+            }
+        }
+        let result = self.runtime.execute_query(query)?;
+        if let Some(token) = result.bookmark.as_deref() {
+            self.inject_bookmark(token)?;
+        }
+        Ok(result)
+    }
+}
+
+fn is_select_query_text(query: &str) -> bool {
+    query
+        .trim_start()
+        .get(..6)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("select"))
 }
 
 pub mod ai;

--- a/crates/reddb-server/src/runtime/impl_config.rs
+++ b/crates/reddb-server/src/runtime/impl_config.rs
@@ -289,6 +289,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             Err(err) => {
@@ -720,6 +721,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -772,6 +774,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -833,6 +836,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -884,6 +888,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "stream",
+            bookmark: None,
         })
     }
 
@@ -1617,6 +1622,7 @@ fn config_write_output(
         } else {
             "update"
         },
+        bookmark: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2445,6 +2445,7 @@ fn decode_result_cache_payload(mut input: &[u8]) -> Option<(RuntimeQueryResult, 
             },
             affected_rows,
             statement_type,
+            bookmark: None,
         },
         scopes,
     ))
@@ -5999,7 +6000,58 @@ impl RedDBRuntime {
             .slow_query_logger
             .record(kind, elapsed_ms, query.to_string(), &scope);
 
+        if let Ok(ref mut query_result) = result {
+            if matches!(query_result.statement_type, "insert" | "update" | "delete") {
+                let bookmark = crate::replication::CausalBookmark::new(
+                    self.current_replication_term(),
+                    self.cdc_current_lsn(),
+                );
+                query_result.bookmark = Some(bookmark.encode());
+            }
+        }
+
         result
+    }
+
+    pub fn causal_session(&self) -> crate::runtime::CausalSession {
+        crate::runtime::CausalSession {
+            runtime: self.clone(),
+            bookmark: None,
+            wait_timeout: std::time::Duration::from_secs(5),
+        }
+    }
+
+    pub fn wait_for_bookmark(
+        &self,
+        bookmark: &crate::replication::CausalBookmark,
+        timeout: std::time::Duration,
+    ) -> RedDBResult<()> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let applied_lsn = self.local_contiguous_applied_lsn();
+            if applied_lsn >= bookmark.commit_lsn() {
+                return Ok(());
+            }
+            let now = std::time::Instant::now();
+            if now >= deadline {
+                return Err(RedDBError::InvalidOperation(format!(
+                    "timed out waiting for causal bookmark lsn {}; applied={}",
+                    bookmark.commit_lsn(),
+                    applied_lsn
+                )));
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            std::thread::sleep(remaining.min(std::time::Duration::from_millis(5)));
+        }
+    }
+
+    fn local_contiguous_applied_lsn(&self) -> u64 {
+        match self.inner.db.options().replication.role {
+            crate::replication::ReplicationRole::Replica { .. } => {
+                self.config_u64("red.replication.last_applied_lsn", 0)
+            }
+            _ => self.cdc_current_lsn(),
+        }
     }
 
     #[inline(never)]
@@ -6195,6 +6247,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueryExpr::Table(table) => {
@@ -6226,6 +6279,7 @@ impl RedDBRuntime {
                         result: self.execute_table_function(&name, &args, &named_args)?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     };
                     frame.write_result_cache(self, &tvf_result, result_cache_scopes.clone());
                     return Ok(tvf_result);
@@ -6257,6 +6311,7 @@ impl RedDBRuntime {
                         )?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     };
                     frame.write_result_cache(self, &inline_result, result_cache_scopes);
                     return Ok(inline_result);
@@ -6275,6 +6330,7 @@ impl RedDBRuntime {
                         )?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
 
@@ -6293,6 +6349,7 @@ impl RedDBRuntime {
                         result: view_result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
 
@@ -6305,6 +6362,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
 
@@ -6330,6 +6388,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
 
@@ -6363,6 +6422,7 @@ impl RedDBRuntime {
                         result: empty,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -6377,6 +6437,7 @@ impl RedDBRuntime {
                     )?,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueryExpr::Join(join) => {
@@ -6402,6 +6463,7 @@ impl RedDBRuntime {
                             result: crate::storage::query::unified::UnifiedResult::empty(),
                             affected_rows: 0,
                             statement_type: "select",
+                            bookmark: None,
                         });
                     }
                 };
@@ -6413,6 +6475,7 @@ impl RedDBRuntime {
                     result: execute_runtime_join_query(&self.inner.db, &join_with_rls)?,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueryExpr::Vector(vector) => Ok(RuntimeQueryResult {
@@ -6423,6 +6486,7 @@ impl RedDBRuntime {
                 result: execute_runtime_vector_query(&self.inner.db, &vector)?,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             }),
             QueryExpr::Hybrid(hybrid) => Ok(RuntimeQueryResult {
                 query: query.to_string(),
@@ -6432,6 +6496,7 @@ impl RedDBRuntime {
                 result: execute_runtime_hybrid_query(&self.inner.db, &hybrid)?,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             }),
             // DML execution
             QueryExpr::Insert(ref insert) if super::red_schema::is_virtual_table(&insert.table) => {
@@ -6642,6 +6707,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             // SHOW CONFIG [prefix]
@@ -6658,6 +6724,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 let manager = store
@@ -6704,6 +6771,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             // Session-local multi-tenancy handle (Phase 2.5.3).
@@ -6741,6 +6809,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             // Transaction control (Phase 2.3 PG parity).
@@ -8668,6 +8737,7 @@ impl RedDBRuntime {
                         result: self.execute_table_function(&name, &args, &named_args)?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 // Inline-graph TVF (issue #799) on the prepared-statement /
@@ -8693,6 +8763,7 @@ impl RedDBRuntime {
                         )?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 if super::red_schema::is_virtual_table(&table.table) {
@@ -8709,6 +8780,7 @@ impl RedDBRuntime {
                         )?,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 // `<graph>.<output>` analytics virtual view (issue #800).
@@ -8724,6 +8796,7 @@ impl RedDBRuntime {
                         result: view_result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 let Some(table_with_rls) = self.authorize_relational_table_select(
@@ -8739,6 +8812,7 @@ impl RedDBRuntime {
                         result: crate::storage::query::unified::UnifiedResult::empty(),
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -8753,6 +8827,7 @@ impl RedDBRuntime {
                     )?,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueryExpr::Join(join) => {
@@ -8770,6 +8845,7 @@ impl RedDBRuntime {
                         result: crate::storage::query::unified::UnifiedResult::empty(),
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -8780,6 +8856,7 @@ impl RedDBRuntime {
                     result: execute_runtime_join_query(&self.inner.db, &join_with_rls)?,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueryExpr::Vector(vector) => Ok(RuntimeQueryResult {
@@ -8790,6 +8867,7 @@ impl RedDBRuntime {
                 result: execute_runtime_vector_query(&self.inner.db, &vector)?,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             }),
             QueryExpr::Hybrid(hybrid) => Ok(RuntimeQueryResult {
                 query: query_str.to_string(),
@@ -8799,6 +8877,7 @@ impl RedDBRuntime {
                 result: execute_runtime_hybrid_query(&self.inner.db, &hybrid)?,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             }),
             QueryExpr::Insert(ref insert) if super::red_schema::is_virtual_table(&insert.table) => {
                 Err(RedDBError::Query(
@@ -9387,6 +9466,7 @@ impl RedDBRuntime {
             },
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         }))
     }
 
@@ -10993,6 +11073,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -12972,6 +13053,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -13046,6 +13128,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -13142,6 +13225,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -13312,6 +13396,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -13389,6 +13474,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 }

--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -241,5 +241,6 @@ fn backfill_result(
         result,
         affected_rows: enqueued,
         statement_type: "insert",
+        bookmark: None,
     }
 }

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -52,6 +52,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::ShortestPath {
@@ -109,6 +110,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Properties { source } => {
@@ -175,6 +177,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
                 let res = self.graph_properties(None)?;
@@ -202,6 +205,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Traverse {
@@ -243,6 +247,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Centrality {
@@ -297,6 +302,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Community {
@@ -357,6 +363,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Components {
@@ -388,6 +395,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Cycles { max_length } => {
@@ -408,6 +416,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::Clustering => {
@@ -438,6 +447,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             GraphCommand::TopologicalSort => {
@@ -462,6 +472,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
         }
@@ -577,6 +588,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::Text {
@@ -634,6 +646,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::Hybrid {
@@ -678,6 +691,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::Multimodal {
@@ -711,6 +725,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::Index {
@@ -753,6 +768,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::Context {
@@ -830,6 +846,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::SpatialRadius {
@@ -884,6 +901,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::SpatialBbox {
@@ -933,6 +951,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             SearchCommand::SpatialNearest {
@@ -983,6 +1002,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
         }

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -1368,6 +1368,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 1,
                     statement_type: if created { "insert" } else { "update" },
+                    bookmark: None,
                 })
             }
             KvCommand::InvalidateTags { collection, tags } => {
@@ -1394,6 +1395,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: invalidated as u64,
                     statement_type: "delete",
+                    bookmark: None,
                 })
             }
 
@@ -1523,6 +1525,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
 
@@ -1564,6 +1567,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
 
@@ -1633,6 +1637,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: purged as u64,
                     statement_type: "delete",
+                    bookmark: None,
                 })
             }
 
@@ -1679,6 +1684,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     });
                 }
 
@@ -1727,6 +1733,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             KvCommand::Watch {
@@ -1781,6 +1788,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "stream",
+                    bookmark: None,
                 })
             }
 
@@ -1909,6 +1917,7 @@ impl RedDBRuntime {
                             result,
                             affected_rows: 0,
                             statement_type: "select",
+                            bookmark: None,
                         })
                     }
                     Err(err) => {
@@ -1966,6 +1975,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 1,
                     statement_type: "update",
+                    bookmark: None,
                 })
             }
 
@@ -2011,6 +2021,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: if ok { 1 } else { 0 },
                     statement_type: "update",
+                    bookmark: None,
                 })
             }
 
@@ -2081,6 +2092,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: if deleted { 1 } else { 0 },
                     statement_type: "delete",
+                    bookmark: None,
                 })
             }
         }
@@ -2228,6 +2240,7 @@ fn vault_write_result(
         result,
         affected_rows,
         statement_type,
+        bookmark: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -396,6 +396,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     })
                 } else {
                     // Multi-HLL count = union count
@@ -419,6 +420,7 @@ impl RedDBRuntime {
                         result,
                         affected_rows: 0,
                         statement_type: "select",
+                        bookmark: None,
                     })
                 }
             }
@@ -473,6 +475,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::DropHll { name, if_exists } => {
@@ -588,6 +591,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::SketchMerge { dest, sources } => {
@@ -662,6 +666,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::DropSketch { name, if_exists } => {
@@ -772,6 +777,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::FilterDelete { name, element } => {
@@ -818,6 +824,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::FilterInfo { name } => {
@@ -851,6 +858,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             ProbabilisticCommand::DropFilter { name, if_exists } => {

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -799,6 +799,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 1,
                     statement_type: "insert",
+                    bookmark: None,
                 })
             }
             QueueCommand::Pop { queue, side, count } => {
@@ -833,6 +834,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: popped_count,
                     statement_type: "delete",
+                    bookmark: None,
                 })
             }
             QueueCommand::Peek { queue, count } => {
@@ -861,6 +863,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueueCommand::Len { queue } => {
@@ -882,6 +885,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueueCommand::Purge { queue } => {
@@ -1016,6 +1020,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueueCommand::Pending { queue, group } => {
@@ -1065,6 +1070,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows: 0,
                     statement_type: "select",
+                    bookmark: None,
                 })
             }
             QueueCommand::Claim {
@@ -1115,6 +1121,7 @@ impl RedDBRuntime {
                     result,
                     affected_rows,
                     statement_type: "update",
+                    bookmark: None,
                 })
             }
             QueueCommand::Ack {
@@ -1313,6 +1320,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -1443,6 +1451,7 @@ impl RedDBRuntime {
             result,
             affected_rows: selected_count,
             statement_type: "update",
+            bookmark: None,
         })
     }
 

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1632,6 +1632,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 
@@ -1730,6 +1731,7 @@ impl RedDBRuntime {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         })
     }
 

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -491,6 +491,7 @@ fn execute_pg_query_result(
                 result,
                 affected_rows: 0,
                 statement_type: "select",
+                bookmark: None,
             }),
             Ok(None) => {
                 run_runtime_blocking(|| runtime.execute_query(sql)).map_err(|err| err.to_string())
@@ -523,6 +524,7 @@ fn try_execute_pg_scalar_select(
         result,
         affected_rows: 0,
         statement_type: "select",
+        bookmark: None,
     })
 }
 
@@ -757,6 +759,7 @@ where
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         }),
         Ok(None) => run_runtime_blocking(|| runtime.execute_query(sql)),
         Err(err) => Err(err),
@@ -1358,6 +1361,7 @@ mod tests {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         };
 
         let mut out = Vec::new();

--- a/tests/e2e_issue_827_causal_bookmarks.rs
+++ b/tests/e2e_issue_827_causal_bookmarks.rs
@@ -1,0 +1,110 @@
+//! Issue #827 — causal bookmarks and contiguous replica apply waits.
+
+mod support;
+
+use std::time::Duration;
+
+use reddb::replication::cdc::ChangeRecord;
+use reddb::replication::logical::{ApplyMode, LogicalChangeApplier};
+use reddb::replication::{CausalBookmark, DEFAULT_REPLICATION_TERM};
+use reddb::storage::RedDB;
+use reddb::{RedDBOptions, RedDBRuntime, ReplicationConfig};
+
+fn temp_path(prefix: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "reddb-issue-827-{prefix}-{}-{}.rdb",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ))
+}
+
+fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
+    support::logical_insert_record("issue_827_users", lsn, 1000 + lsn, payload)
+}
+
+#[test]
+fn writes_return_opaque_bookmark_with_term_and_commit_lsn() {
+    let rt = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary().with_term(7)),
+    )
+    .expect("runtime");
+
+    rt.execute_query("CREATE TABLE issue_827_bookmark (id INT, name TEXT)")
+        .expect("create table");
+    let inserted = rt
+        .execute_query("INSERT INTO issue_827_bookmark (id, name) VALUES (1, 'ana')")
+        .expect("insert");
+
+    let token = inserted.bookmark.expect("write returns bookmark");
+    assert!(
+        token.starts_with("rbm1."),
+        "bookmark token should be opaque and versioned: {token}"
+    );
+
+    let bookmark = CausalBookmark::decode(&token).expect("bookmark decodes internally");
+    assert_eq!(bookmark.term(), 7);
+    assert_eq!(bookmark.commit_lsn(), rt.cdc_current_lsn());
+}
+
+#[test]
+fn causal_session_carries_extracts_and_injects_bookmark() {
+    let rt = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("runtime");
+    rt.execute_query("CREATE TABLE issue_827_session (id INT, name TEXT)")
+        .expect("create table");
+
+    let mut writer = rt.causal_session();
+    writer
+        .execute_query("INSERT INTO issue_827_session (id, name) VALUES (1, 'rio')")
+        .expect("insert through session");
+    let token = writer.bookmark_token().expect("session exposes bookmark");
+
+    let mut reader = rt.causal_session();
+    reader.inject_bookmark(&token).expect("inject bookmark");
+    let result = reader
+        .execute_query("SELECT name FROM issue_827_session WHERE id = 1")
+        .expect("causal read waits and succeeds");
+
+    assert_eq!(result.result.records.len(), 1);
+}
+
+#[test]
+fn bookmark_wait_uses_contiguous_applied_lsn_not_gappy_received_frontier() {
+    let path = temp_path("gap-wait");
+    let _ = std::fs::remove_file(&path);
+    let db = RedDB::open(&path).expect("db");
+    let applier = LogicalChangeApplier::new(0);
+
+    applier
+        .apply(&db, &record(1, b"a"), ApplyMode::Replica)
+        .expect("apply lsn 1");
+    let bookmark = CausalBookmark::new(DEFAULT_REPLICATION_TERM, 5);
+
+    let gap = applier
+        .apply(&db, &record(5, b"e"), ApplyMode::Replica)
+        .expect_err("later LSN with missing predecessors is gappy");
+    assert!(gap.to_string().contains("LSN gap"));
+    assert_eq!(applier.received_frontier_lsn(), 5);
+    assert_eq!(applier.last_applied_lsn(), 1);
+
+    let err = applier
+        .wait_for_bookmark(&bookmark, Duration::from_millis(25))
+        .expect_err("wait must not release on the gappy received frontier");
+    assert!(err.is_timeout(), "expected timeout, got {err:?}");
+
+    for lsn in 2..=5 {
+        applier
+            .apply(&db, &record(lsn, &[lsn as u8]), ApplyMode::Replica)
+            .unwrap_or_else(|err| panic!("apply lsn {lsn}: {err}"));
+    }
+    applier
+        .wait_for_bookmark(&bookmark, Duration::from_secs(1))
+        .expect("contiguous apply reaches bookmark");
+
+    let _ = std::fs::remove_file(&path);
+}


### PR DESCRIPTION
Automated AFK landing for #827. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782758484&installation_id=129708444&pr_number=862&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F862&signature=463f72331ff4981718aa9eefabe025b4ae38863e3021f450270a2b8c127dccfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query results now include optional bookmark tokens for causal consistency tracking.
  * New causal session API enables users to inject bookmark tokens and execute causally consistent queries, ensuring reads reflect previously committed writes.

* **Tests**
  * Added end-to-end tests validating causal bookmark functionality and replica apply semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->