### PR TITLE
merge: #830 Replication: slot-pinned, resumable replica bootstrap

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -57,6 +57,38 @@ fn insert_snapshot_sidecar(
     Ok(())
 }
 
+/// Parse an optional unsigned-integer replication snapshot control header
+/// (issue #830 resumable transfer). Returns `Ok(None)` when the header is
+/// absent so callers can fall back to whole-snapshot behaviour.
+fn snapshot_metadata_usize(
+    metadata: &tonic::metadata::MetadataMap,
+    key: &str,
+) -> Result<Option<usize>, Status> {
+    let Some(value) = metadata.get(key) else {
+        return Ok(None);
+    };
+    let raw = value
+        .to_str()
+        .map_err(|_| Status::invalid_argument(format!("{key} must be ascii")))?;
+    raw.parse::<usize>()
+        .map(Some)
+        .map_err(|_| Status::invalid_argument(format!("{key} must be an unsigned integer")))
+}
+
+/// Parse an optional ASCII replication snapshot control header (issue #830).
+fn snapshot_metadata_string(
+    metadata: &tonic::metadata::MetadataMap,
+    key: &str,
+) -> Result<Option<String>, Status> {
+    let Some(value) = metadata.get(key) else {
+        return Ok(None);
+    };
+    value
+        .to_str()
+        .map(|value| Some(value.to_string()))
+        .map_err(|_| Status::invalid_argument(format!("{key} must be ascii")))
+}
+
 fn ask_reply_from_runtime_result(result: &RuntimeQueryResult) -> Result<AskReply, Status> {
     let ask = ask_result_from_unified_result(&result.result)
         .ok_or_else(|| Status::internal("ASK runtime result did not contain an answer row"))?;
@@ -3121,67 +3153,129 @@ impl RedDb for GrpcRuntime {
         &self,
         request: Request<Empty>,
     ) -> Result<Response<PayloadReply>, Status> {
-        self.authorize_replication_stream(&request)?;
+        // Issue #830 resumable transfer control headers (all optional — their
+        // absence preserves the legacy whole-snapshot envelope).
+        let snapshot_max_bytes =
+            snapshot_metadata_usize(request.metadata(), "x-reddb-snapshot-max-bytes")?;
+        let snapshot_offset =
+            snapshot_metadata_usize(request.metadata(), "x-reddb-snapshot-offset")?.unwrap_or(0);
+        let requested_snapshot_token =
+            snapshot_metadata_string(request.metadata(), "x-reddb-snapshot-token")?;
+        let replica_id = self.authorize_replication_stream(&request)?;
         let db = self.runtime.db();
 
-        if db.replication.is_none() {
-            return Err(Status::failed_precondition(
-                "this instance is not a replication primary",
-            ));
-        }
+        let repl = db.replication.as_ref().ok_or_else(|| {
+            Status::failed_precondition("this instance is not a replication primary")
+        })?;
+        // Pin a replication slot for this replica at bootstrap start so the WAL
+        // frontier it needs is retained until catch-up finishes (issue #830 —
+        // kills the initial-sync-vs-retention race that produces stalled_gap).
+        let slot_restart_lsn = repl.register_replica(replica_id.clone());
 
         // Trigger a checkpoint first to ensure data is flushed
         db.flush().map_err(|e| Status::internal(e.to_string()))?;
 
+        let snapshot_lsn = repl
+            .logical_wal_spool
+            .as_ref()
+            .map(|spool| spool.current_lsn())
+            .unwrap_or_else(|| repl.wal_buffer.current_lsn());
+
         let mut map = crate::json::Map::new();
         map.insert("snapshot_available".into(), JsonValue::Bool(true));
+        map.insert("replica_id".into(), JsonValue::String(replica_id.clone()));
+        map.insert(
+            "slot_restart_lsn".into(),
+            JsonValue::Number(slot_restart_lsn as f64),
+        );
         if let Some(path) = db.path() {
             let bytes = std::fs::read(path).map_err(|e| Status::internal(e.to_string()))?;
-            map.insert("snapshot_hex".into(), JsonValue::String(hex::encode(bytes)));
+            // A resumable snapshot token is keyed to the replica, the pinned
+            // snapshot LSN, and the total size so a resuming caller is matched
+            // to the same byte stream it started.
+            let snapshot_token = requested_snapshot_token.unwrap_or_else(|| {
+                format!("snapshot:{replica_id}:{snapshot_lsn}:{}", bytes.len())
+            });
+            map.insert(
+                "snapshot_token".into(),
+                JsonValue::String(snapshot_token.clone()),
+            );
+            map.insert(
+                "snapshot_total_bytes".into(),
+                JsonValue::Number(bytes.len() as f64),
+            );
             map.insert(
                 "snapshot_path".into(),
                 JsonValue::String(path.display().to_string()),
             );
 
-            insert_snapshot_sidecar(
-                &mut map,
-                "metadata_binary_hex",
-                &crate::physical::PhysicalMetadataFile::metadata_binary_path_for(path),
-            )?;
-            insert_snapshot_sidecar(
-                &mut map,
-                "metadata_json_hex",
-                &crate::physical::PhysicalMetadataFile::metadata_path_for(path),
-            )?;
+            if let Some(max_bytes) = snapshot_max_bytes {
+                // Chunked, resumable transfer: serve [offset, offset+max_bytes)
+                // and tell the caller where to resume from next.
+                let max_bytes = max_bytes.max(1);
+                if snapshot_offset > bytes.len() {
+                    return Err(Status::invalid_argument(
+                        "x-reddb-snapshot-offset is beyond snapshot size",
+                    ));
+                }
+                let next_offset = snapshot_offset.saturating_add(max_bytes).min(bytes.len());
+                map.insert(
+                    "snapshot_offset".into(),
+                    JsonValue::Number(snapshot_offset as f64),
+                );
+                map.insert(
+                    "snapshot_chunk_hex".into(),
+                    JsonValue::String(hex::encode(&bytes[snapshot_offset..next_offset])),
+                );
+                map.insert(
+                    "next_snapshot_offset".into(),
+                    JsonValue::Number(next_offset as f64),
+                );
+                map.insert(
+                    "snapshot_complete".into(),
+                    JsonValue::Bool(next_offset == bytes.len()),
+                );
+            } else {
+                // Legacy whole-snapshot envelope (plus sidecars) for callers
+                // that do not opt into chunked transfer.
+                let snapshot_total = JsonValue::Number(bytes.len() as f64);
+                map.insert("snapshot_hex".into(), JsonValue::String(hex::encode(bytes)));
+                map.insert("snapshot_offset".into(), JsonValue::Number(0.0));
+                map.insert("next_snapshot_offset".into(), snapshot_total);
+                map.insert("snapshot_complete".into(), JsonValue::Bool(true));
 
-            let mut header_shadow = path.to_path_buf().into_os_string();
-            header_shadow.push("-hdr");
-            insert_snapshot_sidecar(
-                &mut map,
-                "header_shadow_hex",
-                &std::path::PathBuf::from(header_shadow),
-            )?;
+                insert_snapshot_sidecar(
+                    &mut map,
+                    "metadata_binary_hex",
+                    &crate::physical::PhysicalMetadataFile::metadata_binary_path_for(path),
+                )?;
+                insert_snapshot_sidecar(
+                    &mut map,
+                    "metadata_json_hex",
+                    &crate::physical::PhysicalMetadataFile::metadata_path_for(path),
+                )?;
 
-            let mut metadata_shadow = path.to_path_buf().into_os_string();
-            metadata_shadow.push("-meta");
-            insert_snapshot_sidecar(
-                &mut map,
-                "metadata_shadow_hex",
-                &std::path::PathBuf::from(metadata_shadow),
-            )?;
+                let mut header_shadow = path.to_path_buf().into_os_string();
+                header_shadow.push("-hdr");
+                insert_snapshot_sidecar(
+                    &mut map,
+                    "header_shadow_hex",
+                    &std::path::PathBuf::from(header_shadow),
+                )?;
+
+                let mut metadata_shadow = path.to_path_buf().into_os_string();
+                metadata_shadow.push("-meta");
+                insert_snapshot_sidecar(
+                    &mut map,
+                    "metadata_shadow_hex",
+                    &std::path::PathBuf::from(metadata_shadow),
+                )?;
+            }
         }
-        if let Some(ref repl) = db.replication {
-            map.insert(
-                "snapshot_lsn".into(),
-                JsonValue::Number(
-                    repl.logical_wal_spool
-                        .as_ref()
-                        .map(|spool| spool.current_lsn())
-                        .unwrap_or_else(|| repl.wal_buffer.current_lsn())
-                        as f64,
-                ),
-            );
-        }
+        map.insert(
+            "snapshot_lsn".into(),
+            JsonValue::Number(snapshot_lsn as f64),
+        );
 
         Ok(Response::new(json_payload_reply(JsonValue::Object(map))))
     }

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -1592,6 +1592,32 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_slot_pin_prevents_wal_removed_rebootstrap_after_prune() {
+        let primary = PrimaryReplication::new(None);
+        for lsn in 1..=5 {
+            primary.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+
+        let slot_lsn = primary.register_replica("bootstrapping".to_string());
+        assert_eq!(slot_lsn, 5, "bootstrap pins the current frontier");
+
+        for lsn in 6..=8 {
+            primary.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+
+        assert_eq!(
+            primary.prune_retained_wal_through(8).unwrap(),
+            5,
+            "bootstrap slot keeps the frontier retained"
+        );
+        assert_eq!(
+            primary.slot_rebootstrap_reason("bootstrapping", 0, primary.wal_buffer.oldest_lsn()),
+            None,
+            "a caller resuming from its slot must not see wal-removed after slot-aware pruning"
+        );
+    }
+
+    #[test]
     fn default_config_enables_finite_slot_retention_cap() {
         let config = crate::replication::ReplicationConfig::primary();
 

--- a/crates/reddb-server/src/replication/replica.rs
+++ b/crates/reddb-server/src/replication/replica.rs
@@ -34,6 +34,8 @@ impl ReplicaReplication {
 /// Resume point recovered from a previously checkpointed bootstrap intent.
 pub struct ResumePoint {
     pub last_applied_lsn: u64,
+    pub snapshot_token: Option<String>,
+    pub snapshot_offset: u64,
 }
 
 /// Manages bootstrap lifecycle using [`AdminIntentLog`] for crash-resumability.
@@ -86,9 +88,21 @@ impl ReplicaBootstrapper {
             .and_then(|v| v.as_f64())
             .map(|f| f as u64)
             .unwrap_or(0);
+        let snapshot_token = progress
+            .get("snapshot_cursor")
+            .or_else(|| progress.get("snapshot_token"))
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned);
+        let snapshot_offset = progress
+            .get("snapshot_offset")
+            .and_then(|v| v.as_f64())
+            .map(|f| f as u64)
+            .unwrap_or(0);
 
         Some(ResumePoint {
             last_applied_lsn: lsn,
+            snapshot_token,
+            snapshot_offset,
         })
     }
 
@@ -139,6 +153,35 @@ impl<'a> BootstrapHandle<'a> {
     ) -> Result<(), IntentLogError> {
         self.checkpoint_n += 1;
         let progress = IntentProgress::new()
+            .insert(
+                "last_applied_lsn",
+                JsonValue::Number(last_applied_lsn as f64),
+            )
+            .insert("batches_applied", JsonValue::Number(batches_applied as f64));
+        self.handle.checkpoint(self.checkpoint_n, Some(progress))?;
+        self.last_applied_lsn = last_applied_lsn;
+        Ok(())
+    }
+
+    /// Checkpoint an in-flight snapshot transfer so an interrupted bootstrap
+    /// can resume from the last persisted byte offset instead of restarting
+    /// from zero (issue #830).
+    ///
+    /// The snapshot token is stored under `snapshot_cursor` because
+    /// [`AdminIntentLog`] redacts progress keys containing `token`; the public
+    /// [`ResumePoint`] still surfaces it as `snapshot_token` to callers, which
+    /// also read the legacy `snapshot_token` key as a fallback.
+    pub fn checkpoint_snapshot_transfer(
+        &mut self,
+        snapshot_token: impl Into<String>,
+        snapshot_offset: u64,
+        last_applied_lsn: u64,
+        batches_applied: u64,
+    ) -> Result<(), IntentLogError> {
+        self.checkpoint_n += 1;
+        let progress = IntentProgress::new()
+            .insert("snapshot_cursor", JsonValue::String(snapshot_token.into()))
+            .insert("snapshot_offset", JsonValue::Number(snapshot_offset as f64))
             .insert(
                 "last_applied_lsn",
                 JsonValue::Number(last_applied_lsn as f64),
@@ -260,6 +303,31 @@ mod tests {
         assert_eq!(r1, Some(300), "replica-1 resumes at 300");
         assert_eq!(r2, Some(700), "replica-2 resumes at 700");
         assert!(r3.is_none(), "replica-3 has no intent");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn resume_from_snapshot_transfer_checkpoint_after_crash() {
+        let path = tmp_path("snapshot-resume");
+        let bootstrapper = ReplicaBootstrapper::new("replica-snapshot");
+
+        {
+            let log = open_log(&path);
+            let mut handle = bootstrapper.begin(&log, 10, 1000).unwrap();
+            handle
+                .checkpoint_snapshot_transfer("snapshot-token-10", 4096, 10, 0)
+                .unwrap();
+            std::mem::forget(handle);
+        }
+
+        {
+            let log2 = open_log(&path);
+            let resume = bootstrapper.scan_for_resume(&log2).expect("should resume");
+            assert_eq!(resume.last_applied_lsn, 10);
+            assert_eq!(resume.snapshot_token.as_deref(), Some("snapshot-token-10"));
+            assert_eq!(resume.snapshot_offset, 4096);
+        }
 
         let _ = std::fs::remove_file(&path);
     }

--- a/tests/e2e_issue_830_replication_bootstrap.rs
+++ b/tests/e2e_issue_830_replication_bootstrap.rs
@@ -1,0 +1,253 @@
+//! Issue #830 — slot-pinned replica bootstrap.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb::auth::policies::Policy;
+use reddb::auth::store::PrincipalRef;
+use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::grpc::proto::red_db_client::RedDbClient;
+use reddb::grpc::proto::Empty;
+use reddb::replication::ReplicationConfig;
+use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions, RedDBRuntime};
+use tonic::metadata::MetadataValue;
+use tonic::transport::Endpoint;
+
+fn pick_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+async fn wait_for_port(port: u16) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while tokio::time::Instant::now() < deadline {
+        if tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("gRPC server never came up on port {port}");
+}
+
+async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
+    let endpoint = Endpoint::from_shared(format!("http://127.0.0.1:{port}"))
+        .unwrap()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5));
+    RedDbClient::new(endpoint.connect().await.expect("client connect"))
+}
+
+fn install_replication_policy(store: &AuthStore, username: &str) {
+    let policy_json = format!(
+        r#"{{"id":"p_{username}_replication","version":1,"statements":[{{"effect":"allow","actions":["cluster:replication:stream"],"resources":["cluster:replication"]}}]}}"#
+    );
+    store
+        .put_policy(Policy::from_json_str(&policy_json).expect("policy parses"))
+        .expect("put policy");
+    store
+        .attach_policy(
+            PrincipalRef::User(UserId::platform(username)),
+            &format!("p_{username}_replication"),
+        )
+        .expect("attach policy");
+}
+
+fn bearer_empty(token: &str) -> tonic::Request<Empty> {
+    let mut request = tonic::Request::new(Empty {});
+    let value: MetadataValue<_> = format!("Bearer {token}").parse().unwrap();
+    request.metadata_mut().insert("authorization", value);
+    request
+}
+
+fn bearer_snapshot_chunk(
+    token: &str,
+    max_bytes: usize,
+    offset: usize,
+    snapshot_token: Option<&str>,
+) -> tonic::Request<Empty> {
+    let mut request = bearer_empty(token);
+    request.metadata_mut().insert(
+        "x-reddb-snapshot-max-bytes",
+        max_bytes.to_string().parse().unwrap(),
+    );
+    request.metadata_mut().insert(
+        "x-reddb-snapshot-offset",
+        offset.to_string().parse().unwrap(),
+    );
+    if let Some(snapshot_token) = snapshot_token {
+        request
+            .metadata_mut()
+            .insert("x-reddb-snapshot-token", snapshot_token.parse().unwrap());
+    }
+    request
+}
+
+#[tokio::test]
+async fn replication_snapshot_pins_authenticated_replica_slot_at_bootstrap_start() {
+    let primary = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("primary runtime");
+    primary
+        .execute_query("CREATE TABLE issue_830_bootstrap (id INTEGER, name TEXT)")
+        .expect("create table");
+    primary
+        .execute_query("INSERT INTO issue_830_bootstrap (id, name) VALUES (1, 'one')")
+        .expect("insert bootstrap row");
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("replica_a", "p", Role::Read).unwrap();
+    let replica_key = store
+        .create_api_key("replica_a", "replication-a", Role::Read)
+        .unwrap();
+    install_replication_policy(&store, "replica_a");
+
+    let port = pick_port();
+    let server = RedDBGrpcServer::with_options(
+        primary.clone(),
+        GrpcServerOptions {
+            bind_addr: format!("127.0.0.1:{port}"),
+            tls: None,
+        },
+        store,
+    );
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port).await;
+
+    let mut client = connect_client(port).await;
+    let snapshot = client
+        .replication_snapshot(bearer_empty(&replica_key.key))
+        .await
+        .expect("replication snapshot starts bootstrap")
+        .into_inner();
+    let snapshot_body: serde_json::Value =
+        serde_json::from_str(&snapshot.payload).expect("snapshot body");
+    let snapshot_lsn = snapshot_body["snapshot_lsn"]
+        .as_u64()
+        .expect("snapshot_lsn");
+    assert_eq!(snapshot_body["replica_id"], "replica_a");
+    assert_eq!(
+        snapshot_body["slot_restart_lsn"].as_u64(),
+        Some(snapshot_lsn)
+    );
+
+    let status = client
+        .replication_status(bearer_empty(&replica_key.key))
+        .await
+        .expect("replication status")
+        .into_inner();
+    let status_body: serde_json::Value = serde_json::from_str(&status.payload).expect("status");
+    let slots = status_body["slots"].as_array().expect("slots array");
+    let slot = slots
+        .iter()
+        .find(|slot| slot["id"] == "replica_a")
+        .expect("bootstrap slot registered");
+    assert_eq!(slot["restart_lsn"].as_u64(), Some(snapshot_lsn));
+    assert_eq!(slot["invalidated"].as_bool(), Some(false));
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn replication_snapshot_resumes_from_checkpoint_token_offset() {
+    let primary = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+    )
+    .expect("primary runtime");
+    primary
+        .execute_query("CREATE TABLE issue_830_snapshot_resume (id INTEGER, name TEXT)")
+        .expect("create table");
+    for id in 0..8 {
+        primary
+            .execute_query(&format!(
+                "INSERT INTO issue_830_snapshot_resume (id, name) VALUES ({id}, 'row-{id}')"
+            ))
+            .expect("insert row");
+    }
+
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..AuthConfig::default()
+    }));
+    store.create_user("replica_b", "p", Role::Read).unwrap();
+    let replica_key = store
+        .create_api_key("replica_b", "replication-b", Role::Read)
+        .unwrap();
+    install_replication_policy(&store, "replica_b");
+
+    let port = pick_port();
+    let server = RedDBGrpcServer::with_options(
+        primary,
+        GrpcServerOptions {
+            bind_addr: format!("127.0.0.1:{port}"),
+            tls: None,
+        },
+        store,
+    );
+    let handle = tokio::spawn(async move {
+        let _ = server.serve().await;
+    });
+    wait_for_port(port).await;
+
+    let mut client = connect_client(port).await;
+    let first = client
+        .replication_snapshot(bearer_snapshot_chunk(&replica_key.key, 64, 0, None))
+        .await
+        .expect("first snapshot chunk")
+        .into_inner();
+    let first_body: serde_json::Value = serde_json::from_str(&first.payload).expect("first body");
+    let snapshot_token = first_body["snapshot_token"]
+        .as_str()
+        .expect("snapshot token")
+        .to_string();
+    let next_offset = first_body["next_snapshot_offset"]
+        .as_u64()
+        .expect("next offset");
+    assert_eq!(first_body["snapshot_offset"].as_u64(), Some(0));
+    assert!(
+        next_offset > 0,
+        "first chunk must advance the resumable offset"
+    );
+    assert_eq!(first_body["snapshot_complete"].as_bool(), Some(false));
+
+    let resumed = client
+        .replication_snapshot(bearer_snapshot_chunk(
+            &replica_key.key,
+            64,
+            next_offset as usize,
+            Some(&snapshot_token),
+        ))
+        .await
+        .expect("resumed snapshot chunk")
+        .into_inner();
+    let resumed_body: serde_json::Value =
+        serde_json::from_str(&resumed.payload).expect("resumed body");
+    assert_eq!(
+        resumed_body["snapshot_token"].as_str(),
+        Some(snapshot_token.as_str())
+    );
+    assert_eq!(resumed_body["snapshot_offset"].as_u64(), Some(next_offset));
+    assert!(
+        resumed_body["snapshot_chunk_hex"]
+            .as_str()
+            .map(|chunk| !chunk.is_empty())
+            .unwrap_or(false),
+        "resumed chunk must carry snapshot bytes from the checkpoint"
+    );
+
+    handle.abort();
+}


### PR DESCRIPTION
Automated AFK landing for #830. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782768700&installation_id=129708444&pr_number=868&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F868&signature=873075362910536351a6069b2335ceba97857b6ba74f799806bc7fdad5593aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented resumable snapshot transfers for replica bootstrapping, enabling interrupted transfers to resume from checkpoints.
  * Enhanced crash recovery during replica bootstrap to preserve transfer progress across restarts.

* **Tests**
  * Added end-to-end integration tests for authenticated replica snapshot bootstrapping scenarios.
  * Added regression tests for replication slot pinning across pruning operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reddb-io/reddb/pull/868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->