### PR TITLE
merge: #828 Replication: tail-follow WAL streaming replaces 100ms polling

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2937,12 +2937,16 @@ impl RedDb for GrpcRuntime {
         let payload = parse_json_payload_allow_empty(&request.into_inner().payload_json)?;
         let mut since_lsn = json_usize_field(&payload, "since_lsn").unwrap_or(0) as u64;
         let max_count = json_usize_field(&payload, "max_count").unwrap_or(1000);
-        let current_lsn = repl
+        let await_data = json_bool_field(&payload, "await_data").unwrap_or(false);
+        let await_timeout_ms = json_usize_field(&payload, "await_timeout_ms")
+            .unwrap_or(30_000)
+            .clamp(1, 30_000) as u64;
+        let mut current_lsn = repl
             .logical_wal_spool
             .as_ref()
             .map(|spool| spool.current_lsn())
             .unwrap_or_else(|| repl.wal_buffer.current_lsn());
-        let oldest_available_lsn = repl
+        let mut oldest_available_lsn = repl
             .logical_wal_spool
             .as_ref()
             .and_then(|spool| spool.oldest_lsn().ok().flatten())
@@ -2977,6 +2981,26 @@ impl RedDb for GrpcRuntime {
             if let Some(slot) = repl.slot_snapshots().into_iter().find(|slot| slot.id == *id) {
                 since_lsn = since_lsn.max(slot.restart_lsn);
             }
+        }
+
+        if await_data && current_lsn <= since_lsn {
+            let repl_for_wait = repl.clone();
+            let timeout = std::time::Duration::from_millis(await_timeout_ms);
+            tokio::task::spawn_blocking(move || {
+                repl_for_wait.wait_for_logical_lsn_after(since_lsn, timeout)
+            })
+            .await
+            .map_err(|err| Status::internal(format!("await-data worker failed: {err}")))?;
+            current_lsn = repl
+                .logical_wal_spool
+                .as_ref()
+                .map(|spool| spool.current_lsn())
+                .unwrap_or_else(|| repl.wal_buffer.current_lsn());
+            oldest_available_lsn = repl
+                .logical_wal_spool
+                .as_ref()
+                .and_then(|spool| spool.oldest_lsn().ok().flatten())
+                .or_else(|| repl.wal_buffer.oldest_lsn());
         }
 
         let records = if let Some(spool) = &repl.logical_wal_spool {

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -51,8 +51,8 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, RwLock};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::{Arc, Condvar, Mutex, RwLock};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use tracing::warn;
 
@@ -860,6 +860,7 @@ pub struct PrimaryReplication {
     pub wal_buffer: Arc<WalBuffer>,
     pub logical_wal_spool: Option<Arc<LogicalWalSpool>>,
     pub replicas: RwLock<Vec<ReplicaState>>,
+    wal_appended: (Mutex<u64>, Condvar),
     slot_path: Option<PathBuf>,
     slots: RwLock<BTreeMap<String, ReplicationSlot>>,
     slot_retention_max_lag_lsn: u64,
@@ -901,12 +902,18 @@ impl PrimaryReplication {
         let now_ms = crate::utils::now_unix_millis() as u128;
         let slot_path = data_path.map(Self::slot_path_for);
         let slots = load_replication_slots(slot_path.as_deref(), now_ms);
+        let logical_wal_spool = data_path
+            .and_then(|path| LogicalWalSpool::open(path).ok())
+            .map(Arc::new);
+        let current_lsn = logical_wal_spool
+            .as_ref()
+            .map(|spool| spool.current_lsn())
+            .unwrap_or(0);
         Self {
             wal_buffer: Arc::new(WalBuffer::new(100_000)),
-            logical_wal_spool: data_path
-                .and_then(|path| LogicalWalSpool::open(path).ok())
-                .map(Arc::new),
+            logical_wal_spool,
             replicas: RwLock::new(Vec::new()),
+            wal_appended: (Mutex::new(current_lsn), Condvar::new()),
             slot_path,
             slots: RwLock::new(slots),
             slot_retention_max_lag_lsn: config.slot_retention_max_lag_lsn,
@@ -914,6 +921,41 @@ impl PrimaryReplication {
             commit_waiter: Arc::new(crate::replication::commit_waiter::CommitWaiter::new()),
             topology_epoch: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    pub fn append_logical_record(&self, lsn: u64, encoded: Vec<u8>) {
+        self.wal_buffer.append(lsn, encoded.clone());
+        if let Some(spool) = &self.logical_wal_spool {
+            let _ = spool.append(lsn, &encoded);
+        }
+        let (lock, cvar) = &self.wal_appended;
+        let mut latest = lock.lock().unwrap_or_else(|e| e.into_inner());
+        *latest = (*latest).max(lsn);
+        cvar.notify_all();
+    }
+
+    pub fn wait_for_logical_lsn_after(&self, since_lsn: u64, timeout: Duration) -> bool {
+        if self.current_logical_lsn() > since_lsn {
+            return true;
+        }
+        let deadline = Instant::now() + timeout;
+        let (lock, cvar) = &self.wal_appended;
+        let mut latest = lock.lock().unwrap_or_else(|e| e.into_inner());
+        while *latest <= since_lsn {
+            let now = Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let remaining = deadline.saturating_duration_since(now);
+            let (guard, result) = cvar
+                .wait_timeout(latest, remaining)
+                .unwrap_or_else(|e| e.into_inner());
+            latest = guard;
+            if result.timed_out() && *latest <= since_lsn {
+                return false;
+            }
+        }
+        true
     }
 
     pub fn register_replica(&self, id: String) -> u64 {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4455,10 +4455,7 @@ impl RedDBRuntime {
                 refresh_records: None,
             };
             let encoded = record.encode();
-            primary.wal_buffer.append(record.lsn, encoded.clone());
-            if let Some(spool) = &primary.logical_wal_spool {
-                let _ = spool.append(record.lsn, &encoded);
-            }
+            primary.append_logical_record(record.lsn, encoded);
         }
         lsn
     }
@@ -4543,10 +4540,7 @@ impl RedDBRuntime {
                 refresh_records: None,
             };
             let encoded = record.encode();
-            primary.wal_buffer.append(record.lsn, encoded.clone());
-            if let Some(spool) = &primary.logical_wal_spool {
-                let _ = spool.append(record.lsn, &encoded);
-            }
+            primary.append_logical_record(record.lsn, encoded);
         }
         lsn
     }
@@ -4674,10 +4668,7 @@ impl RedDBRuntime {
                 refresh_records: None,
             };
             let encoded = record.encode();
-            primary.wal_buffer.append(record.lsn, encoded.clone());
-            if let Some(spool) = &primary.logical_wal_spool {
-                let _ = spool.append(record.lsn, &encoded);
-            }
+            primary.append_logical_record(record.lsn, encoded);
         }
 
         lsn
@@ -4773,7 +4764,9 @@ impl RedDBRuntime {
                 let payload = crate::json!({
                     "since_lsn": since_lsn,
                     "max_count": max_count,
-                    "replica_id": replica_id
+                    "replica_id": replica_id,
+                    "await_data": true,
+                    "await_timeout_ms": 30_000
                 });
                 let request = tonic::Request::new(JsonPayloadRequest {
                     payload_json: crate::json::to_string(&payload)
@@ -4984,9 +4977,8 @@ impl RedDBRuntime {
                         None,
                         None,
                     );
+                    std::thread::sleep(std::time::Duration::from_millis(poll_ms.max(250)));
                 }
-
-                std::thread::sleep(std::time::Duration::from_millis(poll_ms));
             }
         });
     }
@@ -7407,10 +7399,7 @@ impl RedDBRuntime {
                             )
                             .with_term(self.current_replication_term());
                             let encoded = record.encode();
-                            primary.wal_buffer.append(record.lsn, encoded.clone());
-                            if let Some(spool) = &primary.logical_wal_spool {
-                                let _ = spool.append(record.lsn, &encoded);
-                            }
+                            primary.append_logical_record(record.lsn, encoded);
                         }
 
                         let duration_ms = started.elapsed().as_millis() as u64;

--- a/tests/e2e_issue_828_replication_tail_follow.rs
+++ b/tests/e2e_issue_828_replication_tail_follow.rs
@@ -1,0 +1,271 @@
+//! Issue #828 — replica WAL tail-follow stream with await-data semantics.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::JsonPayloadRequest;
+use reddb::replication::cdc::ChangeRecord;
+use reddb::replication::logical::{ApplyMode, LogicalChangeApplier};
+use reddb::replication::ReplicationConfig;
+use reddb::storage::RedDB;
+use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions, RedDBRuntime};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+
+use support::prometheus::get;
+
+fn pick_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
+    let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5));
+    RedDbClient::new(endpoint.connect().await.expect("client connect"))
+}
+
+fn install_replication_policy(store: &AuthStore, username: &str) {
+    let policy_json = format!(
+        r#"{{"id":"p_{username}_replication","version":1,"statements":[{{"effect":"allow","actions":["cluster:replication:stream","cluster:replication:ack"],"resources":["cluster:replication"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(
+            PrincipalRef::User(UserId::platform(username)),
+            &format!("p_{username}_replication"),
+        )
+        .expect("attach policy");
+}
+
+fn bearer_request(message: JsonPayloadRequest, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    let mut request = tonic::Request::new(message);
+    let value: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+fn pull_request(
+    replica_id: &str,
+    token: &str,
+    since_lsn: u64,
+    await_data: bool,
+) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","since_lsn":{since_lsn},"max_count":10,"await_data":{await_data},"await_timeout_ms":5000}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn ack_request(
+    replica_id: &str,
+    token: &str,
+    applied_lsn: u64,
+) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","applied_lsn":{applied_lsn},"durable_lsn":{applied_lsn}}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn parse_records(body: &serde_json::Value) -> Vec<ChangeRecord> {
+    body["records"]
+        .as_array()
+        .expect("records array")
+        .iter()
+        .map(|entry| {
+            let data = entry["data"].as_str().expect("record data hex");
+            let bytes = decode_hex(data).expect("record data decodes");
+            ChangeRecord::decode(&bytes).expect("change record decodes")
+        })
+        .collect()
+}
+
+fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
+    if s.len() % 2 != 0 {
+        return Err("hex input has odd length".to_string());
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    let bytes = s.as_bytes();
+    for pair in bytes.chunks_exact(2) {
+        let hi = hex_nibble(pair[0])?;
+        let lo = hex_nibble(pair[1])?;
+        out.push((hi << 4) | lo);
+    }
+    Ok(out)
+}
+
+fn hex_nibble(b: u8) -> Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(format!("invalid hex byte {b:#x}")),
+    }
+}
+
+fn metric_value(body: &str, prefix: &str) -> u64 {
+    for line in body.lines() {
+        if let Some(value) = line.strip_prefix(prefix) {
+            return value
+                .trim()
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("invalid metric value for {prefix:?}: {line}"));
+        }
+    }
+    panic!("metric line not found: {prefix:?}\n{body}");
+}
+
+#[tokio::test]
+async fn tail_follow_pull_waits_applies_and_resumes_from_slot() {
+    let primary = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("primary runtime");
+    primary
+        .execute_query("CREATE TABLE issue_828_tail (id INTEGER, name TEXT)")
+        .expect("create table");
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("replica_a", "p", Role::Read).unwrap();
+    let replica_key = store
+        .create_api_key("replica_a", "replication-a", Role::Read)
+        .unwrap();
+    install_replication_policy(&store, "replica_a");
+
+    let port = pick_port();
+    let server = RedDBGrpcServer::with_options(
+        primary.clone(),
+        GrpcServerOptions {
+            bind_addr: format!("127.0.0.1:{port}"),
+            tls: None,
+        },
+        store,
+    );
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port).await;
+
+    let mut client = connect_client(port).await;
+    let registered = client
+        .pull_wal_records(pull_request("replica_a", &replica_key.key, 0, false))
+        .await
+        .expect("register replica")
+        .into_inner();
+    let registered_body: serde_json::Value =
+        serde_json::from_str(&registered.payload).expect("registration body");
+    let slot_lsn = registered_body["current_lsn"]
+        .as_u64()
+        .expect("current_lsn");
+
+    let token = replica_key.key.clone();
+    let mut tail_client = connect_client(port).await;
+    let pending = tokio::spawn(async move {
+        tail_client
+            .pull_wal_records(pull_request("replica_a", &token, slot_lsn, true))
+            .await
+            .expect("await-data pull")
+            .into_inner()
+    });
+    tokio::time::sleep(Duration::from_millis(40)).await;
+    assert!(
+        !pending.is_finished(),
+        "await-data pull must wait for the next WAL record instead of returning an empty poll"
+    );
+
+    primary
+        .execute_query("INSERT INTO issue_828_tail (id, name) VALUES (1, 'one')")
+        .expect("insert first row");
+    let pushed = tokio::time::timeout(Duration::from_secs(2), pending)
+        .await
+        .expect("tail-follow pull returns after primary write")
+        .expect("tail task joins");
+    let pushed_body: serde_json::Value =
+        serde_json::from_str(&pushed.payload).expect("pushed body");
+    let records = parse_records(&pushed_body);
+    assert_eq!(records.len(), 1, "tail-follow pull returns the live record");
+    assert_eq!(records[0].lsn, slot_lsn + 1);
+
+    let replica = RedDB::new();
+    let applier = LogicalChangeApplier::new(slot_lsn);
+    applier
+        .apply(&replica, &records[0], ApplyMode::Replica)
+        .expect("replica applies pushed record");
+
+    client
+        .ack_replica_lsn(ack_request("replica_a", &replica_key.key, records[0].lsn))
+        .await
+        .expect("ack pushed record");
+    let (status, metrics) = get(primary.clone(), "/metrics");
+    assert_eq!(status, 200, "unexpected metrics response: {metrics}");
+    assert_eq!(
+        metric_value(
+            &metrics,
+            "reddb_replica_lag_records{replica_id=\"replica_a\"} "
+        ),
+        0,
+        "acked streamed apply should drive replica lag to zero without waiting for a poll tick"
+    );
+
+    primary
+        .execute_query("INSERT INTO issue_828_tail (id, name) VALUES (2, 'two')")
+        .expect("insert second row");
+    let resumed = client
+        .pull_wal_records(pull_request("replica_a", &replica_key.key, 0, false))
+        .await
+        .expect("resume from slot")
+        .into_inner();
+    let resumed_body: serde_json::Value =
+        serde_json::from_str(&resumed.payload).expect("resumed body");
+    let resumed_records = parse_records(&resumed_body);
+    assert_eq!(
+        resumed_records.len(),
+        1,
+        "primary must resume from the slot LSN, not the stale caller since_lsn"
+    );
+    assert_eq!(resumed_records[0].lsn, records[0].lsn + 1);
+    applier
+        .apply(&replica, &resumed_records[0], ApplyMode::Replica)
+        .expect("replica applies resumed record");
+
+    handle.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #828. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782759900&installation_id=129708444&pr_number=863&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F863&signature=179f009ec5b265cd98658ed86c512be07af2847f60d06a6553696e40267563eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WAL record polling now supports configurable await mode with timeout control (1-30 seconds).
  * Enhanced replication coordination for logical WAL advancement tracking.

* **Tests**
  * Added end-to-end replication test for WAL polling and replica synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->