### PR TITLE
merge: #892 Probe st_blksize at DB open + warn when PAGE_SIZE % f_bsize != 0 (diagnostic)

### DIFF
--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -687,4 +687,41 @@ mod tests {
         let _ = fs::remove_file(&wal_path);
         cleanup(&db_path);
     }
+
+    // -----------------------------------------------------------------
+    // gh-892: filesystem block-size alignment diagnostic
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn block_size_warn_fires_for_mismatched_block_size() {
+        // A block size that does not divide the 16 KiB page size means a
+        // page write straddles FS blocks — the predicate must report a
+        // misalignment so `open()` emits the warning.
+        assert!(Pager::page_size_misaligned_with_block(PAGE_SIZE, 6000));
+        // Block larger than the page (e.g. 1 MiB): 16384 % 1048576 != 0.
+        assert!(Pager::page_size_misaligned_with_block(PAGE_SIZE, 1_048_576));
+        // 6 KiB also fails to divide 16 KiB.
+        assert!(Pager::page_size_misaligned_with_block(PAGE_SIZE, 6 * 1024));
+    }
+
+    #[test]
+    fn block_size_silent_for_divisor() {
+        // Block sizes that evenly divide the page size: no straddle, no warn.
+        assert!(!Pager::page_size_misaligned_with_block(PAGE_SIZE, 4096));
+        assert!(!Pager::page_size_misaligned_with_block(PAGE_SIZE, 16384));
+        assert!(!Pager::page_size_misaligned_with_block(PAGE_SIZE, 512));
+        assert!(!Pager::page_size_misaligned_with_block(PAGE_SIZE, 8192));
+    }
+
+    #[test]
+    fn block_size_unavailable_is_silent() {
+        // st_blksize == 0 means the probe is unavailable; never warn on it.
+        assert!(!Pager::page_size_misaligned_with_block(PAGE_SIZE, 0));
+    }
+
+    #[test]
+    fn page_size_is_unchanged_16kib() {
+        // The diagnostic must never alter the compile-time page size.
+        assert_eq!(PAGE_SIZE, 16 * 1024);
+    }
 }

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -119,7 +119,7 @@ impl Pager {
     /// treated as aligned so a missing probe never produces a warning.
     /// Pure function with no I/O so the warn decision is unit-testable.
     pub(crate) fn page_size_misaligned_with_block(page_size: usize, fs_block_size: u64) -> bool {
-        fs_block_size != 0 && (page_size as u64) % fs_block_size != 0
+        fs_block_size != 0 && !(page_size as u64).is_multiple_of(fs_block_size)
     }
 
     /// Inspect page 0 for the `RDBE` encryption marker, then resolve

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -29,6 +29,30 @@ impl Pager {
             .create(config.create && !config.read_only)
             .open(&path)?;
 
+        // gh-892: diagnostic probe of the filesystem block size. If the
+        // compile-time 16 KiB PAGE_SIZE is not a multiple of the FS block
+        // size, page writes straddle FS blocks and incur read-modify-write
+        // amplification. Pure diagnostic — emitted once per open, never
+        // mutates the page size. `blksize()` is the fstat `st_blksize`.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            if let Ok(meta) = file.metadata() {
+                let fs_block_size = meta.blksize();
+                if Self::page_size_misaligned_with_block(PAGE_SIZE, fs_block_size) {
+                    tracing::warn!(
+                        page_size = PAGE_SIZE,
+                        fs_block_size,
+                        path = %path.display(),
+                        "database page size is not a multiple of the filesystem \
+                         block size; page writes will straddle FS blocks \
+                         (read-modify-write amplification). Diagnostic only — \
+                         the page size is unchanged."
+                    );
+                }
+            }
+        }
+
         // Acquire file lock (exclusive for writes, shared for read-only)
         let lock_file = if !config.read_only {
             let lf = OpenOptions::new().read(true).write(true).open(&path)?;
@@ -86,6 +110,16 @@ impl Pager {
         }
 
         Ok(pager)
+    }
+
+    /// gh-892 diagnostic predicate: returns `true` when the database
+    /// `page_size` is **not** an integer multiple of the filesystem's
+    /// reported block size (`st_blksize`), i.e. `page_size % fs_block_size
+    /// != 0`. A `fs_block_size` of `0` (probe unavailable / unknown) is
+    /// treated as aligned so a missing probe never produces a warning.
+    /// Pure function with no I/O so the warn decision is unit-testable.
+    pub(crate) fn page_size_misaligned_with_block(page_size: usize, fs_block_size: u64) -> bool {
+        fs_block_size != 0 && (page_size as u64) % fs_block_size != 0
     }
 
     /// Inspect page 0 for the `RDBE` encryption marker, then resolve


### PR DESCRIPTION
Automated AFK landing for #892. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782828635&installation_id=129708444&pr_number=898&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F898&signature=1391eece71aa1f62b3dbe00f2b5f1076993c6c01bf7c4ac414def19c836f79d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for storage engine block-size alignment diagnostics.

* **Improvements**
  * Added diagnostic warnings during database initialization when filesystem block-size alignment issues are detected on Unix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->