### PR TITLE
merge: #920 RedWire live queue wait: cancellation outcome on connection close / server shutdown

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -316,6 +316,17 @@ impl RedDBRuntime {
     /// runtime queue types); an empty Vec means the deadline elapsed
     /// without a delivery, and a cancellation surfaces as the same
     /// [`QUEUE_READ_WAIT_CANCELLED`] error the sync path uses.
+    /// True when `err` is the cancellation sentinel
+    /// [`redwire_queue_wait_json`](Self::redwire_queue_wait_json) returns
+    /// once the wait registry is cancelled (server shutdown) while a wait
+    /// is parked. Lets the RedWire transport map a cancelled wait to a
+    /// distinct `queue_wait_cancelled` frame rather than aliasing it with
+    /// a generic runtime failure (issue #920): cancellation and a real
+    /// `QUEUE READ` error are different wire outcomes.
+    pub(crate) fn redwire_wait_error_is_cancellation(err: &RedDBError) -> bool {
+        matches!(err, RedDBError::Query(message) if message == QUEUE_READ_WAIT_CANCELLED)
+    }
+
     pub(crate) async fn redwire_queue_wait_json(
         &self,
         queue: &str,

--- a/crates/reddb-server/src/runtime/queue_wait_registry.rs
+++ b/crates/reddb-server/src/runtime/queue_wait_registry.rs
@@ -98,6 +98,27 @@ impl QueueWaitRegistry {
         self.cancelled.store(false, Ordering::Release);
     }
 
+    /// Number of in-flight waiter references parked on `(scope, queue)`
+    /// beyond the registry's own retained slot reference. Each live
+    /// [`Snapshot`] (sync condvar path) and [`AsyncWaiter`] (RedWire
+    /// async edge) holds one `Arc<Slot>` clone, so this is the count of
+    /// waiters currently registered on the key. Returns 0 when no slot
+    /// has been created yet.
+    ///
+    /// The observable the queue-wait cancellation surface relies on
+    /// (issue #920 AC #3): when an in-flight wait is cancelled — by a
+    /// connection close aborting the wait task, or by `cancel_all` at
+    /// shutdown — its waiter is dropped and this count falls back to 0,
+    /// proving the slot reference (and the tokio worker holding it) was
+    /// released promptly rather than lingering to the wait deadline.
+    pub fn live_waiters(&self, scope: &str, queue: &str) -> usize {
+        let slots = self.slots.lock();
+        slots
+            .get(&(scope.to_string(), queue.to_string()))
+            .map(|slot| Arc::strong_count(slot).saturating_sub(1))
+            .unwrap_or(0)
+    }
+
     fn slot(&self, scope: &str, queue: &str) -> Arc<Slot> {
         let mut slots = self.slots.lock();
         if let Some(existing) = slots.get(&(scope.to_string(), queue.to_string())) {
@@ -386,6 +407,60 @@ mod tests {
             .wait_until_async(&waiter, Instant::now() + Duration::from_secs(5))
             .await;
         assert_eq!(outcome, WaitOutcome::Woken);
+    }
+
+    #[tokio::test]
+    async fn cancel_all_wakes_async_waiter_with_cancelled() {
+        // Issue #920 AC #4: the same `cancel_all` that wakes the
+        // synchronous condvar waiters wakes an async waiter parked on
+        // the registry's async wake head, surfacing `Cancelled` (not a
+        // timeout, not a spurious `Woken`).
+        let reg = Arc::new(QueueWaitRegistry::new());
+        let waiter = reg.async_waiter("t", "q");
+        let reg_clone = reg.clone();
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            reg_clone.cancel_all();
+        });
+        // A generous deadline: the wait must end on cancellation, well
+        // before this elapses, or the assertion below is meaningless.
+        let outcome = reg
+            .wait_until_async(&waiter, Instant::now() + Duration::from_secs(5))
+            .await;
+        canceller.await.unwrap();
+        assert_eq!(outcome, WaitOutcome::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn cancelled_async_waiter_releases_its_slot_reference() {
+        // Issue #920 AC #3: a cancelled async wait drops its waiter and
+        // hence its `Arc<Slot>` clone promptly, so `live_waiters` falls
+        // back to 0 — the slot reference (and the worker holding it) is
+        // not stranded until the original wait deadline.
+        let reg = Arc::new(QueueWaitRegistry::new());
+        let reg_task = reg.clone();
+        let park = tokio::spawn(async move {
+            let waiter = reg_task.async_waiter("t", "q");
+            reg_task
+                .wait_until_async(&waiter, Instant::now() + Duration::from_secs(30))
+                .await
+        });
+        // Let the task register its waiter and park.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(reg.live_waiters("t", "q"), 1, "waiter should be parked");
+
+        // Abort mid-wait (the connection-close analogue) and confirm the
+        // slot reference is released well before the 30s deadline.
+        park.abort();
+        let mut released = false;
+        for _ in 0..200 {
+            if reg.live_waiters("t", "q") == 0 {
+                released = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(released, "aborted waiter must drop its slot reference");
     }
 
     #[test]

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -101,8 +101,27 @@ where
     // without colliding (AC #2).
     let mut input_registry = super::input_stream::InputStreamRegistry::new();
 
+    // In-flight live queue-wait tasks (issue #920). Unlike the
+    // output-stream workers — which notice a closed connection the
+    // instant they try to push and self-terminate — a queue-wait task
+    // parks on the registry's async wake head and would otherwise linger
+    // until its `wait_ms` deadline after the client disconnects, holding
+    // a registry slot reference and a tokio worker the whole time. Owning
+    // the tasks in a `JoinSet` scoped to this connection fixes that: when
+    // the frame loop returns (Bye / EOF / I/O error), the set is dropped
+    // and every still-parked wait is aborted, dropping its waiter and so
+    // releasing the slot reference promptly (AC #1, AC #3). The
+    // registry's own `cancel_all` still drives the server-shutdown path
+    // (AC #2/#4) independently of this connection-scoped abort.
+    let mut queue_wait_tasks: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
     let mut buf = vec![0u8; FRAME_HEADER_SIZE];
     loop {
+        // Reap finished wait tasks so the set does not accumulate joined
+        // handles over a long-lived connection. Non-blocking — only
+        // already-complete tasks are drained.
+        while queue_wait_tasks.try_join_next().is_some() {}
+
         // Read header.
         if let Err(err) = reader.read_exact(&mut buf[..FRAME_HEADER_SIZE]).await {
             if err.kind() == io::ErrorKind::UnexpectedEof {
@@ -396,7 +415,10 @@ where
                 };
                 let runtime_ref = Arc::clone(&runtime);
                 let out = out_tx.clone();
-                tokio::spawn(async move {
+                // Owned by the connection-scoped `JoinSet` so a client
+                // disconnect (frame loop return) aborts a still-parked
+                // wait and releases its registry slot promptly (#920).
+                queue_wait_tasks.spawn(async move {
                     match runtime_ref
                         .redwire_queue_wait_json(
                             &req.queue,
@@ -424,10 +446,22 @@ where
                             }
                         }
                         Err(err) => {
+                            // A cancellation (server shutdown woke this
+                            // parked wait via the registry's `cancel_all`)
+                            // is a distinct wire outcome from a genuine
+                            // runtime failure: emit `queue_wait_cancelled`
+                            // so the client never mistakes shutdown for a
+                            // query error — or, conversely, an error for a
+                            // clean cancellation (#920 AC #2).
+                            let code = if RedDBRuntime::redwire_wait_error_is_cancellation(&err) {
+                                "queue_wait_cancelled"
+                            } else {
+                                "queue_wait_failed"
+                            };
                             if let Ok(ef) = qw::build_queue_wait_error_frame(
                                 frame_id,
                                 sid,
-                                "queue_wait_failed",
+                                code,
                                 &err.to_string(),
                             ) {
                                 let _ = queue_send(&out, encode_frame(&ef));

--- a/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
+++ b/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
@@ -164,3 +164,135 @@ async fn wait_opened_then_post_open_push_is_delivered() {
         "push must carry the message_id, got {body}"
     );
 }
+
+/// Issue #920 AC #2/#4 — server shutdown mid-wait surfaces a distinct
+/// cancellation error to an in-flight RedWire waiter.
+///
+/// The waiter opens on an empty queue and parks. We then drive the
+/// shutdown signal the way every sibling transport's smoke test does —
+/// `QueueWaitRegistry::cancel_all()`, the sanctioned in-process analogue
+/// of a server drain (AC #4: the same cancel that wakes the synchronous
+/// condvar waiters wakes the async one). The waiter must emit a
+/// `StreamError` carrying the `queue_wait_cancelled` code — a wire
+/// outcome distinct from a `QueueEventPush` delivery and from the silent
+/// no-frame timeout — echoing the open's correlation and stream so the
+/// client pairs it with the wait it opened.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_shutdown_mid_wait_emits_distinct_cancellation_error() {
+    let server = start_server().await;
+    server
+        .runtime
+        .execute_query("CREATE QUEUE jobs")
+        .expect("create queue");
+    server
+        .runtime
+        .execute_query("QUEUE GROUP CREATE jobs workers")
+        .expect("create group");
+
+    let mut client = connect_and_handshake(server.addr).await;
+
+    // Open a long wait on the empty queue — it will still be parked when
+    // the shutdown signal fires.
+    let open = Frame::new(
+        MessageKind::QueueWaitOpen,
+        91,
+        br#"{"queue":"jobs","group":"workers","consumer":"c1","count":1,"wait_ms":5000}"#.to_vec(),
+    )
+    .with_stream(4);
+    write_frame(&mut client, &open).await;
+
+    // Give the session time to register its waiter and park, then drive
+    // the shutdown drain through the registry.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    server.runtime.queue_wait_registry().cancel_all();
+
+    let frame = read_frame(&mut client).await;
+    assert_eq!(
+        frame.kind,
+        MessageKind::StreamError,
+        "cancellation must surface as a StreamError, not a QueueEventPush"
+    );
+    assert_ne!(
+        frame.kind,
+        MessageKind::QueueEventPush,
+        "a cancelled wait delivered no message"
+    );
+    assert_eq!(frame.stream_id, 4, "error echoes the wait's stream_id");
+    assert_eq!(
+        frame.correlation_id, 91,
+        "error echoes the open correlation"
+    );
+    let body = String::from_utf8(frame.payload.clone()).expect("utf8 payload");
+    assert!(
+        body.contains("queue_wait_cancelled"),
+        "cancellation code must be distinct from queue_wait_failed, got {body}"
+    );
+}
+
+/// Issue #920 AC #1/#3 — closing the connection mid-wait aborts the
+/// in-flight wait and releases its registry slot promptly, rather than
+/// stranding the waiter (and a tokio worker) until the `wait_ms`
+/// deadline.
+///
+/// Observability hook: `QueueWaitRegistry::live_waiters` counts the
+/// `Arc<Slot>` references held by parked waiters on a key. The waiter
+/// opens with a deliberately long `wait_ms`; once parked the count is 1.
+/// After the client socket is dropped, the session's frame loop hits EOF
+/// and returns, dropping the connection-scoped `JoinSet` and aborting
+/// the wait — so the count must fall back to 0 far inside the wait
+/// budget, distinct from a timeout that would only fire at the deadline.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn connection_close_mid_wait_releases_registry_slot() {
+    let server = start_server().await;
+    server
+        .runtime
+        .execute_query("CREATE QUEUE jobs")
+        .expect("create queue");
+    server
+        .runtime
+        .execute_query("QUEUE GROUP CREATE jobs workers")
+        .expect("create group");
+
+    let mut client = connect_and_handshake(server.addr).await;
+
+    // A 30s budget: a release observed within a couple of seconds is
+    // unambiguously the connection-close abort, not the wait deadline.
+    let open = Frame::new(
+        MessageKind::QueueWaitOpen,
+        55,
+        br#"{"queue":"jobs","group":"workers","consumer":"c1","count":1,"wait_ms":30000}"#.to_vec(),
+    )
+    .with_stream(6);
+    write_frame(&mut client, &open).await;
+
+    let registry = server.runtime.queue_wait_registry();
+
+    // Wait for the session to park its waiter (live_waiters → 1). The
+    // scope is the default (empty) tenant the RedWire path resolves to.
+    let mut parked = false;
+    for _ in 0..200 {
+        if registry.live_waiters("", "jobs") == 1 {
+            parked = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(parked, "waiter should be parked before we close the socket");
+
+    // Close the connection mid-wait.
+    drop(client);
+
+    // The slot reference must be released well before the 30s deadline.
+    let mut released = false;
+    for _ in 0..300 {
+        if registry.live_waiters("", "jobs") == 0 {
+            released = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        released,
+        "closing the connection must abort the parked wait and release its slot promptly"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #920. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782894785&installation_id=129708444&pr_number=928&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F928&signature=ae369fd22dac934da1291877c5ed1aeccf0674b44f83a1484bb7198ad29c8cb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced queue read wait error handling to distinguish between server-side cancellations and genuine runtime failures
  * Improved session cleanup to properly release and abort queue wait operations when client connections terminate

* **Tests**
  * Added integration tests validating queue wait behavior during server shutdown and client disconnection scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->