### PR TITLE
merge: #866 Phase 0: persist hypertable chunk metadata across restart

### DIFF
--- a/crates/reddb-server/src/physical.rs
+++ b/crates/reddb-server/src/physical.rs
@@ -580,6 +580,36 @@ pub struct PhysicalTreeDefinition {
     pub updated_at_unix_ms: u128,
 }
 
+/// A single persisted hypertable chunk. Mirror of
+/// `storage::timeseries::ChunkMeta`, flattened for the metadata
+/// sidecar so the registry's routing spine survives a restart
+/// (issue #866). `start_ns` plus the owning hypertable name is the
+/// chunk's stable identity.
+#[derive(Debug, Clone)]
+pub struct PhysicalHypertableChunk {
+    pub start_ns: u64,
+    pub end_ns_exclusive: u64,
+    pub row_count: u64,
+    pub min_ts_ns: u64,
+    pub max_ts_ns: u64,
+    pub sealed: bool,
+    pub ttl_override_ns: Option<u64>,
+}
+
+/// A persisted hypertable spec plus all of its chunks. Stored in the
+/// physical metadata sidecar alongside collection contracts so chunk
+/// bounds / routing / TTL are recovered identically after a restart
+/// — the same durability path the rest of the catalog already uses,
+/// not a parallel one (issue #866).
+#[derive(Debug, Clone)]
+pub struct PhysicalHypertable {
+    pub name: String,
+    pub time_column: String,
+    pub chunk_interval_ns: u64,
+    pub default_ttl_ns: Option<u64>,
+    pub chunks: Vec<PhysicalHypertableChunk>,
+}
+
 #[derive(Debug, Clone)]
 pub struct PhysicalMetadataFile {
     pub protocol_version: String,
@@ -595,6 +625,10 @@ pub struct PhysicalMetadataFile {
     pub tree_definitions: Vec<PhysicalTreeDefinition>,
     pub collection_ttl_defaults_ms: BTreeMap<String, u64>,
     pub collection_contracts: Vec<CollectionContract>,
+    /// Persisted hypertable chunk spine (issue #866). Empty on legacy
+    /// sidecars written before the feature and for non-hypertable
+    /// databases.
+    pub hypertables: Vec<PhysicalHypertable>,
     pub exports: Vec<ExportDescriptor>,
     pub superblock: SuperblockHeader,
     pub snapshots: Vec<SnapshotDescriptor>,

--- a/crates/reddb-server/src/physical/json_codec.rs
+++ b/crates/reddb-server/src/physical/json_codec.rs
@@ -1613,6 +1613,104 @@ pub(super) fn tree_definition_from_json(value: &JsonValue) -> io::Result<Physica
     })
 }
 
+pub(super) fn hypertable_chunk_to_json(chunk: &PhysicalHypertableChunk) -> JsonValue {
+    let mut object = Map::new();
+    object.insert("start_ns".to_string(), json_u64(chunk.start_ns));
+    object.insert(
+        "end_ns_exclusive".to_string(),
+        json_u64(chunk.end_ns_exclusive),
+    );
+    object.insert("row_count".to_string(), json_u64(chunk.row_count));
+    object.insert("min_ts_ns".to_string(), json_u64(chunk.min_ts_ns));
+    object.insert("max_ts_ns".to_string(), json_u64(chunk.max_ts_ns));
+    object.insert("sealed".to_string(), JsonValue::Bool(chunk.sealed));
+    object.insert(
+        "ttl_override_ns".to_string(),
+        chunk
+            .ttl_override_ns
+            .map(json_u64)
+            .unwrap_or(JsonValue::Null),
+    );
+    JsonValue::Object(object)
+}
+
+pub(super) fn hypertable_chunk_from_json(value: &JsonValue) -> io::Result<PhysicalHypertableChunk> {
+    let object = expect_object(value, "hypertable chunk")?;
+    Ok(PhysicalHypertableChunk {
+        start_ns: json_u64_required(object, "start_ns")?,
+        end_ns_exclusive: json_u64_required(object, "end_ns_exclusive")?,
+        row_count: json_u64_required(object, "row_count")?,
+        min_ts_ns: json_u64_required(object, "min_ts_ns")?,
+        max_ts_ns: json_u64_required(object, "max_ts_ns")?,
+        sealed: object
+            .get("sealed")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false),
+        ttl_override_ns: match object.get("ttl_override_ns") {
+            Some(JsonValue::Null) | None => None,
+            Some(value) => Some(json_u64_value(value)?),
+        },
+    })
+}
+
+pub(super) fn hypertable_to_json(hypertable: &PhysicalHypertable) -> JsonValue {
+    let mut object = Map::new();
+    object.insert(
+        "name".to_string(),
+        JsonValue::String(hypertable.name.clone()),
+    );
+    object.insert(
+        "time_column".to_string(),
+        JsonValue::String(hypertable.time_column.clone()),
+    );
+    object.insert(
+        "chunk_interval_ns".to_string(),
+        json_u64(hypertable.chunk_interval_ns),
+    );
+    object.insert(
+        "default_ttl_ns".to_string(),
+        hypertable
+            .default_ttl_ns
+            .map(json_u64)
+            .unwrap_or(JsonValue::Null),
+    );
+    object.insert(
+        "chunks".to_string(),
+        JsonValue::Array(
+            hypertable
+                .chunks
+                .iter()
+                .map(hypertable_chunk_to_json)
+                .collect(),
+        ),
+    );
+    JsonValue::Object(object)
+}
+
+pub(super) fn hypertable_from_json(value: &JsonValue) -> io::Result<PhysicalHypertable> {
+    let object = expect_object(value, "hypertable")?;
+    Ok(PhysicalHypertable {
+        name: json_string_required(object, "name")?,
+        time_column: json_string_required(object, "time_column")?,
+        chunk_interval_ns: json_u64_required(object, "chunk_interval_ns")?,
+        default_ttl_ns: match object.get("default_ttl_ns") {
+            Some(JsonValue::Null) | None => None,
+            Some(value) => Some(json_u64_value(value)?),
+        },
+        chunks: object
+            .get("chunks")
+            .and_then(JsonValue::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .map(hypertable_chunk_from_json)
+                    .collect::<io::Result<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default(),
+    })
+}
+
 pub(super) fn index_kind_from_str(value: &str) -> io::Result<IndexKind> {
     match value {
         "btree" => Ok(IndexKind::BTree),

--- a/crates/reddb-server/src/physical/metadata_file.rs
+++ b/crates/reddb-server/src/physical/metadata_file.rs
@@ -77,6 +77,9 @@ impl PhysicalMetadataFile {
             collection_contracts: previous
                 .map(|previous| previous.collection_contracts.clone())
                 .unwrap_or_default(),
+            hypertables: previous
+                .map(|previous| previous.hypertables.clone())
+                .unwrap_or_default(),
             exports: previous
                 .map(|previous| previous.exports.clone())
                 .unwrap_or_default(),
@@ -364,6 +367,10 @@ impl PhysicalMetadataFile {
             ),
         );
         root.insert(
+            "hypertables".to_string(),
+            JsonValue::Array(self.hypertables.iter().map(hypertable_to_json).collect()),
+        );
+        root.insert(
             "exports".to_string(),
             JsonValue::Array(self.exports.iter().map(export_descriptor_to_json).collect()),
         );
@@ -474,6 +481,17 @@ impl PhysicalMetadataFile {
                     values
                         .iter()
                         .map(collection_contract_from_json)
+                        .collect::<io::Result<Vec<_>>>()
+                })
+                .transpose()?
+                .unwrap_or_default(),
+            hypertables: object
+                .get("hypertables")
+                .and_then(JsonValue::as_array)
+                .map(|values| {
+                    values
+                        .iter()
+                        .map(hypertable_from_json)
                         .collect::<io::Result<Vec<_>>>()
                 })
                 .transpose()?

--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -490,6 +490,50 @@ impl HypertableRegistry {
         guard.specs.keys().cloned().collect()
     }
 
+    /// True when no hypertable is registered and no chunk is tracked.
+    /// Lets the durability layer skip the persist step entirely for
+    /// workloads that never declared a hypertable (zero overhead).
+    pub fn is_empty(&self) -> bool {
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        guard.specs.is_empty() && guard.chunks.is_empty()
+    }
+
+    /// Snapshot every chunk across all hypertables, ordered by
+    /// `(hypertable, start_ns)` so the persisted form is deterministic.
+    /// Pairs with [`restore_chunk`] on boot. Specs are snapshotted via
+    /// [`list`].
+    pub fn snapshot_chunks(&self) -> Vec<ChunkMeta> {
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        guard.chunks.values().cloned().collect()
+    }
+
+    /// Reinstate a chunk verbatim during recovery. Overwrites any
+    /// existing entry for the same `(hypertable, start_ns)`.
+    ///
+    /// Unlike [`route`], this does **not** observe a timestamp — it
+    /// restores the persisted counters (`row_count`, `min_ts_ns`,
+    /// `max_ts_ns`, `sealed`, `ttl_override_ns`) exactly so the
+    /// post-restart registry is identical to the pre-restart one. The
+    /// caller is expected to [`register`] the owning spec first; a
+    /// chunk whose hypertable has no spec is still tracked (routing
+    /// falls back to the spec once it is registered), matching the
+    /// pre-restart invariant that chunks outlive a missing spec only
+    /// transiently.
+    pub fn restore_chunk(&self, meta: ChunkMeta) {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let key = (meta.id.hypertable.clone(), meta.id.start_ns);
+        guard.chunks.insert(key, meta);
+    }
+
     /// Drop the whole hypertable (spec + every chunk). Returns the
     /// number of chunks removed.
     pub fn drop_hypertable(&self, name: &str) -> usize {
@@ -777,6 +821,69 @@ mod tests {
         reg.set_chunk_ttl_ns(&id, Some(HOUR_NS));
         let dropped = reg.sweep_expired("m", 10 * HOUR_NS);
         assert_eq!(dropped.len(), 1);
+    }
+
+    #[test]
+    fn snapshot_then_restore_reproduces_registry_identically() {
+        // Pre-restart registry: two hypertables, several chunks, with a
+        // sealed chunk and a per-chunk TTL override — the bits that are
+        // NOT derivable from row data and so must round-trip verbatim.
+        let reg = HypertableRegistry::new();
+        reg.register(HypertableSpec::new("metrics", "ts", DAY_NS).with_ttl_ns(7 * DAY_NS));
+        reg.register(HypertableSpec::new("events", "ts", HOUR_NS));
+        for t in [0, DAY_NS + 5, DAY_NS + 9, 2 * DAY_NS] {
+            reg.route("metrics", t).unwrap();
+        }
+        let id = reg.route("events", 0).unwrap();
+        reg.seal_chunk(&id);
+        reg.set_chunk_ttl_ns(&id, Some(3 * HOUR_NS));
+
+        let specs = reg.list();
+        let chunks = reg.snapshot_chunks();
+        assert!(!reg.is_empty());
+
+        // Simulated restart: rebuild a fresh registry from the snapshot.
+        let restored = HypertableRegistry::new();
+        assert!(restored.is_empty());
+        for spec in specs {
+            restored.register(spec);
+        }
+        for chunk in chunks {
+            restored.restore_chunk(chunk);
+        }
+
+        // Specs identical.
+        let before = reg.get("metrics").unwrap();
+        let after = restored.get("metrics").unwrap();
+        assert_eq!(after.chunk_interval_ns, before.chunk_interval_ns);
+        assert_eq!(after.time_column, before.time_column);
+        assert_eq!(after.default_ttl_ns, before.default_ttl_ns);
+
+        // Chunk metadata identical (bounds, counts, sealed, TTL override).
+        let m_before = reg.show_chunks("metrics");
+        let m_after = restored.show_chunks("metrics");
+        assert_eq!(m_after.len(), m_before.len());
+        for (a, b) in m_after.iter().zip(m_before.iter()) {
+            assert_eq!(a.id.start_ns, b.id.start_ns);
+            assert_eq!(a.end_ns_exclusive, b.end_ns_exclusive);
+            assert_eq!(a.row_count, b.row_count);
+            assert_eq!(a.min_ts_ns, b.min_ts_ns);
+            assert_eq!(a.max_ts_ns, b.max_ts_ns);
+        }
+        let e_after = restored.show_chunks("events");
+        assert_eq!(e_after.len(), 1);
+        assert!(e_after[0].sealed, "sealed flag must survive restore");
+        assert_eq!(e_after[0].ttl_override_ns, Some(3 * HOUR_NS));
+
+        // A post-restart write routes to the EXISTING chunk — no
+        // duplicate allocation.
+        let routed = restored.route("metrics", DAY_NS + 1).unwrap();
+        assert_eq!(routed.start_ns, DAY_NS);
+        assert_eq!(
+            restored.show_chunks("metrics").len(),
+            m_before.len(),
+            "write after restore must not allocate a new chunk"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
@@ -391,6 +391,10 @@ impl RedDB {
             // that caused stack overflow / 12-second hang on startup.
         }
         self.load_collection_ttl_defaults_from_metadata();
+        // Issue #866 — rehydrate the hypertable chunk spine before the
+        // API opens so chunk routing / pruning / TTL work immediately
+        // after a restart.
+        self.load_hypertables_from_metadata();
         self.recover_queue_pending_state();
         Ok(self)
     }
@@ -417,6 +421,10 @@ impl RedDB {
             previous.as_ref(),
         );
         metadata.collection_ttl_defaults_ms = self.collection_ttl_defaults_snapshot();
+        // Issue #866 — persist the hypertable chunk spine (specs +
+        // chunk bounds / routing / TTL) onto the same metadata path as
+        // collection contracts so a restart recovers it identically.
+        metadata.hypertables = self.hypertable_registry_snapshot();
         metadata.save_for_data_path(path)?;
         self.persist_native_physical_header(&metadata)?;
         Ok(())
@@ -786,6 +794,9 @@ impl RedDB {
                 .unwrap_or_default(),
             collection_contracts: previous
                 .map(|metadata| metadata.collection_contracts.clone())
+                .unwrap_or_default(),
+            hypertables: previous
+                .map(|metadata| metadata.hypertables.clone())
                 .unwrap_or_default(),
             tree_definitions: previous
                 .map(|metadata| metadata.tree_definitions.clone())

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
@@ -250,6 +250,88 @@ impl RedDB {
         }
     }
 
+    /// Snapshot the live hypertable registry (specs + every chunk)
+    /// into the sidecar-serialisable form. Called from
+    /// [`persist_metadata`] so the chunk routing spine is durable on
+    /// the same metadata path as collection contracts — issue #866.
+    /// Returns an empty vec (and touches nothing) when no hypertable
+    /// has ever been declared, so non-hypertable databases pay no
+    /// persist cost.
+    pub(crate) fn hypertable_registry_snapshot(&self) -> Vec<crate::physical::PhysicalHypertable> {
+        let registry = self.hypertables();
+        if registry.is_empty() {
+            return Vec::new();
+        }
+        use std::collections::BTreeMap;
+        let mut chunks_by_table: BTreeMap<String, Vec<crate::physical::PhysicalHypertableChunk>> =
+            BTreeMap::new();
+        for chunk in registry.snapshot_chunks() {
+            chunks_by_table
+                .entry(chunk.id.hypertable.clone())
+                .or_default()
+                .push(crate::physical::PhysicalHypertableChunk {
+                    start_ns: chunk.id.start_ns,
+                    end_ns_exclusive: chunk.end_ns_exclusive,
+                    row_count: chunk.row_count,
+                    min_ts_ns: chunk.min_ts_ns,
+                    max_ts_ns: chunk.max_ts_ns,
+                    sealed: chunk.sealed,
+                    ttl_override_ns: chunk.ttl_override_ns,
+                });
+        }
+        registry
+            .list()
+            .into_iter()
+            .map(|spec| crate::physical::PhysicalHypertable {
+                chunks: chunks_by_table.remove(&spec.name).unwrap_or_default(),
+                name: spec.name,
+                time_column: spec.time_column,
+                chunk_interval_ns: spec.chunk_interval_ns,
+                default_ttl_ns: spec.default_ttl_ns,
+            })
+            .collect()
+    }
+
+    /// Rehydrate the hypertable registry from the physical metadata
+    /// sidecar at boot. Mirror of
+    /// [`load_collection_ttl_defaults_from_metadata`] — specs and
+    /// chunks are restored verbatim so bounds / routing / TTL are
+    /// identical to the pre-restart state (issue #866).
+    pub(crate) fn load_hypertables_from_metadata(&self) {
+        let Some(metadata) = self.physical_metadata() else {
+            return;
+        };
+        if metadata.hypertables.is_empty() {
+            return;
+        }
+        let registry = self.hypertables();
+        for hypertable in &metadata.hypertables {
+            let mut spec = crate::storage::timeseries::HypertableSpec::new(
+                hypertable.name.clone(),
+                hypertable.time_column.clone(),
+                hypertable.chunk_interval_ns,
+            );
+            if let Some(ttl) = hypertable.default_ttl_ns {
+                spec = spec.with_ttl_ns(ttl);
+            }
+            registry.register(spec);
+            for chunk in &hypertable.chunks {
+                registry.restore_chunk(crate::storage::timeseries::ChunkMeta {
+                    id: crate::storage::timeseries::ChunkId {
+                        hypertable: hypertable.name.clone(),
+                        start_ns: chunk.start_ns,
+                    },
+                    end_ns_exclusive: chunk.end_ns_exclusive,
+                    row_count: chunk.row_count,
+                    min_ts_ns: chunk.min_ts_ns,
+                    max_ts_ns: chunk.max_ts_ns,
+                    sealed: chunk.sealed,
+                    ttl_override_ns: chunk.ttl_override_ns,
+                });
+            }
+        }
+    }
+
     pub fn run_maintenance(&self) -> Result<(), Box<dyn std::error::Error>> {
         self.store.run_maintenance()?;
         self.persist_metadata()?;

--- a/tests/e2e_hypertable_persist_restart.rs
+++ b/tests/e2e_hypertable_persist_restart.rs
@@ -1,0 +1,155 @@
+//! Issue #866 — Phase 0: the hypertable chunk spine must survive a
+//! restart. Create a hypertable, allocate chunks across several time
+//! buckets, checkpoint, reopen the engine, and confirm chunk bounds /
+//! routing / TTL come back identical — and that a write after the
+//! restart routes to the correct existing chunk instead of allocating
+//! a duplicate.
+//!
+//! Persistence rides the SAME metadata path as collection contracts
+//! (the physical metadata sidecar), written by `persist_metadata()` on
+//! the checkpoint/flush durability boundary — not a parallel durability
+//! mechanism.
+
+mod support;
+
+use support::{checkpoint_and_reopen, PersistentDbPath};
+
+use reddb::application::ExecuteQueryInput;
+use reddb::storage::timeseries::ChunkMeta;
+use reddb::QueryUseCases;
+
+const DAY_NS: u64 = 86_400_000_000_000;
+const HOUR_NS: u64 = 3_600_000_000_000;
+
+/// Stable comparison key for a chunk — every field that must round-trip.
+fn chunk_fingerprint(m: &ChunkMeta) -> (u64, u64, u64, u64, u64, bool, Option<u64>) {
+    (
+        m.id.start_ns,
+        m.end_ns_exclusive,
+        m.row_count,
+        m.min_ts_ns,
+        m.max_ts_ns,
+        m.sealed,
+        m.ttl_override_ns,
+    )
+}
+
+#[test]
+fn hypertable_chunk_metadata_survives_restart() {
+    let path = PersistentDbPath::new("hypertable_persist_restart");
+    let rt = path.open_runtime();
+    let q = QueryUseCases::new(&rt);
+
+    q.execute(ExecuteQueryInput {
+        query: "CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1d' TTL '7d'".into(),
+    })
+    .expect("create hypertable ok");
+
+    // Write across four distinct day-chunks. Multiple writes land in
+    // the first chunk so row_count / min / max are non-trivial.
+    {
+        let db = rt.db();
+        let reg = db.hypertables();
+        for t in [10u64, 100, DAY_NS - 1] {
+            reg.route("metrics", t).expect("route day-0");
+        }
+        reg.route("metrics", DAY_NS + 5).expect("route day-1");
+        reg.route("metrics", 2 * DAY_NS + 9).expect("route day-2");
+        let last = reg.route("metrics", 5 * DAY_NS).expect("route day-5");
+
+        // Exercise the bits that are NOT derivable from row data: a
+        // sealed flag and a per-chunk TTL override must persist too.
+        assert!(reg.seal_chunk(&last));
+        assert!(reg.set_chunk_ttl_ns(&last, Some(3 * HOUR_NS)));
+    }
+
+    // Snapshot pre-restart state.
+    let before: Vec<_> = rt
+        .db()
+        .hypertables()
+        .show_chunks("metrics")
+        .iter()
+        .map(chunk_fingerprint)
+        .collect();
+    assert_eq!(before.len(), 4, "four chunks allocated pre-restart");
+
+    // Durable checkpoint, then reopen the engine from disk.
+    let rt = checkpoint_and_reopen(&path, rt);
+
+    // Spec recovered identically.
+    let spec = rt
+        .db()
+        .hypertables()
+        .get("metrics")
+        .expect("hypertable spec recovered after restart");
+    assert_eq!(spec.time_column, "ts");
+    assert_eq!(spec.chunk_interval_ns, DAY_NS);
+    assert_eq!(
+        spec.default_ttl_ns,
+        Some(7 * DAY_NS),
+        "default TTL recovered after restart"
+    );
+
+    // Chunks recovered identically — bounds, counts, sealed, override.
+    let after: Vec<_> = rt
+        .db()
+        .hypertables()
+        .show_chunks("metrics")
+        .iter()
+        .map(chunk_fingerprint)
+        .collect();
+    assert_eq!(
+        after, before,
+        "chunk metadata must be recovered identical to pre-restart"
+    );
+
+    // The sealed + TTL-overridden chunk specifically survived.
+    let recovered = rt.db().hypertables().show_chunks("metrics");
+    let last = recovered
+        .iter()
+        .find(|c| c.id.start_ns == 5 * DAY_NS)
+        .expect("day-5 chunk recovered");
+    assert!(last.sealed, "sealed flag must survive restart");
+    assert_eq!(last.ttl_override_ns, Some(3 * HOUR_NS));
+
+    // A write after restart routes to the EXISTING day-0 chunk — no
+    // duplicate / incorrect allocation.
+    let db = rt.db();
+    let reg = db.hypertables();
+    let routed = reg.route("metrics", 42).expect("route after restart");
+    assert_eq!(routed.start_ns, 0, "post-restart write routes to day-0");
+    assert_eq!(
+        reg.show_chunks("metrics").len(),
+        4,
+        "post-restart write must not allocate a new chunk"
+    );
+    // The existing chunk's row_count advanced from the recovered value.
+    let day0 = reg
+        .show_chunks("metrics")
+        .into_iter()
+        .find(|c| c.id.start_ns == 0)
+        .expect("day-0 chunk");
+    assert_eq!(
+        day0.row_count, 4,
+        "3 pre-restart rows + 1 post-restart row in day-0 chunk"
+    );
+}
+
+#[test]
+fn non_hypertable_database_persists_no_hypertables() {
+    // Guard: a database that never declared a hypertable carries an
+    // empty hypertable spine — the persist step is a no-op for it.
+    let path = PersistentDbPath::new("no_hypertable_persist");
+    let rt = path.open_runtime();
+    let q = QueryUseCases::new(&rt);
+    q.execute(ExecuteQueryInput {
+        query: "CREATE TABLE plain (id INTEGER, name TEXT)".into(),
+    })
+    .expect("create table ok");
+
+    let rt = checkpoint_and_reopen(&path, rt);
+    assert!(
+        rt.db().hypertables().is_empty(),
+        "no hypertables should be registered after restart"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #866. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782826178&installation_id=129708444&pr_number=896&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F896&signature=a5913cc1c6c9b9db531bdc0c5106df1a37c512a63aced1a713b87fce4d858cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->