### PR TITLE
feat(replication): auto-rollback deposed primary to common point (#840)

### DIFF
--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -31,6 +31,7 @@ pub mod logical;
 pub mod primary;
 pub mod quorum;
 pub mod replica;
+pub mod rollback;
 pub mod scheduler;
 pub mod swap_db;
 pub mod topology_advertiser;
@@ -45,6 +46,10 @@ pub use failover::{
 pub use flow_control::{Admission, FlowController};
 pub use lease::{LeaseError, LeaseStore, WriterLease};
 pub use quorum::{QuorumConfig, QuorumCoordinator, QuorumError};
+pub use rollback::{
+    DivergentTail, RollbackCoordinator, RollbackError, RollbackEvent, RollbackOutcome,
+    RollbackPlan, RollbackRequest, RollbackTransport, TailRecord,
+};
 pub use swap_db::{RebootstrapInProgress, SwapDb};
 pub use topology_advertiser::{
     LagConfig, TopologyAdvertiser, TopologyAuthGate, DEFAULT_REPLICA_TIMEOUT_MS,

--- a/crates/reddb-server/src/replication/rollback.rs
+++ b/crates/reddb-server/src/replication/rollback.rs
@@ -1,0 +1,679 @@
+//! Auto-rollback of a deposed primary to the common point (issue #840,
+//! PRD #819, ADR 0030).
+//!
+//! When a former primary rejoins after a failover still holding writes
+//! above the point its log last agreed with the new primary — a
+//! *divergent tail* — it must drop that tail to rejoin a single timeline.
+//! The tail is, by definition, **non-committed**: it sits above the
+//! commit watermark (the highest LSN durably replicated to a quorum), so
+//! removing it from the live timeline is correct (ADR 0030,
+//! `NeverRollbackCommitted`).
+//!
+//! This module is the *recover-to-LSN* mechanism that does that drop:
+//!
+//! 1. **Plan & guard the boundary.** The recover target is the *common
+//!    point* — the LSN up to which the deposed primary's log still agrees
+//!    with the new primary (produced by the election, #834). The hard
+//!    invariant is that the common point is **at or above the commit
+//!    watermark** (#822): nothing at or below the watermark is ever rolled
+//!    back. If the common point is below the watermark, the coordinator
+//!    **refuses** to roll back rather than destroy committed data.
+//! 2. **Preserve the tail.** Read the divergent tail and persist it to a
+//!    rollback file *before* anything is removed. Rollback is never
+//!    silent: if the tail cannot be persisted, the recovery aborts and no
+//!    data is dropped.
+//! 3. **Recover-to-LSN.** Roll the live timeline back to the common point
+//!    over the MVCC history store (ADR 0014), discarding the tail's
+//!    versions and restoring the pre-images visible at the common point.
+//! 4. **Surface a loud operator event** so the discarded writes stay
+//!    auditable and reconcilable.
+//! 5. **Rejoin as a replica** of the new primary under the new term.
+//!
+//! ## Module shape
+//!
+//! [`RollbackCoordinator::run`] is a pure state machine. The boundary
+//! math ([`RollbackPlan::compute`]) is separated out so the invariant can
+//! be asserted in isolation. Every side effect — reading the tail,
+//! writing the rollback file, the MVCC recover-to-LSN, the operator
+//! event, the role swap — is injected behind [`RollbackTransport`], so
+//! the whole flow runs deterministically against a scripted fake with no
+//! engine, disk, clock, or network dependency. Wiring the transport onto
+//! the real MVCC history store and the gRPC role-swap belongs to the
+//! transport layer once the election (#834) and stale-term fencing (#835)
+//! are live; this slice builds and proves the mechanism in isolation.
+
+use super::failover::NodeRole;
+
+/// A single record from the divergent tail that is about to be discarded.
+///
+/// Carries enough to reconstruct the write for an operator who later
+/// reconciles a rollback file: its LSN, the term that produced it, and the
+/// opaque record payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TailRecord {
+    /// LSN of this record on the deposed primary's local timeline.
+    pub lsn: u64,
+    /// The replication term under which the deposed primary wrote it.
+    pub term: u64,
+    /// Opaque encoded record bytes, preserved verbatim in the rollback
+    /// file.
+    pub payload: Vec<u8>,
+}
+
+impl TailRecord {
+    pub fn new(lsn: u64, term: u64, payload: impl Into<Vec<u8>>) -> Self {
+        Self {
+            lsn,
+            term,
+            payload: payload.into(),
+        }
+    }
+}
+
+/// The divergent tail removed from the live timeline: the records in
+/// `(common_point_lsn, to_lsn]` that never reached quorum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DivergentTail {
+    /// The common point — exclusive lower bound. Records at or below this
+    /// LSN are kept; this is the recover-to-LSN target.
+    pub common_point_lsn: u64,
+    /// Inclusive upper bound — the deposed primary's local frontier.
+    pub to_lsn: u64,
+    /// The tail records, in LSN order. May be shorter than the LSN span
+    /// (e.g. sparse / coalesced records); the span is authoritative for
+    /// the boundary, the records are what gets preserved.
+    pub records: Vec<TailRecord>,
+}
+
+impl DivergentTail {
+    /// Number of LSNs removed from the live timeline.
+    pub fn span_lsns(&self) -> u64 {
+        self.to_lsn.saturating_sub(self.common_point_lsn)
+    }
+}
+
+/// The computed, side-effect-free rollback plan. Splitting this out lets
+/// the boundary invariant be asserted without driving any transport.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackPlan {
+    /// The recover-to-LSN target: the common point with the new primary.
+    pub recover_to_lsn: u64,
+    /// The deposed primary's local frontier (inclusive tail upper bound).
+    pub local_frontier: u64,
+    /// The commit watermark — the durable floor that bounds the recover
+    /// target from below.
+    pub commit_watermark: u64,
+    /// Number of LSNs the tail spans (`local_frontier - recover_to_lsn`).
+    pub tail_lsns: u64,
+}
+
+impl RollbackPlan {
+    /// Compute and validate the rollback plan for `req`.
+    ///
+    /// Enforces the hard invariant: the recover target (common point)
+    /// must be **at or above** the commit watermark, so nothing at or
+    /// below the watermark is ever rolled back. A common point below the
+    /// watermark means the election handed us a target that would discard
+    /// committed data — a contract violation we refuse rather than honour.
+    pub fn compute(req: &RollbackRequest) -> Result<Self, RollbackError> {
+        if req.common_point < req.commit_watermark {
+            return Err(RollbackError::WatermarkViolation {
+                common_point: req.common_point,
+                commit_watermark: req.commit_watermark,
+            });
+        }
+        Ok(Self {
+            recover_to_lsn: req.common_point,
+            local_frontier: req.local_frontier,
+            commit_watermark: req.commit_watermark,
+            tail_lsns: req.local_frontier.saturating_sub(req.common_point),
+        })
+    }
+
+    /// Whether there is a divergent tail to roll back. When the local
+    /// frontier is at or below the common point the node is already on the
+    /// shared timeline and only needs to rejoin.
+    pub fn has_divergent_tail(&self) -> bool {
+        self.local_frontier > self.recover_to_lsn
+    }
+}
+
+/// A request to auto-rollback a deposed primary to the common point and
+/// rejoin it as a replica.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackRequest {
+    /// The deposed primary's highest local LSN (tail upper bound).
+    pub local_frontier: u64,
+    /// The common point with the new primary — the recover-to-LSN target,
+    /// produced by the election (#834).
+    pub common_point: u64,
+    /// The commit watermark — the highest LSN durably replicated to a
+    /// quorum (#822). The recover target may never fall below this.
+    pub commit_watermark: u64,
+    /// Dial address of the new primary the node rejoins as a replica of.
+    pub new_primary_addr: String,
+    /// The term the new primary serves; the rejoining replica follows it.
+    pub new_term: u64,
+}
+
+/// The loud operator event payload describing a completed rollback,
+/// handed to [`RollbackTransport::emit_rollback_event`]. Mirrors
+/// [`crate::telemetry::operator_event::OperatorEvent::DeposedPrimaryRollback`]
+/// so the production transport can forward it verbatim while a test
+/// transport can capture it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackEvent {
+    pub common_point_lsn: u64,
+    pub tail_to_lsn: u64,
+    pub tail_lsns: u64,
+    pub commit_watermark: u64,
+    pub rollback_file: String,
+    pub new_primary_addr: String,
+    pub new_term: u64,
+}
+
+/// The result of a completed rejoin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RollbackOutcome {
+    /// The LSN the node recovered to — the common point.
+    pub recovered_to_lsn: u64,
+    /// Number of LSNs removed from the live timeline (`0` when there was
+    /// no divergent tail).
+    pub tail_lsns: u64,
+    /// Where the discarded tail was preserved. `None` only when there was
+    /// no tail to preserve.
+    pub rollback_file: Option<String>,
+    /// Whether the loud operator event fired. Always `true` when a tail
+    /// was discarded; `false` for a clean rejoin with no tail.
+    pub event_fired: bool,
+    /// The role the node now plays — a replica of the new primary under
+    /// the new term.
+    pub role: NodeRole,
+}
+
+impl RollbackOutcome {
+    /// True when a divergent tail was actually rolled back (as opposed to
+    /// a clean rejoin with nothing to discard).
+    pub fn rolled_back_tail(&self) -> bool {
+        self.tail_lsns > 0
+    }
+}
+
+/// Why an auto-rollback could not complete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RollbackError {
+    /// The common point is below the commit watermark, so recovering to it
+    /// would roll back committed data. Refused — nothing was changed. This
+    /// should never happen given the election vote rule (ADR 0030); if it
+    /// does, the cluster has a deeper consistency fault that needs an
+    /// operator, not a silent data loss.
+    WatermarkViolation {
+        common_point: u64,
+        commit_watermark: u64,
+    },
+    /// The divergent tail could not be persisted to a rollback file.
+    /// Recovery aborted **before** removing anything: rollback is never
+    /// silent, so if the tail cannot be preserved it is not discarded.
+    TailPersistFailed { reason: String },
+    /// The recover-to-LSN over the MVCC history store failed. The tail was
+    /// already preserved to a rollback file, but the live timeline was not
+    /// rolled back; the node must not rejoin until an operator resolves it.
+    RecoverFailed { target_lsn: u64, reason: String },
+}
+
+impl std::fmt::Display for RollbackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RollbackError::WatermarkViolation {
+                common_point,
+                commit_watermark,
+            } => write!(
+                f,
+                "auto-rollback refused: common point {common_point} is below the commit watermark \
+                 {commit_watermark}; recovering to it would roll back committed data",
+            ),
+            RollbackError::TailPersistFailed { reason } => write!(
+                f,
+                "auto-rollback aborted: could not persist divergent tail to a rollback file \
+                 ({reason}); nothing was rolled back",
+            ),
+            RollbackError::RecoverFailed { target_lsn, reason } => write!(
+                f,
+                "auto-rollback failed: recover-to-LSN {target_lsn} over the MVCC history store \
+                 failed ({reason}); the divergent tail was preserved but the timeline was not \
+                 rolled back",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RollbackError {}
+
+/// Side effects the rollback coordinator drives, injected so the state
+/// machine stays pure and deterministically testable.
+///
+/// Production implementors back these onto the MVCC history store
+/// (ADR 0014) for the recover-to-LSN, the rollback-file writer, the
+/// [`crate::telemetry::operator_event::OperatorEvent`] bus, and the gRPC
+/// role-swap. Tests back them onto a scripted fake.
+pub trait RollbackTransport {
+    /// Read the divergent tail records in `(from_exclusive, to_inclusive]`
+    /// from the local timeline / MVCC history store, in LSN order.
+    fn read_divergent_tail(&mut self, from_exclusive: u64, to_inclusive: u64) -> Vec<TailRecord>;
+
+    /// Persist the divergent tail to a durable rollback file and return a
+    /// path/handle that identifies it. Returning `Err` aborts the
+    /// rollback **before** any data is removed — rollback is never silent.
+    fn persist_rollback_file(&mut self, tail: &DivergentTail) -> Result<String, String>;
+
+    /// Recover the live timeline to `target_lsn` over the MVCC history
+    /// store, discarding every version above it and restoring the
+    /// pre-images visible at `target_lsn`.
+    fn recover_to_lsn(&mut self, target_lsn: u64) -> Result<(), String>;
+
+    /// Emit the loud, auditable operator event for the completed rollback.
+    fn emit_rollback_event(&mut self, event: RollbackEvent);
+
+    /// Reconfigure the node to stream as a replica of `primary_addr` under
+    /// `term`.
+    fn rejoin_as_replica(&mut self, primary_addr: &str, term: u64);
+}
+
+/// The deposed-primary auto-rollback state machine.
+pub struct RollbackCoordinator;
+
+impl RollbackCoordinator {
+    /// Execute the auto-rollback described by `req`, driving the node
+    /// through `tx`.
+    ///
+    /// Ordering is chosen so the hard guarantees hold even on partial
+    /// failure:
+    ///
+    /// 1. Compute & guard the boundary — refuse if it would cross the
+    ///    watermark, changing nothing.
+    /// 2. If there is no divergent tail, just rejoin.
+    /// 3. Read and **persist** the tail before removing anything; abort if
+    ///    it cannot be preserved.
+    /// 4. Recover-to-LSN to the common point.
+    /// 5. Fire the loud operator event.
+    /// 6. Rejoin as a replica of the new primary.
+    pub fn run(
+        req: &RollbackRequest,
+        tx: &mut dyn RollbackTransport,
+    ) -> Result<RollbackOutcome, RollbackError> {
+        let plan = RollbackPlan::compute(req)?;
+
+        let role = NodeRole::Replica {
+            primary_addr: req.new_primary_addr.clone(),
+            term: req.new_term,
+        };
+
+        // No divergent tail: the node is already on the shared timeline.
+        // Just rejoin — nothing to preserve, nothing to roll back, no
+        // operator event.
+        if !plan.has_divergent_tail() {
+            tx.rejoin_as_replica(&req.new_primary_addr, req.new_term);
+            return Ok(RollbackOutcome {
+                recovered_to_lsn: plan.recover_to_lsn,
+                tail_lsns: 0,
+                rollback_file: None,
+                event_fired: false,
+                role,
+            });
+        }
+
+        // Read the tail and preserve it BEFORE removing anything. If we
+        // cannot persist it, abort without rolling back — rollback is
+        // never silent.
+        let records = tx.read_divergent_tail(plan.recover_to_lsn, plan.local_frontier);
+        let tail = DivergentTail {
+            common_point_lsn: plan.recover_to_lsn,
+            to_lsn: plan.local_frontier,
+            records,
+        };
+        let rollback_file = tx
+            .persist_rollback_file(&tail)
+            .map_err(|reason| RollbackError::TailPersistFailed { reason })?;
+
+        // Recover the live timeline to the common point over the MVCC
+        // history store. The tail is already safe in the rollback file.
+        tx.recover_to_lsn(plan.recover_to_lsn)
+            .map_err(|reason| RollbackError::RecoverFailed {
+                target_lsn: plan.recover_to_lsn,
+                reason,
+            })?;
+
+        // Surface the discarded writes loudly so they stay auditable.
+        tx.emit_rollback_event(RollbackEvent {
+            common_point_lsn: plan.recover_to_lsn,
+            tail_to_lsn: plan.local_frontier,
+            tail_lsns: plan.tail_lsns,
+            commit_watermark: plan.commit_watermark,
+            rollback_file: rollback_file.clone(),
+            new_primary_addr: req.new_primary_addr.clone(),
+            new_term: req.new_term,
+        });
+
+        // Rejoin as a replica of the new primary under the new term.
+        tx.rejoin_as_replica(&req.new_primary_addr, req.new_term);
+
+        Ok(RollbackOutcome {
+            recovered_to_lsn: plan.recover_to_lsn,
+            tail_lsns: plan.tail_lsns,
+            rollback_file: Some(rollback_file),
+            event_fired: true,
+            role,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A scripted fake recording every side effect so tests can assert
+    /// ordering and content. `persist_should_fail` / `recover_should_fail`
+    /// drive the abort paths.
+    struct FakeTransport {
+        /// Records the fake hands back from `read_divergent_tail`.
+        available_tail: Vec<TailRecord>,
+        persist_should_fail: bool,
+        recover_should_fail: bool,
+        // Captured effects, in order.
+        persisted: Option<DivergentTail>,
+        recovered_to: Option<u64>,
+        emitted: Option<RollbackEvent>,
+        rejoined: Option<(String, u64)>,
+        /// Order log of effect names, to assert preserve-before-recover.
+        order: Vec<&'static str>,
+    }
+
+    impl FakeTransport {
+        fn new(available_tail: Vec<TailRecord>) -> Self {
+            Self {
+                available_tail,
+                persist_should_fail: false,
+                recover_should_fail: false,
+                persisted: None,
+                recovered_to: None,
+                emitted: None,
+                rejoined: None,
+                order: Vec::new(),
+            }
+        }
+    }
+
+    impl RollbackTransport for FakeTransport {
+        fn read_divergent_tail(
+            &mut self,
+            from_exclusive: u64,
+            to_inclusive: u64,
+        ) -> Vec<TailRecord> {
+            self.order.push("read");
+            self.available_tail
+                .iter()
+                .filter(|r| r.lsn > from_exclusive && r.lsn <= to_inclusive)
+                .cloned()
+                .collect()
+        }
+
+        fn persist_rollback_file(&mut self, tail: &DivergentTail) -> Result<String, String> {
+            self.order.push("persist");
+            if self.persist_should_fail {
+                return Err("disk full".to_string());
+            }
+            self.persisted = Some(tail.clone());
+            Ok(format!(
+                "/data/rollback/lsn-{}-{}.rbk",
+                tail.common_point_lsn, tail.to_lsn
+            ))
+        }
+
+        fn recover_to_lsn(&mut self, target_lsn: u64) -> Result<(), String> {
+            self.order.push("recover");
+            if self.recover_should_fail {
+                return Err("history truncated".to_string());
+            }
+            self.recovered_to = Some(target_lsn);
+            Ok(())
+        }
+
+        fn emit_rollback_event(&mut self, event: RollbackEvent) {
+            self.order.push("emit");
+            self.emitted = Some(event);
+        }
+
+        fn rejoin_as_replica(&mut self, primary_addr: &str, term: u64) {
+            self.order.push("rejoin");
+            self.rejoined = Some((primary_addr.to_string(), term));
+        }
+    }
+
+    fn request(local_frontier: u64, common_point: u64, watermark: u64) -> RollbackRequest {
+        RollbackRequest {
+            local_frontier,
+            common_point,
+            commit_watermark: watermark,
+            new_primary_addr: "http://node-b:50051".to_string(),
+            new_term: 8,
+        }
+    }
+
+    fn tail(lsns: &[u64], term: u64) -> Vec<TailRecord> {
+        lsns.iter()
+            .map(|lsn| TailRecord::new(*lsn, term, vec![*lsn as u8]))
+            .collect()
+    }
+
+    // ------------------------------------------------------------------
+    // Boundary math (pure plan)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn plan_recovers_to_common_point_and_sizes_the_tail() {
+        let plan = RollbackPlan::compute(&request(230, 200, 200)).expect("valid plan");
+        assert_eq!(
+            plan.recover_to_lsn, 200,
+            "recover target is the common point"
+        );
+        assert_eq!(plan.tail_lsns, 30, "tail spans common_point..frontier");
+        assert!(plan.has_divergent_tail());
+    }
+
+    #[test]
+    fn plan_with_common_point_above_watermark_is_allowed() {
+        // The common point may sit ABOVE the watermark — the deposed
+        // primary agreed with the new primary past the durable floor.
+        // Only what is above the common point is rolled back.
+        let plan = RollbackPlan::compute(&request(300, 250, 200)).expect("valid plan");
+        assert_eq!(plan.recover_to_lsn, 250);
+        assert_eq!(plan.tail_lsns, 50);
+    }
+
+    #[test]
+    fn plan_refuses_common_point_below_watermark() {
+        // HARD INVARIANT: nothing at or below the commit watermark is ever
+        // rolled back. A common point below the watermark would do exactly
+        // that, so the plan is refused.
+        let err = RollbackPlan::compute(&request(300, 150, 200)).expect_err("must refuse");
+        assert_eq!(
+            err,
+            RollbackError::WatermarkViolation {
+                common_point: 150,
+                commit_watermark: 200,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_at_watermark_is_the_inclusive_floor() {
+        // common_point == watermark is allowed: the watermark itself is
+        // kept, only strictly-above records are rolled back.
+        let plan = RollbackPlan::compute(&request(220, 200, 200)).expect("valid at floor");
+        assert_eq!(plan.recover_to_lsn, 200);
+        assert_eq!(plan.tail_lsns, 20);
+    }
+
+    // ------------------------------------------------------------------
+    // Full run: happy path
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn run_preserves_tail_then_recovers_then_emits_then_rejoins() {
+        let mut tx = FakeTransport::new(tail(&[201, 210, 230], 7));
+        let outcome =
+            RollbackCoordinator::run(&request(230, 200, 200), &mut tx).expect("rollback succeeds");
+
+        // Boundary: recovered to the common point, tail sized correctly.
+        assert_eq!(outcome.recovered_to_lsn, 200);
+        assert_eq!(outcome.tail_lsns, 30);
+        assert!(outcome.rolled_back_tail());
+
+        // Tail preserved: the rollback file holds exactly the records
+        // above the common point.
+        let persisted = tx.persisted.as_ref().expect("tail persisted");
+        assert_eq!(persisted.common_point_lsn, 200);
+        assert_eq!(persisted.to_lsn, 230);
+        assert_eq!(persisted.records, tail(&[201, 210, 230], 7));
+        assert_eq!(
+            outcome.rollback_file.as_deref(),
+            Some("/data/rollback/lsn-200-230.rbk")
+        );
+
+        // Recover-to-LSN hit the common point.
+        assert_eq!(tx.recovered_to, Some(200));
+
+        // Loud operator event fired with the boundary + file.
+        assert!(outcome.event_fired);
+        let ev = tx.emitted.as_ref().expect("event emitted");
+        assert_eq!(ev.common_point_lsn, 200);
+        assert_eq!(ev.tail_to_lsn, 230);
+        assert_eq!(ev.tail_lsns, 30);
+        assert_eq!(ev.commit_watermark, 200);
+        assert_eq!(ev.rollback_file, "/data/rollback/lsn-200-230.rbk");
+        assert_eq!(ev.new_term, 8);
+
+        // Rejoined as a replica of the new primary under the new term.
+        assert_eq!(tx.rejoined, Some(("http://node-b:50051".to_string(), 8)));
+        assert_eq!(
+            outcome.role,
+            NodeRole::Replica {
+                primary_addr: "http://node-b:50051".to_string(),
+                term: 8,
+            }
+        );
+
+        // Critical ordering: tail is preserved BEFORE the timeline is
+        // recovered, and the event fires before rejoin.
+        assert_eq!(
+            tx.order,
+            vec!["read", "persist", "recover", "emit", "rejoin"]
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Full run: no divergent tail → clean rejoin, no rollback, no event
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn run_with_no_tail_just_rejoins() {
+        // Frontier == common point: nothing diverged.
+        let mut tx = FakeTransport::new(vec![]);
+        let outcome =
+            RollbackCoordinator::run(&request(200, 200, 200), &mut tx).expect("clean rejoin");
+
+        assert_eq!(outcome.tail_lsns, 0);
+        assert!(!outcome.rolled_back_tail());
+        assert!(!outcome.event_fired, "no event when nothing is discarded");
+        assert_eq!(outcome.rollback_file, None);
+        assert!(tx.persisted.is_none(), "nothing persisted");
+        assert!(tx.recovered_to.is_none(), "nothing recovered");
+        assert!(tx.emitted.is_none(), "no operator event");
+        assert_eq!(tx.rejoined, Some(("http://node-b:50051".to_string(), 8)));
+        assert_eq!(tx.order, vec!["rejoin"]);
+    }
+
+    #[test]
+    fn run_with_frontier_below_common_point_is_a_clean_rejoin() {
+        // A node strictly behind the common point has no divergent tail;
+        // it just streams forward as a replica.
+        let mut tx = FakeTransport::new(vec![]);
+        let outcome =
+            RollbackCoordinator::run(&request(180, 200, 150), &mut tx).expect("clean rejoin");
+        assert_eq!(outcome.recovered_to_lsn, 200);
+        assert_eq!(outcome.tail_lsns, 0);
+        assert!(!outcome.event_fired);
+        assert_eq!(tx.order, vec!["rejoin"]);
+    }
+
+    // ------------------------------------------------------------------
+    // Full run: refusal & abort paths
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn run_refuses_when_common_point_below_watermark_and_touches_nothing() {
+        let mut tx = FakeTransport::new(tail(&[160, 200, 300], 7));
+        let err = RollbackCoordinator::run(&request(300, 150, 200), &mut tx)
+            .expect_err("must refuse to cross the watermark");
+        assert!(matches!(err, RollbackError::WatermarkViolation { .. }));
+
+        // Nothing was touched: no read, no persist, no recover, no rejoin.
+        assert!(tx.persisted.is_none());
+        assert!(tx.recovered_to.is_none());
+        assert!(tx.emitted.is_none());
+        assert!(tx.rejoined.is_none());
+        assert!(tx.order.is_empty());
+    }
+
+    #[test]
+    fn run_aborts_without_recovering_when_tail_cannot_be_persisted() {
+        // Rollback is never silent: if the tail cannot be saved, the
+        // timeline is NOT rolled back.
+        let mut tx = FakeTransport::new(tail(&[210, 230], 7));
+        tx.persist_should_fail = true;
+        let err = RollbackCoordinator::run(&request(230, 200, 200), &mut tx)
+            .expect_err("must abort when persist fails");
+        assert!(matches!(err, RollbackError::TailPersistFailed { .. }));
+
+        // Read + attempted persist happened; recover/emit/rejoin did NOT.
+        assert!(tx.recovered_to.is_none(), "must not roll back the timeline");
+        assert!(tx.emitted.is_none());
+        assert!(tx.rejoined.is_none());
+        assert_eq!(tx.order, vec!["read", "persist"]);
+    }
+
+    #[test]
+    fn run_surfaces_recover_failure_after_preserving_the_tail() {
+        let mut tx = FakeTransport::new(tail(&[210, 230], 7));
+        tx.recover_should_fail = true;
+        let err = RollbackCoordinator::run(&request(230, 200, 200), &mut tx)
+            .expect_err("recover failure surfaces");
+        match err {
+            RollbackError::RecoverFailed { target_lsn, .. } => assert_eq!(target_lsn, 200),
+            other => panic!("expected RecoverFailed, got {other:?}"),
+        }
+
+        // The tail was preserved before the failed recover, so the writes
+        // are not lost; but the node did not rejoin on a half-rolled state.
+        assert!(tx.persisted.is_some(), "tail preserved before recover");
+        assert!(
+            tx.emitted.is_none(),
+            "no completion event on failed recover"
+        );
+        assert!(
+            tx.rejoined.is_none(),
+            "must not rejoin after a failed recover"
+        );
+        assert_eq!(tx.order, vec!["read", "persist", "recover"]);
+    }
+
+    #[test]
+    fn span_lsns_counts_the_removed_range() {
+        let t = DivergentTail {
+            common_point_lsn: 200,
+            to_lsn: 230,
+            records: tail(&[210, 230], 7),
+        };
+        assert_eq!(t.span_lsns(), 30);
+    }
+}

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -159,6 +159,35 @@ pub enum OperatorEvent {
         attempts: u32,
         reason: String,
     },
+    /// A deposed primary auto-rolled-back its divergent tail to the common
+    /// point on rejoin (issue #840, ADR 0030). The tail is, by definition,
+    /// non-committed (above the commit watermark), so removing it from the
+    /// live timeline is correct — but the discarded writes are **always**
+    /// persisted to a rollback file so they remain auditable and
+    /// reconcilable. Rollback is never silent. The `common_point_lsn` is the
+    /// recover-to-LSN target; everything in `(common_point_lsn,
+    /// tail_to_lsn]` was removed from the live timeline and saved to
+    /// `rollback_file`. `commit_watermark` is the durable floor that was
+    /// never crossed.
+    DeposedPrimaryRollback {
+        /// LSN the deposed primary recovered to — the common point with the
+        /// new primary, the recover-to-LSN target.
+        common_point_lsn: u64,
+        /// Highest LSN in the discarded divergent tail (inclusive).
+        tail_to_lsn: u64,
+        /// Number of LSNs removed from the live timeline.
+        tail_lsns: u64,
+        /// The commit watermark — the durable floor. The invariant holds:
+        /// `common_point_lsn >= commit_watermark`, so nothing at or below
+        /// the watermark was rolled back.
+        commit_watermark: u64,
+        /// Path/handle of the rollback file the discarded tail was saved to.
+        rollback_file: String,
+        /// The new primary the node rejoins as a replica of.
+        new_primary_addr: String,
+        /// The term the node now follows.
+        new_term: u64,
+    },
 }
 
 impl OperatorEvent {
@@ -182,6 +211,7 @@ impl OperatorEvent {
             "SubscriptionSchemaChange",
             "OutboxDlqActivated",
             "QueueDlqPromoted",
+            "DeposedPrimaryRollback",
         ]
     }
 
@@ -205,6 +235,7 @@ impl OperatorEvent {
             Self::SubscriptionSchemaChange { .. } => "SubscriptionSchemaChange",
             Self::OutboxDlqActivated { .. } => "OutboxDlqActivated",
             Self::QueueDlqPromoted { .. } => "QueueDlqPromoted",
+            Self::DeposedPrimaryRollback { .. } => "DeposedPrimaryRollback",
         }
     }
 
@@ -463,6 +494,32 @@ impl OperatorEvent {
                     AuditFieldEscaper::field("reason", reason),
                 ];
                 ("operator/queue_dlq_promoted", fields, summary)
+            }
+            Self::DeposedPrimaryRollback {
+                common_point_lsn,
+                tail_to_lsn,
+                tail_lsns,
+                commit_watermark,
+                rollback_file,
+                new_primary_addr,
+                new_term,
+            } => {
+                let summary = format!(
+                    "deposed primary auto-rollback: recovered to common_point_lsn={common_point_lsn} \
+                     (commit_watermark={commit_watermark}); discarded divergent tail of {tail_lsns} LSN(s) \
+                     up to {tail_to_lsn} saved to {rollback_file}; rejoining as replica of \
+                     {new_primary_addr} under term {new_term}"
+                );
+                let fields = vec![
+                    AuditFieldEscaper::field("common_point_lsn", common_point_lsn),
+                    AuditFieldEscaper::field("tail_to_lsn", tail_to_lsn),
+                    AuditFieldEscaper::field("tail_lsns", tail_lsns),
+                    AuditFieldEscaper::field("commit_watermark", commit_watermark),
+                    AuditFieldEscaper::field("rollback_file", rollback_file),
+                    AuditFieldEscaper::field("new_primary_addr", new_primary_addr),
+                    AuditFieldEscaper::field("new_term", new_term),
+                ];
+                ("operator/deposed_primary_rollback", fields, summary)
             }
         }
     }
@@ -764,6 +821,37 @@ mod tests {
             .and_then(|d| d.get("lsn"))
             .and_then(|x| x.as_i64());
         assert_eq!(lsn, Some(42_000));
+    }
+
+    #[test]
+    fn deposed_primary_rollback_emits() {
+        let (logger, path) = make_logger();
+        OperatorEvent::DeposedPrimaryRollback {
+            common_point_lsn: 200,
+            tail_to_lsn: 230,
+            tail_lsns: 30,
+            commit_watermark: 200,
+            rollback_file: "/data/rollback/term7-lsn200-230.rbk".into(),
+            new_primary_addr: "http://node-b:50051".into(),
+            new_term: 8,
+        }
+        .emit(&logger);
+        drain(&logger);
+        let v = read_last_line(&path);
+        assert_eq!(
+            v.get("action").and_then(|x| x.as_str()),
+            Some("operator/deposed_primary_rollback")
+        );
+        let cp = v
+            .get("detail")
+            .and_then(|d| d.get("common_point_lsn"))
+            .and_then(|x| x.as_i64());
+        assert_eq!(cp, Some(200));
+        let file = v
+            .get("detail")
+            .and_then(|d| d.get("rollback_file"))
+            .and_then(|x| x.as_str());
+        assert_eq!(file, Some("/data/rollback/term7-lsn200-230.rbk"));
     }
 
     // ------------------------------------------------------------------

--- a/crates/reddb-server/src/telemetry/operator_event_router.rs
+++ b/crates/reddb-server/src/telemetry/operator_event_router.rs
@@ -838,6 +838,23 @@ mod tests {
                 attempts: *attempts,
                 reason: reason.clone(),
             },
+            OperatorEvent::DeposedPrimaryRollback {
+                common_point_lsn,
+                tail_to_lsn,
+                tail_lsns,
+                commit_watermark,
+                rollback_file,
+                new_primary_addr,
+                new_term,
+            } => OperatorEvent::DeposedPrimaryRollback {
+                common_point_lsn: *common_point_lsn,
+                tail_to_lsn: *tail_to_lsn,
+                tail_lsns: *tail_lsns,
+                commit_watermark: *commit_watermark,
+                rollback_file: rollback_file.clone(),
+                new_primary_addr: new_primary_addr.clone(),
+                new_term: *new_term,
+            },
         }
     }
 

--- a/tests/e2e_issue_840_replication_auto_rollback.rs
+++ b/tests/e2e_issue_840_replication_auto_rollback.rs
@@ -1,0 +1,300 @@
+//! Issue #840 — auto-rollback of a deposed primary to the common point,
+//! preserving the divergent tail (PRD #819, ADR 0030).
+//!
+//! Models a deposed primary rejoining after a failover while still
+//! holding a *divergent tail* — writes above the point its log last
+//! agreed with the new primary. The [`RollbackCoordinator`] recovers the
+//! node to the common point (bounded by the commit watermark), preserves
+//! the discarded tail to a rollback file, fires a loud operator event,
+//! and rejoins the node as a replica. The test asserts the four
+//! acceptance criteria:
+//!
+//! 1. recover to the common point + rejoin without operator surgery;
+//! 2. the discarded tail is persisted to a rollback file *and* surfaced
+//!    via a real `OperatorEvent` written to the tamper-evident audit log;
+//! 3. nothing at or below the commit watermark is rolled back;
+//! 4. the rollback boundary, tail preservation, and event emission hold.
+//!
+//! The full "induce a live failover with a divergent tail" end-to-end
+//! exercise depends on the election (#834) and stale-term fencing (#835)
+//! being live; those are informational dependencies for this slice, so
+//! the cluster here is a deterministic in-memory model that drives the
+//! recover-to-LSN mechanism exactly as the live wiring will.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use reddb::replication::failover::NodeRole;
+use reddb::replication::rollback::{
+    DivergentTail, RollbackCoordinator, RollbackError, RollbackEvent, RollbackRequest,
+    RollbackTransport, TailRecord,
+};
+use reddb::runtime::audit_log::AuditLogger;
+use reddb::telemetry::operator_event::OperatorEvent;
+
+/// A modelled deposed-primary node. Its `timeline` is the ordered list of
+/// LSNs currently materialised on the live store; recover-to-LSN truncates
+/// it to the common point. A real [`AuditLogger`] receives the operator
+/// event so the test proves the *loud* event wiring, not just a captured
+/// struct.
+struct DeposedPrimary {
+    /// LSNs currently on the live timeline (sorted ascending).
+    timeline: Vec<u64>,
+    /// Term each LSN was written under (parallel to `timeline`).
+    term_of: Vec<u64>,
+    /// Directory rollback files are written to.
+    rollback_dir: PathBuf,
+    /// Real audit logger the operator event is emitted through.
+    audit: AuditLogger,
+    /// Live role of the node; flips to Replica on rejoin.
+    role: Option<NodeRole>,
+}
+
+impl DeposedPrimary {
+    fn new(timeline: Vec<(u64, u64)>, rollback_dir: PathBuf, audit: AuditLogger) -> Self {
+        let term_of = timeline.iter().map(|(_, t)| *t).collect();
+        let timeline = timeline.iter().map(|(lsn, _)| *lsn).collect();
+        Self {
+            timeline,
+            term_of,
+            rollback_dir,
+            audit,
+            role: None,
+        }
+    }
+
+    fn frontier(&self) -> u64 {
+        self.timeline.last().copied().unwrap_or(0)
+    }
+}
+
+impl RollbackTransport for DeposedPrimary {
+    fn read_divergent_tail(&mut self, from_exclusive: u64, to_inclusive: u64) -> Vec<TailRecord> {
+        self.timeline
+            .iter()
+            .zip(self.term_of.iter())
+            .filter(|(lsn, _)| **lsn > from_exclusive && **lsn <= to_inclusive)
+            .map(|(lsn, term)| TailRecord::new(*lsn, *term, lsn.to_le_bytes().to_vec()))
+            .collect()
+    }
+
+    fn persist_rollback_file(&mut self, tail: &DivergentTail) -> Result<String, String> {
+        std::fs::create_dir_all(&self.rollback_dir).map_err(|e| e.to_string())?;
+        let path = self.rollback_dir.join(format!(
+            "rollback-lsn-{}-{}.rbk",
+            tail.common_point_lsn, tail.to_lsn
+        ));
+        // Persist one line per discarded record so an operator can
+        // reconcile them later.
+        let mut body = format!(
+            "# divergent tail discarded on rejoin: common_point={} to={}\n",
+            tail.common_point_lsn, tail.to_lsn
+        );
+        for r in &tail.records {
+            body.push_str(&format!(
+                "lsn={} term={} bytes={}\n",
+                r.lsn,
+                r.term,
+                r.payload.len()
+            ));
+        }
+        std::fs::write(&path, body).map_err(|e| e.to_string())?;
+        Ok(path.to_string_lossy().into_owned())
+    }
+
+    fn recover_to_lsn(&mut self, target_lsn: u64) -> Result<(), String> {
+        // Drop every materialised version strictly above the target — the
+        // live timeline now ends at the common point.
+        let keep: Vec<usize> = self
+            .timeline
+            .iter()
+            .enumerate()
+            .filter(|(_, lsn)| **lsn <= target_lsn)
+            .map(|(i, _)| i)
+            .collect();
+        self.timeline = keep.iter().map(|i| self.timeline[*i]).collect();
+        self.term_of = keep.iter().map(|i| self.term_of[*i]).collect();
+        Ok(())
+    }
+
+    fn emit_rollback_event(&mut self, event: RollbackEvent) {
+        // Forward to the REAL operator event bus (tamper-evident audit
+        // log first), exactly as the production transport will.
+        OperatorEvent::DeposedPrimaryRollback {
+            common_point_lsn: event.common_point_lsn,
+            tail_to_lsn: event.tail_to_lsn,
+            tail_lsns: event.tail_lsns,
+            commit_watermark: event.commit_watermark,
+            rollback_file: event.rollback_file,
+            new_primary_addr: event.new_primary_addr,
+            new_term: event.new_term,
+        }
+        .emit(&self.audit);
+    }
+
+    fn rejoin_as_replica(&mut self, primary_addr: &str, term: u64) {
+        self.role = Some(NodeRole::Replica {
+            primary_addr: primary_addr.to_string(),
+            term,
+        });
+    }
+}
+
+fn make_audit() -> (AuditLogger, PathBuf) {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "reddb-840-{}-{}",
+        std::process::id(),
+        reddb::utils::now_unix_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(".audit.log");
+    (AuditLogger::with_path(path.clone()), path)
+}
+
+fn last_audit_line(path: &std::path::Path) -> reddb::json::Value {
+    let body = std::fs::read_to_string(path).unwrap();
+    let line = body.lines().last().expect("at least one audit line");
+    reddb::json::from_str(line).expect("valid JSON")
+}
+
+#[test]
+fn deposed_primary_auto_rolls_back_divergent_tail_and_rejoins() {
+    let (audit, audit_path) = make_audit();
+    let rollback_dir = audit_path.parent().unwrap().join("rollback");
+
+    // The deposed primary's timeline: committed history up to 200 (term 7)
+    // then a divergent tail 210/220/230 it wrote alone before being
+    // deposed and never replicated to quorum.
+    let mut node = DeposedPrimary::new(
+        vec![(180, 7), (200, 7), (210, 7), (220, 7), (230, 7)],
+        rollback_dir.clone(),
+        audit,
+    );
+    assert_eq!(node.frontier(), 230);
+
+    // The election (#834) produced common point 200, and the commit
+    // watermark (#822) is 200 — everything at/below 200 reached quorum.
+    let req = RollbackRequest {
+        local_frontier: node.frontier(),
+        common_point: 200,
+        commit_watermark: 200,
+        new_primary_addr: "http://node-b:50051".to_string(),
+        new_term: 8,
+    };
+
+    let outcome = RollbackCoordinator::run(&req, &mut node).expect("auto-rollback succeeds");
+
+    // (1) Recovered to the common point and rejoined as a replica — no
+    // operator surgery.
+    assert_eq!(outcome.recovered_to_lsn, 200);
+    assert_eq!(
+        node.role,
+        Some(NodeRole::Replica {
+            primary_addr: "http://node-b:50051".to_string(),
+            term: 8,
+        }),
+    );
+
+    // (3) Nothing at or below the watermark (200) was rolled back; the
+    // divergent tail above it is gone.
+    assert_eq!(
+        node.timeline,
+        vec![180, 200],
+        "tail above 200 removed, history kept"
+    );
+    assert_eq!(node.frontier(), 200);
+    assert_eq!(outcome.tail_lsns, 30);
+
+    // (2) The discarded tail is persisted to a rollback file...
+    let file = outcome.rollback_file.expect("rollback file written");
+    let saved = std::fs::read_to_string(&file).expect("rollback file readable");
+    assert!(saved.contains("lsn=210"));
+    assert!(saved.contains("lsn=220"));
+    assert!(saved.contains("lsn=230"));
+    assert!(
+        !saved.contains("lsn=200"),
+        "committed LSN must not be in the rollback file"
+    );
+
+    // ...and surfaced via a real operator event on the tamper-evident
+    // audit log.
+    assert!(outcome.event_fired);
+    assert!(
+        node.audit.wait_idle(Duration::from_secs(2)),
+        "audit drain timed out"
+    );
+    let ev = last_audit_line(&audit_path);
+    assert_eq!(
+        ev.get("action").and_then(|x| x.as_str()),
+        Some("operator/deposed_primary_rollback"),
+    );
+    let detail = ev.get("detail").expect("event detail");
+    assert_eq!(
+        detail.get("common_point_lsn").and_then(|x| x.as_i64()),
+        Some(200)
+    );
+    assert_eq!(detail.get("tail_lsns").and_then(|x| x.as_i64()), Some(30));
+    assert_eq!(
+        detail.get("commit_watermark").and_then(|x| x.as_i64()),
+        Some(200)
+    );
+}
+
+#[test]
+fn rollback_refuses_to_cross_the_commit_watermark() {
+    // A pathological common point BELOW the watermark would discard
+    // committed data. The coordinator must refuse and change nothing —
+    // the invariant "nothing at/below the watermark is ever rolled back"
+    // is enforced even against a bad election result.
+    let (audit, audit_path) = make_audit();
+    let rollback_dir = audit_path.parent().unwrap().join("rollback");
+    let mut node = DeposedPrimary::new(vec![(150, 7), (200, 7), (250, 7)], rollback_dir, audit);
+
+    let req = RollbackRequest {
+        local_frontier: 250,
+        common_point: 150, // below the watermark!
+        commit_watermark: 200,
+        new_primary_addr: "http://node-b:50051".to_string(),
+        new_term: 8,
+    };
+
+    let err = RollbackCoordinator::run(&req, &mut node).expect_err("must refuse");
+    assert!(matches!(err, RollbackError::WatermarkViolation { .. }));
+
+    // Nothing changed: timeline intact, no rejoin, no event.
+    assert_eq!(node.timeline, vec![150, 200, 250]);
+    assert!(node.role.is_none());
+    assert!(
+        !std::path::Path::new(&audit_path).exists() || {
+            // Audit file may exist but must carry no rollback event.
+            let body = std::fs::read_to_string(&audit_path).unwrap_or_default();
+            !body.contains("deposed_primary_rollback")
+        }
+    );
+}
+
+#[test]
+fn caught_up_ex_primary_rejoins_without_a_rollback() {
+    // An ex-primary whose frontier equals the common point has no
+    // divergent tail: it rejoins cleanly, with no rollback file and no
+    // operator event.
+    let (audit, audit_path) = make_audit();
+    let rollback_dir = audit_path.parent().unwrap().join("rollback");
+    let mut node = DeposedPrimary::new(vec![(180, 7), (200, 7)], rollback_dir, audit);
+
+    let req = RollbackRequest {
+        local_frontier: 200,
+        common_point: 200,
+        commit_watermark: 200,
+        new_primary_addr: "http://node-b:50051".to_string(),
+        new_term: 8,
+    };
+
+    let outcome = RollbackCoordinator::run(&req, &mut node).expect("clean rejoin");
+    assert_eq!(outcome.tail_lsns, 0);
+    assert!(!outcome.event_fired);
+    assert!(outcome.rollback_file.is_none());
+    assert_eq!(node.timeline, vec![180, 200], "timeline untouched");
+    assert!(matches!(node.role, Some(NodeRole::Replica { .. })));
+}


### PR DESCRIPTION
## What

Auto-rollback of a deposed primary to the common point via **recover-to-LSN** over the MVCC history store (ADR 0014, ADR 0030). Closes #840 (PRD #819).

When a former primary rejoins after a failover still holding a **divergent tail** — writes above the point its log last agreed with the new primary — it must drop that tail to rejoin a single timeline. The tail is non-committed by definition (above the commit watermark), so removing it from the live timeline is correct; but it is **always** preserved to a rollback file and surfaced via a loud operator event, so nothing is lost silently.

## How

Added the recover-to-LSN mechanism as a pure, deterministically-testable state machine (`crates/reddb-server/src/replication/rollback.rs`), mirroring the shape of `failover.rs`:

- **`RollbackPlan::compute`** — boundary math, split out so the hard invariant is assertable in isolation: the common point must be **at or above** the commit watermark, else it **refuses** (`WatermarkViolation`). Nothing at or below the watermark is ever rolled back.
- **`RollbackCoordinator::run` + `RollbackTransport`** — ordered so guarantees hold on partial failure: guard the boundary → preserve the tail to a rollback file **before** removing anything (abort if it can't be persisted) → recover-to-LSN → fire the loud event → rejoin as replica.
- **`OperatorEvent::DeposedPrimaryRollback`** — loud, auditable event (rollback file path + boundary + watermark), wired through the existing operator-event bus and router.

Every side effect is injected behind `RollbackTransport`, so the flow runs against a scripted fake with no engine/disk/clock/network dependency.

## Invariant (hard)

Nothing at or below the commit watermark is ever rolled back — enforced in `RollbackPlan::compute` and proven by `plan_refuses_common_point_below_watermark` + `run_refuses_when_common_point_below_watermark_and_touches_nothing`.

## Tests

- 11 unit tests (rollback boundary, tail preservation, event emission, watermark-violation refusal, persist-failure abort, recover-failure surfacing, clean no-tail rejoin).
- 3 e2e tests (`tests/e2e_issue_840_replication_auto_rollback.rs`) driving the real `OperatorEvent` onto the tamper-evident audit log.
- 1 operator-event audit test for the new variant.

## Scope / deps

The transport is built and proven in isolation. Wiring it onto the live apply loop + gRPC role-swap depends on the election (#834, produces the common point) and stale-term fencing (#835) being live — **informational** deps per the brief, not gating this slice. The full "induce a live failover with a divergent tail" E2E lands once #834/#835 are live.

## Review note

HITL slice (MVCC recovery). Design was reviewed and approved via the issue's human-guidance thread; opening as a PR for human code review rather than admin-merge, per the brief.

Refs: ADR 0014 (MVCC history store), ADR 0030 (replication consistency & failover model).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783009496&installation_id=129708444&pr_number=940&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F940&signature=8c24b7edfde6f14ed71ac35e9c03f70bbf0acb4636ba7dc98dc7633a32b27dfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic rollback functionality enabling deposed primary nodes to safely restore to a common point and rejoin the cluster as replicas.
  * Includes watermark validation to prevent invalid rollbacks.
  * New audit telemetry events for tracking deposed primary rollback operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->