### PR TITLE
merge: #859 Phase 1 (verify): columnar chunks evict via existing hypertable TTL

### DIFF
--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -896,6 +896,121 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------
+    // Columnar chunk eviction via the EXISTING TTL/drop path (issue #859)
+    //
+    // A sealed *columnar* chunk is one whose `ChunkMeta.columnar_page` is
+    // `Some(..)` — the RDCC `ColumnBlock` discriminant (PRD #850 Phase 1).
+    // These guards prove the retention path is storage-form agnostic: the
+    // SAME `sweep_expired` / `drop_chunks_before` metadata sweep that drops
+    // row chunks drops columnar chunks too, in O(1) metadata work (no
+    // per-row delete), and hands the `columnar_page` back on the dropped
+    // meta so the physical-storage callback can release the RDCC block.
+    // No separate columnar TTL/partition subsystem exists or is needed.
+    // -----------------------------------------------------------------
+
+    /// Build a sealed columnar chunk meta directly — mirrors what the
+    /// boot/seal path restores: a chunk carrying its RDCC `columnar_page`.
+    fn columnar_chunk(hypertable: &str, start_ns: u64, max_ts_ns: u64) -> ChunkMeta {
+        let mut meta = ChunkMeta::new(
+            ChunkId {
+                hypertable: hypertable.into(),
+                start_ns,
+            },
+            start_ns + DAY_NS,
+        );
+        meta.row_count = 1;
+        meta.min_ts_ns = max_ts_ns;
+        meta.max_ts_ns = max_ts_ns;
+        meta.sealed = true;
+        meta.columnar_page = Some(PageLocation::new(7, 0, 1234));
+        meta
+    }
+
+    #[test]
+    fn columnar_chunk_evicts_via_sweep_expired_carrying_its_page() {
+        let reg = HypertableRegistry::new();
+        reg.register(HypertableSpec::new("metrics", "ts", DAY_NS).with_ttl_ns(DAY_NS));
+        // Inject a sealed columnar chunk (max_ts=0 → expiry at 1d).
+        reg.restore_chunk(columnar_chunk("metrics", 0, 0));
+        assert!(reg.show_chunks("metrics")[0].columnar_page.is_some());
+
+        // now = 3d → past the 1d TTL. The existing partition sweep drops it.
+        let dropped = reg.sweep_expired("metrics", 3 * DAY_NS);
+        assert_eq!(dropped.len(), 1, "columnar chunk must evict via TTL sweep");
+        assert_eq!(
+            dropped[0].columnar_page,
+            Some(PageLocation::new(7, 0, 1234)),
+            "dropped meta must carry columnar_page so physical release frees the RDCC block"
+        );
+        assert!(reg.show_chunks("metrics").is_empty());
+    }
+
+    #[test]
+    fn columnar_chunk_evicts_via_drop_chunks_before() {
+        let reg = HypertableRegistry::new();
+        reg.register(HypertableSpec::new("metrics", "ts", DAY_NS));
+        reg.restore_chunk(columnar_chunk("metrics", 0, 0));
+
+        let dropped = reg.drop_chunks_before("metrics", DAY_NS);
+        assert_eq!(dropped.len(), 1);
+        assert!(
+            dropped[0].columnar_page.is_some(),
+            "drop_chunks_before is metadata-only and carries columnar_page through"
+        );
+        assert!(reg.show_chunks("metrics").is_empty());
+    }
+
+    #[test]
+    fn columnar_and_row_chunks_share_one_eviction_path() {
+        // Regression guard (acceptance #3): a row chunk and a columnar
+        // chunk with identical bounds + TTL must produce identical sweep
+        // outcomes. If a separate columnar TTL subsystem were ever
+        // introduced, the two would diverge here.
+        let mk = |columnar: bool| {
+            let reg = HypertableRegistry::new();
+            reg.register(HypertableSpec::new("m", "ts", DAY_NS).with_ttl_ns(DAY_NS));
+            if columnar {
+                reg.restore_chunk(columnar_chunk("m", 0, 0));
+            } else {
+                reg.route("m", 0).unwrap(); // row chunk, max_ts=0
+            }
+            reg.sweep_expired("m", 3 * DAY_NS).len()
+        };
+        assert_eq!(mk(false), 1, "row chunk evicts");
+        assert_eq!(mk(true), 1, "columnar chunk evicts the same way");
+    }
+
+    #[test]
+    fn columnar_chunk_prunes_by_time_bounds_like_row_chunk() {
+        // Acceptance #2: the partition pruner selects chunks by their
+        // [start_ns, end_ns_exclusive) bounds (surfaced via show_chunks) —
+        // it never inspects columnar_page, so a columnar chunk outside the
+        // query window is eliminated identically to a row chunk. We assert
+        // the bounds the pruner consumes survive verbatim for a columnar
+        // chunk.
+        let reg = HypertableRegistry::new();
+        reg.register(HypertableSpec::new("m", "ts", DAY_NS));
+        reg.restore_chunk(columnar_chunk("m", 0, 0));
+        reg.restore_chunk(columnar_chunk("m", 2 * DAY_NS, 2 * DAY_NS));
+        let chunks = reg.show_chunks("m");
+        // A window of [2d, 3d) overlaps only the second chunk — same
+        // arithmetic the RangeChild pruner runs against these bounds.
+        let lo = 2 * DAY_NS;
+        let hi = 3 * DAY_NS;
+        let overlapping: Vec<u64> = chunks
+            .iter()
+            .filter(|c| c.id.start_ns < hi && c.end_ns_exclusive > lo)
+            .map(|c| c.id.start_ns)
+            .collect();
+        assert_eq!(
+            overlapping,
+            vec![2 * DAY_NS],
+            "only in-window columnar chunk kept"
+        );
+        assert!(chunks.iter().all(|c| c.columnar_page.is_some()));
+    }
+
     #[test]
     fn chunks_expiring_within_previews_without_dropping() {
         let reg = HypertableRegistry::new();

--- a/tests/e2e_issue_859_columnar_chunk_eviction.rs
+++ b/tests/e2e_issue_859_columnar_chunk_eviction.rs
@@ -1,0 +1,144 @@
+//! Issue #859 — Phase 1 (verify): sealed *columnar* chunks evict via the
+//! EXISTING hypertable TTL / `drop_chunks` / partition-prune path.
+//!
+//! PRD #850 decision: reuse the live hypertable time-partition + TTL — do
+//! not rebuild it. A columnar chunk is one whose `ChunkMeta.columnar_page`
+//! is `Some(..)` (the RDCC `ColumnBlock` discriminant). These end-to-end
+//! tests inject such a chunk through the public registry (the same
+//! `restore_chunk` call the boot path uses) and drive eviction + pruning
+//! over the SQL scalar surface, proving the retention path is storage-form
+//! agnostic: columnar chunks drop in O(1) metadata work (no per-row
+//! delete) and are pruned out of time-range queries exactly like row
+//! chunks. No new TTL/partition subsystem is involved.
+
+use reddb::application::ExecuteQueryInput;
+use reddb::storage::engine::PageLocation;
+use reddb::storage::schema::Value;
+use reddb::storage::timeseries::{ChunkId, ChunkMeta};
+use reddb::{QueryUseCases, RedDBRuntime};
+
+const HOUR_NS: u64 = 3_600_000_000_000;
+
+fn rt() -> RedDBRuntime {
+    RedDBRuntime::in_memory().expect("in-memory runtime")
+}
+
+/// A sealed columnar chunk: carries an RDCC `columnar_page` and one row at
+/// `max_ts_ns` so it has a finite TTL expiry.
+fn columnar_chunk(hypertable: &str, start_ns: u64, max_ts_ns: u64) -> ChunkMeta {
+    let mut meta = ChunkMeta::new(
+        ChunkId {
+            hypertable: hypertable.into(),
+            start_ns,
+        },
+        start_ns + HOUR_NS,
+    );
+    meta.row_count = 1;
+    meta.min_ts_ns = max_ts_ns;
+    meta.max_ts_ns = max_ts_ns;
+    meta.sealed = true;
+    meta.columnar_page = Some(PageLocation::new(7, 0, 1234));
+    meta
+}
+
+#[test]
+fn columnar_chunk_evicts_via_sweep_expired_over_sql() {
+    let rt = rt();
+    let q = QueryUseCases::new(&rt);
+    // 1-hour chunks, 1-hour TTL — a chunk with max_ts=0 expires at 1h.
+    q.execute(ExecuteQueryInput {
+        query: "CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1h' TTL '1h'".into(),
+    })
+    .expect("create ok");
+
+    // Inject a sealed columnar chunk — the read-bridge / INSERT→seal wiring
+    // is out of scope (#861); we restore the chunk the boot path would.
+    rt.db()
+        .hypertables()
+        .restore_chunk(columnar_chunk("metrics", 0, 0));
+    assert!(
+        rt.db().hypertables().show_chunks("metrics")[0]
+            .columnar_page
+            .is_some(),
+        "precondition: the chunk is columnar-backed"
+    );
+
+    // Sweep at 3h via the existing scalar — the columnar chunk must drop.
+    let now_ns = 3 * HOUR_NS;
+    let r = q
+        .execute(ExecuteQueryInput {
+            query: format!("SELECT HYPERTABLE_SWEEP_EXPIRED('metrics', {now_ns}) AS n"),
+        })
+        .expect("sweep ok");
+    let n = r.result.records[0].get("n").expect("n");
+    assert!(
+        matches!(n, Value::Integer(1)),
+        "columnar chunk must evict via the existing TTL sweep, got {n:?}"
+    );
+    assert!(
+        rt.db().hypertables().show_chunks("metrics").is_empty(),
+        "sweep must reclaim the columnar chunk metadata"
+    );
+}
+
+#[test]
+fn columnar_chunk_drops_via_drop_chunks_before_over_sql() {
+    let rt = rt();
+    let q = QueryUseCases::new(&rt);
+    q.execute(ExecuteQueryInput {
+        query: "CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1h'".into(),
+    })
+    .expect("create ok");
+    rt.db()
+        .hypertables()
+        .restore_chunk(columnar_chunk("metrics", 0, 0));
+
+    let r = q
+        .execute(ExecuteQueryInput {
+            query: format!("SELECT HYPERTABLE_DROP_CHUNKS_BEFORE('metrics', {HOUR_NS}) AS n"),
+        })
+        .expect("drop ok");
+    let n = r.result.records[0].get("n").expect("n");
+    assert!(
+        matches!(n, Value::Integer(1)),
+        "drop_chunks_before must drop the columnar chunk, got {n:?}"
+    );
+    assert!(rt.db().hypertables().show_chunks("metrics").is_empty());
+}
+
+#[test]
+fn columnar_chunk_is_pruned_outside_time_range_over_sql() {
+    // Acceptance #2: partition pruning (Phase 0 #902) holds for columnar
+    // chunks — the pruner selects on chunk bounds, never on columnar_page.
+    let rt = rt();
+    let q = QueryUseCases::new(&rt);
+    q.execute(ExecuteQueryInput {
+        query: "CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1h'".into(),
+    })
+    .expect("create ok");
+    let db = rt.db();
+    let reg = db.hypertables();
+    reg.restore_chunk(columnar_chunk("metrics", 0, 0));
+    reg.restore_chunk(columnar_chunk("metrics", HOUR_NS, HOUR_NS));
+    reg.restore_chunk(columnar_chunk("metrics", 2 * HOUR_NS, 2 * HOUR_NS));
+
+    // Window [1h, 2h) overlaps exactly the middle columnar chunk.
+    let r = q
+        .execute(ExecuteQueryInput {
+            query: format!(
+                "SELECT HYPERTABLE_PRUNE_CHUNKS('metrics', {lo}, {hi}) AS kept",
+                lo = HOUR_NS,
+                hi = 2 * HOUR_NS,
+            ),
+        })
+        .expect("prune ok");
+    let kept = r.result.records[0].get("kept").expect("kept");
+    match kept {
+        Value::Array(v) => assert_eq!(
+            v.len(),
+            1,
+            "exactly one in-window columnar chunk kept, got {v:?}"
+        ),
+        other => panic!("expected Array, got {other:?}"),
+    }
+}


### PR DESCRIPTION
Automated AFK landing for #859. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782855158&installation_id=129708444&pr_number=907&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F907&signature=bc1b2e887c100fb529d4ffb9ec38ab8690c9a338cb6bd9097f38759cf698abf0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended hypertable test suite with comprehensive coverage for columnar chunk eviction and pruning behavior, including TTL sweeps, metadata dropping, and time-range query pruning validation.

**Note:** This release contains internal testing improvements with no user-facing feature changes or public API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->