### PR TITLE
merge: #891 Deploy-time FS tuning guidance: ZFS recordsize=16K, btrfs nodatacow, ext4/XFS notes

### DIFF
--- a/docs/deployment/server.md
+++ b/docs/deployment/server.md
@@ -56,6 +56,49 @@ degraded and why.
 - [ ] Set up monitoring at `/stats`
 - [ ] Enable snapshots for backup
 - [ ] Configure systemd or Docker for restart policy
+- [ ] Tune the data filesystem (see [Filesystem Tuning](#filesystem-tuning))
+
+## Filesystem Tuning
+
+RedDB writes its data file in 16 KiB pages (the engine `PAGE_SIZE`). Matching the
+underlying filesystem's block/record size to that page avoids read-modify-write
+amplification and keeps `fsync` cheap. Apply these at deploy time, before the
+data file is created, on the dataset or file that holds `--path`.
+
+### ZFS
+
+```bash
+# On the dataset backing --path, before first write
+zfs set recordsize=16K rpool/reddb
+```
+
+ZFS defaults to a 128 KiB recordsize, so every 16 KiB page write forces a
+read-modify-write of a full 128 KiB record — roughly **8× write amplification**.
+Setting `recordsize=16K` aligns the record to the RedDB page and eliminates it.
+
+### btrfs
+
+```bash
+# Disable copy-on-write on the data file (or its parent dir before creation)
+chattr +C /var/lib/reddb/data.rdb
+```
+
+btrfs copy-on-write relocates every overwritten block, fragmenting the data file
+and doubling write traffic under RedDB's in-place page updates and WAL fsync.
+`chattr +C` (nodatacow) keeps overwrites in place. Set it on an empty file or on
+the parent directory before the data file is created — the flag only takes
+effect for files created afterward.
+
+### ext4 / XFS
+
+```bash
+# Default 4 KiB block size is fine; ensure the volume is mounted without atime churn
+mount -o noatime /dev/sdX /var/lib/reddb
+```
+
+ext4 and XFS need no special tuning: their default 4 KiB block size divides the
+16 KiB page evenly, so there is no record-level write amplification. Mount with
+`noatime` to avoid metadata writes on every read.
 
 ## Systemd
 


### PR DESCRIPTION
Automated AFK landing for #891. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782826553&installation_id=129708444&pr_number=897&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F897&signature=ddab2fa1ce38be779d7b8ae6d145de8e7ab30fca487775758c2306ff3ecd6081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Filesystem Tuning section to deployment guide with optimization recommendations for ZFS, btrfs, ext4, and XFS configurations to enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->