### PR TITLE
merge: #912 docs: document the RDCC columnar chunk format + how to enable columnar/analytical storage

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -93,6 +93,7 @@
   - [WAL & Recovery](/engine/wal.md)
   - [SIEVE Cache](/engine/cache.md)
   - [Columnar Batch Execution](/engine/columnar-execution.md)
+  - [Columnar Chunk Format (RDCC)](/engine/columnar-chunk-format.md)
   - [Encryption at Rest](/engine/encryption.md)
 
 - **Architecture**

--- a/docs/data-models/hypertables.md
+++ b/docs/data-models/hypertables.md
@@ -86,6 +86,31 @@ Column lists alongside the DDL land with the unified
 Until then declare schemas via `CREATE TABLE` + `CREATE HYPERTABLE`
 pointing at the same name, or rely on dynamic typing.
 
+## Columnar storage
+
+Append the `COLUMNAR` keyword to opt a hypertable into **columnar**
+analytical storage. Sealed chunks are then written in the column-major
+[RDCC format](../engine/columnar-chunk-format.md) instead of the default
+row form — per-column codecs plus a sparse min/max granule index and a
+per-granule bloom skip index, so analytical scans over sealed history prune
+and decode only the data they need.
+
+```sql
+-- Same hypertable, sealed chunks stored columnar.
+CREATE HYPERTABLE cpu
+  TIME_COLUMN ts
+  CHUNK_INTERVAL '1h'
+  COLUMNAR;
+```
+
+`COLUMNAR` composes with `TIME_COLUMN`, `CHUNK_INTERVAL`, `TTL`, and
+`RETENTION` in any order. It is a per-collection, create-time choice: only
+chunks that seal *after* the flag is set are written columnar, and open
+chunks ingest identically to the row engine. Leave it off (the default) for
+general-purpose collections. See
+[Time-Series → When to use columnar vs row](./timeseries.md#when-to-use-columnar-vs-row)
+for the decision note.
+
 ## API
 
 | Statement                                     | Behaviour |

--- a/docs/data-models/timeseries.md
+++ b/docs/data-models/timeseries.md
@@ -152,6 +152,61 @@ Time-series data uses a chunked storage model for efficiency:
 - **Chunks seal automatically** when full, enabling immutable compressed storage
 - **Retention policies** run in the maintenance cycle, dropping expired chunks
 
+## Columnar analytical storage
+
+By default a sealed chunk is stored **row-oriented**. For analytical
+workloads — large scans and aggregations over sealed history — you can opt a
+collection into **columnar** storage with the `COLUMNAR` keyword at create
+time. Sealed chunks are then written in the column-major
+[RDCC format](../engine/columnar-chunk-format.md): each column is compressed
+with a codec matched to its shape (delta-of-delta for timestamps, Gorilla
+XOR for float values) and carries skip indexes so the reader prunes data it
+cannot need.
+
+```sql
+-- A columnar time-series collection.
+CREATE TIMESERIES cpu_cold COLUMNAR RETENTION 365 d
+```
+
+`COLUMNAR` is a standalone keyword and composes with the other clauses in any
+order (`RETENTION`, `CHUNK_SIZE`, `DOWNSAMPLE`, …). It is also accepted on
+`CREATE HYPERTABLE` — see [Hypertables → Columnar storage](./hypertables.md#columnar-storage).
+
+### Worked example
+
+```sql
+-- 1. Create a columnar hypertable: sealed chunks land in RDCC form.
+CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h' COLUMNAR;
+
+-- 2. Ingest normally — writes are buffered in the open (row) chunk.
+INSERT INTO cpu (ts, value) VALUES (1000000000, 10);
+INSERT INTO cpu (ts, value) VALUES (2000000000, 20);
+INSERT INTO cpu (ts, value) VALUES (3000000000, 30);
+
+-- 3. Query as usual.
+SELECT ts, value FROM cpu WHERE ts BETWEEN 1000000000 AND 3000000000;
+```
+
+What changes is purely physical: when a chunk **seals**, a columnar
+collection emits an RDCC `ColumnBlock` instead of a row-sealed chunk, and
+records it in the chunk's `columnar_page`. On read, that block is pruned by
+the per-column **sparse granule index** (min/max per granule, for range
+predicates) and the **per-granule bloom** (for equality predicates) before
+any surviving granule is decoded. Open (unsealed) chunks are unaffected —
+ingestion and recent-data queries behave identically to the row engine.
+
+### When to use columnar vs row
+
+| Workload | Storage |
+|:---------|:--------|
+| Analytical scans / aggregations over large sealed history | **Columnar** (`COLUMNAR`) |
+| General-purpose collections, point lookups, recent-data reads | **Row** (default) |
+
+Columnar wins when queries sweep many sealed rows but touch few columns and
+benefit from granule + bloom skipping. The row engine stays the default for
+everything else — it has lower per-chunk overhead and no transpose cost on
+seal. The choice is per collection and fixed at create time.
+
 ## Retention Policies
 
 Three complementary knobs, strongest first:

--- a/docs/engine/columnar-chunk-format.md
+++ b/docs/engine/columnar-chunk-format.md
@@ -1,0 +1,228 @@
+# RDCC — Columnar Chunk Format
+
+When a time-series / hypertable collection is created with the
+[`COLUMNAR`](../data-models/timeseries.md#columnar-analytical-storage)
+option, a sealed chunk is written to disk in a column-major envelope
+called **`RDCC`** (RedDB Columnar Chunk) instead of the default row form.
+This page documents that on-disk byte contract. It is engine-facing: it
+describes exactly what the writer emits so the format stays auditable and a
+reader can be implemented from this page alone.
+
+> Source of truth:
+> [`storage/unified/column_block.rs`](../../../crates/reddb-server/src/storage/unified/column_block.rs)
+> (the envelope) and
+> [`storage/unified/segment_codec.rs`](../../../crates/reddb-server/src/storage/unified/segment_codec.rs)
+> (the per-column codec pipeline). The chunk-level writer/reader live in
+> [`storage/timeseries/chunk.rs`](../../../crates/reddb-server/src/storage/timeseries/chunk.rs).
+
+An `RDCC` block is **not** a parallel object alongside the chunk — the
+sealed chunk *is* the columnar segment. PRD #850 explicitly rejects a
+standalone "columnar segment" as a storage-bloat vector. The block is
+emitted as a [`PageType::ColumnBlock`](pager.md) page, and the sealed
+chunk records its `PageLocation` in `ChunkMeta.columnar_page`.
+
+## Why columnar at all
+
+A sealed chunk is immutable history. Analytical scans over it read one or
+two columns out of many and run min/max/sum/count reductions. Storing the
+chunk column-major lets the engine:
+
+- compress each column with a codec matched to its shape (timestamps vs.
+  float gauges compress very differently);
+- skip whole **granules** (row ranges) that cannot match a predicate,
+  using a sparse min/max index for ranges and a per-granule bloom for
+  equality — without decompressing them;
+- decode only the columns a query references (projection pushdown).
+
+The row engine stays the default for general-purpose collections. See
+[When to use columnar vs row](../data-models/timeseries.md#when-to-use-columnar-vs-row).
+
+## Block layout
+
+All multi-byte integers are **little-endian**. The block opens and closes
+with the magic `b"RDCC"`, so a truncated or corrupt block is caught at both
+ends, and an interior CRC32 guards the payload.
+
+```text
+Header (52 bytes)
+  magic            b"RDCC"   (4)
+  format_version   u16  = 1
+  flags            u16  = 0           reserved
+  chunk_id         u64
+  schema_ref       u64                catalog schema id the column_ids resolve against
+  row_count        u64
+  column_count     u32
+  min_ts_ns        u64                mirrors ChunkMeta → block is self-describing
+  max_ts_ns        u64
+
+Column directory   (column_count entries, 54 bytes each, at offset 52)
+  column_id            u32
+  logical_type         u8             value type tag (DataType::to_byte)
+  codec                u8             leading (semantic) ColumnCodec tag
+  stream_offset        u64            byte offset of this column's stream
+  stream_len           u64
+  granule_index_off    u64            offset of this column's granule index (0 = none)
+  granule_index_len    u64            length of the granule index blob (0 = none)
+  bloom_off            u64            offset of this column's granule bloom (0 = none)
+  bloom_len            u64            length of the granule bloom blob (0 = none)
+
+Column streams        column_count codec-pipeline runs, back-to-back
+Granule indexes       per-column min/max blobs, back-to-back
+Granule blooms        per-column bloom blobs, back-to-back
+
+Footer (24 bytes)
+  col_directory_off    u64
+  col_directory_len    u64
+  crc32                u32            over every byte before the footer
+  magic_tail           b"RDCC"  (4)
+```
+
+The header is fixed at **52 bytes**, each directory entry is **54 bytes**,
+and the footer is **24 bytes**. `format_version` is `1`; the directory
+carries reserved offset/length fields (granule index, bloom) so additive
+extensions land without bumping the version — a reader rejects any version
+it does not understand.
+
+### CRC coverage
+
+The footer's `crc32` is computed over **every byte before the footer** —
+header, directory, all column streams, all granule indexes, and all granule
+blooms. (The inline code comment abbreviates this as "header+directory+
+streams"; the writer in fact CRCs the whole pre-footer buffer.) On read the
+CRC is always verified before any column is decoded — integrity is not
+negotiable, even under projection pushdown.
+
+## Column directory
+
+One 54-byte entry per column, in write order. `logical_type` is the
+`DataType::to_byte()` tag; `codec` is the **leading** codec of the column's
+pipeline (see below), recorded purely as self-describing bookkeeping — the
+reader actually decodes from each stream's own header, never from this byte.
+`stream_offset`/`stream_len` locate the column's compressed bytes. The
+`granule_index_*` and `bloom_*` pairs locate the column's skip indexes, or
+are both zero when the column has none (e.g. variable-width columns).
+
+A time-series chunk writes exactly two columns:
+
+| `column_id` | meaning | `logical_type` | semantics → codec |
+|:-----------:|:--------|:---------------|:------------------|
+| `0` | timestamp (ns) | `UnsignedInteger` | `Timestamp` → DoubleDelta + ZSTD(3) |
+| `1` | value | `Float` | `Gauge` → Xor + ZSTD(3) |
+
+## Per-column codec pipeline
+
+Each column stream is one `segment_codec` pipeline output. The codec chain
+is chosen **per column from its semantics**, not globally. The directory's
+`codec` byte records the leading (semantic) codec; the full chain is
+self-described inside the stream header so reads never consult the schema.
+
+Codec tags (one byte, stored in stream + directory headers):
+
+| Tag | Codec | Best on |
+|:---:|:------|:--------|
+| 0 | `None` | small / already-compressed data |
+| 1 | `Lz4` | generic fast compression |
+| 2 | `Zstd { level }` | generic, higher ratio than LZ4 |
+| 3 | `Delta` | monotonic / near-monotonic ints (counters) |
+| 4 | `DoubleDelta` | regular-interval timestamps |
+| 5 | `Dict` | low-cardinality strings / enums |
+| 6 | `Xor` | floating-point gauges (Gorilla XOR) |
+
+Semantics drive selection. Every semantic codec is chained with `ZSTD(3)`
+so the residual stream the leading codec re-shapes into mostly-zero bytes is
+actually shrunk on disk — the ClickHouse `CODEC(DoubleDelta, ZSTD)` posture:
+
+| Column semantics | Pipeline |
+|:-----------------|:---------|
+| `Timestamp` | `DoubleDelta` → `ZSTD(3)` |
+| `Gauge` | `Xor` → `ZSTD(3)` |
+| `Counter` | `Delta` → `ZSTD(3)` |
+| `LowCardinality` | `Dict` → `ZSTD(3)` |
+| `Generic` | `ZSTD(3)` |
+
+The stream header records the chain so decode just runs the codecs in
+reverse. Round-trips are lossless for every codec/type pair the selector
+emits, including special floats (NaN / ±inf / signed zero survive the XOR
+path bit-for-bit).
+
+## Sparse granule index (range pruning)
+
+A column's rows are tiled into fixed-size **granules** — one min/max mark
+per `granule_size` rows. The default stride is **8192 rows**
+(`DEFAULT_GRANULE_SIZE`), configurable per seal. This is the chunk's
+BRIN-style skip index made granular: the reader keeps only granules whose
+`[min, max]` interval can intersect a range predicate and materialises just
+those, leaving the rest compressed.
+
+```text
+Granule index blob (per indexed column)
+  granule_size_rows    u32            rows per mark (the last mark may be shorter)
+  value_width          u32            bytes per min/max value (8 for u64/f64)
+  granule_count        u32
+  per granule:  min[value_width]  max[value_width]   raw column-encoded bytes
+```
+
+`min`/`max` are stored in the column's own little-endian encoding, but the
+*ordering* used to compute them is type-aware (`i64` / `u64` / `f64` via
+`f64::total_cmp`) because raw byte order is wrong for signed ints and floats.
+The index covers only fixed-width numeric columns; variable-width streams
+(e.g. dictionary-coded text) get a zero-length slice and no index.
+
+**Soundness:** a granule survives whenever `granule_min <= end &&
+granule_max >= start`, i.e. exactly when it *could* hold a matching row, so
+pruning never drops a match regardless of where granule boundaries fall.
+When a block carries no index, every row is scanned (still correct). Pruning
+is observable — a selective scan reports `granules_scanned < granules_total`.
+
+## Per-granule bloom skip index (equality pruning)
+
+Where min/max serves ranges, a **split-block bloom filter** per granule —
+tiled on the same boundaries — serves equality / point predicates. Each
+value in a granule is folded through `hash_bytes_u32` and inserted; an
+equality probe keeps only granules whose bloom *may* contain the target.
+
+```text
+Granule bloom blob (per indexed column)
+  granule_size_rows    u32            rows per bloom (the last bloom may cover fewer)
+  granule_count        u32
+  per granule:  num_blocks u32        then num_blocks × 32 bytes of bloom words
+```
+
+**Soundness:** a split-block bloom never reports a false negative, so a
+granule that actually holds the target always probes true and survives —
+equality pruning over-includes (false positives) but never under-includes.
+Survivors are still compared exactly per row, on the raw 8-byte encoding the
+bloom was built from.
+
+## Projection pushdown
+
+`read_column_block_projected(bytes, want)` decodes only the columns whose
+`column_id` appears in `want`. Columns outside the set are skipped *before*
+the expensive decode / granule / bloom parse — their compressed bytes are
+never touched — so a scan that references a subset of columns pays only for
+the columns it reads. The whole-block CRC is still verified regardless.
+
+## Read path
+
+The chunk-level reader transposes the two column streams back into
+`(timestamp_ns, value)` rows:
+
+- `points_from_column_block(bytes)` — full decode, every row.
+- `query_column_block_range(bytes, start_ns, end_ns)` — range scan that
+  prunes via the timestamp column's granule index.
+- `query_column_block_value_eq(bytes, target)` — point query that prunes via
+  the value column's granule bloom.
+
+The range and value-eq scans return a `PrunedColumnScan` carrying
+`granules_total` and `granules_scanned`, which is how pruning is made
+measurable end to end.
+
+## See also
+
+- [Columnar Batch Execution](columnar-execution.md) — the vectorized
+  `ColumnBatch` operators that consume decoded columns.
+- [`.rdb` File Format Specification](file-format.md) — the page-based
+  container an `RDCC` block lives inside (`PageType::ColumnBlock`).
+- [Time-Series → Columnar analytical storage](../data-models/timeseries.md#columnar-analytical-storage)
+  — how an operator turns this on.
+- PRD #850 (analytics storage engine); activation shipped in #911.

--- a/docs/engine/columnar-execution.md
+++ b/docs/engine/columnar-execution.md
@@ -71,10 +71,16 @@ ClickHouse's `CODEC(...)` syntax. Supported:
 * `Delta` — monotonic int streams (shares the TS Delta-of-Delta code)
 * `DoubleDelta` — regular-interval timestamps
 * `Dict` — low-cardinality strings
+* `Xor` — floating-point gauges (Gorilla XOR)
 
 Codecs chain: `CODEC(Delta, ZSTD(3))` encodes Delta first, then
 zstd. Decoding reverses the order. The header records the full
 chain, so reads never need the DDL.
+
+These codecs are the pipeline a sealed **columnar chunk** writes each
+column with. The on-disk envelope that wraps the streams — directory,
+granule index, bloom skip index, footer — is documented in
+[Columnar Chunk Format (RDCC)](columnar-chunk-format.md).
 
 ## Parallelism
 


### PR DESCRIPTION
Automated AFK landing for #912. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782874637&installation_id=129708444&pr_number=914&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F914&signature=c6375c2eb43d8f3cdc34e213cb6c8af45cc173fbdb56fdc39065e5a7693c2cb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for columnar storage in time-series data and hypertables, including the `COLUMNAR` keyword for opt-in column-major storage of sealed chunks.
  * Documented columnar chunk format (RDCC) specifications, including codec pipeline, skip-index mechanisms, and projection pushdown behavior.
  * Added guidance on when to use columnar vs row storage for different workload patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->