### PR TITLE
merge: #829 Replication: mutual TLS per-node identity for the replication channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ dependencies = [
  "tracing-subscriber",
  "trybuild",
  "ureq",
+ "x509-parser",
  "zstd",
 ]
 

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -62,6 +62,7 @@ fs2 = "0.4"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "logging", "ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
+x509-parser = "0.18"
 rcgen = "0.14"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/crates/reddb-server/src/cluster/identity.rs
+++ b/crates/reddb-server/src/cluster/identity.rs
@@ -1,0 +1,81 @@
+//! Per-node cluster identities shared by replication and voting.
+
+use rustls::pki_types::CertificateDer;
+
+/// Stable identity for a node participating in cluster protocols.
+///
+/// The value is the X.509 subject distinguished name from a validated
+/// node certificate. Replication peers and cluster voters intentionally
+/// use this same type so acknowledgements and votes cannot drift into
+/// separate identity namespaces.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeIdentity(String);
+
+/// Replication and witness-voting identities are the same cluster node identity.
+pub type ReplicationPeerIdentity = NodeIdentity;
+pub type ClusterVoterIdentity = NodeIdentity;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NodeIdentityError {
+    EmptySubject,
+    CertificateParse(String),
+}
+
+impl std::fmt::Display for NodeIdentityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptySubject => write!(f, "certificate subject is empty"),
+            Self::CertificateParse(err) => write!(f, "certificate parse error: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for NodeIdentityError {}
+
+impl NodeIdentity {
+    pub fn from_certificate_subject(subject: impl AsRef<str>) -> Result<Self, NodeIdentityError> {
+        let subject = subject.as_ref().trim();
+        if subject.is_empty() {
+            return Err(NodeIdentityError::EmptySubject);
+        }
+        Ok(Self(subject.to_string()))
+    }
+
+    pub fn from_peer_certificate_der(cert: &CertificateDer<'_>) -> Result<Self, NodeIdentityError> {
+        let (_, parsed) = x509_parser::parse_x509_certificate(cert.as_ref())
+            .map_err(|err| NodeIdentityError::CertificateParse(format!("{err:?}")))?;
+        Self::from_certificate_subject(parsed.subject().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for NodeIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_identity_rejects_empty_certificate_subjects() {
+        assert_eq!(
+            NodeIdentity::from_certificate_subject("   ").unwrap_err(),
+            NodeIdentityError::EmptySubject
+        );
+    }
+
+    #[test]
+    fn cluster_voter_and_replication_peer_share_node_identity() {
+        let voter = ClusterVoterIdentity::from_certificate_subject("CN=node-a").unwrap();
+        let replica = ReplicationPeerIdentity::from_certificate_subject("CN=node-a").unwrap();
+
+        assert_eq!(voter, replica);
+        assert_eq!(voter.as_str(), "CN=node-a");
+    }
+}

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -1,0 +1,7 @@
+//! Shared cluster identity model.
+
+pub mod identity;
+
+pub use identity::{
+    ClusterVoterIdentity, NodeIdentity, NodeIdentityError, ReplicationPeerIdentity,
+};

--- a/crates/reddb-server/src/grpc.rs
+++ b/crates/reddb-server/src/grpc.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::api::{RedDBOptions, RedDBResult};
-use crate::auth::middleware::{check_permission, AuthResult};
+use crate::auth::middleware::{check_permission, AuthResult, AuthSource};
 use crate::auth::store::AuthStore;
 use crate::auth::Role;
 use crate::health::{HealthProvider, HealthState};

--- a/crates/reddb-server/src/grpc/control_support.rs
+++ b/crates/reddb-server/src/grpc/control_support.rs
@@ -132,26 +132,26 @@ impl GrpcRuntime {
         check_permission(&auth, false, true).map_err(Status::permission_denied)
     }
 
-    pub(crate) fn authorize_replication_stream(
+    pub(crate) fn authorize_replication_stream<T>(
         &self,
-        metadata: &MetadataMap,
+        request: &Request<T>,
     ) -> Result<String, Status> {
-        self.authorize_replication_capability(metadata, "cluster:replication:stream")
+        self.authorize_replication_capability(request, "cluster:replication:stream")
     }
 
-    pub(crate) fn authorize_replication_ack(
+    pub(crate) fn authorize_replication_ack<T>(
         &self,
-        metadata: &MetadataMap,
+        request: &Request<T>,
     ) -> Result<String, Status> {
-        self.authorize_replication_capability(metadata, "cluster:replication:ack")
+        self.authorize_replication_capability(request, "cluster:replication:ack")
     }
 
-    fn authorize_replication_capability(
+    fn authorize_replication_capability<T>(
         &self,
-        metadata: &MetadataMap,
+        request: &Request<T>,
         action: &str,
     ) -> Result<String, Status> {
-        let auth = self.resolve_auth(metadata);
+        let auth = self.resolve_replication_auth(request);
         let username = match auth {
             AuthResult::Authenticated { username, .. } => username,
             AuthResult::Denied(reason) => return Err(Status::unauthenticated(reason)),
@@ -175,6 +175,25 @@ impl GrpcRuntime {
                 "policy: principal '{username}' is not allowed to perform '{action}'"
             ))),
         }
+    }
+
+    fn resolve_replication_auth<T>(&self, request: &Request<T>) -> AuthResult {
+        if let Some(certs) = request.peer_certs() {
+            let Some(cert) = certs.first() else {
+                return AuthResult::Denied("mTLS peer certificate missing".into());
+            };
+            let identity = match crate::cluster::NodeIdentity::from_peer_certificate_der(cert) {
+                Ok(identity) => identity,
+                Err(err) => return AuthResult::Denied(format!("mTLS peer identity: {err}")),
+            };
+            return AuthResult::Authenticated {
+                username: identity.to_string(),
+                role: Role::Read,
+                source: AuthSource::ClientCert,
+            };
+        }
+
+        self.resolve_auth(request.metadata())
     }
 
     /// PLAN.md Phase 11.4 — call after a successful gRPC write to

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2928,7 +2928,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<JsonPayloadRequest>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_replication_stream(request.metadata())?;
+        self.authorize_replication_stream(&request)?;
         let db = self.runtime.db();
         let repl = db.replication.as_ref().ok_or_else(|| {
             Status::failed_precondition("this instance is not a replication primary")
@@ -3052,7 +3052,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<JsonPayloadRequest>,
     ) -> Result<Response<PayloadReply>, Status> {
-        let authenticated_replica_id = self.authorize_replication_ack(request.metadata())?;
+        let authenticated_replica_id = self.authorize_replication_ack(&request)?;
         let db = self.runtime.db();
         let repl = db.replication.as_ref().ok_or_else(|| {
             Status::failed_precondition("this instance is not a replication primary")
@@ -3117,7 +3117,7 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<Empty>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_replication_stream(request.metadata())?;
+        self.authorize_replication_stream(&request)?;
         let db = self.runtime.db();
 
         if db.replication.is_none() {

--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -18,6 +18,7 @@ pub mod auth;
 pub mod backup_bootstrap;
 pub mod catalog;
 pub mod cli;
+pub mod cluster;
 pub mod config;
 pub mod crypto;
 pub mod ec;

--- a/tests/e2e_issue_829_replication_mtls_identity.rs
+++ b/tests/e2e_issue_829_replication_mtls_identity.rs
@@ -1,0 +1,240 @@
+//! Issue #829 — replication mTLS peer identity and ack attribution.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa,
+    Issuer, KeyPair, KeyUsagePurpose,
+};
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::{Empty, JsonPayloadRequest};
+use reddb::replication::ReplicationConfig;
+use reddb::runtime::RedDBRuntime;
+use reddb::{GrpcServerOptions, GrpcTlsOptions, RedDBGrpcServer, RedDBOptions};
+use rustls::pki_types::CertificateDer;
+use tonic::transport::{Certificate as TonicCertificate, ClientTlsConfig, Endpoint, Identity};
+use tonic::Code;
+
+fn pick_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16, max_ms: u64) {
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(max_ms);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+struct TestCa {
+    cert: Certificate,
+    issuer: Issuer<'static, KeyPair>,
+}
+
+struct TestCert {
+    cert_pem: String,
+    key_pem: String,
+    der: Vec<u8>,
+}
+
+fn test_ca() -> TestCa {
+    let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params
+        .distinguished_name
+        .push(DnType::CommonName, "reddb-test-ca");
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params.key_usages.push(KeyUsagePurpose::KeyCertSign);
+    params.key_usages.push(KeyUsagePurpose::CrlSign);
+
+    let key_pair = KeyPair::generate().unwrap();
+    let cert = params.self_signed(&key_pair).unwrap();
+    let issuer = Issuer::new(params, key_pair);
+    TestCa { cert, issuer }
+}
+
+fn signed_cert(ca: &Issuer<'static, KeyPair>, common_name: &str, server: bool) -> TestCert {
+    let sans = if server {
+        vec!["localhost".to_string()]
+    } else {
+        Vec::new()
+    };
+    let mut params = CertificateParams::new(sans).unwrap();
+    params
+        .distinguished_name
+        .push(DnType::CommonName, common_name);
+    params.use_authority_key_identifier_extension = true;
+    params.key_usages.push(KeyUsagePurpose::DigitalSignature);
+    params.extended_key_usages.push(if server {
+        ExtendedKeyUsagePurpose::ServerAuth
+    } else {
+        ExtendedKeyUsagePurpose::ClientAuth
+    });
+
+    let key_pair = KeyPair::generate().unwrap();
+    let cert = params.signed_by(&key_pair, ca).unwrap();
+    TestCert {
+        cert_pem: cert.pem(),
+        key_pem: key_pair.serialize_pem(),
+        der: cert.der().to_vec(),
+    }
+}
+
+fn install_policy(store: &AuthStore, username: &str, id: &str, actions: &[&str]) {
+    let actions_json = actions
+        .iter()
+        .map(|action| format!("\"{action}\""))
+        .collect::<Vec<_>>()
+        .join(",");
+    let policy_json = format!(
+        r#"{{"id":"{id}","version":1,"statements":[{{"effect":"allow","actions":[{actions_json}],"resources":["cluster:replication"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(PrincipalRef::User(UserId::platform(username)), id)
+        .expect("attach policy");
+}
+
+async fn connect_mtls_client(
+    port: u16,
+    ca_pem: &str,
+    client: Option<&TestCert>,
+) -> RedDbClient<tonic::transport::Channel> {
+    let mut tls = ClientTlsConfig::new()
+        .domain_name("localhost")
+        .ca_certificate(TonicCertificate::from_pem(ca_pem.as_bytes()));
+    if let Some(client) = client {
+        tls = tls.identity(Identity::from_pem(
+            client.cert_pem.as_bytes(),
+            client.key_pem.as_bytes(),
+        ));
+    }
+    let endpoint = Endpoint::from_shared(format!("https://localhost:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(5))
+        .connect_timeout(Duration::from_secs(5))
+        .tls_config(tls)
+        .unwrap();
+    RedDbClient::new(endpoint.connect().await.expect("mTLS connect"))
+}
+
+fn pull_request(replica_id: &str) -> tonic::Request<JsonPayloadRequest> {
+    tonic::Request::new(JsonPayloadRequest {
+        payload_json: format!(r#"{{"replica_id":"{replica_id}","since_lsn":0,"max_count":10}}"#),
+    })
+}
+
+fn ack_request(replica_id: &str, applied_lsn: u64) -> tonic::Request<JsonPayloadRequest> {
+    tonic::Request::new(JsonPayloadRequest {
+        payload_json: format!(
+            r#"{{"replica_id":"{replica_id}","applied_lsn":{applied_lsn},"durable_lsn":{applied_lsn}}}"#
+        ),
+    })
+}
+
+#[tokio::test]
+async fn replication_mtls_subject_identity_binds_ack_attribution() {
+    let ca = test_ca();
+    let server_cert = signed_cert(&ca.issuer, "primary", true);
+    let replica_cert = signed_cert(&ca.issuer, "replica_a", false);
+    let peer_identity = reddb::cluster::NodeIdentity::from_peer_certificate_der(
+        &CertificateDer::from(replica_cert.der.clone()),
+    )
+    .expect("client cert subject becomes node identity");
+    let voter_identity =
+        reddb::cluster::ClusterVoterIdentity::from_certificate_subject(peer_identity.as_str())
+            .expect("witness voting uses the same node identity model");
+    assert_eq!(voter_identity, peer_identity);
+    assert_eq!(peer_identity.as_str(), "CN=replica_a");
+
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("runtime");
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store
+        .create_user(peer_identity.as_str(), "unused", Role::Read)
+        .unwrap();
+    install_policy(
+        &store,
+        peer_identity.as_str(),
+        "p_replica_a_cert",
+        &["cluster:replication:stream", "cluster:replication:ack"],
+    );
+
+    let port = pick_port();
+    let bind = format!("127.0.0.1:{port}");
+    let server = RedDBGrpcServer::with_options(
+        runtime.clone(),
+        GrpcServerOptions {
+            bind_addr: bind,
+            tls: Some(GrpcTlsOptions {
+                cert_pem: server_cert.cert_pem.into_bytes(),
+                key_pem: server_cert.key_pem.into_bytes(),
+                client_ca_pem: Some(ca.cert.pem().into_bytes()),
+            }),
+        },
+        store,
+    );
+    let server_handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port, 5000).await;
+
+    let mut no_cert_client = connect_mtls_client(port, &ca.cert.pem(), None).await;
+    let no_cert = no_cert_client
+        .health(tonic::Request::new(Empty {}))
+        .await
+        .expect_err("mTLS-required replication listener rejects clients without certs");
+    assert_ne!(no_cert.code(), Code::Ok);
+
+    let mut client = connect_mtls_client(port, &ca.cert.pem(), Some(&replica_cert)).await;
+    client
+        .pull_wal_records(pull_request(peer_identity.as_str()))
+        .await
+        .expect("cert-identified replica can stream WAL records");
+
+    let forged = client
+        .ack_replica_lsn(ack_request("CN=replica_b", 25))
+        .await
+        .expect_err("client cert subject cannot ack as another replica");
+    assert_eq!(forged.code(), Code::PermissionDenied);
+
+    let ack = client
+        .ack_replica_lsn(ack_request(peer_identity.as_str(), 25))
+        .await
+        .expect("client cert subject can ack as itself")
+        .into_inner();
+    let body: serde_json::Value = serde_json::from_str(&ack.payload).expect("ack reply JSON");
+    assert_eq!(body["replica_id"], peer_identity.as_str());
+
+    let replica = runtime
+        .primary_replica_snapshots()
+        .into_iter()
+        .find(|replica| replica.id == peer_identity.as_str())
+        .expect("replica registered by cert identity");
+    assert_eq!(replica.last_acked_lsn, 25);
+
+    server_handle.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #829. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782761333&installation_id=129708444&pr_number=864&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F864&signature=24dea625c8410dcf7747933df7de839bb6204d64ade25306e65b4d9afbc99c59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replication now supports mutual TLS (mTLS) authentication, enabling cluster peers to be securely identified and authenticated using X.509 certificates with configurable access control policies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->