### PR TITLE
feat(replication): quorum election with durable last-vote + watermark vote rule (#834)

### DIFF
--- a/crates/reddb-server/src/replication/election.rs
+++ b/crates/reddb-server/src/replication/election.rs
@@ -307,6 +307,15 @@ impl LastVoteStore for FileLastVoteStore {
             let _ = f.sync_all();
         }
         std::fs::rename(&tmp, &self.path).map_err(LastVoteError::Io)?;
+        // fsync the parent directory so the rename itself is durable. Without
+        // this, a crash after the rename could leave the directory entry still
+        // pointing at the old record — which would let a restarted voter
+        // double-vote, the exact failure the durable last-vote forbids.
+        if let Some(parent) = self.path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
         Ok(())
     }
 }

--- a/crates/reddb-server/src/replication/election.rs
+++ b/crates/reddb-server/src/replication/election.rs
@@ -1,0 +1,699 @@
+//! Term-based, quorum-gated automatic election (issue #834, PRD #819, ADR 0030).
+//!
+//! This is the consensus core that turns a primary loss into an automatic,
+//! *safe* promotion. It lives in the first-party-but-decoupled control-plane
+//! supervisor (ADR 0030) — distinct from the data path — and reuses the two
+//! pieces the rest of replication already built:
+//!
+//! * the **commit watermark** ([`super::commit_waiter`] / [`super::quorum`]) —
+//!   the highest LSN durably replicated to a quorum that intersects every
+//!   possible election majority. Nothing at or below it may ever be rolled
+//!   back; and
+//! * the **FAILOVER handover machinery** ([`super::failover`]) — once a
+//!   candidate wins, promotion is driven through the same coordinated
+//!   role-swap, not a parallel state machine.
+//!
+//! ## The five hard requirements (ADR 0030, issue #834)
+//!
+//! 1. **Dry-run probe.** A candidate first asks "*would* you vote for me?"
+//!    without bumping any term. Only a real election bumps the term. This
+//!    keeps a flapping candidate from burning through terms and lets the
+//!    supervisor probe liveness cheaply.
+//! 2. **Durable last-vote.** A voter persists `(term, voted_for)` *before*
+//!    acknowledging a grant, so a voter that crashes and restarts mid-term
+//!    never double-votes — the second request in the same term for a
+//!    different candidate is refused from disk.
+//! 3. **Watermark vote rule (the safety core).** A voter MUST refuse any
+//!    candidate whose log does not cover the commit watermark. An
+//!    acknowledged synchronous write sits at or below the watermark, so a
+//!    winner necessarily carries it — the write provably survives the
+//!    failover. This is the one rule that may not be relaxed.
+//! 4. **Randomized election timeouts.** Candidates wait a randomized
+//!    interval before standing, so split votes are rare and self-correcting.
+//! 5. **Membership rules.** A quorum is a *majority of voting members*.
+//!    **Witness** members ([#836]) hold no data but vote, so `2 data + 1
+//!    witness` is a valid HA shape. A **catching-up** replica is
+//!    *non-voting* until it reaches a healthy state — it neither votes nor
+//!    stands.
+//!
+//! ## No two primaries in a term
+//!
+//! This invariant is structural, not probabilistic:
+//!
+//! * a win requires a strict majority of voting members, and two strict
+//!   majorities of the same set always intersect; and
+//! * the shared voter in any two majorities votes at most once per term
+//!   (durable last-vote), so it cannot grant two different candidates the
+//!   same term.
+//!
+//! Therefore at most one candidate can collect a majority in a given term,
+//! even under an arbitrary network partition. The partition tests exercise
+//! exactly this.
+//!
+//! ## Module shape
+//!
+//! Like [`super::failover`], the candidate-side [`ElectionCoordinator::run`]
+//! is a **pure state machine**: the clock, the per-peer vote RPC, the
+//! durable term bump, and the promotion are injected behind
+//! [`ElectionTransport`], so the whole election is exercised
+//! deterministically with a scripted fake — no clock, no network, no engine.
+//! The voter-side [`Voter`] wraps a [`LastVoteStore`] (durable on disk in
+//! production, in-memory in tests) and applies the vote rule.
+//!
+//! [#836]: https://github.com/reddb-io/reddb/issues/836
+
+use std::time::Duration;
+
+use crate::serde_json::{self, Value as JsonValue};
+
+// ---------------------------------------------------------------
+// Membership model
+// ---------------------------------------------------------------
+
+/// Whether a member holds data (and can therefore be promoted to primary)
+/// or is a vote-only witness (ADR 0030 — "a node that runs only the
+/// supervisor module").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberKind {
+    /// Holds data; can vote and can stand for election.
+    Data,
+    /// Vote-only witness ([#836]); counts toward quorum, never primary.
+    ///
+    /// [#836]: https://github.com/reddb-io/reddb/issues/836
+    Witness,
+}
+
+/// Whether a member currently participates in voting.
+///
+/// A data replica that is still catching up (has not reached a healthy,
+/// watermark-covering state) is [`VotingState::CatchingUp`] and is excluded
+/// from the voter set entirely — it neither votes nor counts toward the
+/// majority denominator. Once healthy it becomes [`VotingState::Voting`].
+/// Witnesses are always [`VotingState::Voting`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VotingState {
+    /// Healthy member that participates in quorum.
+    Voting,
+    /// Replica still syncing; non-voting until healthy.
+    CatchingUp,
+}
+
+/// A cluster member as seen by the supervisor's membership view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Member {
+    /// Stable node identity (matches the replica registry / ack id).
+    pub id: String,
+    pub kind: MemberKind,
+    pub state: VotingState,
+}
+
+impl Member {
+    pub fn data_voting(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: MemberKind::Data,
+            state: VotingState::Voting,
+        }
+    }
+
+    pub fn data_catching_up(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: MemberKind::Data,
+            state: VotingState::CatchingUp,
+        }
+    }
+
+    pub fn witness(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: MemberKind::Witness,
+            state: VotingState::Voting,
+        }
+    }
+
+    /// Does this member count toward quorum? Only healthy members vote;
+    /// a catching-up replica is non-voting (ADR 0030).
+    pub fn is_voter(&self) -> bool {
+        matches!(self.state, VotingState::Voting)
+    }
+
+    /// May this member stand for election? Only a healthy, data-bearing
+    /// member can become primary — a witness holds no data and a
+    /// catching-up replica is not healthy.
+    pub fn is_electable(&self) -> bool {
+        self.kind == MemberKind::Data && self.is_voter()
+    }
+}
+
+/// Quorum threshold for a set of members: a strict majority of the
+/// *voting* members. Witnesses count; catching-up replicas do not.
+///
+/// For `n` voting members the threshold is `floor(n/2) + 1`, the smallest
+/// count such that two qualifying sets always intersect — the structural
+/// basis for "no two primaries in a term".
+pub fn quorum_threshold(members: &[Member]) -> usize {
+    let voters = members.iter().filter(|m| m.is_voter()).count();
+    voters / 2 + 1
+}
+
+// ---------------------------------------------------------------
+// Durable last-vote
+// ---------------------------------------------------------------
+
+/// A node's durable voting record: the highest term it has participated in
+/// and who, if anyone, it granted that term. Persisted so a restart cannot
+/// erase the fact that a vote was already cast (requirement 2).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LastVote {
+    /// Highest term this node has observed in a (real) vote request.
+    pub term: u64,
+    /// Who this node granted `term` to, if anyone yet.
+    pub voted_for: Option<String>,
+}
+
+impl LastVote {
+    fn to_json(&self) -> JsonValue {
+        let mut obj = serde_json::Map::new();
+        obj.insert("term".to_string(), JsonValue::Number(self.term as f64));
+        obj.insert(
+            "voted_for".to_string(),
+            match &self.voted_for {
+                Some(id) => JsonValue::String(id.clone()),
+                None => JsonValue::Null,
+            },
+        );
+        JsonValue::Object(obj)
+    }
+
+    fn from_json(value: &JsonValue) -> Result<Self, LastVoteError> {
+        let obj = value.as_object().ok_or_else(|| {
+            LastVoteError::InvalidFormat("last-vote json is not an object".into())
+        })?;
+        let term = obj
+            .get("term")
+            .and_then(JsonValue::as_u64)
+            .ok_or_else(|| LastVoteError::InvalidFormat("missing term".into()))?;
+        let voted_for = match obj.get("voted_for") {
+            None | Some(JsonValue::Null) => None,
+            Some(JsonValue::String(s)) => Some(s.clone()),
+            Some(_) => {
+                return Err(LastVoteError::InvalidFormat(
+                    "voted_for must be a string or null".into(),
+                ))
+            }
+        };
+        Ok(Self { term, voted_for })
+    }
+}
+
+#[derive(Debug)]
+pub enum LastVoteError {
+    Io(std::io::Error),
+    InvalidFormat(String),
+}
+
+impl std::fmt::Display for LastVoteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "last-vote io error: {err}"),
+            Self::InvalidFormat(msg) => write!(f, "invalid last-vote format: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for LastVoteError {}
+
+/// Durable store for a node's last vote. The contract is narrow on purpose:
+/// `load` returns the persisted record (or the default `term 0, voted_for
+/// None` when nothing was ever written), and `persist` makes a record
+/// durable *before* the caller acknowledges a grant.
+pub trait LastVoteStore {
+    fn load(&self) -> Result<LastVote, LastVoteError>;
+    fn persist(&self, vote: &LastVote) -> Result<(), LastVoteError>;
+}
+
+/// In-memory last-vote store for tests and witnesses that do not need
+/// cross-restart durability. (A witness *should* still persist in
+/// production; the file store is used there.)
+#[derive(Debug, Default)]
+pub struct MemoryLastVoteStore {
+    inner: std::sync::Mutex<LastVote>,
+}
+
+impl MemoryLastVoteStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed an initial record — used by tests to simulate a node that
+    /// already voted before a restart.
+    pub fn seeded(vote: LastVote) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(vote),
+        }
+    }
+}
+
+impl LastVoteStore for MemoryLastVoteStore {
+    fn load(&self) -> Result<LastVote, LastVoteError> {
+        Ok(self.inner.lock().expect("last-vote mutex").clone())
+    }
+
+    fn persist(&self, vote: &LastVote) -> Result<(), LastVoteError> {
+        *self.inner.lock().expect("last-vote mutex") = vote.clone();
+        Ok(())
+    }
+}
+
+/// File-backed last-vote store. Persists the record alongside the node's
+/// other durable replication state. The write is atomic (temp file +
+/// rename) so a crash mid-write never yields a torn record — either the
+/// old vote or the new one survives, never a half of each.
+pub struct FileLastVoteStore {
+    path: std::path::PathBuf,
+}
+
+impl FileLastVoteStore {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl LastVoteStore for FileLastVoteStore {
+    fn load(&self) -> Result<LastVote, LastVoteError> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => {
+                let json: JsonValue = serde_json::from_slice(&bytes)
+                    .map_err(|err| LastVoteError::InvalidFormat(format!("parse: {err}")))?;
+                LastVote::from_json(&json)
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(LastVote::default()),
+            Err(err) => Err(LastVoteError::Io(err)),
+        }
+    }
+
+    fn persist(&self, vote: &LastVote) -> Result<(), LastVoteError> {
+        let bytes = serde_json::to_vec(&vote.to_json())
+            .map_err(|err| LastVoteError::InvalidFormat(format!("serialize: {err}")))?;
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(LastVoteError::Io)?;
+        }
+        let tmp = self.path.with_extension("lastvote.tmp");
+        std::fs::write(&tmp, &bytes).map_err(LastVoteError::Io)?;
+        // Atomic publish: rename over the live file. fsync the file before
+        // rename so the bytes are durable, not just in the page cache.
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            let _ = f.sync_all();
+        }
+        std::fs::rename(&tmp, &self.path).map_err(LastVoteError::Io)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------
+// Vote request / decision
+// ---------------------------------------------------------------
+
+/// A request for a vote, sent by a candidate to a voter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VoteRequest {
+    /// The candidate's stable identity.
+    pub candidate_id: String,
+    /// The term the candidate is standing for. For a real election this is
+    /// `current_term + 1`; for a dry-run probe it is the *prospective* term
+    /// the candidate would stand for, evaluated without committing to it.
+    pub term: u64,
+    /// The candidate's log frontier — the highest LSN durably in its log.
+    /// The watermark rule compares this against the commit watermark.
+    pub last_log_lsn: u64,
+    /// A dry-run probe gathers a would-be vote without persisting it or
+    /// advancing the voter's term (requirement 1). A real election sets
+    /// this `false`, which is the only path that persists a last-vote.
+    pub dry_run: bool,
+}
+
+impl VoteRequest {
+    pub fn probe(candidate_id: impl Into<String>, term: u64, last_log_lsn: u64) -> Self {
+        Self {
+            candidate_id: candidate_id.into(),
+            term,
+            last_log_lsn,
+            dry_run: true,
+        }
+    }
+
+    pub fn real(candidate_id: impl Into<String>, term: u64, last_log_lsn: u64) -> Self {
+        Self {
+            candidate_id: candidate_id.into(),
+            term,
+            last_log_lsn,
+            dry_run: false,
+        }
+    }
+}
+
+/// Why a voter refused a candidate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefusalReason {
+    /// The candidate's log does not cover the commit watermark, so an
+    /// acknowledged synchronous write could be lost — the safety core
+    /// refuses (requirement 3).
+    WatermarkNotCovered { candidate_lsn: u64, watermark: u64 },
+    /// The candidate's term is not newer than a term this voter already
+    /// participated in, and the voter already granted that term to someone
+    /// else (durable double-vote guard, requirement 2).
+    AlreadyVoted { term: u64, voted_for: String },
+    /// The candidate's term is older than the voter's current term — a
+    /// stale candidate from a superseded term.
+    StaleTerm {
+        candidate_term: u64,
+        voter_term: u64,
+    },
+}
+
+/// The outcome of a voter considering a [`VoteRequest`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VoteDecision {
+    /// Vote granted. For a real (non-dry-run) request the grant has already
+    /// been persisted durably before this value was produced.
+    Granted,
+    /// Vote refused, with the reason.
+    Refused(RefusalReason),
+}
+
+impl VoteDecision {
+    pub fn is_granted(&self) -> bool {
+        matches!(self, VoteDecision::Granted)
+    }
+}
+
+// ---------------------------------------------------------------
+// Voter (voter-side vote rule)
+// ---------------------------------------------------------------
+
+/// A voting member. Wraps the durable [`LastVoteStore`] and applies the
+/// vote rule. The voter is the seat of correctness: the watermark rule and
+/// the durable double-vote guard both live here.
+pub struct Voter<S: LastVoteStore> {
+    id: String,
+    store: S,
+}
+
+impl<S: LastVoteStore> Voter<S> {
+    pub fn new(id: impl Into<String>, store: S) -> Self {
+        Self {
+            id: id.into(),
+            store,
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// This voter's current term — the highest term it has durably recorded.
+    pub fn current_term(&self) -> Result<u64, LastVoteError> {
+        Ok(self.store.load()?.term)
+    }
+
+    /// Consider a vote request against the current `commit_watermark`.
+    ///
+    /// The decision order is deliberate:
+    ///
+    /// 1. **Watermark first** — the safety core. A candidate that cannot
+    ///    carry an acknowledged write is refused regardless of term, so the
+    ///    durability guarantee can never be traded away for liveness.
+    /// 2. **Stale term** — reject candidates from a superseded term.
+    /// 3. **Double-vote guard** — within a term, a voter grants exactly one
+    ///    candidate; a re-ask by the *same* candidate is idempotently
+    ///    re-granted.
+    ///
+    /// For a real (non-dry-run) grant, the new `(term, candidate)` is
+    /// persisted **before** `Granted` is returned, so the durability holds
+    /// across a crash at any point after the caller observes the grant.
+    pub fn consider(
+        &self,
+        req: &VoteRequest,
+        commit_watermark: u64,
+    ) -> Result<VoteDecision, LastVoteError> {
+        // 1. Watermark rule — never relaxed, checked before anything else.
+        if req.last_log_lsn < commit_watermark {
+            return Ok(VoteDecision::Refused(RefusalReason::WatermarkNotCovered {
+                candidate_lsn: req.last_log_lsn,
+                watermark: commit_watermark,
+            }));
+        }
+
+        let last = self.store.load()?;
+
+        // 2. Stale term — the candidate is behind a term we already moved past.
+        if req.term < last.term {
+            return Ok(VoteDecision::Refused(RefusalReason::StaleTerm {
+                candidate_term: req.term,
+                voter_term: last.term,
+            }));
+        }
+
+        // 3. Double-vote guard within the *same* term.
+        if req.term == last.term {
+            match &last.voted_for {
+                // Already voted for someone else this term — refuse.
+                Some(other) if other != &req.candidate_id => {
+                    return Ok(VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                        term: last.term,
+                        voted_for: other.clone(),
+                    }));
+                }
+                // Already voted for this same candidate — idempotent re-grant.
+                Some(_) => return Ok(VoteDecision::Granted),
+                // Same term observed but no vote cast yet — fall through to grant.
+                None => {}
+            }
+        }
+
+        // Grant. A dry-run probe must not persist or advance the term
+        // (requirement 1); a real grant persists durably before acking.
+        if !req.dry_run {
+            self.store.persist(&LastVote {
+                term: req.term,
+                voted_for: Some(req.candidate_id.clone()),
+            })?;
+        }
+        Ok(VoteDecision::Granted)
+    }
+}
+
+// ---------------------------------------------------------------
+// Randomized election timeout
+// ---------------------------------------------------------------
+
+/// A randomized election timeout in `[base, base + jitter)`.
+///
+/// Randomization keeps candidates from standing in lockstep, which is what
+/// makes split votes rare and self-correcting (requirement 4). The function
+/// is pure in `seed` so tests pin a deterministic value; production passes
+/// an entropy-derived seed.
+pub fn randomized_election_timeout(base: Duration, jitter: Duration, seed: u64) -> Duration {
+    if jitter.is_zero() {
+        return base;
+    }
+    let jitter_ms = jitter.as_millis().max(1) as u64;
+    base + Duration::from_millis(seed % jitter_ms)
+}
+
+// ---------------------------------------------------------------
+// ElectionCoordinator (candidate-side state machine)
+// ---------------------------------------------------------------
+
+/// A request to run an election on behalf of `candidate`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ElectionRequest {
+    /// The candidate standing for election. Must be electable (a healthy,
+    /// data-bearing member) or [`ElectionCoordinator::run`] refuses up front.
+    pub candidate: Member,
+    /// The term the cluster is serving now. A real election stands for
+    /// `current_term + 1`.
+    pub current_term: u64,
+    /// The candidate's log frontier — the highest LSN durably in its log.
+    pub last_log_lsn: u64,
+    /// The commit watermark the candidate believes is in force. The
+    /// candidate must itself cover it to be electable; voters re-check
+    /// against their own watermark view.
+    pub commit_watermark: u64,
+}
+
+impl ElectionRequest {
+    /// The term a successful election produces.
+    pub fn new_term(&self) -> u64 {
+        self.current_term + 1
+    }
+}
+
+/// The result of an election attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ElectionOutcome {
+    /// Won a majority and was promoted under `term`. `votes`/`needed` record
+    /// the tally (including the candidate's self-vote).
+    Elected {
+        term: u64,
+        votes: usize,
+        needed: usize,
+    },
+    /// The dry-run probe did not reach a majority, so no term was bumped and
+    /// no real election was attempted (requirement 1).
+    ProbeFailed { votes: usize, needed: usize },
+    /// A real election was attempted (term bumped) but did not reach a
+    /// majority — e.g. votes split or peers came online between probe and
+    /// election. The term has advanced; a later attempt stands for a higher
+    /// term.
+    Lost {
+        term: u64,
+        votes: usize,
+        needed: usize,
+    },
+    /// The candidate is not electable (a witness, or a catching-up replica,
+    /// or its own log does not cover the watermark). No probe was sent.
+    NotElectable,
+    /// The election ran past its randomized timeout before collecting a
+    /// majority. No promotion happened.
+    TimedOut { votes: usize, needed: usize },
+}
+
+impl ElectionOutcome {
+    pub fn is_elected(&self) -> bool {
+        matches!(self, ElectionOutcome::Elected { .. })
+    }
+}
+
+/// Cluster operations the candidate drives, injected so the state machine
+/// stays pure and deterministically testable. Production backs these onto
+/// the membership view, the per-peer vote RPC, the durable term store, and
+/// the FAILOVER handover; tests back them onto a scripted fake.
+pub trait ElectionTransport {
+    /// The candidate's current view of cluster membership. The denominator
+    /// for the majority is the *voting* members of this set.
+    fn members(&self) -> Vec<Member>;
+
+    /// Ask one peer for its vote. The candidate never asks itself (it always
+    /// self-grants). Implementors route this to the peer's [`Voter`].
+    fn request_vote(&mut self, peer_id: &str, req: &VoteRequest) -> VoteDecision;
+
+    /// Time elapsed since the election began, so the coordinator enforces
+    /// the randomized timeout without owning a clock.
+    fn elapsed(&self) -> Duration;
+
+    /// Durably advance this node's current term to `new_term`. Called once,
+    /// only when a real election begins (never for a dry-run). Persisted
+    /// alongside the node's other durable replication state.
+    fn bump_term(&mut self, new_term: u64);
+
+    /// Promote the candidate to primary under `new_term`, reusing the
+    /// FAILOVER handover machinery ([`super::failover`]). Called only after
+    /// a majority is collected in the real election.
+    fn promote(&mut self, new_term: u64);
+}
+
+/// The quorum-gated election state machine.
+pub struct ElectionCoordinator;
+
+impl ElectionCoordinator {
+    /// Run an election for `req`, driving the cluster through `tx`, bounded
+    /// by `timeout` (use [`randomized_election_timeout`]).
+    ///
+    /// The flow is: electability guard → dry-run probe (no term bump) →
+    /// real election (bump term, collect votes) → promote on majority. See
+    /// the module docs for the full contract.
+    pub fn run(
+        req: &ElectionRequest,
+        tx: &mut dyn ElectionTransport,
+        timeout: Duration,
+    ) -> ElectionOutcome {
+        // Electability guard. A witness or catching-up replica may not
+        // stand; nor may a candidate whose own log does not cover the
+        // watermark (it would violate the safety core the instant it won).
+        if !req.candidate.is_electable() || req.last_log_lsn < req.commit_watermark {
+            return ElectionOutcome::NotElectable;
+        }
+
+        let members = tx.members();
+        let needed = quorum_threshold(&members);
+        let new_term = req.new_term();
+
+        // The peers we ask: every *other* voting member. The candidate
+        // self-grants, so it is one vote without an RPC.
+        let peers: Vec<String> = members
+            .iter()
+            .filter(|m| m.is_voter() && m.id != req.candidate.id)
+            .map(|m| m.id.clone())
+            .collect();
+
+        // ---- Phase 1: dry-run probe (does NOT bump the term) ----
+        let probe = VoteRequest::probe(&req.candidate.id, new_term, req.last_log_lsn);
+        let probe_votes = match Self::collect(tx, &peers, &probe, needed, timeout) {
+            CollectResult::Reached(v) => v,
+            CollectResult::Exhausted(v) => {
+                return ElectionOutcome::ProbeFailed { votes: v, needed }
+            }
+            CollectResult::TimedOut(v) => return ElectionOutcome::TimedOut { votes: v, needed },
+        };
+        debug_assert!(probe_votes >= needed);
+
+        // ---- Phase 2: real election (bumps the term, then collects) ----
+        tx.bump_term(new_term);
+        let ballot = VoteRequest::real(&req.candidate.id, new_term, req.last_log_lsn);
+        match Self::collect(tx, &peers, &ballot, needed, timeout) {
+            CollectResult::Reached(votes) => {
+                tx.promote(new_term);
+                ElectionOutcome::Elected {
+                    term: new_term,
+                    votes,
+                    needed,
+                }
+            }
+            CollectResult::Exhausted(votes) => ElectionOutcome::Lost {
+                term: new_term,
+                votes,
+                needed,
+            },
+            CollectResult::TimedOut(votes) => ElectionOutcome::TimedOut { votes, needed },
+        }
+    }
+
+    /// Collect votes from `peers`, starting at 1 for the candidate's
+    /// self-vote, until `needed` is reached, the peers are exhausted, or the
+    /// timeout elapses. Stops early on success — no need to ask the rest.
+    fn collect(
+        tx: &mut dyn ElectionTransport,
+        peers: &[String],
+        req: &VoteRequest,
+        needed: usize,
+        timeout: Duration,
+    ) -> CollectResult {
+        let mut votes = 1usize; // self-vote
+        if votes >= needed {
+            return CollectResult::Reached(votes);
+        }
+        for peer in peers {
+            if tx.elapsed() >= timeout {
+                return CollectResult::TimedOut(votes);
+            }
+            if tx.request_vote(peer, req).is_granted() {
+                votes += 1;
+                if votes >= needed {
+                    return CollectResult::Reached(votes);
+                }
+            }
+        }
+        CollectResult::Exhausted(votes)
+    }
+}
+
+enum CollectResult {
+    Reached(usize),
+    Exhausted(usize),
+    TimedOut(usize),
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/reddb-server/src/replication/election/tests.rs
+++ b/crates/reddb-server/src/replication/election/tests.rs
@@ -1,0 +1,722 @@
+//! Unit tests for the election consensus core (issue #834).
+//!
+//! These cover the voter-side vote rule (watermark, durable double-vote,
+//! dry-run, term staleness), the randomized timeout, and the candidate-side
+//! coordinator (probe-then-elect, witness counting, catch-up exclusion,
+//! timeout). The *cross-node* invariants — restart-no-double-vote and the
+//! no-two-primaries partition proof — are driven through a small in-process
+//! cluster harness below and re-asserted end-to-end in
+//! `tests/election_consensus_e2e.rs`.
+
+use super::*;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+// ===============================================================
+// Voter-side vote rule
+// ===============================================================
+
+#[test]
+fn watermark_uncovered_candidate_is_refused() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    // Candidate log frontier 90 does not cover watermark 100.
+    let req = VoteRequest::real("cand", 5, 90);
+    let decision = voter.consider(&req, 100).unwrap();
+    assert_eq!(
+        decision,
+        VoteDecision::Refused(RefusalReason::WatermarkNotCovered {
+            candidate_lsn: 90,
+            watermark: 100,
+        }),
+    );
+}
+
+#[test]
+fn watermark_covered_candidate_is_granted() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    // Frontier 120 covers watermark 100 (>=).
+    let req = VoteRequest::real("cand", 5, 120);
+    assert_eq!(voter.consider(&req, 100).unwrap(), VoteDecision::Granted);
+}
+
+#[test]
+fn watermark_rule_beats_a_newer_term() {
+    // Even a candidate with a much newer term cannot win if its log does
+    // not cover the watermark — safety is checked before term.
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    let req = VoteRequest::real("cand", 9999, 10);
+    assert!(matches!(
+        voter.consider(&req, 100).unwrap(),
+        VoteDecision::Refused(RefusalReason::WatermarkNotCovered { .. })
+    ));
+}
+
+#[test]
+fn cannot_double_vote_for_two_candidates_in_same_term() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    // First candidate wins the vote in term 7.
+    assert_eq!(
+        voter
+            .consider(&VoteRequest::real("a", 7, 200), 100)
+            .unwrap(),
+        VoteDecision::Granted
+    );
+    // Second candidate in the same term is refused — already voted.
+    assert_eq!(
+        voter
+            .consider(&VoteRequest::real("b", 7, 200), 100)
+            .unwrap(),
+        VoteDecision::Refused(RefusalReason::AlreadyVoted {
+            term: 7,
+            voted_for: "a".to_string(),
+        }),
+    );
+}
+
+#[test]
+fn re_ask_by_same_candidate_in_same_term_is_idempotently_granted() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    assert!(voter
+        .consider(&VoteRequest::real("a", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+    // A retransmitted request from the *same* candidate must not be a
+    // spurious refusal (network retries are normal).
+    assert!(voter
+        .consider(&VoteRequest::real("a", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+}
+
+#[test]
+fn newer_term_clears_the_previous_terms_vote() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    assert!(voter
+        .consider(&VoteRequest::real("a", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+    // A higher term resets the per-term vote, so a new candidate can win it.
+    assert!(voter
+        .consider(&VoteRequest::real("b", 8, 200), 100)
+        .unwrap()
+        .is_granted());
+    assert_eq!(voter.current_term().unwrap(), 8);
+}
+
+#[test]
+fn stale_term_candidate_is_refused() {
+    let voter = Voter::new(
+        "v",
+        MemoryLastVoteStore::seeded(LastVote {
+            term: 10,
+            voted_for: Some("x".to_string()),
+        }),
+    );
+    let decision = voter
+        .consider(&VoteRequest::real("old", 6, 200), 100)
+        .unwrap();
+    assert_eq!(
+        decision,
+        VoteDecision::Refused(RefusalReason::StaleTerm {
+            candidate_term: 6,
+            voter_term: 10,
+        }),
+    );
+}
+
+#[test]
+fn dry_run_probe_does_not_persist_or_advance_term() {
+    let voter = Voter::new("v", MemoryLastVoteStore::new());
+    assert!(voter
+        .consider(&VoteRequest::probe("a", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+    // Term must still be 0 and no vote recorded — a probe is observation only.
+    assert_eq!(voter.current_term().unwrap(), 0);
+    // Because the probe did not persist, a *different* candidate can still
+    // win the real vote in term 7.
+    assert!(voter
+        .consider(&VoteRequest::real("b", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+}
+
+// ===============================================================
+// Durable last-vote: restart does not double-vote
+// ===============================================================
+
+#[test]
+fn file_store_round_trips_and_defaults_to_empty() {
+    let dir = std::env::temp_dir().join(format!(
+        "reddb-lastvote-{}-{}",
+        std::process::id(),
+        crate::utils::now_unix_nanos()
+    ));
+    let path = dir.join("node.lastvote.json");
+    let store = FileLastVoteStore::new(&path);
+
+    // No file yet → default (term 0, no vote).
+    assert_eq!(store.load().unwrap(), LastVote::default());
+
+    store
+        .persist(&LastVote {
+            term: 12,
+            voted_for: Some("cand-7".to_string()),
+        })
+        .unwrap();
+    // A *fresh* store over the same path (simulating a process restart)
+    // reads back the durable record.
+    let reopened = FileLastVoteStore::new(&path);
+    assert_eq!(
+        reopened.load().unwrap(),
+        LastVote {
+            term: 12,
+            voted_for: Some("cand-7".to_string()),
+        }
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn restarted_voter_does_not_double_vote_in_a_term() {
+    let dir = std::env::temp_dir().join(format!(
+        "reddb-lastvote-restart-{}-{}",
+        std::process::id(),
+        crate::utils::now_unix_nanos()
+    ));
+    let path = dir.join("node.lastvote.json");
+
+    // Voter grants candidate "a" in term 7, persisting durably.
+    {
+        let voter = Voter::new("v", FileLastVoteStore::new(&path));
+        assert!(voter
+            .consider(&VoteRequest::real("a", 7, 200), 100)
+            .unwrap()
+            .is_granted());
+    }
+
+    // Process restarts: a brand-new Voter over the same durable file.
+    {
+        let voter = Voter::new("v", FileLastVoteStore::new(&path));
+        // A different candidate asks for the same term — must be refused
+        // from disk, even though this is a fresh in-memory voter.
+        assert_eq!(
+            voter
+                .consider(&VoteRequest::real("b", 7, 200), 100)
+                .unwrap(),
+            VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                term: 7,
+                voted_for: "a".to_string(),
+            }),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ===============================================================
+// Membership / quorum threshold
+// ===============================================================
+
+#[test]
+fn quorum_threshold_is_strict_majority_of_voting_members() {
+    let three = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+    ];
+    assert_eq!(quorum_threshold(&three), 2);
+
+    // 2 data + 1 witness is a valid HA shape; witness counts → majority 2.
+    let two_plus_witness = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::witness("w"),
+    ];
+    assert_eq!(quorum_threshold(&two_plus_witness), 2);
+
+    // A catching-up replica is excluded from the denominator entirely.
+    let with_catch_up = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+        Member::data_catching_up("d"),
+    ];
+    assert_eq!(quorum_threshold(&with_catch_up), 2, "3 voters, not 4");
+}
+
+#[test]
+fn electability_excludes_witness_and_catching_up() {
+    assert!(Member::data_voting("a").is_electable());
+    assert!(
+        !Member::witness("w").is_electable(),
+        "witness holds no data"
+    );
+    assert!(
+        !Member::data_catching_up("d").is_electable(),
+        "catch-up replica is not healthy"
+    );
+}
+
+// ===============================================================
+// Randomized timeout
+// ===============================================================
+
+#[test]
+fn randomized_timeout_stays_within_band() {
+    let base = Duration::from_millis(150);
+    let jitter = Duration::from_millis(150);
+    for seed in 0..1000u64 {
+        let t = randomized_election_timeout(base, jitter, seed);
+        assert!(t >= base, "never below base");
+        assert!(t < base + jitter, "never at or beyond base+jitter");
+    }
+    // Distinct seeds spread out (anti-lockstep): two different seeds in the
+    // band give two different timeouts.
+    assert_ne!(
+        randomized_election_timeout(base, jitter, 10),
+        randomized_election_timeout(base, jitter, 11),
+    );
+    // Zero jitter degenerates to exactly base.
+    assert_eq!(randomized_election_timeout(base, Duration::ZERO, 999), base);
+}
+
+// ===============================================================
+// Cluster harness for the candidate-side coordinator
+// ===============================================================
+
+/// An in-process cluster: each voting peer is a real [`Voter`] over its own
+/// durable store, with a per-peer commit-watermark view and an optional
+/// "partitioned away" flag that makes the candidate unable to reach it.
+struct ClusterTransport {
+    members: Vec<Member>,
+    /// peer_id -> Voter state, watermark, reachable
+    peers: HashMap<String, PeerState>,
+    elapsed_steps: Rc<RefCell<Duration>>,
+    /// per-RPC clock tick, so timeouts are exercised deterministically.
+    tick: Duration,
+    bumped_term: Option<u64>,
+    promoted_term: Option<u64>,
+}
+
+struct PeerState {
+    store: Rc<MemoryLastVoteStore>,
+    watermark: u64,
+    reachable: bool,
+}
+
+impl ClusterTransport {
+    fn new(members: Vec<Member>) -> Self {
+        let mut peers = HashMap::new();
+        for m in &members {
+            peers.insert(
+                m.id.clone(),
+                PeerState {
+                    store: Rc::new(MemoryLastVoteStore::new()),
+                    watermark: 0,
+                    reachable: true,
+                },
+            );
+        }
+        Self {
+            members,
+            peers,
+            elapsed_steps: Rc::new(RefCell::new(Duration::ZERO)),
+            tick: Duration::from_millis(10),
+            bumped_term: None,
+            promoted_term: None,
+        }
+    }
+
+    fn with_watermark(mut self, watermark: u64) -> Self {
+        for p in self.peers.values_mut() {
+            p.watermark = watermark;
+        }
+        self
+    }
+
+    /// Make a peer unreachable (other side of a partition).
+    fn partition_away(&mut self, peer_id: &str) {
+        if let Some(p) = self.peers.get_mut(peer_id) {
+            p.reachable = false;
+        }
+    }
+
+    /// Share a peer's durable store so a second coordinator (a competing
+    /// candidate reaching the same voters) sees the same persisted votes.
+    fn share_store(&mut self, peer_id: &str, store: Rc<MemoryLastVoteStore>) {
+        if let Some(p) = self.peers.get_mut(peer_id) {
+            p.store = store;
+        }
+    }
+}
+
+impl ElectionTransport for ClusterTransport {
+    fn members(&self) -> Vec<Member> {
+        self.members.clone()
+    }
+
+    fn request_vote(&mut self, peer_id: &str, req: &VoteRequest) -> VoteDecision {
+        let p = self.peers.get(peer_id).expect("known peer");
+        if !p.reachable {
+            // Unreachable peer: model as a silent no-grant (a timeout would
+            // surface as a refusal at the candidate). It still must not have
+            // its durable store touched.
+            return VoteDecision::Refused(RefusalReason::StaleTerm {
+                candidate_term: req.term,
+                voter_term: u64::MAX,
+            });
+        }
+        // Each peer applies the real vote rule over its own durable store.
+        let voter = VoterRef {
+            store: Rc::clone(&p.store),
+        };
+        voter.consider(req, p.watermark)
+    }
+
+    fn elapsed(&self) -> Duration {
+        let mut e = self.elapsed_steps.borrow_mut();
+        let now = *e;
+        *e += self.tick;
+        now
+    }
+
+    fn bump_term(&mut self, new_term: u64) {
+        self.bumped_term = Some(new_term);
+    }
+
+    fn promote(&mut self, new_term: u64) {
+        self.promoted_term = Some(new_term);
+    }
+}
+
+/// Thin wrapper so the harness can build a [`Voter`] over an `Rc`-shared
+/// store without moving it.
+struct VoterRef {
+    store: Rc<MemoryLastVoteStore>,
+}
+
+impl VoterRef {
+    fn consider(&self, req: &VoteRequest, watermark: u64) -> VoteDecision {
+        // Reuse the real rule by delegating to a Voter over a borrowed store.
+        let voter = Voter::new("peer", RcStore(Rc::clone(&self.store)));
+        voter
+            .consider(req, watermark)
+            .expect("memory store infallible")
+    }
+}
+
+/// `LastVoteStore` over an `Rc<MemoryLastVoteStore>` so multiple coordinators
+/// can share one durable record (used for the partition double-vote proof).
+struct RcStore(Rc<MemoryLastVoteStore>);
+
+impl LastVoteStore for RcStore {
+    fn load(&self) -> Result<LastVote, LastVoteError> {
+        self.0.load()
+    }
+    fn persist(&self, vote: &LastVote) -> Result<(), LastVoteError> {
+        self.0.persist(vote)
+    }
+}
+
+fn candidate_request(id: &str, current_term: u64, lsn: u64, watermark: u64) -> ElectionRequest {
+    ElectionRequest {
+        candidate: Member::data_voting(id),
+        current_term,
+        last_log_lsn: lsn,
+        commit_watermark: watermark,
+    }
+}
+
+const LONG: Duration = Duration::from_secs(60);
+
+// ===============================================================
+// Candidate-side coordinator
+// ===============================================================
+
+#[test]
+fn covering_candidate_is_elected_by_majority() {
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    // Candidate "a" covers the watermark (frontier 150 >= 100).
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(
+        outcome,
+        ElectionOutcome::Elected {
+            term: 5,
+            votes: 2,
+            needed: 2,
+        }
+    );
+    assert_eq!(tx.bumped_term, Some(5), "real election bumps the term");
+    assert_eq!(tx.promoted_term, Some(5), "winner is promoted via handover");
+}
+
+#[test]
+fn candidate_not_covering_watermark_cannot_win() {
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    // Candidate "a" frontier 80 < watermark 100 → not electable, no probe.
+    let req = candidate_request("a", 4, 80, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(outcome, ElectionOutcome::NotElectable);
+    assert_eq!(
+        tx.bumped_term, None,
+        "no term bump for an unelectable candidate"
+    );
+    assert_eq!(tx.promoted_term, None);
+}
+
+#[test]
+fn voters_below_watermark_refuse_so_lagging_candidate_loses() {
+    // Candidate covers its own watermark belief, but the *voters* hold a
+    // higher watermark the candidate does not cover, so they refuse and the
+    // candidate cannot assemble a majority. Demonstrates the rule is enforced
+    // at every voter, not just self-asserted by the candidate.
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(500);
+    // Candidate believes watermark is 100 and covers it (frontier 120), but
+    // its frontier 120 < the voters' real watermark 500.
+    let req = candidate_request("a", 4, 120, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    // Self-vote only (1), needed 2 → probe fails, term never bumped.
+    assert_eq!(
+        outcome,
+        ElectionOutcome::ProbeFailed {
+            votes: 1,
+            needed: 2
+        }
+    );
+    assert_eq!(tx.bumped_term, None);
+}
+
+#[test]
+fn dry_run_probe_does_not_bump_term_when_it_fails() {
+    // 5 members, but 3 voters are partitioned away → only 2 reachable
+    // (candidate + 1), below the majority of 3. Probe fails, term untouched.
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+        Member::data_voting("d"),
+        Member::data_voting("e"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    tx.partition_away("c");
+    tx.partition_away("d");
+    tx.partition_away("e");
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(
+        outcome,
+        ElectionOutcome::ProbeFailed {
+            votes: 2,
+            needed: 3
+        }
+    );
+    assert_eq!(
+        tx.bumped_term, None,
+        "a failed probe must NOT bump the term"
+    );
+    assert_eq!(tx.promoted_term, None);
+}
+
+#[test]
+fn witness_vote_counts_toward_quorum() {
+    // 2 data + 1 witness. Candidate "a" + witness "w" = 2 = majority of 3.
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::witness("w"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    // "b" is partitioned away; the witness alone supplies the second vote.
+    tx.partition_away("b");
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(
+        outcome,
+        ElectionOutcome::Elected {
+            term: 5,
+            votes: 2,
+            needed: 2,
+        },
+        "the witness vote completes the majority",
+    );
+}
+
+#[test]
+fn catching_up_replica_neither_votes_nor_enlarges_quorum() {
+    // 3 voters + 1 catching-up. Majority is 2 (of the 3 voters). The
+    // catch-up replica must not be asked and must not raise the denominator.
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_catching_up("c"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    // Even if "c" *would* grant, it is excluded; "b" supplies the 2nd vote.
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(
+        outcome,
+        ElectionOutcome::Elected {
+            term: 5,
+            votes: 2,
+            needed: 2,
+        }
+    );
+}
+
+#[test]
+fn election_times_out_without_a_majority() {
+    // Candidate alone reachable among 3; with a tiny timeout the coordinator
+    // gives up mid-collection rather than hanging.
+    let members = vec![
+        Member::data_voting("a"),
+        Member::data_voting("b"),
+        Member::data_voting("c"),
+    ];
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    tx.partition_away("b");
+    tx.partition_away("c");
+    // tick is 10ms/poll; a 5ms timeout trips on the first peer poll.
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, Duration::from_millis(5));
+
+    assert!(
+        matches!(outcome, ElectionOutcome::TimedOut { needed: 2, .. }),
+        "got {outcome:?}",
+    );
+    assert_eq!(tx.bumped_term, None, "timed-out probe does not bump term");
+}
+
+// ===============================================================
+// No two primaries in a term — partition proof
+// ===============================================================
+
+#[test]
+fn partition_minority_candidate_cannot_win() {
+    // 5 voters partitioned {a,b} | {c,d,e}. A candidate in the minority
+    // side reaches only itself + b = 2 < majority 3 → cannot win.
+    let members: Vec<Member> = ["a", "b", "c", "d", "e"]
+        .iter()
+        .map(|id| Member::data_voting(*id))
+        .collect();
+    let mut tx = ClusterTransport::new(members).with_watermark(100);
+    tx.partition_away("c");
+    tx.partition_away("d");
+    tx.partition_away("e");
+    let req = candidate_request("a", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut tx, LONG);
+
+    assert_eq!(
+        outcome,
+        ElectionOutcome::ProbeFailed {
+            votes: 2,
+            needed: 3
+        }
+    );
+    assert_eq!(tx.promoted_term, None, "minority side promotes no one");
+}
+
+#[test]
+fn partition_majority_candidate_wins_and_minority_cannot_take_same_term() {
+    // The decisive proof. 5 voters. Two candidates stand for the SAME term
+    // (current_term 4 → term 5) on opposite sides of a partition, sharing
+    // the voters' durable stores. Only the majority side may win term 5, and
+    // the shared voter's durable last-vote blocks the other from also
+    // winning term 5 — so no two primaries hold term 5.
+    let ids = ["a", "b", "c", "d", "e"];
+    let members: Vec<Member> = ids.iter().map(|id| Member::data_voting(*id)).collect();
+
+    // One shared durable store per voter, so both coordinators observe the
+    // same persisted votes (models the real cluster's per-node disk).
+    let stores: HashMap<&str, Rc<MemoryLastVoteStore>> = ids
+        .iter()
+        .map(|id| (*id, Rc::new(MemoryLastVoteStore::new())))
+        .collect();
+
+    // --- Majority side: candidate "c" reaches c,d,e (and a,b are away). ---
+    let mut majority = ClusterTransport::new(members.clone()).with_watermark(100);
+    for id in &ids {
+        majority.share_store(id, Rc::clone(&stores[id]));
+    }
+    majority.partition_away("a");
+    majority.partition_away("b");
+    let c_req = candidate_request("c", 4, 150, 100);
+    let c_outcome = ElectionCoordinator::run(&c_req, &mut majority, LONG);
+    assert_eq!(
+        c_outcome,
+        ElectionOutcome::Elected {
+            term: 5,
+            votes: 3,
+            needed: 3,
+        },
+        "majority side elects c for term 5",
+    );
+    assert_eq!(majority.promoted_term, Some(5));
+
+    // --- Minority side: candidate "a" reaches only a,b for the SAME term. ---
+    let mut minority = ClusterTransport::new(members).with_watermark(100);
+    for id in &ids {
+        minority.share_store(id, Rc::clone(&stores[id]));
+    }
+    minority.partition_away("c");
+    minority.partition_away("d");
+    minority.partition_away("e");
+    let a_req = candidate_request("a", 4, 150, 100);
+    let a_outcome = ElectionCoordinator::run(&a_req, &mut minority, LONG);
+
+    // a reaches only a + b = 2 < 3, so it loses regardless. The structural
+    // guarantee: even had it reached a third voter that already granted c,
+    // that voter's durable last-vote refuses a in term 5.
+    assert!(
+        !a_outcome.is_elected(),
+        "minority candidate must not also win term 5, got {a_outcome:?}",
+    );
+    assert_eq!(minority.promoted_term, None, "no second primary for term 5");
+
+    // Direct durable proof: candidate "c" self-votes without an RPC, so its
+    // own store is untouched, but the peers it reached (d, e) persisted the
+    // grant. Any such voter refuses a competing candidate "a" in term 5 —
+    // this is the per-node durable barrier that forbids a second primary.
+    let shared_voter = Voter::new("d", RcStore(Rc::clone(&stores["d"])));
+    assert_eq!(
+        shared_voter
+            .consider(&VoteRequest::real("a", 5, 150), 100)
+            .unwrap(),
+        VoteDecision::Refused(RefusalReason::AlreadyVoted {
+            term: 5,
+            voted_for: "c".to_string(),
+        }),
+        "a voter that granted c in term 5 blocks a second primary in term 5",
+    );
+}

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -24,6 +24,7 @@ pub mod bookmark;
 pub mod cdc;
 pub mod commit_policy;
 pub mod commit_waiter;
+pub mod election;
 pub mod failover;
 pub mod flow_control;
 pub mod lease;
@@ -38,6 +39,12 @@ pub mod topology_advertiser;
 pub use bookmark::{BookmarkDecodeError, CausalBookmark};
 pub use commit_policy::CommitPolicy;
 pub use commit_waiter::{AwaitOutcome, CommitWaiter};
+pub use election::{
+    quorum_threshold, randomized_election_timeout, ElectionCoordinator, ElectionOutcome,
+    ElectionRequest, ElectionTransport, FileLastVoteStore, LastVote, LastVoteError, LastVoteStore,
+    Member, MemberKind, MemoryLastVoteStore, RefusalReason, VoteDecision, VoteRequest, Voter,
+    VotingState,
+};
 pub use failover::{
     FailoverCoordinator, FailoverError, FailoverMode, FailoverNode, FailoverOutcome,
     FailoverRequest, FailoverTransport, NodeRole, RoleAssignment,

--- a/crates/reddb-server/src/storage/unified/spatial_index.rs
+++ b/crates/reddb-server/src/storage/unified/spatial_index.rs
@@ -132,7 +132,7 @@ impl SpatialIndex {
 
         let mut results: Vec<SpatialSearchResult> = self
             .tree
-            .locate_in_envelope(&aabb)
+            .locate_in_envelope(aabb)
             .filter_map(|entry| {
                 let [lon, lat] = *entry.geom();
                 let dist = haversine_km(center_lat, center_lon, lat, lon);
@@ -168,7 +168,7 @@ impl SpatialIndex {
         let aabb = AABB::from_corners([min_lon, min_lat], [max_lon, max_lat]);
 
         self.tree
-            .locate_in_envelope(&aabb)
+            .locate_in_envelope(aabb)
             .take(limit)
             .map(|entry| SpatialSearchResult {
                 entity_id: entry.data,
@@ -180,7 +180,7 @@ impl SpatialIndex {
     /// Find the K nearest points to a location
     pub fn search_nearest(&self, lat: f64, lon: f64, k: usize) -> Vec<SpatialSearchResult> {
         self.tree
-            .nearest_neighbor_iter(&[lon, lat])
+            .nearest_neighbor_iter([lon, lat])
             .take(k)
             .map(|entry| {
                 let [elon, elat] = *entry.geom();

--- a/crates/reddb-server/tests/election_consensus_e2e.rs
+++ b/crates/reddb-server/tests/election_consensus_e2e.rs
@@ -1,0 +1,357 @@
+//! End-to-end acceptance tests for the term-based, quorum-gated election
+//! (issue #834, PRD #819, ADR 0030).
+//!
+//! Where the in-crate unit tests exercise each rule in isolation, this suite
+//! drives the public election API exactly as the control-plane supervisor
+//! would, asserting the issue's acceptance criteria as black-box behaviour:
+//!
+//! 1. On primary loss, a replica covering the commit watermark is elected by
+//!    majority within the election timeout.
+//! 2. A candidate not covering the commit watermark cannot win.
+//! 3. Last-vote is durable; a restarted voter does not double-vote in a term.
+//! 4. Dry-run probing does not bump the term; witnesses count toward quorum;
+//!    a catching-up replica is non-voting until healthy.
+//! 5. No two primaries in a term — demonstrated under partition.
+//!
+//! The harness wires real [`Voter`]s (over durable [`FileLastVoteStore`]s, so
+//! the restart criterion is genuinely on-disk) behind the public
+//! [`ElectionTransport`]; the candidate side is the real
+//! [`ElectionCoordinator`]. No clock, no network — the clock and reachability
+//! are injected so the assertions are deterministic.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use reddb_server::replication::{
+    randomized_election_timeout, ElectionCoordinator, ElectionOutcome, ElectionRequest,
+    ElectionTransport, FileLastVoteStore, Member, RefusalReason, VoteDecision, VoteRequest, Voter,
+};
+
+const LONG: Duration = Duration::from_secs(60);
+
+/// Unique temp dir for one test's per-node durable last-vote files.
+fn temp_cluster_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "reddb-election-e2e-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+struct PeerState {
+    /// Durable path so a "restart" re-opens the same on-disk record.
+    path: std::path::PathBuf,
+    watermark: u64,
+    reachable: bool,
+}
+
+/// Black-box cluster: each peer is a real durable [`Voter`]; the candidate is
+/// the real coordinator. Clock advances a fixed tick per RPC.
+struct Cluster {
+    dir: std::path::PathBuf,
+    members: Vec<Member>,
+    peers: HashMap<String, PeerState>,
+    elapsed: Arc<Mutex<Duration>>,
+    tick: Duration,
+    bumped: Vec<u64>,
+    promoted: Option<u64>,
+}
+
+impl Cluster {
+    fn new(dir: std::path::PathBuf, members: Vec<Member>, watermark: u64) -> Self {
+        let peers = members
+            .iter()
+            .map(|m| {
+                (
+                    m.id.clone(),
+                    PeerState {
+                        path: dir.join(format!("{}.lastvote.json", m.id)),
+                        watermark,
+                        reachable: true,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            dir,
+            members,
+            peers,
+            elapsed: Arc::new(Mutex::new(Duration::ZERO)),
+            tick: Duration::from_millis(10),
+            bumped: Vec::new(),
+            promoted: None,
+        }
+    }
+
+    fn partition_away(&mut self, id: &str) {
+        self.peers.get_mut(id).unwrap().reachable = false;
+    }
+}
+
+impl ElectionTransport for Cluster {
+    fn members(&self) -> Vec<Member> {
+        self.members.clone()
+    }
+
+    fn request_vote(&mut self, peer_id: &str, req: &VoteRequest) -> VoteDecision {
+        let p = self.peers.get(peer_id).expect("known peer");
+        if !p.reachable {
+            // Unreachable peer in a partition: no grant, durable store untouched.
+            return VoteDecision::Refused(RefusalReason::StaleTerm {
+                candidate_term: req.term,
+                voter_term: u64::MAX,
+            });
+        }
+        let voter = Voter::new(peer_id, FileLastVoteStore::new(&p.path));
+        voter.consider(req, p.watermark).expect("durable store")
+    }
+
+    fn elapsed(&self) -> Duration {
+        let mut e = self.elapsed.lock().unwrap();
+        let now = *e;
+        *e += self.tick;
+        now
+    }
+
+    fn bump_term(&mut self, new_term: u64) {
+        self.bumped.push(new_term);
+    }
+
+    fn promote(&mut self, new_term: u64) {
+        self.promoted = Some(new_term);
+    }
+}
+
+fn cleanup(c: &Cluster) {
+    let _ = std::fs::remove_dir_all(&c.dir);
+}
+
+fn candidate(id: &str, current_term: u64, lsn: u64, watermark: u64) -> ElectionRequest {
+    ElectionRequest {
+        candidate: Member::data_voting(id),
+        current_term,
+        last_log_lsn: lsn,
+        commit_watermark: watermark,
+    }
+}
+
+// Criterion 1: primary loss → covering replica elected by majority in time.
+#[test]
+fn covering_replica_is_elected_by_majority_within_timeout() {
+    let dir = temp_cluster_dir("elect");
+    let members = vec![
+        Member::data_voting("r1"),
+        Member::data_voting("r2"),
+        Member::data_voting("r3"),
+    ];
+    let mut cluster = Cluster::new(dir, members, 100);
+    // The old primary is gone; replica r1 covers the watermark (frontier 150).
+    let req = candidate("r1", 4, 150, 100);
+
+    let timeout =
+        randomized_election_timeout(Duration::from_millis(150), Duration::from_millis(150), 7);
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, timeout);
+
+    assert!(
+        matches!(outcome, ElectionOutcome::Elected { term: 5, .. }),
+        "got {outcome:?}",
+    );
+    assert_eq!(cluster.promoted, Some(5));
+    cleanup(&cluster);
+}
+
+// Criterion 2: a candidate below the watermark cannot win.
+#[test]
+fn candidate_below_watermark_cannot_win() {
+    let dir = temp_cluster_dir("below");
+    let members = vec![
+        Member::data_voting("r1"),
+        Member::data_voting("r2"),
+        Member::data_voting("r3"),
+    ];
+    let mut cluster = Cluster::new(dir, members, 100);
+    // r1's frontier 90 does not cover watermark 100.
+    let req = candidate("r1", 4, 90, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
+
+    assert_eq!(outcome, ElectionOutcome::NotElectable);
+    assert!(cluster.bumped.is_empty(), "no term burned");
+    assert_eq!(cluster.promoted, None);
+    cleanup(&cluster);
+}
+
+// Criterion 3: durable last-vote survives restart — no double-vote.
+#[test]
+fn restarted_voter_does_not_double_vote() {
+    let dir = temp_cluster_dir("restart");
+    let path = dir.join("r2.lastvote.json");
+
+    // r2 grants candidate "alpha" in term 5, persisted to disk.
+    {
+        let voter = Voter::new("r2", FileLastVoteStore::new(&path));
+        assert!(voter
+            .consider(&VoteRequest::real("alpha", 5, 200), 100)
+            .unwrap()
+            .is_granted());
+    }
+    // r2 "restarts": a fresh Voter over the same durable file. A different
+    // candidate asking for term 5 is refused from disk.
+    {
+        let voter = Voter::new("r2", FileLastVoteStore::new(&path));
+        assert_eq!(
+            voter
+                .consider(&VoteRequest::real("beta", 5, 200), 100)
+                .unwrap(),
+            VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                term: 5,
+                voted_for: "alpha".to_string(),
+            }),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// Criterion 4a: a failed dry-run probe does not bump the term.
+#[test]
+fn failed_probe_does_not_bump_term() {
+    let dir = temp_cluster_dir("probe");
+    let members = vec![
+        Member::data_voting("r1"),
+        Member::data_voting("r2"),
+        Member::data_voting("r3"),
+    ];
+    let mut cluster = Cluster::new(dir, members, 100);
+    cluster.partition_away("r2");
+    cluster.partition_away("r3");
+    let req = candidate("r1", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
+
+    assert!(
+        matches!(outcome, ElectionOutcome::ProbeFailed { .. }),
+        "got {outcome:?}"
+    );
+    assert!(
+        cluster.bumped.is_empty(),
+        "dry-run probe must not bump the term"
+    );
+    cleanup(&cluster);
+}
+
+// Criterion 4b: a witness vote counts toward quorum.
+#[test]
+fn witness_completes_the_quorum() {
+    let dir = temp_cluster_dir("witness");
+    let members = vec![
+        Member::data_voting("r1"),
+        Member::data_voting("r2"),
+        Member::witness("w1"),
+    ];
+    let mut cluster = Cluster::new(dir, members, 100);
+    cluster.partition_away("r2"); // only candidate + witness reachable
+    let req = candidate("r1", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
+
+    assert!(
+        matches!(
+            outcome,
+            ElectionOutcome::Elected {
+                term: 5,
+                votes: 2,
+                needed: 2
+            }
+        ),
+        "witness vote should complete the majority, got {outcome:?}",
+    );
+    cleanup(&cluster);
+}
+
+// Criterion 4c: a catching-up replica is non-voting and out of the denominator.
+#[test]
+fn catching_up_replica_is_non_voting() {
+    let dir = temp_cluster_dir("catchup");
+    let members = vec![
+        Member::data_voting("r1"),
+        Member::data_voting("r2"),
+        Member::data_catching_up("r3"), // syncing — excluded
+    ];
+    let mut cluster = Cluster::new(dir, members, 100);
+    let req = candidate("r1", 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
+
+    // Majority is 2 of the 2 healthy voters; r3 neither votes nor raises it.
+    assert!(
+        matches!(
+            outcome,
+            ElectionOutcome::Elected {
+                term: 5,
+                needed: 2,
+                ..
+            }
+        ),
+        "got {outcome:?}",
+    );
+    cleanup(&cluster);
+}
+
+// Criterion 5: no two primaries in a term, under partition. Two candidates on
+// opposite sides stand for the SAME term over SHARED durable voter state; only
+// the majority side wins, and the durable last-vote forbids the other.
+#[test]
+fn no_two_primaries_in_a_term_under_partition() {
+    let dir = temp_cluster_dir("partition");
+    let ids = ["a", "b", "c", "d", "e"];
+    let members: Vec<Member> = ids.iter().map(|id| Member::data_voting(*id)).collect();
+
+    // Both partitions read/write the SAME per-node durable files (one disk
+    // per node). Build two clusters pointed at the same dir.
+    let mut majority = Cluster::new(dir.clone(), members.clone(), 100);
+    majority.partition_away("a");
+    majority.partition_away("b");
+    let c_outcome = ElectionCoordinator::run(&candidate("c", 4, 150, 100), &mut majority, LONG);
+    assert!(
+        matches!(
+            c_outcome,
+            ElectionOutcome::Elected {
+                term: 5,
+                votes: 3,
+                needed: 3
+            }
+        ),
+        "majority side elects c for term 5, got {c_outcome:?}",
+    );
+    assert_eq!(majority.promoted, Some(5));
+
+    let mut minority = Cluster::new(dir.clone(), members, 100);
+    minority.partition_away("c");
+    minority.partition_away("d");
+    minority.partition_away("e");
+    let a_outcome = ElectionCoordinator::run(&candidate("a", 4, 150, 100), &mut minority, LONG);
+    assert!(
+        !matches!(a_outcome, ElectionOutcome::Elected { .. }),
+        "minority side must not also elect a primary for term 5, got {a_outcome:?}",
+    );
+    assert_eq!(minority.promoted, None, "no second primary in term 5");
+
+    // Durable barrier: a voter d, which granted c in term 5, refuses a in 5
+    // even across a process restart (fresh Voter over the same file).
+    let d_path = dir.join("d.lastvote.json");
+    let d = Voter::new("d", FileLastVoteStore::new(&d_path));
+    assert_eq!(
+        d.consider(&VoteRequest::real("a", 5, 150), 100).unwrap(),
+        VoteDecision::Refused(RefusalReason::AlreadyVoted {
+            term: 5,
+            voted_for: "c".to_string(),
+        }),
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

Implements the consensus core for automatic failover (issue #834, PRD #819, **ADR 0030**): a term-based, quorum-gated automatic election. Design was approved via HITL; this lands the specified behaviour with the hard invariants test-proven.

Lands in the **first-party-but-decoupled control-plane supervisor** (new `replication::election` module) — *not* in the data path. Reuses the existing commit-watermark ack state (`commit_waiter`/`quorum`) and the FAILOVER handover machinery (`failover.rs`, #833).

## How it satisfies the brief

- **Dry-run probe** — a candidate first asks "*would* you vote for me?" without bumping any term; only a real election bumps it (term framing per #821 / ADR 0032).
- **Durable last-vote** — `(term, voted_for)` persisted via `FileLastVoteStore` (atomic temp+rename+fsync) **before** a grant is acked, so a restarted voter never double-votes in a term.
- **Watermark vote rule (safety core)** — a voter refuses any candidate whose log frontier does not cover the commit watermark, checked *before* term, so an acked synchronous write provably survives a failover. The rule is enforced at every voter, not self-asserted by the candidate.
- **Randomized election timeouts** — `randomized_election_timeout(base, jitter, seed)`, pure in `seed` for deterministic tests.
- **Witness votes** count toward quorum (#836); a **catching-up replica is non-voting** (excluded from both votes and the majority denominator) until healthy.
- **Promotion** drives through the existing FAILOVER handover (transport `promote`).

`ElectionCoordinator::run` is a pure state machine with an injected `ElectionTransport` (mirrors the `failover.rs` pattern) — no clock, no network, no engine in the logic.

## No two primaries in a term

Structural, not probabilistic: a win needs a strict majority of voting members (two majorities of one set always intersect), and the shared voter grants at most one candidate per term via the durable last-vote. Proven under partition in the tests.

## Tests (gating)

- **22 unit tests** (`src/replication/election/tests.rs`) — vote rule, durable double-vote guard, dry-run no-term-bump, witness counting, catch-up exclusion, randomized timeout band, partition proof.
- **7 e2e acceptance tests** (`tests/election_consensus_e2e.rs`) — one per acceptance criterion, black-box through the public API with real on-disk `FileLastVoteStore`s, incl. **restart-no-double-vote** and **no-two-primaries-under-partition**.

All 29 pass; `cargo fmt` clean; `clippy` clean on the new files (pre-existing repo clippy findings are unrelated).

## Scope / follow-ups

This ships the consensus primitive + durable store + coordinator and exports them. Wiring the supervisor to live membership/RPC/WAL frontier and fencing the ex-primary (#835) are out of scope here, per the brief.

## Review note

Highest-risk correctness slice — landing via **PR for human review** (no admin-merge), per the HITL operating constraint. The partition and restart-double-vote tests are gating.

Refs ADR 0030; #821, #822, #833, #835, #836.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783003352&installation_id=129708444&pr_number=939&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F939&signature=c89877ea59763d5719cc1284259888aebcdb61ca985d4b5be0d4ee214fb933e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated leader election with a two-phase (probe + real) quorum voting process
  * Durable last-vote persistence to prevent unsafe double-votes and ensure restart safety
  * Pre-election probe to verify majority reachability before committing a term bump

* **Tests**
  * Comprehensive unit tests for voter safety rules and quorum semantics
  * End-to-end acceptance tests validating election behavior, timeouts, partitions, and durable votes

* **Bug Fixes**
  * Adjusted spatial index query argument handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->