### PR TITLE
merge: #853 Columnar segment: per-column codec selection by semantics

### DIFF
--- a/crates/reddb-server/src/storage/timeseries/chunk.rs
+++ b/crates/reddb-server/src/storage/timeseries/chunk.rs
@@ -14,6 +14,7 @@ use crate::storage::schema::types::DataType;
 use crate::storage::unified::column_block::{
     read_column_block, write_column_block, ColumnBlockError, ColumnInput,
 };
+use crate::storage::unified::segment_codec::ColumnSemantics;
 
 /// Stable column id of the timestamp column within a v1 columnar chunk.
 pub const COLUMNAR_TS_COLUMN_ID: u32 = 0;
@@ -213,9 +214,11 @@ impl TimeSeriesChunk {
 
     /// Seal the chunk and emit its **columnar** on-disk form: an `RDCC`
     /// [`ColumnBlock`](crate::storage::engine::PageType::ColumnBlock)
-    /// transposing the live `(ts, value)` columns into two ZSTD streams
-    /// (PRD #850, Phase 1). Sealing first (via [`seal`](Self::seal))
-    /// guarantees timestamp order, so the columns are written sorted.
+    /// transposing the live `(ts, value)` columns into per-column codec
+    /// streams — delta-of-delta+ZSTD for the monotonic timestamps,
+    /// Gorilla/XOR+ZSTD for the float gauge (#853, PRD #850 Phase 1).
+    /// Sealing first (via [`seal`](Self::seal)) guarantees timestamp
+    /// order, so the columns are written sorted.
     ///
     /// `chunk_id` / `schema_ref` are recorded verbatim in the block header
     /// so a reader is self-describing. The returned bytes are written into
@@ -246,11 +249,15 @@ impl TimeSeriesChunk {
                 ColumnInput {
                     column_id: COLUMNAR_TS_COLUMN_ID,
                     logical_type: DataType::UnsignedInteger.to_byte(),
+                    // Monotonic, sealed-sorted timestamps → delta-of-delta.
+                    semantics: ColumnSemantics::Timestamp,
                     data: &ts_bytes,
                 },
                 ColumnInput {
                     column_id: COLUMNAR_VALUE_COLUMN_ID,
                     logical_type: DataType::Float.to_byte(),
+                    // Floating-point gauge readings → Gorilla/XOR.
+                    semantics: ColumnSemantics::Gauge,
                     data: &val_bytes,
                 },
             ],

--- a/crates/reddb-server/src/storage/unified/column_block.rs
+++ b/crates/reddb-server/src/storage/unified/column_block.rs
@@ -7,11 +7,14 @@
 //! as a [`PageType::ColumnBlock`](crate::storage::engine::PageType) page.
 //!
 //! It is the first real caller of [`segment_codec`](super::segment_codec):
-//! every column stream is one `segment_codec` pipeline output. v1 writes a
-//! single codec (ZSTD level 3) for every column — per-column codec
-//! *selection* is #853; granule skip-indexes are #854; per-granule blooms
-//! are #855. The directory reserves zeroed fields for all three so those
-//! slices extend within this envelope without forcing a format v2.
+//! every column stream is one `segment_codec` pipeline output. The codec
+//! chain is chosen **per column** from its [`ColumnSemantics`] via
+//! [`select_codecs`](super::segment_codec::select_codecs) (#853) — the
+//! directory's `codec` byte records the leading (semantic) codec so the
+//! sealed chunk is self-describing; granule skip-indexes are #854 and
+//! per-granule blooms are #855. The directory reserves zeroed fields for
+//! both so those slices extend within this envelope without forcing a
+//! format v2.
 //!
 //! # Layout (`RDCC`)
 //!
@@ -47,7 +50,9 @@
 //!   magic_tail           b"RDCC"  (4)
 //! ```
 
-use super::segment_codec::{decode_bytes, encode_bytes, CodecError, ColumnCodec};
+use super::segment_codec::{
+    decode_bytes, encode_bytes, select_codecs, CodecError, ColumnCodec, ColumnSemantics,
+};
 use crate::storage::engine::crc32::crc32;
 
 /// `b"RDCC"` — RedDB Columnar Chunk. Opens and closes every block.
@@ -69,6 +74,9 @@ pub struct ColumnInput<'a> {
     pub column_id: u32,
     /// Logical type tag (`DataType::to_byte()`).
     pub logical_type: u8,
+    /// The column's role — drives per-column codec selection (#853).
+    /// Callers that have no semantic hint pass [`ColumnSemantics::Generic`].
+    pub semantics: ColumnSemantics,
     /// Raw little-endian column bytes (pre-compression).
     pub data: &'a [u8],
 }
@@ -142,9 +150,10 @@ impl From<CodecError> for ColumnBlockError {
 }
 
 /// Serialize `columns` into the v1 `RDCC` layout. Each column's raw bytes
-/// are compressed with ZSTD(3) through `segment_codec`; the directory
-/// records the codec tag so the reader decodes by the *recorded* codec
-/// (#853 changes only write-time selection, never the read path).
+/// run through the codec chain [`select_codecs`] picks from its
+/// [`ColumnSemantics`]; the directory records the *leading* (semantic)
+/// codec tag. The reader decodes from each stream's own self-describing
+/// header, so #853 changed only write-time selection, never the read path.
 pub fn write_column_block(
     chunk_id: u64,
     schema_ref: u64,
@@ -159,10 +168,16 @@ pub fn write_column_block(
     let streams_off = dir_off + dir_len;
 
     // Encode every column stream first so we know each length/offset.
-    let codec = ColumnCodec::Zstd { level: 3 };
+    // The codec chain is chosen per column from its semantics; the tag we
+    // record in the directory is the *leading* (semantic) codec — the one
+    // that characterises the column. An empty chain (never produced by
+    // `select_codecs`) records `None`.
     let mut streams: Vec<Vec<u8>> = Vec::with_capacity(column_count);
+    let mut codec_tags: Vec<u8> = Vec::with_capacity(column_count);
     for col in columns {
-        streams.push(encode_bytes(std::slice::from_ref(&codec), col.data)?);
+        let codecs = select_codecs(col.logical_type, col.semantics);
+        codec_tags.push(codecs.first().unwrap_or(&ColumnCodec::None).tag());
+        streams.push(encode_bytes(&codecs, col.data)?);
     }
 
     let mut out = Vec::with_capacity(streams_off + streams.iter().map(Vec::len).sum::<usize>());
@@ -181,10 +196,10 @@ pub fn write_column_block(
 
     // --- Column directory ---
     let mut cursor = streams_off as u64;
-    for (col, stream) in columns.iter().zip(streams.iter()) {
+    for ((col, stream), codec_tag) in columns.iter().zip(streams.iter()).zip(codec_tags.iter()) {
         out.extend_from_slice(&col.column_id.to_le_bytes());
         out.push(col.logical_type);
-        out.push(codec.tag());
+        out.push(*codec_tag);
         out.extend_from_slice(&cursor.to_le_bytes()); // stream_offset
         out.extend_from_slice(&(stream.len() as u64).to_le_bytes()); // stream_len
         out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_off (reserved #854)
@@ -335,11 +350,13 @@ mod tests {
                 ColumnInput {
                     column_id: 0,
                     logical_type: 2,
+                    semantics: ColumnSemantics::Timestamp,
                     data: &ts_raw,
                 },
                 ColumnInput {
                     column_id: 1,
                     logical_type: 3,
+                    semantics: ColumnSemantics::Gauge,
                     data: &val_raw,
                 },
             ],
@@ -355,12 +372,59 @@ mod tests {
         assert_eq!(decoded.columns.len(), 2);
         assert_eq!(decoded.columns[0].column_id, 0);
         assert_eq!(decoded.columns[0].logical_type, 2);
-        assert_eq!(
-            decoded.columns[0].codec_tag,
-            ColumnCodec::Zstd { level: 3 }.tag()
-        );
+        // Per-column selection: the directory records the *leading*
+        // semantic codec — DoubleDelta for the timestamp column, XOR for
+        // the float gauge — not a single uniform ZSTD tag.
+        assert_eq!(decoded.columns[0].codec_tag, ColumnCodec::DoubleDelta.tag());
+        assert_eq!(decoded.columns[1].codec_tag, ColumnCodec::Xor.tag());
+        // …yet both still decode byte-for-byte (criterion 1 + 2).
         assert_eq!(decoded.columns[0].data, ts_raw);
         assert_eq!(decoded.columns[1].data, val_raw);
+    }
+
+    fn str_stream(items: &[&str]) -> Vec<u8> {
+        let mut out = (items.len() as u32).to_le_bytes().to_vec();
+        for s in items {
+            out.extend_from_slice(&(s.len() as u16).to_le_bytes());
+            out.extend_from_slice(s.as_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn records_counter_and_low_cardinality_codecs_and_round_trips() {
+        let counter = u64_stream(&(0..300).map(|i| (i * 5) as u64).collect::<Vec<_>>());
+        let labels: Vec<&str> = (0..300).map(|i| ["a", "b", "c"][i % 3]).collect();
+        let labels_raw = str_stream(&labels);
+
+        let block = write_column_block(
+            9,
+            1,
+            300,
+            0,
+            0,
+            &[
+                ColumnInput {
+                    column_id: 10,
+                    logical_type: 2,
+                    semantics: ColumnSemantics::Counter,
+                    data: &counter,
+                },
+                ColumnInput {
+                    column_id: 11,
+                    logical_type: 4,
+                    semantics: ColumnSemantics::LowCardinality,
+                    data: &labels_raw,
+                },
+            ],
+        )
+        .unwrap();
+
+        let decoded = read_column_block(&block).unwrap();
+        assert_eq!(decoded.columns[0].codec_tag, ColumnCodec::Delta.tag());
+        assert_eq!(decoded.columns[1].codec_tag, ColumnCodec::Dict.tag());
+        assert_eq!(decoded.columns[0].data, counter);
+        assert_eq!(decoded.columns[1].data, labels_raw);
     }
 
     #[test]
@@ -399,6 +463,7 @@ mod tests {
             &[ColumnInput {
                 column_id: 0,
                 logical_type: 2,
+                semantics: ColumnSemantics::Generic,
                 data: &raw,
             }],
         )
@@ -422,6 +487,7 @@ mod tests {
             &[ColumnInput {
                 column_id: 0,
                 logical_type: 3,
+                semantics: ColumnSemantics::Gauge,
                 data: &raw,
             }],
         )

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -109,6 +109,7 @@ pub use segment::{
     ColZone, SegmentConfig, SegmentError, SegmentId, SegmentState, SegmentStats, UnifiedSegment,
     ZoneColPred, ZoneColPredKind,
 };
+pub use segment_codec::{select_codecs, ColumnSemantics};
 pub use spatial_index::{
     SpatialIndex, SpatialIndexManager, SpatialIndexStats, SpatialSearchResult,
 };

--- a/crates/reddb-server/src/storage/unified/segment_codec.rs
+++ b/crates/reddb-server/src/storage/unified/segment_codec.rs
@@ -17,6 +17,7 @@
 //! | `Delta`        | monotonic or near-monotonic ints  | reuses `t64_encode` for residuals |
 //! | `DoubleDelta`  | regular time-series timestamps    | reuses existing DoD path |
 //! | `Dict`         | low-cardinality strings / ints    | builds inline dictionary |
+//! | `Xor`          | floating-point gauges             | reuses Gorilla `xor_*_values` |
 //!
 //! Codecs chain: callers compose a `Vec<ColumnCodec>` and apply them
 //! outer → inner on encode, inner → outer on decode. The pipeline
@@ -24,8 +25,8 @@
 //! the schema declaration — just the byte buffer.
 
 use crate::storage::timeseries::compression::{
-    delta_decode_timestamps, delta_encode_timestamps, t64_decode, t64_encode, zstd_compress,
-    zstd_decompress,
+    delta_decode_timestamps, delta_encode_timestamps, t64_decode, t64_encode, xor_decode_values,
+    xor_encode_values, zstd_compress, zstd_decompress,
 };
 
 /// Codec identifiers. Stored as a single byte in the header.
@@ -33,10 +34,16 @@ use crate::storage::timeseries::compression::{
 pub enum ColumnCodec {
     None,
     Lz4,
-    Zstd { level: i32 },
+    Zstd {
+        level: i32,
+    },
     Delta,
     DoubleDelta,
     Dict,
+    /// Gorilla XOR for floating-point gauges. Reuses the existing
+    /// time-series `xor_encode_values`/`xor_decode_values` — #853 only
+    /// *wires* the codec into the pipeline, it adds no new algorithm.
+    Xor,
 }
 
 impl ColumnCodec {
@@ -51,6 +58,7 @@ impl ColumnCodec {
             ColumnCodec::Delta => 3,
             ColumnCodec::DoubleDelta => 4,
             ColumnCodec::Dict => 5,
+            ColumnCodec::Xor => 6,
         }
     }
 
@@ -65,7 +73,58 @@ impl ColumnCodec {
             3 => Some(ColumnCodec::Delta),
             4 => Some(ColumnCodec::DoubleDelta),
             5 => Some(ColumnCodec::Dict),
+            6 => Some(ColumnCodec::Xor),
             _ => None,
+        }
+    }
+}
+
+/// Column semantics — the *role* a column plays, independent of its raw
+/// logical type. This is the signal [`select_codecs`] keys off: a numeric
+/// column can be a monotonic timestamp, an oscillating gauge, or a
+/// monotonic counter, and each wants a different codec even though all
+/// three are stored as 8-byte little-endian values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnSemantics {
+    /// Monotonic, regularly-spaced timestamps → delta-of-delta + ZSTD.
+    Timestamp,
+    /// Floating-point gauge (oscillating reading) → Gorilla/XOR + ZSTD.
+    Gauge,
+    /// Monotonic-ish integer counter → delta + ZSTD.
+    Counter,
+    /// Low-cardinality string / enum label → dictionary + ZSTD.
+    LowCardinality,
+    /// No semantic hint — fall back to a generic ZSTD codec.
+    Generic,
+}
+
+/// Pick the codec pipeline for a column from its semantics (and, for the
+/// `Generic` case, its logical type). This is the whole of #853: it wires
+/// *selection* over the existing codecs — delta-of-delta for timestamps,
+/// Gorilla/XOR for gauges, delta for counters, dictionary for
+/// low-cardinality strings, ZSTD otherwise. Every semantic codec is
+/// chained with `Zstd(3)` so the residual stream (which the leading codec
+/// only *re-shapes* into mostly-zero bytes) is actually shrunk on disk —
+/// the ClickHouse `CODEC(DoubleDelta, ZSTD)` parity posture.
+///
+/// The leading codec is the *semantic* one; [`crate::storage::unified::column_block`]
+/// records its tag in the chunk directory as the column's chosen codec.
+/// The full chain is always self-described by the stream header, so the
+/// reader never consults this function.
+pub fn select_codecs(logical_type: u8, semantics: ColumnSemantics) -> Vec<ColumnCodec> {
+    let zstd = ColumnCodec::Zstd { level: 3 };
+    match semantics {
+        ColumnSemantics::Timestamp => vec![ColumnCodec::DoubleDelta, zstd],
+        ColumnSemantics::Gauge => vec![ColumnCodec::Xor, zstd],
+        ColumnSemantics::Counter => vec![ColumnCodec::Delta, zstd],
+        ColumnSemantics::LowCardinality => vec![ColumnCodec::Dict, zstd],
+        // `Generic` ignores the logical type today — there is no
+        // type-only heuristic that beats ZSTD without a semantic hint.
+        // The parameter is kept so a future slice can refine the fallback
+        // (e.g. bit-pack narrow ints) without changing this signature.
+        ColumnSemantics::Generic => {
+            let _ = logical_type;
+            vec![zstd]
         }
     }
 }
@@ -190,6 +249,24 @@ fn apply_encode(codec: &ColumnCodec, data: &[u8]) -> CodecResult<Vec<u8>> {
             }
             Ok(out)
         }
+        ColumnCodec::Xor => {
+            // f64 stream required.
+            if !data.len().is_multiple_of(8) {
+                return Err(CodecError::InvalidPayload("xor expects f64 stream"));
+            }
+            let values: Vec<f64> = data
+                .chunks_exact(8)
+                .map(|c| f64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            let encoded = xor_encode_values(&values);
+            // Pack as (count:u32) + u64 XOR words.
+            let mut out = Vec::with_capacity(4 + encoded.len() * 8);
+            out.extend_from_slice(&(encoded.len() as u32).to_le_bytes());
+            for v in encoded {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Ok(out)
+        }
         ColumnCodec::Dict => encode_dict(data),
     }
 }
@@ -223,6 +300,27 @@ fn apply_decode(codec: &ColumnCodec, data: &[u8]) -> CodecResult<Vec<u8>> {
                 .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
                 .collect();
             let decoded = delta_decode_timestamps(&encoded);
+            let mut out = Vec::with_capacity(decoded.len() * 8);
+            for v in decoded {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+            Ok(out)
+        }
+        ColumnCodec::Xor => {
+            if data.len() < 4 {
+                return Err(CodecError::Truncated);
+            }
+            let count = u32::from_le_bytes(data[0..4].try_into().unwrap()) as usize;
+            let payload = &data[4..];
+            if payload.len() < count * 8 {
+                return Err(CodecError::Truncated);
+            }
+            let encoded: Vec<u64> = payload
+                .chunks_exact(8)
+                .take(count)
+                .map(|c| u64::from_le_bytes(c.try_into().unwrap()))
+                .collect();
+            let decoded = xor_decode_values(&encoded);
             let mut out = Vec::with_capacity(decoded.len() * 8);
             for v in decoded {
                 out.extend_from_slice(&v.to_le_bytes());
@@ -456,5 +554,167 @@ mod tests {
     fn delta_codec_rejects_non_multiple_of_eight() {
         let encoded = encode_bytes(&[ColumnCodec::Delta], &[1u8, 2, 3]);
         assert!(encoded.is_err());
+    }
+
+    fn f64_stream(values: &[f64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    fn u64_stream(values: &[u64]) -> Vec<u8> {
+        values.iter().flat_map(|v| v.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn xor_codec_round_trips_gauge_floats() {
+        // Slowly-varying gauge — the case Gorilla/XOR targets.
+        let values: Vec<f64> = (0..2000).map(|i| 95.0 + (i % 13) as f64 * 0.125).collect();
+        let raw = f64_stream(&values);
+        let encoded = encode_bytes(&[ColumnCodec::Xor], &raw).unwrap();
+        let decoded = decode_bytes(&encoded).unwrap();
+        assert_eq!(decoded, raw);
+    }
+
+    #[test]
+    fn xor_codec_is_lossless_for_special_floats() {
+        // NaN / inf / signed zero must survive bit-for-bit.
+        let values = vec![
+            f64::NAN,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+            0.0,
+            -0.0,
+            1.5,
+            -1.5,
+        ];
+        let raw = f64_stream(&values);
+        let encoded = encode_bytes(&[ColumnCodec::Xor], &raw).unwrap();
+        let decoded = decode_bytes(&encoded).unwrap();
+        assert_eq!(decoded, raw);
+    }
+
+    #[test]
+    fn xor_codec_rejects_non_multiple_of_eight() {
+        assert!(encode_bytes(&[ColumnCodec::Xor], &[1u8, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn xor_tag_round_trips() {
+        assert_eq!(
+            ColumnCodec::from_tag(ColumnCodec::Xor.tag()),
+            Some(ColumnCodec::Xor)
+        );
+    }
+
+    #[test]
+    fn select_codecs_maps_semantics_to_expected_chains() {
+        let z = ColumnCodec::Zstd { level: 3 };
+        assert_eq!(
+            select_codecs(0, ColumnSemantics::Timestamp),
+            vec![ColumnCodec::DoubleDelta, z.clone()]
+        );
+        assert_eq!(
+            select_codecs(0, ColumnSemantics::Gauge),
+            vec![ColumnCodec::Xor, z.clone()]
+        );
+        assert_eq!(
+            select_codecs(0, ColumnSemantics::Counter),
+            vec![ColumnCodec::Delta, z.clone()]
+        );
+        assert_eq!(
+            select_codecs(0, ColumnSemantics::LowCardinality),
+            vec![ColumnCodec::Dict, z.clone()]
+        );
+        assert_eq!(select_codecs(0, ColumnSemantics::Generic), vec![z]);
+    }
+
+    /// Criterion 2: round-trip stays lossless for every codec/type
+    /// combination the selector can produce.
+    #[test]
+    fn selected_codecs_round_trip_losslessly() {
+        let ts = u64_stream(
+            &(0..1000)
+                .map(|i| 1_700_000_000_000 + i * 1_000_000)
+                .collect::<Vec<_>>(),
+        );
+        let gauge = f64_stream(
+            &(0..1000)
+                .map(|i| 50.0 + (i % 9) as f64 * 0.5)
+                .collect::<Vec<_>>(),
+        );
+        let counter = u64_stream(&(0..1000).map(|i| (i * 7) as u64).collect::<Vec<_>>());
+        let strings = str_stream(&["a", "a", "b", "c", "a", "b", "b", "a", "c", "a"]);
+        let cases = [
+            (ColumnSemantics::Timestamp, 2u8, &ts),
+            (ColumnSemantics::Gauge, 3u8, &gauge),
+            (ColumnSemantics::Counter, 2u8, &counter),
+            (ColumnSemantics::LowCardinality, 4u8, &strings),
+            (ColumnSemantics::Generic, 4u8, &strings),
+        ];
+        for (sem, ty, raw) in cases {
+            let codecs = select_codecs(ty, sem);
+            let encoded = encode_bytes(&codecs, raw).unwrap();
+            let decoded = decode_bytes(&encoded).unwrap();
+            assert_eq!(decoded, *raw, "lossless round-trip failed for {sem:?}");
+        }
+    }
+
+    /// Criterion 3: loose compression-ratio sanity bounds per codec so a
+    /// regression that bloats storage is caught. Bands are deliberately
+    /// generous — they assert "this codec actually shrinks its target
+    /// shape", not a precise ratio.
+    #[test]
+    fn selected_codecs_meet_loose_ratio_bounds() {
+        // Regular timestamps: delta-of-delta collapses to ~0 residuals,
+        // ZSTD then crushes them. Expect a large win.
+        let ts = u64_stream(
+            &(0..4000)
+                .map(|i| 1_700_000_000_000 + i * 1_000_000)
+                .collect::<Vec<_>>(),
+        );
+        let enc = encode_bytes(&select_codecs(2, ColumnSemantics::Timestamp), &ts).unwrap();
+        assert!(
+            enc.len() < ts.len() / 4,
+            "timestamp codec ratio too weak: {} -> {}",
+            ts.len(),
+            enc.len()
+        );
+
+        // Slowly-varying gauge: XOR yields long zero runs, ZSTD shrinks.
+        let gauge = f64_stream(
+            &(0..4000)
+                .map(|i| 95.0 + (i % 5) as f64 * 0.1)
+                .collect::<Vec<_>>(),
+        );
+        let enc = encode_bytes(&select_codecs(3, ColumnSemantics::Gauge), &gauge).unwrap();
+        assert!(
+            enc.len() < gauge.len() / 2,
+            "gauge codec ratio too weak: {} -> {}",
+            gauge.len(),
+            enc.len()
+        );
+
+        // Monotonic counter: constant delta → ~0 residuals.
+        let counter = u64_stream(&(0..4000).map(|i| (i * 3) as u64).collect::<Vec<_>>());
+        let enc = encode_bytes(&select_codecs(2, ColumnSemantics::Counter), &counter).unwrap();
+        assert!(
+            enc.len() < counter.len() / 4,
+            "counter codec ratio too weak: {} -> {}",
+            counter.len(),
+            enc.len()
+        );
+
+        // Low-cardinality strings: dictionary folds repeats.
+        let labels: Vec<&str> = (0..4000)
+            .map(|i| ["us-east-1", "eu-west-1", "apac-south-1"][i % 3])
+            .collect();
+        let strings = str_stream(&labels);
+        let enc =
+            encode_bytes(&select_codecs(4, ColumnSemantics::LowCardinality), &strings).unwrap();
+        assert!(
+            enc.len() < strings.len() / 2,
+            "low-cardinality codec ratio too weak: {} -> {}",
+            strings.len(),
+            enc.len()
+        );
     }
 }


### PR DESCRIPTION
Automated AFK landing for #853. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782850388&installation_id=129708444&pr_number=905&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F905&signature=e4da5ed3b922ad3e4df2a67d0b5d5c9707543e013cc6d01e13166175e3ad9f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented intelligent, semantic-aware per-column codec selection for time-series storage that automatically optimizes compression and encoding strategies based on data characteristics.
  * Enhanced database storage efficiency with specialized encoding techniques tailored to different metric types, improving both compression ratios and query performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->