### PR TITLE
merge: #837 Replication: stay-readable during re-bootstrap (swapdb) + causal routing guard

### DIFF
--- a/crates/reddb-client/src/bookmark_routing.rs
+++ b/crates/reddb-client/src/bookmark_routing.rs
@@ -98,20 +98,31 @@ pub struct ReadEndpoint {
     pub lag_ms: u32,
     /// Contiguous applied frontier (`ReplicaInfo::last_applied_lsn`).
     pub frontier_lsn: u64,
-    /// `true` when this replica can serve the bookmark *now*: healthy
-    /// and its frontier already covers the bookmark commit LSN.
+    /// `true` while this replica is re-bootstrapping (issue #837). Its
+    /// advertised frontier describes data it is about to discard, so it
+    /// is never eligible for a causal read regardless of how far ahead
+    /// that frontier sits.
+    pub rebootstrapping: bool,
+    /// `true` when this replica can serve the bookmark *now*: healthy,
+    /// **not** re-bootstrapping, and its frontier already covers the
+    /// bookmark commit LSN.
     pub bookmark_eligible: bool,
 }
 
 impl ReadEndpoint {
     fn from_replica(info: &ReplicaInfo, bookmark: BookmarkTarget) -> Self {
-        let eligible = info.healthy && info.last_applied_lsn >= bookmark.commit_lsn;
+        // A re-bootstrapping replica is excluded even when its frontier
+        // covers the bookmark: that frontier describes data it is about
+        // to throw away on the atomic swap (issue #837).
+        let eligible =
+            info.healthy && !info.rebootstrapping && info.last_applied_lsn >= bookmark.commit_lsn;
         Self {
             addr: info.addr.clone(),
             region: info.region.clone(),
             healthy: info.healthy,
             lag_ms: info.lag_ms,
             frontier_lsn: info.last_applied_lsn,
+            rebootstrapping: info.rebootstrapping,
             bookmark_eligible: eligible,
         }
     }
@@ -257,20 +268,29 @@ impl RoutingTable {
             .collect()
     }
 
-    /// Pick the index of the wait target: a healthy replica, preferring
-    /// `preferred_region`, otherwise the first healthy replica in
-    /// advertised order. `None` when no replica is healthy.
+    /// Pick the index of the wait target: a healthy, non-rebuilding
+    /// replica, preferring `preferred_region`, otherwise the first such
+    /// replica in advertised order. `None` when no replica can serve a
+    /// causal read.
+    ///
+    /// A re-bootstrapping replica is skipped entirely (issue #837):
+    /// there is no point waiting on or polling a node whose frontier
+    /// describes data it is about to discard — it can never become a
+    /// valid causal target until its swap completes and it re-advertises
+    /// without the flag.
     fn pick_target_index(&self, preferred_region: Option<&str>) -> Option<usize> {
         if let Some(region) = preferred_region {
             if let Some(i) = self
                 .replicas
                 .iter()
-                .position(|r| r.healthy && r.region == region)
+                .position(|r| r.healthy && !r.rebootstrapping && r.region == region)
             {
                 return Some(i);
             }
         }
-        self.replicas.iter().position(|r| r.healthy)
+        self.replicas
+            .iter()
+            .position(|r| r.healthy && !r.rebootstrapping)
     }
 
     /// Resolve a causal read with bounded-wait-then-fallback.
@@ -333,7 +353,10 @@ impl RoutingTable {
         waited: Duration,
     ) -> RouteDecision {
         let caught_up = self.replicas.iter().enumerate().find(|(i, r)| {
-            Some(*i) != exclude && r.healthy && r.last_applied_lsn >= bookmark.commit_lsn
+            Some(*i) != exclude
+                && r.healthy
+                && !r.rebootstrapping
+                && r.last_applied_lsn >= bookmark.commit_lsn
         });
         match caught_up {
             Some((_, r)) => RouteDecision {
@@ -369,6 +392,21 @@ mod tests {
             healthy,
             lag_ms: if healthy { 5 } else { u32::MAX },
             last_applied_lsn: frontier,
+            rebootstrapping: false,
+        }
+    }
+
+    /// A re-bootstrapping replica: healthy and far ahead on its
+    /// advertised frontier, but rebuilding — so never causally
+    /// eligible (issue #837).
+    fn rebuilding_replica(addr: &str, region: &str, frontier: u64) -> ReplicaInfo {
+        ReplicaInfo {
+            addr: addr.into(),
+            region: region.into(),
+            healthy: true,
+            lag_ms: 5,
+            last_applied_lsn: frontier,
+            rebootstrapping: true,
         }
     }
 
@@ -472,6 +510,101 @@ mod tests {
         // frontier == commit_lsn must count as eligible.
         let reads = table.read_endpoints(BookmarkTarget::new(1, 100));
         assert!(reads[0].bookmark_eligible);
+    }
+
+    // ---- rebootstrapping replicas are excluded from causal reads ----
+
+    #[test]
+    fn rebootstrapping_replica_is_never_bookmark_eligible_despite_frontier() {
+        // Frontier 999 is well past the bookmark, but the node is
+        // rebuilding — its frontier describes data it will discard.
+        let table = RoutingTable::from_membership(
+            membership(vec![rebuilding_replica("rebuild:5050", "us-east-1", 999)]),
+            1,
+        );
+        let reads = table.read_endpoints(BookmarkTarget::new(1, 100));
+        assert_eq!(reads[0].frontier_lsn, 999);
+        assert!(reads[0].rebootstrapping);
+        assert!(
+            !reads[0].bookmark_eligible,
+            "a rebuilding node must never be bookmark-eligible"
+        );
+    }
+
+    #[test]
+    fn route_skips_rebuilding_node_and_falls_back_to_caught_up_peer() {
+        // The rebuilding node is first in advertised order and far
+        // ahead, but causal reads must bounce to the caught-up peer —
+        // without ever polling the rebuilding node.
+        let table = RoutingTable::from_membership(
+            membership(vec![
+                rebuilding_replica("rebuild:5050", "us-east-1", 999),
+                replica("caught-up:5050", "us-east-1", true, 300),
+            ]),
+            1,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![], Duration::from_millis(10));
+        let decision = table.route_causal_read(
+            BookmarkTarget::new(1, 100),
+            &CausalReadOptions::with_deadline(Duration::from_millis(500)),
+            &mut waiter,
+        );
+        // The caught-up peer is the target chosen straight away; the
+        // rebuilding node was never selected as the wait target.
+        assert_eq!(decision.endpoint.addr, "caught-up:5050");
+        assert!(!decision.kind.is_fallback());
+        assert!(
+            waiter.polled_addrs.iter().all(|a| a != "rebuild:5050"),
+            "must never poll a rebuilding node"
+        );
+    }
+
+    #[test]
+    fn route_falls_back_to_primary_when_every_replica_is_rebuilding() {
+        // All replicas are rebuilding (and ahead of the bookmark);
+        // a causal read must still resolve — to the primary.
+        let table = RoutingTable::from_membership(
+            membership(vec![
+                rebuilding_replica("rebuild-a:5050", "us-east-1", 999),
+                rebuilding_replica("rebuild-b:5050", "us-west-2", 999),
+            ]),
+            4,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![], Duration::from_millis(10));
+        let decision = table.route_causal_read(
+            BookmarkTarget::new(4, 100),
+            &CausalReadOptions::with_deadline(Duration::from_millis(500)),
+            &mut waiter,
+        );
+        assert_eq!(decision.kind, RouteKind::FallbackPrimary);
+        assert_eq!(decision.endpoint.addr, "primary:5050");
+        assert!(
+            waiter.polled_addrs.is_empty(),
+            "no rebuilding node should be polled"
+        );
+    }
+
+    #[test]
+    fn rebuilding_node_excluded_as_fallback_target() {
+        // The wait target (region-preferred, lagging) never catches up;
+        // the only frontier-ahead peer is rebuilding, so the fallback
+        // skips it and lands on the primary rather than serving a
+        // bookmark from data about to be discarded.
+        let table = RoutingTable::from_membership(
+            membership(vec![
+                replica("east-lag:5050", "us-east-1", true, 10),
+                rebuilding_replica("west-rebuild:5050", "us-west-2", 999),
+            ]),
+            2,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![10, 20, 30], Duration::from_millis(10));
+        let decision = table.route_causal_read(
+            BookmarkTarget::new(2, 100),
+            &CausalReadOptions::with_deadline(Duration::from_millis(25)).prefer_region("us-east-1"),
+            &mut waiter,
+        );
+        assert_eq!(decision.kind, RouteKind::FallbackPrimary);
+        assert_eq!(decision.endpoint.addr, "primary:5050");
     }
 
     // ---- route: immediate eligible target (no wait) ----

--- a/crates/reddb-client/src/topology.rs
+++ b/crates/reddb-client/src/topology.rs
@@ -452,6 +452,7 @@ mod tests {
                     healthy: true,
                     lag_ms: 12,
                     last_applied_lsn: 4242,
+                    rebootstrapping: false,
                 },
                 ReplicaInfo {
                     addr: "replica-b.example.com:5050".into(),
@@ -459,6 +460,7 @@ mod tests {
                     healthy: false,
                     lag_ms: 999,
                     last_applied_lsn: 4100,
+                    rebootstrapping: false,
                 },
             ],
         }

--- a/crates/reddb-client/tests/rebootstrap_e2e.rs
+++ b/crates/reddb-client/tests/rebootstrap_e2e.rs
@@ -1,0 +1,226 @@
+//! End-to-end: stay-readable during re-bootstrap + causal routing
+//! bounce + atomic swap (issue #837, PRD #819).
+//!
+//! Wires the three pieces that ship in production across the crate
+//! boundary, with no mocked seams on the path under test:
+//!
+//!   1. **Server `SwapDb`** — the re-bootstrapping replica's local
+//!      store. It keeps serving non-causal reads from the old data,
+//!      refuses causal reads while rebuilding, and swaps atomically.
+//!   2. **Server `TopologyAdvertiser` + `reddb-wire` codec** — the
+//!      primary advertises the fleet; the rebuilding replica's state
+//!      carries `rebootstrapping: true`, which is encoded onto the
+//!      wire and decoded by the client (the same v1 blob both
+//!      transports carry).
+//!   3. **Client `RoutingTable`** — consumes the decoded advertisement
+//!      and bounces causal reads off the rebuilding node to a
+//!      caught-up peer, then treats it as eligible again once it swaps
+//!      and re-advertises without the flag.
+//!
+//! Gated behind the default `embedded` feature so the test can reach
+//! the in-process `reddb-server` crate directly (the npm gates do not
+//! run `cargo test`; this is verified via `cargo test`).
+
+#![cfg(feature = "embedded")]
+
+use std::time::Duration;
+
+use reddb_client::bookmark_routing::{BookmarkTarget, CausalReadOptions, RouteKind, RoutingTable};
+use reddb_client::topology::TopologyConsumer;
+use reddb_server::auth::middleware::{AuthResult, AuthSource};
+use reddb_server::auth::Role;
+use reddb_server::replication::primary::ReplicaState;
+use reddb_server::replication::swap_db::SwapDb;
+use reddb_server::replication::topology_advertiser::{LagConfig, TopologyAdvertiser};
+use reddb_server::replication::DEFAULT_REPLICA_TIMEOUT_MS;
+use reddb_wire::topology::{encode_topology, Endpoint};
+
+/// Pinned clock so health computation is deterministic.
+const NOW_MS: u128 = 1_700_000_000_000;
+
+fn authed() -> AuthResult {
+    AuthResult::Authenticated {
+        username: "operator".into(),
+        role: Role::Admin,
+        source: AuthSource::Password,
+    }
+}
+
+fn primary_ep() -> Endpoint {
+    Endpoint {
+        addr: "primary:5050".into(),
+        region: "us-east-1".into(),
+    }
+}
+
+fn lag() -> LagConfig {
+    LagConfig {
+        replica_timeout_ms: DEFAULT_REPLICA_TIMEOUT_MS,
+        records_per_ms: None,
+        now_unix_ms: NOW_MS,
+    }
+}
+
+/// Build a registry replica state with an explicit re-bootstrap flag
+/// and applied frontier.
+fn replica_state(id: &str, region: &str, frontier: u64, rebootstrapping: bool) -> ReplicaState {
+    ReplicaState {
+        id: id.to_string(),
+        last_acked_lsn: frontier,
+        last_sent_lsn: frontier,
+        last_durable_lsn: frontier,
+        apply_error_count: 0,
+        divergence_count: 0,
+        connected_at_unix_ms: NOW_MS,
+        last_seen_at_unix_ms: NOW_MS,
+        region: Some(region.to_string()),
+        rebootstrapping,
+    }
+}
+
+/// Encode the advertisement the primary would ship for `replicas`,
+/// then decode it client-side through the wire codec into a routing
+/// table — exercising the exact encode → wire → decode → route path.
+fn route_table_from(replicas: &[ReplicaState], epoch: u64, term: u64) -> RoutingTable {
+    let topo = TopologyAdvertiser::advertise(
+        replicas,
+        &authed(),
+        epoch,
+        primary_ep(),
+        /* primary_current_lsn */ 1_000,
+        &lag(),
+    );
+    let bytes = encode_topology(&topo);
+    let membership = TopologyConsumer::consume_bytes(&bytes, None).expect("decode advertisement");
+    RoutingTable::from_membership(membership, term)
+}
+
+#[test]
+fn rebootstrap_stay_readable_causal_bounce_then_atomic_swap() {
+    // The replica's local store starts with the old dataset.
+    let store: SwapDb<Vec<u32>> = SwapDb::new(vec![10, 20, 30]);
+
+    // ---- 1. Enter re-bootstrap: stays readable, refuses causal. ----
+    store.begin_rebootstrap();
+    assert!(store.is_rebootstrapping());
+    // Non-causal reads keep flowing from the OLD data.
+    assert_eq!(
+        *store.read_noncausal(),
+        vec![10, 20, 30],
+        "must keep serving non-causal reads from old data during rebuild"
+    );
+    // Causal reads are refused locally — the node won't serve a
+    // bookmark from data it is about to discard.
+    assert!(
+        store.read_causal().is_err(),
+        "must refuse causal reads while re-bootstrapping"
+    );
+
+    // ---- 2. Causal routing bounces off the rebuilding node. ----
+    // The rebuilding replica is far ahead on its advertised frontier
+    // (500) but flagged; a healthy peer sits at 300. The bookmark
+    // needs LSN 100, which BOTH frontiers cover — yet causal routing
+    // must pick the peer, never the rebuilding node.
+    let rebuilding = replica_state("rebuild:5050", "us-east-1", 500, true);
+    let peer = replica_state("peer:5050", "us-east-1", 300, false);
+    let table = route_table_from(&[rebuilding.clone(), peer.clone()], 1, 1);
+
+    // The advertisement carried the flag across the wire.
+    let bookmark = BookmarkTarget::new(1, 100);
+    let reads = table.read_endpoints(bookmark);
+    let rebuild_read = reads.iter().find(|r| r.addr == "rebuild:5050").unwrap();
+    assert!(rebuild_read.rebootstrapping, "flag must survive the wire");
+    assert_eq!(rebuild_read.frontier_lsn, 500);
+    assert!(
+        !rebuild_read.bookmark_eligible,
+        "rebuilding node must be ineligible despite a covering frontier"
+    );
+
+    let mut waiter = NeverPollWaiter::default();
+    let decision = table.route_causal_read(
+        bookmark,
+        &CausalReadOptions::with_deadline(Duration::from_millis(500)),
+        &mut waiter,
+    );
+    assert_eq!(
+        decision.endpoint.addr, "peer:5050",
+        "causal read bounced to the caught-up peer"
+    );
+    assert!(
+        !decision.kind.is_fallback(),
+        "peer is the chosen target, not a fallback"
+    );
+    assert!(
+        waiter.polled.iter().all(|a| a != "rebuild:5050"),
+        "must never wait/poll on the rebuilding node"
+    );
+
+    // If the peer were also rebuilding, the read must still resolve —
+    // to the primary.
+    let peer_rebuilding = replica_state("peer:5050", "us-east-1", 300, true);
+    let all_rebuilding = route_table_from(&[rebuilding.clone(), peer_rebuilding], 1, 1);
+    let mut waiter2 = NeverPollWaiter::default();
+    let fallback = all_rebuilding.route_causal_read(
+        bookmark,
+        &CausalReadOptions::with_deadline(Duration::from_millis(500)),
+        &mut waiter2,
+    );
+    assert_eq!(fallback.kind, RouteKind::FallbackPrimary);
+    assert_eq!(fallback.endpoint.addr, "primary:5050");
+
+    // ---- 3. Atomic swap: new data installed, node eligible again. --
+    let old = store.complete_rebootstrap(vec![11, 22, 33, 44]);
+    assert_eq!(*old, vec![10, 20, 30], "swap returns the prior dataset");
+    assert!(!store.is_rebootstrapping());
+    // Both read paths now serve the fresh data.
+    assert_eq!(*store.read_noncausal(), vec![11, 22, 33, 44]);
+    assert_eq!(
+        *store.read_causal().expect("causal ok"),
+        vec![11, 22, 33, 44]
+    );
+
+    // The replica re-advertises without the flag (and a higher epoch),
+    // and the routing table now treats it as causally eligible.
+    let recovered = replica_state("rebuild:5050", "us-east-1", 500, false);
+    let table_after = route_table_from(&[recovered, peer], 2, 1);
+    let reads_after = table_after.read_endpoints(bookmark);
+    let rebuilt = reads_after
+        .iter()
+        .find(|r| r.addr == "rebuild:5050")
+        .unwrap();
+    assert!(!rebuilt.rebootstrapping);
+    assert!(
+        rebuilt.bookmark_eligible,
+        "after the swap the node is eligible for causal reads again"
+    );
+
+    let mut waiter3 = NeverPollWaiter::default();
+    let decision_after = table_after.route_causal_read(
+        bookmark,
+        &CausalReadOptions::with_deadline(Duration::from_millis(500)),
+        &mut waiter3,
+    );
+    assert_eq!(decision_after.kind, RouteKind::EligibleTarget);
+    assert_eq!(decision_after.endpoint.addr, "rebuild:5050");
+}
+
+/// A waiter that asserts the fast/exclusion paths never need to poll.
+/// If the routing table ever tried to wait on a node here, `polled`
+/// would record it and the test assertions would catch it.
+#[derive(Default)]
+struct NeverPollWaiter {
+    polled: Vec<String>,
+}
+
+impl reddb_client::bookmark_routing::BookmarkWaiter for NeverPollWaiter {
+    fn elapsed(&self) -> Duration {
+        // Report the deadline as already blown so any wait loop exits
+        // immediately rather than spinning — the node selection, not
+        // the wait, is what this test exercises.
+        Duration::from_secs(3600)
+    }
+    fn poll(&mut self, target_addr: &str) -> u64 {
+        self.polled.push(target_addr.to_string());
+        0
+    }
+}

--- a/crates/reddb-client/tests/topology_e2e.rs
+++ b/crates/reddb-client/tests/topology_e2e.rs
@@ -400,6 +400,7 @@ fn make_topology_bytes(primary: &SocketAddr, replicas: &[SocketAddr]) -> Vec<u8>
                 healthy: true,
                 lag_ms: 0,
                 last_applied_lsn: 100 + i as u64,
+                rebootstrapping: false,
             })
             .collect(),
     };

--- a/crates/reddb-grpc-proto/src/lib.rs
+++ b/crates/reddb-grpc-proto/src/lib.rs
@@ -41,6 +41,7 @@ mod topology_tests {
                 healthy: true,
                 lag_ms: 4,
                 last_applied_lsn: 99,
+                rebootstrapping: false,
             }],
         }
     }

--- a/crates/reddb-server/src/replication/flow_control.rs
+++ b/crates/reddb-server/src/replication/flow_control.rs
@@ -196,6 +196,7 @@ mod tests {
             connected_at_unix_ms: 0,
             last_seen_at_unix_ms: 0,
             region: region.map(String::from),
+            rebootstrapping: false,
         }
     }
 

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -32,6 +32,7 @@ pub mod primary;
 pub mod quorum;
 pub mod replica;
 pub mod scheduler;
+pub mod swap_db;
 pub mod topology_advertiser;
 
 pub use bookmark::{BookmarkDecodeError, CausalBookmark};
@@ -44,6 +45,7 @@ pub use failover::{
 pub use flow_control::{Admission, FlowController};
 pub use lease::{LeaseError, LeaseStore, WriterLease};
 pub use quorum::{QuorumConfig, QuorumCoordinator, QuorumError};
+pub use swap_db::{RebootstrapInProgress, SwapDb};
 pub use topology_advertiser::{
     LagConfig, TopologyAdvertiser, TopologyAuthGate, DEFAULT_REPLICA_TIMEOUT_MS,
     TOPOLOGY_READ_CAPABILITY,

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -1023,6 +1023,13 @@ pub struct ReplicaState {
     /// handshake extension lands in 2.6.2; the quorum coordinator's
     /// region-binding map covers the in-process case meanwhile.
     pub region: Option<String>,
+    /// `true` while this replica is re-bootstrapping — loading a fresh
+    /// snapshot to replace its current dataset (issue #837). It keeps
+    /// serving non-causal reads from the old data, but the advertiser
+    /// surfaces this flag so a causal reader routes bookmark reads
+    /// elsewhere: the replica's `last_acked_lsn` describes data it is
+    /// about to discard. Cleared atomically when the swap completes.
+    pub rebootstrapping: bool,
 }
 
 /// Primary-side replication progress derived from the replica registry.
@@ -1214,10 +1221,39 @@ impl PrimaryReplication {
             connected_at_unix_ms: now_ms,
             last_seen_at_unix_ms: now_ms,
             region,
+            rebootstrapping: false,
         });
         drop(replicas);
         self.bump_topology_epoch();
         resume_lsn
+    }
+
+    /// Mark (or clear) a replica's re-bootstrap state (issue #837).
+    ///
+    /// While `rebootstrapping` is `true` the replica keeps serving
+    /// non-causal reads from its existing data, but the advertiser
+    /// surfaces the flag so causal (bookmark) reads route to a
+    /// caught-up peer instead — the rebuilding replica's applied
+    /// frontier describes data it is about to discard. The primary
+    /// flips this back to `false` when the replica reports its atomic
+    /// snapshot swap complete.
+    ///
+    /// A change to the flag is a registry-shape change for routing
+    /// purposes, so it bumps the topology epoch to force consumers to
+    /// re-read the advertisement. Returns `true` when a replica with
+    /// `id` was present and updated.
+    pub fn set_replica_rebootstrapping(&self, id: &str, rebootstrapping: bool) -> bool {
+        let mut replicas = self.replicas.write().unwrap_or_else(|e| e.into_inner());
+        let Some(state) = replicas.iter_mut().find(|r| r.id == id) else {
+            return false;
+        };
+        if state.rebootstrapping == rebootstrapping {
+            return true;
+        }
+        state.rebootstrapping = rebootstrapping;
+        drop(replicas);
+        self.bump_topology_epoch();
+        true
     }
 
     /// Ensure a replica identifying itself with `id` is present in the
@@ -2146,6 +2182,7 @@ mod tests {
                 connected_at_unix_ms: now,
                 last_seen_at_unix_ms: now,
                 region: None,
+                rebootstrapping: false,
             },
             ReplicaState {
                 id: "slow".to_string(),
@@ -2157,6 +2194,7 @@ mod tests {
                 connected_at_unix_ms: now,
                 last_seen_at_unix_ms: now,
                 region: None,
+                rebootstrapping: false,
             },
         ];
 

--- a/crates/reddb-server/src/replication/swap_db.rs
+++ b/crates/reddb-server/src/replication/swap_db.rs
@@ -1,0 +1,224 @@
+//! Stay-readable re-bootstrap with an atomic dataset swap (issue #837,
+//! PRD #819).
+//!
+//! When a replica must re-bootstrap — discard its current dataset and
+//! load a fresh snapshot from the primary — it must not go dark. Read
+//! capacity is most precious exactly then, because a re-bootstrap is
+//! often triggered *because* another node is already down. [`SwapDb`]
+//! keeps the old data fully readable for the entire rebuild and swaps
+//! to the fresh dataset in one atomic step at the end.
+//!
+//! ## The two-state guarantee
+//!
+//! * **Stay-readable.** Non-causal reads ([`SwapDb::read_noncausal`])
+//!   are *always* served from the currently-installed dataset — the
+//!   old data throughout the rebuild, the new data after the swap.
+//!   They never block and never fail.
+//! * **Causal correctness.** While a rebuild is in flight the node's
+//!   applied frontier describes data it is *about to throw away*, so a
+//!   bookmark read served from it could observe a commit that the
+//!   post-swap dataset has not yet reached. [`SwapDb::read_causal`]
+//!   therefore refuses ([`RebootstrapInProgress`]) for the duration of
+//!   the rebuild; the caller routes that read to a caught-up peer. The
+//!   same signal is surfaced on the wire via
+//!   [`crate::replication::primary::ReplicaState::rebootstrapping`] so
+//!   the *client* routing table excludes the node before the read ever
+//!   reaches it.
+//!
+//! ## Atomicity
+//!
+//! The installed dataset is an `Arc<D>` behind an `RwLock`. A reader
+//! clones the `Arc` under a short read lock and then works against its
+//! own handle. [`SwapDb::complete_rebootstrap`] takes the write lock
+//! just long enough to replace the pointer. A reader that captured the
+//! old `Arc` before the swap keeps observing a complete old dataset;
+//! a reader that captures after the swap sees a complete new one.
+//! There is no window in which a half-built dataset is visible — the
+//! swap publishes the fresh `D` only once it is fully constructed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+
+/// A causal read was requested while the node is re-bootstrapping.
+///
+/// The node is intentionally refusing to serve a bookmark read from a
+/// dataset it is about to discard. The caller is expected to route the
+/// read elsewhere (a caught-up peer, or the primary) — never to treat
+/// this as a hard error surfaced to the application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RebootstrapInProgress;
+
+impl std::fmt::Display for RebootstrapInProgress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "node is re-bootstrapping; causal read must route to a caught-up peer"
+        )
+    }
+}
+
+impl std::error::Error for RebootstrapInProgress {}
+
+/// A dataset that stays readable across an atomic re-bootstrap swap.
+///
+/// Generic over the installed dataset `D` so the replication engine,
+/// the integration tests, and any future caller share one swap
+/// discipline rather than re-implementing the lock dance. `D` is held
+/// behind an `Arc`, so a "swap" is a single pointer write and old
+/// readers keep their snapshot alive.
+pub struct SwapDb<D> {
+    /// The currently-installed dataset. Readers clone the `Arc`; the
+    /// rebuild replaces the pointer under the write lock.
+    current: RwLock<Arc<D>>,
+    /// `true` from [`Self::begin_rebootstrap`] until the matching
+    /// [`Self::complete_rebootstrap`]. Gates causal reads and is the
+    /// value mirrored into the topology advertisement.
+    rebootstrapping: AtomicBool,
+}
+
+impl<D> SwapDb<D> {
+    /// Install `data` as the initial dataset. The node starts *not*
+    /// re-bootstrapping — it is serving normally.
+    pub fn new(data: D) -> Self {
+        Self {
+            current: RwLock::new(Arc::new(data)),
+            rebootstrapping: AtomicBool::new(false),
+        }
+    }
+
+    /// `true` while a re-bootstrap is in flight. This is exactly the
+    /// value the topology advertiser surfaces as
+    /// `ReplicaInfo::rebootstrapping`.
+    pub fn is_rebootstrapping(&self) -> bool {
+        self.rebootstrapping.load(Ordering::Acquire)
+    }
+
+    /// The currently-installed dataset, cloned as an `Arc`. Always
+    /// available — this is the stay-readable path. During a rebuild it
+    /// returns the *old* data; after [`Self::complete_rebootstrap`] it
+    /// returns the new data.
+    pub fn snapshot(&self) -> Arc<D> {
+        Arc::clone(&self.current.read().unwrap_or_else(|e| e.into_inner()))
+    }
+
+    /// Serve a non-causal read: always the currently-installed
+    /// dataset, rebuild in flight or not. Never blocks on the rebuild,
+    /// never fails. Identical to [`Self::snapshot`]; named for intent
+    /// at the call site.
+    pub fn read_noncausal(&self) -> Arc<D> {
+        self.snapshot()
+    }
+
+    /// Serve a causal (bookmark) read.
+    ///
+    /// Returns the installed dataset only when the node is *not*
+    /// re-bootstrapping. While a rebuild is in flight it returns
+    /// [`RebootstrapInProgress`] so the caller bounces the read to a
+    /// caught-up peer — never serving a bookmark from data the node is
+    /// about to discard.
+    pub fn read_causal(&self) -> Result<Arc<D>, RebootstrapInProgress> {
+        if self.is_rebootstrapping() {
+            return Err(RebootstrapInProgress);
+        }
+        Ok(self.snapshot())
+    }
+
+    /// Enter the re-bootstrap state. Idempotent: calling it while
+    /// already rebuilding is a no-op. The installed dataset is left
+    /// untouched, so non-causal reads keep flowing from the old data
+    /// while the fresh snapshot loads in the background.
+    pub fn begin_rebootstrap(&self) {
+        self.rebootstrapping.store(true, Ordering::Release);
+    }
+
+    /// Atomically install `fresh` as the new dataset and leave the
+    /// re-bootstrap state.
+    ///
+    /// The pointer swap happens under the write lock; the
+    /// `rebootstrapping` flag is cleared only *after* the new dataset
+    /// is published, so there is no instant at which the node both
+    /// claims to be caught up and still serves the old data to a
+    /// causal reader. Returns the previously-installed dataset (the
+    /// old `Arc`) so the caller can keep or drop it; outstanding
+    /// readers that already cloned it stay valid regardless.
+    pub fn complete_rebootstrap(&self, fresh: D) -> Arc<D> {
+        let new = Arc::new(fresh);
+        let old = {
+            let mut guard = self.current.write().unwrap_or_else(|e| e.into_inner());
+            std::mem::replace(&mut *guard, new)
+        };
+        // Publish the new dataset before re-enabling causal reads.
+        self.rebootstrapping.store(false, Ordering::Release);
+        old
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serves_noncausal_reads_from_old_data_during_rebuild() {
+        let db = SwapDb::new(vec![1, 2, 3]);
+        db.begin_rebootstrap();
+        assert!(db.is_rebootstrapping());
+        // Old data stays readable for non-causal reads.
+        assert_eq!(*db.read_noncausal(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn refuses_causal_reads_during_rebuild() {
+        let db = SwapDb::new(vec![1, 2, 3]);
+        assert!(db.read_causal().is_ok());
+        db.begin_rebootstrap();
+        assert_eq!(db.read_causal(), Err(RebootstrapInProgress));
+    }
+
+    #[test]
+    fn swap_replaces_data_and_resumes_causal_reads() {
+        let db = SwapDb::new(vec![1, 2, 3]);
+        db.begin_rebootstrap();
+        let old = db.complete_rebootstrap(vec![9, 9, 9, 9]);
+        assert_eq!(*old, vec![1, 2, 3]);
+        assert!(!db.is_rebootstrapping());
+        // New data is now served on both paths.
+        assert_eq!(*db.read_noncausal(), vec![9, 9, 9, 9]);
+        assert_eq!(*db.read_causal().expect("causal ok"), vec![9, 9, 9, 9]);
+    }
+
+    #[test]
+    fn swap_is_atomic_old_reader_keeps_complete_old_dataset() {
+        let db = SwapDb::new(vec![1, 2, 3]);
+        // Capture the dataset before the swap.
+        let pre = db.read_noncausal();
+        db.begin_rebootstrap();
+        db.complete_rebootstrap(vec![7, 8]);
+        // The pre-swap handle still observes the *whole* old dataset —
+        // never a torn/half-built view.
+        assert_eq!(*pre, vec![1, 2, 3]);
+        // A fresh read sees the new dataset.
+        assert_eq!(*db.read_noncausal(), vec![7, 8]);
+    }
+
+    #[test]
+    fn begin_rebootstrap_is_idempotent() {
+        let db = SwapDb::new(0u64);
+        db.begin_rebootstrap();
+        db.begin_rebootstrap();
+        assert!(db.is_rebootstrapping());
+        db.complete_rebootstrap(42);
+        assert!(!db.is_rebootstrapping());
+        assert_eq!(*db.snapshot(), 42);
+    }
+
+    #[test]
+    fn rebuild_then_swap_cycle_can_repeat() {
+        let db = SwapDb::new(1u32);
+        for n in 2..=5 {
+            db.begin_rebootstrap();
+            assert!(db.read_causal().is_err());
+            db.complete_rebootstrap(n);
+            assert_eq!(*db.read_causal().expect("ok"), n);
+        }
+    }
+}

--- a/crates/reddb-server/src/replication/topology_advertiser.rs
+++ b/crates/reddb-server/src/replication/topology_advertiser.rs
@@ -184,6 +184,9 @@ fn replica_to_info(state: &ReplicaState, primary_lsn: u64, lag: &LagConfig) -> R
         healthy,
         lag_ms,
         last_applied_lsn: state.last_acked_lsn,
+        // Surface the replica's re-bootstrap state so the consumer's
+        // routing table can exclude it from causal reads (issue #837).
+        rebootstrapping: state.rebootstrapping,
     }
 }
 
@@ -290,6 +293,7 @@ mod tests {
             connected_at_unix_ms: now,
             last_seen_at_unix_ms: last_seen,
             region: region.map(String::from),
+            rebootstrapping: false,
         }
     }
 

--- a/crates/reddb-server/src/runtime/write_gate.rs
+++ b/crates/reddb-server/src/runtime/write_gate.rs
@@ -604,6 +604,7 @@ mod tests {
             connected_at_unix_ms: 0,
             last_seen_at_unix_ms: 0,
             region: region.map(String::from),
+            rebootstrapping: false,
         }
     }
 

--- a/crates/reddb-wire/src/topology.rs
+++ b/crates/reddb-wire/src/topology.rs
@@ -85,6 +85,19 @@ pub struct ReplicaInfo {
     pub healthy: bool,
     pub lag_ms: u32,
     pub last_applied_lsn: u64,
+    /// `true` while this replica is re-bootstrapping (loading a fresh
+    /// snapshot). Its `last_applied_lsn` describes data it is about to
+    /// discard, so a causal reader must treat it as ineligible for
+    /// bookmark reads even when the advertised frontier covers the
+    /// bookmark (issue #837). Non-causal reads are unaffected.
+    ///
+    /// Additive field (ADR 0008 §4): it rides the existing `0x01`
+    /// version tag as a trailing per-replica flag block appended after
+    /// the replica records. An old decoder stops after the records and
+    /// ignores the trailing bytes (defaulting every replica to
+    /// `false`); a new decoder reading old bytes finds no trailing
+    /// block and likewise defaults to `false`. No version bump.
+    pub rebootstrapping: bool,
 }
 
 /// Decode-side errors. Distinct from "unknown version tag", which
@@ -140,6 +153,14 @@ pub fn encode_topology(topology: &Topology) -> Vec<u8> {
         body.push(if r.healthy { 1 } else { 0 });
         body.extend_from_slice(&r.lag_ms.to_le_bytes());
         body.extend_from_slice(&r.last_applied_lsn.to_le_bytes());
+    }
+    // Additive trailing block (ADR 0008 §4): one `rebootstrapping`
+    // byte per replica, in advertised order, appended after the
+    // records. Placed at the tail rather than interleaved into each
+    // record so an old decoder — which stops after `replicas.len`
+    // records — skips it cleanly instead of mis-framing every field.
+    for r in &topology.replicas {
+        body.push(if r.rebootstrapping { 1 } else { 0 });
     }
 
     let mut out = Vec::with_capacity(TOPOLOGY_HEADER_SIZE + body.len());
@@ -197,7 +218,23 @@ pub fn decode_topology(bytes: &[u8]) -> Result<Option<Topology>, TopologyError> 
             healthy,
             lag_ms,
             last_applied_lsn,
+            // Default until the trailing block is read below. A
+            // pre-#837 advertisement carries no trailing block, so
+            // every replica stays `false`.
+            rebootstrapping: false,
         });
+    }
+    // Additive trailing block: a `rebootstrapping` byte per replica.
+    // Present only when the producer is post-#837. When the producer
+    // is older the cursor has no bytes left here and every flag keeps
+    // its `false` default. A partial/truncated block (fewer bytes than
+    // replicas) leaves the unread tail `false` rather than erroring —
+    // forward-compat posture per ADR 0008 §4.
+    for r in replicas.iter_mut() {
+        if cur.remaining() == 0 {
+            break;
+        }
+        r.rebootstrapping = cur.read_u8()? != 0;
     }
     Ok(Some(Topology {
         epoch,
@@ -215,6 +252,8 @@ fn estimate_body_size(t: &Topology) -> usize {
     for r in &t.replicas {
         n += 4 + r.addr.len() + 4 + r.region.len() + 1 + 4 + 8;
     }
+    // Trailing `rebootstrapping` flag block: one byte per replica.
+    n += t.replicas.len();
     n
 }
 
@@ -398,6 +437,7 @@ mod tests {
                     healthy: true,
                     lag_ms: 12,
                     last_applied_lsn: 4242,
+                    rebootstrapping: false,
                 },
                 ReplicaInfo {
                     addr: "replica-b.example.com:5050".into(),
@@ -405,6 +445,7 @@ mod tests {
                     healthy: false,
                     lag_ms: 999,
                     last_applied_lsn: 4100,
+                    rebootstrapping: true,
                 },
             ],
         }
@@ -471,6 +512,42 @@ mod tests {
         // reserves the bump for genuinely breaking changes; a PR
         // adding an optional field must NOT touch this value.
         assert_eq!(TOPOLOGY_WIRE_VERSION_V1, 0x01);
+    }
+
+    #[test]
+    fn rebootstrapping_flag_round_trips_per_replica() {
+        // The additive #837 flag survives a full encode/decode and is
+        // carried independently per replica.
+        let t = fixture();
+        let decoded = decode_topology(&encode_topology(&t))
+            .expect("decode")
+            .expect("v1 known");
+        assert!(!decoded.replicas[0].rebootstrapping);
+        assert!(decoded.replicas[1].rebootstrapping);
+    }
+
+    #[test]
+    fn legacy_blob_without_trailing_block_defaults_rebootstrapping_false() {
+        // Backward-compat (ADR 0008 §4): a pre-#837 producer emits no
+        // trailing flag block. Synthesise that blob by encoding, then
+        // truncating the trailing per-replica flag bytes off the body
+        // and fixing the declared length. The decoder must still parse
+        // and default every replica to `false`.
+        let t = fixture();
+        let full = encode_topology(&t);
+        let trailing = t.replicas.len();
+        let body_len = (full.len() - TOPOLOGY_HEADER_SIZE - trailing) as u32;
+        let mut legacy = Vec::new();
+        legacy.push(TOPOLOGY_WIRE_VERSION_V1);
+        legacy.extend_from_slice(&body_len.to_le_bytes());
+        legacy.extend_from_slice(&full[TOPOLOGY_HEADER_SIZE..full.len() - trailing]);
+        let decoded = decode_topology(&legacy).expect("decode").expect("v1 known");
+        assert_eq!(decoded.replicas.len(), 2);
+        assert!(decoded.replicas.iter().all(|r| !r.rebootstrapping));
+        // Every other field is preserved verbatim — only the new flag
+        // is absent.
+        assert_eq!(decoded.replicas[0].last_applied_lsn, 4242);
+        assert_eq!(decoded.replicas[1].lag_ms, 999);
     }
 
     #[test]


### PR DESCRIPTION
Lands the verified #837 a2 work (worker wYIT2). Branch is a clean fast-forward over main (ahead=12, behind=0); all four gates passed on the a2 attempt (test/typecheck/lint/build :root ✓). Prior AFK auto-merge bounced on a diverged local-main checkout, not on this work. Landing via admin-PR per ADR 0030.

Closes #837

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782783906&installation_id=129708444&pr_number=873&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F873&signature=eb96769f726a66978e5484f6ff3ec969cfa49c689a9b6dc4db7a51062fa828ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replicas can now undergo data refresh operations while maintaining service continuity. Causal reads automatically route around rebootstrapping replicas; non-causal reads continue from the existing dataset until refresh completes.

* **Tests**
  * Extended test coverage for replica refresh scenarios, including routing behavior and fallback patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->