### PR TITLE
merge: #852 Phase 1: sealed hypertable chunk columnar layout v1 (round-trip write+read, defines on-disk contract)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -128,6 +128,7 @@ fn ensure_collection_model_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     })
     .map(|_| ())
     .map_err(|err| crate::RedDBError::Internal(err.to_string()))

--- a/crates/reddb-server/src/catalog.rs
+++ b/crates/reddb-server/src/catalog.rs
@@ -31,6 +31,31 @@ pub enum CollectionModel {
     Metrics,
 }
 
+/// Per-collection analytical-storage seam (PRD #850, Phase 1).
+///
+/// Declares that a `Metrics`/`TimeSeries` collection's hypertable chunks
+/// are backed by the **columnar** sealed-chunk layout
+/// ([`column_block`](crate::storage::unified::column_block)) rather than
+/// the default row engine. `columnar = false` (or the whole config
+/// absent) keeps the row engine — the seal dispatch routes only
+/// columnar-flagged chunks to the `ColumnBlock` writer.
+///
+/// `time_key` / `order_by_key` mirror the ClickHouse `ORDER BY` intent so
+/// downstream slices (#854 granules, #856 vectorized read) can lay the
+/// columns out in their natural sort order; v1 records them as the durable
+/// contract without yet acting on `order_by_key`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnalyticalStorageConfig {
+    /// When true, sealing a chunk routes to the columnar `ColumnBlock`
+    /// writer; otherwise the row engine stays the default.
+    pub columnar: bool,
+    /// Column carrying the time axis (the chunk's partition key).
+    pub time_key: String,
+    /// Optional secondary sort key (ClickHouse `ORDER BY` tail). `None`
+    /// orders by `time_key` alone.
+    pub order_by_key: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SchemaMode {
     Strict,

--- a/crates/reddb-server/src/physical.rs
+++ b/crates/reddb-server/src/physical.rs
@@ -420,6 +420,12 @@ pub struct CollectionContract {
     /// retention_duration_ms` by the collection's timestamp column.
     /// Issue #580 — DeclarativeRetention slice 1.
     pub retention_duration_ms: Option<u64>,
+    /// Analytical-storage seam (PRD #850, Phase 1). When present and
+    /// `columnar = true`, sealing this collection's hypertable chunks
+    /// routes to the columnar `ColumnBlock` writer; `None` (the default)
+    /// keeps the row engine. Decodes to `None` on sidecars written before
+    /// the feature.
+    pub analytical_storage: Option<crate::catalog::AnalyticalStorageConfig>,
 }
 
 /// Canonical artifact lifecycle states.
@@ -594,6 +600,11 @@ pub struct PhysicalHypertableChunk {
     pub max_ts_ns: u64,
     pub sealed: bool,
     pub ttl_override_ns: Option<u64>,
+    /// Columnar-vs-row migration discriminant — mirror of
+    /// `ChunkMeta.columnar_page` (PRD #850, Phase 1). `Some` → the chunk's
+    /// `RDCC` `ColumnBlock` location; `None` → legacy row-stored. Absent on
+    /// sidecars written before the feature, decoding to `None`.
+    pub columnar_page: Option<crate::storage::engine::PageLocation>,
 }
 
 /// A persisted hypertable spec plus all of its chunks. Stored in the

--- a/crates/reddb-server/src/physical/json_codec.rs
+++ b/crates/reddb-server/src/physical/json_codec.rs
@@ -440,6 +440,14 @@ pub(super) fn collection_contract_to_json(contract: &CollectionContract) -> Json
             .unwrap_or(JsonValue::Null),
     );
     object.insert(
+        "analytical_storage".to_string(),
+        contract
+            .analytical_storage
+            .as_ref()
+            .map(analytical_storage_to_json)
+            .unwrap_or(JsonValue::Null),
+    );
+    object.insert(
         "table_def".to_string(),
         contract
             .table_def
@@ -448,6 +456,40 @@ pub(super) fn collection_contract_to_json(contract: &CollectionContract) -> Json
             .unwrap_or(JsonValue::Null),
     );
     JsonValue::Object(object)
+}
+
+fn analytical_storage_to_json(cfg: &crate::catalog::AnalyticalStorageConfig) -> JsonValue {
+    let mut object = Map::new();
+    object.insert("columnar".to_string(), JsonValue::Bool(cfg.columnar));
+    object.insert(
+        "time_key".to_string(),
+        JsonValue::String(cfg.time_key.clone()),
+    );
+    object.insert(
+        "order_by_key".to_string(),
+        cfg.order_by_key
+            .as_ref()
+            .map(|k| JsonValue::String(k.clone()))
+            .unwrap_or(JsonValue::Null),
+    );
+    JsonValue::Object(object)
+}
+
+fn analytical_storage_from_json(
+    value: &JsonValue,
+) -> io::Result<crate::catalog::AnalyticalStorageConfig> {
+    let object = expect_object(value, "analytical_storage")?;
+    Ok(crate::catalog::AnalyticalStorageConfig {
+        columnar: object
+            .get("columnar")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(false),
+        time_key: json_string_required(object, "time_key")?,
+        order_by_key: object
+            .get("order_by_key")
+            .and_then(JsonValue::as_str)
+            .map(str::to_string),
+    })
 }
 
 pub(super) fn collection_contract_from_json(value: &JsonValue) -> io::Result<CollectionContract> {
@@ -600,6 +642,12 @@ pub(super) fn collection_contract_from_json(value: &JsonValue) -> io::Result<Col
         retention_duration_ms: match object.get("retention_duration_ms") {
             Some(JsonValue::Null) | None => None,
             Some(value) => Some(json_u64_value(value)?),
+        },
+        // Legacy sidecars written before the columnar analytical-storage
+        // seam lack this key — default None (row engine). PRD #850 Phase 1.
+        analytical_storage: match object.get("analytical_storage") {
+            Some(JsonValue::Null) | None => None,
+            Some(value) => Some(analytical_storage_from_json(value)?),
         },
     })
 }
@@ -1631,7 +1679,31 @@ pub(super) fn hypertable_chunk_to_json(chunk: &PhysicalHypertableChunk) -> JsonV
             .map(json_u64)
             .unwrap_or(JsonValue::Null),
     );
+    object.insert(
+        "columnar_page".to_string(),
+        chunk
+            .columnar_page
+            .map(page_location_to_json)
+            .unwrap_or(JsonValue::Null),
+    );
     JsonValue::Object(object)
+}
+
+fn page_location_to_json(loc: crate::storage::engine::PageLocation) -> JsonValue {
+    let mut object = Map::new();
+    object.insert("page_id".to_string(), json_u64(loc.page_id as u64));
+    object.insert("offset".to_string(), json_u64(loc.offset as u64));
+    object.insert("length".to_string(), json_u64(loc.length as u64));
+    JsonValue::Object(object)
+}
+
+fn page_location_from_json(value: &JsonValue) -> io::Result<crate::storage::engine::PageLocation> {
+    let object = expect_object(value, "page location")?;
+    Ok(crate::storage::engine::PageLocation {
+        page_id: json_u64_required(object, "page_id")? as u32,
+        offset: json_u64_required(object, "offset")? as u32,
+        length: json_u64_required(object, "length")? as u32,
+    })
 }
 
 pub(super) fn hypertable_chunk_from_json(value: &JsonValue) -> io::Result<PhysicalHypertableChunk> {
@@ -1649,6 +1721,10 @@ pub(super) fn hypertable_chunk_from_json(value: &JsonValue) -> io::Result<Physic
         ttl_override_ns: match object.get("ttl_override_ns") {
             Some(JsonValue::Null) | None => None,
             Some(value) => Some(json_u64_value(value)?),
+        },
+        columnar_page: match object.get("columnar_page") {
+            Some(JsonValue::Null) | None => None,
+            Some(value) => Some(page_location_from_json(value)?),
         },
     })
 }
@@ -1836,5 +1912,67 @@ mod tests {
         let value = minimal_contract_object(Some(true));
         let contract = collection_contract_from_json(&value).expect("decode");
         assert!(contract.context_index_enabled);
+    }
+
+    #[test]
+    fn columnar_page_round_trips_through_chunk_json() {
+        // The migration discriminant MUST survive the sidecar (PRD #850).
+        let chunk = PhysicalHypertableChunk {
+            start_ns: 10,
+            end_ns_exclusive: 20,
+            row_count: 3,
+            min_ts_ns: 11,
+            max_ts_ns: 19,
+            sealed: true,
+            ttl_override_ns: Some(99),
+            columnar_page: Some(crate::storage::engine::PageLocation::new(7, 0, 1234)),
+        };
+        let decoded =
+            hypertable_chunk_from_json(&hypertable_chunk_to_json(&chunk)).expect("decode");
+        assert_eq!(
+            decoded.columnar_page,
+            Some(crate::storage::engine::PageLocation::new(7, 0, 1234))
+        );
+        assert!(decoded.sealed);
+        assert_eq!(decoded.ttl_override_ns, Some(99));
+    }
+
+    #[test]
+    fn legacy_chunk_without_columnar_page_decodes_none() {
+        // A sidecar written before the feature lacks the key — a
+        // row-stored chunk must never be mis-read as columnar.
+        let mut obj = Map::new();
+        obj.insert("start_ns".to_string(), JsonValue::Number(0.0));
+        obj.insert("end_ns_exclusive".to_string(), JsonValue::Number(1.0));
+        obj.insert("row_count".to_string(), JsonValue::Number(0.0));
+        obj.insert("min_ts_ns".to_string(), JsonValue::Number(0.0));
+        obj.insert("max_ts_ns".to_string(), JsonValue::Number(0.0));
+        let decoded = hypertable_chunk_from_json(&JsonValue::Object(obj)).expect("decode");
+        assert_eq!(decoded.columnar_page, None);
+    }
+
+    #[test]
+    fn analytical_storage_round_trips_and_defaults_none() {
+        // Absent key (legacy sidecar) → row engine (None).
+        let contract = collection_contract_from_json(&minimal_contract_object(None)).expect("dec");
+        assert!(contract.analytical_storage.is_none());
+
+        // Present + columnar → preserved verbatim.
+        let JsonValue::Object(mut obj) = minimal_contract_object(None) else {
+            unreachable!()
+        };
+        let mut cfg = Map::new();
+        cfg.insert("columnar".to_string(), JsonValue::Bool(true));
+        cfg.insert("time_key".to_string(), JsonValue::String("ts".to_string()));
+        cfg.insert(
+            "order_by_key".to_string(),
+            JsonValue::String("host".to_string()),
+        );
+        obj.insert("analytical_storage".to_string(), JsonValue::Object(cfg));
+        let contract = collection_contract_from_json(&JsonValue::Object(obj)).expect("dec");
+        let cfg = contract.analytical_storage.expect("present");
+        assert!(cfg.columnar);
+        assert_eq!(cfg.time_key, "ts");
+        assert_eq!(cfg.order_by_key.as_deref(), Some("host"));
     }
 }

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -1943,6 +1943,7 @@ mod tests {
             session_key: None,
             session_gap_ms: None,
             retention_duration_ms: None,
+            analytical_storage: None,
         })
         .expect("save graph contract");
     }

--- a/crates/reddb-server/src/runtime/impl_config.rs
+++ b/crates/reddb-server/src/runtime/impl_config.rs
@@ -935,6 +935,7 @@ impl RedDBRuntime {
                 session_key: None,
                 session_gap_ms: None,
                 retention_duration_ms: None,
+                analytical_storage: None,
             })
             .map(|_| ())
             .map_err(|err| RedDBError::Internal(err.to_string()))

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -559,6 +559,7 @@ fn system_keyed_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -1778,6 +1778,7 @@ fn collection_contract_from_create_table(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     })
 }
 
@@ -1811,6 +1812,7 @@ fn default_collection_contract_for_existing_table(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 
@@ -1846,6 +1848,7 @@ fn keyed_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 
@@ -1882,6 +1885,7 @@ fn metrics_collection_contract(query: &CreateTableQuery) -> crate::physical::Col
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 
@@ -1913,6 +1917,7 @@ fn vector_collection_contract(query: &CreateVectorQuery) -> crate::physical::Col
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 
@@ -2496,6 +2501,7 @@ fn event_queue_collection_contract(queue: &str) -> crate::physical::CollectionCo
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -2838,6 +2838,7 @@ fn ensure_graph_insert_contract(runtime: &RedDBRuntime, collection: &str) -> Red
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     })
     .map(|_| ())
     .map_err(|err| RedDBError::Internal(err.to_string()))

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -2536,6 +2536,7 @@ fn kv_collection_contract(name: &str) -> crate::physical::CollectionContract {
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -46,6 +46,7 @@ fn probabilistic_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -2749,6 +2749,7 @@ fn queue_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -2879,6 +2879,7 @@ fn ask_audit_collection_contract() -> crate::physical::CollectionContract {
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -313,6 +313,7 @@ fn hypertable_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 
@@ -354,6 +355,7 @@ fn timeseries_collection_contract(
         session_key: query.session_key.clone(),
         session_gap_ms: query.session_gap_ms,
         retention_duration_ms: None,
+        analytical_storage: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/retention_filter.rs
+++ b/crates/reddb-server/src/runtime/retention_filter.rs
@@ -132,6 +132,7 @@ mod tests {
             session_key: None,
             session_gap_ms: None,
             retention_duration_ms: Some(60_000), // 1 minute
+            analytical_storage: None,
         }
     }
 

--- a/crates/reddb-server/src/runtime/sessionize.rs
+++ b/crates/reddb-server/src/runtime/sessionize.rs
@@ -241,6 +241,7 @@ mod tests {
             session_key: Some("user_id".to_string()),
             session_gap_ms: Some(30_000),
             retention_duration_ms: None,
+            analytical_storage: None,
         }
     }
 

--- a/crates/reddb-server/src/server/transport.rs
+++ b/crates/reddb-server/src/server/transport.rs
@@ -468,10 +468,17 @@ mod transport_tests {
         // never be paired with Allow-Credentials (the browser rejects
         // that combination), so this also pins its absence.
         let head = String::from_utf8_lossy(&json_ok("hi").to_http_bytes()).into_owned();
-        assert!(head.contains("\r\nAccess-Control-Allow-Origin: *\r\n"), "got: {head}");
-        assert!(head.contains("\r\nAccess-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n"));
+        assert!(
+            head.contains("\r\nAccess-Control-Allow-Origin: *\r\n"),
+            "got: {head}"
+        );
+        assert!(head.contains(
+            "\r\nAccess-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS\r\n"
+        ));
         assert!(head.contains("\r\nAccess-Control-Allow-Headers: *\r\n"));
-        assert!(!head.to_ascii_lowercase().contains("access-control-allow-credentials"));
+        assert!(!head
+            .to_ascii_lowercase()
+            .contains("access-control-allow-credentials"));
         // Framing invariant survives: still exactly one header/body split.
         assert_eq!(head.matches("\r\n\r\n").count(), 1);
     }

--- a/crates/reddb-server/src/storage/engine/mod.rs
+++ b/crates/reddb-server/src/storage/engine/mod.rs
@@ -71,7 +71,7 @@ pub use encrypted_pager::{EncryptedPager, EncryptedPagerConfig, EncryptedPagerEr
 pub use freelist::FreeList;
 pub use graph_store::{GraphStore, LabelId, LabelRegistry, StoredEdge, StoredNode, TableRef};
 pub use graph_table_index::{GraphTableIndex, GraphTableIndexStats, RowKey};
-pub use page::{Page, PageHeader, PageType, HEADER_SIZE, PAGE_SIZE};
+pub use page::{Page, PageHeader, PageLocation, PageType, HEADER_SIZE, PAGE_SIZE};
 pub use page_cache::PageCache;
 pub use pager::{Pager, PagerConfig, PhysicalFileHeader};
 

--- a/crates/reddb-server/src/storage/engine/page.rs
+++ b/crates/reddb-server/src/storage/engine/page.rs
@@ -78,6 +78,12 @@ pub enum PageType {
     NativeMeta = 11,
     /// Encrypted auth vault page (users, API keys, bootstrap state)
     Vault = 12,
+    /// Sealed hypertable chunk in columnar form — carries one `RDCC`
+    /// column block (header + per-column ZSTD streams + footer). Written
+    /// by the columnar chunk-seal path (PRD #850, Phase 1). A trailing
+    /// variant: old engines never wrote 13, so its presence is itself a
+    /// columnar discriminant gated by the page `format_version`.
+    ColumnBlock = 13,
 }
 
 impl PageType {
@@ -97,7 +103,35 @@ impl PageType {
             10 => Some(Self::GraphMeta),
             11 => Some(Self::NativeMeta),
             12 => Some(Self::Vault),
+            13 => Some(Self::ColumnBlock),
             _ => None,
+        }
+    }
+}
+
+/// Coordinate of a stored block within the page file — the page that
+/// holds it plus the `[offset, offset + length)` byte window inside that
+/// page's content area. Introduced for `ChunkMeta.columnar_page` (the
+/// columnar-vs-row migration discriminant, PRD #850 Phase 1): a sealed
+/// chunk records where its `RDCC` [`PageType::ColumnBlock`] block lives so
+/// reads decode the columnar form, while `None` means a legacy row-stored
+/// chunk served by the entity path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PageLocation {
+    /// Page id holding the block.
+    pub page_id: u32,
+    /// Byte offset of the block within that page's content area.
+    pub offset: u32,
+    /// Byte length of the block.
+    pub length: u32,
+}
+
+impl PageLocation {
+    pub fn new(page_id: u32, offset: u32, length: u32) -> Self {
+        Self {
+            page_id,
+            offset,
+            length,
         }
     }
 }
@@ -511,6 +545,7 @@ mod tests {
             PageType::GraphMeta,
             PageType::NativeMeta,
             PageType::Vault,
+            PageType::ColumnBlock,
         ];
 
         for (i, &pt) in page_types.iter().enumerate() {
@@ -528,7 +563,8 @@ mod tests {
         assert_eq!(PageType::from_u8(10), Some(PageType::GraphMeta));
         assert_eq!(PageType::from_u8(11), Some(PageType::NativeMeta));
         assert_eq!(PageType::from_u8(12), Some(PageType::Vault));
-        assert_eq!(PageType::from_u8(13), None);
+        assert_eq!(PageType::from_u8(13), Some(PageType::ColumnBlock));
+        assert_eq!(PageType::from_u8(14), None);
         assert_eq!(PageType::from_u8(255), None);
     }
 

--- a/crates/reddb-server/src/storage/timeseries/chunk.rs
+++ b/crates/reddb-server/src/storage/timeseries/chunk.rs
@@ -8,7 +8,17 @@ use std::collections::HashMap;
 use super::compression::{
     delta_decode_timestamps, delta_encode_timestamps, xor_decode_values, xor_encode_values,
 };
+use crate::catalog::AnalyticalStorageConfig;
 use crate::storage::index::{BloomSegment, HasBloom, ZoneDecision, ZoneMap, ZonePredicate};
+use crate::storage::schema::types::DataType;
+use crate::storage::unified::column_block::{
+    read_column_block, write_column_block, ColumnBlockError, ColumnInput,
+};
+
+/// Stable column id of the timestamp column within a v1 columnar chunk.
+pub const COLUMNAR_TS_COLUMN_ID: u32 = 0;
+/// Stable column id of the value column within a v1 columnar chunk.
+pub const COLUMNAR_VALUE_COLUMN_ID: u32 = 1;
 
 /// A single time-series data point
 #[derive(Debug, Clone, PartialEq)]
@@ -201,6 +211,52 @@ impl TimeSeriesChunk {
         self.sealed = true;
     }
 
+    /// Seal the chunk and emit its **columnar** on-disk form: an `RDCC`
+    /// [`ColumnBlock`](crate::storage::engine::PageType::ColumnBlock)
+    /// transposing the live `(ts, value)` columns into two ZSTD streams
+    /// (PRD #850, Phase 1). Sealing first (via [`seal`](Self::seal))
+    /// guarantees timestamp order, so the columns are written sorted.
+    ///
+    /// `chunk_id` / `schema_ref` are recorded verbatim in the block header
+    /// so a reader is self-describing. The returned bytes are written into
+    /// a `ColumnBlock` page by the caller, which records the resulting
+    /// [`PageLocation`](crate::storage::engine::PageLocation) in
+    /// `ChunkMeta.columnar_page`.
+    pub fn seal_columnar(
+        &mut self,
+        chunk_id: u64,
+        schema_ref: u64,
+    ) -> Result<Vec<u8>, ColumnBlockError> {
+        if !self.sealed {
+            self.seal();
+        }
+        let ts_bytes: Vec<u8> = self
+            .timestamps
+            .iter()
+            .flat_map(|t| t.to_le_bytes())
+            .collect();
+        let val_bytes: Vec<u8> = self.values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        write_column_block(
+            chunk_id,
+            schema_ref,
+            self.timestamps.len() as u64,
+            self.min_timestamp().unwrap_or(0),
+            self.max_timestamp().unwrap_or(0),
+            &[
+                ColumnInput {
+                    column_id: COLUMNAR_TS_COLUMN_ID,
+                    logical_type: DataType::UnsignedInteger.to_byte(),
+                    data: &ts_bytes,
+                },
+                ColumnInput {
+                    column_id: COLUMNAR_VALUE_COLUMN_ID,
+                    logical_type: DataType::Float.to_byte(),
+                    data: &val_bytes,
+                },
+            ],
+        )
+    }
+
     /// Query points within a time range [start_ns, end_ns] inclusive.
     ///
     /// BRIN-style pre-filter: if the chunk's timestamp zone map proves no
@@ -306,6 +362,67 @@ impl TimeSeriesChunk {
     }
 }
 
+/// Outcome of routing a chunk seal through the analytical-storage seam.
+#[derive(Debug)]
+pub enum SealedChunkStorage {
+    /// The collection was flagged columnar — the sealed chunk's `RDCC`
+    /// `ColumnBlock` bytes, ready to write into a `ColumnBlock` page.
+    Columnar(Vec<u8>),
+    /// Default row engine — the chunk was sealed in place; nothing
+    /// columnar was emitted.
+    Row,
+}
+
+/// Seal `chunk`, routing to the columnar `ColumnBlock` writer when the
+/// collection's [`AnalyticalStorageConfig`] flags it columnar; otherwise
+/// the row engine stays the default and the chunk is sealed in place
+/// (PRD #850, Phase 1 — acceptance criterion 1).
+pub fn seal_chunk_with_config(
+    chunk: &mut TimeSeriesChunk,
+    config: Option<&AnalyticalStorageConfig>,
+    chunk_id: u64,
+    schema_ref: u64,
+) -> Result<SealedChunkStorage, ColumnBlockError> {
+    if config.map(|c| c.columnar).unwrap_or(false) {
+        Ok(SealedChunkStorage::Columnar(
+            chunk.seal_columnar(chunk_id, schema_ref)?,
+        ))
+    } else {
+        chunk.seal();
+        Ok(SealedChunkStorage::Row)
+    }
+}
+
+/// Decode a sealed columnar chunk's `RDCC` block back into points,
+/// transposing the two column streams into `(timestamp_ns, value)` rows.
+/// The inverse of [`TimeSeriesChunk::seal_columnar`].
+pub fn points_from_column_block(bytes: &[u8]) -> Result<Vec<TimeSeriesPoint>, ColumnBlockError> {
+    let block = read_column_block(bytes)?;
+    let ts_col = block
+        .columns
+        .iter()
+        .find(|c| c.column_id == COLUMNAR_TS_COLUMN_ID)
+        .ok_or(ColumnBlockError::BadDirectory)?;
+    let val_col = block
+        .columns
+        .iter()
+        .find(|c| c.column_id == COLUMNAR_VALUE_COLUMN_ID)
+        .ok_or(ColumnBlockError::BadDirectory)?;
+    if ts_col.data.len() % 8 != 0 || val_col.data.len() % 8 != 0 {
+        return Err(ColumnBlockError::BadDirectory);
+    }
+    let points = ts_col
+        .data
+        .chunks_exact(8)
+        .zip(val_col.data.chunks_exact(8))
+        .map(|(t, v)| TimeSeriesPoint {
+            timestamp_ns: u64::from_le_bytes(t.try_into().unwrap()),
+            value: f64::from_le_bytes(v.try_into().unwrap()),
+        })
+        .collect();
+    Ok(points)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -381,6 +498,131 @@ mod tests {
         // the data.
         let _ = chunk.may_contain_timestamp(9999);
         assert!(chunk.query_range(9999, 9999).is_empty());
+    }
+
+    // -----------------------------------------------------------------
+    // Columnar sealed-chunk layout v1 (PRD #850, Phase 1)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn seal_columnar_round_trips_points_value_for_value() {
+        let mut chunk = TimeSeriesChunk::new("cpu.idle", make_tags("srv1"));
+        let expected: Vec<TimeSeriesPoint> = (0..200)
+            .map(|i| TimeSeriesPoint {
+                timestamp_ns: 1_700_000_000_000 + i * 1_000_000,
+                value: 95.0 + (i % 11) as f64 * 0.125,
+            })
+            .collect();
+        for p in &expected {
+            assert!(chunk.append(p.timestamp_ns, p.value));
+        }
+
+        let block = chunk.seal_columnar(7, 42).expect("seal columnar");
+        assert!(chunk.is_sealed());
+
+        let decoded = points_from_column_block(&block).expect("decode block");
+        assert_eq!(decoded.len(), expected.len());
+        assert_eq!(decoded, expected, "lossless value-for-value round-trip");
+    }
+
+    #[test]
+    fn seal_chunk_with_config_routes_columnar_vs_row() {
+        // Columnar-flagged → ColumnBlock bytes.
+        let mut columnar = TimeSeriesChunk::new("m", HashMap::new());
+        for i in 0..50 {
+            columnar.append(i * 1000, i as f64);
+        }
+        let cfg = AnalyticalStorageConfig {
+            columnar: true,
+            time_key: "ts".to_string(),
+            order_by_key: None,
+        };
+        let routed = seal_chunk_with_config(&mut columnar, Some(&cfg), 1, 0).unwrap();
+        match routed {
+            SealedChunkStorage::Columnar(bytes) => {
+                assert_eq!(points_from_column_block(&bytes).unwrap().len(), 50);
+            }
+            SealedChunkStorage::Row => panic!("columnar flag must route to ColumnBlock writer"),
+        }
+
+        // No config / columnar=false → row engine stays the default.
+        let mut row = TimeSeriesChunk::new("m", HashMap::new());
+        for i in 0..50 {
+            row.append(i * 1000, i as f64);
+        }
+        assert!(matches!(
+            seal_chunk_with_config(&mut row, None, 1, 0).unwrap(),
+            SealedChunkStorage::Row
+        ));
+        assert!(row.is_sealed());
+
+        let mut row_off = TimeSeriesChunk::new("m", HashMap::new());
+        row_off.append(1, 1.0);
+        let off = AnalyticalStorageConfig {
+            columnar: false,
+            time_key: "ts".to_string(),
+            order_by_key: None,
+        };
+        assert!(matches!(
+            seal_chunk_with_config(&mut row_off, Some(&off), 1, 0).unwrap(),
+            SealedChunkStorage::Row
+        ));
+    }
+
+    #[test]
+    fn columnar_chunk_round_trips_through_durable_column_block_page() {
+        use crate::storage::engine::{PageLocation, PageType, Pager};
+
+        // Build + seal a columnar chunk.
+        let mut chunk = TimeSeriesChunk::new("mem.used", make_tags("srv1"));
+        for i in 0..200u64 {
+            chunk.append(1_000_000 + i * 60_000, 72.5 + (i as f64) * 0.1);
+        }
+        let block = chunk.seal_columnar(99, 3).expect("seal columnar");
+
+        // Emit a *durable* PageType::ColumnBlock page through a real Pager.
+        let path = std::env::temp_dir().join(format!(
+            "reddb-columnblock-{}-{}.rdb",
+            std::process::id(),
+            crate::utils::now_unix_nanos()
+        ));
+        let pager = Pager::open_default(&path).expect("open pager");
+        let mut page = pager
+            .allocate_page(PageType::ColumnBlock)
+            .expect("allocate column block page");
+        assert_eq!(page.page_type().unwrap(), PageType::ColumnBlock);
+        let page_id = page.page_id();
+        page.content_mut()[..block.len()].copy_from_slice(&block);
+        pager.write_page(page_id, page).expect("write page");
+
+        // The discriminant a sealed chunk records in ChunkMeta.columnar_page.
+        let loc = PageLocation::new(page_id, 0, block.len() as u32);
+
+        // Read it back from disk and decode by the recorded location.
+        let read = pager.read_page(loc.page_id).expect("read page");
+        assert_eq!(read.page_type().unwrap(), PageType::ColumnBlock);
+        let start = loc.offset as usize;
+        let stored = &read.content()[start..start + loc.length as usize];
+        let points = points_from_column_block(stored).expect("decode page block");
+
+        // "Query the collection" end-to-end: same rows back, value-for-value.
+        assert_eq!(points, chunk.points());
+        // And a range query over the reconstructed points matches the source.
+        let reconstructed = {
+            let mut c = TimeSeriesChunk::new("mem.used", make_tags("srv1"));
+            for p in &points {
+                c.append(p.timestamp_ns, p.value);
+            }
+            c.seal();
+            c
+        };
+        assert_eq!(
+            reconstructed.query_range(1_000_000, 1_000_000 + 50 * 60_000),
+            chunk.query_range(1_000_000, 1_000_000 + 50 * 60_000)
+        );
+
+        drop(pager);
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -29,6 +29,7 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use super::retention::parse_duration_ns;
+use crate::storage::engine::PageLocation;
 
 /// Spec declared by `CREATE HYPERTABLE`.
 #[derive(Debug, Clone)]
@@ -135,6 +136,14 @@ pub struct ChunkMeta {
     /// current month of data forever but expire everything older
     /// than 90 days.
     pub ttl_override_ns: Option<u64>,
+    /// Columnar-vs-row **migration discriminant** (PRD #850, Phase 1).
+    /// `Some(loc)` → this chunk was sealed columnar; its `RDCC`
+    /// [`ColumnBlock`](crate::storage::engine::PageType::ColumnBlock) lives
+    /// at `loc` and reads decode the columnar form. `None` → a legacy
+    /// row-stored chunk served by the entity path (read-bridge lands in
+    /// #861). This MUST persist so pre-existing row-stored data is never
+    /// mis-read as columnar after a restart.
+    pub columnar_page: Option<PageLocation>,
 }
 
 impl ChunkMeta {
@@ -147,6 +156,7 @@ impl ChunkMeta {
             max_ts_ns: 0,
             sealed: false,
             ttl_override_ns: None,
+            columnar_page: None,
         }
     }
 

--- a/crates/reddb-server/src/storage/unified/column_block.rs
+++ b/crates/reddb-server/src/storage/unified/column_block.rs
@@ -1,0 +1,444 @@
+//! Sealed hypertable chunk — columnar on-disk layout v1 (`RDCC`).
+//!
+//! This is the **physical columnar form of a sealed hypertable chunk**,
+//! not a parallel object: PRD #850 rejects a standalone "columnar
+//! segment" as a bloat vector. The sealed chunk *is* the columnar
+//! segment, and this module defines its durable byte contract — emitted
+//! as a [`PageType::ColumnBlock`](crate::storage::engine::PageType) page.
+//!
+//! It is the first real caller of [`segment_codec`](super::segment_codec):
+//! every column stream is one `segment_codec` pipeline output. v1 writes a
+//! single codec (ZSTD level 3) for every column — per-column codec
+//! *selection* is #853; granule skip-indexes are #854; per-granule blooms
+//! are #855. The directory reserves zeroed fields for all three so those
+//! slices extend within this envelope without forcing a format v2.
+//!
+//! # Layout (`RDCC`)
+//!
+//! ```text
+//! Header (52 bytes)
+//!   magic            b"RDCC"   (4)
+//!   format_version   u16  = 1
+//!   flags            u16  = 0           reserved
+//!   chunk_id         u64
+//!   schema_ref       u64                catalog schema id column_ids resolve against
+//!   row_count        u64
+//!   column_count     u32
+//!   min_ts_ns        u64                mirror ChunkMeta → self-describing read
+//!   max_ts_ns        u64
+//!
+//! Column directory   (column_count entries, 54 bytes each, at offset 52)
+//!   column_id            u32
+//!   logical_type         u8             Value type tag (DataType::to_byte)
+//!   codec                u8             ColumnCodec tag (segment_codec)
+//!   stream_offset        u64            byte offset of this column's stream within the block
+//!   stream_len           u64
+//!   granule_index_off    u64  = 0       reserved → #854
+//!   granule_index_len    u64  = 0
+//!   bloom_off            u64  = 0       reserved → #855
+//!   bloom_len            u64  = 0
+//!
+//! Column streams        column_count segment_codec runs, back-to-back
+//!
+//! Footer (24 bytes)
+//!   col_directory_off    u64
+//!   col_directory_len    u64
+//!   crc32                u32            over header+directory+streams
+//!   magic_tail           b"RDCC"  (4)
+//! ```
+
+use super::segment_codec::{decode_bytes, encode_bytes, CodecError, ColumnCodec};
+use crate::storage::engine::crc32::crc32;
+
+/// `b"RDCC"` — RedDB Columnar Chunk. Opens and closes every block.
+pub const COLUMN_BLOCK_MAGIC: [u8; 4] = *b"RDCC";
+/// On-disk format version. Bumped only on a breaking layout change;
+/// #853–#856 extend the reserved directory fields without a bump.
+pub const COLUMN_BLOCK_VERSION_V1: u16 = 1;
+
+const HEADER_LEN: usize = 52;
+const DIR_ENTRY_LEN: usize = 54;
+const FOOTER_LEN: usize = 24;
+
+/// A logical column handed to [`write_column_block`]. `data` is the
+/// column's raw, uncompressed, little-endian value bytes; the writer runs
+/// it through the `segment_codec` pipeline to produce the stored stream.
+#[derive(Debug, Clone)]
+pub struct ColumnInput<'a> {
+    /// Stable column id resolved against `schema_ref`.
+    pub column_id: u32,
+    /// Logical type tag (`DataType::to_byte()`).
+    pub logical_type: u8,
+    /// Raw little-endian column bytes (pre-compression).
+    pub data: &'a [u8],
+}
+
+/// One decoded column produced by [`read_column_block`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedColumn {
+    pub column_id: u32,
+    pub logical_type: u8,
+    /// Codec tag recorded in the directory for this column.
+    pub codec_tag: u8,
+    /// Decompressed raw little-endian column bytes — identical to the
+    /// `ColumnInput::data` the writer was given.
+    pub data: Vec<u8>,
+}
+
+/// A fully decoded column block: the self-describing header plus every
+/// column's raw bytes, ready to transpose back into rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedColumnBlock {
+    pub chunk_id: u64,
+    pub schema_ref: u64,
+    pub row_count: u64,
+    pub min_ts_ns: u64,
+    pub max_ts_ns: u64,
+    pub columns: Vec<DecodedColumn>,
+}
+
+/// Failures decoding (or, rarely, encoding) a column block.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColumnBlockError {
+    /// Buffer shorter than the fixed header/footer it must contain.
+    Truncated,
+    /// Leading magic was not `RDCC`.
+    BadMagic([u8; 4]),
+    /// Trailing magic was not `RDCC` (block was clipped or corrupt).
+    BadTailMagic([u8; 4]),
+    /// `format_version` is newer than this build understands.
+    UnsupportedVersion(u16),
+    /// A directory entry points outside the block's byte range.
+    BadDirectory,
+    /// CRC32 over header+directory+streams did not match the footer.
+    ChecksumMismatch { expected: u32, actual: u32 },
+    /// A column stream failed to decode through `segment_codec`.
+    Codec(CodecError),
+}
+
+impl std::fmt::Display for ColumnBlockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Truncated => write!(f, "column block truncated"),
+            Self::BadMagic(m) => write!(f, "bad column block magic: {m:?}"),
+            Self::BadTailMagic(m) => write!(f, "bad column block tail magic: {m:?}"),
+            Self::UnsupportedVersion(v) => write!(f, "unsupported column block version: {v}"),
+            Self::BadDirectory => write!(f, "column directory entry out of range"),
+            Self::ChecksumMismatch { expected, actual } => write!(
+                f,
+                "column block checksum mismatch: expected 0x{expected:08X}, got 0x{actual:08X}"
+            ),
+            Self::Codec(e) => write!(f, "column stream codec error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ColumnBlockError {}
+
+impl From<CodecError> for ColumnBlockError {
+    fn from(e: CodecError) -> Self {
+        Self::Codec(e)
+    }
+}
+
+/// Serialize `columns` into the v1 `RDCC` layout. Each column's raw bytes
+/// are compressed with ZSTD(3) through `segment_codec`; the directory
+/// records the codec tag so the reader decodes by the *recorded* codec
+/// (#853 changes only write-time selection, never the read path).
+pub fn write_column_block(
+    chunk_id: u64,
+    schema_ref: u64,
+    row_count: u64,
+    min_ts_ns: u64,
+    max_ts_ns: u64,
+    columns: &[ColumnInput<'_>],
+) -> Result<Vec<u8>, ColumnBlockError> {
+    let column_count = columns.len();
+    let dir_off = HEADER_LEN;
+    let dir_len = column_count * DIR_ENTRY_LEN;
+    let streams_off = dir_off + dir_len;
+
+    // Encode every column stream first so we know each length/offset.
+    let codec = ColumnCodec::Zstd { level: 3 };
+    let mut streams: Vec<Vec<u8>> = Vec::with_capacity(column_count);
+    for col in columns {
+        streams.push(encode_bytes(std::slice::from_ref(&codec), col.data)?);
+    }
+
+    let mut out = Vec::with_capacity(streams_off + streams.iter().map(Vec::len).sum::<usize>());
+
+    // --- Header ---
+    out.extend_from_slice(&COLUMN_BLOCK_MAGIC);
+    out.extend_from_slice(&COLUMN_BLOCK_VERSION_V1.to_le_bytes());
+    out.extend_from_slice(&0u16.to_le_bytes()); // flags (reserved)
+    out.extend_from_slice(&chunk_id.to_le_bytes());
+    out.extend_from_slice(&schema_ref.to_le_bytes());
+    out.extend_from_slice(&row_count.to_le_bytes());
+    out.extend_from_slice(&(column_count as u32).to_le_bytes());
+    out.extend_from_slice(&min_ts_ns.to_le_bytes());
+    out.extend_from_slice(&max_ts_ns.to_le_bytes());
+    debug_assert_eq!(out.len(), HEADER_LEN);
+
+    // --- Column directory ---
+    let mut cursor = streams_off as u64;
+    for (col, stream) in columns.iter().zip(streams.iter()) {
+        out.extend_from_slice(&col.column_id.to_le_bytes());
+        out.push(col.logical_type);
+        out.push(codec.tag());
+        out.extend_from_slice(&cursor.to_le_bytes()); // stream_offset
+        out.extend_from_slice(&(stream.len() as u64).to_le_bytes()); // stream_len
+        out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_off (reserved #854)
+        out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_len
+        out.extend_from_slice(&0u64.to_le_bytes()); // bloom_off (reserved #855)
+        out.extend_from_slice(&0u64.to_le_bytes()); // bloom_len
+        cursor += stream.len() as u64;
+    }
+    debug_assert_eq!(out.len(), streams_off);
+
+    // --- Column streams ---
+    for stream in &streams {
+        out.extend_from_slice(stream);
+    }
+
+    // --- Footer ---
+    let crc = crc32(&out); // over header+directory+streams
+    out.extend_from_slice(&(dir_off as u64).to_le_bytes());
+    out.extend_from_slice(&(dir_len as u64).to_le_bytes());
+    out.extend_from_slice(&crc.to_le_bytes());
+    out.extend_from_slice(&COLUMN_BLOCK_MAGIC);
+
+    Ok(out)
+}
+
+/// Decode a v1 `RDCC` block: verify both magics, the version, and the
+/// CRC, then decode each column stream back to its raw bytes.
+pub fn read_column_block(bytes: &[u8]) -> Result<DecodedColumnBlock, ColumnBlockError> {
+    if bytes.len() < HEADER_LEN + FOOTER_LEN {
+        return Err(ColumnBlockError::Truncated);
+    }
+    let magic: [u8; 4] = bytes[0..4].try_into().unwrap();
+    if magic != COLUMN_BLOCK_MAGIC {
+        return Err(ColumnBlockError::BadMagic(magic));
+    }
+    let version = u16::from_le_bytes([bytes[4], bytes[5]]);
+    if version != COLUMN_BLOCK_VERSION_V1 {
+        return Err(ColumnBlockError::UnsupportedVersion(version));
+    }
+
+    // --- Footer (fixed, at the tail) ---
+    let footer_start = bytes.len() - FOOTER_LEN;
+    let tail_magic: [u8; 4] = bytes[bytes.len() - 4..].try_into().unwrap();
+    if tail_magic != COLUMN_BLOCK_MAGIC {
+        return Err(ColumnBlockError::BadTailMagic(tail_magic));
+    }
+    let dir_off = u64::from_le_bytes(bytes[footer_start..footer_start + 8].try_into().unwrap());
+    let dir_len = u64::from_le_bytes(
+        bytes[footer_start + 8..footer_start + 16]
+            .try_into()
+            .unwrap(),
+    );
+    let stored_crc = u32::from_le_bytes(
+        bytes[footer_start + 16..footer_start + 20]
+            .try_into()
+            .unwrap(),
+    );
+    let actual_crc = crc32(&bytes[..footer_start]);
+    if actual_crc != stored_crc {
+        return Err(ColumnBlockError::ChecksumMismatch {
+            expected: stored_crc,
+            actual: actual_crc,
+        });
+    }
+
+    // --- Header fields needed for reconstruction ---
+    let chunk_id = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    let schema_ref = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+    let row_count = u64::from_le_bytes(bytes[24..32].try_into().unwrap());
+    let column_count = u32::from_le_bytes(bytes[32..36].try_into().unwrap()) as usize;
+    let min_ts_ns = u64::from_le_bytes(bytes[36..44].try_into().unwrap());
+    let max_ts_ns = u64::from_le_bytes(bytes[44..52].try_into().unwrap());
+
+    let dir_off = dir_off as usize;
+    let dir_len = dir_len as usize;
+    if dir_off != HEADER_LEN
+        || dir_len != column_count * DIR_ENTRY_LEN
+        || dir_off + dir_len > footer_start
+    {
+        return Err(ColumnBlockError::BadDirectory);
+    }
+
+    let mut columns = Vec::with_capacity(column_count);
+    for i in 0..column_count {
+        let base = dir_off + i * DIR_ENTRY_LEN;
+        let column_id = u32::from_le_bytes(bytes[base..base + 4].try_into().unwrap());
+        let logical_type = bytes[base + 4];
+        let codec_tag = bytes[base + 5];
+        let stream_offset =
+            u64::from_le_bytes(bytes[base + 6..base + 14].try_into().unwrap()) as usize;
+        let stream_len =
+            u64::from_le_bytes(bytes[base + 14..base + 22].try_into().unwrap()) as usize;
+        let end = stream_offset
+            .checked_add(stream_len)
+            .ok_or(ColumnBlockError::BadDirectory)?;
+        if stream_offset < dir_off + dir_len || end > footer_start {
+            return Err(ColumnBlockError::BadDirectory);
+        }
+        // Decode by the recorded stream (its own segment_codec header
+        // carries the codec); the directory tag is bookkeeping for #853.
+        let data = decode_bytes(&bytes[stream_offset..end])?;
+        columns.push(DecodedColumn {
+            column_id,
+            logical_type,
+            codec_tag,
+            data,
+        });
+    }
+
+    Ok(DecodedColumnBlock {
+        chunk_id,
+        schema_ref,
+        row_count,
+        min_ts_ns,
+        max_ts_ns,
+        columns,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u64_stream(values: &[u64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    fn f64_stream(values: &[f64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn round_trips_two_columns_value_for_value() {
+        let ts: Vec<u64> = (0..500)
+            .map(|i| 1_700_000_000_000 + i * 1_000_000)
+            .collect();
+        let vals: Vec<f64> = (0..500).map(|i| 95.0 + (i % 7) as f64 * 0.25).collect();
+        let ts_raw = u64_stream(&ts);
+        let val_raw = f64_stream(&vals);
+
+        let block = write_column_block(
+            42,
+            7,
+            ts.len() as u64,
+            *ts.first().unwrap(),
+            *ts.last().unwrap(),
+            &[
+                ColumnInput {
+                    column_id: 0,
+                    logical_type: 2,
+                    data: &ts_raw,
+                },
+                ColumnInput {
+                    column_id: 1,
+                    logical_type: 3,
+                    data: &val_raw,
+                },
+            ],
+        )
+        .unwrap();
+
+        let decoded = read_column_block(&block).unwrap();
+        assert_eq!(decoded.chunk_id, 42);
+        assert_eq!(decoded.schema_ref, 7);
+        assert_eq!(decoded.row_count, 500);
+        assert_eq!(decoded.min_ts_ns, *ts.first().unwrap());
+        assert_eq!(decoded.max_ts_ns, *ts.last().unwrap());
+        assert_eq!(decoded.columns.len(), 2);
+        assert_eq!(decoded.columns[0].column_id, 0);
+        assert_eq!(decoded.columns[0].logical_type, 2);
+        assert_eq!(
+            decoded.columns[0].codec_tag,
+            ColumnCodec::Zstd { level: 3 }.tag()
+        );
+        assert_eq!(decoded.columns[0].data, ts_raw);
+        assert_eq!(decoded.columns[1].data, val_raw);
+    }
+
+    #[test]
+    fn header_carries_magic_and_version() {
+        let block = write_column_block(1, 0, 0, 0, 0, &[]).unwrap();
+        assert_eq!(&block[0..4], &COLUMN_BLOCK_MAGIC);
+        assert_eq!(
+            u16::from_le_bytes([block[4], block[5]]),
+            COLUMN_BLOCK_VERSION_V1
+        );
+        assert_eq!(&block[block.len() - 4..], &COLUMN_BLOCK_MAGIC);
+        // Empty (zero-column) block still decodes.
+        let decoded = read_column_block(&block).unwrap();
+        assert!(decoded.columns.is_empty());
+    }
+
+    #[test]
+    fn rejects_bad_leading_magic() {
+        let mut block = write_column_block(1, 0, 0, 0, 0, &[]).unwrap();
+        block[0] = b'X';
+        assert!(matches!(
+            read_column_block(&block),
+            Err(ColumnBlockError::BadMagic(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_future_version() {
+        let raw = u64_stream(&[1, 2, 3]);
+        let mut block = write_column_block(
+            1,
+            0,
+            3,
+            1,
+            3,
+            &[ColumnInput {
+                column_id: 0,
+                logical_type: 2,
+                data: &raw,
+            }],
+        )
+        .unwrap();
+        block[4..6].copy_from_slice(&(COLUMN_BLOCK_VERSION_V1 + 1).to_le_bytes());
+        assert!(matches!(
+            read_column_block(&block),
+            Err(ColumnBlockError::UnsupportedVersion(_))
+        ));
+    }
+
+    #[test]
+    fn detects_payload_corruption_via_crc() {
+        let raw = f64_stream(&[1.5, 2.5, 3.5, 4.5]);
+        let mut block = write_column_block(
+            1,
+            0,
+            4,
+            0,
+            0,
+            &[ColumnInput {
+                column_id: 0,
+                logical_type: 3,
+                data: &raw,
+            }],
+        )
+        .unwrap();
+        // Flip a byte inside the stream region (after the header).
+        block[HEADER_LEN + DIR_ENTRY_LEN] ^= 0xFF;
+        assert!(matches!(
+            read_column_block(&block),
+            Err(ColumnBlockError::ChecksumMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_buffer() {
+        assert!(matches!(
+            read_column_block(&[0u8; 8]),
+            Err(ColumnBlockError::Truncated)
+        ));
+    }
+}

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
@@ -277,6 +277,7 @@ impl RedDB {
                     max_ts_ns: chunk.max_ts_ns,
                     sealed: chunk.sealed,
                     ttl_override_ns: chunk.ttl_override_ns,
+                    columnar_page: chunk.columnar_page,
                 });
         }
         registry
@@ -327,6 +328,7 @@ impl RedDB {
                     max_ts_ns: chunk.max_ts_ns,
                     sealed: chunk.sealed,
                     ttl_override_ns: chunk.ttl_override_ns,
+                    columnar_page: chunk.columnar_page,
                 });
             }
         }

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -38,6 +38,7 @@
 
 pub mod bitmap_index;
 pub mod bloom_index;
+pub mod column_block;
 pub mod context_index;
 pub mod devx;
 pub mod dsl;
@@ -57,6 +58,10 @@ pub mod tokenization;
 
 pub use bitmap_index::{BitmapColumnIndex, BitmapIndexManager, BitmapIndexStats};
 pub use bloom_index::{BloomFilterRegistry, BloomRegistryStats};
+pub use column_block::{
+    read_column_block, write_column_block, ColumnBlockError, ColumnInput, DecodedColumn,
+    DecodedColumnBlock, COLUMN_BLOCK_MAGIC, COLUMN_BLOCK_VERSION_V1,
+};
 pub use context_index::{ContextIndex, ContextIndexStats, ContextPosting, ContextSearchHit};
 pub use devx::{
     BatchBuilder, BatchResult, DevXError, EdgeBuilder, IndexConfig, LinkedEntity,

--- a/crates/reddb-server/src/storage/unified/segment_codec.rs
+++ b/crates/reddb-server/src/storage/unified/segment_codec.rs
@@ -40,7 +40,10 @@ pub enum ColumnCodec {
 }
 
 impl ColumnCodec {
-    fn tag(&self) -> u8 {
+    /// Single-byte codec discriminant recorded in stream + column-block
+    /// directory headers. Public so the columnar chunk layout
+    /// (`column_block`) can store the codec each column was written with.
+    pub fn tag(&self) -> u8 {
         match self {
             ColumnCodec::None => 0,
             ColumnCodec::Lz4 => 1,
@@ -51,7 +54,10 @@ impl ColumnCodec {
         }
     }
 
-    fn from_tag(tag: u8) -> Option<ColumnCodec> {
+    /// Inverse of [`ColumnCodec::tag`]. `Zstd` decodes to the default
+    /// level (3); the real level is carried inline by the stream header,
+    /// so a tag round-trip is only used for directory bookkeeping.
+    pub fn from_tag(tag: u8) -> Option<ColumnCodec> {
         match tag {
             0 => Some(ColumnCodec::None),
             1 => Some(ColumnCodec::Lz4),

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -1367,6 +1367,7 @@ mod tests {
             session_key: None,
             session_gap_ms: None,
             retention_duration_ms: None,
+            analytical_storage: None,
         })
         .expect("save graph contract");
     }

--- a/tests/e2e_ddl_drop_foundation.rs
+++ b/tests/e2e_ddl_drop_foundation.rs
@@ -115,6 +115,7 @@ fn register_collection(rt: &RedDBRuntime, name: &str, model: CollectionModel) {
             session_key: None,
             session_gap_ms: None,
             retention_duration_ms: None,
+            analytical_storage: None,
         })
         .unwrap_or_else(|err| panic!("contract {name}: {err}"));
 }


### PR DESCRIPTION
Automated AFK landing for #852. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782848686&installation_id=129708444&pr_number=904&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F904&signature=cc6f01f3020783da3c8fe19f337e5db2131923257ca3487a031b3c67d451fae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytical storage configuration infrastructure enabling columnar storage format support for collections
  * Introduced configuration options to control storage layout (columnar vs. row-based) and ordering semantics
  * Added column block storage format for optimized data persistence

* **Tests**
  * Added comprehensive validation tests for columnar storage round-trip serialization and legacy compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->