### PR TITLE
merge: #885 Per-owner buffer arena for query-result rows (StatementFrame-owned)

### DIFF
--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -6445,10 +6445,17 @@ impl RedDBRuntime {
                     mode,
                     statement,
                     engine: "runtime-table",
-                    result: execute_runtime_table_query(
+                    // #885: lend the frame-owned row-buffer arena to the
+                    // streaming path so chunk buffers are reused across
+                    // this statement's chunk-fetches instead of allocated
+                    // fresh per chunk. This is the table-query dispatch
+                    // that runs under a `StatementExecutionFrame`; the
+                    // frameless prepared/subquery paths keep `None`.
+                    result: execute_runtime_table_query_in(
                         &self.inner.db,
                         &table_with_rls,
                         Some(&self.inner.index_store),
+                        Some(frame.row_arena()),
                     )?,
                     affected_rows: 0,
                     statement_type: "select",

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -45,7 +45,7 @@ use table::{
     RuntimeTableExecutionContext,
 };
 
-pub(crate) use row_stream::{RowStream, DEFAULT_HIGH_WATER_MARK};
+pub(crate) use row_stream::{RowBufferArena, RowStream, DEFAULT_HIGH_WATER_MARK};
 
 /// Public table-query entry. Produces its result through the #806
 /// bounded-memory streaming channel ([`RowStream`]) and collects the
@@ -60,8 +60,30 @@ pub(super) fn execute_runtime_table_query(
     query: &TableQuery,
     index_store: Option<&super::index_store::IndexStore>,
 ) -> RedDBResult<UnifiedResult> {
+    execute_runtime_table_query_in(db, query, index_store, None)
+}
+
+/// Arena-aware variant of [`execute_runtime_table_query`] (#885). When a
+/// `StatementFrame`-owned [`RowBufferArena`] is supplied, the streaming
+/// channel's chunk buffers are leased from / recycled to it instead of
+/// allocated fresh per chunk, reusing one buffer across the chunk-fetches
+/// of the statement. Passing `None` reproduces the original
+/// allocate-per-chunk behaviour exactly, so observable results are
+/// byte-identical either way. The frameless dispatch paths (prepared
+/// statements, view/CTE subqueries) call the `None` form above.
+pub(super) fn execute_runtime_table_query_in(
+    db: &RedDB,
+    query: &TableQuery,
+    index_store: Option<&super::index_store::IndexStore>,
+    arena: Option<std::rc::Rc<std::cell::RefCell<RowBufferArena>>>,
+) -> RedDBResult<UnifiedResult> {
     let materialized = execute_runtime_table_query_materialized(db, query, index_store)?;
-    RowStream::from_unified(materialized, DEFAULT_HIGH_WATER_MARK).collect_unified()
+    let stream = RowStream::from_unified(materialized, DEFAULT_HIGH_WATER_MARK);
+    let stream = match arena {
+        Some(arena) => stream.with_arena(arena),
+        None => stream,
+    };
+    stream.collect_unified()
 }
 
 fn execute_runtime_table_query_materialized(

--- a/crates/reddb-server/src/runtime/query_exec/row_stream.rs
+++ b/crates/reddb-server/src/runtime/query_exec/row_stream.rs
@@ -31,10 +31,96 @@
 //! `{"end": …}` / `{"error": …}` frames at the executor level.
 
 use super::*;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 /// Default chunk high-water mark (rows). Bounds the resident record set
 /// of a [`RowStream`] regardless of how many rows the source yields.
 pub(crate) const DEFAULT_HIGH_WATER_MARK: usize = 1024;
+
+/// Per-owner buffer arena for query-result row chunks (#885).
+///
+/// A [`RowStream`] historically allocated a fresh `Vec<UnifiedRecord>`
+/// for every chunk it assembled in [`RowStream::next_chunk`]. For a
+/// result that spans many chunks that is one heap allocation per
+/// chunk-fetch on the row-streaming path. This arena keeps a small
+/// free-list of emptied buffers so the chunk Vec is reused across the
+/// chunk-fetches of a single statement instead of reallocated.
+///
+/// Ownership model (the safety argument from the issue): the arena is
+/// owned by the `StatementFrame` that already owns the query lifecycle
+/// and lent to the stream it spawns via an `Rc`. It is **not** a
+/// `thread_local!` scratch — under tokio's multi-threaded work-stealing
+/// runtime a task may resume on a different worker after `.await`, which
+/// would make thread-local scratch unsound; tying the buffer lifetime to
+/// the frame sidesteps that entirely. The arena is single-owner and
+/// never shared across threads.
+///
+/// Reuse is leak-free by construction: a buffer is cleared the moment it
+/// is recycled (and again when leased), so no record from a prior chunk
+/// can bleed into a reused buffer — only the backing allocation is
+/// retained. Caps bound how much memory the free-list can pin so a single
+/// oversized chunk does not hoard capacity for the rest of the frame.
+#[derive(Debug, Default)]
+pub(crate) struct RowBufferArena {
+    /// Emptied buffers available for reuse. Each is `len == 0`; only the
+    /// backing capacity is retained.
+    free: Vec<Vec<UnifiedRecord>>,
+}
+
+impl RowBufferArena {
+    /// Maximum number of buffers the free-list retains. Only one chunk
+    /// buffer is ever in flight per stream (lease → consume → recycle),
+    /// so a small cap is plenty; the extra slots absorb the rare case of
+    /// nested streams sharing one frame arena.
+    const MAX_BUFFERS: usize = 4;
+    /// Drop (rather than retain) any recycled buffer whose capacity grew
+    /// past this many records, so a one-off huge chunk cannot pin a large
+    /// allocation for the remainder of the frame.
+    const MAX_BUFFER_CAPACITY: usize = DEFAULT_HIGH_WATER_MARK * 4;
+
+    pub(crate) fn new() -> Self {
+        Self { free: Vec::new() }
+    }
+
+    /// Hand out a cleared buffer for the next chunk. Reuses a recycled
+    /// allocation when one is available, otherwise allocates fresh. The
+    /// returned buffer is always empty, so a reused buffer never carries
+    /// rows from a prior chunk.
+    pub(crate) fn lease(&mut self) -> Vec<UnifiedRecord> {
+        match self.free.pop() {
+            Some(mut buf) => {
+                buf.clear();
+                buf
+            }
+            None => Vec::new(),
+        }
+    }
+
+    /// Return a drained buffer to the free-list for reuse. Clears it first
+    /// so no record can bleed across reuses, and refuses to retain it when
+    /// the free-list is full or the buffer's capacity is oversized.
+    pub(crate) fn recycle(&mut self, mut buf: Vec<UnifiedRecord>) {
+        if self.free.len() >= Self::MAX_BUFFERS || buf.capacity() > Self::MAX_BUFFER_CAPACITY {
+            return;
+        }
+        buf.clear();
+        self.free.push(buf);
+    }
+
+    /// Reclaim the arena to a clean state at frame end — drops every
+    /// retained buffer so nothing is pinned past the frame that owns it.
+    pub(crate) fn reset(&mut self) {
+        self.free.clear();
+    }
+
+    /// Number of buffers currently held for reuse. Observability surface
+    /// for the reuse / no-bleed unit tests.
+    #[cfg(test)]
+    pub(crate) fn pooled(&self) -> usize {
+        self.free.len()
+    }
+}
 
 /// One bounded batch of rows emitted by a [`RowStream`]. Its length never
 /// exceeds the stream's high-water mark.
@@ -95,6 +181,12 @@ pub(crate) struct RowStream {
     peak_buffered: usize,
     /// Set once the source drains or errors.
     terminal: Option<StreamTerminal>,
+    /// Optional per-owner buffer arena (#885). When present, chunk
+    /// buffers are leased from / recycled to this arena instead of
+    /// allocated fresh per chunk. `None` preserves the original
+    /// allocate-per-chunk behaviour exactly (used by every consumer that
+    /// is not driven by a `StatementFrame`-owned arena).
+    arena: Option<Rc<RefCell<RowBufferArena>>>,
 }
 
 impl RowStream {
@@ -115,6 +207,7 @@ impl RowStream {
             row_count: 0,
             peak_buffered: 0,
             terminal: None,
+            arena: None,
         }
     }
 
@@ -140,7 +233,17 @@ impl RowStream {
             row_count: 0,
             peak_buffered: 0,
             terminal: None,
+            arena: None,
         }
+    }
+
+    /// Bind a per-owner buffer arena (#885) to this stream. Chunk buffers
+    /// will be leased from / recycled to it instead of allocated fresh per
+    /// chunk. Builder-style so existing constructors keep their original
+    /// signatures and the arena stays opt-in.
+    pub(crate) fn with_arena(mut self, arena: Rc<RefCell<RowBufferArena>>) -> Self {
+        self.arena = Some(arena);
+        self
     }
 
     /// Largest record count ever resident in one in-flight chunk. Bounded
@@ -163,7 +266,13 @@ impl RowStream {
         if self.terminal.is_some() {
             return None;
         }
-        let mut records: Vec<UnifiedRecord> = Vec::new();
+        // Lease a chunk buffer from the per-owner arena when one is wired
+        // (#885); otherwise allocate fresh, preserving the original
+        // per-chunk allocation behaviour byte-for-byte.
+        let mut records: Vec<UnifiedRecord> = match &self.arena {
+            Some(arena) => arena.borrow_mut().lease(),
+            None => Vec::new(),
+        };
         while records.len() < self.high_water_mark {
             match self.source.next() {
                 Some(Ok(record)) => records.push(record),
@@ -189,7 +298,13 @@ impl RowStream {
         self.row_count += records.len() as u64;
         if records.is_empty() {
             // Either we errored with nothing buffered, or the source was
-            // empty; ensure a terminal is set and stop.
+            // empty; ensure a terminal is set and stop. Recycle the
+            // (empty) leased buffer rather than dropping it, so a stream
+            // whose row count is an exact multiple of the high-water mark
+            // does not silently discard the chunk allocation (#885).
+            if let Some(arena) = &self.arena {
+                arena.borrow_mut().recycle(records);
+            }
             if self.terminal.is_none() {
                 self.terminal = Some(StreamTerminal::End {
                     row_count: self.row_count,
@@ -208,7 +323,16 @@ impl RowStream {
     pub(crate) fn collect_unified(mut self) -> RedDBResult<UnifiedResult> {
         let mut records: Vec<UnifiedRecord> = Vec::new();
         while let Some(chunk) = self.next_chunk() {
-            records.extend(chunk.records);
+            // `append` moves the chunk's rows into the accumulator in
+            // order (identical to the old `extend`) and leaves the chunk
+            // buffer empty-but-allocated, so it can be recycled to the
+            // arena for the next chunk-fetch (#885). Without an arena the
+            // buffer simply drops here, exactly as before.
+            let mut buf = chunk.records;
+            records.append(&mut buf);
+            if let Some(arena) = &self.arena {
+                arena.borrow_mut().recycle(buf);
+            }
         }
         if let Some(StreamTerminal::Error { message, .. }) = self.terminal {
             return Err(RedDBError::Query(message));
@@ -227,7 +351,13 @@ impl RowStream {
     pub(crate) fn collect_records(mut self) -> RedDBResult<Vec<UnifiedRecord>> {
         let mut records: Vec<UnifiedRecord> = Vec::new();
         while let Some(chunk) = self.next_chunk() {
-            records.extend(chunk.records);
+            // See `collect_unified`: append-then-recycle reuses the chunk
+            // buffer via the arena (#885) while preserving row order.
+            let mut buf = chunk.records;
+            records.append(&mut buf);
+            if let Some(arena) = &self.arena {
+                arena.borrow_mut().recycle(buf);
+            }
         }
         if let Some(StreamTerminal::Error { message, .. }) = self.terminal {
             return Err(RedDBError::Query(message));
@@ -361,6 +491,116 @@ mod tests {
             stream.terminal(),
             Some(&StreamTerminal::End { row_count: 0 })
         );
+    }
+
+    /// A leased buffer is always empty even when reused — recycling a
+    /// buffer that held rows must not let those rows bleed into the next
+    /// lease (#885 acceptance: "no data bleeds across requests when a
+    /// buffer is reused").
+    #[test]
+    fn arena_lease_never_bleeds_prior_rows() {
+        let mut arena = RowBufferArena::new();
+        let mut buf = arena.lease();
+        assert!(buf.is_empty(), "fresh lease is empty");
+        buf.push(row(1));
+        buf.push(row(2));
+        arena.recycle(buf);
+        assert_eq!(arena.pooled(), 1, "recycled buffer is retained for reuse");
+
+        let reused = arena.lease();
+        assert!(
+            reused.is_empty(),
+            "a reused buffer carries no rows from the prior chunk"
+        );
+        assert_eq!(arena.pooled(), 0, "leasing drains the free-list slot");
+    }
+
+    /// `reset()` reclaims the arena to a clean state — every retained
+    /// buffer is dropped (#885 acceptance: "reset to a clean state at
+    /// frame end").
+    #[test]
+    fn arena_reset_drops_retained_buffers() {
+        let mut arena = RowBufferArena::new();
+        let buf = arena.lease();
+        arena.recycle(buf);
+        let buf2 = arena.lease();
+        arena.recycle(buf2);
+        assert!(arena.pooled() >= 1);
+        arena.reset();
+        assert_eq!(arena.pooled(), 0, "reset clears the free-list");
+    }
+
+    /// Driving a multi-chunk stream through an arena recycles the single
+    /// in-flight chunk buffer across chunk-fetches instead of allocating a
+    /// fresh one each time, and the collected result is byte-identical to
+    /// the arena-free baseline (#885 acceptance: byte-identical results,
+    /// buffer reuse).
+    #[test]
+    fn arena_backed_stream_reuses_buffer_and_matches_baseline() {
+        const N: u64 = 5_000;
+        const HWM: usize = 256;
+
+        let baseline = RowStream::from_lazy(
+            vec!["n".into()],
+            Default::default(),
+            HWM,
+            Box::new((0..N).map(|i| Ok(row(i)))),
+        )
+        .collect_records()
+        .expect("baseline collects");
+
+        let arena = Rc::new(RefCell::new(RowBufferArena::new()));
+        let arena_backed = RowStream::from_lazy(
+            vec!["n".into()],
+            Default::default(),
+            HWM,
+            Box::new((0..N).map(|i| Ok(row(i)))),
+        )
+        .with_arena(Rc::clone(&arena))
+        .collect_records()
+        .expect("arena-backed collects");
+
+        assert_eq!(
+            arena_backed.len(),
+            baseline.len(),
+            "row count identical to the per-request-allocation baseline"
+        );
+        for (a, b) in arena_backed.iter().zip(baseline.iter()) {
+            assert_eq!(
+                a.get("n"),
+                b.get("n"),
+                "each row is byte-identical to the baseline"
+            );
+        }
+        // After draining a many-chunk stream the arena holds exactly the
+        // one recycled chunk buffer — proof the buffer was reused rather
+        // than reallocated per chunk.
+        assert_eq!(
+            arena.borrow().pooled(),
+            1,
+            "one chunk buffer is recycled and reused across all chunk-fetches"
+        );
+    }
+
+    /// `from_unified` round-trips byte-identically whether or not an arena
+    /// is bound — the arena is a pure allocation optimisation (#885
+    /// acceptance: byte-identical observable results).
+    #[test]
+    fn arena_backed_from_unified_round_trips_verbatim() {
+        let original = UnifiedResult {
+            columns: vec!["a".into(), "b".into()],
+            records: vec![row(1), row(2), row(3)],
+            stats: Default::default(),
+            pre_serialized_json: Some("{\"fast\":true}".into()),
+        };
+        let arena = Rc::new(RefCell::new(RowBufferArena::new()));
+        let collected = RowStream::from_unified(original.clone(), 2)
+            .with_arena(arena)
+            .collect_unified()
+            .expect("arena-backed stream collects ok");
+        assert_eq!(collected.columns, original.columns);
+        assert_eq!(collected.records.len(), original.records.len());
+        assert_eq!(collected.pre_serialized_json, original.pre_serialized_json);
     }
 
     /// Bounded-memory over a *real* table scan: a query producing N rows

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -1,4 +1,6 @@
+use std::cell::RefCell;
 use std::collections::HashSet;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use super::impl_core::{
@@ -261,6 +263,14 @@ pub(super) struct StatementExecutionFrame {
     /// scoring (issue #119). `None` when no auth store is wired
     /// (embedded test mode) — AI search refuses on `None`.
     visible_collections: Option<HashSet<String>>,
+    /// Per-owner buffer arena for query-result row chunks (#885). Owned
+    /// by the frame because the frame already owns the query lifecycle;
+    /// lent to the row-streaming path (`execute_runtime_table_query_in`)
+    /// so chunk buffers are reused across the statement's chunk-fetches
+    /// instead of allocated fresh per chunk. Reclaimed when the frame
+    /// drops at statement end — no `thread_local!` scratch, which would
+    /// be unsound under tokio's work-stealing runtime.
+    row_arena: Rc<RefCell<super::query_exec::RowBufferArena>>,
 }
 
 pub(super) struct StatementFrameGuards {
@@ -332,7 +342,16 @@ impl StatementExecutionFrame {
             required_privilege,
             lock_intent,
             visible_collections,
+            row_arena: Rc::new(RefCell::new(super::query_exec::RowBufferArena::new())),
         })
+    }
+
+    /// Lend the frame's per-owner row-buffer arena (#885) to the
+    /// row-streaming path. Returns a cloned `Rc` handle; the frame remains
+    /// the owner and the arena is reclaimed when the frame drops at
+    /// statement end.
+    pub(super) fn row_arena(&self) -> Rc<RefCell<super::query_exec::RowBufferArena>> {
+        Rc::clone(&self.row_arena)
     }
 
     pub(super) fn install(&self, runtime: &RedDBRuntime) -> StatementFrameGuards {
@@ -1309,6 +1328,55 @@ mod tests {
             msg.contains("permission denied") && msg.contains("Write"),
             "expected frame-level Write deny, got: {msg}"
         );
+
+        reset_thread_locals();
+    }
+
+    /// End-to-end proof that the frame-owned row-buffer arena (#885) is
+    /// wired into the SELECT path and produces observable results
+    /// byte-identical to the per-request-allocation baseline.
+    ///
+    /// A table with more rows than the streaming high-water mark
+    /// (`DEFAULT_HIGH_WATER_MARK`) forces the `execute_runtime_table_query_in`
+    /// path to assemble many chunks, each leasing/recycling the frame
+    /// arena's single chunk buffer. Driving it through `execute_query`
+    /// (which builds a `StatementExecutionFrame` and lends its arena)
+    /// must return every inserted row, in order — exactly what the
+    /// allocate-per-chunk path returned. A bug in the arena wiring
+    /// (dropped rows, bled rows, mis-ordering) would surface here.
+    #[test]
+    fn large_select_through_frame_arena_returns_all_rows_in_order() {
+        reset_thread_locals();
+        let rt = fresh_runtime();
+        rt.execute_query("CREATE TABLE big (id INT)")
+            .expect("create table");
+
+        // > DEFAULT_HIGH_WATER_MARK (1024) rows so the streaming channel
+        // spans multiple chunks and the arena buffer is reused.
+        const N: usize = 2_500;
+        let values = (0..N)
+            .map(|i| format!("({i})"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        rt.execute_query(&format!("INSERT INTO big (id) VALUES {values}"))
+            .expect("insert rows");
+
+        let result = rt
+            .execute_query("SELECT id FROM big ORDER BY id")
+            .expect("large SELECT executes through the frame arena path");
+        assert_eq!(result.statement_type, "select");
+        assert_eq!(
+            result.result.records.len(),
+            N,
+            "every inserted row streams back through the arena-backed channel"
+        );
+        for (i, record) in result.result.records.iter().enumerate() {
+            assert_eq!(
+                record.get("id"),
+                Some(&crate::storage::schema::Value::Integer(i as i64)),
+                "row {i} is byte-identical to the per-request-allocation baseline"
+            );
+        }
 
         reset_thread_locals();
     }


### PR DESCRIPTION
Automated AFK landing for #885. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782800835&installation_id=129708444&pr_number=889&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F889&signature=880af6aa2b2e3d2c1b5f07014ac52e54f8bba78dccb0f0c5016d55f57fa956ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized memory management for large query result sets, enabling more efficient buffer reuse during multi-chunk result streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->