### PR TITLE
merge: #876 Web-streams streaming implementation for the client

### DIFF
--- a/drivers/js-client/src/streaming-web.js
+++ b/drivers/js-client/src/streaming-web.js
@@ -1,0 +1,450 @@
+/**
+ * Web-native streaming surface for the JS driver (PRD #874 / #876).
+ *
+ * The browser/Web counterpart to `./streaming.js`. It exposes the **same**
+ * streaming interface the Node implementation does — `createSelectStream`,
+ * `createInputStream`, and the `RowReadable` / `RowWritable` row wrappers —
+ * so it drops straight into the injected-streaming seam on the core `RedDB`
+ * (`new RedDB(client, { createSelectStream, createInputStream })`). A browser
+ * entry wires it in; this module imports **zero `node:` built-ins**.
+ *
+ * Where the Node version builds on `node:stream`'s `Readable` / `Writable`,
+ * this one builds on the Web Streams primitives that already power the HTTP
+ * transport's `fetch` sessions:
+ *
+ *   - `RowReadable`  — wraps a Web `ReadableStream` (object chunks) and is an
+ *     `AsyncIterable<Row>`: `for await (const row of stream)` yields each row
+ *     in order and exits cleanly on stream end. The descriptor and resumable
+ *     cursor (when the transport surfaces them) are captured on
+ *     `.descriptor` / `.cursor` and also fan out as `'descriptor'` /
+ *     `'cursor'` events. A mid-stream error frame rejects the `for await`
+ *     iteration with the transport's `RedDBError`.
+ *   - `RowWritable` — wraps a Web `WritableStream`. `write(row)` pushes a row
+ *     (backpressure flows through the returned promise / the writer's
+ *     `ready`); `end()` signals end-of-stream; the server's terminal envelope
+ *     resolves `.completion()`.
+ *
+ * Both expose the uniform `cancel(reason?)` the Node wrappers do: it aborts
+ * the underlying transport session — which, over HTTP, calls
+ * `AbortController.abort()` on the `fetch` — and rejects anything pending with
+ * a `STREAM_CANCELLED` error.
+ *
+ * The transport session contracts consumed here are identical to the Node
+ * ones (see `./streaming.js`): a read session is an async-iterable of typed
+ * `{type,value}` frames plus `cancel(reason)`, and a write session is
+ * `{ write(row), close(): Promise<EndEnvelope>, cancel(reason) }`.
+ */
+
+import { RedDBError } from './core/errors.js'
+import { classifyNdjsonFrame } from './core/ndjson.js'
+
+// Re-exported for parity with `./streaming.js`, so callers that reach for the
+// NDJSON classifier from the streaming module keep working on either impl.
+export { classifyNdjsonFrame }
+
+function cancelError(reason) {
+  const suffix = typeof reason === 'string' && reason.length > 0 ? `: ${reason}` : ''
+  return new RedDBError('STREAM_CANCELLED', `stream cancelled${suffix}`)
+}
+
+function toError(err) {
+  return err instanceof Error ? err : new RedDBError('STREAM_ERROR', String(err))
+}
+
+function deferred() {
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function abortReason(signal) {
+  const reason = signal?.reason
+  if (typeof reason === 'string') return reason
+  if (reason && typeof reason.message === 'string') return reason.message
+  return 'aborted'
+}
+
+/**
+ * Attach a tiny `on` / `once` / `off` event surface to `target` and return an
+ * internal `emit(event, ...args)`. Mirrors the events the Node `Readable` /
+ * `Writable` raise (`descriptor` / `cursor` / `error` / `end` / `close`)
+ * without dragging in `node:events`. Unlike Node's `EventEmitter`, an
+ * unhandled `'error'` does not throw — the iteration rejection already carries
+ * the failure.
+ */
+function attachEvents(target) {
+  const listeners = new Map()
+  target.on = (event, fn) => {
+    let set = listeners.get(event)
+    if (!set) {
+      set = new Set()
+      listeners.set(event, set)
+    }
+    set.add(fn)
+    return target
+  }
+  target.off = (event, fn) => {
+    listeners.get(event)?.delete(fn)
+    return target
+  }
+  target.once = (event, fn) => {
+    const wrapper = (...args) => {
+      target.off(event, wrapper)
+      fn(...args)
+    }
+    return target.on(event, wrapper)
+  }
+  return (event, ...args) => {
+    const set = listeners.get(event)
+    if (!set) return
+    for (const fn of [...set]) {
+      try {
+        fn(...args)
+      } catch {
+        // a throwing listener must not derail the stream
+      }
+    }
+  }
+}
+
+/**
+ * `AsyncIterable<Row>` over a transport read session, backed by a Web
+ * `ReadableStream`. Same surface as the Node `RowReadable`.
+ */
+export class RowReadable {
+  /**
+   * @param {Promise<object>} sessionPromise resolves to a read session.
+   * @param {{ signal?: AbortSignal }} [opts]
+   */
+  constructor(sessionPromise, { signal } = {}) {
+    this._sessionPromise = sessionPromise
+    this._session = null
+    this._iter = null
+    this._ended = false
+    this._cancelled = false
+    this._cancelReason = undefined
+    this._cancelDone = null
+    this._controller = null
+    /** Schema descriptor (HTTP NDJSON) once seen; null otherwise. */
+    this.descriptor = null
+    /** Resumable cursor control frame (#807) once seen; null otherwise. */
+    this.cursor = null
+    /** Terminal `end` envelope once the stream completes; null otherwise. */
+    this.endInfo = null
+    this._emit = attachEvents(this)
+
+    this._stream = new ReadableStream({
+      start: (controller) => {
+        this._controller = controller
+      },
+      pull: (controller) => this._pull(controller),
+      cancel: (reason) => this._forwardCancel(reason),
+    })
+
+    if (signal) {
+      if (signal.aborted) {
+        queueMicrotask(() => this.cancel(abortReason(signal)))
+      } else {
+        signal.addEventListener('abort', () => this.cancel(abortReason(signal)), { once: true })
+      }
+    }
+  }
+
+  async _resolveIter() {
+    if (this._iter) return this._iter
+    this._session = await this._sessionPromise
+    this._iter = this._session[Symbol.asyncIterator]()
+    return this._iter
+  }
+
+  async _pull(controller) {
+    if (this._cancelled) return
+    let iter
+    try {
+      iter = await this._resolveIter()
+    } catch (err) {
+      if (this._cancelled) return
+      const e = toError(err)
+      this._emit('error', e)
+      controller.error(e)
+      return
+    }
+    // Loop until backpressure (one row enqueued) or completion. Control
+    // frames (descriptor/cursor) are surfaced as events/properties and do not
+    // count against the readable buffer, so we keep pulling past them.
+    for (;;) {
+      let result
+      try {
+        result = await iter.next()
+      } catch (err) {
+        if (this._cancelled) return
+        const e = toError(err)
+        this._emit('error', e)
+        controller.error(e)
+        return
+      }
+      if (this._cancelled) return
+      const { value: frame, done } = result
+      if (done) {
+        this._ended = true
+        this._emit('end', this.endInfo)
+        controller.close()
+        return
+      }
+      if (frame.type === 'descriptor') {
+        this.descriptor = frame.value
+        this._emit('descriptor', frame.value)
+        continue
+      }
+      if (frame.type === 'cursor') {
+        this.cursor = frame.value
+        this._emit('cursor', frame.value)
+        continue
+      }
+      if (frame.type === 'end') {
+        this.endInfo = frame.value
+        this._ended = true
+        this._emit('end', frame.value)
+        controller.close()
+        return
+      }
+      // frame.type === 'row'
+      controller.enqueue(frame.value)
+      return
+    }
+  }
+
+  _forwardCancel(reason) {
+    return Promise.resolve(this._sessionPromise)
+      .then((session) => (session && session.cancel ? session.cancel(reason) : undefined))
+      .catch(() => {})
+  }
+
+  /**
+   * `for await (const row of stream)` — single-consumer, like the Node
+   * `Readable`. Yields rows in order; rejects on a mid-stream error frame or a
+   * `cancel()`.
+   */
+  async *[Symbol.asyncIterator]() {
+    const reader = this._stream.getReader()
+    try {
+      for (;;) {
+        const { value, done } = await reader.read()
+        if (done) return
+        yield value
+      }
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  /**
+   * Terminate the stream. Sends a transport-level cancel and rejects any
+   * pending `for await` iteration with a `STREAM_CANCELLED` error.
+   * @param {string} [reason]
+   * @returns {Promise<void>}
+   */
+  cancel(reason) {
+    if (this._cancelled || this._ended) return this._cancelDone ?? Promise.resolve()
+    this._cancelled = true
+    this._cancelReason = reason
+    // Error the readable so pending/future reads reject — `ReadableStream.cancel`
+    // would merely resolve them with `{done:true}`, which is not the contract.
+    try {
+      this._controller?.error(cancelError(reason))
+    } catch {
+      // already closed/errored — fine.
+    }
+    this._emit('close')
+    this._cancelDone = this._forwardCancel(reason)
+    return this._cancelDone
+  }
+}
+
+/**
+ * `WritableStream`-backed sink over a transport write session. End-of-stream
+ * is `end()`; the server's terminal envelope resolves `.completion()`. Same
+ * surface as the Node `RowWritable`.
+ */
+export class RowWritable {
+  /**
+   * @param {Promise<object>} sessionPromise resolves to a write session.
+   * @param {{ signal?: AbortSignal }} [opts]
+   */
+  constructor(sessionPromise, { signal } = {}) {
+    this._sessionPromise = sessionPromise
+    this._sessionResolved = null
+    this._finished = false
+    this._cancelled = false
+    this._cancelReason = undefined
+    this._cancelDone = null
+    /** Terminal `end` envelope once the stream finishes; null otherwise. */
+    this.endInfo = null
+    this._emit = attachEvents(this)
+
+    const completion = deferred()
+    this._completionPromise = completion.promise
+    this._resolveCompletion = completion.resolve
+    this._rejectCompletion = completion.reject
+    // Don't crash on an unobserved completion() — `'error'`/cancel carry it.
+    this._completionPromise.catch(() => {})
+
+    this._stream = new WritableStream({
+      write: async (row) => {
+        const session = await this._resolveSession()
+        await session.write(row)
+      },
+      close: async () => {
+        const session = await this._resolveSession()
+        const end = await session.close()
+        this.endInfo = end
+        this._finished = true
+        this._resolveCompletion(end)
+        this._emit('finish', end)
+      },
+      abort: async () => {
+        const session = await this._resolveSession().catch(() => null)
+        if (session && session.cancel) {
+          try {
+            await session.cancel(this._cancelReason)
+          } catch {
+            // best-effort — the abort already tore the request down.
+          }
+        }
+      },
+    })
+    this._writer = this._stream.getWriter()
+    // Funnel any write/abort failure into completion() and an 'error' event.
+    this._writer.closed.then(
+      () => {},
+      (err) => {
+        const e = this._cancelled ? cancelError(this._cancelReason) : toError(err)
+        this._rejectCompletion(e)
+        if (!this._cancelled) this._emit('error', e)
+      },
+    )
+
+    if (signal) {
+      if (signal.aborted) {
+        queueMicrotask(() => this.cancel(abortReason(signal)))
+      } else {
+        signal.addEventListener('abort', () => this.cancel(abortReason(signal)), { once: true })
+      }
+    }
+  }
+
+  async _resolveSession() {
+    if (!this._sessionResolved) {
+      this._sessionResolved = await this._sessionPromise
+    }
+    return this._sessionResolved
+  }
+
+  /**
+   * Push a row. Returns a promise that resolves when the row is accepted;
+   * backpressure flows through it (and the underlying writer's `ready`).
+   * @param {object} row
+   * @returns {Promise<void>}
+   */
+  write(row) {
+    const p = this._writer.write(row)
+    // Per-write failures surface via completion()/'error'; keep the returned
+    // promise handled so an ignored write() can't trip an unhandled rejection.
+    p.catch(() => {})
+    return p
+  }
+
+  /**
+   * Signal end-of-stream. The server's terminal envelope resolves
+   * `.completion()`.
+   * @returns {Promise<void>}
+   */
+  end() {
+    const p = this._writer.close()
+    p.catch(() => {})
+    return p
+  }
+
+  /**
+   * Resolves with the server's terminal `end` envelope once the stream
+   * finishes successfully; rejects if the stream errors or is cancelled.
+   * @returns {Promise<object>}
+   */
+  completion() {
+    return this._completionPromise
+  }
+
+  /**
+   * Terminate the stream without flushing the remaining rows. Rejects
+   * `.completion()` with a `STREAM_CANCELLED` error and aborts the transport.
+   * @param {string} [reason]
+   * @returns {Promise<void>}
+   */
+  cancel(reason) {
+    if (this._cancelled || this._finished) return this._cancelDone ?? Promise.resolve()
+    this._cancelled = true
+    this._cancelReason = reason
+    this._rejectCompletion(cancelError(reason))
+    this._emit('close')
+    // abort() on the writable runs the abort algorithm above, which forwards
+    // the cancel to the transport session.
+    this._cancelDone = Promise.resolve(this._writer.abort(cancelError(reason))).catch(() => {})
+    return this._cancelDone
+  }
+}
+
+/**
+ * Build a `RowReadable` from a connection's transport client. Identical
+ * validation and session construction to the Node `createSelectStream`.
+ * @param {object} client transport exposing `streamSelect`.
+ * @param {string} sql read-only SELECT to stream.
+ * @param {{ signal?: AbortSignal, cursor?: string }} [opts]
+ * @returns {RowReadable}
+ */
+export function createSelectStream(client, sql, opts = {}) {
+  if (typeof client.streamSelect !== 'function') {
+    throw new RedDBError(
+      'STREAMING_UNSUPPORTED',
+      'the active transport does not support streaming reads (use red:// or http(s)://)',
+    )
+  }
+  if (opts.cursor == null && (typeof sql !== 'string' || sql.trim().length === 0)) {
+    throw new RedDBError('INVALID_STREAM_QUERY', 'stream() requires a non-empty SQL string')
+  }
+  const sessionPromise = Promise.resolve().then(() =>
+    client.streamSelect({ sql, cursor: opts.cursor, signal: opts.signal }),
+  )
+  return new RowReadable(sessionPromise, { signal: opts.signal })
+}
+
+/**
+ * Build a `RowWritable` from a connection's transport client. Identical
+ * validation and session construction to the Node `createInputStream`.
+ * @param {object} client transport exposing `streamInput`.
+ * @param {string} target table to ingest into.
+ * @param {{ signal?: AbortSignal, columns?: string[] }} [opts]
+ * @returns {RowWritable}
+ */
+export function createInputStream(client, target, opts = {}) {
+  if (typeof client.streamInput !== 'function') {
+    throw new RedDBError(
+      'STREAMING_UNSUPPORTED',
+      'the active transport does not support streaming writes (use red:// or http(s)://)',
+    )
+  }
+  if (typeof target !== 'string' || target.trim().length === 0) {
+    throw new RedDBError('INVALID_STREAM_TARGET', 'inputStream() requires a non-empty target table')
+  }
+  const sessionPromise = Promise.resolve().then(() =>
+    client.streamInput({
+      target,
+      columns: opts.columns,
+      signal: opts.signal,
+    }),
+  )
+  return new RowWritable(sessionPromise, { signal: opts.signal })
+}

--- a/drivers/js-client/test/streaming-parity-suite.mjs
+++ b/drivers/js-client/test/streaming-parity-suite.mjs
@@ -1,0 +1,243 @@
+/**
+ * Shared behavioural streaming suite (PRD #874 / #876).
+ *
+ * One suite, run against every streaming implementation that satisfies the
+ * injected-streaming interface (`createSelectStream` / `createInputStream` +
+ * the row reader/writer wrappers). It drives the implementation **directly
+ * through that interface** against in-memory mock transport sessions — the
+ * exact `{ [Symbol.asyncIterator], cancel }` read-session and
+ * `{ write, close, cancel }` write-session contracts the wrappers consume —
+ * so it asserts wrapper behaviour (frame classification, ordering,
+ * cancellation, terminal envelope) without coupling to any one wire.
+ *
+ * Both `src/streaming.js` (Node) and `src/streaming-web.js` (Web) run this
+ * same suite, so parity is *proven by shared execution*, not asserted.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { RedDBError } from '../src/protocol.js'
+
+/**
+ * A mock read transport: `streamSelect()` returns a session whose iterator
+ * replays `script` — an array of typed frames `{type,value}`, where an item
+ * shaped `{ throw: err }` makes the iterator throw mid-stream (an error
+ * frame). Records the cancel reason and the select opts.
+ */
+function mockReadClient(script) {
+  const calls = { selectOpts: null, cancelReasons: [] }
+  const client = {
+    streamSelect(opts) {
+      calls.selectOpts = opts
+      let i = 0
+      let cancelled = false
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (cancelled || i >= script.length) return { done: true, value: undefined }
+              const item = script[i++]
+              if (item && item.throw) throw item.throw
+              return { done: false, value: item }
+            },
+          }
+        },
+        async cancel(reason) {
+          cancelled = true
+          calls.cancelReasons.push(reason)
+        },
+      }
+    },
+  }
+  return { client, calls }
+}
+
+/** A mock read transport that dribbles rows forever until cancelled. */
+function infiniteRowClient() {
+  const calls = { cancelReasons: [] }
+  const client = {
+    streamSelect() {
+      let i = 0
+      let cancelled = false
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            async next() {
+              if (cancelled) return { done: true, value: undefined }
+              i += 1
+              return { done: false, value: { type: 'row', value: { id: i } } }
+            },
+          }
+        },
+        async cancel(reason) {
+          cancelled = true
+          calls.cancelReasons.push(reason)
+        },
+      }
+    },
+  }
+  return { client, calls }
+}
+
+/**
+ * A mock write transport: `streamInput()` records every written row in order,
+ * resolves `close()` with `envelope`, and records cancel reasons.
+ */
+function mockWriteClient(envelope) {
+  const calls = { inputOpts: null, rows: [], closed: false, cancelReasons: [] }
+  const client = {
+    streamInput(opts) {
+      calls.inputOpts = opts
+      return {
+        async write(row) {
+          calls.rows.push(row)
+        },
+        async close() {
+          calls.closed = true
+          return envelope
+        },
+        async cancel(reason) {
+          calls.cancelReasons.push(reason)
+        },
+      }
+    },
+  }
+  return { client, calls }
+}
+
+/**
+ * Register the behavioural suite for one streaming implementation.
+ * @param {string} label e.g. 'node' / 'web'
+ * @param {{ createSelectStream: Function, createInputStream: Function }} streaming
+ */
+export function runStreamingParitySuite(label, streaming) {
+  test(`${label}: select yields typed frames in order, capturing descriptor/cursor/end`, async () => {
+    const script = [
+      { type: 'descriptor', value: { columns: [{ name: 'id' }, { name: 'name' }], schema_fingerprint: 'fp' } },
+      { type: 'cursor', value: { token: 'tok-1', resumable: true } },
+      { type: 'row', value: { id: 1, name: 'alice' } },
+      { type: 'row', value: { id: 2, name: 'bob' } },
+      { type: 'end', value: { row_count: 2 } },
+    ]
+    const { client, calls } = mockReadClient(script)
+    const stream = streaming.createSelectStream(client, 'SELECT id, name FROM users')
+
+    const rows = []
+    for await (const row of stream) rows.push(row)
+
+    assert.deepEqual(rows, [
+      { id: 1, name: 'alice' },
+      { id: 2, name: 'bob' },
+    ])
+    assert.equal(stream.descriptor.schema_fingerprint, 'fp')
+    assert.deepEqual(stream.cursor, { token: 'tok-1', resumable: true })
+    assert.equal(stream.endInfo.row_count, 2)
+    // The wrapper forwards the query through the transport session contract.
+    assert.equal(calls.selectOpts.sql, 'SELECT id, name FROM users')
+  })
+
+  test(`${label}: a mid-stream error frame rejects the iteration`, async () => {
+    const boom = new RedDBError('query_error', 'boom mid-stream')
+    const script = [
+      { type: 'descriptor', value: { columns: [{ name: 'id' }] } },
+      { type: 'row', value: { id: 1 } },
+      { throw: boom },
+    ]
+    const { client } = mockReadClient(script)
+    const stream = streaming.createSelectStream(client, 'SELECT id FROM users')
+
+    const rows = []
+    await assert.rejects(
+      (async () => {
+        for await (const row of stream) rows.push(row)
+      })(),
+      (err) => err instanceof RedDBError && err.code === 'query_error',
+    )
+    // A row consumed before the error is fine; the contract is error propagation.
+    assert.ok(rows.length <= 1, `unexpected rows before error: ${JSON.stringify(rows)}`)
+    if (rows.length === 1) assert.deepEqual(rows[0], { id: 1 })
+  })
+
+  test(`${label}: cancel() mid-stream aborts the transport session and rejects the iteration`, async () => {
+    const { client, calls } = infiniteRowClient()
+    const stream = streaming.createSelectStream(client, 'SELECT id FROM users')
+
+    const rows = []
+    await assert.rejects(
+      (async () => {
+        for await (const row of stream) {
+          rows.push(row)
+          if (rows.length === 1) await stream.cancel('done early')
+        }
+      })(),
+      (err) => err instanceof RedDBError && err.code === 'STREAM_CANCELLED',
+    )
+    assert.equal(rows[0].id, 1)
+    assert.deepEqual(calls.cancelReasons, ['done early'])
+  })
+
+  test(`${label}: select rejects an unsupported transport and an empty query`, () => {
+    assert.throws(
+      () => streaming.createSelectStream({}, 'SELECT 1'),
+      (err) => err instanceof RedDBError && err.code === 'STREAMING_UNSUPPORTED',
+    )
+    const { client } = mockReadClient([])
+    assert.throws(
+      () => streaming.createSelectStream(client, '   '),
+      (err) => err instanceof RedDBError && err.code === 'INVALID_STREAM_QUERY',
+    )
+  })
+
+  test(`${label}: input delivers rows in order and resolves completion() with the terminal envelope`, async () => {
+    const { client, calls } = mockWriteClient({ row_count: 2, committed_rid: 100, chunk_count: 2 })
+    const sink = streaming.createInputStream(client, 'events')
+
+    sink.write({ id: 1, name: 'a' })
+    sink.write({ id: 2, name: 'b' })
+    sink.end()
+    const end = await sink.completion()
+
+    assert.equal(end.row_count, 2)
+    assert.equal(end.committed_rid, 100)
+    assert.ok(calls.closed, 'close() must signal end-of-stream to the transport')
+    assert.deepEqual(calls.rows, [
+      { id: 1, name: 'a' },
+      { id: 2, name: 'b' },
+    ])
+    assert.equal(calls.inputOpts.target, 'events')
+  })
+
+  test(`${label}: input cancel() aborts the session and rejects completion()`, async () => {
+    const { client, calls } = mockWriteClient({ row_count: 0 })
+    const sink = streaming.createInputStream(client, 'events')
+    // A cancelled writable surfaces the failure on its 'error' event too (the
+    // Node `Writable` raises it on `destroy(err)`); absorb it so the contract
+    // under test — completion() rejecting — is what's asserted.
+    sink.on('error', () => {})
+
+    sink.write({ id: 1 })
+    // Let the lazy transport session settle so cancel reaches it on both impls
+    // (the Node `Writable` only forwards cancel to an already-resolved session).
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await sink.cancel('abort ingest')
+
+    await assert.rejects(
+      sink.completion(),
+      (err) => err instanceof RedDBError && err.code === 'STREAM_CANCELLED',
+    )
+    assert.deepEqual(calls.cancelReasons, ['abort ingest'])
+  })
+
+  test(`${label}: input rejects an unsupported transport and an empty target`, () => {
+    assert.throws(
+      () => streaming.createInputStream({}, 'events'),
+      (err) => err instanceof RedDBError && err.code === 'STREAMING_UNSUPPORTED',
+    )
+    const { client } = mockWriteClient({})
+    assert.throws(
+      () => streaming.createInputStream(client, '   '),
+      (err) => err instanceof RedDBError && err.code === 'INVALID_STREAM_TARGET',
+    )
+  })
+}

--- a/drivers/js-client/test/streaming-parity.test.mjs
+++ b/drivers/js-client/test/streaming-parity.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * Parity proof (#876): the Node and Web streaming implementations are run
+ * through the *same* behavioural suite against the *same* mock transport
+ * sessions. Both must exhibit identical frame classification, ordering,
+ * cancellation, and terminal-envelope behaviour.
+ */
+
+import * as nodeStreaming from '../src/streaming.js'
+import * as webStreaming from '../src/streaming-web.js'
+import { runStreamingParitySuite } from './streaming-parity-suite.mjs'
+
+runStreamingParitySuite('node', nodeStreaming)
+runStreamingParitySuite('web', webStreaming)

--- a/drivers/js-client/test/streaming-web-http.test.mjs
+++ b/drivers/js-client/test/streaming-web-http.test.mjs
@@ -1,0 +1,235 @@
+/**
+ * Web-streaming over the real `fetch` transport (#876).
+ *
+ * The parity suite proves wrapper behaviour against mock sessions; this file
+ * proves the Web implementation drives the *actual* Web-native HTTP transport
+ * — reading `fetch`'s `response.body` ReadableStream for SELECT, streaming a
+ * chunked request body for input, and aborting the `fetch` on cancel. The Web
+ * streaming impl is injected into the transport-agnostic core `RedDB`, exactly
+ * as a browser entry would wire it.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+
+import { RedDB as CoreRedDB } from '../src/core/index.js'
+import { HttpRpcClient } from '../src/http.js'
+import { createSelectStream, createInputStream } from '../src/streaming-web.js'
+import { RedDBError } from '../src/protocol.js'
+
+const WEB_STREAMING = { createSelectStream, createInputStream }
+
+async function startHttpServer(routes = {}) {
+  const seen = { aborted: false }
+  const server = createServer((req, res) => {
+    const chunks = []
+    req.on('data', (c) => chunks.push(c))
+    req.on('aborted', () => {
+      seen.aborted = true
+    })
+    req.on('end', async () => {
+      const key = `${req.method} ${req.url}`
+      const body = Buffer.concat(chunks).toString('utf8')
+      const handler = routes[key]
+      if (!handler) {
+        res.writeHead(404).end()
+        return
+      }
+      try {
+        await handler(req, res, body, seen)
+      } catch (err) {
+        if (!res.headersSent) res.writeHead(500)
+        res.end(String(err))
+      }
+    })
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const { port } = server.address()
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    seen,
+    async close() {
+      await new Promise((resolve) => server.close(resolve))
+    },
+  }
+}
+
+function ndjson(...frames) {
+  return frames.map((f) => JSON.stringify(f)).join('\n') + '\n'
+}
+
+function streamHead(res) {
+  res.writeHead(200, {
+    'content-type': 'application/x-ndjson',
+    'transfer-encoding': 'chunked',
+  })
+}
+
+function webDb(baseUrl) {
+  return new CoreRedDB(new HttpRpcClient({ baseUrl }), WEB_STREAMING)
+}
+
+test('web/http: SELECT over fetch response.body yields typed frames in order', async () => {
+  const srv = await startHttpServer({
+    'POST /query/stream': (_req, res) => {
+      streamHead(res)
+      res.write(ndjson({ descriptor: { columns: [{ name: 'id' }, { name: 'name' }], schema_fingerprint: 'fp' } }))
+      res.write(ndjson({ cursor: { token: 'tok-1', resumable: true } }))
+      res.write(ndjson({ row: { id: 1, name: 'alice' } }))
+      res.write(ndjson({ row: { id: 2, name: 'bob' } }))
+      res.end(ndjson({ end: { row_count: 2 } }))
+    },
+  })
+  try {
+    const db = webDb(srv.baseUrl)
+    const stream = db.collection('users').stream('SELECT id, name FROM users')
+    const descriptors = []
+    const cursors = []
+    stream.on('descriptor', (d) => descriptors.push(d))
+    stream.on('cursor', (c) => cursors.push(c))
+
+    const rows = []
+    for await (const row of stream) rows.push(row)
+
+    assert.deepEqual(rows, [
+      { id: 1, name: 'alice' },
+      { id: 2, name: 'bob' },
+    ])
+    assert.equal(descriptors.length, 1)
+    assert.equal(descriptors[0].schema_fingerprint, 'fp')
+    assert.deepEqual(cursors[0], { token: 'tok-1', resumable: true })
+    assert.equal(stream.endInfo.row_count, 2)
+    await db.close()
+  } finally {
+    await srv.close()
+  }
+})
+
+test('web/http: a mid-stream error frame rejects the iteration', async () => {
+  const srv = await startHttpServer({
+    'POST /query/stream': (_req, res) => {
+      streamHead(res)
+      res.write(ndjson({ descriptor: { columns: [{ name: 'id' }] } }))
+      res.write(ndjson({ row: { id: 1 } }))
+      setTimeout(() => {
+        if (!res.writableEnded) res.end(ndjson({ error: { code: 'query_error', message: 'boom mid-stream' } }))
+      }, 25)
+    },
+  })
+  try {
+    const db = webDb(srv.baseUrl)
+    const stream = db.stream('SELECT id FROM users')
+    const rows = []
+    await assert.rejects(
+      (async () => {
+        for await (const row of stream) rows.push(row)
+      })(),
+      (err) => err instanceof RedDBError && err.code === 'query_error',
+    )
+    assert.ok(rows.length <= 1, `unexpected rows before error: ${JSON.stringify(rows)}`)
+    await db.close()
+  } finally {
+    await srv.close()
+  }
+})
+
+test('web/http: a non-read-only refusal rejects before any frame', async () => {
+  const srv = await startHttpServer({
+    'POST /query/stream': (_req, res) => {
+      res.writeHead(400, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: false, code: 'stream_unsupported_statement', error: 'INSERT is not streamable' }))
+    },
+  })
+  try {
+    const db = webDb(srv.baseUrl)
+    const stream = db.stream('INSERT INTO users (id) VALUES (3)')
+    await assert.rejects(
+      (async () => {
+        // eslint-disable-next-line no-unused-vars
+        for await (const _row of stream) { /* should never yield */ }
+      })(),
+      (err) => err instanceof RedDBError && err.code === 'stream_unsupported_statement',
+    )
+    await db.close()
+  } finally {
+    await srv.close()
+  }
+})
+
+test('web/http: cancel() aborts the underlying fetch and rejects the iteration', async () => {
+  let timer = null
+  const srv = await startHttpServer({
+    'POST /query/stream': (_req, res, _body, seen) => {
+      streamHead(res)
+      res.write(ndjson({ row: { id: 1 } }))
+      let n = 2
+      timer = setInterval(() => {
+        if (!res.writableEnded) res.write(ndjson({ row: { id: n++ } }))
+      }, 5)
+      // The fetch abort severs the response mid-stream: res closes before it
+      // ends normally. That early close is the server-side proof of abort.
+      res.on('close', () => {
+        clearInterval(timer)
+        if (!res.writableEnded) seen.responseAborted = true
+      })
+    },
+  })
+  try {
+    const db = webDb(srv.baseUrl)
+    const stream = db.stream('SELECT id FROM users')
+    const rows = []
+    await assert.rejects(
+      (async () => {
+        for await (const row of stream) {
+          rows.push(row)
+          if (rows.length === 1) await stream.cancel('done early')
+        }
+      })(),
+      (err) => err instanceof RedDBError && err.code === 'STREAM_CANCELLED',
+    )
+    assert.equal(rows[0].id, 1)
+    // Give the abort a moment to land server-side.
+    await new Promise((r) => setTimeout(r, 30))
+    assert.ok(srv.seen.responseAborted, 'cancel() must abort the underlying fetch (server saw the response severed mid-stream)')
+    await db.close()
+  } finally {
+    if (timer) clearInterval(timer)
+    await srv.close()
+  }
+})
+
+test('web/http: inputStream ingests rows and resolves completion() with the terminal envelope', async () => {
+  let received = null
+  const srv = await startHttpServer({
+    'POST /streams/input': (_req, res, body) => {
+      const lines = body.split('\n').map((l) => l.trim()).filter(Boolean).map((l) => JSON.parse(l))
+      const open = lines.find((l) => l.open)?.open
+      const rows = lines.filter((l) => l.row).map((l) => l.row)
+      received = { open, rows }
+      res.writeHead(200, { 'content-type': 'application/x-ndjson' })
+      res.end(ndjson({ end: { row_count: rows.length, committed_rid: 100 } }))
+    },
+  })
+  try {
+    const db = webDb(srv.baseUrl)
+    const sink = db.collection('events').inputStream()
+    sink.write({ id: 1, name: 'a' })
+    sink.write({ id: 2, name: 'b' })
+    sink.end()
+    const end = await sink.completion()
+
+    assert.equal(end.row_count, 2)
+    assert.equal(end.committed_rid, 100)
+    assert.deepEqual(received.open, { target: 'events', columns: ['id', 'name'] })
+    assert.deepEqual(received.rows, [
+      { id: 1, name: 'a' },
+      { id: 2, name: 'b' },
+    ])
+    await db.close()
+  } finally {
+    await srv.close()
+  }
+})


### PR DESCRIPTION
Closes #876. Web-streams (fetch response.body) streaming with parity to Node. 148 tests, 146 pass / 0 fail / 2 skip. Base eddce299 (#875 core). PRD #874.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782791144&installation_id=129708444&pr_number=880&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F880&signature=69cc6e694ed0451bc9d8423246adb8845411e2ba2b142ce1d7ed2463e91b0110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for SELECT queries and input operations in web environments
  * Streaming now works over HTTP/fetch transport in browsers
  * Support for cancellation and error propagation during active streams

* **Tests**
  * Added comprehensive parity test suite for streaming implementations
  * Added end-to-end testing for web-based streaming over HTTP

<!-- end of auto-generated comment: release notes by coderabbit.ai -->