### PR TITLE
merge: #854 Columnar segment: sparse granule index + min/max skip

### DIFF
--- a/crates/reddb-server/src/storage/timeseries/chunk.rs
+++ b/crates/reddb-server/src/storage/timeseries/chunk.rs
@@ -20,6 +20,10 @@ use crate::storage::unified::segment_codec::ColumnSemantics;
 pub const COLUMNAR_TS_COLUMN_ID: u32 = 0;
 /// Stable column id of the value column within a v1 columnar chunk.
 pub const COLUMNAR_VALUE_COLUMN_ID: u32 = 1;
+/// Default sparse-granule-index stride: one min/max mark per ~8192 rows
+/// (PRD #850 Phase 1, #854). Configurable per seal via
+/// [`TimeSeriesChunk::seal_columnar_with_granule_size`].
+pub const DEFAULT_GRANULE_SIZE: u32 = 8192;
 
 /// A single time-series data point
 #[derive(Debug, Clone, PartialEq)]
@@ -230,6 +234,20 @@ impl TimeSeriesChunk {
         chunk_id: u64,
         schema_ref: u64,
     ) -> Result<Vec<u8>, ColumnBlockError> {
+        self.seal_columnar_with_granule_size(chunk_id, schema_ref, DEFAULT_GRANULE_SIZE)
+    }
+
+    /// As [`seal_columnar`](Self::seal_columnar), but with an explicit
+    /// sparse-granule-index stride (#854). The writer records one min/max
+    /// mark per `granule_size` rows for each numeric column (timestamp +
+    /// value) in the block's footer; a reader prunes granules that cannot
+    /// match a range predicate. `granule_size == 0` writes no index.
+    pub fn seal_columnar_with_granule_size(
+        &mut self,
+        chunk_id: u64,
+        schema_ref: u64,
+        granule_size: u32,
+    ) -> Result<Vec<u8>, ColumnBlockError> {
         if !self.sealed {
             self.seal();
         }
@@ -245,6 +263,7 @@ impl TimeSeriesChunk {
             self.timestamps.len() as u64,
             self.min_timestamp().unwrap_or(0),
             self.max_timestamp().unwrap_or(0),
+            granule_size,
             &[
                 ColumnInput {
                     column_id: COLUMNAR_TS_COLUMN_ID,
@@ -430,9 +449,114 @@ pub fn points_from_column_block(bytes: &[u8]) -> Result<Vec<TimeSeriesPoint>, Co
     Ok(points)
 }
 
+/// Result of a granule-pruned range scan over a sealed columnar chunk.
+/// `granules_total` vs `granules_scanned` makes pruning observable: a
+/// selective predicate decodes fewer granules than the chunk holds
+/// (PRD #850 Phase 1, #854 — criterion 2).
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrunedColumnScan {
+    /// Matching points, in timestamp order, drawn only from surviving
+    /// granules and filtered to the query window.
+    pub points: Vec<TimeSeriesPoint>,
+    /// Total granule marks in the timestamp column's sparse index.
+    pub granules_total: usize,
+    /// Granules that survived pruning and were materialised.
+    pub granules_scanned: usize,
+}
+
+/// Range query `[start_ns, end_ns]` (inclusive) over a sealed columnar
+/// chunk that uses the timestamp column's **sparse granule index** to skip
+/// granules whose min/max prove they cannot intersect the window. Only
+/// surviving granules are materialised into points; rows within a
+/// surviving granule are still filtered to the window (granule boundaries
+/// are coarse). The inverse-with-pruning of [`points_from_column_block`].
+///
+/// **Soundness**: a granule is kept whenever `granule_min <= end_ns &&
+/// granule_max >= start_ns`, i.e. exactly when it *could* hold a matching
+/// row — so pruning never drops a matching row regardless of where the
+/// granule boundaries fall (#854 — criterion 3). When the block carries no
+/// granule index, every row is scanned (`granules_total == granules_scanned
+/// == 1`).
+pub fn query_column_block_range(
+    bytes: &[u8],
+    start_ns: u64,
+    end_ns: u64,
+) -> Result<PrunedColumnScan, ColumnBlockError> {
+    let block = read_column_block(bytes)?;
+    let ts_col = block
+        .columns
+        .iter()
+        .find(|c| c.column_id == COLUMNAR_TS_COLUMN_ID)
+        .ok_or(ColumnBlockError::BadDirectory)?;
+    let val_col = block
+        .columns
+        .iter()
+        .find(|c| c.column_id == COLUMNAR_VALUE_COLUMN_ID)
+        .ok_or(ColumnBlockError::BadDirectory)?;
+    if !ts_col.data.len().is_multiple_of(8) || !val_col.data.len().is_multiple_of(8) {
+        return Err(ColumnBlockError::BadDirectory);
+    }
+    let n = ts_col.data.len() / 8;
+    if val_col.data.len() / 8 != n {
+        return Err(ColumnBlockError::BadDirectory);
+    }
+
+    let ts_at =
+        |i: usize| -> u64 { u64::from_le_bytes(ts_col.data[i * 8..i * 8 + 8].try_into().unwrap()) };
+    let val_at = |i: usize| -> f64 {
+        f64::from_le_bytes(val_col.data[i * 8..i * 8 + 8].try_into().unwrap())
+    };
+    let take_row = |i: usize, out: &mut Vec<TimeSeriesPoint>| {
+        let ts = ts_at(i);
+        if ts >= start_ns && ts <= end_ns {
+            out.push(TimeSeriesPoint {
+                timestamp_ns: ts,
+                value: val_at(i),
+            });
+        }
+    };
+
+    let mut points = Vec::new();
+    let (granules_total, granules_scanned) = match &ts_col.granule_index {
+        Some(gi) if gi.granule_count() > 0 => {
+            // Keep a granule when its [min, max] timestamp interval can
+            // intersect the query window — the BRIN MINMAX skip rule.
+            let survivors = gi.surviving_granules(|min, max| {
+                if min.len() < 8 || max.len() < 8 {
+                    return true; // malformed mark → conservative keep
+                }
+                let gmin = u64::from_le_bytes(min[..8].try_into().unwrap());
+                let gmax = u64::from_le_bytes(max[..8].try_into().unwrap());
+                gmin <= end_ns && gmax >= start_ns
+            });
+            for &g in &survivors {
+                let (s, e) = gi.row_range(g, n);
+                for i in s..e {
+                    take_row(i, &mut points);
+                }
+            }
+            (gi.granule_count(), survivors.len())
+        }
+        // No granule index → full scan (conservative, still correct).
+        _ => {
+            for i in 0..n {
+                take_row(i, &mut points);
+            }
+            (1, 1)
+        }
+    };
+
+    Ok(PrunedColumnScan {
+        points,
+        granules_total,
+        granules_scanned,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     fn make_tags(host: &str) -> HashMap<String, String> {
         let mut tags = HashMap::new();
@@ -630,6 +754,136 @@ mod tests {
 
         drop(pager);
         let _ = std::fs::remove_file(&path);
+    }
+
+    // -----------------------------------------------------------------
+    // Sparse granule index + min/max skip (PRD #850, Phase 1 — #854)
+    // -----------------------------------------------------------------
+
+    /// Criterion 1: a sealed columnar chunk carries granule marks +
+    /// per-granule min/max in the footer, for both numeric columns.
+    #[test]
+    fn sealed_columnar_chunk_carries_granule_index_in_footer() {
+        let mut chunk = TimeSeriesChunk::with_max_points("cpu.idle", make_tags("srv1"), 1000);
+        for i in 0..1000u64 {
+            chunk.append(1_000 + i, 50.0 + (i % 7) as f64);
+        }
+        let block = chunk
+            .seal_columnar_with_granule_size(1, 0, 100)
+            .expect("seal columnar");
+
+        let decoded = read_column_block(&block).expect("decode");
+        for col in &decoded.columns {
+            let gi = col
+                .granule_index
+                .as_ref()
+                .expect("both numeric columns carry a granule index");
+            assert_eq!(gi.granule_size, 100);
+            assert_eq!(gi.granule_count(), 10); // 1000 / 100
+            assert_eq!(gi.granules.len(), 10);
+            // Each mark has a real min/max (8-byte values).
+            assert!(gi
+                .granules
+                .iter()
+                .all(|g| g.min.len() == 8 && g.max.len() == 8));
+        }
+    }
+
+    /// Criterion 2: a selective range query reads only the granules that
+    /// can match, and the pruning is observable (fewer granules scanned).
+    #[test]
+    fn range_query_prunes_non_matching_granules() {
+        let mut chunk = TimeSeriesChunk::with_max_points("mem.used", make_tags("srv1"), 1000);
+        // Monotonic timestamps 0,10,20,… → granule g covers [g*1000, …].
+        for i in 0..1000u64 {
+            chunk.append(i * 10, i as f64);
+        }
+        let block = chunk
+            .seal_columnar_with_granule_size(1, 0, 100)
+            .expect("seal columnar");
+
+        // Window [2050, 2150] lands wholly inside the 3rd granule
+        // (rows 200..300 → ts 2000..2990).
+        let scan = query_column_block_range(&block, 2_050, 2_150).expect("scan");
+        assert_eq!(scan.granules_total, 10);
+        assert!(
+            scan.granules_scanned < scan.granules_total,
+            "pruning must skip granules: scanned {} of {}",
+            scan.granules_scanned,
+            scan.granules_total
+        );
+        assert_eq!(scan.granules_scanned, 1);
+        // ts 2050,2060,…,2150 (multiples of 10 in the window) → 11 points.
+        assert_eq!(scan.points.len(), 11);
+        assert!(scan
+            .points
+            .iter()
+            .all(|p| p.timestamp_ns >= 2_050 && p.timestamp_ns <= 2_150));
+        // Points come back in timestamp order.
+        assert!(scan
+            .points
+            .windows(2)
+            .all(|w| w[0].timestamp_ns <= w[1].timestamp_ns));
+
+        // A window past the end prunes everything.
+        let empty = query_column_block_range(&block, 100_000, 200_000).expect("scan");
+        assert_eq!(empty.granules_scanned, 0);
+        assert!(empty.points.is_empty());
+    }
+
+    /// Criterion 3: pruning NEVER drops a row that matches the predicate,
+    /// regardless of granule boundaries. The pruned scan must equal a full
+    /// scan filtered to the same window — as a multiset of points.
+    fn sort_points(mut v: Vec<TimeSeriesPoint>) -> Vec<TimeSeriesPoint> {
+        v.sort_by(|a, b| {
+            a.timestamp_ns
+                .cmp(&b.timestamp_ns)
+                .then_with(|| a.value.to_bits().cmp(&b.value.to_bits()))
+        });
+        v
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        #[test]
+        fn granule_pruning_never_drops_a_matching_row(
+            rows in prop::collection::vec(
+                (0u64..5_000, prop::num::f64::NORMAL),
+                0..400,
+            ),
+            granule_size in 1u32..50,
+            a in 0u64..5_000,
+            b in 0u64..5_000,
+        ) {
+            let (start, end) = (a.min(b), a.max(b));
+
+            let mut chunk = TimeSeriesChunk::with_max_points("m", HashMap::new(), 512);
+            for (ts, v) in &rows {
+                chunk.append(*ts, *v);
+            }
+            let block = chunk
+                .seal_columnar_with_granule_size(1, 0, granule_size)
+                .expect("seal columnar");
+
+            let scan = query_column_block_range(&block, start, end).expect("pruned scan");
+
+            // Reference: full decode, filtered to the window. seal() sorted
+            // the points, so this is the ground-truth match set.
+            let expected: Vec<TimeSeriesPoint> = points_from_column_block(&block)
+                .expect("full decode")
+                .into_iter()
+                .filter(|p| p.timestamp_ns >= start && p.timestamp_ns <= end)
+                .collect();
+
+            prop_assert_eq!(
+                sort_points(scan.points.clone()),
+                sort_points(expected),
+                "granule pruning dropped or invented a row for [{}, {}] @ g={}",
+                start, end, granule_size
+            );
+            prop_assert!(scan.granules_scanned <= scan.granules_total);
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/unified/column_block.rs
+++ b/crates/reddb-server/src/storage/unified/column_block.rs
@@ -11,10 +11,13 @@
 //! chain is chosen **per column** from its [`ColumnSemantics`] via
 //! [`select_codecs`](super::segment_codec::select_codecs) (#853) — the
 //! directory's `codec` byte records the leading (semantic) codec so the
-//! sealed chunk is self-describing; granule skip-indexes are #854 and
-//! per-granule blooms are #855. The directory reserves zeroed fields for
-//! both so those slices extend within this envelope without forcing a
-//! format v2.
+//! sealed chunk is self-describing. A column's **sparse granule index**
+//! (one min/max mark per `granule_size` rows — #854) is stored as a
+//! self-describing blob whose offset/length live in the directory's
+//! `granule_index_off`/`granule_index_len` (zeroed when a column has no
+//! index, e.g. variable-width streams); per-granule blooms are #855 and
+//! still occupy reserved zeroed fields. All extensions live inside this
+//! envelope without forcing a format v2.
 //!
 //! # Layout (`RDCC`)
 //!
@@ -36,12 +39,19 @@
 //!   codec                u8             ColumnCodec tag (segment_codec)
 //!   stream_offset        u64            byte offset of this column's stream within the block
 //!   stream_len           u64
-//!   granule_index_off    u64  = 0       reserved → #854
-//!   granule_index_len    u64  = 0
+//!   granule_index_off    u64            byte offset of this column's granule index (0 = none) #854
+//!   granule_index_len    u64            length of the granule index blob (0 = none)
 //!   bloom_off            u64  = 0       reserved → #855
 //!   bloom_len            u64  = 0
 //!
 //! Column streams        column_count segment_codec runs, back-to-back
+//! Granule indexes       per-column granule-index blobs, back-to-back (#854)
+//!
+//! Granule index blob (per indexed column)
+//!   granule_size_rows    u32            rows per mark (last mark may be shorter)
+//!   value_width          u32            bytes per min/max value (8 for u64/f64)
+//!   granule_count        u32
+//!   per granule:  min[value_width]  max[value_width]   raw column-encoded bytes
 //!
 //! Footer (24 bytes)
 //!   col_directory_off    u64
@@ -91,6 +101,10 @@ pub struct DecodedColumn {
     /// Decompressed raw little-endian column bytes — identical to the
     /// `ColumnInput::data` the writer was given.
     pub data: Vec<u8>,
+    /// Sparse granule index for this column (#854), or `None` when the
+    /// directory recorded a zero-length granule slice (variable-width /
+    /// non-numeric columns, or `granule_size == 0` at write time).
+    pub granule_index: Option<GranuleIndex>,
 }
 
 /// A fully decoded column block: the self-describing header plus every
@@ -149,6 +163,209 @@ impl From<CodecError> for ColumnBlockError {
     }
 }
 
+/// Per-granule min/max statistics for one column. `min`/`max` are raw
+/// value bytes in the *same* little-endian encoding as the column data,
+/// so a reader interprets them with the column's logical type — the index
+/// itself stays type-agnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GranuleStats {
+    pub min: Vec<u8>,
+    pub max: Vec<u8>,
+}
+
+/// Sparse granule index over one column: one [`GranuleStats`] mark per
+/// `granule_size` rows (PRD #850 Phase 1, #854). It is RAM-resident — the
+/// reader prunes granules whose `[min, max]` cannot match a range/point
+/// predicate and materialises only the survivors. There is no dense
+/// per-key index; this is the chunk's BRIN-style skip index made granular.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GranuleIndex {
+    /// Rows per granule mark. The final granule may hold fewer rows.
+    pub granule_size: u32,
+    /// Width in bytes of each min/max value (8 for u64/f64 columns).
+    pub value_width: u32,
+    /// One min/max pair per granule, in row order.
+    pub granules: Vec<GranuleStats>,
+}
+
+impl GranuleIndex {
+    /// Number of granule marks.
+    pub fn granule_count(&self) -> usize {
+        self.granules.len()
+    }
+
+    /// Row range `[start, end)` covered by granule `i`, clamped to
+    /// `row_count`. Granules tile the column in `granule_size` strides, so
+    /// the range is derived rather than stored.
+    pub fn row_range(&self, i: usize, row_count: usize) -> (usize, usize) {
+        let g = (self.granule_size as usize).max(1);
+        let start = i.saturating_mul(g).min(row_count);
+        let end = (i + 1).saturating_mul(g).min(row_count);
+        (start, end)
+    }
+
+    /// Indices of granules whose `[min, max]` interval may satisfy a
+    /// predicate, per the caller-supplied `overlaps(min, max)` test.
+    /// Granules the test rejects are pruned. The test receives the raw
+    /// min/max bytes and interprets them with the column's logical type.
+    pub fn surviving_granules<F>(&self, overlaps: F) -> Vec<usize>
+    where
+        F: Fn(&[u8], &[u8]) -> bool,
+    {
+        (0..self.granules.len())
+            .filter(|&i| overlaps(&self.granules[i].min, &self.granules[i].max))
+            .collect()
+    }
+
+    /// Serialize to the self-describing blob the column directory points at.
+    fn serialize(&self) -> Vec<u8> {
+        let w = self.value_width as usize;
+        let mut out = Vec::with_capacity(12 + self.granules.len() * w * 2);
+        out.extend_from_slice(&self.granule_size.to_le_bytes());
+        out.extend_from_slice(&self.value_width.to_le_bytes());
+        out.extend_from_slice(&(self.granules.len() as u32).to_le_bytes());
+        for g in &self.granules {
+            out.extend_from_slice(&g.min);
+            out.extend_from_slice(&g.max);
+        }
+        out
+    }
+
+    /// Inverse of [`GranuleIndex::serialize`]. A malformed blob is reported
+    /// as [`ColumnBlockError::BadDirectory`] — the index lives inside the
+    /// CRC-covered region, so corruption is caught upstream; this guards
+    /// only against internally-inconsistent lengths.
+    fn deserialize(bytes: &[u8]) -> Result<GranuleIndex, ColumnBlockError> {
+        if bytes.len() < 12 {
+            return Err(ColumnBlockError::BadDirectory);
+        }
+        let granule_size = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let value_width = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        let count = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+        let w = value_width as usize;
+        if w == 0 {
+            return Err(ColumnBlockError::BadDirectory);
+        }
+        let need = 12usize
+            .checked_add(
+                count
+                    .checked_mul(w * 2)
+                    .ok_or(ColumnBlockError::BadDirectory)?,
+            )
+            .ok_or(ColumnBlockError::BadDirectory)?;
+        if bytes.len() < need {
+            return Err(ColumnBlockError::BadDirectory);
+        }
+        let mut granules = Vec::with_capacity(count);
+        let mut cur = 12;
+        for _ in 0..count {
+            let min = bytes[cur..cur + w].to_vec();
+            cur += w;
+            let max = bytes[cur..cur + w].to_vec();
+            cur += w;
+            granules.push(GranuleStats { min, max });
+        }
+        Ok(GranuleIndex {
+            granule_size,
+            value_width,
+            granules,
+        })
+    }
+}
+
+/// Type-aware ordering for the fixed-width numeric columns a granule index
+/// covers. The min/max bytes are stored in the column's own little-endian
+/// encoding, but the *ordering* differs per type (raw byte order is wrong
+/// for signed ints and floats), so the index is built and compared through
+/// this kind.
+#[derive(Debug, Clone, Copy)]
+enum NumKind {
+    I64,
+    U64,
+    F64,
+}
+
+impl NumKind {
+    /// Map a [`DataType::to_byte`](crate::storage::schema::types::DataType::to_byte)
+    /// tag to a fixed-width numeric kind, or `None` for variable-width /
+    /// non-numeric columns (which get no granule index in v1).
+    fn from_logical(logical_type: u8) -> Option<NumKind> {
+        match logical_type {
+            // Integer / Timestamp / Duration are all i64-shaped on the wire.
+            1 | 7 | 8 => Some(NumKind::I64),
+            2 => Some(NumKind::U64), // UnsignedInteger
+            3 => Some(NumKind::F64), // Float
+            _ => None,
+        }
+    }
+}
+
+/// Build a sparse granule index over a fixed-width numeric column. Returns
+/// `None` for `granule_size == 0`, empty/ragged data, or a column type
+/// that has no total numeric order (variable-width streams are skipped in
+/// v1 — the directory slice stays zero-length). min/max are computed under
+/// the type's correct ordering and stored as raw 8-byte little-endian.
+fn build_granule_index(logical_type: u8, granule_size: u32, data: &[u8]) -> Option<GranuleIndex> {
+    if granule_size == 0 {
+        return None;
+    }
+    let kind = NumKind::from_logical(logical_type)?;
+    if data.is_empty() || !data.len().is_multiple_of(8) {
+        return None;
+    }
+    let n = data.len() / 8;
+    let g = granule_size as usize;
+    let mut granules = Vec::with_capacity(n.div_ceil(g));
+    let mut start = 0usize;
+    while start < n {
+        let end = (start + g).min(n);
+        let granule = &data[start * 8..end * 8];
+        let (min, max) = granule_min_max(kind, granule);
+        granules.push(GranuleStats {
+            min: min.to_vec(),
+            max: max.to_vec(),
+        });
+        start = end;
+    }
+    Some(GranuleIndex {
+        granule_size,
+        value_width: 8,
+        granules,
+    })
+}
+
+/// min/max over one granule's worth of 8-byte numeric values, returned as
+/// the raw little-endian bytes of the extreme elements (so they re-encode
+/// identically to the column). `slice.len()` is a non-zero multiple of 8.
+fn granule_min_max(kind: NumKind, slice: &[u8]) -> ([u8; 8], [u8; 8]) {
+    let mut elems = slice.chunks_exact(8);
+    let first: [u8; 8] = elems.next().unwrap().try_into().unwrap();
+    let mut min = first;
+    let mut max = first;
+    for e in elems {
+        let cur: [u8; 8] = e.try_into().unwrap();
+        if num_lt(kind, &cur, &min) {
+            min = cur;
+        }
+        if num_lt(kind, &max, &cur) {
+            max = cur;
+        }
+    }
+    (min, max)
+}
+
+/// `a < b` for two 8-byte little-endian values under `kind`'s ordering.
+/// Floats use [`f64::total_cmp`] so NaN/±0 are ordered deterministically.
+fn num_lt(kind: NumKind, a: &[u8; 8], b: &[u8; 8]) -> bool {
+    match kind {
+        NumKind::I64 => i64::from_le_bytes(*a) < i64::from_le_bytes(*b),
+        NumKind::U64 => u64::from_le_bytes(*a) < u64::from_le_bytes(*b),
+        NumKind::F64 => f64::from_le_bytes(*a)
+            .total_cmp(&f64::from_le_bytes(*b))
+            .is_lt(),
+    }
+}
+
 /// Serialize `columns` into the v1 `RDCC` layout. Each column's raw bytes
 /// run through the codec chain [`select_codecs`] picks from its
 /// [`ColumnSemantics`]; the directory records the *leading* (semantic)
@@ -160,6 +377,7 @@ pub fn write_column_block(
     row_count: u64,
     min_ts_ns: u64,
     max_ts_ns: u64,
+    granule_size: u32,
     columns: &[ColumnInput<'_>],
 ) -> Result<Vec<u8>, ColumnBlockError> {
     let column_count = columns.len();
@@ -171,16 +389,35 @@ pub fn write_column_block(
     // The codec chain is chosen per column from its semantics; the tag we
     // record in the directory is the *leading* (semantic) codec — the one
     // that characterises the column. An empty chain (never produced by
-    // `select_codecs`) records `None`.
+    // `select_codecs`) records `None`. Alongside each stream we build the
+    // column's sparse granule index (#854) from the *raw* (pre-codec)
+    // bytes, so min/max reflect real values; variable-width columns get
+    // `None` and a zero-length directory slice.
     let mut streams: Vec<Vec<u8>> = Vec::with_capacity(column_count);
     let mut codec_tags: Vec<u8> = Vec::with_capacity(column_count);
+    let mut granule_blobs: Vec<Vec<u8>> = Vec::with_capacity(column_count);
     for col in columns {
         let codecs = select_codecs(col.logical_type, col.semantics);
         codec_tags.push(codecs.first().unwrap_or(&ColumnCodec::None).tag());
         streams.push(encode_bytes(&codecs, col.data)?);
+        granule_blobs.push(
+            build_granule_index(col.logical_type, granule_size, col.data)
+                .map(|gi| gi.serialize())
+                .unwrap_or_default(),
+        );
     }
 
-    let mut out = Vec::with_capacity(streams_off + streams.iter().map(Vec::len).sum::<usize>());
+    // Granule indexes are laid back-to-back after all streams. Compute the
+    // start of that region so directory offsets can be filled in one pass.
+    let granule_region_off =
+        streams_off as u64 + streams.iter().map(|s| s.len() as u64).sum::<u64>();
+
+    let mut out = Vec::with_capacity(
+        streams_off
+            + streams.iter().map(Vec::len).sum::<usize>()
+            + granule_blobs.iter().map(Vec::len).sum::<usize>()
+            + FOOTER_LEN,
+    );
 
     // --- Header ---
     out.extend_from_slice(&COLUMN_BLOCK_MAGIC);
@@ -196,14 +433,26 @@ pub fn write_column_block(
 
     // --- Column directory ---
     let mut cursor = streams_off as u64;
-    for ((col, stream), codec_tag) in columns.iter().zip(streams.iter()).zip(codec_tags.iter()) {
+    let mut granule_cursor = granule_region_off;
+    for (((col, stream), codec_tag), granule) in columns
+        .iter()
+        .zip(streams.iter())
+        .zip(codec_tags.iter())
+        .zip(granule_blobs.iter())
+    {
         out.extend_from_slice(&col.column_id.to_le_bytes());
         out.push(col.logical_type);
         out.push(*codec_tag);
         out.extend_from_slice(&cursor.to_le_bytes()); // stream_offset
         out.extend_from_slice(&(stream.len() as u64).to_le_bytes()); // stream_len
-        out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_off (reserved #854)
-        out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_len
+        if granule.is_empty() {
+            out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_off (none)
+            out.extend_from_slice(&0u64.to_le_bytes()); // granule_index_len
+        } else {
+            out.extend_from_slice(&granule_cursor.to_le_bytes()); // granule_index_off (#854)
+            out.extend_from_slice(&(granule.len() as u64).to_le_bytes()); // granule_index_len
+            granule_cursor += granule.len() as u64;
+        }
         out.extend_from_slice(&0u64.to_le_bytes()); // bloom_off (reserved #855)
         out.extend_from_slice(&0u64.to_le_bytes()); // bloom_len
         cursor += stream.len() as u64;
@@ -213,6 +462,12 @@ pub fn write_column_block(
     // --- Column streams ---
     for stream in &streams {
         out.extend_from_slice(stream);
+    }
+    debug_assert_eq!(out.len() as u64, granule_region_off);
+
+    // --- Granule indexes (#854) ---
+    for granule in &granule_blobs {
+        out.extend_from_slice(granule);
     }
 
     // --- Footer ---
@@ -292,6 +547,10 @@ pub fn read_column_block(bytes: &[u8]) -> Result<DecodedColumnBlock, ColumnBlock
             u64::from_le_bytes(bytes[base + 6..base + 14].try_into().unwrap()) as usize;
         let stream_len =
             u64::from_le_bytes(bytes[base + 14..base + 22].try_into().unwrap()) as usize;
+        let granule_off =
+            u64::from_le_bytes(bytes[base + 22..base + 30].try_into().unwrap()) as usize;
+        let granule_len =
+            u64::from_le_bytes(bytes[base + 30..base + 38].try_into().unwrap()) as usize;
         let end = stream_offset
             .checked_add(stream_len)
             .ok_or(ColumnBlockError::BadDirectory)?;
@@ -301,11 +560,25 @@ pub fn read_column_block(bytes: &[u8]) -> Result<DecodedColumnBlock, ColumnBlock
         // Decode by the recorded stream (its own segment_codec header
         // carries the codec); the directory tag is bookkeeping for #853.
         let data = decode_bytes(&bytes[stream_offset..end])?;
+        // Parse the sparse granule index (#854) when present. A
+        // zero-length slice means the column was written without an index.
+        let granule_index = if granule_len == 0 {
+            None
+        } else {
+            let g_end = granule_off
+                .checked_add(granule_len)
+                .ok_or(ColumnBlockError::BadDirectory)?;
+            if granule_off < dir_off + dir_len || g_end > footer_start {
+                return Err(ColumnBlockError::BadDirectory);
+            }
+            Some(GranuleIndex::deserialize(&bytes[granule_off..g_end])?)
+        };
         columns.push(DecodedColumn {
             column_id,
             logical_type,
             codec_tag,
             data,
+            granule_index,
         });
     }
 
@@ -346,6 +619,7 @@ mod tests {
             ts.len() as u64,
             *ts.first().unwrap(),
             *ts.last().unwrap(),
+            128,
             &[
                 ColumnInput {
                     column_id: 0,
@@ -380,6 +654,29 @@ mod tests {
         // …yet both still decode byte-for-byte (criterion 1 + 2).
         assert_eq!(decoded.columns[0].data, ts_raw);
         assert_eq!(decoded.columns[1].data, val_raw);
+
+        // Both numeric columns carry a sparse granule index (#854): 500
+        // rows / 128 per granule → 4 marks (last short).
+        for col in &decoded.columns {
+            let gi = col
+                .granule_index
+                .as_ref()
+                .expect("numeric column must carry a granule index");
+            assert_eq!(gi.granule_size, 128);
+            assert_eq!(gi.value_width, 8);
+            assert_eq!(gi.granule_count(), 4);
+        }
+        // Timestamp granule mins are the per-granule first timestamps
+        // (the column is monotonic), so granule 0's min is the global min.
+        let ts_gi = decoded.columns[0].granule_index.as_ref().unwrap();
+        assert_eq!(
+            u64::from_le_bytes(ts_gi.granules[0].min.clone().try_into().unwrap()),
+            *ts.first().unwrap()
+        );
+        assert_eq!(
+            u64::from_le_bytes(ts_gi.granules[3].max.clone().try_into().unwrap()),
+            *ts.last().unwrap()
+        );
     }
 
     fn str_stream(items: &[&str]) -> Vec<u8> {
@@ -403,6 +700,7 @@ mod tests {
             300,
             0,
             0,
+            64,
             &[
                 ColumnInput {
                     column_id: 10,
@@ -425,11 +723,15 @@ mod tests {
         assert_eq!(decoded.columns[1].codec_tag, ColumnCodec::Dict.tag());
         assert_eq!(decoded.columns[0].data, counter);
         assert_eq!(decoded.columns[1].data, labels_raw);
+        // The numeric counter column is indexed; the variable-width
+        // low-cardinality string column is not (zero-length slice → None).
+        assert!(decoded.columns[0].granule_index.is_some());
+        assert!(decoded.columns[1].granule_index.is_none());
     }
 
     #[test]
     fn header_carries_magic_and_version() {
-        let block = write_column_block(1, 0, 0, 0, 0, &[]).unwrap();
+        let block = write_column_block(1, 0, 0, 0, 0, 0, &[]).unwrap();
         assert_eq!(&block[0..4], &COLUMN_BLOCK_MAGIC);
         assert_eq!(
             u16::from_le_bytes([block[4], block[5]]),
@@ -443,7 +745,7 @@ mod tests {
 
     #[test]
     fn rejects_bad_leading_magic() {
-        let mut block = write_column_block(1, 0, 0, 0, 0, &[]).unwrap();
+        let mut block = write_column_block(1, 0, 0, 0, 0, 0, &[]).unwrap();
         block[0] = b'X';
         assert!(matches!(
             read_column_block(&block),
@@ -460,6 +762,7 @@ mod tests {
             3,
             1,
             3,
+            0,
             &[ColumnInput {
                 column_id: 0,
                 logical_type: 2,
@@ -484,6 +787,7 @@ mod tests {
             4,
             0,
             0,
+            0,
             &[ColumnInput {
                 column_id: 0,
                 logical_type: 3,
@@ -498,6 +802,46 @@ mod tests {
             read_column_block(&block),
             Err(ColumnBlockError::ChecksumMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn granule_index_round_trips_and_prunes_on_u64() {
+        // 250 u64 timestamps, 100 rows per granule → 3 marks (100/100/50).
+        let ts: Vec<u64> = (0..250).map(|i| 1_000 + i * 10).collect();
+        let raw = u64_stream(&ts);
+        let block = write_column_block(
+            1,
+            0,
+            ts.len() as u64,
+            *ts.first().unwrap(),
+            *ts.last().unwrap(),
+            100,
+            &[ColumnInput {
+                column_id: 0,
+                logical_type: 2,
+                semantics: ColumnSemantics::Timestamp,
+                data: &raw,
+            }],
+        )
+        .unwrap();
+
+        let decoded = read_column_block(&block).unwrap();
+        let gi = decoded.columns[0].granule_index.as_ref().unwrap();
+        assert_eq!(gi.granule_count(), 3);
+        // Per-granule min/max for a monotonic column: [1000,1990],[2000,2990],[3000,3490].
+        let as_u64 = |b: &[u8]| u64::from_le_bytes(b.try_into().unwrap());
+        assert_eq!(as_u64(&gi.granules[0].min), 1_000);
+        assert_eq!(as_u64(&gi.granules[0].max), 1_990);
+        assert_eq!(as_u64(&gi.granules[2].min), 3_000);
+        assert_eq!(as_u64(&gi.granules[2].max), 3_490);
+
+        // A range hitting only the middle granule prunes the other two.
+        let survivors = gi.surviving_granules(|min, max| {
+            let (lo, hi) = (2_100u64, 2_200u64);
+            as_u64(min) <= hi && as_u64(max) >= lo
+        });
+        assert_eq!(survivors, vec![1]);
+        assert_eq!(gi.row_range(1, ts.len()), (100, 200));
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -60,7 +60,7 @@ pub use bitmap_index::{BitmapColumnIndex, BitmapIndexManager, BitmapIndexStats};
 pub use bloom_index::{BloomFilterRegistry, BloomRegistryStats};
 pub use column_block::{
     read_column_block, write_column_block, ColumnBlockError, ColumnInput, DecodedColumn,
-    DecodedColumnBlock, COLUMN_BLOCK_MAGIC, COLUMN_BLOCK_VERSION_V1,
+    DecodedColumnBlock, GranuleIndex, GranuleStats, COLUMN_BLOCK_MAGIC, COLUMN_BLOCK_VERSION_V1,
 };
 pub use context_index::{ContextIndex, ContextIndexStats, ContextPosting, ContextSearchHit};
 pub use devx::{


### PR DESCRIPTION
Automated AFK landing for #854. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782853015&installation_id=129708444&pr_number=906&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F906&signature=1849e380297c5533292d0e20c4a3f8f537baf82cd99b9b4d4a938f78bdc325eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Time series data querying is now more efficient with sparse granule indexing, enabling selective data access based on timestamp ranges.
  * Columnar range queries automatically skip unnecessary data blocks by leveraging min/max timestamp metadata from granule indexes.

* **Tests**
  * Enhanced test coverage validates granule indexing presence, pruning behavior, and correctness of filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->