### PR TITLE
merge: #826 Replication: flow control throttles the primary on in-quorum replica lag

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -3093,6 +3093,10 @@ impl RedDb for GrpcRuntime {
             apply_errors_total,
             divergence_total,
         );
+        // Issue #826 — an ack moves a replica forward; re-evaluate flow
+        // control so the throttle releases as soon as an in-quorum
+        // member catches up below the soft target.
+        self.runtime.refresh_replication_flow_control();
 
         let mut reply = crate::json::Map::new();
         reply.insert("ok".into(), JsonValue::Bool(true));
@@ -3727,6 +3731,7 @@ mod tests {
             result,
             affected_rows: 0,
             statement_type: "select",
+            bookmark: None,
         }
     }
 

--- a/crates/reddb-server/src/replication/flow_control.rs
+++ b/crates/reddb-server/src/replication/flow_control.rs
@@ -1,0 +1,325 @@
+//! Write-admission flow control keyed on in-quorum replica lag (issue #826).
+//!
+//! The primary streams WAL to every connected replica, but only some of
+//! those replicas count toward the configured commit quorum. When a
+//! *quorum member* falls behind, the primary should slow incoming writes
+//! so the lagging member can catch up — otherwise sync/quorum commits
+//! stall and the lag compounds. Replicas that are pure read scale-out
+//! (async, not in the quorum) must never exert this back-pressure: read
+//! fan-out should not be able to throttle write throughput.
+//!
+//! `FlowController` implements that policy as a ticket-based admission
+//! gate. It watches the max lag across *in-quorum* replicas against a
+//! soft target (in LSN records):
+//!
+//! * lag `<=` soft target → tickets flow, writes admitted.
+//! * lag `>`  soft target → throttle engaged, admission tickets denied
+//!   until the quorum member recovers below the target.
+//!
+//! A soft target of `0` disables the feature entirely (the default), so
+//! standalone and async-commit deployments are unaffected. The decision
+//! mirrors the engine-managed graceful-pause precedent in
+//! [`crate::runtime::write_gate`] (issue #519 archive-lag auto-pause):
+//! an independent, automatically-engaging/releasing gate that the
+//! operator's manual read-only pin never stomps.
+//!
+//! In-quorum membership is derived from the active [`QuorumConfig`]:
+//!
+//! * [`QuorumMode::Async`] — no replica is synchronous, so *nothing* is
+//!   in-quorum and the controller never throttles.
+//! * [`QuorumMode::Sync`] — every connected replica is a candidate for
+//!   the synchronous quorum and counts toward the lag signal.
+//! * [`QuorumMode::Regions`] — only replicas whose declared region is in
+//!   the required set count; replicas in other regions (or with no
+//!   region) are async read-replicas and are excluded.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use super::primary::ReplicaState;
+use super::quorum::{QuorumConfig, QuorumMode};
+
+/// Outcome of a write-admission attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Admission {
+    /// A ticket was issued — the write may proceed.
+    Granted,
+    /// Throttle engaged — an in-quorum replica's lag exceeds the soft
+    /// target. The caller must not proceed with the write.
+    Throttled,
+}
+
+impl Admission {
+    pub fn is_granted(self) -> bool {
+        matches!(self, Admission::Granted)
+    }
+}
+
+/// Is `replica` a member of the commit quorum under `quorum`?
+///
+/// Async read-replicas (not in the quorum) return `false` and are
+/// therefore excluded from the flow-control lag signal.
+pub fn is_in_quorum(replica: &ReplicaState, quorum: &QuorumConfig) -> bool {
+    match &quorum.mode {
+        // Async-commit: nobody is synchronous, so no replica gates writes.
+        QuorumMode::Async => false,
+        // Sync(n): every connected replica is a quorum candidate.
+        QuorumMode::Sync { .. } => true,
+        // Regions: only replicas in a required region are in-quorum.
+        QuorumMode::Regions { required } => replica
+            .region
+            .as_deref()
+            .map(|region| required.contains(region))
+            .unwrap_or(false),
+    }
+}
+
+/// Max lag in LSN records across the in-quorum replicas, measured as the
+/// distance from the primary's current LSN to each replica's last acked
+/// LSN. Async read-replicas are excluded. Returns `0` when no replica is
+/// in-quorum (so the controller never throttles on read scale-out alone).
+pub fn in_quorum_max_lag_lsn(
+    replicas: &[ReplicaState],
+    primary_lsn: u64,
+    quorum: &QuorumConfig,
+) -> u64 {
+    replicas
+        .iter()
+        .filter(|replica| is_in_quorum(replica, quorum))
+        .map(|replica| primary_lsn.saturating_sub(replica.last_acked_lsn))
+        .max()
+        .unwrap_or(0)
+}
+
+/// Ticket-based write-admission flow controller.
+///
+/// Holds the soft-target policy and the live throttle state. Cheap to
+/// share: every field is a single atomic plus the immutable quorum
+/// config, so [`Self::try_admit`] on the write hot path is a couple of
+/// relaxed loads.
+#[derive(Debug)]
+pub struct FlowController {
+    /// Soft target lag in LSN records. `0` disables throttling.
+    soft_target_lsn: AtomicU64,
+    /// Whether the throttle is currently engaged.
+    throttled: AtomicBool,
+    /// Most recent observed max in-quorum lag (for metrics).
+    observed_lag_lsn: AtomicU64,
+    /// Active quorum shape — decides which replicas count as in-quorum.
+    quorum: QuorumConfig,
+}
+
+impl FlowController {
+    /// A disabled controller (soft target `0`): never throttles.
+    pub fn disabled() -> Self {
+        Self::new(0, QuorumConfig::async_commit())
+    }
+
+    /// Build a controller with an explicit soft target and quorum shape.
+    pub fn new(soft_target_lsn: u64, quorum: QuorumConfig) -> Self {
+        Self {
+            soft_target_lsn: AtomicU64::new(soft_target_lsn),
+            throttled: AtomicBool::new(false),
+            observed_lag_lsn: AtomicU64::new(0),
+            quorum,
+        }
+    }
+
+    /// Install (or change) the soft target at runtime. `0` disables the
+    /// feature and immediately releases any active throttle.
+    pub fn configure_soft_target(&self, soft_target_lsn: u64) {
+        self.soft_target_lsn
+            .store(soft_target_lsn, Ordering::Release);
+        if soft_target_lsn == 0 {
+            self.throttled.store(false, Ordering::Release);
+        }
+    }
+
+    /// Soft target in LSN records. `0` means disabled.
+    pub fn soft_target_lsn(&self) -> u64 {
+        self.soft_target_lsn.load(Ordering::Acquire)
+    }
+
+    /// Whether flow control is enabled (soft target `> 0`).
+    pub fn is_enabled(&self) -> bool {
+        self.soft_target_lsn() > 0
+    }
+
+    /// Whether the throttle is currently engaged.
+    pub fn is_throttled(&self) -> bool {
+        self.throttled.load(Ordering::Acquire)
+    }
+
+    /// Most recent observed max in-quorum replica lag in LSN records.
+    pub fn observed_lag_lsn(&self) -> u64 {
+        self.observed_lag_lsn.load(Ordering::Acquire)
+    }
+
+    /// Re-evaluate the throttle from a replica snapshot.
+    ///
+    /// Computes the max lag across in-quorum replicas (async read-replicas
+    /// excluded) and engages the throttle when it exceeds the soft target,
+    /// releasing it when the quorum member recovers to/below the target.
+    /// Returns the resulting `throttled` state.
+    pub fn observe(&self, replicas: &[ReplicaState], primary_lsn: u64) -> bool {
+        let soft_target = self.soft_target_lsn();
+        let lag = in_quorum_max_lag_lsn(replicas, primary_lsn, &self.quorum);
+        self.observed_lag_lsn.store(lag, Ordering::Release);
+        // Disabled (soft target 0) can never throttle.
+        let throttled = soft_target > 0 && lag > soft_target;
+        self.throttled.store(throttled, Ordering::Release);
+        throttled
+    }
+
+    /// Request a write-admission ticket. `Granted` unless the throttle is
+    /// engaged. The check is a single relaxed load on the hot path.
+    pub fn try_admit(&self) -> Admission {
+        if self.is_throttled() {
+            Admission::Throttled
+        } else {
+            Admission::Granted
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn replica(id: &str, region: Option<&str>, last_acked_lsn: u64) -> ReplicaState {
+        ReplicaState {
+            id: id.to_string(),
+            last_acked_lsn,
+            last_sent_lsn: last_acked_lsn,
+            last_durable_lsn: last_acked_lsn,
+            apply_error_count: 0,
+            divergence_count: 0,
+            connected_at_unix_ms: 0,
+            last_seen_at_unix_ms: 0,
+            region: region.map(String::from),
+        }
+    }
+
+    #[test]
+    fn async_mode_classifies_no_replica_in_quorum() {
+        let q = QuorumConfig::async_commit();
+        assert!(!is_in_quorum(&replica("r1", Some("us"), 0), &q));
+    }
+
+    #[test]
+    fn sync_mode_classifies_every_replica_in_quorum() {
+        let q = QuorumConfig::sync(2);
+        assert!(is_in_quorum(&replica("r1", None, 0), &q));
+        assert!(is_in_quorum(&replica("r2", Some("eu"), 0), &q));
+    }
+
+    #[test]
+    fn regions_mode_classifies_only_required_regions_in_quorum() {
+        let q = QuorumConfig::regions(["us", "eu"]);
+        assert!(is_in_quorum(&replica("r1", Some("us"), 0), &q));
+        assert!(is_in_quorum(&replica("r2", Some("eu"), 0), &q));
+        // async read-replica in a non-required region — excluded.
+        assert!(!is_in_quorum(&replica("r3", Some("ap"), 0), &q));
+        // no declared region — excluded.
+        assert!(!is_in_quorum(&replica("r4", None, 0), &q));
+    }
+
+    #[test]
+    fn disabled_controller_never_throttles() {
+        let fc = FlowController::disabled();
+        let replicas = vec![replica("r1", Some("us"), 0)];
+        // Huge lag, but soft target 0 → no throttle.
+        assert!(!fc.observe(&replicas, 1_000_000));
+        assert!(!fc.is_throttled());
+        assert_eq!(fc.try_admit(), Admission::Granted);
+    }
+
+    #[test]
+    fn engages_when_in_quorum_replica_exceeds_soft_target() {
+        let fc = FlowController::new(100, QuorumConfig::sync(1));
+        // primary at 500, replica acked 350 → lag 150 > 100.
+        let replicas = vec![replica("r1", Some("us"), 350)];
+        assert!(fc.observe(&replicas, 500));
+        assert!(fc.is_throttled());
+        assert_eq!(fc.observed_lag_lsn(), 150);
+        assert_eq!(fc.try_admit(), Admission::Throttled);
+    }
+
+    #[test]
+    fn releases_when_in_quorum_replica_recovers() {
+        let fc = FlowController::new(100, QuorumConfig::sync(1));
+        let lagging = vec![replica("r1", Some("us"), 350)];
+        assert!(fc.observe(&lagging, 500));
+        assert_eq!(fc.try_admit(), Admission::Throttled);
+
+        // Replica catches up to within the soft target (lag 50 <= 100).
+        let recovered = vec![replica("r1", Some("us"), 450)];
+        assert!(!fc.observe(&recovered, 500));
+        assert!(!fc.is_throttled());
+        assert_eq!(fc.observed_lag_lsn(), 50);
+        assert_eq!(fc.try_admit(), Admission::Granted);
+    }
+
+    #[test]
+    fn at_soft_target_boundary_does_not_throttle() {
+        let fc = FlowController::new(100, QuorumConfig::sync(1));
+        // lag exactly == soft target → not throttled (strictly greater).
+        let replicas = vec![replica("r1", Some("us"), 400)];
+        assert!(!fc.observe(&replicas, 500));
+        assert!(!fc.is_throttled());
+    }
+
+    #[test]
+    fn async_read_replica_lag_never_engages_throttling() {
+        // Regions quorum requires "us". An async read-replica in "ap"
+        // lags massively, but the in-quorum "us" replica is caught up.
+        let fc = FlowController::new(100, QuorumConfig::regions(["us"]));
+        let replicas = vec![
+            replica("in-quorum-us", Some("us"), 500), // caught up
+            replica("async-ap", Some("ap"), 0),       // lag 500, excluded
+        ];
+        assert!(!fc.observe(&replicas, 500));
+        assert!(!fc.is_throttled());
+        // The lag signal reflects only the in-quorum replica (0), not the
+        // async read-replica's 500-record lag.
+        assert_eq!(fc.observed_lag_lsn(), 0);
+        assert_eq!(fc.try_admit(), Admission::Granted);
+    }
+
+    #[test]
+    fn in_quorum_replica_still_throttles_with_async_replica_present() {
+        // Same shape, but now the in-quorum "us" replica lags past target
+        // while the async "ap" replica is caught up — must still throttle.
+        let fc = FlowController::new(100, QuorumConfig::regions(["us"]));
+        let replicas = vec![
+            replica("in-quorum-us", Some("us"), 300), // lag 200 > 100
+            replica("async-ap", Some("ap"), 500),     // caught up, excluded
+        ];
+        assert!(fc.observe(&replicas, 500));
+        assert!(fc.is_throttled());
+        assert_eq!(fc.observed_lag_lsn(), 200);
+    }
+
+    #[test]
+    fn configure_soft_target_zero_releases_throttle() {
+        let fc = FlowController::new(100, QuorumConfig::sync(1));
+        assert!(fc.observe(&[replica("r1", Some("us"), 0)], 500));
+        assert!(fc.is_throttled());
+        // Operator disables flow control — throttle releases immediately.
+        fc.configure_soft_target(0);
+        assert!(!fc.is_enabled());
+        assert!(!fc.is_throttled());
+        assert_eq!(fc.try_admit(), Admission::Granted);
+    }
+
+    #[test]
+    fn no_in_quorum_replicas_never_throttles() {
+        // Sync quorum configured but only async (region-excluded under a
+        // regions quorum) — here Sync counts all, so use regions with no
+        // matching replica to prove "no in-quorum members → lag 0".
+        let fc = FlowController::new(10, QuorumConfig::regions(["us"]));
+        let replicas = vec![replica("ap-only", Some("ap"), 0)];
+        assert!(!fc.observe(&replicas, 1_000));
+        assert_eq!(fc.observed_lag_lsn(), 0);
+        assert!(!fc.is_throttled());
+    }
+}

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -24,6 +24,7 @@ pub mod bookmark;
 pub mod cdc;
 pub mod commit_policy;
 pub mod commit_waiter;
+pub mod flow_control;
 pub mod lease;
 pub mod logical;
 pub mod primary;
@@ -35,6 +36,7 @@ pub mod topology_advertiser;
 pub use bookmark::{BookmarkDecodeError, CausalBookmark};
 pub use commit_policy::CommitPolicy;
 pub use commit_waiter::{AwaitOutcome, CommitWaiter};
+pub use flow_control::{Admission, FlowController};
 pub use lease::{LeaseError, LeaseStore, WriterLease};
 pub use quorum::{QuorumConfig, QuorumCoordinator, QuorumError};
 pub use topology_advertiser::{

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -1178,7 +1178,10 @@ impl PrimaryReplication {
             .len()
     }
 
-    fn current_logical_lsn(&self) -> u64 {
+    /// Current primary write position (logical WAL LSN, falling back to
+    /// the in-memory WAL buffer). Used as the reference point for
+    /// per-replica lag — including issue #826 flow control.
+    pub fn current_logical_lsn(&self) -> u64 {
         self.logical_wal_spool
             .as_ref()
             .map(|spool| spool.current_lsn())

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -5097,6 +5097,29 @@ impl RedDBRuntime {
             .unwrap_or_default()
     }
 
+    /// Issue #826 — re-evaluate write-admission flow control from the
+    /// live primary replica registry and return the resulting throttle
+    /// state. Computes the max lag across in-quorum replicas (async
+    /// read-replicas excluded) against the primary's current LSN and
+    /// engages/releases the `WriteGate` throttle accordingly.
+    ///
+    /// No-op (returns `false`) on non-primary instances or when flow
+    /// control is disabled (soft target `0`). Cheap enough to call on
+    /// the replica-ack path and from `/metrics` scrapes so the throttle
+    /// tracks lag without a dedicated background loop.
+    pub fn refresh_replication_flow_control(&self) -> bool {
+        let flow = self.inner.write_gate.flow_control();
+        if !flow.is_enabled() {
+            return false;
+        }
+        let Some(repl) = self.inner.db.replication.as_ref() else {
+            return false;
+        };
+        let primary_lsn = repl.current_logical_lsn();
+        let replicas = repl.replica_snapshots();
+        flow.observe(&replicas, primary_lsn)
+    }
+
     /// PLAN.md Phase 11.4 — active commit policy. Reads
     /// `RED_PRIMARY_COMMIT_POLICY` once at runtime construction;
     /// future env reloads will need a reload endpoint. Default is

--- a/crates/reddb-server/src/runtime/write_gate.rs
+++ b/crates/reddb-server/src/runtime/write_gate.rs
@@ -24,7 +24,12 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 
 use crate::api::{RedDBError, RedDBOptions, RedDBResult};
+use crate::replication::flow_control::{Admission, FlowController};
 use crate::replication::ReplicationRole;
+
+/// Env var that sets the flow-control soft target (in LSN records).
+/// `0` / unset disables write-admission throttling (the default).
+pub const FLOW_CONTROL_SOFT_TARGET_ENV: &str = "RED_REPLICATION_FLOW_CONTROL_SOFT_TARGET_LSN";
 
 /// Categorises the write so the rejection error can name a sensible
 /// surface in operator-facing logs without leaking internal call sites.
@@ -123,10 +128,20 @@ pub struct WriteGate {
     /// disabled — `evaluate_archive_lag` short-circuits without
     /// touching `auto_paused`.
     pause_threshold_secs: AtomicU64,
+    /// Issue #826 — write-admission flow control keyed on in-quorum
+    /// replica lag. Independent of `read_only` / `auto_paused`: the
+    /// throttle engages and releases automatically as a quorum member
+    /// lags and recovers, and an operator read-only pin never clears it.
+    /// Disabled by default (soft target `0`).
+    flow: FlowController,
 }
 
 impl WriteGate {
     pub fn from_options(options: &RedDBOptions) -> Self {
+        let soft_target = std::env::var(FLOW_CONTROL_SOFT_TARGET_ENV)
+            .ok()
+            .and_then(|raw| raw.trim().parse::<u64>().ok())
+            .unwrap_or(0);
         Self {
             read_only: AtomicBool::new(options.read_only),
             role: options.replication.role.clone(),
@@ -134,6 +149,7 @@ impl WriteGate {
             auto_paused: AtomicBool::new(false),
             last_archive_at_ms: AtomicU64::new(0),
             pause_threshold_secs: AtomicU64::new(0),
+            flow: FlowController::new(soft_target, options.replication.quorum.clone()),
         }
     }
 
@@ -184,6 +200,17 @@ impl WriteGate {
                 kind.label()
             )));
         }
+        // Issue #826 — write-admission flow control. Lowest-precedence
+        // gate: only consulted once the structural / operator / archive
+        // checks pass. Throttles when an in-quorum replica's lag exceeds
+        // the soft target; releases automatically as it catches up.
+        if matches!(self.flow.try_admit(), Admission::Throttled) {
+            return Err(RedDBError::ReadOnly(format!(
+                "write admission throttled — in-quorum replica lag exceeded soft target ({} records) — {} rejected",
+                self.flow.soft_target_lsn(),
+                kind.label()
+            )));
+        }
         Ok(crate::application::WriteConsent {
             kind,
             _seal: crate::application::WriteConsentSeal::new(),
@@ -214,6 +241,20 @@ impl WriteGate {
 
     pub fn role(&self) -> &ReplicationRole {
         &self.role
+    }
+
+    /// Issue #826 — borrow the write-admission flow controller. Callers
+    /// drive `observe()` from the primary's replica registry and read
+    /// throttle state for `/metrics`.
+    pub fn flow_control(&self) -> &FlowController {
+        &self.flow
+    }
+
+    /// Whether write admission is currently throttled by in-quorum
+    /// replica lag (issue #826). Distinct from [`is_read_only`] — a
+    /// throttle is transient back-pressure, not a read-only posture.
+    pub fn is_flow_throttled(&self) -> bool {
+        self.flow.is_throttled()
     }
 
     /// PLAN.md Phase 4.3 — dynamic read-only toggle. Flipping a
@@ -321,6 +362,7 @@ mod tests {
             auto_paused: AtomicBool::new(false),
             last_archive_at_ms: AtomicU64::new(0),
             pause_threshold_secs: AtomicU64::new(0),
+            flow: FlowController::disabled(),
         }
     }
 
@@ -529,6 +571,92 @@ mod tests {
         g.set_read_only(false);
         assert!(g.is_auto_paused());
         assert!(g.check(WriteKind::Dml).is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Issue #826 — write-admission flow control on in-quorum replica lag.
+    // ---------------------------------------------------------------
+
+    fn gate_with_flow(soft_target: u64, quorum: crate::replication::QuorumConfig) -> WriteGate {
+        WriteGate {
+            read_only: AtomicBool::new(false),
+            role: ReplicationRole::Primary,
+            lease: AtomicU8::new(LeaseGateState::NotRequired as u8),
+            auto_paused: AtomicBool::new(false),
+            last_archive_at_ms: AtomicU64::new(0),
+            pause_threshold_secs: AtomicU64::new(0),
+            flow: FlowController::new(soft_target, quorum),
+        }
+    }
+
+    fn flow_replica(
+        id: &str,
+        region: Option<&str>,
+        last_acked_lsn: u64,
+    ) -> crate::replication::primary::ReplicaState {
+        crate::replication::primary::ReplicaState {
+            id: id.to_string(),
+            last_acked_lsn,
+            last_sent_lsn: last_acked_lsn,
+            last_durable_lsn: last_acked_lsn,
+            apply_error_count: 0,
+            divergence_count: 0,
+            connected_at_unix_ms: 0,
+            last_seen_at_unix_ms: 0,
+            region: region.map(String::from),
+        }
+    }
+
+    #[test]
+    fn flow_throttle_rejects_writes_when_in_quorum_replica_lags_and_releases() {
+        let g = gate_with_flow(100, crate::replication::QuorumConfig::sync(1));
+        // Healthy: no observation yet → writes admitted.
+        assert!(g.check(WriteKind::Dml).is_ok());
+        assert!(!g.is_flow_throttled());
+
+        // In-quorum replica lags 150 > soft target 100 → throttle engages.
+        g.flow_control()
+            .observe(&[flow_replica("r1", Some("us"), 350)], 500);
+        assert!(g.is_flow_throttled());
+        let err = g.check(WriteKind::Dml).unwrap_err();
+        match err {
+            RedDBError::ReadOnly(msg) => assert!(msg.contains("throttled"), "{msg}"),
+            other => panic!("expected ReadOnly throttle, got {other:?}"),
+        }
+        // Throttle is not the read-only posture.
+        assert!(!g.is_read_only());
+
+        // Replica catches up (lag 50 <= 100) → throttle releases.
+        g.flow_control()
+            .observe(&[flow_replica("r1", Some("us"), 450)], 500);
+        assert!(!g.is_flow_throttled());
+        assert!(g.check(WriteKind::Dml).is_ok());
+    }
+
+    #[test]
+    fn flow_throttle_excludes_async_read_replica() {
+        // Regions quorum requires "us"; an async read-replica in "ap"
+        // lags hugely but must never engage throttling.
+        let g = gate_with_flow(100, crate::replication::QuorumConfig::regions(["us"]));
+        g.flow_control().observe(
+            &[
+                flow_replica("in-quorum-us", Some("us"), 500),
+                flow_replica("async-ap", Some("ap"), 0),
+            ],
+            500,
+        );
+        assert!(!g.is_flow_throttled());
+        assert!(g.check(WriteKind::Dml).is_ok());
+    }
+
+    #[test]
+    fn flow_throttle_disabled_by_default() {
+        let g = gate(false, ReplicationRole::Primary);
+        // Even a huge lag observation cannot throttle a disabled controller.
+        g.flow_control()
+            .observe(&[flow_replica("r1", Some("us"), 0)], 1_000_000);
+        assert!(!g.is_flow_throttled());
+        assert!(g.check(WriteKind::Dml).is_ok());
     }
 
     #[test]

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -1276,6 +1276,53 @@ impl RedDBServer {
             }
         }
 
+        // Issue #826 — write-admission flow control on in-quorum replica
+        // lag. Refresh from the live registry so the scrape reflects the
+        // current throttle decision, then export the gate state, the soft
+        // target, and the observed in-quorum lag. Emitted on every primary
+        // scrape (even when disabled) so dashboards can chart engage/release.
+        self.runtime.refresh_replication_flow_control();
+        let flow = self.runtime.write_gate().flow_control();
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_flow_control_throttled 1 when write admission is throttled by in-quorum replica lag."
+        );
+        let _ = writeln!(
+            body,
+            "# TYPE reddb_replication_flow_control_throttled gauge"
+        );
+        let _ = writeln!(
+            body,
+            "reddb_replication_flow_control_throttled {}",
+            u8::from(flow.is_throttled())
+        );
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_flow_control_soft_target_lsn Soft target lag (LSN records) above which writes throttle; 0 disables."
+        );
+        let _ = writeln!(
+            body,
+            "# TYPE reddb_replication_flow_control_soft_target_lsn gauge"
+        );
+        let _ = writeln!(
+            body,
+            "reddb_replication_flow_control_soft_target_lsn {}",
+            flow.soft_target_lsn()
+        );
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_flow_control_in_quorum_lag_lsn Most recent max lag (LSN records) across in-quorum replicas; excludes async read-replicas."
+        );
+        let _ = writeln!(
+            body,
+            "# TYPE reddb_replication_flow_control_in_quorum_lag_lsn gauge"
+        );
+        let _ = writeln!(
+            body,
+            "reddb_replication_flow_control_in_quorum_lag_lsn {}",
+            flow.observed_lag_lsn()
+        );
+
         // PLAN.md Phase 11.5 — replica apply error counters and
         // current health label. Counters are global across the
         // instance lifetime; the health label reflects whatever the

--- a/tests/e2e_issue_826_replication_flow_control.rs
+++ b/tests/e2e_issue_826_replication_flow_control.rs
@@ -1,0 +1,238 @@
+//! Issue #826 — replication flow control throttles the primary when an
+//! in-quorum replica lags past a soft target, and releases as it recovers.
+//!
+//! Drives the real write-admission path: a registered in-quorum replica
+//! that falls behind the primary's LSN engages the `WriteGate` throttle
+//! (observable via `/metrics` and a rejected DML write); acking the
+//! replica forward releases it.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::JsonPayloadRequest;
+use reddb::replication::{QuorumConfig, ReplicationConfig};
+use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions, RedDBRuntime};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+
+use support::prometheus::get;
+
+fn pick_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
+    let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5));
+    RedDbClient::new(endpoint.connect().await.expect("client connect"))
+}
+
+fn install_replication_policy(store: &AuthStore, username: &str) {
+    let policy_id = format!("p_{username}_replication");
+    let policy_json = format!(
+        r#"{{"id":"{policy_id}","version":1,"statements":[{{"effect":"allow","actions":["cluster:replication:stream","cluster:replication:ack"],"resources":["cluster:replication"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(PrincipalRef::User(UserId::platform(username)), &policy_id)
+        .expect("attach policy");
+}
+
+fn bearer_request(message: JsonPayloadRequest, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    let mut request = tonic::Request::new(message);
+    let value: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+fn pull_request(replica_id: &str, token: &str) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","since_lsn":0,"max_count":100}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn ack_request(
+    replica_id: &str,
+    applied_lsn: u64,
+    durable_lsn: u64,
+    token: &str,
+) -> tonic::Request<JsonPayloadRequest> {
+    bearer_request(
+        JsonPayloadRequest {
+            payload_json: format!(
+                r#"{{"replica_id":"{replica_id}","applied_lsn":{applied_lsn},"durable_lsn":{durable_lsn}}}"#
+            ),
+        },
+        token,
+    )
+}
+
+fn metric_value(body: &str, prefix: &str) -> u64 {
+    for line in body.lines() {
+        if let Some(value) = line.strip_prefix(prefix) {
+            return value
+                .trim()
+                .parse::<u64>()
+                .unwrap_or_else(|_| panic!("invalid metric value for {prefix:?}: {line}"));
+        }
+    }
+    panic!("metric line not found: {prefix:?}\n{body}");
+}
+
+#[tokio::test]
+async fn flow_control_throttles_on_in_quorum_lag_and_releases_on_recovery() {
+    // Sync(1) quorum → a registered replica is an in-quorum member, so
+    // its lag drives flow control.
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory()
+            .with_replication(ReplicationConfig::primary().with_quorum(QuorumConfig::sync(1))),
+    )
+    .expect("runtime");
+
+    // Small soft target so a few inserts push the lagging replica past it.
+    runtime.write_gate().flow_control().configure_soft_target(2);
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("replica_a", "p", Role::Read).unwrap();
+    let replica_a_key = store
+        .create_api_key("replica_a", "replication-a", Role::Read)
+        .unwrap();
+    install_replication_policy(&store, "replica_a");
+
+    let port = pick_port();
+    let server = RedDBGrpcServer::with_options(
+        runtime.clone(),
+        GrpcServerOptions {
+            bind_addr: format!("127.0.0.1:{port}"),
+            tls: None,
+        },
+        store,
+    );
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port).await;
+    let mut client = connect_client(port).await;
+
+    // Register replica_a (in-quorum) at LSN 0.
+    client
+        .pull_wal_records(pull_request("replica_a", &replica_a_key.key))
+        .await
+        .expect("replica_a registers");
+
+    // Initially caught up → no throttle, writes admitted.
+    runtime
+        .execute_query("CREATE TABLE issue_826_flow (id INTEGER, name TEXT)")
+        .expect("create table");
+    let (_, metrics) = get(runtime.clone(), "/metrics");
+    assert_eq!(
+        metric_value(&metrics, "reddb_replication_flow_control_soft_target_lsn "),
+        2
+    );
+
+    // Advance the primary LSN well past the soft target while replica_a
+    // stays behind (it has not acked the new LSNs).
+    for id in 1..=8 {
+        runtime
+            .execute_query(&format!(
+                "INSERT INTO issue_826_flow (id, name) VALUES ({id}, 'r{id}')"
+            ))
+            .expect("insert row");
+    }
+
+    // Scrape refreshes flow control from the live registry → throttled.
+    let (status, metrics) = get(runtime.clone(), "/metrics");
+    assert_eq!(status, 200, "unexpected /metrics response: {metrics}");
+    assert_eq!(
+        metric_value(&metrics, "reddb_replication_flow_control_throttled "),
+        1,
+        "in-quorum replica lag should engage throttle:\n{metrics}"
+    );
+    assert!(
+        metric_value(
+            &metrics,
+            "reddb_replication_flow_control_in_quorum_lag_lsn "
+        ) > 2,
+        "observed in-quorum lag should exceed soft target:\n{metrics}"
+    );
+
+    // Write admission is throttled: a DML write is now rejected.
+    let throttled = runtime.execute_query("INSERT INTO issue_826_flow (id, name) VALUES (99, 'x')");
+    assert!(
+        throttled.is_err(),
+        "write must be throttled while in-quorum replica lags: {throttled:?}"
+    );
+
+    // Replica catches up: pull then ack the current LSN.
+    let pull = client
+        .pull_wal_records(pull_request("replica_a", &replica_a_key.key))
+        .await
+        .expect("replica_a pulls WAL")
+        .into_inner();
+    let pull_body: serde_json::Value = serde_json::from_str(&pull.payload).expect("pull JSON");
+    let current_lsn = pull_body["current_lsn"].as_u64().expect("current_lsn");
+    client
+        .ack_replica_lsn(ack_request(
+            "replica_a",
+            current_lsn,
+            current_lsn,
+            &replica_a_key.key,
+        ))
+        .await
+        .expect("replica_a acks current LSN");
+
+    // Ack-path refresh releases the throttle.
+    assert!(
+        !runtime.write_gate().is_flow_throttled(),
+        "throttle must release once the in-quorum replica catches up"
+    );
+    let (_, metrics) = get(runtime.clone(), "/metrics");
+    assert_eq!(
+        metric_value(&metrics, "reddb_replication_flow_control_throttled "),
+        0,
+        "throttle metric should clear after recovery:\n{metrics}"
+    );
+
+    // Writes are admitted again.
+    runtime
+        .execute_query("INSERT INTO issue_826_flow (id, name) VALUES (100, 'ok')")
+        .expect("write admitted after recovery");
+
+    handle.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #826. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782767755&installation_id=129708444&pr_number=867&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F867&signature=f0b51c5f237485cdd2f1b446c997a131a04a6bc87e39d5a0cc98a87f7a0a5648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Write admission flow control now automatically throttles writes when in-quorum replicas fall behind the primary beyond a configured soft target threshold, resuming when replicas catch up.
  * Soft target lag threshold is configurable via environment variable.
  * Added metrics to monitor throttling status, configured soft target, and observed replica lag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->