### PR TITLE
merge: #911 Phase 3: activate columnar storage end-to-end (flush→seal_chunk_with_config + DDL surface to set analytical_storage.columnar)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_schema.rs
+++ b/crates/reddb-server/src/application/ports_impls_schema.rs
@@ -105,6 +105,9 @@ impl RuntimeSchemaPort for RedDBRuntime {
             hypertable: None,
             session_key: None,
             session_gap_ms: None,
+            // Programmatic create_timeseries has no DDL surface for the
+            // columnar flag; default to the row engine (#911).
+            columnar: false,
         };
         RedDBRuntime::execute_create_timeseries(self, &raw_query, &query)
     }

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -198,6 +198,153 @@ impl RedDBRuntime {
             "drop",
         ))
     }
+
+    /// Seal every still-open chunk of a hypertable, routing each seal
+    /// through [`seal_chunk_with_config`](crate::storage::timeseries::chunk::seal_chunk_with_config)
+    /// — the production caller PRD #850 lacked (#911). For a collection
+    /// whose contract carries `analytical_storage.columnar = true`, the
+    /// chunk's rows are materialised from the entity store into a
+    /// `TimeSeriesChunk`, sealed columnar, and the resulting RDCC
+    /// `ColumnBlock` recorded in `ChunkMeta.columnar_page` (bytes stashed
+    /// for read-back). Without the flag the chunk falls to the row seal
+    /// and `columnar_page` stays `None` — no behaviour change. Returns the
+    /// number of chunks sealed columnar.
+    pub fn seal_hypertable_chunks(&self, collection: &str) -> RedDBResult<usize> {
+        let analytical = self
+            .inner
+            .db
+            .collection_contract(collection)
+            .and_then(|c| c.analytical_storage.clone());
+        let registry = self.inner.db.hypertables();
+        let Some(spec) = registry.get(collection) else {
+            return Ok(0);
+        };
+        let time_col = spec.time_column.clone();
+        let store = self.inner.db.store();
+        let Some(manager) = store.get_collection(collection) else {
+            return Ok(0);
+        };
+
+        let mut sealed_columnar = 0usize;
+        for meta in registry.show_chunks(collection) {
+            if meta.sealed {
+                continue;
+            }
+            let start = meta.id.start_ns;
+            let end = meta.end_ns_exclusive;
+
+            // Materialise (ts, value) for rows whose time-column value
+            // lands in this chunk's `[start, end)` window.
+            let mut points: Vec<(u64, f64)> = manager
+                .query_all(|entity| {
+                    entity
+                        .data
+                        .as_row()
+                        .and_then(|row| row.get_field(&time_col))
+                        .and_then(field_as_u64)
+                        .is_some_and(|ts| ts >= start && ts < end)
+                })
+                .iter()
+                .filter_map(|entity| {
+                    let row = entity.data.as_row()?;
+                    let ts = row.get_field(&time_col).and_then(field_as_u64)?;
+                    let value = row.get_field("value").and_then(field_as_f64).unwrap_or(0.0);
+                    Some((ts, value))
+                })
+                .collect();
+            points.sort_by_key(|(ts, _)| *ts);
+
+            let mut chunk = crate::storage::timeseries::TimeSeriesChunk::with_max_points(
+                collection.to_string(),
+                HashMap::new(),
+                points.len().max(1),
+            );
+            for (ts, value) in &points {
+                chunk.append(*ts, *value);
+            }
+
+            let routed = crate::storage::timeseries::chunk::seal_chunk_with_config(
+                &mut chunk,
+                analytical.as_ref(),
+                start,
+                0,
+            )
+            .map_err(|err| RedDBError::Internal(format!("columnar seal failed: {err:?}")))?;
+
+            match routed {
+                crate::storage::timeseries::chunk::SealedChunkStorage::Columnar(bytes) => {
+                    let page = crate::storage::engine::PageLocation::new(0, 0, bytes.len() as u32);
+                    registry.seal_chunk_columnar(&meta.id, page, bytes);
+                    sealed_columnar += 1;
+                }
+                crate::storage::timeseries::chunk::SealedChunkStorage::Row => {
+                    registry.seal_chunk(&meta.id);
+                }
+            }
+        }
+        Ok(sealed_columnar)
+    }
+
+    /// Count this hypertable's chunks that were sealed columnar — i.e.
+    /// whose `ChunkMeta.columnar_page` is set (#911). Lets a caller assert
+    /// the columnar arm fired without exposing the registry's chunk type.
+    pub fn columnar_chunk_count(&self, collection: &str) -> usize {
+        self.inner
+            .db
+            .hypertables()
+            .show_chunks(collection)
+            .iter()
+            .filter(|meta| meta.columnar_page.is_some())
+            .count()
+    }
+
+    /// Read back a columnar-sealed chunk's points over `[start_ns, end_ns]`
+    /// (inclusive) via the #856 column-block range scan, decoding the RDCC
+    /// `ColumnBlock` recorded by [`seal_hypertable_chunks`](Self::seal_hypertable_chunks).
+    /// `None` when the chunk was not sealed columnar (or its bytes are not
+    /// RAM-resident). Points come back as `(timestamp_ns, value)`.
+    pub fn columnar_chunk_points(
+        &self,
+        collection: &str,
+        chunk_start_ns: u64,
+        start_ns: u64,
+        end_ns: u64,
+    ) -> Option<Vec<(u64, f64)>> {
+        let id = crate::storage::timeseries::ChunkId {
+            hypertable: collection.to_string(),
+            start_ns: chunk_start_ns,
+        };
+        let bytes = self.inner.db.hypertables().columnar_block(&id)?;
+        let scan =
+            crate::storage::timeseries::chunk::query_column_block_range(&bytes, start_ns, end_ns)
+                .ok()?;
+        Some(
+            scan.points
+                .iter()
+                .map(|p| (p.timestamp_ns, p.value))
+                .collect(),
+        )
+    }
+}
+
+/// Read a row field as a non-negative `u64` timestamp, accepting the
+/// integer shapes the INSERT path stores for a time column (#911).
+fn field_as_u64(value: &Value) -> Option<u64> {
+    match value {
+        Value::Integer(n) | Value::BigInt(n) | Value::Timestamp(n) if *n >= 0 => Some(*n as u64),
+        Value::UnsignedInteger(n) => Some(*n),
+        _ => None,
+    }
+}
+
+/// Read a row field as `f64` for the columnar value column (#911).
+fn field_as_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Float(f) => Some(*f),
+        Value::Integer(n) | Value::BigInt(n) => Some(*n as f64),
+        Value::UnsignedInteger(n) => Some(*n as f64),
+        _ => None,
+    }
 }
 
 fn save_timeseries_metadata(
@@ -276,10 +423,31 @@ fn remove_timeseries_metadata(store: &crate::storage::unified::UnifiedStore, ser
     }
 }
 
+/// Build the contract's [`AnalyticalStorageConfig`] when the DDL carried
+/// `COLUMNAR` (#911). `time_key` is the column carrying the time axis —
+/// the hypertable's declared time column, or the timeseries `timestamp`
+/// convention. `None` when columnar was not requested, so non-columnar
+/// collections keep the row engine default.
+fn analytical_storage_for(
+    columnar: bool,
+    time_key: &str,
+) -> Option<crate::catalog::AnalyticalStorageConfig> {
+    columnar.then(|| crate::catalog::AnalyticalStorageConfig {
+        columnar: true,
+        time_key: time_key.to_string(),
+        order_by_key: None,
+    })
+}
+
 fn hypertable_collection_contract(
     query: &CreateTimeSeriesQuery,
 ) -> crate::physical::CollectionContract {
     let now = current_unix_ms();
+    let time_key = query
+        .hypertable
+        .as_ref()
+        .map(|ht| ht.time_column.as_str())
+        .unwrap_or("timestamp");
     crate::physical::CollectionContract {
         name: query.name.clone(),
         // Table model — rows go through the normal INSERT path,
@@ -313,7 +481,7 @@ fn hypertable_collection_contract(
         session_key: None,
         session_gap_ms: None,
         retention_duration_ms: None,
-        analytical_storage: None,
+        analytical_storage: analytical_storage_for(query.columnar, time_key),
     }
 }
 
@@ -355,7 +523,9 @@ fn timeseries_collection_contract(
         session_key: query.session_key.clone(),
         session_gap_ms: query.session_gap_ms,
         retention_duration_ms: None,
-        analytical_storage: None,
+        // Plain timeseries store points under the `timestamp` axis
+        // convention (the `value` column carries the measurement).
+        analytical_storage: analytical_storage_for(query.columnar, "timestamp"),
     }
 }
 

--- a/crates/reddb-server/src/storage/query/core.rs
+++ b/crates/reddb-server/src/storage/query/core.rs
@@ -2714,6 +2714,12 @@ pub struct CreateTimeSeriesQuery {
     /// `SESSION_GAP <duration>` — default inactivity gap (ms) for the
     /// `SESSIONIZE` operator. Issue #576 slice 1.
     pub session_gap_ms: Option<u64>,
+    /// `COLUMNAR` — activate columnar analytical storage (PRD #850,
+    /// #911). When true the collection contract is built with
+    /// `analytical_storage.columnar = true`, so sealing a chunk routes
+    /// through `seal_chunk_with_config`'s columnar arm and emits an
+    /// RDCC `ColumnBlock` instead of the row seal.
+    pub columnar: bool,
 }
 
 /// Hypertable-specific DDL fields — set only when the caller used

--- a/crates/reddb-server/src/storage/query/parser/timeseries.rs
+++ b/crates/reddb-server/src/storage/query/parser/timeseries.rs
@@ -20,6 +20,7 @@ impl<'a> Parser<'a> {
         let mut downsample_policies = Vec::new();
         let mut session_key: Option<String> = None;
         let mut session_gap_ms: Option<u64> = None;
+        let mut columnar = false;
 
         // Parse optional clauses in any order
         loop {
@@ -29,6 +30,9 @@ impl<'a> Parser<'a> {
                 retention_ms = Some((value * unit) as u64);
             } else if self.consume_ident_ci("CHUNK_SIZE")? || self.consume_ident_ci("CHUNKSIZE")? {
                 chunk_size = Some(self.parse_integer()? as usize);
+            } else if self.consume_ident_ci("COLUMNAR")? {
+                // `COLUMNAR` — activate columnar analytical storage (#911).
+                columnar = true;
             } else if self.consume_ident_ci("DOWNSAMPLE")? {
                 downsample_policies.push(self.parse_downsample_policy_spec()?);
                 while self.consume(&Token::Comma)? {
@@ -55,6 +59,7 @@ impl<'a> Parser<'a> {
             hypertable: None,
             session_key,
             session_gap_ms,
+            columnar,
         }))
     }
 
@@ -353,12 +358,16 @@ impl<'a> Parser<'a> {
         let mut chunk_interval_ns: Option<u64> = None;
         let mut ttl_ns: Option<u64> = None;
         let mut retention_ms = None;
+        let mut columnar = false;
 
         loop {
             if self.consume_ident_ci("TIME_COLUMN")? {
                 time_column = Some(self.expect_ident()?);
             } else if self.consume_ident_ci("CHUNK_INTERVAL")? {
                 chunk_interval_ns = Some(self.parse_duration_ns_literal("CHUNK_INTERVAL")?);
+            } else if self.consume_ident_ci("COLUMNAR")? {
+                // `COLUMNAR` — activate columnar analytical storage (#911).
+                columnar = true;
             } else if self.consume_ident_ci("TTL")? {
                 ttl_ns = Some(self.parse_duration_ns_literal("TTL")?);
             } else if self.consume(&Token::Retention)? {
@@ -396,6 +405,7 @@ impl<'a> Parser<'a> {
             }),
             session_key: None,
             session_gap_ms: None,
+            columnar,
         }))
     }
 

--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -211,6 +211,13 @@ struct RegistryInner {
     /// by name produce an ordered view (show_chunks must be
     /// deterministic).
     chunks: BTreeMap<(String, u64), ChunkMeta>,
+    /// `(hypertable, start_ns)` → the sealed chunk's RDCC `ColumnBlock`
+    /// bytes, populated by [`seal_chunk_columnar`](HypertableRegistry::seal_chunk_columnar)
+    /// (PRD #850, #911). RAM-resident: the migration discriminant
+    /// `ChunkMeta.columnar_page` persists across restart, but durable
+    /// engine-page persistence of these bytes is a follow-up — until the
+    /// page-write bridge lands, a columnar chunk's block lives only here.
+    columnar_blocks: BTreeMap<(String, u64), Vec<u8>>,
 }
 
 impl std::fmt::Debug for HypertableRegistry {
@@ -474,6 +481,43 @@ impl HypertableRegistry {
         } else {
             false
         }
+    }
+
+    /// Seal a chunk **columnar** (PRD #850, #911): mark it sealed, record
+    /// where its RDCC `ColumnBlock` lives in `ChunkMeta.columnar_page`,
+    /// and stash the block `bytes` so the columnar read path can decode
+    /// them. The columnar counterpart of [`seal_chunk`](Self::seal_chunk)
+    /// — the production caller (`seal_chunk_with_config`'s columnar arm)
+    /// hands the sealed bytes here. Returns `true` if the chunk existed.
+    pub fn seal_chunk_columnar(&self, id: &ChunkId, page: PageLocation, bytes: Vec<u8>) -> bool {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let key = (id.hypertable.clone(), id.start_ns);
+        if let Some(meta) = guard.chunks.get_mut(&key) {
+            meta.sealed = true;
+            meta.columnar_page = Some(page);
+            guard.columnar_blocks.insert(key, bytes);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Fetch the RDCC `ColumnBlock` bytes recorded for a columnar-sealed
+    /// chunk by [`seal_chunk_columnar`](Self::seal_chunk_columnar). `None`
+    /// for row-sealed chunks or chunks whose bytes are not RAM-resident
+    /// (e.g. after a restart, pending the durable page-write bridge).
+    pub fn columnar_block(&self, id: &ChunkId) -> Option<Vec<u8>> {
+        let guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        guard
+            .columnar_blocks
+            .get(&(id.hypertable.clone(), id.start_ns))
+            .cloned()
     }
 
     /// Total row count across every chunk of `hypertable`. Used by

--- a/crates/reddb-server/tests/columnar_activation_e2e.rs
+++ b/crates/reddb-server/tests/columnar_activation_e2e.rs
@@ -1,0 +1,93 @@
+//! #911 — columnar storage activation, end-to-end.
+//!
+//! PRD #850 built the RDCC columnar engine (seal, granule index, bloom
+//! skip, vectorized read) but left it dark: no production path activated
+//! it. This test pins the activation wiring this slice adds:
+//!
+//!   1. `CREATE HYPERTABLE ... COLUMNAR` sets the contract's
+//!      `analytical_storage.columnar = true`.
+//!   2. `RedDBRuntime::seal_hypertable_chunks` — the production caller of
+//!      `seal_chunk_with_config` — routes a columnar chunk's seal through
+//!      the columnar arm, emitting an RDCC `ColumnBlock` and recording
+//!      `ChunkMeta.columnar_page`.
+//!   3. Read-back over that columnar chunk (the #856 column-block range
+//!      scan) returns the ingested points.
+//!   4. A hypertable created WITHOUT `COLUMNAR` still seals row-oriented:
+//!      no `columnar_page`, no columnar block.
+
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+/// Points ingested in both cases. Timestamps are nanoseconds; with a 1h
+/// chunk interval they all land in the single chunk that starts at 0.
+const POINTS: &[(u64, i64)] = &[
+    (1_000_000_000, 10),
+    (2_000_000_000, 20),
+    (3_000_000_000, 30),
+    (4_000_000_000, 40),
+    (5_000_000_000, 50),
+];
+
+fn seed(rt: &RedDBRuntime, ddl: &str, collection: &str) {
+    rt.execute_query(ddl).expect("create hypertable");
+    for (ts, value) in POINTS {
+        rt.execute_query(&format!(
+            "INSERT INTO {collection} (ts, value) VALUES ({ts}, {value})"
+        ))
+        .unwrap_or_else(|e| panic!("insert ({ts}, {value}): {e}"));
+    }
+}
+
+#[test]
+fn columnar_hypertable_seals_through_columnar_arm_and_reads_back() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    seed(
+        &rt,
+        "CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h' COLUMNAR",
+        "cpu",
+    );
+
+    // Criterion 1: sealing routes through seal_chunk_with_config's
+    // columnar arm — the single chunk seals columnar.
+    let sealed = rt.seal_hypertable_chunks("cpu").expect("seal cpu");
+    assert_eq!(sealed, 1, "the single chunk must seal columnar");
+
+    // ... and the sealed chunk records a `ChunkMeta.columnar_page` (RDCC),
+    // proving it did NOT take the row arm.
+    assert_eq!(
+        rt.columnar_chunk_count("cpu"),
+        1,
+        "columnar chunk must record ChunkMeta.columnar_page"
+    );
+
+    // Criterion 2: read-back over the columnar chunk via the #856
+    // column-block range scan returns every ingested point.
+    let got = rt
+        .columnar_chunk_points("cpu", 0, 0, u64::MAX)
+        .expect("columnar chunk decodes back to points");
+    let want: Vec<(u64, f64)> = POINTS.iter().map(|(ts, v)| (*ts, *v as f64)).collect();
+    assert_eq!(got, want, "read-back must return the ingested points");
+}
+
+#[test]
+fn non_columnar_hypertable_seals_row_oriented() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    seed(
+        &rt,
+        "CREATE HYPERTABLE mem TIME_COLUMN ts CHUNK_INTERVAL '1h'",
+        "mem",
+    );
+
+    // Criterion 3: without the flag the chunk seals row-oriented — no
+    // columnar seal, no columnar_page, no columnar block to read.
+    let sealed = rt.seal_hypertable_chunks("mem").expect("seal mem");
+    assert_eq!(sealed, 0, "no chunk should seal columnar without the flag");
+    assert_eq!(
+        rt.columnar_chunk_count("mem"),
+        0,
+        "row-sealed chunk must NOT carry a columnar_page"
+    );
+    assert!(
+        rt.columnar_chunk_points("mem", 0, 0, u64::MAX).is_none(),
+        "row-sealed chunk exposes no columnar block"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #911. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782872561&installation_id=129708444&pr_number=913&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F913&signature=41e5680b00b28c519140d252d0512f8d5bbecb5a6f2f02ffef62da893365a378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `COLUMNAR` option for time-series and hypertable creation to enable columnar storage format.
  * Introduced `seal_hypertable_chunks()` to convert and seal time-series data chunks in columnar format.
  * Added `columnar_chunk_count()` to inspect the number of sealed columnar chunks.
  * Added `columnar_chunk_points()` to retrieve data points from columnar chunks within a timestamp range.

* **Tests**
  * Added end-to-end tests validating columnar activation for hypertables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->