### PR TITLE
merge: #918 Leaderboard rank: exact MVCC-correct top-K head over a table score column (Ranking capability + RANK() SQL surface)

### DIFF
--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1369,6 +1369,7 @@ pub(crate) mod queue_lifecycle;
 pub(crate) mod queue_telemetry;
 pub(crate) mod queue_wait_registry;
 pub mod quota_bucket;
+pub(crate) mod ranking_descriptor_catalog;
 mod record_search;
 mod red_schema;
 pub(crate) mod replica_queue_store;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -66,6 +66,26 @@ thread_local! {
         const { std::cell::RefCell::new(None) };
 }
 
+/// Read a numeric score column out of a result record as `f64`, matching
+/// the column name case-insensitively. Used by the leaderboard-rank head
+/// walk (#918) to compare scores; non-numeric / missing columns yield
+/// `None` so a row with no comparable score never shifts a rank.
+fn record_column_f64(
+    rec: &crate::storage::query::unified::UnifiedRecord,
+    column: &str,
+) -> Option<f64> {
+    let value = rec
+        .get(column)
+        .or_else(|| rec.get(&column.to_lowercase()))?;
+    match value {
+        Value::Integer(n) => Some(*n as f64),
+        Value::UnsignedInteger(n) => Some(*n as f64),
+        Value::Float(n) => Some(*n),
+        Value::Timestamp(n) | Value::Duration(n) => Some(*n as f64),
+        _ => None,
+    }
+}
+
 fn secret_sql_value_to_string(value: &Value) -> RedDBResult<String> {
     match value {
         Value::Text(s) => Ok(s.to_string()),
@@ -184,6 +204,167 @@ impl RedDBRuntime {
             &format!("metric descriptor '{}' created", query.path),
             "create",
         ))
+    }
+
+    /// `CREATE RANKING <name> ON <table> (<column> [ASC|DESC]) [TOP <k>]`
+    /// — declare a Ranking capability over an ordinary table's score
+    /// column (issue #918 / ADR 0035). Persists a WAL-backed catalog
+    /// record; no new Collection model is introduced. Authorized through
+    /// the same DDL write gate as `CREATE METRIC`/`CREATE INDEX`.
+    fn execute_create_ranking(
+        &self,
+        raw_query: &str,
+        req: super::ranking_descriptor_catalog::CreateRankingRequest,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        self.check_write(crate::runtime::write_gate::WriteKind::Ddl)?;
+        let store = self.inner.db.store();
+        let descriptor = super::ranking_descriptor_catalog::create(store.as_ref(), &req)?;
+        self.invalidate_result_cache();
+        Ok(RuntimeQueryResult::ok_message(
+            raw_query.to_string(),
+            &format!(
+                "ranking '{}' created on {}({})",
+                descriptor.name, descriptor.table, descriptor.column
+            ),
+            "create",
+        ))
+    }
+
+    /// `SHOW RANKINGS` — project the declared Ranking capabilities back as
+    /// rows, so a declared capability is observable (the Analytics
+    /// "prefer SELECT over admin verbs" rule).
+    fn execute_show_rankings(&self, raw_query: &str) -> RedDBResult<RuntimeQueryResult> {
+        let store = self.inner.db.store();
+        let entries = super::ranking_descriptor_catalog::list(store.as_ref());
+        let columns = vec![
+            "name".to_string(),
+            "table".to_string(),
+            "column".to_string(),
+            "direction".to_string(),
+            "top_k".to_string(),
+        ];
+        let rows = entries
+            .into_iter()
+            .map(|e| {
+                vec![
+                    ("name".to_string(), Value::text(e.name)),
+                    ("table".to_string(), Value::text(e.table)),
+                    ("column".to_string(), Value::text(e.column)),
+                    (
+                        "direction".to_string(),
+                        Value::text(if e.descending { "DESC" } else { "ASC" }.to_string()),
+                    ),
+                    ("top_k".to_string(), Value::UnsignedInteger(e.top_k)),
+                ]
+            })
+            .collect();
+        Ok(RuntimeQueryResult::ok_records(
+            raw_query.to_string(),
+            columns,
+            rows,
+            "select",
+        ))
+    }
+
+    /// `RANK OF <id> IN <name>` — exact, MVCC-correct rank of a specific
+    /// row within the capability's bounded top-K head (issue #918).
+    ///
+    /// Returns a single `rank` row when the row is visible *and* falls
+    /// inside the exact head; an empty result otherwise (not visible, or
+    /// in the approximate tail — a separate slice). The computation runs
+    /// entirely over the regular read pipeline so it inherits MVCC
+    /// visibility, RLS/policy, and tenant scope from ordinary reads.
+    fn execute_rank_of(
+        &self,
+        raw_query: &str,
+        req: super::ranking_descriptor_catalog::RankOfRequest,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let store = self.inner.db.store();
+        let descriptor = super::ranking_descriptor_catalog::get(store.as_ref(), &req.ranking)
+            .ok_or_else(|| {
+                RedDBError::Query(format!("ranking '{}' does not exist", req.ranking))
+            })?;
+        let rank = self.compute_exact_head_rank(&descriptor, req.entity_id)?;
+        let columns = vec!["rank".to_string()];
+        let rows = match rank {
+            Some(rank) => vec![vec![("rank".to_string(), Value::UnsignedInteger(rank))]],
+            None => Vec::new(),
+        };
+        Ok(RuntimeQueryResult::ok_records(
+            raw_query.to_string(),
+            columns,
+            rows,
+            "select",
+        ))
+    }
+
+    /// Compute the exact rank of `target_id` within the descriptor's
+    /// bounded top-K head, or `None` if the row is invisible to the
+    /// querying snapshot or beyond the exact head.
+    ///
+    /// Faithful to ADR 0035: it walks the sorted index head
+    /// (`ORDER BY <col> {DESC|ASC} LIMIT k`, served by
+    /// `try_sorted_index_lookup` + the per-row MVCC visibility re-check)
+    /// and counts only rows visible to the current snapshot. Running the
+    /// head scan through `execute_query_inner` keeps it on the same
+    /// snapshot/tenant/policy frame as ordinary reads, so the rank agrees
+    /// with `ORDER BY <col> {DESC|ASC} LIMIT` under that snapshot by
+    /// construction. RANK semantics: tied scores share a rank, so the
+    /// rank is `1 + (number of strictly-better visible rows)`.
+    fn compute_exact_head_rank(
+        &self,
+        descriptor: &super::ranking_descriptor_catalog::RankingDescriptor,
+        target_id: u64,
+    ) -> RedDBResult<Option<u64>> {
+        let table = &descriptor.table;
+        let column = &descriptor.column;
+
+        // The exact head: top-K rows in rank order. Each row here already
+        // passed MVCC visibility *and* RLS/tenant filtering during the
+        // scan, so identifying the target *within* this result (rather
+        // than via a separate `red_entity_id` lookup, which takes the
+        // direct entity-fetch path that bypasses the RLS gate) is what
+        // makes the rank honor policy/tenant scope (criterion 5).
+        let dir = if descriptor.descending { "DESC" } else { "ASC" };
+        let head_sql = format!(
+            "SELECT * FROM {table} ORDER BY {column} {dir} LIMIT {}",
+            descriptor.top_k
+        );
+        let head_result = self.execute_query_inner(&head_sql)?;
+        let head = &head_result.result.records;
+
+        // Locate the target inside the head. Not present ⇒ either invisible
+        // to this snapshot/tenant, or beyond the exact head — both correctly
+        // yield "no exact rank" (the approximate tail is a separate slice).
+        let target_score = head.iter().find_map(|rec| {
+            let rid = match rec.get("rid") {
+                Some(Value::UnsignedInteger(n)) => *n,
+                Some(Value::Integer(n)) if *n >= 0 => *n as u64,
+                _ => return None,
+            };
+            (rid == target_id).then(|| record_column_f64(rec, column))?
+        });
+        let Some(target_score) = target_score else {
+            return Ok(None);
+        };
+
+        // RANK semantics: tied scores share a rank, so the rank is
+        // 1 + (number of strictly-better visible rows in the head).
+        let mut strictly_better = 0u64;
+        for rec in head {
+            let Some(score) = record_column_f64(rec, column) else {
+                continue;
+            };
+            let better = if descriptor.descending {
+                score > target_score
+            } else {
+                score < target_score
+            };
+            if better {
+                strictly_better += 1;
+            }
+        }
+        Ok(Some(strictly_better + 1))
     }
 
     fn execute_alter_metric(
@@ -6171,6 +6352,22 @@ impl RedDBRuntime {
             return Err(super::metric_descriptor_catalog::read_output_unsupported(
                 &path,
             ));
+        }
+
+        // Issue #918 / ADR 0035 — leaderboard rank capability. These are
+        // narrow string intercepts (the `READ METRIC` precedent) so the
+        // surface stays off the recursive-descent grammar. `RANK() OVER`
+        // window projections are unaffected — they parse `SELECT … RANK()`
+        // and never match the `RANK OF`/`CREATE RANKING`/`SHOW RANKINGS`
+        // statement heads.
+        if let Some(parsed) = super::ranking_descriptor_catalog::parse_create_ranking(query) {
+            return self.execute_create_ranking(query, parsed?);
+        }
+        if super::ranking_descriptor_catalog::parse_show_rankings(query) {
+            return self.execute_show_rankings(query);
+        }
+        if let Some(parsed) = super::ranking_descriptor_catalog::parse_rank_of(query) {
+            return self.execute_rank_of(query, parsed?);
         }
 
         let rewritten_query = super::red_schema::rewrite_virtual_names(query);

--- a/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
+++ b/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
@@ -1,0 +1,454 @@
+//! Ranking capability catalog persisted in `red_config`.
+//!
+//! Issue #918 / ADR 0035 — leaderboard rank as a *table capability*. A
+//! `CREATE RANKING` statement declares order-statistics over an ordinary
+//! table's score column and stores a WAL-backed catalog record (exactly
+//! like the metric-descriptor catalog), reusing MVCC, the sorted index,
+//! policy, and WAL. No new `sortedset` Collection model is introduced.
+//!
+//! This module owns three things:
+//!   1. the [`RankingDescriptor`] record and its persistence in
+//!      `red_config` (mirroring [`super::metric_descriptor_catalog`]);
+//!   2. the narrow statement parsers (`CREATE RANKING`, `SHOW RANKINGS`,
+//!      `RANK OF … IN …`) that keep the surface off the recursive-descent
+//!      grammar — the same intercept pattern `READ METRIC` uses; and
+//!   3. validation of the declared identifiers.
+//!
+//! The exact rank *computation* lives in the runtime (`impl_core`) because
+//! it walks the sorted index through the existing read pipeline.
+
+use crate::api::{RedDBError, RedDBResult};
+use crate::storage::schema::Value;
+use crate::storage::unified::{EntityData, UnifiedStore};
+use crate::utils::json::{parse_json, JsonValue};
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const REGISTRY_KEY: &str = "red.ranking.entries_json";
+
+/// Default size of the exact top-K head when `TOP <k>` is omitted.
+///
+/// K is a tuning knob, not a wire contract (ADR 0035): it bounds how far
+/// the exact, MVCC-correct walk descends before a row is considered part
+/// of the approximate tail (a separate slice). 1000 comfortably covers a
+/// leaderboard's visible head.
+pub const DEFAULT_TOP_K: u64 = 1000;
+
+/// A declared Ranking capability over `(table, column)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankingDescriptor {
+    /// Capability name — the identity a `RANK OF … IN <name>` read binds to.
+    pub name: String,
+    /// The ordinary table the capability is declared on.
+    pub table: String,
+    /// The score column ranked over.
+    pub column: String,
+    /// `true` → higher score ranks first (`ORDER BY column DESC`), the
+    /// leaderboard default; `false` → lower score ranks first.
+    pub descending: bool,
+    /// Size of the exact head (see [`DEFAULT_TOP_K`]).
+    pub top_k: u64,
+    pub created_at_ms: u128,
+}
+
+/// Parsed `CREATE RANKING` request, before validation/persistence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateRankingRequest {
+    pub name: String,
+    pub table: String,
+    pub column: String,
+    pub descending: bool,
+    pub top_k: u64,
+}
+
+/// Parsed `RANK OF <id> IN <name>` read request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankOfRequest {
+    pub entity_id: u64,
+    pub ranking: String,
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0)
+}
+
+// ───────────────────────── catalog operations ─────────────────────────
+
+pub fn create(store: &UnifiedStore, req: &CreateRankingRequest) -> RedDBResult<RankingDescriptor> {
+    validate_identifier(&req.name, "ranking name")?;
+    validate_identifier(&req.table, "ranking table")?;
+    validate_identifier(&req.column, "ranking column")?;
+    if req.top_k == 0 {
+        return Err(RedDBError::Query(
+            "ranking TOP must be greater than zero".to_string(),
+        ));
+    }
+
+    let mut entries = load(store);
+    if entries.iter().any(|entry| entry.name == req.name) {
+        return Err(RedDBError::Query(format!(
+            "ranking '{}' already exists",
+            req.name
+        )));
+    }
+
+    let descriptor = RankingDescriptor {
+        name: req.name.clone(),
+        table: req.table.clone(),
+        column: req.column.clone(),
+        descending: req.descending,
+        top_k: req.top_k,
+        created_at_ms: now_ms(),
+    };
+    entries.push(descriptor.clone());
+    save(store, &entries);
+    Ok(descriptor)
+}
+
+pub fn list(store: &UnifiedStore) -> Vec<RankingDescriptor> {
+    load(store)
+}
+
+pub fn get(store: &UnifiedStore, name: &str) -> Option<RankingDescriptor> {
+    load(store).into_iter().find(|entry| entry.name == name)
+}
+
+fn validate_identifier(value: &str, label: &str) -> RedDBResult<()> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    {
+        return Err(RedDBError::Query(format!(
+            "invalid {label} '{value}': expected an alphanumeric/underscore identifier"
+        )));
+    }
+    Ok(())
+}
+
+// ───────────────────────── statement parsers ─────────────────────────
+
+/// Split SQL into whitespace tokens with `(` and `)` as standalone tokens.
+fn tokenize(sql: &str) -> Vec<String> {
+    let trimmed = sql.trim().trim_end_matches(';');
+    let spaced = trimmed.replace('(', " ( ").replace(')', " ) ");
+    spaced.split_whitespace().map(str::to_string).collect()
+}
+
+fn eq(token: &str, keyword: &str) -> bool {
+    token.eq_ignore_ascii_case(keyword)
+}
+
+/// Parse `CREATE RANKING <name> ON <table> (<column> [ASC|DESC]) [TOP <k>]`.
+///
+/// Returns `None` for any statement that is not `CREATE RANKING …`, leaving
+/// the regular SQL pipeline untouched. A malformed `CREATE RANKING` returns
+/// `Some(Err(..))` so the caller surfaces a targeted error instead of the
+/// generic parser's "unknown statement".
+pub fn parse_create_ranking(sql: &str) -> Option<RedDBResult<CreateRankingRequest>> {
+    let tokens = tokenize(sql);
+    if tokens.len() < 2 || !eq(&tokens[0], "CREATE") || !eq(&tokens[1], "RANKING") {
+        return None;
+    }
+    Some(parse_create_ranking_inner(&tokens))
+}
+
+fn parse_create_ranking_inner(tokens: &[String]) -> RedDBResult<CreateRankingRequest> {
+    let err = |msg: &str| {
+        RedDBError::Query(format!(
+            "invalid CREATE RANKING: {msg}; expected \
+             CREATE RANKING <name> ON <table> (<column> [ASC|DESC]) [TOP <k>]"
+        ))
+    };
+
+    let name = tokens.get(2).ok_or_else(|| err("missing ranking name"))?;
+    if !tokens.get(3).is_some_and(|t| eq(t, "ON")) {
+        return Err(err("expected ON after ranking name"));
+    }
+    let table = tokens.get(4).ok_or_else(|| err("missing table name"))?;
+    if tokens.get(5).is_none_or(|t| t != "(") {
+        return Err(err("expected '(' before score column"));
+    }
+    let column = tokens.get(6).ok_or_else(|| err("missing score column"))?;
+
+    // After the column: optional ASC/DESC, then mandatory ')'.
+    let mut idx = 7;
+    let mut descending = true; // leaderboard default: higher score first
+    if let Some(dir) = tokens.get(idx) {
+        if eq(dir, "ASC") {
+            descending = false;
+            idx += 1;
+        } else if eq(dir, "DESC") {
+            descending = true;
+            idx += 1;
+        }
+    }
+    if tokens.get(idx).is_none_or(|t| t != ")") {
+        return Err(err("expected ')' after score column"));
+    }
+    idx += 1;
+
+    // Optional TOP <k>.
+    let mut top_k = DEFAULT_TOP_K;
+    if let Some(top) = tokens.get(idx) {
+        if !eq(top, "TOP") {
+            return Err(err("unexpected token after ')'"));
+        }
+        let k_str = tokens
+            .get(idx + 1)
+            .ok_or_else(|| err("missing TOP value"))?;
+        top_k = k_str
+            .parse::<u64>()
+            .map_err(|_| err("TOP value must be a positive integer"))?;
+        if tokens.get(idx + 2).is_some() {
+            return Err(err("trailing tokens after TOP value"));
+        }
+    }
+
+    Ok(CreateRankingRequest {
+        name: name.clone(),
+        table: table.clone(),
+        column: column.clone(),
+        descending,
+        top_k,
+    })
+}
+
+/// Recognise `SHOW RANKINGS`.
+pub fn parse_show_rankings(sql: &str) -> bool {
+    let tokens = tokenize(sql);
+    tokens.len() == 2 && eq(&tokens[0], "SHOW") && eq(&tokens[1], "RANKINGS")
+}
+
+/// Parse `RANK OF <id> IN <name>`.
+///
+/// Returns `None` unless the statement starts with `RANK OF`. A malformed
+/// tail returns `Some(Err(..))` for a targeted error.
+pub fn parse_rank_of(sql: &str) -> Option<RedDBResult<RankOfRequest>> {
+    let tokens = tokenize(sql);
+    if tokens.len() < 2 || !eq(&tokens[0], "RANK") || !eq(&tokens[1], "OF") {
+        return None;
+    }
+    let err = || {
+        RedDBError::Query("invalid RANK OF: expected RANK OF <id> IN <ranking-name>".to_string())
+    };
+    let result = (|| {
+        let id_str = tokens.get(2).ok_or_else(err)?;
+        let entity_id = id_str.parse::<u64>().map_err(|_| err())?;
+        if !tokens.get(3).is_some_and(|t| eq(t, "IN")) {
+            return Err(err());
+        }
+        let ranking = tokens.get(4).ok_or_else(err)?;
+        if tokens.get(5).is_some() {
+            return Err(err());
+        }
+        Ok(RankOfRequest {
+            entity_id,
+            ranking: ranking.clone(),
+        })
+    })();
+    Some(result)
+}
+
+// ───────────────────────── persistence ─────────────────────────
+
+fn read_latest_registry_json(store: &UnifiedStore) -> Option<String> {
+    let manager = store.get_collection("red_config")?;
+    let mut all = manager.query_all(|_| true);
+    all.sort_by_key(|entity| std::cmp::Reverse(entity.id.raw()));
+    for entity in all {
+        let EntityData::Row(row) = &entity.data else {
+            continue;
+        };
+        let Some(named) = &row.named else { continue };
+        let matches = matches!(
+            named.get("key"),
+            Some(Value::Text(value)) if value.as_ref() == REGISTRY_KEY
+        );
+        if matches {
+            if let Some(Value::Text(value)) = named.get("value") {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn load(store: &UnifiedStore) -> Vec<RankingDescriptor> {
+    let raw = match read_latest_registry_json(store) {
+        Some(raw) => raw,
+        None => return Vec::new(),
+    };
+    let Ok(parsed) = parse_json(&raw) else {
+        return Vec::new();
+    };
+    let Some(arr) = parsed.as_array() else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::with_capacity(arr.len());
+    for item in arr {
+        let Some(obj) = item.as_object() else {
+            continue;
+        };
+        let lookup = |k: &str| obj.iter().find(|(key, _)| key == k).map(|(_, value)| value);
+        let Some(name) = lookup("name").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let Some(table) = lookup("table").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let Some(column) = lookup("column").and_then(JsonValue::as_str) else {
+            continue;
+        };
+        let descending = lookup("descending")
+            .and_then(JsonValue::as_bool)
+            .unwrap_or(true);
+        let top_k = lookup("top_k")
+            .and_then(JsonValue::as_f64)
+            .map(|n| n as u64)
+            .filter(|k| *k > 0)
+            .unwrap_or(DEFAULT_TOP_K);
+        let created_at_ms = lookup("created_at_ms")
+            .and_then(JsonValue::as_f64)
+            .unwrap_or(0.0);
+        out.push(RankingDescriptor {
+            name: name.to_string(),
+            table: table.to_string(),
+            column: column.to_string(),
+            descending,
+            top_k,
+            created_at_ms: created_at_ms as u128,
+        });
+    }
+    out
+}
+
+fn save(store: &UnifiedStore, entries: &[RankingDescriptor]) {
+    let arr = crate::serde_json::Value::Array(entries.iter().map(entry_to_json).collect());
+    store.set_config_tree(
+        REGISTRY_KEY,
+        &crate::serde_json::Value::String(arr.to_string()),
+    );
+}
+
+fn entry_to_json(entry: &RankingDescriptor) -> crate::serde_json::Value {
+    let mut obj = crate::serde_json::Map::new();
+    obj.insert(
+        "name".to_string(),
+        crate::serde_json::Value::String(entry.name.clone()),
+    );
+    obj.insert(
+        "table".to_string(),
+        crate::serde_json::Value::String(entry.table.clone()),
+    );
+    obj.insert(
+        "column".to_string(),
+        crate::serde_json::Value::String(entry.column.clone()),
+    );
+    obj.insert(
+        "descending".to_string(),
+        crate::serde_json::Value::Bool(entry.descending),
+    );
+    obj.insert(
+        "top_k".to_string(),
+        crate::serde_json::Value::Number(entry.top_k as f64),
+    );
+    obj.insert(
+        "created_at_ms".to_string(),
+        crate::serde_json::Value::Number(entry.created_at_ms as f64),
+    );
+    crate::serde_json::Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_create_ranking_full() {
+        let req = parse_create_ranking("CREATE RANKING top_players ON players (score DESC) TOP 50")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(
+            req,
+            CreateRankingRequest {
+                name: "top_players".to_string(),
+                table: "players".to_string(),
+                column: "score".to_string(),
+                descending: true,
+                top_k: 50,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_create_ranking_defaults_desc_and_top_k() {
+        let req = parse_create_ranking("create ranking r ON t (pts)")
+            .expect("recognised")
+            .expect("valid");
+        assert!(req.descending, "direction defaults to DESC (leaderboard)");
+        assert_eq!(req.top_k, DEFAULT_TOP_K);
+    }
+
+    #[test]
+    fn parse_create_ranking_asc() {
+        let req = parse_create_ranking("CREATE RANKING r ON t (latency ASC)")
+            .expect("recognised")
+            .expect("valid");
+        assert!(!req.descending);
+    }
+
+    #[test]
+    fn parse_create_ranking_rejects_missing_on() {
+        let err = parse_create_ranking("CREATE RANKING r t (score)")
+            .expect("recognised")
+            .expect_err("malformed");
+        assert!(err.to_string().contains("ON"), "{err}");
+    }
+
+    #[test]
+    fn parse_create_ranking_ignores_other_statements() {
+        assert!(parse_create_ranking("SELECT * FROM players").is_none());
+        assert!(parse_create_ranking("CREATE TABLE players (id INT)").is_none());
+    }
+
+    #[test]
+    fn parse_rank_of_full() {
+        let req = parse_rank_of("RANK OF 42 IN top_players")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(
+            req,
+            RankOfRequest {
+                entity_id: 42,
+                ranking: "top_players".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rank_of_rejects_non_numeric_id() {
+        let err = parse_rank_of("RANK OF abc IN r")
+            .expect("recognised")
+            .expect_err("bad id");
+        assert!(err.to_string().contains("RANK OF"), "{err}");
+    }
+
+    #[test]
+    fn parse_rank_of_ignores_other_statements() {
+        assert!(parse_rank_of("SELECT 1").is_none());
+        // `RANK() OVER (...)` is a window projection, not the RANK OF read.
+        assert!(parse_rank_of("SELECT RANK() OVER (ORDER BY s DESC) FROM t").is_none());
+    }
+
+    #[test]
+    fn parse_show_rankings_recognised() {
+        assert!(parse_show_rankings("SHOW RANKINGS"));
+        assert!(parse_show_rankings("show rankings;"));
+        assert!(!parse_show_rankings("SHOW TABLES"));
+    }
+}

--- a/crates/reddb-server/tests/leaderboard_rank_e2e.rs
+++ b/crates/reddb-server/tests/leaderboard_rank_e2e.rs
@@ -1,0 +1,336 @@
+//! #918 / ADR 0035 — leaderboard rank tracer bullet, end-to-end.
+//!
+//! Pins the slice this issue adds:
+//!
+//!   1. A Ranking capability declared on an ordinary table's score column
+//!      as a catalog record (`CREATE RANKING …`, observable via
+//!      `SHOW RANKINGS`) — no new Collection model, no `CREATE SORTEDSET`.
+//!   2. `RANK() OVER (ORDER BY score DESC)` window semantics and a
+//!      `RANK OF <id> IN <ranking>` rank-of-row read return a position
+//!      within the bounded top-K head.
+//!   3. The exact rank counts only rows visible to the querying MVCC
+//!      snapshot — a row committed by a later transaction does not shift
+//!      the rank seen under an older (snapshot-isolated) transaction.
+//!   4. The exact rank agrees with the order `ORDER BY score DESC LIMIT`
+//!      returns under the same snapshot (ties share a rank).
+//!   5. Rank reads honor the same RLS/tenant scope as ordinary reads.
+//!   6. Existing top-N (`ORDER BY score LIMIT`) is unchanged.
+
+use std::sync::mpsc;
+use std::sync::Arc;
+use std::thread;
+
+use reddb_server::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb_server::storage::schema::Value;
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  -> {e}"));
+}
+
+/// Single `rank` cell from a `RANK OF …` read, or `None` when the read
+/// returned no row (not visible / beyond the exact head).
+fn rank_of(rt: &RedDBRuntime, sql: &str) -> Option<u64> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  -> {e}"));
+    result
+        .result
+        .records
+        .first()
+        .and_then(|rec| match rec.get("rank") {
+            Some(Value::UnsignedInteger(n)) => Some(*n),
+            Some(Value::Integer(n)) => Some(*n as u64),
+            _ => None,
+        })
+}
+
+/// Entity id (`rid`) of the row whose `name` column matches.
+fn rid_of(rt: &RedDBRuntime, table: &str, name: &str) -> u64 {
+    let result = rt
+        .execute_query(&format!("SELECT * FROM {table}"))
+        .expect("scan");
+    for rec in &result.result.records {
+        let matches = matches!(rec.get("name"), Some(Value::Text(t)) if t.as_ref() == name);
+        if matches {
+            return match rec.get("rid") {
+                Some(Value::UnsignedInteger(n)) => *n,
+                other => panic!("rid not an unsigned integer: {other:?}"),
+            };
+        }
+    }
+    panic!("no row named {name} in {table}");
+}
+
+fn seed_players(rt: &RedDBRuntime, rows: &[(&str, i64)]) {
+    exec(rt, "CREATE TABLE players (name TEXT, score INT)");
+    for (name, score) in rows {
+        exec(
+            rt,
+            &format!("INSERT INTO players (name, score) VALUES ('{name}', {score})"),
+        );
+    }
+}
+
+// ── Criterion 1: capability declared as a catalog record ──────────────
+
+#[test]
+fn ranking_is_declared_as_a_catalog_capability() {
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE players (name TEXT, score INT)");
+    exec(
+        &rt,
+        "CREATE RANKING top_players ON players (score DESC) TOP 100",
+    );
+
+    let shown = rt.execute_query("SHOW RANKINGS").expect("show rankings");
+    assert_eq!(shown.result.records.len(), 1, "one ranking declared");
+    let rec = &shown.result.records[0];
+    assert!(matches!(rec.get("name"), Some(Value::Text(t)) if t.as_ref() == "top_players"));
+    assert!(matches!(rec.get("table"), Some(Value::Text(t)) if t.as_ref() == "players"));
+    assert!(matches!(rec.get("column"), Some(Value::Text(t)) if t.as_ref() == "score"));
+    assert!(matches!(rec.get("direction"), Some(Value::Text(t)) if t.as_ref() == "DESC"));
+    assert!(matches!(
+        rec.get("top_k"),
+        Some(Value::UnsignedInteger(100))
+    ));
+
+    // No Collection model was minted for the capability: the ranking name
+    // is not a queryable collection.
+    assert!(
+        rt.execute_query("SELECT * FROM top_players").is_err(),
+        "ranking must not materialize a collection named after itself"
+    );
+
+    // Declaring the same ranking twice is rejected.
+    assert!(
+        rt.execute_query("CREATE RANKING top_players ON players (score)")
+            .is_err(),
+        "duplicate ranking must be rejected"
+    );
+}
+
+// ── Criteria 2 & 4: rank-of-row + window RANK agree with ORDER BY ─────
+
+#[test]
+fn rank_of_row_agrees_with_order_by_and_window_rank() {
+    let rt = runtime();
+    // Deliberate tie: bob and eve both score 80.
+    seed_players(
+        &rt,
+        &[
+            ("alice", 100),
+            ("bob", 80),
+            ("eve", 80),
+            ("carol", 60),
+            ("dave", 40),
+        ],
+    );
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+
+    // Rank-of-row matches RANK() semantics: alice=1, bob=eve=2 (tie),
+    // carol=4 (gap after the tie), dave=5.
+    let id = |name| rid_of(&rt, "players", name);
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {} IN r", id("alice"))),
+        Some(1)
+    );
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {} IN r", id("bob"))),
+        Some(2)
+    );
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {} IN r", id("eve"))),
+        Some(2)
+    );
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {} IN r", id("carol"))),
+        Some(4)
+    );
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {} IN r", id("dave"))),
+        Some(5)
+    );
+
+    // The canonical SQL window form returns the same ranks.
+    let windowed = rt
+        .execute_query("SELECT name, RANK() OVER (ORDER BY score DESC) AS rnk FROM players")
+        .expect("window rank");
+    let mut by_name: Vec<(String, i64)> = windowed
+        .result
+        .records
+        .iter()
+        .map(|rec| {
+            let name = match rec.get("name") {
+                Some(Value::Text(t)) => t.to_string(),
+                other => panic!("name missing: {other:?}"),
+            };
+            let rnk = match rec.get("rnk") {
+                Some(Value::Integer(n)) => *n,
+                Some(Value::UnsignedInteger(n)) => *n as i64,
+                other => panic!("rnk missing: {other:?}"),
+            };
+            (name, rnk)
+        })
+        .collect();
+    by_name.sort();
+    assert_eq!(
+        by_name,
+        vec![
+            ("alice".to_string(), 1),
+            ("bob".to_string(), 2),
+            ("carol".to_string(), 4),
+            ("dave".to_string(), 5),
+            ("eve".to_string(), 2),
+        ],
+        "window RANK() must agree with the rank-of-row read"
+    );
+
+    // A non-existent / not-visible row id yields no rank row.
+    assert_eq!(rank_of(&rt, "RANK OF 999999 IN r"), None);
+}
+
+// ── Criterion 4 (bound): rows beyond the exact head are not served ────
+
+#[test]
+fn rows_beyond_the_top_k_head_return_no_exact_rank() {
+    let rt = runtime();
+    seed_players(&rt, &[("a", 100), ("b", 90), ("c", 80), ("d", 70)]);
+    // Exact head of size 2: only the top two ranks are served exactly.
+    exec(&rt, "CREATE RANKING r ON players (score DESC) TOP 2");
+
+    let id = |name| rid_of(&rt, "players", name);
+    assert_eq!(rank_of(&rt, &format!("RANK OF {} IN r", id("a"))), Some(1));
+    assert_eq!(rank_of(&rt, &format!("RANK OF {} IN r", id("b"))), Some(2));
+    // c would rank 3, beyond the K=2 head ⇒ no exact rank (approximate
+    // tail is a separate slice).
+    assert_eq!(rank_of(&rt, &format!("RANK OF {} IN r", id("c"))), None);
+    assert_eq!(rank_of(&rt, &format!("RANK OF {} IN r", id("d"))), None);
+}
+
+// ── Criterion 3: MVCC snapshot correctness ────────────────────────────
+
+#[test]
+fn uncommitted_row_in_another_transaction_does_not_shift_rank() {
+    let rt = Arc::new(runtime());
+    seed_players(&rt, &[("alice", 100), ("carol", 60)]);
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+    let carol = rid_of(&rt, "players", "carol");
+
+    // Baseline: carol is 2nd (alice above).
+    assert_eq!(rank_of(&rt, &format!("RANK OF {carol} IN r")), Some(2));
+
+    // A writer on another connection inserts a higher-scoring row inside
+    // an *open, uncommitted* transaction and holds it open until the
+    // reader has checked the rank. Channels make the handshake
+    // deterministic — no sleeps, no timing assumptions.
+    let (inserted_tx, inserted_rx) = mpsc::channel::<()>();
+    let (commit_tx, commit_rx) = mpsc::channel::<()>();
+    let writer = rt.clone();
+    let writer_thread = thread::spawn(move || {
+        // Bind a distinct connection id so this thread is an independent
+        // session — otherwise it shares the default (auto-commit) id 0
+        // with the reader and its uncommitted write would be self-visible.
+        set_current_connection_id(2);
+        writer.execute_query("BEGIN").expect("begin");
+        writer
+            .execute_query("INSERT INTO players (name, score) VALUES ('dave', 90)")
+            .expect("insert dave");
+        inserted_tx.send(()).expect("signal inserted");
+        commit_rx.recv().expect("await commit signal");
+        writer.execute_query("COMMIT").expect("commit");
+        clear_current_connection_id();
+    });
+
+    // Wait until dave exists but is still uncommitted, then read the rank.
+    inserted_rx.recv().expect("await insert");
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {carol} IN r")),
+        Some(2),
+        "an uncommitted row in another transaction must not shift the rank"
+    );
+
+    // Let the writer commit, then a fresh read sees dave: carol is 3rd.
+    commit_tx.send(()).expect("signal commit");
+    writer_thread.join().expect("writer thread");
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {carol} IN r")),
+        Some(3),
+        "once committed, the row counts and carol drops to 3rd"
+    );
+}
+
+// ── Criterion 5: rank reads honor RLS / tenant scope ──────────────────
+
+#[test]
+fn rank_reads_honor_tenant_rls() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE players (name TEXT, tenant_id TEXT, score INT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO players (name, tenant_id, score) VALUES ('alice', 'acme', 100)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO players (name, tenant_id, score) VALUES ('zoe', 'globex', 200)",
+    );
+    let alice = rid_of(&rt, "players", "alice");
+
+    exec(
+        &rt,
+        "CREATE POLICY tenant_only ON players FOR SELECT USING (tenant_id = CURRENT_TENANT())",
+    );
+    exec(&rt, "ALTER TABLE players ENABLE ROW LEVEL SECURITY");
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+
+    // Under tenant acme, zoe (score 200, globex) is invisible, so alice
+    // ranks 1 — NOT 2. The rank walk inherits the same RLS filter as an
+    // ordinary read.
+    assert_eq!(
+        rank_of(&rt, &format!("WITHIN TENANT 'acme' RANK OF {alice} IN r")),
+        Some(1),
+        "RLS must hide the other tenant's higher-scoring row from the rank"
+    );
+
+    // Under tenant globex, alice's own row is hidden ⇒ no rank.
+    assert_eq!(
+        rank_of(&rt, &format!("WITHIN TENANT 'globex' RANK OF {alice} IN r")),
+        None,
+        "a row hidden by RLS has no rank for that tenant"
+    );
+}
+
+// ── Criterion 6: existing top-N is unchanged ──────────────────────────
+
+#[test]
+fn top_n_order_by_limit_is_unchanged() {
+    let rt = runtime();
+    seed_players(
+        &rt,
+        &[("alice", 100), ("bob", 80), ("carol", 60), ("dave", 40)],
+    );
+    // Declaring a ranking must not perturb ordinary top-N reads.
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+
+    let top2 = rt
+        .execute_query("SELECT name FROM players ORDER BY score DESC LIMIT 2")
+        .expect("top-2");
+    let names: Vec<String> = top2
+        .result
+        .records
+        .iter()
+        .map(|rec| match rec.get("name") {
+            Some(Value::Text(t)) => t.to_string(),
+            other => panic!("name missing: {other:?}"),
+        })
+        .collect();
+    assert_eq!(names, vec!["alice".to_string(), "bob".to_string()]);
+}


### PR DESCRIPTION
Automated AFK landing for #918. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782886418&installation_id=129708444&pr_number=926&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F926&signature=d33c9850eafea93f4972bb7590332f4f9c652c0ceda82a6207d137e9c0add148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leaderboard ranking capability with three new SQL commands: `CREATE RANKING` to define rankings, `SHOW RANKINGS` to list all rankings, and `RANK OF` to compute exact ranks for entities within a ranking.
  * Rankings support configurable sort order and top-K limits with snapshot consistency and tenant isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->