### PR TITLE
merge: #883 SIMD IEEE-CRC32 for WAL records (same polynomial, no format change)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,6 +2297,7 @@ version = "1.7.0"
 dependencies = [
  "aes-gcm",
  "blake3",
+ "crc32fast",
  "criterion",
  "crossbeam-queue",
  "ed25519-dalek",

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -25,6 +25,13 @@ reddb-grpc-proto = { package = "reddb-io-grpc-proto", version = "1.0", path = ".
 reddb-client-connector = { package = "reddb-io-client-connector", version = "1.0", path = "../reddb-client-connector" }
 aes-gcm = "0.10"
 blake3 = "1"
+# SIMD/PCLMULQDQ CRC32 (IEEE 802.3 polynomial) for WAL/page record
+# checksums (issue #883 / PRD #882). Runtime CPU feature detection
+# selects the pclmulqdq path with a table-based scalar fallback —
+# byte-identical to the previous hand-rolled software CRC32, so no
+# on-disk WAL format change. Already in the tree transitively via
+# flate2; promoted here to a direct dependency.
+crc32fast = "1.5"
 hmac = "0.13"
 itoa = "1"
 zstd = { version = "0.13", default-features = false }

--- a/crates/reddb-server/src/storage/engine/crc32.rs
+++ b/crates/reddb-server/src/storage/engine/crc32.rs
@@ -1,6 +1,7 @@
-//! CRC32 checksum implementation (IEEE 802.3 polynomial)
+//! CRC32 checksum implementation (IEEE 802.3 polynomial), SIMD-accelerated.
 //!
-//! Used for page integrity verification. Detects corruption on read.
+//! Used for page and WAL-record integrity verification. Detects corruption
+//! on read.
 //!
 //! # Algorithm
 //!
@@ -11,27 +12,18 @@
 //! - Final XOR: 0xFFFFFFFF
 //!
 //! This matches zlib/gzip/PNG CRC32.
-
-/// CRC32 lookup table (pre-computed for polynomial 0xEDB88320)
-const CRC32_TABLE: [u32; 256] = {
-    let mut table = [0u32; 256];
-    let mut i = 0;
-    while i < 256 {
-        let mut crc = i as u32;
-        let mut j = 0;
-        while j < 8 {
-            if crc & 1 != 0 {
-                crc = (crc >> 1) ^ 0xEDB88320;
-            } else {
-                crc >>= 1;
-            }
-            j += 1;
-        }
-        table[i] = crc;
-        i += 1;
-    }
-    table
-};
+//!
+//! # Implementation
+//!
+//! Backed by [`crc32fast`], which performs runtime CPU-feature detection and
+//! selects a SIMD/PCLMULQDQ folding implementation (carry-less multiply over
+//! the reflected IEEE polynomial) when the host supports it, falling back to a
+//! table-based scalar routine otherwise. The polynomial, reflection, initial
+//! value and final XOR are identical to the previous hand-rolled
+//! byte-at-a-time software CRC32, so checksums are **byte-for-byte identical**:
+//! WAL records (and pages) written before and after this change remain mutually
+//! verifiable and the on-disk format — magic, version byte, layout — is
+//! unchanged. See issue #883 / PRD #882.
 
 /// Compute CRC32 checksum of data.
 ///
@@ -42,24 +34,20 @@ const CRC32_TABLE: [u32; 256] = {
 /// assert_eq!(checksum, 0x0D4A1185);
 /// ```
 pub fn crc32(data: &[u8]) -> u32 {
-    let mut crc = 0xFFFFFFFF_u32;
-    for &byte in data {
-        let index = ((crc ^ byte as u32) & 0xFF) as usize;
-        crc = CRC32_TABLE[index] ^ (crc >> 8);
-    }
-    crc ^ 0xFFFFFFFF
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(data);
+    hasher.finalize()
 }
 
 /// Compute CRC32 checksum, continuing from a previous value.
 ///
-/// Useful for computing checksum in chunks.
+/// `crc` is a previously finalized CRC32 (as returned by [`crc32`] or an
+/// earlier `crc32_update`). Useful for computing a checksum in chunks; the
+/// result is identical to hashing the concatenated input in one call.
 pub fn crc32_update(crc: u32, data: &[u8]) -> u32 {
-    let mut crc = crc ^ 0xFFFFFFFF;
-    for &byte in data {
-        let index = ((crc ^ byte as u32) & 0xFF) as usize;
-        crc = CRC32_TABLE[index] ^ (crc >> 8);
-    }
-    crc ^ 0xFFFFFFFF
+    let mut hasher = crc32fast::Hasher::new_with_initial(crc);
+    hasher.update(data);
+    hasher.finalize()
 }
 
 /// Verify data against expected CRC32.
@@ -71,6 +59,49 @@ pub fn crc32_verify(data: &[u8], expected: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Pre-computed lookup table for the previous hand-rolled software CRC32
+    /// (polynomial 0xEDB88320). Retained here as the byte-parity reference the
+    /// SIMD implementation is checked against.
+    const CRC32_TABLE: [u32; 256] = {
+        let mut table = [0u32; 256];
+        let mut i = 0;
+        while i < 256 {
+            let mut crc = i as u32;
+            let mut j = 0;
+            while j < 8 {
+                if crc & 1 != 0 {
+                    crc = (crc >> 1) ^ 0xEDB88320;
+                } else {
+                    crc >>= 1;
+                }
+                j += 1;
+            }
+            table[i] = crc;
+            i += 1;
+        }
+        table
+    };
+
+    /// The previous byte-at-a-time software CRC32, used only as the parity
+    /// oracle for the SIMD implementation.
+    fn crc32_scalar_reference(data: &[u8]) -> u32 {
+        let mut crc = 0xFFFFFFFF_u32;
+        for &byte in data {
+            let index = ((crc ^ byte as u32) & 0xFF) as usize;
+            crc = CRC32_TABLE[index] ^ (crc >> 8);
+        }
+        crc ^ 0xFFFFFFFF
+    }
+
+    /// Deterministic pseudo-random corpus byte (no external rng dependency).
+    fn corpus_byte(seed: u64) -> u8 {
+        // splitmix64-style mixing — deterministic and well-distributed.
+        let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        (z ^ (z >> 31)) as u8
+    }
 
     #[test]
     fn test_crc32_empty() {
@@ -127,9 +158,56 @@ mod tests {
         assert!(!crc32_verify(data, checksum + 1));
     }
 
+    /// Byte-parity: the SIMD implementation must produce identical checksums
+    /// to the previous software implementation across a corpus spanning the
+    /// SIMD folding boundaries (sub-16, single-block, multi-block, tail).
+    #[test]
+    fn simd_matches_software_across_corpus() {
+        // Length 0 through 600 exercises the <16-byte scalar tail, the
+        // 16-byte PCLMULQDQ block, and many full + partial folding rounds.
+        for len in 0..=600usize {
+            let data: Vec<u8> = (0..len as u64).map(corpus_byte).collect();
+            assert_eq!(
+                crc32(&data),
+                crc32_scalar_reference(&data),
+                "SIMD/software CRC32 diverged at len={len}"
+            );
+        }
+    }
+
+    /// The known CRC32 test vectors must match the software reference too,
+    /// closing acceptance criterion #2 (corpus + known vectors).
+    #[test]
+    fn simd_matches_software_on_known_vectors() {
+        for v in [
+            &b""[..],
+            &b"123456789"[..],
+            &b"hello"[..],
+            &b"Hello, World!"[..],
+            &[0u8; 32][..],
+            &[0xFFu8; 17][..],
+        ] {
+            assert_eq!(crc32(v), crc32_scalar_reference(v));
+        }
+    }
+
+    /// Chunked `crc32_update` must equal a single-shot `crc32` regardless of
+    /// where the input is split — the property the WAL reader relies on when
+    /// it folds the running CRC field-by-field.
+    #[test]
+    fn crc32_update_chunking_is_split_invariant() {
+        let data: Vec<u8> = (0..512u64).map(corpus_byte).collect();
+        let expected = crc32(&data);
+        for split in 0..=data.len() {
+            let (head, tail) = data.split_at(split);
+            let crc = crc32_update(crc32(head), tail);
+            assert_eq!(crc, expected, "chunk split at {split} diverged");
+        }
+    }
+
     #[test]
     fn test_crc32_table_generation() {
-        // Verify first few table entries match expected values
+        // Verify first few reference-table entries match expected values
         assert_eq!(CRC32_TABLE[0], 0x00000000);
         assert_eq!(CRC32_TABLE[1], 0x77073096);
         assert_eq!(CRC32_TABLE[2], 0xEE0E612C);


### PR DESCRIPTION
Automated AFK landing for #883. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782797514&installation_id=129708444&pr_number=887&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F887&signature=376a7fa91e8d033f05c2a2b2df0543cf73bb008161328610a6990cf4981955af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized checksum computation for improved performance using efficient algorithms, while maintaining full compatibility with existing database formats and record structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->