### PR TITLE
merge: #917 RedWire live queue wait: end-to-end deliver happy path (dual-headed registry + subscribe frame + session push)

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -303,6 +303,79 @@ impl RedDBRuntime {
         }
     }
 
+    /// Issue #917 — async live-wait edge used by the RedWire session.
+    ///
+    /// Unlike [`group_read_with_optional_wait`](Self::group_read_with_optional_wait)
+    /// (the synchronous HTTP/condvar caller), this parks on the
+    /// registry's async wake head and never holds a blocking OS thread:
+    /// the awaiting tokio worker is released back to the runtime for the
+    /// wait duration. On every wake it re-probes the *normal* queue
+    /// delivery path (`group_read`), so a delivered message is genuinely
+    /// claimed, not merely observed. Returns the delivered messages
+    /// rendered as JSON values (so the transport edge stays free of
+    /// runtime queue types); an empty Vec means the deadline elapsed
+    /// without a delivery, and a cancellation surfaces as the same
+    /// [`QUEUE_READ_WAIT_CANCELLED`] error the sync path uses.
+    pub(crate) async fn redwire_queue_wait_json(
+        &self,
+        queue: &str,
+        group: Option<&str>,
+        consumer: &str,
+        count: usize,
+        wait_ms: u64,
+    ) -> RedDBResult<Vec<crate::serde_json::Value>> {
+        let group_owned = {
+            let store = self.inner.db.store();
+            ensure_queue_exists(store.as_ref(), queue)?;
+            let config = load_queue_config(store.as_ref(), queue);
+            resolve_read_group(store.as_ref(), queue, group, consumer, &config)?
+        };
+        let group_ref = group_owned.as_str();
+
+        let do_read =
+            |runtime: &RedDBRuntime| -> RedDBResult<Vec<crate::runtime::queue_lifecycle::DeliveredMessage>> {
+                let (lifecycle, _ps, txn) = runtime_lifecycle(runtime, queue);
+                lifecycle
+                    .group_read(&txn, queue, group_ref, consumer, count)
+                    .map_err(map_qse)
+            };
+
+        // Fast path: a message is already deliverable at open time.
+        let delivered = do_read(self)?;
+        if !delivered.is_empty() {
+            return Ok(delivered.into_iter().map(delivered_message_json).collect());
+        }
+
+        let registry = self.queue_wait_registry();
+        let scope = queue_wait_scope();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(wait_ms);
+        loop {
+            // Register the async waiter (snapshot the generation) BEFORE
+            // the re-probe so a notify landing between probe and park is
+            // observed as a generation move rather than a lost wake.
+            let waiter = registry.async_waiter(&scope, queue);
+            let delivered = do_read(self)?;
+            if !delivered.is_empty() {
+                return Ok(delivered.into_iter().map(delivered_message_json).collect());
+            }
+            if registry.is_cancelled() {
+                return Err(RedDBError::Query(QUEUE_READ_WAIT_CANCELLED.to_string()));
+            }
+            if std::time::Instant::now() >= deadline {
+                return Ok(Vec::new());
+            }
+            match registry.wait_until_async(&waiter, deadline).await {
+                crate::runtime::queue_wait_registry::WaitOutcome::Woken => continue,
+                crate::runtime::queue_wait_registry::WaitOutcome::Timeout => {
+                    return Ok(Vec::new());
+                }
+                crate::runtime::queue_wait_registry::WaitOutcome::Cancelled => {
+                    return Err(RedDBError::Query(QUEUE_READ_WAIT_CANCELLED.to_string()));
+                }
+            }
+        }
+    }
+
     pub(crate) fn enqueue_event_payload(
         &self,
         queue: &str,
@@ -2646,6 +2719,32 @@ pub static TUPLE_DEPRECATION_EMITS: std::sync::atomic::AtomicU64 =
 
 fn message_id_string(message_id: EntityId) -> String {
     message_id.raw().to_string()
+}
+
+/// Issue #917 — render a delivered queue message as the JSON object the
+/// RedWire `QueueEventPush` frame carries. Mirrors the column shape the
+/// SQL `QUEUE READ` projection emits (`message_id` / `payload` /
+/// `consumer` / `delivery_count`) so the wire push and the pull path
+/// stay client-compatible.
+fn delivered_message_json(
+    message: crate::runtime::queue_lifecycle::DeliveredMessage,
+) -> crate::serde_json::Value {
+    use crate::serde_json::{Map, Value as JsonValue};
+    let mut obj = Map::new();
+    obj.insert(
+        "message_id".to_string(),
+        JsonValue::String(message_id_string(EntityId::new(message.message_id))),
+    );
+    obj.insert(
+        "payload".to_string(),
+        crate::presentation::entity_json::storage_value_to_json(&message.payload),
+    );
+    obj.insert("consumer".to_string(), JsonValue::String(message.consumer));
+    obj.insert(
+        "delivery_count".to_string(),
+        JsonValue::Number(message.delivery_count as f64),
+    );
+    JsonValue::Object(obj)
 }
 
 /// Slice 10 of issue #527 — render-time scan of pending entries

--- a/crates/reddb-server/src/runtime/queue_wait_registry.rs
+++ b/crates/reddb-server/src/runtime/queue_wait_registry.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use parking_lot::{Condvar, Mutex};
+use tokio::sync::Notify;
 
 /// What happened to a waiter when it returned from `wait`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,6 +39,16 @@ pub enum WaitOutcome {
 struct Slot {
     state: Mutex<u64>,
     cond: Condvar,
+    /// Async wake head (issue #917). Bumped by the same `notify` /
+    /// `cancel_all` that drives the synchronous condvar, so a single
+    /// producer wake releases both a parked HTTP condvar waiter and an
+    /// awaiting RedWire session for the same `(scope, queue)` key. The
+    /// generation counter in `state` makes the async park lost-wake-free
+    /// the same way it does for the condvar: a waiter snapshots the
+    /// generation before its re-probe, so a notify that lands between
+    /// probe and park is observed as a generation move rather than a
+    /// missed `notify_waiters`.
+    notify: Notify,
 }
 
 impl Slot {
@@ -45,6 +56,7 @@ impl Slot {
         Self {
             state: Mutex::new(0),
             cond: Condvar::new(),
+            notify: Notify::new(),
         }
     }
 }
@@ -148,7 +160,11 @@ impl QueueWaitRegistry {
         let mut guard = slot.state.lock();
         *guard = guard.wrapping_add(1);
         drop(guard);
+        // Bump both wake heads off the same generation move: the
+        // synchronous condvar (HTTP path) and the async Notify (the
+        // RedWire session edge, issue #917).
         slot.cond.notify_all();
+        slot.notify.notify_waiters();
     }
 
     /// Shutdown drain: set the cancellation flag and wake every slot's
@@ -159,6 +175,9 @@ impl QueueWaitRegistry {
         for slot in slots.values() {
             let _g = slot.state.lock();
             slot.cond.notify_all();
+            // Wake async waiters too — they re-check `is_cancelled`
+            // after the park returns and surface `Cancelled`.
+            slot.notify.notify_waiters();
         }
         drop(slots);
         let _g = self.cancel_mu.lock();
@@ -173,6 +192,81 @@ impl QueueWaitRegistry {
 pub struct Snapshot {
     slot: Arc<Slot>,
     gen: u64,
+}
+
+/// Async analogue of [`Snapshot`] for the RedWire session edge (issue
+/// #917). Captures the slot and its generation before the caller's
+/// re-probe; [`QueueWaitRegistry::wait_until_async`] then parks on the
+/// slot's async wake head without holding a blocking OS thread.
+pub struct AsyncWaiter {
+    slot: Arc<Slot>,
+    gen: u64,
+}
+
+impl QueueWaitRegistry {
+    /// Register an async waiter on `(scope, queue)`. Mirrors
+    /// [`snapshot`](Self::snapshot): take this BEFORE the second
+    /// non-blocking probe so a notify firing between the probe and
+    /// [`wait_until_async`](Self::wait_until_async) is seen as a
+    /// generation move (lost-wake-free).
+    pub fn async_waiter(&self, scope: &str, queue: &str) -> AsyncWaiter {
+        let slot = self.slot(scope, queue);
+        let gen = *slot.state.lock();
+        AsyncWaiter { slot, gen }
+    }
+
+    /// Await the waiter's slot until a notify bumps the generation
+    /// past `waiter.gen`, the deadline elapses, or `cancel_all` fires.
+    /// Holds no OS thread for the wait duration — the tokio worker is
+    /// released back to the runtime while parked (the property the
+    /// RedWire async transport edge relies on).
+    pub async fn wait_until_async(&self, waiter: &AsyncWaiter, deadline: Instant) -> WaitOutcome {
+        if self.is_cancelled() {
+            return WaitOutcome::Cancelled;
+        }
+        loop {
+            // Arm the notification future BEFORE the generation check
+            // so a `notify_waiters` racing with this check cannot be
+            // lost: `enable()` registers interest, then the generation
+            // re-read catches any bump that already happened.
+            let notified = waiter.slot.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            if self.is_cancelled() {
+                return WaitOutcome::Cancelled;
+            }
+            if *waiter.slot.state.lock() != waiter.gen {
+                return WaitOutcome::Woken;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                return WaitOutcome::Timeout;
+            }
+            let sleep = tokio::time::sleep(deadline - now);
+            tokio::select! {
+                _ = notified => {
+                    if self.is_cancelled() {
+                        return WaitOutcome::Cancelled;
+                    }
+                    if *waiter.slot.state.lock() != waiter.gen {
+                        return WaitOutcome::Woken;
+                    }
+                    // Spurious (or a notify that did not move our
+                    // generation) — re-arm and re-check.
+                }
+                _ = sleep => {
+                    if self.is_cancelled() {
+                        return WaitOutcome::Cancelled;
+                    }
+                    if *waiter.slot.state.lock() != waiter.gen {
+                        return WaitOutcome::Woken;
+                    }
+                    return WaitOutcome::Timeout;
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -237,6 +331,61 @@ mod tests {
         reg.notify("default", "q2");
         let outcome = reg.wait_until(&snap, Instant::now() + Duration::from_millis(60));
         assert_eq!(outcome, WaitOutcome::Timeout);
+    }
+
+    #[tokio::test]
+    async fn notify_wakes_both_sync_and_async_waiter_for_same_key() {
+        // Issue #917 AC: a single `notify(scope, queue)` releases both
+        // a synchronous condvar waiter and an async waiter parked on
+        // the same key. The sync park runs on a blocking thread; the
+        // async park awaits the wake head on this task.
+        let reg = Arc::new(QueueWaitRegistry::new());
+
+        let sync_reg = reg.clone();
+        let sync_park = tokio::task::spawn_blocking(move || {
+            let snap = sync_reg.snapshot("t", "q");
+            sync_reg.wait_until(&snap, Instant::now() + Duration::from_secs(5))
+        });
+
+        let async_waiter = reg.async_waiter("t", "q");
+        let async_reg = reg.clone();
+        let async_park = tokio::spawn(async move {
+            async_reg
+                .wait_until_async(&async_waiter, Instant::now() + Duration::from_secs(5))
+                .await
+        });
+
+        // Give both waiters time to park before the single notify.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        reg.notify("t", "q");
+
+        assert_eq!(async_park.await.unwrap(), WaitOutcome::Woken);
+        assert_eq!(sync_park.await.unwrap(), WaitOutcome::Woken);
+    }
+
+    #[tokio::test]
+    async fn async_waiter_times_out_without_notify() {
+        let reg = QueueWaitRegistry::new();
+        let waiter = reg.async_waiter("t", "q");
+        let start = Instant::now();
+        let outcome = reg
+            .wait_until_async(&waiter, start + Duration::from_millis(120))
+            .await;
+        assert_eq!(outcome, WaitOutcome::Timeout);
+        assert!(start.elapsed() >= Duration::from_millis(100));
+    }
+
+    #[tokio::test]
+    async fn async_notify_before_wait_is_observed_through_generation() {
+        // A notify that fires AFTER the waiter snapshots the generation
+        // but BEFORE the await must still return Woken (no lost wake).
+        let reg = QueueWaitRegistry::new();
+        let waiter = reg.async_waiter("t", "q");
+        reg.notify("t", "q");
+        let outcome = reg
+            .wait_until_async(&waiter, Instant::now() + Duration::from_secs(5))
+            .await;
+        assert_eq!(outcome, WaitOutcome::Woken);
     }
 
     #[test]

--- a/crates/reddb-server/src/wire/redwire/mod.rs
+++ b/crates/reddb-server/src/wire/redwire/mod.rs
@@ -18,6 +18,7 @@ pub mod frame;
 pub mod input_stream;
 pub mod listener;
 pub mod output_stream;
+pub mod queue_wait;
 pub mod session;
 
 pub use codec::{decode_frame, encode_frame, FrameError};

--- a/crates/reddb-server/src/wire/redwire/queue_wait.rs
+++ b/crates/reddb-server/src/wire/redwire/queue_wait.rs
@@ -1,0 +1,207 @@
+//! RedWire live queue-wait dispatch (issue #917, PRD #915).
+//!
+//! Carries the wire-side envelopes for the live queue-wait happy path:
+//!   - `QueueWaitOpen`  (client→server) — open a wait on a queue. The
+//!     awaiting session parks on the queue-wait registry's async wake
+//!     head (no blocking OS thread) and re-probes the normal delivery
+//!     path on each wake.
+//!   - `QueueEventPush` (server→client) — the delivered message,
+//!     pushed the instant one becomes deliverable on that queue.
+//!
+//! Distinct from the `OpenStream`/`StreamChunk` output-stream family in
+//! [`super::output_stream`], which stays query-result pull. These
+//! envelopes carry queue delivery and reuse the frame's `stream_id` for
+//! multiplexing so a wait can coexist with other streams on the same
+//! connection.
+
+use crate::serde_json::{self, Value as JsonValue};
+use reddb_wire::redwire::frame::{Frame, MessageKind};
+
+use super::FrameBuilder;
+
+/// Parsed `QueueWaitOpen` payload. Shape:
+///
+/// ```json
+/// { "queue": "jobs", "group": "g?", "consumer": "w1",
+///   "count": 1, "wait_ms": 5000 }
+/// ```
+///
+/// `group` is optional (the runtime resolves the default work / fanout
+/// group when absent, matching the SQL `QUEUE READ` path). `count`
+/// defaults to 1 and `wait_ms` to 0 (a single re-probe of current
+/// state) when omitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueWaitOpenRequest {
+    pub queue: String,
+    pub group: Option<String>,
+    pub consumer: String,
+    pub count: usize,
+    pub wait_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueueWaitParseError {
+    NotJson,
+    NotObject,
+    MissingQueue,
+    MissingConsumer,
+}
+
+impl QueueWaitParseError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::NotJson | Self::NotObject => "queue_wait_invalid_payload",
+            Self::MissingQueue => "queue_wait_missing_queue",
+            Self::MissingConsumer => "queue_wait_missing_consumer",
+        }
+    }
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::NotJson => "QueueWaitOpen payload must be JSON",
+            Self::NotObject => "QueueWaitOpen payload must be a JSON object",
+            Self::MissingQueue => "QueueWaitOpen payload missing 'queue' string field",
+            Self::MissingConsumer => "QueueWaitOpen payload missing 'consumer' string field",
+        }
+    }
+}
+
+pub fn parse_queue_wait_open(payload: &[u8]) -> Result<QueueWaitOpenRequest, QueueWaitParseError> {
+    let v: JsonValue = serde_json::from_slice(payload).map_err(|_| QueueWaitParseError::NotJson)?;
+    let obj = v.as_object().ok_or(QueueWaitParseError::NotObject)?;
+    let queue = obj
+        .get("queue")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or(QueueWaitParseError::MissingQueue)?
+        .to_string();
+    let consumer = obj
+        .get("consumer")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or(QueueWaitParseError::MissingConsumer)?
+        .to_string();
+    let group = obj
+        .get("group")
+        .and_then(|x| x.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    // `count` defaults to 1; clamp to at least 1 so a wait always asks
+    // for a deliverable message.
+    let count = obj
+        .get("count")
+        .and_then(|x| x.as_f64())
+        .map(|n| (n as usize).max(1))
+        .unwrap_or(1);
+    let wait_ms = obj
+        .get("wait_ms")
+        .and_then(|x| x.as_f64())
+        .map(|n| n.max(0.0) as u64)
+        .unwrap_or(0);
+    Ok(QueueWaitOpenRequest {
+        queue,
+        group,
+        consumer,
+        count,
+        wait_ms,
+    })
+}
+
+/// Build the `QueueEventPush` payload for one delivered message. The
+/// `message` value is the JSON object rendered by the runtime
+/// (`message_id` / `payload` / `consumer` / `delivery_count`).
+pub fn build_event_push_payload(message: &JsonValue) -> Vec<u8> {
+    serde_json::to_vec(message).unwrap_or_default()
+}
+
+/// Build a `QueueEventPush` frame echoing the open request's
+/// `correlation_id` and `stream_id` so the client pairs the push with
+/// the wait it opened.
+pub fn build_event_push_frame(
+    correlation_id: u64,
+    stream_id: u16,
+    message: &JsonValue,
+) -> Result<Frame, super::BuildError> {
+    FrameBuilder::reply_to(correlation_id)
+        .kind(MessageKind::QueueEventPush)
+        .stream_id(stream_id)
+        .payload(build_event_push_payload(message))
+        .build()
+}
+
+/// Build a `StreamError` frame carrying a queue-wait parse/validation
+/// failure for a specific `stream_id`. Non-fatal at the connection
+/// level — the session keeps reading other frames.
+pub fn build_queue_wait_error_frame(
+    correlation_id: u64,
+    stream_id: u16,
+    code: &str,
+    message: &str,
+) -> Result<Frame, super::BuildError> {
+    let mut obj = serde_json::Map::new();
+    obj.insert("code".to_string(), JsonValue::String(code.to_string()));
+    obj.insert(
+        "message".to_string(),
+        JsonValue::String(message.to_string()),
+    );
+    FrameBuilder::reply_to(correlation_id)
+        .kind(MessageKind::StreamError)
+        .stream_id(stream_id)
+        .payload(serde_json::to_vec(&JsonValue::Object(obj)).unwrap_or_default())
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_minimal_request_applies_defaults() {
+        let req = parse_queue_wait_open(br#"{"queue":"jobs","consumer":"w1"}"#).unwrap();
+        assert_eq!(req.queue, "jobs");
+        assert_eq!(req.consumer, "w1");
+        assert_eq!(req.group, None);
+        assert_eq!(req.count, 1);
+        assert_eq!(req.wait_ms, 0);
+    }
+
+    #[test]
+    fn parse_full_request() {
+        let req = parse_queue_wait_open(
+            br#"{"queue":"jobs","group":"g","consumer":"w1","count":3,"wait_ms":5000}"#,
+        )
+        .unwrap();
+        assert_eq!(req.group.as_deref(), Some("g"));
+        assert_eq!(req.count, 3);
+        assert_eq!(req.wait_ms, 5000);
+    }
+
+    #[test]
+    fn parse_rejects_missing_queue_and_consumer() {
+        assert_eq!(
+            parse_queue_wait_open(br#"{"consumer":"w1"}"#).unwrap_err(),
+            QueueWaitParseError::MissingQueue
+        );
+        assert_eq!(
+            parse_queue_wait_open(br#"{"queue":"jobs"}"#).unwrap_err(),
+            QueueWaitParseError::MissingConsumer
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_json() {
+        assert_eq!(
+            parse_queue_wait_open(b"not json").unwrap_err(),
+            QueueWaitParseError::NotJson
+        );
+    }
+
+    #[test]
+    fn event_push_frame_echoes_correlation_and_stream() {
+        let mut obj = serde_json::Map::new();
+        obj.insert("message_id".to_string(), JsonValue::String("42".into()));
+        let frame = build_event_push_frame(99, 7, &JsonValue::Object(obj)).unwrap();
+        assert_eq!(frame.kind, MessageKind::QueueEventPush);
+        assert_eq!(frame.correlation_id, 99);
+        assert_eq!(frame.stream_id, 7);
+    }
+}

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -371,6 +371,71 @@ where
                     registry_ref.unregister(sid).await;
                 });
             }
+            // Live queue wait (issue #917 / PRD #915). Parse the open
+            // request, then spawn a task that awaits the runtime's async
+            // wait edge (parks on the registry's async wake head — no
+            // blocking OS thread) and pushes a `QueueEventPush` the
+            // instant a message becomes deliverable. The dispatch loop
+            // returns to reading immediately so the wait multiplexes
+            // with other frames on the connection.
+            MessageKind::QueueWaitOpen => {
+                use super::queue_wait as qw;
+                let frame_id = frame.correlation_id;
+                let sid = frame.stream_id;
+                let req = match qw::parse_queue_wait_open(&frame.payload) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let err =
+                            qw::build_queue_wait_error_frame(frame_id, sid, e.code(), e.message())
+                                .map_err(|e| {
+                                    io::Error::other(format!("build queue-wait error: {e}"))
+                                })?;
+                        queue_send(&out_tx, encode_frame(&err))?;
+                        continue;
+                    }
+                };
+                let runtime_ref = Arc::clone(&runtime);
+                let out = out_tx.clone();
+                tokio::spawn(async move {
+                    match runtime_ref
+                        .redwire_queue_wait_json(
+                            &req.queue,
+                            req.group.as_deref(),
+                            &req.consumer,
+                            req.count,
+                            req.wait_ms,
+                        )
+                        .await
+                    {
+                        Ok(messages) => {
+                            // Happy path: push each delivered message.
+                            // An empty Vec (deadline elapsed without a
+                            // delivery) pushes nothing — the timeout
+                            // surface is a later slice.
+                            for message in messages {
+                                match qw::build_event_push_frame(frame_id, sid, &message) {
+                                    Ok(push) => {
+                                        if queue_send(&out, encode_frame(&push)).is_err() {
+                                            return;
+                                        }
+                                    }
+                                    Err(_) => return,
+                                }
+                            }
+                        }
+                        Err(err) => {
+                            if let Ok(ef) = qw::build_queue_wait_error_frame(
+                                frame_id,
+                                sid,
+                                "queue_wait_failed",
+                                &err.to_string(),
+                            ) {
+                                let _ = queue_send(&out, encode_frame(&ef));
+                            }
+                        }
+                    }
+                });
+            }
             // Input-stream chunk (issue #764 / S5). A `StreamChunk`
             // from the client carries a chunk of rows for an open
             // input stream. Each chunk commits synchronously and

--- a/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
+++ b/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
@@ -1,0 +1,166 @@
+//! Issue #917 / PRD #915 — RedWire live queue-wait end-to-end happy
+//! path.
+//!
+//! A RedWire client opens a wait on an empty queue, then a producer
+//! makes a message deliverable *after* the wait opened. The awaiting
+//! session — parked on the queue-wait registry's async wake head, with
+//! no blocking OS thread — re-probes the normal delivery path on wake
+//! and pushes a `QueueEventPush` carrying the delivered message.
+//!
+//! The delivery test runs on a **current-thread** tokio runtime on
+//! purpose: the producer (the test task) and the awaiting session task
+//! share one OS thread, so if the wait held that thread the push could
+//! never run and the test would deadlock against its own timeout. A
+//! clean pass is therefore also the AC that the session does not hold a
+//! blocking OS thread for the wait duration.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb_server::wire::redwire::{
+    decode_frame, encode_frame, Frame, MessageKind, FRAME_HEADER_SIZE, MAX_KNOWN_MINOR_VERSION,
+    REDWIRE_MAGIC,
+};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(20);
+
+struct ServerHandle {
+    addr: SocketAddr,
+    runtime: Arc<RedDBRuntime>,
+    _join: tokio::task::JoinHandle<()>,
+}
+
+async fn start_server() -> ServerHandle {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let runtime = Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap());
+    let rt = runtime.clone();
+    let join = tokio::spawn(async move {
+        let _ = reddb_server::wire::redwire::start_redwire_listener_on(listener, rt).await;
+    });
+    ServerHandle {
+        addr,
+        runtime,
+        _join: join,
+    }
+}
+
+/// Read one full RedWire frame off the socket: 16-byte header, then the
+/// declared payload length, then decode.
+async fn read_frame(stream: &mut TcpStream) -> Frame {
+    let mut header = [0u8; FRAME_HEADER_SIZE];
+    timeout(EXCHANGE_TIMEOUT, stream.read_exact(&mut header))
+        .await
+        .expect("frame header within budget")
+        .expect("read header");
+    let length = u32::from_le_bytes([header[0], header[1], header[2], header[3]]) as usize;
+    let mut buf = vec![0u8; length];
+    buf[..FRAME_HEADER_SIZE].copy_from_slice(&header);
+    if length > FRAME_HEADER_SIZE {
+        timeout(
+            EXCHANGE_TIMEOUT,
+            stream.read_exact(&mut buf[FRAME_HEADER_SIZE..]),
+        )
+        .await
+        .expect("frame payload within budget")
+        .expect("read payload");
+    }
+    let (frame, _) = decode_frame(&buf).expect("decode frame");
+    frame
+}
+
+async fn write_frame(stream: &mut TcpStream, frame: &Frame) {
+    stream
+        .write_all(&encode_frame(frame))
+        .await
+        .expect("write frame");
+}
+
+/// Drive the anonymous handshake and return the connected, authed
+/// stream ready for the data-plane frame loop.
+async fn connect_and_handshake(addr: SocketAddr) -> TcpStream {
+    let mut stream = TcpStream::connect(addr).await.expect("connect");
+    // Startup magic + negotiated minor version byte.
+    stream.write_all(&[REDWIRE_MAGIC]).await.unwrap();
+    stream.write_all(&[MAX_KNOWN_MINOR_VERSION]).await.unwrap();
+    // Hello: advertise v1 + anonymous.
+    write_frame(
+        &mut stream,
+        &Frame::new(
+            MessageKind::Hello,
+            1,
+            br#"{"versions":[1],"auth_methods":["anonymous"],"features":0,"client_name":"redwire-smoke"}"#.to_vec(),
+        ),
+    )
+    .await;
+    let ack = read_frame(&mut stream).await;
+    assert_eq!(ack.kind, MessageKind::HelloAck, "expected HelloAck");
+    // AuthResponse: anonymous carries no proof.
+    write_frame(
+        &mut stream,
+        &Frame::new(MessageKind::AuthResponse, 2, b"{}".to_vec()),
+    )
+    .await;
+    let ok = read_frame(&mut stream).await;
+    assert_eq!(ok.kind, MessageKind::AuthOk, "expected AuthOk");
+    stream
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn wait_opened_then_post_open_push_is_delivered() {
+    let server = start_server().await;
+    server
+        .runtime
+        .execute_query("CREATE QUEUE jobs")
+        .expect("create queue");
+    server
+        .runtime
+        .execute_query("QUEUE GROUP CREATE jobs workers")
+        .expect("create group");
+
+    let mut client = connect_and_handshake(server.addr).await;
+
+    // Open the wait on the (currently empty) queue, stream_id 3.
+    let open = Frame::new(
+        MessageKind::QueueWaitOpen,
+        77,
+        br#"{"queue":"jobs","group":"workers","consumer":"c1","count":1,"wait_ms":5000}"#.to_vec(),
+    )
+    .with_stream(3);
+    write_frame(&mut client, &open).await;
+
+    // Make a message deliverable AFTER the wait opened — it did not
+    // exist at open time. The producer is this (single) thread; if the
+    // session held a blocking OS thread for the wait, this push could
+    // not run and the read below would hit its timeout.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    server
+        .runtime
+        .execute_query("QUEUE PUSH jobs 'hello-live'")
+        .expect("push");
+
+    // The push frame arrives over the session writer-drain.
+    let push = read_frame(&mut client).await;
+    assert_eq!(
+        push.kind,
+        MessageKind::QueueEventPush,
+        "expected a QueueEventPush"
+    );
+    assert_eq!(push.stream_id, 3, "push echoes the wait's stream_id");
+    assert_eq!(push.correlation_id, 77, "push echoes the open correlation");
+
+    let body = String::from_utf8(push.payload.clone()).expect("utf8 payload");
+    assert!(
+        body.contains("hello-live"),
+        "push must carry the delivered payload, got {body}"
+    );
+    assert!(
+        body.contains("\"message_id\""),
+        "push must carry the message_id, got {body}"
+    );
+}

--- a/crates/reddb-wire/src/redwire/codec.rs
+++ b/crates/reddb-wire/src/redwire/codec.rs
@@ -407,6 +407,33 @@ mod tests {
     }
 
     #[test]
+    fn queue_wait_envelopes_round_trip() {
+        // Golden encode/decode for the live queue-wait envelopes added
+        // in issue #917 / PRD #915. Pins the new byte values and
+        // confirms the request/push pair round-trips equal through the
+        // codec, multiplexed over `stream_id` like the other streamed
+        // envelopes.
+        let open = Frame::new(
+            MessageKind::QueueWaitOpen,
+            10,
+            br#"{"queue":"jobs","consumer":"w1","count":1,"wait_ms":5000}"#.to_vec(),
+        )
+        .with_stream(3);
+        round_trip(open.clone());
+        assert_eq!(encode_frame(&open)[4], 0x2E);
+
+        let push = Frame::new(
+            MessageKind::QueueEventPush,
+            10,
+            br#"{"message_id":"42","payload":{"hello":"world"},"consumer":"w1","delivery_count":1}"#
+                .to_vec(),
+        )
+        .with_stream(3);
+        round_trip(push.clone());
+        assert_eq!(encode_frame(&push)[4], 0x2F);
+    }
+
+    #[test]
     fn uncompressed_frame_decodes_unchanged_when_flag_unset() {
         let payload = b"hello world".to_vec();
         let frame = Frame::new(MessageKind::Result, 1, payload.clone());

--- a/crates/reddb-wire/src/redwire/frame.rs
+++ b/crates/reddb-wire/src/redwire/frame.rs
@@ -113,6 +113,16 @@ pub enum MessageKind {
     StreamChunk = 0x2B,
     StreamError = 0x2C,
     StreamCancel = 0x2D,
+
+    // Live queue wait (issue #917 / PRD #915). A `QueueWaitOpen`
+    // registers an async waiter on a queue; the server pushes a
+    // `QueueEventPush` the instant a message becomes deliverable.
+    // Distinct from the OpenStream/StreamChunk output-stream family
+    // (which stays query-result pull) — these carry queue delivery,
+    // multiplexed over the frame's `stream_id` like the other
+    // streamed envelopes.
+    QueueWaitOpen = 0x2E,
+    QueueEventPush = 0x2F,
 }
 
 /// Coarse routing class for a `MessageKind`.
@@ -186,7 +196,11 @@ impl MessageKind {
             | Self::OpenAck
             | Self::StreamChunk
             | Self::StreamError
-            | Self::StreamCancel => MessageClass::Streamed,
+            | Self::StreamCancel
+            // Live queue-wait envelopes (issue #917) describe an
+            // in-flight subscription multiplexed by `stream_id`.
+            | Self::QueueWaitOpen
+            | Self::QueueEventPush => MessageClass::Streamed,
 
             // 0x10..0x1F — handshake / lifecycle.
             Self::Hello
@@ -277,7 +291,9 @@ impl MessageKind {
             | Self::GraphTraverse
             | Self::QueryWithParams
             | Self::OpenStream
-            | Self::StreamCancel => MessageDirection::ClientToServer,
+            | Self::StreamCancel
+            // Client opens a live queue wait (issue #917).
+            | Self::QueueWaitOpen => MessageDirection::ClientToServer,
 
             // `StreamChunk` is symmetric (issue #764 / PRD #759 S5):
             // the server emits chunks on an *output* stream, and the
@@ -301,7 +317,9 @@ impl MessageKind {
             | Self::RowDescription
             | Self::StreamEnd
             | Self::OpenAck
-            | Self::StreamError => MessageDirection::ServerToClient,
+            | Self::StreamError
+            // Server pushes the delivered queue message (issue #917).
+            | Self::QueueEventPush => MessageDirection::ServerToClient,
 
             // Symmetric — either peer may initiate. (`StreamChunk` is
             // also symmetric but has its own arm above — see issue
@@ -353,6 +371,8 @@ impl MessageKind {
             0x2B => Some(Self::StreamChunk),
             0x2C => Some(Self::StreamError),
             0x2D => Some(Self::StreamCancel),
+            0x2E => Some(Self::QueueWaitOpen),
+            0x2F => Some(Self::QueueEventPush),
             _ => None,
         }
     }
@@ -442,6 +462,8 @@ mod catalog_tests {
         MessageKind::StreamChunk,
         MessageKind::StreamError,
         MessageKind::StreamCancel,
+        MessageKind::QueueWaitOpen,
+        MessageKind::QueueEventPush,
     ];
 
     #[test]
@@ -491,6 +513,11 @@ mod catalog_tests {
         assert_eq!(MessageKind::StreamChunk.class(), MessageClass::Streamed);
         assert_eq!(MessageKind::StreamError.class(), MessageClass::Streamed);
         assert_eq!(MessageKind::StreamCancel.class(), MessageClass::Streamed);
+
+        // Live queue-wait envelopes (issue #917) — Streamed class,
+        // multiplexed by `stream_id` like the output-stream family.
+        assert_eq!(MessageKind::QueueWaitOpen.class(), MessageClass::Streamed);
+        assert_eq!(MessageKind::QueueEventPush.class(), MessageClass::Streamed);
 
         // Control plane.
         assert_eq!(MessageKind::Cancel.class(), MessageClass::ControlPlane);
@@ -617,6 +644,7 @@ mod catalog_tests {
             MessageKind::QueryWithParams,
             MessageKind::OpenStream,
             MessageKind::StreamCancel,
+            MessageKind::QueueWaitOpen,
         ] {
             assert_eq!(
                 k.direction(),
@@ -642,6 +670,7 @@ mod catalog_tests {
             MessageKind::StreamEnd,
             MessageKind::OpenAck,
             MessageKind::StreamError,
+            MessageKind::QueueEventPush,
         ] {
             assert_eq!(
                 k.direction(),


### PR DESCRIPTION
Automated AFK landing for #917. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782887842&installation_id=129708444&pr_number=927&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F927&signature=9a6897e74e642f18cb732f9874996fd39ac923c30338cc871e56269f3c6d76ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RedWire protocol now supports live asynchronous queue-wait operations, enabling clients to monitor queues without polling and receive real-time push notifications when messages become available.
  * Added wire protocol support for queue-wait requests and event-push responses, facilitating message multiplexing across concurrent queue operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->