### PR TITLE
merge: #877 Browser entry + runtime-conditional exports

### DIFF
--- a/drivers/js-client/index.browser.d.ts
+++ b/drivers/js-client/index.browser.d.ts
@@ -1,0 +1,453 @@
+/**
+ * @reddb-io/client — TypeScript definitions for the **browser** entrypoint
+ * (`src/index.browser.js`). Hand-written, kept in sync with the Node stub
+ * `index.d.ts`.
+ *
+ * The browser surface is identical to Node's, with two deliberate differences:
+ *
+ *   - It declares **no `node:stream` dependency**: the streaming row wrappers
+ *     `RowReadable` / `RowWritable` are described by their public surface
+ *     (`AsyncIterable<Row>`, `cancel()`, `completion()`) rather than by
+ *     extending Node's `Readable` / `Writable`, so browser type-checking never
+ *     pulls in `@types/node`.
+ *   - It omits `splitNdjson()` (a `node:stream` `Transform`), which has no
+ *     browser counterpart.
+ *
+ * `connect()` only reaches `http(s)://` from a browser; `grpc(s)://`,
+ * `red(s)://`, and `pg` throw `RedDBError` with code
+ * `'BROWSER_TRANSPORT_UNSUPPORTED'`, and embedded URIs throw
+ * `EmbeddedNotSupported`.
+ */
+
+export type AuthOptions =
+  | { token: string }
+  | { apiKey: string }
+  | { username: string; password: string; loginUrl?: string }
+
+export interface ConnectOptions {
+  /** Authentication credentials for the HTTP transport. */
+  auth?: AuthOptions
+}
+
+export interface QueryResult {
+  statement: string
+  affected: number
+  columns: string[]
+  rows: Array<Record<string, unknown>>
+}
+
+export type QueryParam =
+  | null
+  | boolean
+  | number
+  | string
+  | Uint8Array
+  | Date
+  | Float32Array
+  | Float64Array
+  | number[]
+  | Record<string, unknown>
+
+export interface InsertResult { affected: number; rid: string | number; id: string | number }
+export interface BulkInsertResult {
+  affected: number
+  rids: Array<string | number>
+  ids: Array<string | number>
+}
+export interface GetResult { entity: Record<string, unknown> | null }
+export interface DeleteResult { affected: number }
+export interface CollectionMeta {
+  name: string
+  model: string
+  capabilities: string[]
+  [key: string]: unknown
+}
+export interface HealthResult { ok: boolean; version: string }
+export interface VersionResult { version: string; protocol: string }
+
+export type Role = 'read' | 'write' | 'admin'
+
+export interface LoginResult {
+  token: string
+  username: string
+  role: Role
+  expires_at: number
+}
+
+export interface WhoamiResult { username: string; role: Role }
+export interface CreateApiKeyResult { key: string; role: Role; created_at: number }
+export interface ChangePasswordResult { ok: true }
+export interface RevokeApiKeyResult { ok: true }
+
+export class RedDBError extends Error {
+  readonly name: 'RedDBError'
+  readonly code: string
+  readonly data: unknown
+  constructor(code: string, message: string, data?: unknown)
+}
+
+// ---------------------------------------------------------------------------
+// Cache API
+// ---------------------------------------------------------------------------
+
+export interface CachePutOptions {
+  ttl_ms?: number
+  tags?: string[]
+  policy?: {
+    idle_evict_ms?: number
+    stale_while_revalidate_ms?: number
+    jitter_ms?: number
+  }
+}
+
+export type CacheExistsStatus = 'present' | 'absent' | 'maybe'
+
+export class CacheClient {
+  get(namespace: string, key: string): Promise<Uint8Array | null>
+  put(
+    namespace: string,
+    key: string,
+    value: Uint8Array | string,
+    opts?: CachePutOptions,
+  ): Promise<void>
+  exists(namespace: string, key: string): Promise<CacheExistsStatus>
+  invalidate(namespace: string, key: string): Promise<void>
+  invalidatePrefix(namespace: string, prefix: string): Promise<number>
+  invalidateTags(namespace: string, tags: string[]): Promise<number>
+  flushNamespace(namespace: string): Promise<void>
+}
+
+export interface KvWatchEvent {
+  key: string
+  op: 'insert' | 'update' | 'delete'
+  before: unknown
+  after: unknown
+  lsn: number
+  committed_at: number
+  dropped_event_count: number
+}
+
+export class KvClient {
+  put(
+    key: string,
+    value: unknown,
+    options?: { collection?: string; expireMs?: number; tags?: string[] },
+  ): Promise<QueryResult>
+  get(key: string, options?: { collection?: string }): Promise<unknown | null>
+  getMany(keys: string[], options?: { collection?: string }): Promise<Array<unknown | null>>
+  exists(key: string, options?: { collection?: string }): Promise<{ exists: boolean }>
+  delete(key: string, options?: { collection?: string }): Promise<DeleteResult>
+  list(options?: { collection?: string; prefix?: string; limit?: number }): Promise<{
+    items: Array<{ key: string; value: unknown }>
+  }>
+  invalidateTags(tags: string[], options?: { collection?: string }): Promise<number>
+  watch(
+    key: string,
+    options?: { collection?: string; sinceLsn?: number; limit?: number },
+  ): AsyncIterable<KvWatchEvent>
+  watchPrefix(
+    prefix: string,
+    options?: { collection?: string; sinceLsn?: number; limit?: number },
+  ): AsyncIterable<KvWatchEvent>
+}
+
+export interface DocumentInsertResult<T extends Record<string, unknown> = Record<string, unknown>> {
+  affected: number
+  rid: string | number
+  item: T & { rid: string | number }
+}
+
+export class DocumentClient {
+  insert<T extends Record<string, unknown> = Record<string, unknown>>(
+    collection: string,
+    document: Record<string, unknown>,
+  ): Promise<DocumentInsertResult<T>>
+  get<T extends Record<string, unknown> = Record<string, unknown>>(
+    collection: string,
+    rid: string | number,
+  ): Promise<T & { rid: string | number }>
+  list<T extends Record<string, unknown> = Record<string, unknown>>(
+    collection: string,
+    options?: { filter?: string; orderBy?: string; order_by?: string; limit?: number },
+  ): Promise<{ items: Array<T & { rid: string | number }> }>
+  patch<T extends Record<string, unknown> = Record<string, unknown>>(
+    collection: string,
+    rid: string | number,
+    patch: Record<string, unknown>,
+  ): Promise<T & { rid: string | number }>
+  delete(collection: string, rid: string | number): Promise<DeleteResult>
+}
+
+export class QueueClient {
+  push(
+    queue: string,
+    value: unknown,
+    options?: { priority?: number },
+  ): Promise<QueryResult>
+  pop(queue: string, count?: number): Promise<unknown[]>
+  peek(queue: string, count?: number): Promise<unknown[]>
+  len(queue: string): Promise<number>
+  purge(queue: string): Promise<QueryResult>
+  readWait(
+    queue: string,
+    consumer: string,
+    options: { waitMs: number; group?: string; count?: number },
+  ): Promise<unknown[]>
+}
+
+/**
+ * Caller-typed SELECT builder. RedDB does not infer `T`; provide it
+ * explicitly with `db.from<T>('collection')`.
+ */
+export class TypedQueryBuilder<T extends Record<string, unknown> = Record<string, unknown>> {
+  select(): TypedQueryBuilder<T>
+  select(column: '*'): TypedQueryBuilder<T>
+  select<K extends keyof T & string>(...columns: K[]): TypedQueryBuilder<Pick<T, K>>
+  select<K extends keyof T & string>(columns: K[]): TypedQueryBuilder<Pick<T, K>>
+  where(condition: string, params: QueryParam[]): TypedQueryBuilder<T>
+  where(condition: string, ...params: QueryParam[]): TypedQueryBuilder<T>
+  run(): Promise<T[]>
+}
+
+// ---------------------------------------------------------------------------
+// Streaming API (PRD #759 / S11) — Web-streams variant
+// ---------------------------------------------------------------------------
+
+export type Row = Record<string, unknown>
+
+export interface StreamDescriptor {
+  result_kind?: string
+  columns?: Array<{ name: string; type?: string; nullable?: boolean }>
+  schema_fingerprint?: string
+  [key: string]: unknown
+}
+
+export interface StreamCursor {
+  token: string
+  snapshot_lsn?: number
+  ttl_ms?: number
+  expires_at_ms?: number
+  resumable?: boolean
+}
+
+export interface StreamEndEnvelope {
+  row_count?: number
+  committed_rid?: number
+  chunk_count?: number
+  lease_handle?: string
+  snapshot_lsn?: number
+  [key: string]: unknown
+}
+
+export interface StreamOptions {
+  /** Abort the stream when this signal fires. */
+  signal?: AbortSignal
+  /** Resume a prior stream from an opaque cursor token (HTTP only). */
+  cursor?: string
+}
+
+export interface InputStreamOptions {
+  signal?: AbortSignal
+  /** Ingest column set; inferred from the first row's keys when omitted. */
+  columns?: string[]
+}
+
+/**
+ * A streaming read backed by a Web `ReadableStream`. Conforms to
+ * `AsyncIterable<Row>` — `for await (const row of stream)` yields rows as they
+ * arrive. `'descriptor'` / `'cursor'` events fire when the transport surfaces
+ * them. Unlike the Node entry, this does **not** extend `node:stream`'s
+ * `Readable`.
+ */
+export class RowReadable implements AsyncIterable<Row> {
+  /** Schema descriptor (HTTP NDJSON) once seen, else null. */
+  readonly descriptor: StreamDescriptor | null
+  /** Resumable cursor control frame once seen, else null. */
+  readonly cursor: StreamCursor | null
+  /** Terminal `end` envelope once the stream completes, else null. */
+  readonly endInfo: StreamEndEnvelope | null
+  /** Subscribe to `'descriptor'` / `'cursor'` / `'error'` / `'end'` events. */
+  on(event: string, listener: (...args: unknown[]) => void): this
+  once(event: string, listener: (...args: unknown[]) => void): this
+  off(event: string, listener: (...args: unknown[]) => void): this
+  /** Terminate the stream; rejects pending iterations with a cancellation error. */
+  cancel(reason?: string): Promise<void>
+  [Symbol.asyncIterator](): AsyncIterableIterator<Row>
+}
+
+/**
+ * A streaming write backed by a Web `WritableStream`. `write(row)` pushes a
+ * row (backpressure flows through the returned promise); `end()` signals
+ * end-of-stream and the server's terminal envelope resolves `.completion()`.
+ * Unlike the Node entry, this does **not** extend `node:stream`'s `Writable`.
+ */
+export class RowWritable {
+  /** Terminal `end` envelope once the write completes, else null. */
+  readonly endInfo: StreamEndEnvelope | null
+  /** Push a row; the returned promise resolves when backpressure clears. */
+  write(row: Row): Promise<void>
+  /** Signal end-of-stream. */
+  end(): Promise<void>
+  /** Resolves with the server's terminal envelope; rejects on error/cancel. */
+  completion(): Promise<StreamEndEnvelope>
+  /** Abandon the ingest; rejects `.completion()` with a cancellation error. */
+  cancel(reason?: string): Promise<void>
+}
+
+/**
+ * A streaming-capable collection/table handle. `query()` is a one-shot
+ * Promise; `stream()` / `inputStream()` are the streaming surfaces.
+ */
+export class Collection {
+  readonly name: string
+  query(sql: string): Promise<QueryResult>
+  query(sql: string, params: QueryParam[]): Promise<QueryResult>
+  query(sql: string, ...params: QueryParam[]): Promise<QueryResult>
+  stream(sql: string, opts?: StreamOptions): RowReadable
+  inputStream(opts?: InputStreamOptions): RowWritable
+}
+
+export class ConfigClient {
+  put(
+    key: string,
+    value: unknown,
+    options?: {
+      collection?: string
+      tags?: string[]
+      secretRef?: { collection: string; key: string }
+    },
+  ): Promise<QueryResult>
+  get(key: string, options?: { collection?: string }): Promise<QueryResult>
+  resolve(key: string, options?: { collection?: string }): Promise<QueryResult>
+}
+
+export class VaultClient {
+  put(
+    key: string,
+    value: unknown,
+    options?: { collection?: string; tags?: string[] },
+  ): Promise<QueryResult>
+  get(key: string, options?: { collection?: string }): Promise<QueryResult>
+  unseal(key: string, options?: { collection?: string }): Promise<QueryResult>
+}
+
+/**
+ * Specialised error thrown when an embedded URI is passed to the
+ * thin client. Always has `code === 'EmbeddedNotSupported'`. Use
+ * `@reddb-io/sdk` instead for in-memory or file-backed engines.
+ */
+export class EmbeddedNotSupported extends RedDBError {
+  readonly name: 'EmbeddedNotSupported'
+  readonly code: 'EmbeddedNotSupported'
+  readonly uri: string
+  constructor(uri: string)
+}
+
+export const EMBEDDED_REJECTION_MESSAGE: string
+
+/** Returns true when `uri` selects the embedded engine. */
+export function isEmbeddedUri(uri: string): boolean
+
+export interface RedDBTransaction {
+  query(sql: string): Promise<QueryResult>
+  query(sql: string, params: QueryParam[]): Promise<QueryResult>
+  query(sql: string, ...params: QueryParam[]): Promise<QueryResult>
+  execute(sql: string): Promise<QueryResult>
+  execute(sql: string, params: QueryParam[]): Promise<QueryResult>
+  execute(sql: string, ...params: QueryParam[]): Promise<QueryResult>
+  insert(collection: string, payload: Record<string, unknown>): Promise<InsertResult>
+  bulkInsert(
+    collection: string,
+    payloads: Array<Record<string, unknown>>,
+  ): Promise<BulkInsertResult>
+  transaction<T>(
+    callback: (tx: RedDBTransaction) => T | Promise<T>,
+  ): Promise<T>
+}
+
+export class RedDB {
+  readonly cache: CacheClient
+  readonly queue: QueueClient
+  readonly documents: DocumentClient
+  readonly kv: KvClient & ((collection?: string) => KvClient)
+  readonly config: (collection?: string) => ConfigClient
+  readonly vault: (collection?: string) => VaultClient
+
+  query(sql: string): Promise<QueryResult>
+  query(sql: string, params: QueryParam[]): Promise<QueryResult>
+  query(sql: string, ...params: QueryParam[]): Promise<QueryResult>
+  execute(sql: string): Promise<QueryResult>
+  execute(sql: string, params: QueryParam[]): Promise<QueryResult>
+  execute(sql: string, ...params: QueryParam[]): Promise<QueryResult>
+  insert(collection: string, payload: Record<string, unknown>): Promise<InsertResult>
+  bulkInsert(
+    collection: string,
+    payloads: Array<Record<string, unknown>>,
+  ): Promise<BulkInsertResult>
+  transaction<T>(
+    callback: (tx: RedDBTransaction) => T | Promise<T>,
+  ): Promise<T>
+  exists(collection: string): Promise<boolean>
+  list(): Promise<CollectionMeta[]>
+  /**
+   * Caller-typed collection handle. Supply `T`; the SDK does not
+   * generate or validate row types at runtime.
+   */
+  from<T extends Record<string, unknown> = Record<string, unknown>>(
+    collection: string,
+  ): TypedQueryBuilder<T>
+  /** Streaming-capable handle for a collection/table (PRD #759 S11). */
+  collection(name: string): Collection
+  /** Stream a read-only SELECT as an `AsyncIterable<Row>` over HTTP NDJSON. */
+  stream(sql: string, opts?: StreamOptions): RowReadable
+  /**
+   * Open a streaming write into `target`; `.completion()` resolves with
+   * the server's terminal envelope.
+   */
+  inputStream(target: string, opts?: InputStreamOptions): RowWritable
+  get(collection: string, id: string | number): Promise<GetResult>
+  delete(collection: string, id: string | number): Promise<DeleteResult>
+  health(): Promise<HealthResult>
+  version(): Promise<VersionResult>
+
+  login(username: string, password: string): Promise<LoginResult>
+  whoami(): Promise<WhoamiResult>
+  changePassword(currentPassword: string, newPassword: string): Promise<ChangePasswordResult>
+  createApiKey(opts?: { username?: string; role?: Role }): Promise<CreateApiKeyResult>
+  revokeApiKey(key: string): Promise<RevokeApiKeyResult>
+
+  close(): Promise<void>
+}
+
+/**
+ * Connect to a remote RedDB instance from a browser.
+ *
+ * Only `http://host:port` / `https://host:port` are reachable from a browser
+ * sandbox. `grpc(s)://`, `red(s)://`, and `pg` throw `RedDBError` with code
+ * `'BROWSER_TRANSPORT_UNSUPPORTED'`. Embedded URIs (`memory://`, `memory:`,
+ * `file:///path`, `red:///`, `red://:memory[:]`) throw `EmbeddedNotSupported`.
+ */
+export function connect(uri: string, options?: ConnectOptions): Promise<RedDB>
+
+/** Exchange username + password for a bearer token via /auth/login. */
+export function login(
+  loginUrl: string,
+  credentials: { username: string; password: string },
+): Promise<LoginResult>
+
+export interface ParsedUri {
+  kind: 'embedded' | 'http' | 'https' | 'red' | 'reds' | 'grpc' | 'grpcs' | 'pg'
+  host?: string
+  port?: number
+  path?: string
+  username?: string
+  password?: string
+  token?: string
+  apiKey?: string
+  loginUrl?: string
+  params?: URLSearchParams
+  originalUri: string
+}
+
+export function parseUri(uri: string): ParsedUri
+export function deriveLoginUrl(parsed: ParsedUri): string

--- a/drivers/js-client/package.json
+++ b/drivers/js-client/package.json
@@ -4,16 +4,53 @@
   "description": "Thin remote-only RedDB driver. Downloads the `red_client` binary on install. Speaks RedWire/gRPC/HTTP. Embedded URIs (memory://, file://, red:///path) are rejected — use @reddb-io/sdk for those.",
   "type": "module",
   "main": "src/index.js",
+  "browser": "./src/index.browser.js",
   "exports": {
     ".": {
-      "import": "./src/index.js",
-      "types": "./index.d.ts"
-    }
+      "browser": {
+        "types": "./index.browser.d.ts",
+        "import": "./src/index.browser.js"
+      },
+      "node": {
+        "types": "./index.d.ts",
+        "import": "./src/index.js"
+      },
+      "bun": {
+        "types": "./index.d.ts",
+        "import": "./src/index.js"
+      },
+      "deno": {
+        "types": "./index.d.ts",
+        "import": "./src/index.js"
+      },
+      "default": {
+        "types": "./index.browser.d.ts",
+        "import": "./src/index.browser.js"
+      }
+    },
+    "./node": {
+      "types": "./index.d.ts",
+      "import": "./src/index.js"
+    },
+    "./browser": {
+      "types": "./index.browser.d.ts",
+      "import": "./src/index.browser.js"
+    },
+    "./bun": {
+      "types": "./index.d.ts",
+      "import": "./src/index.js"
+    },
+    "./deno": {
+      "types": "./index.d.ts",
+      "import": "./src/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "./index.d.ts",
   "files": [
     "src/",
     "index.d.ts",
+    "index.browser.d.ts",
     "postinstall.js",
     "README.md",
     "LICENSE"

--- a/drivers/js-client/src/index.browser.js
+++ b/drivers/js-client/src/index.browser.js
@@ -1,0 +1,156 @@
+/**
+ * @reddb-io/client — browser entrypoint.
+ *
+ * The browser counterpart to `./index.js`. It builds `connect()` on the
+ * transport-agnostic core (`./core/index.js`), dispatching only the
+ * browser-reachable wires:
+ *
+ *   - 'http://host:port'   — HTTP JSON-RPC over `fetch`
+ *   - 'https://host:port'  — HTTPS JSON-RPC over `fetch`
+ *
+ * Streaming is the Web-streams implementation (`./streaming-web.js`), so the
+ * full transport-agnostic surface works client-side: query, execute, insert,
+ * bulkInsert, transactions, the kv/documents/queue/cache/config/vault clients,
+ * the typed query builder, and streaming (`stream()` / `inputStream()`).
+ *
+ * This module imports **neither** the gRPC transport (`./grpc.js`, which pulls
+ * `node:http2`) **nor** the RedWire transport (`./redwire.js`) **nor** the
+ * `node:stream` streaming impl (`./streaming.js`). No `node:` built-in enters
+ * the browser bundle graph through it. A portability guard test
+ * (`test/browser-portability.test.mjs`) is the regression net for that.
+ *
+ * Schemes that need a raw TCP socket or HTTP/2 — `grpc://`, `grpcs://`,
+ * `red://`, `reds://`, and `pg` — are not reachable from a browser sandbox.
+ * `connect()` rejects them with an actionable error (see
+ * `BROWSER_TRANSPORT_UNSUPPORTED` below) instead of crashing the bundler or
+ * runtime. Embedded URIs (`memory://`, `file://`, `red:///path`) are rejected
+ * with the same wording as the Node entry.
+ */
+
+import {
+  RedDBError,
+  RedDB as CoreRedDB,
+  Collection,
+  EmbeddedNotSupported,
+  EMBEDDED_REJECTION_MESSAGE,
+  isEmbeddedUri,
+  rejectEmbeddedUri,
+  parseUri,
+  login,
+  mergeAuthFromUri,
+} from './core/index.js'
+import { HttpRpcClient } from './http.js'
+import { createSelectStream, createInputStream } from './streaming-web.js'
+
+export { RedDBError, EmbeddedNotSupported, EMBEDDED_REJECTION_MESSAGE, isEmbeddedUri }
+export { RowReadable, RowWritable } from './streaming-web.js'
+export { CacheClient } from './cache.js'
+export { KvClient } from './kv.js'
+export { QueueClient } from './queue.js'
+export { DocumentClient } from './documents.js'
+export { ConfigClient } from './config.js'
+export { VaultClient } from './vault.js'
+export { TypedQueryBuilder } from './db-helpers.js'
+export { parseUri, deriveLoginUrl } from './url.js'
+export { login }
+
+// The Web-streams streaming implementation, injected into the core `RedDB` so
+// its `stream()` / `inputStream()` return Web-streams-backed row wrappers. The
+// core itself never statically references Web (or `node:`) streams.
+const WEB_STREAMING = { createSelectStream, createInputStream }
+
+/**
+ * Shared wording for schemes a browser sandbox cannot reach: they need a raw
+ * TCP socket (`red(s)://`, `pg`) or HTTP/2 (`grpc(s)://`), neither of which a
+ * browser exposes to JavaScript. The remedy is the same in every case — point
+ * the client at an HTTP(S) endpoint or gateway in front of the server.
+ */
+function browserTransportError(scheme) {
+  return new RedDBError(
+    'BROWSER_TRANSPORT_UNSUPPORTED',
+    `'${scheme}' connections are not available in the browser: the `
+      + `browser sandbox exposes no raw TCP socket (red://, reds://, pg) or `
+      + `HTTP/2 client (grpc://, grpcs://) to JavaScript. Connect to an `
+      + `HTTP(S) endpoint instead — e.g. 'http://host:port' / `
+      + `'https://host:port' — by running RedDB's HTTP JSON-RPC listener or `
+      + `an HTTP gateway in front of the server, then call `
+      + `connect('https://…').`,
+  )
+}
+
+/**
+ * Connect to a remote RedDB instance from a browser.
+ *
+ * @param {string} uri Connection URI. Only `http(s)://` is reachable from a
+ *   browser; other schemes raise `BROWSER_TRANSPORT_UNSUPPORTED`.
+ * @param {object} [options]
+ * @param {object} [options.auth] Authentication credentials.
+ * @param {string} [options.auth.token] Bearer / API-key token.
+ * @param {string} [options.auth.apiKey] Alias for `token`.
+ * @param {string} [options.auth.username] Username for password login.
+ * @param {string} [options.auth.password] Password for password login.
+ * @param {string} [options.auth.loginUrl] Override URL for the password
+ *   exchange (defaults to deriving `/auth/login` from `uri`).
+ * @returns {Promise<RedDB>}
+ */
+export async function connect(uri, options = {}) {
+  // Reject embedded shapes upfront with the same wording the Node entry and
+  // the Rust binary use, before the URL parser would map them to kind=embedded.
+  rejectEmbeddedUri(uri)
+
+  const parsed = parseUri(uri)
+
+  // Belt-and-braces: if the parser still produced an embedded kind, reject it.
+  if (parsed.kind === 'embedded') {
+    throw new EmbeddedNotSupported(uri)
+  }
+
+  if (parsed.kind === 'http' || parsed.kind === 'https') {
+    const merged = mergeAuthFromUri(parsed, options.auth)
+    const baseUrl = `${parsed.kind}://${parsed.host}:${parsed.port}`
+    let token = merged.token
+    if (!token && merged.username && merged.password) {
+      const loginUrl = merged.loginUrl ?? `${baseUrl}/auth/login`
+      const session = await login(loginUrl, {
+        username: merged.username,
+        password: merged.password,
+      })
+      token = session.token
+    }
+    const client = new HttpRpcClient({ baseUrl, token })
+    await client.call('query', { sql: 'SELECT 1' })
+    return new RedDB(client)
+  }
+
+  if (
+    parsed.kind === 'grpc'
+    || parsed.kind === 'grpcs'
+    || parsed.kind === 'red'
+    || parsed.kind === 'reds'
+    || parsed.kind === 'pg'
+  ) {
+    throw browserTransportError(parsed.kind)
+  }
+
+  throw new RedDBError(
+    'UNSUPPORTED_KIND',
+    `internal: parsed kind '${parsed.kind}' has no browser transport`,
+  )
+}
+
+/**
+ * Browser connection handle. The full request-shaping surface lives in the
+ * transport-agnostic core `RedDB`; this subclass exists only to inject the
+ * Web-streams streaming implementation so `stream()` / `inputStream()` return
+ * Web-streams-backed row wrappers. The public surface — every method, the
+ * `kv`/`config`/`vault` factory shapes, the `cache`/`queue`/`documents`
+ * clients — is the core's, unchanged.
+ */
+export class RedDB extends CoreRedDB {
+  /** @param {HttpRpcClient} client */
+  constructor(client) {
+    super(client, WEB_STREAMING)
+  }
+}
+
+export { Collection }

--- a/drivers/js-client/test/browser-portability.test.mjs
+++ b/drivers/js-client/test/browser-portability.test.mjs
@@ -1,0 +1,277 @@
+/**
+ * Browser-entry portability guard + functional smoke (#877).
+ *
+ * The regression net for the failure that motivated PRD #874: a stray `node:`
+ * built-in sneaking into the browser import graph. This file statically walks
+ * the transitive static-import graph rooted at `src/index.browser.js` and
+ * asserts it contains **zero** `node:` specifiers — so a future stray Node
+ * import fails CI here, not in a downstream app's bundler. It also proves the
+ * browser entry's `connect()` works over HTTP and rejects the non-browser
+ * schemes with the documented, actionable errors.
+ *
+ * Run with: node --test test/*.test.mjs
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createServer } from 'node:http'
+import { once } from 'node:events'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import {
+  connect,
+  RedDB,
+  RedDBError,
+  EmbeddedNotSupported,
+  RowReadable,
+  RowWritable,
+} from '../src/index.browser.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = resolve(HERE, '..', 'src')
+const BROWSER_ENTRY = resolve(SRC, 'index.browser.js')
+
+// Node-only modules the browser entry must never pull in (directly or
+// transitively): the gRPC transport (node:http2), the RedWire transport, and
+// the node:stream-based streaming impl.
+const FORBIDDEN_MODULES = ['grpc.js', 'redwire.js', 'streaming.js']
+
+/**
+ * Extract every static `import ... from '<spec>'`, `export ... from '<spec>'`,
+ * and bare `import '<spec>'` specifier from a module's source. Good enough for
+ * this codebase (pure ESM, no dynamic import of node: built-ins in the browser
+ * path); intentionally conservative — it over-collects rather than missing one.
+ */
+function importSpecifiers(source) {
+  const specs = []
+  const re = /(?:^|[\s;])(?:import|export)\b[^'"`]*?from\s*['"]([^'"]+)['"]|(?:^|[\s;])import\s*['"]([^'"]+)['"]/g
+  let m
+  while ((m = re.exec(source)) !== null) {
+    specs.push(m[1] ?? m[2])
+  }
+  return specs
+}
+
+/** Walk the transitive static-import graph from `entry` (absolute path). */
+function walkImportGraph(entry) {
+  const visited = new Set()
+  const nodeBuiltins = []
+  const queue = [entry]
+  while (queue.length > 0) {
+    const file = queue.pop()
+    if (visited.has(file)) continue
+    visited.add(file)
+
+    const source = readFileSync(file, 'utf8')
+    for (const spec of importSpecifiers(source)) {
+      if (spec.startsWith('node:')) {
+        nodeBuiltins.push({ file, spec })
+        continue
+      }
+      // Only relative specifiers stay inside the package graph. A bare
+      // (non-relative, non-node:) specifier would be an external dependency —
+      // none are expected; record it so the assertion surfaces it.
+      if (spec.startsWith('./') || spec.startsWith('../')) {
+        queue.push(resolve(dirname(file), spec))
+      } else {
+        nodeBuiltins.push({ file, spec: `(bare) ${spec}` })
+      }
+    }
+  }
+  return { visited, nodeBuiltins }
+}
+
+test('portability: browser entry import graph has zero node: built-ins', () => {
+  const { visited, nodeBuiltins } = walkImportGraph(BROWSER_ENTRY)
+
+  assert.deepEqual(
+    nodeBuiltins,
+    [],
+    `browser entry must not import node: built-ins or external deps, found: `
+      + JSON.stringify(nodeBuiltins),
+  )
+
+  // Sanity: the walk actually traversed the core/http/streaming-web graph.
+  assert.ok(visited.size > 5, `expected a multi-module graph, walked ${visited.size}`)
+  const names = [...visited].map((f) => f.replace(SRC + '/', ''))
+  assert.ok(names.includes('http.js'), 'browser entry should reach http.js')
+  assert.ok(names.includes('streaming-web.js'), 'browser entry should reach streaming-web.js')
+  assert.ok(names.some((n) => n.startsWith('core/')), 'browser entry should reach the core')
+})
+
+test('portability: browser graph excludes the node-only transports', () => {
+  const { visited } = walkImportGraph(BROWSER_ENTRY)
+  const names = [...visited].map((f) => f.replace(SRC + '/', ''))
+  for (const forbidden of FORBIDDEN_MODULES) {
+    assert.ok(
+      !names.includes(forbidden),
+      `browser graph must not include ${forbidden}; walked: ${names.join(', ')}`,
+    )
+  }
+})
+
+test('portability: browser entry exposes the Web-streams row wrappers', () => {
+  assert.equal(typeof RowReadable, 'function')
+  assert.equal(typeof RowWritable, 'function')
+  assert.equal(typeof connect, 'function')
+})
+
+// ---------------------------------------------------------------------------
+// Functional: connect() over HTTP works from the browser entry.
+// ---------------------------------------------------------------------------
+
+function readinessOk() {
+  return { ok: true, statement: 'SELECT', affected: 0, columns: ['1'], rows: [{ 1: 1 }] }
+}
+
+async function startMockServer(handlers) {
+  const defaults = { 'POST /query': () => readinessOk() }
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (chunk) => { body += chunk })
+    req.on('end', async () => {
+      const key = `${req.method} ${req.url}`
+      const handler = handlers[key] ?? defaults[key]
+      if (!handler) {
+        res.statusCode = 404
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify({ ok: false, error: 'not found' }))
+        return
+      }
+      try {
+        const parsed = body ? JSON.parse(body) : {}
+        const out = await handler(parsed, req)
+        res.statusCode = out?.status ?? 200
+        res.setHeader('content-type', 'application/json')
+        res.end(JSON.stringify(out?.body ?? out))
+      } catch (err) {
+        res.statusCode = 500
+        res.end(JSON.stringify({ ok: false, error: String(err.message || err) }))
+      }
+    })
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const { port } = server.address()
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () => new Promise((r) => server.close(r)),
+  }
+}
+
+test('browser connect(http://) returns a RedDB and round-trips query/insert/transaction', async () => {
+  const stub = await startMockServer({
+    'POST /query': (body) => {
+      if (body.query === 'SELECT 1') return readinessOk()
+      return { ok: true, statement: 'SELECT', affected: 0, columns: ['n'], rows: [{ n: 42 }] }
+    },
+    'POST /collections/t/rows': () => ({ ok: true, rid: 7, id: 7, affected: 1 }),
+  })
+  try {
+    const db = await connect(stub.baseUrl)
+    assert.ok(db instanceof RedDB)
+
+    const q = await db.query('SELECT n FROM t')
+    assert.deepEqual(q.rows, [{ n: 42 }])
+
+    const ins = await db.insert('t', { a: 1 })
+    assert.equal(ins.rid, 7)
+
+    const tx = await db.transaction(async (t) => {
+      await t.query('SELECT 1')
+      return 'ok'
+    })
+    assert.equal(tx, 'ok')
+
+    // Data-API factories are present (the core's surface, unchanged).
+    assert.ok(db.cache && db.queue && db.documents)
+    assert.equal(typeof db.kv, 'function')
+    assert.equal(typeof db.config, 'function')
+    assert.equal(typeof db.vault, 'function')
+
+    await db.close()
+  } finally {
+    await stub.close()
+  }
+})
+
+test('browser connect(http://) streams a SELECT over Web streams', async () => {
+  const server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => { body += c })
+    req.on('end', () => {
+      if (req.url === '/query/stream') {
+        res.writeHead(200, { 'content-type': 'application/x-ndjson', 'transfer-encoding': 'chunked' })
+        res.write(JSON.stringify({ descriptor: { columns: [{ name: 'id' }] } }) + '\n')
+        res.write(JSON.stringify({ row: { id: 1 } }) + '\n')
+        res.write(JSON.stringify({ row: { id: 2 } }) + '\n')
+        res.end(JSON.stringify({ end: { row_count: 2 } }) + '\n')
+        return
+      }
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(readinessOk()))
+    })
+  })
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  const { port } = server.address()
+  try {
+    const db = await connect(`http://127.0.0.1:${port}`)
+    const stream = db.stream('SELECT id FROM t')
+    assert.ok(stream instanceof RowReadable)
+    const rows = []
+    for await (const row of stream) rows.push(row)
+    assert.deepEqual(rows, [{ id: 1 }, { id: 2 }])
+    assert.equal(stream.endInfo.row_count, 2)
+    await db.close()
+  } finally {
+    await new Promise((r) => server.close(r))
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Functional: non-browser schemes raise descriptive, non-crashing errors.
+// ---------------------------------------------------------------------------
+
+for (const scheme of ['grpc', 'grpcs', 'red', 'reds']) {
+  test(`browser connect(${scheme}://) throws BROWSER_TRANSPORT_UNSUPPORTED`, async () => {
+    await assert.rejects(
+      connect(`${scheme}://host:5050`),
+      (err) => {
+        assert.ok(err instanceof RedDBError)
+        assert.equal(err.code, 'BROWSER_TRANSPORT_UNSUPPORTED')
+        // Names the limitation and the HTTP remedy.
+        assert.match(err.message, /browser/i)
+        assert.match(err.message, /http\(s\)|https?:\/\//i)
+        assert.match(err.message, /gateway|endpoint/i)
+        return true
+      },
+    )
+  })
+}
+
+test('browser connect(?proto=pg) throws BROWSER_TRANSPORT_UNSUPPORTED', async () => {
+  await assert.rejects(
+    connect('red://host:5432?proto=pg'),
+    (err) => err instanceof RedDBError && err.code === 'BROWSER_TRANSPORT_UNSUPPORTED',
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Functional: embedded URIs rejected with the shared wording.
+// ---------------------------------------------------------------------------
+
+for (const uri of ['memory://', 'file:///tmp/db', 'red:///var/data', 'red://:memory:']) {
+  test(`browser connect(${uri}) rejects embedded with the shared wording`, async () => {
+    await assert.rejects(
+      connect(uri),
+      (err) => {
+        assert.ok(err instanceof EmbeddedNotSupported)
+        assert.match(err.message, /embedded schemes/)
+        return true
+      },
+    )
+  })
+}


### PR DESCRIPTION
Closes #877. Browser entry (src/index.browser.js) on the transport-agnostic core, omitting node-only grpc/streaming; runtime-conditional package.json exports (node/browser/bun/deno); browser type stub + portability guard test. 162 tests, 160 pass / 0 fail / 2 skip. PRD #874.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782793457&installation_id=129708444&pr_number=881&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F881&signature=2fc47de083eb4f6fe5c34c8b8d4f0c120682a3cddfbc634a53cf2b2735900862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser support for the JavaScript client to connect to remote RedDB instances via HTTP(S).
  * Query, insert, delete, and perform transactions from web applications.
  * Stream data efficiently using Web Streams-based APIs.
  * Access cache, key-value storage, documents, queues, configuration, and vault clients in browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->