### PR TITLE
feat(http): always emit permissive CORS headers + answer OPTIONS preflight

### DIFF
--- a/crates/reddb-server/src/server/output_stream.rs
+++ b/crates/reddb-server/src/server/output_stream.rs
@@ -536,8 +536,19 @@ pub fn write_chunked_response_header<W: std::io::Write>(
     status: u16,
     content_type: &str,
 ) -> std::io::Result<()> {
+    // Streaming responses write their own head here instead of going
+    // through `HttpResponse::to_http_bytes`, so they must repeat the
+    // same permissive CORS posture — otherwise a browser that can call
+    // the JSON endpoints cross-origin would still be blocked on the
+    // NDJSON/SSE streaming routes (graph/vector results). API auth is
+    // by header/API key, never cookies, so wildcard origin is safe and
+    // Allow-Credentials is deliberately never sent.
     let header = format!(
-        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
+        "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\nConnection: close\r\n\
+         Access-Control-Allow-Origin: *\r\n\
+         Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n\
+         Access-Control-Allow-Headers: *\r\n\
+         Access-Control-Max-Age: 86400\r\n\r\n",
         status,
         crate::server::transport::status_text(status),
         content_type,

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -272,6 +272,20 @@ impl RedDBServer {
             body,
         } = request;
 
+        // CORS preflight. Browsers send `OPTIONS` with no credentials
+        // before a cross-origin request; it must be answered *before*
+        // auth/surface checks (a 401/404 on preflight would block the
+        // real request). 204 + the permissive `Access-Control-*` headers
+        // that ride on every response (see `HttpResponse::to_http_bytes`).
+        if method == "OPTIONS" {
+            return HttpResponse {
+                status: 204,
+                content_type: "application/json",
+                body: Vec::new(),
+                extra_headers: Vec::new(),
+            };
+        }
+
         // PLAN.md Phase 6.2 — endpoint segregation. Listeners bound
         // to the dedicated admin / metrics ports refuse paths
         // outside their surface so accidentally exposing them does

--- a/crates/reddb-server/src/server/transport.rs
+++ b/crates/reddb-server/src/server/transport.rs
@@ -129,8 +129,21 @@ pub(crate) struct HttpResponse {
 impl HttpResponse {
     pub(crate) fn to_http_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
+        // RedDB is an API, not a website: it authenticates by
+        // `Authorization` header / API key, never cookies. A wildcard
+        // `Access-Control-Allow-Origin: *` is therefore the correct,
+        // credential-safe posture (the browser only forbids `*` paired
+        // with `Access-Control-Allow-Credentials: true`, which we never
+        // send). Emitting these on every response — through the single
+        // serialization choke point — is what lets browser clients call
+        // the HTTP API cross-origin without a reverse proxy. The OPTIONS
+        // preflight is answered in `routing::route` before auth.
         let header = format!(
-            "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n",
+            "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\
+             Access-Control-Allow-Origin: *\r\n\
+             Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n\
+             Access-Control-Allow-Headers: *\r\n\
+             Access-Control-Max-Age: 86400\r\n",
             self.status,
             status_text(self.status),
             self.content_type,
@@ -444,6 +457,23 @@ mod transport_tests {
         assert_eq!(head.matches("\r\n\r\n").count(), 1);
         assert!(head
             .starts_with("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "));
+    }
+
+    #[test]
+    fn to_http_bytes_always_emits_permissive_cors() {
+        // RedDB is an API authenticated by header / API key, never
+        // cookies — so a wildcard CORS posture is correct and rides on
+        // *every* response so browser clients reach the HTTP API
+        // cross-origin without a reverse proxy. Wildcard origin must
+        // never be paired with Allow-Credentials (the browser rejects
+        // that combination), so this also pins its absence.
+        let head = String::from_utf8_lossy(&json_ok("hi").to_http_bytes()).into_owned();
+        assert!(head.contains("\r\nAccess-Control-Allow-Origin: *\r\n"), "got: {head}");
+        assert!(head.contains("\r\nAccess-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n"));
+        assert!(head.contains("\r\nAccess-Control-Allow-Headers: *\r\n"));
+        assert!(!head.to_ascii_lowercase().contains("access-control-allow-credentials"));
+        // Framing invariant survives: still exactly one header/body split.
+        assert_eq!(head.matches("\r\n\r\n").count(), 1);
     }
 }
 pub(crate) fn split_target(target: &str) -> (String, BTreeMap<String, String>) {


### PR DESCRIPTION
Fixes #899. reddb's HTTP API sent no `Access-Control-*` and 404'd OPTIONS preflight → browsers blocked cross-origin (red-ui team report). Wildcard `Allow-Origin: *` is credential-safe here because auth is by Authorization header / API key, never cookies (Allow-Credentials never sent). Headers added at the single serializer choke point (`to_http_bytes`) + the streaming chunked header + an OPTIONS→204 preflight arm before auth. `cargo check` green; transport test pins the CORS headers + framing invariant.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782839362&installation_id=129708444&pr_number=901&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F901&signature=cc925de698766ada36f1509586550809edbc5dfae1e31a09eff873d20b52167e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS (Cross-Origin Resource Sharing) support to all HTTP responses, including streaming responses. The server now handles cross-origin requests with wildcard origin access and properly responds to CORS preflight requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->