### PR TITLE
feat(replication): fence a stale-term ex-primary (#835)

### DIFF
--- a/crates/reddb-server/src/replication/fence.rs
+++ b/crates/reddb-server/src/replication/fence.rs
@@ -1,0 +1,457 @@
+//! Stale-term fencing for a returning ex-primary (issue #835, PRD #819, ADR 0030).
+//!
+//! After a failover the cluster serves a *new term*. A former primary that
+//! rejoins on its old, **stale** term must not be able to corrupt the new
+//! timeline — its term-stamped writes and its stream handshakes have to be
+//! refused until it re-syncs and adopts the new term. This module is the
+//! reusable term-comparison primitive both fencing boundaries share:
+//!
+//! * **Apply boundary** — a replica rejects a WAL/logical record whose term
+//!   is behind its current term. The live replica apply path enforces this
+//!   directly in [`super::logical::LogicalChangeApplier::apply`] (it already
+//!   tracks the last-applied term); [`TermFence::admit_record`] is the same
+//!   rule expressed over a durable term so it survives a restart.
+//! * **Handshake boundary** — when a node opens a replication stream it
+//!   declares the term it is streaming under. [`TermFence::admit_handshake`]
+//!   refuses a handshake whose declared term is behind the current term, so a
+//!   stale ex-primary cannot even establish the stream.
+//!
+//! The decision is deliberately the data-path twin of the election-side
+//! [`super::RefusalReason::StaleTerm`]:
+//!
+//! * `incoming == current` → **admit** at the live term;
+//! * `incoming  > current` → a newer timeline supersedes ours, so **adopt**
+//!   the new term (persisted durably) and then admit. This is how a replica
+//!   moves forward when the legitimate new primary streams to it;
+//! * `incoming  < current` → **fenced**: a superseded primary, refused.
+//!
+//! The current term is held behind a [`TermStore`] so adoption is durable —
+//! a replica that crashes after adopting term *N* comes back fencing stale
+//! term *N-1* records rather than briefly accepting them. Production wires the
+//! file-backed store alongside the node's other durable replication state;
+//! tests use the in-memory store.
+
+use crate::serde_json::{self, Value as JsonValue};
+
+/// The boundary at which a term-stamped message is being admitted. Only
+/// affects diagnostics — the term rule is identical at both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FenceBoundary {
+    /// A WAL/logical record being applied on a replica.
+    Apply,
+    /// A replication stream handshake declaring the streamer's term.
+    Handshake,
+}
+
+impl FenceBoundary {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Apply => "apply",
+            Self::Handshake => "handshake",
+        }
+    }
+}
+
+/// Why the term fence refused a message: the incoming term is behind the
+/// current term, so the sender is a deposed primary on a superseded timeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StaleTermFenced {
+    pub boundary: FenceBoundary,
+    pub incoming_term: u64,
+    pub current_term: u64,
+}
+
+impl std::fmt::Display for StaleTermFenced {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "fenced stale-term {} message: incoming term {} is behind current term {}",
+            self.boundary.as_str(),
+            self.incoming_term,
+            self.current_term
+        )
+    }
+}
+
+impl std::error::Error for StaleTermFenced {}
+
+/// The verdict of the term fence for one incoming term-stamped message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FenceVerdict {
+    /// `incoming == current`: admit at the live term.
+    Admit { term: u64 },
+    /// `incoming > current`: a newer timeline. The fence adopted `new_term`
+    /// (persisting it) and the message is admitted under it.
+    Adopt { new_term: u64 },
+    /// `incoming < current`: stale — refused.
+    Fenced(StaleTermFenced),
+}
+
+impl FenceVerdict {
+    /// Was the message let through (either at the live term or after adopting
+    /// a newer one)?
+    pub fn is_admitted(&self) -> bool {
+        matches!(self, Self::Admit { .. } | Self::Adopt { .. })
+    }
+
+    /// Was the message fenced as stale?
+    pub fn is_fenced(&self) -> bool {
+        matches!(self, Self::Fenced(_))
+    }
+}
+
+/// Error reading or persisting the durable current term.
+#[derive(Debug)]
+pub enum TermStoreError {
+    Io(std::io::Error),
+    InvalidFormat(String),
+}
+
+impl std::fmt::Display for TermStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(err) => write!(f, "term store io error: {err}"),
+            Self::InvalidFormat(msg) => write!(f, "invalid term store format: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for TermStoreError {}
+
+/// Durable store for a node's current replication term. The default (when
+/// nothing was ever written) is
+/// [`DEFAULT_REPLICATION_TERM`](crate::replication::DEFAULT_REPLICATION_TERM),
+/// matching the term records carry before any failover.
+pub trait TermStore {
+    fn load(&self) -> Result<u64, TermStoreError>;
+    fn persist(&self, term: u64) -> Result<(), TermStoreError>;
+}
+
+/// In-memory term store for tests and ephemeral nodes.
+#[derive(Debug)]
+pub struct MemoryTermStore {
+    inner: std::sync::Mutex<u64>,
+}
+
+impl Default for MemoryTermStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MemoryTermStore {
+    pub fn new() -> Self {
+        Self {
+            inner: std::sync::Mutex::new(crate::replication::DEFAULT_REPLICATION_TERM),
+        }
+    }
+
+    /// Seed an initial term — used by tests to simulate a node that already
+    /// adopted a term before a restart.
+    pub fn seeded(term: u64) -> Self {
+        Self {
+            inner: std::sync::Mutex::new(term),
+        }
+    }
+}
+
+impl TermStore for MemoryTermStore {
+    fn load(&self) -> Result<u64, TermStoreError> {
+        Ok(*self.inner.lock().expect("term store mutex"))
+    }
+
+    fn persist(&self, term: u64) -> Result<(), TermStoreError> {
+        *self.inner.lock().expect("term store mutex") = term;
+        Ok(())
+    }
+}
+
+/// File-backed term store. Persisted with the atomic temp-file + rename +
+/// parent-dir fsync discipline used for the durable last-vote
+/// ([`super::FileLastVoteStore`]) so a crash mid-write never yields a torn
+/// record and an adopted term cannot be silently lost.
+pub struct FileTermStore {
+    path: std::path::PathBuf,
+}
+
+impl FileTermStore {
+    pub fn new(path: impl Into<std::path::PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+impl TermStore for FileTermStore {
+    fn load(&self) -> Result<u64, TermStoreError> {
+        match std::fs::read(&self.path) {
+            Ok(bytes) => {
+                let json: JsonValue = serde_json::from_slice(&bytes)
+                    .map_err(|err| TermStoreError::InvalidFormat(format!("parse: {err}")))?;
+                json.get("term")
+                    .and_then(JsonValue::as_u64)
+                    .ok_or_else(|| TermStoreError::InvalidFormat("missing term".into()))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                Ok(crate::replication::DEFAULT_REPLICATION_TERM)
+            }
+            Err(err) => Err(TermStoreError::Io(err)),
+        }
+    }
+
+    fn persist(&self, term: u64) -> Result<(), TermStoreError> {
+        let mut obj = serde_json::Map::new();
+        obj.insert("term".to_string(), JsonValue::Number(term as f64));
+        let bytes = serde_json::to_vec(&JsonValue::Object(obj))
+            .map_err(|err| TermStoreError::InvalidFormat(format!("serialize: {err}")))?;
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent).map_err(TermStoreError::Io)?;
+        }
+        let tmp = self.path.with_extension("term.tmp");
+        std::fs::write(&tmp, &bytes).map_err(TermStoreError::Io)?;
+        if let Ok(f) = std::fs::File::open(&tmp) {
+            let _ = f.sync_all();
+        }
+        std::fs::rename(&tmp, &self.path).map_err(TermStoreError::Io)?;
+        // fsync the parent dir so the rename itself is durable — otherwise a
+        // crash could leave the directory entry pointing at the old term and
+        // let the node briefly accept records it had already fenced.
+        if let Some(parent) = self.path.parent() {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The stale-term fence. Wraps a durable [`TermStore`] and applies the term
+/// rule at the apply and handshake boundaries.
+pub struct TermFence<S: TermStore> {
+    store: S,
+}
+
+impl<S: TermStore> TermFence<S> {
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    /// The node's current (highest adopted) term.
+    pub fn current_term(&self) -> Result<u64, TermStoreError> {
+        self.store.load()
+    }
+
+    /// Classify `incoming_term` against the current term **without** mutating
+    /// anything. Pure read — useful for probing a decision before committing
+    /// to the adoption side-effect.
+    pub fn classify(
+        &self,
+        boundary: FenceBoundary,
+        incoming_term: u64,
+    ) -> Result<FenceVerdict, TermStoreError> {
+        let current = self.store.load()?;
+        Ok(if incoming_term < current {
+            FenceVerdict::Fenced(StaleTermFenced {
+                boundary,
+                incoming_term,
+                current_term: current,
+            })
+        } else if incoming_term > current {
+            FenceVerdict::Adopt {
+                new_term: incoming_term,
+            }
+        } else {
+            FenceVerdict::Admit { term: current }
+        })
+    }
+
+    /// Admit (or fence) a term-stamped **record** at the apply boundary. On a
+    /// newer term the fence adopts it durably before returning `Adopt`.
+    pub fn admit_record(&self, incoming_term: u64) -> Result<FenceVerdict, TermStoreError> {
+        self.admit(FenceBoundary::Apply, incoming_term)
+    }
+
+    /// Admit (or fence) a stream **handshake** declaring `incoming_term`. On a
+    /// newer term the fence adopts it durably before returning `Adopt`.
+    pub fn admit_handshake(&self, incoming_term: u64) -> Result<FenceVerdict, TermStoreError> {
+        self.admit(FenceBoundary::Handshake, incoming_term)
+    }
+
+    fn admit(
+        &self,
+        boundary: FenceBoundary,
+        incoming_term: u64,
+    ) -> Result<FenceVerdict, TermStoreError> {
+        let verdict = self.classify(boundary, incoming_term)?;
+        if let FenceVerdict::Adopt { new_term } = verdict {
+            // Persist the adopted term before admitting so the advance is
+            // durable: a crash right after this cannot un-adopt the new term.
+            self.store.persist(new_term)?;
+        }
+        Ok(verdict)
+    }
+
+    /// Force the current term to `new_term`, persisting it. Used after a node
+    /// re-syncs under a known term (e.g. a deposed primary rejoining as a
+    /// replica) so it stops fencing the timeline it has now adopted. Never
+    /// moves the term backwards.
+    pub fn adopt(&self, new_term: u64) -> Result<(), TermStoreError> {
+        let current = self.store.load()?;
+        if new_term > current {
+            self.store.persist(new_term)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fence(term: u64) -> TermFence<MemoryTermStore> {
+        TermFence::new(MemoryTermStore::seeded(term))
+    }
+
+    // ---- Apply boundary ----
+
+    #[test]
+    fn apply_boundary_fences_stale_term() {
+        let f = fence(5);
+        let verdict = f.admit_record(4).unwrap();
+        assert_eq!(
+            verdict,
+            FenceVerdict::Fenced(StaleTermFenced {
+                boundary: FenceBoundary::Apply,
+                incoming_term: 4,
+                current_term: 5,
+            })
+        );
+        assert!(verdict.is_fenced());
+        // A fenced record must not move the current term.
+        assert_eq!(f.current_term().unwrap(), 5);
+    }
+
+    #[test]
+    fn apply_boundary_admits_current_term() {
+        let f = fence(5);
+        assert_eq!(f.admit_record(5).unwrap(), FenceVerdict::Admit { term: 5 });
+        assert_eq!(f.current_term().unwrap(), 5);
+    }
+
+    #[test]
+    fn apply_boundary_adopts_higher_term_durably() {
+        let f = fence(5);
+        assert_eq!(
+            f.admit_record(8).unwrap(),
+            FenceVerdict::Adopt { new_term: 8 }
+        );
+        // Adoption persisted: the old term is now fenced.
+        assert_eq!(f.current_term().unwrap(), 8);
+        assert!(f.admit_record(5).unwrap().is_fenced());
+    }
+
+    // ---- Handshake boundary ----
+
+    #[test]
+    fn handshake_boundary_fences_stale_term() {
+        let f = fence(7);
+        let verdict = f.admit_handshake(6).unwrap();
+        assert_eq!(
+            verdict,
+            FenceVerdict::Fenced(StaleTermFenced {
+                boundary: FenceBoundary::Handshake,
+                incoming_term: 6,
+                current_term: 7,
+            })
+        );
+        assert!(verdict.is_fenced());
+    }
+
+    #[test]
+    fn handshake_boundary_admits_current_and_adopts_higher() {
+        let f = fence(7);
+        assert_eq!(
+            f.admit_handshake(7).unwrap(),
+            FenceVerdict::Admit { term: 7 }
+        );
+        assert_eq!(
+            f.admit_handshake(9).unwrap(),
+            FenceVerdict::Adopt { new_term: 9 }
+        );
+        assert_eq!(f.current_term().unwrap(), 9);
+    }
+
+    // ---- End-to-end: returning ex-primary on a stale term ----
+
+    #[test]
+    fn returning_ex_primary_is_fenced_until_it_adopts_new_term() {
+        // The replica adopted the new term 6 (handshake from the new primary).
+        let f = fence(5);
+        assert!(matches!(
+            f.admit_handshake(6).unwrap(),
+            FenceVerdict::Adopt { new_term: 6 }
+        ));
+
+        // The ex-primary returns on its stale term 5: both its handshake and
+        // its records are fenced.
+        assert!(f.admit_handshake(5).unwrap().is_fenced());
+        assert!(f.admit_record(5).unwrap().is_fenced());
+
+        // Only after it re-syncs and adopts the new term can it participate —
+        // here it rejoins as a replica that has caught up to term 6.
+        f.adopt(6).unwrap();
+        assert!(f.admit_record(6).unwrap().is_admitted());
+    }
+
+    #[test]
+    fn classify_is_pure_and_does_not_adopt() {
+        let f = fence(3);
+        // Classifying a higher term reports Adopt but must NOT persist it.
+        assert_eq!(
+            f.classify(FenceBoundary::Apply, 9).unwrap(),
+            FenceVerdict::Adopt { new_term: 9 }
+        );
+        assert_eq!(f.current_term().unwrap(), 3, "classify must not mutate");
+    }
+
+    #[test]
+    fn adopt_never_moves_term_backwards() {
+        let f = fence(10);
+        f.adopt(4).unwrap();
+        assert_eq!(f.current_term().unwrap(), 10);
+        f.adopt(12).unwrap();
+        assert_eq!(f.current_term().unwrap(), 12);
+    }
+
+    // ---- File-backed durability ----
+
+    #[test]
+    fn file_term_store_round_trips_and_defaults() {
+        let path = std::env::temp_dir().join(format!(
+            "reddb-term-fence-{}-{}.json",
+            std::process::id(),
+            crate::utils::now_unix_nanos()
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        // Missing file → default base term.
+        let store = FileTermStore::new(&path);
+        assert_eq!(
+            store.load().unwrap(),
+            crate::replication::DEFAULT_REPLICATION_TERM
+        );
+
+        // Adopt across a "restart": a fresh store at the same path still
+        // fences the old term.
+        {
+            let fence = TermFence::new(FileTermStore::new(&path));
+            assert!(matches!(
+                fence.admit_handshake(6).unwrap(),
+                FenceVerdict::Adopt { new_term: 6 }
+            ));
+        }
+        let reopened = TermFence::new(FileTermStore::new(&path));
+        assert_eq!(reopened.current_term().unwrap(), 6);
+        assert!(reopened.admit_record(5).unwrap().is_fenced());
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/reddb-server/src/replication/lease.rs
+++ b/crates/reddb-server/src/replication/lease.rs
@@ -15,6 +15,7 @@
 //! {
 //!   "database_key": "main",
 //!   "holder_id": "instance-uuid",
+//!   "term": 3,
 //!   "generation": 7,
 //!   "acquired_at_ms": 1730000000000,
 //!   "expires_at_ms":  1730000060000
@@ -26,6 +27,12 @@
 //!   stale writer (whose lease was poached because it expired) can be
 //!   detected during reclaim by reading the current lease and
 //!   comparing.
+//! - `term` is the replication term the holder acquired under (issue
+//!   #835, ADR 0030). A contender on a term *behind* the published
+//!   lease's term is a deposed primary and is fenced
+//!   (`LeaseError::Fenced`) — even if the lease has expired and would
+//!   otherwise be poachable. Legacy lease objects without a `term`
+//!   field decode as `DEFAULT_REPLICATION_TERM`.
 //! - `expires_at_ms` is wall-clock millis since UNIX epoch. A holder
 //!   refreshes it periodically; a contender treats anything past it as
 //!   poachable.
@@ -70,6 +77,15 @@ fn lease_temp_path(kind: &str) -> std::path::PathBuf {
 pub struct WriterLease {
     pub database_key: String,
     pub holder_id: String,
+    /// Replication term the holder acquired the lease under (issue #835,
+    /// ADR 0030). Tying the lease to the term is what makes a deposed
+    /// primary fail closed: once a new primary acquires the lease at a
+    /// higher term, the old holder's term is behind and every term-gated
+    /// op it attempts is fenced. Defaults to
+    /// [`DEFAULT_REPLICATION_TERM`](crate::replication::DEFAULT_REPLICATION_TERM)
+    /// when read from a legacy (pre-#835) lease object that did not carry
+    /// a term, so older lease files stay readable.
+    pub term: u64,
     pub generation: u64,
     pub acquired_at_ms: u64,
     pub expires_at_ms: u64,
@@ -78,6 +94,22 @@ pub struct WriterLease {
 impl WriterLease {
     pub fn is_expired(&self, now_ms: u64) -> bool {
         self.expires_at_ms <= now_ms
+    }
+
+    /// Is this lease fenced by `current_term`? A holder whose lease was
+    /// stamped under a term *behind* the cluster's current term is a
+    /// stale writer from a superseded timeline (issue #835) — it must
+    /// fail closed rather than keep mutating the new timeline.
+    pub fn fenced_by_term(&self, current_term: u64) -> bool {
+        self.term < current_term
+    }
+
+    /// The monotonic fencing token `(term, generation)`. Both components
+    /// advance forward across a legitimate handover (a new primary wins a
+    /// higher term *and* takes a fresh lease generation), so a stale
+    /// holder is ordered strictly behind on both axes (ADR 0030).
+    pub fn fencing_token(&self) -> (u64, u64) {
+        (self.term, self.generation)
     }
 
     fn to_json(&self) -> JsonValue {
@@ -90,6 +122,7 @@ impl WriterLease {
             "holder_id".to_string(),
             JsonValue::String(self.holder_id.clone()),
         );
+        object.insert("term".to_string(), JsonValue::Number(self.term as f64));
         object.insert(
             "generation".to_string(),
             JsonValue::Number(self.generation as f64),
@@ -120,6 +153,13 @@ impl WriterLease {
                 .and_then(JsonValue::as_str)
                 .ok_or_else(|| LeaseError::InvalidFormat("missing holder_id".into()))?
                 .to_string(),
+            // Legacy lease objects (pre-#835) carry no term — default to the
+            // base replication term so they stay readable and act as "never
+            // fenced" until a termed primary re-stamps them.
+            term: obj
+                .get("term")
+                .and_then(JsonValue::as_u64)
+                .unwrap_or(crate::replication::DEFAULT_REPLICATION_TERM),
             generation: obj
                 .get("generation")
                 .and_then(JsonValue::as_u64)
@@ -157,6 +197,15 @@ pub enum LeaseError {
         attempted_holder: String,
         attempted_generation: u64,
         observed: Option<WriterLease>,
+    },
+    /// A holder on a term *behind* the current term tried to take or keep
+    /// the lease (issue #835). The deposed primary is fenced: a newer term
+    /// already owns the timeline, so the stale holder fails closed rather
+    /// than mutate it.
+    Fenced {
+        attempted_holder: String,
+        attempted_term: u64,
+        current_term: u64,
     },
 }
 
@@ -199,6 +248,15 @@ impl std::fmt::Display for LeaseError {
                     attempted_holder, attempted_generation
                 ),
             },
+            Self::Fenced {
+                attempted_holder,
+                attempted_term,
+                current_term,
+            } => write!(
+                f,
+                "fenced lease op: '{attempted_holder}' on stale term {attempted_term} \
+                 is behind current term {current_term}"
+            ),
         }
     }
 }
@@ -304,15 +362,56 @@ impl LeaseStore {
     /// - `LeaseError::Held` if a different holder owns a non-expired
     ///   lease.
     /// - `LeaseError::LostRace` if a concurrent contender beat us.
+    ///
+    /// Acquires under the base replication term; use
+    /// [`LeaseStore::try_acquire_for_term`] to stamp a specific term and
+    /// fence stale-term contenders (issue #835).
     pub fn try_acquire(
         &self,
         database_key: &str,
         holder_id: &str,
         ttl_ms: u64,
     ) -> Result<WriterLease, LeaseError> {
+        self.try_acquire_for_term(
+            database_key,
+            holder_id,
+            ttl_ms,
+            crate::replication::DEFAULT_REPLICATION_TERM,
+        )
+    }
+
+    /// Like [`LeaseStore::try_acquire`] but stamps `term` onto the lease
+    /// and **fences** any contender whose `term` is behind the published
+    /// lease's term (issue #835, ADR 0030).
+    ///
+    /// The term tie is what makes a deposed primary fail closed: a new
+    /// primary that won a higher term takes the lease under that term, so
+    /// a returning ex-primary on the old term sees a published lease whose
+    /// term is *ahead* of its own and is refused with `LeaseError::Fenced`
+    /// — even when the lease has since expired and would otherwise be
+    /// poachable. A stale holder can never re-take the writer slot until
+    /// it adopts the new term.
+    pub fn try_acquire_for_term(
+        &self,
+        database_key: &str,
+        holder_id: &str,
+        ttl_ms: u64,
+        term: u64,
+    ) -> Result<WriterLease, LeaseError> {
         let now_ms = crate::utils::now_unix_millis();
 
         let current = self.current_versioned(database_key)?;
+        // Term fence first — a contender behind the published term is a
+        // deposed writer and fails closed regardless of expiry or holder.
+        if let Some(c) = &current {
+            if term < c.lease.term {
+                return Err(LeaseError::Fenced {
+                    attempted_holder: holder_id.to_string(),
+                    attempted_term: term,
+                    current_term: c.lease.term,
+                });
+            }
+        }
         // If a healthy lease exists held by someone else, refuse
         // immediately. Two cases collapse: either the current holder
         // is us (refresh) or it's somebody else with time left.
@@ -330,6 +429,7 @@ impl LeaseStore {
         let new_lease = WriterLease {
             database_key: database_key.to_string(),
             holder_id: holder_id.to_string(),
+            term,
             generation: next_generation,
             acquired_at_ms: now_ms,
             expires_at_ms: now_ms.saturating_add(ttl_ms),
@@ -365,6 +465,7 @@ impl LeaseStore {
                 observed: WriterLease {
                     database_key: database_key.to_string(),
                     holder_id: "<missing>".to_string(),
+                    term: 0,
                     generation: 0,
                     acquired_at_ms: 0,
                     expires_at_ms: 0,
@@ -395,6 +496,7 @@ impl LeaseStore {
                 observed: WriterLease {
                     database_key: database_key.to_string(),
                     holder_id: "<missing>".to_string(),
+                    term: 0,
                     generation: 0,
                     acquired_at_ms: 0,
                     expires_at_ms: 0,
@@ -440,6 +542,31 @@ impl LeaseStore {
                 observed: other.map(|v| v.lease),
             }),
         }
+    }
+
+    /// Refresh the lease, but **fail closed** if the holder's term has
+    /// fallen behind `current_term` (issue #835). This is the keep-alive
+    /// counterpart to the acquire fence: a primary that was deposed while
+    /// holding a live lease cannot keep extending it once the cluster has
+    /// moved to a newer term — its next refresh is fenced before it ever
+    /// touches the backend, so it stops mutating and drains.
+    ///
+    /// When the holder's own term still matches or leads `current_term`,
+    /// this is exactly [`LeaseStore::refresh`].
+    pub fn refresh_for_term(
+        &self,
+        lease: &WriterLease,
+        ttl_ms: u64,
+        current_term: u64,
+    ) -> Result<WriterLease, LeaseError> {
+        if lease.fenced_by_term(current_term) {
+            return Err(LeaseError::Fenced {
+                attempted_holder: lease.holder_id.clone(),
+                attempted_term: lease.term,
+                current_term,
+            });
+        }
+        self.refresh(lease, ttl_ms)
     }
 
     /// Release the lease. Only succeeds when the published lease
@@ -577,6 +704,95 @@ mod tests {
         let _ = s.try_acquire("db", "writer-b", 60_000).unwrap();
         let err = s.refresh(&lease, 60_000).unwrap_err();
         assert!(matches!(err, LeaseError::Stale { .. }));
+    }
+
+    #[test]
+    fn acquire_stamps_term_onto_lease() {
+        let s = store();
+        let lease = s.try_acquire_for_term("db", "writer-a", 60_000, 7).unwrap();
+        assert_eq!(lease.term, 7);
+        assert_eq!(lease.fencing_token(), (7, 1));
+    }
+
+    #[test]
+    fn legacy_lease_defaults_to_base_term() {
+        // A lease acquired through the term-agnostic API carries the base
+        // replication term, so it is never fenced until a termed primary
+        // re-stamps it.
+        let s = store();
+        let lease = s.try_acquire("db", "writer-a", 60_000).unwrap();
+        assert_eq!(lease.term, crate::replication::DEFAULT_REPLICATION_TERM);
+        assert!(!lease.fenced_by_term(crate::replication::DEFAULT_REPLICATION_TERM));
+    }
+
+    #[test]
+    fn stale_term_contender_is_fenced_even_when_lease_expired() {
+        // New primary holds the lease at term 5. The lease then expires,
+        // but a returning ex-primary on the old term 4 still cannot poach
+        // it — the term fence refuses before expiry is even consulted.
+        let s = store();
+        let _new_primary = s.try_acquire_for_term("db", "new-primary", 1, 5).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let err = s
+            .try_acquire_for_term("db", "ex-primary", 60_000, 4)
+            .unwrap_err();
+        match err {
+            LeaseError::Fenced {
+                attempted_term,
+                current_term,
+                ..
+            } => {
+                assert_eq!(attempted_term, 4);
+                assert_eq!(current_term, 5);
+            }
+            other => panic!("expected Fenced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn same_or_higher_term_contender_may_poach_expired_lease() {
+        // The fence only bites a *behind* term. A contender at the same or
+        // a higher term takes an expired lease normally, and the generation
+        // advances with the handover.
+        let s = store();
+        let _ = s.try_acquire_for_term("db", "old", 1, 5).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let lease = s.try_acquire_for_term("db", "new", 60_000, 6).unwrap();
+        assert_eq!(lease.holder_id, "new");
+        assert_eq!(lease.term, 6);
+        assert_eq!(lease.generation, 2, "poaching advances the generation");
+    }
+
+    #[test]
+    fn refresh_for_term_fails_closed_once_term_advances() {
+        // A primary holds a live lease at term 4, then the cluster moves to
+        // term 5 underneath it. Its keep-alive refresh is fenced before it
+        // touches the backend — the deposed holder stops mutating.
+        let s = store();
+        let lease = s.try_acquire_for_term("db", "deposed", 60_000, 4).unwrap();
+        let err = s.refresh_for_term(&lease, 60_000, 5).unwrap_err();
+        match err {
+            LeaseError::Fenced {
+                attempted_holder,
+                attempted_term,
+                current_term,
+            } => {
+                assert_eq!(attempted_holder, "deposed");
+                assert_eq!(attempted_term, 4);
+                assert_eq!(current_term, 5);
+            }
+            other => panic!("expected Fenced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn refresh_for_term_succeeds_while_term_holds() {
+        let s = store();
+        let lease = s.try_acquire_for_term("db", "primary", 1_000, 5).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        let refreshed = s.refresh_for_term(&lease, 60_000, 5).unwrap();
+        assert_eq!(refreshed.term, 5);
+        assert!(refreshed.expires_at_ms > lease.expires_at_ms);
     }
 
     // The legacy `acquire_fails_closed_without_backend_conditional_writes`

--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -31,6 +31,12 @@ pub struct ReplicaApplyMetrics {
     /// #813), but recorded so a missed delete that drives collection-count
     /// drift leaves a trail instead of being swallowed by `let _ =`.
     pub apply_miss_total: std::sync::atomic::AtomicU64,
+    /// Issue #835 — a record carrying a term *behind* the replica's current
+    /// term was fenced at the apply boundary (a returning ex-primary on a
+    /// stale term). Fail-closed: the record is rejected and the LSN/term
+    /// chain does not advance, so the deposed primary cannot move any
+    /// watermark until it re-syncs under the new term.
+    pub fenced_total: std::sync::atomic::AtomicU64,
 }
 
 impl ReplicaApplyMetrics {
@@ -52,10 +58,13 @@ impl ReplicaApplyMetrics {
             ApplyErrorKind::Miss => {
                 self.apply_miss_total.fetch_add(1, Relaxed);
             }
+            ApplyErrorKind::Fenced => {
+                self.fenced_total.fetch_add(1, Relaxed);
+            }
         }
     }
 
-    pub fn snapshot(&self) -> [(ApplyErrorKind, u64); 5] {
+    pub fn snapshot(&self) -> [(ApplyErrorKind, u64); 6] {
         use std::sync::atomic::Ordering::Relaxed;
         [
             (ApplyErrorKind::Gap, self.gap_total.load(Relaxed)),
@@ -69,6 +78,7 @@ impl ReplicaApplyMetrics {
                 self.decode_error_total.load(Relaxed),
             ),
             (ApplyErrorKind::Miss, self.apply_miss_total.load(Relaxed)),
+            (ApplyErrorKind::Fenced, self.fenced_total.load(Relaxed)),
         ]
     }
 }
@@ -82,6 +92,9 @@ pub enum ApplyErrorKind {
     /// Issue #814 — apply ran against a missing target (delete on an
     /// absent collection/entity). Non-fatal divergence signal.
     Miss,
+    /// Issue #835 — a record from a term behind the replica's current term
+    /// was fenced at the apply boundary (a stale ex-primary). Fail-closed.
+    Fenced,
 }
 
 impl ApplyErrorKind {
@@ -92,6 +105,7 @@ impl ApplyErrorKind {
             Self::Apply => "apply",
             Self::Decode => "decode",
             Self::Miss => "apply_miss",
+            Self::Fenced => "fenced",
         }
     }
 }
@@ -102,6 +116,7 @@ impl LogicalApplyError {
             Self::Gap { .. } => ApplyErrorKind::Gap,
             Self::Divergence { .. } => ApplyErrorKind::Divergence,
             Self::Apply { .. } => ApplyErrorKind::Apply,
+            Self::StaleTermFenced { .. } => ApplyErrorKind::Fenced,
         }
     }
 }
@@ -138,12 +153,29 @@ pub enum LogicalApplyError {
         lsn: u64,
         source: RedDBError,
     },
+    /// Issue #835 — the record's term is behind the replica's current
+    /// term: a returning ex-primary streaming on a stale, superseded term.
+    /// Rejected at the apply boundary so the deposed primary cannot apply
+    /// or advance any watermark until it re-syncs under the new term.
+    StaleTermFenced {
+        record_term: u64,
+        current_term: u64,
+        lsn: u64,
+    },
 }
 
 impl std::fmt::Display for LogicalApplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Gap { last, next } => write!(f, "LSN gap on apply: last={last} next={next}"),
+            Self::StaleTermFenced {
+                record_term,
+                current_term,
+                lsn,
+            } => write!(
+                f,
+                "stale-term record fenced at lsn={lsn}: record term {record_term} is behind current term {current_term}"
+            ),
             Self::Divergence {
                 expected_term,
                 got_term,
@@ -318,6 +350,24 @@ impl LogicalChangeApplier {
     ) -> Result<ApplyOutcome, LogicalApplyError> {
         let last = self.last_applied_lsn.load(Ordering::Acquire);
         let last_term = self.last_applied_term.load(Ordering::Acquire);
+
+        // Stale-term fence (issue #835, ADR 0030). A record from a term
+        // *behind* the highest term this replica has adopted is a returning
+        // ex-primary on a superseded timeline. Reject it before the LSN
+        // state machine runs — fail closed regardless of LSN, so a stale
+        // ex-primary can neither apply nor advance the chain/watermark. A
+        // record on the *same* term is admitted; a *higher* term is the new
+        // primary's timeline and is adopted on apply below. This mirrors the
+        // election-side `RefusalReason::StaleTerm` on the data path.
+        if record.term < last_term {
+            self.metrics.record(ApplyErrorKind::Fenced);
+            return Err(LogicalApplyError::StaleTermFenced {
+                record_term: record.term,
+                current_term: last_term,
+                lsn: record.lsn,
+            });
+        }
+
         let payload_hash = record_payload_hash(record);
         self.received_frontier_lsn
             .fetch_max(record.lsn, Ordering::AcqRel);
@@ -828,6 +878,89 @@ mod tests {
         );
         assert_eq!(applier.last_applied_term(), 1);
         assert_eq!(applier.last_applied_lsn(), 7);
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Issue #835 — a record from a term behind the replica's adopted term
+    // is fenced at the apply boundary: rejected, counted, and crucially the
+    // LSN/term chain does NOT advance, so a returning ex-primary on a stale
+    // term cannot move any watermark.
+    #[test]
+    fn apply_fences_stale_term_record() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+
+        // Replica adopts term 5 from the legitimate primary at lsn 1.
+        applier
+            .apply(&db, &record(1, b"a").with_term(5), ApplyMode::Replica)
+            .unwrap();
+        assert_eq!(applier.last_applied_term(), 5);
+        assert_eq!(applier.last_applied_lsn(), 1);
+
+        // A returning ex-primary streams the next record on the old term 4.
+        let before = applier.metrics().fenced_total.load(Ordering::Relaxed);
+        let err = applier
+            .apply(&db, &record(2, b"b").with_term(4), ApplyMode::Replica)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LogicalApplyError::StaleTermFenced {
+                    record_term: 4,
+                    current_term: 5,
+                    lsn: 2,
+                }
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(err.kind(), ApplyErrorKind::Fenced);
+        assert_eq!(
+            applier.metrics().fenced_total.load(Ordering::Relaxed),
+            before + 1,
+            "the fence must leave a metrics trail"
+        );
+        // The fenced record advanced nothing — no apply, no watermark move.
+        assert_eq!(applier.last_applied_lsn(), 1, "watermark must not advance");
+        assert_eq!(applier.last_applied_term(), 5);
+        assert_eq!(
+            applier.received_frontier_lsn(),
+            1,
+            "a fenced record must not even advance the received frontier"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // The fence only bites a *behind* term. A record on the same term
+    // applies normally, and a record on a higher term is the new primary's
+    // timeline — adopted on apply.
+    #[test]
+    fn apply_admits_same_term_and_adopts_higher_term() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+
+        applier
+            .apply(&db, &record(1, b"a").with_term(3), ApplyMode::Replica)
+            .unwrap();
+        // Same term → admitted.
+        applier
+            .apply(&db, &record(2, b"b").with_term(3), ApplyMode::Replica)
+            .unwrap();
+        assert_eq!(applier.last_applied_term(), 3);
+        // Higher term → adopted.
+        applier
+            .apply(&db, &record(3, b"c").with_term(7), ApplyMode::Replica)
+            .unwrap();
+        assert_eq!(applier.last_applied_term(), 7);
+        assert_eq!(applier.last_applied_lsn(), 3);
+
+        // Now a record back on term 3 is fenced.
+        let err = applier
+            .apply(&db, &record(4, b"d").with_term(3), ApplyMode::Replica)
+            .unwrap_err();
+        assert!(
+            matches!(err, LogicalApplyError::StaleTermFenced { .. }),
+            "got {err:?}"
+        );
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -26,6 +26,7 @@ pub mod commit_policy;
 pub mod commit_waiter;
 pub mod election;
 pub mod failover;
+pub mod fence;
 pub mod flow_control;
 pub mod lease;
 pub mod logical;
@@ -49,6 +50,10 @@ pub use election::{
 pub use failover::{
     FailoverCoordinator, FailoverError, FailoverMode, FailoverNode, FailoverOutcome,
     FailoverRequest, FailoverTransport, NodeRole, RoleAssignment,
+};
+pub use fence::{
+    FenceBoundary, FenceVerdict, FileTermStore, MemoryTermStore, StaleTermFenced, TermFence,
+    TermStore, TermStoreError,
 };
 pub use flow_control::{Admission, FlowController};
 pub use lease::{LeaseError, LeaseStore, WriterLease};

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -5076,6 +5076,12 @@ impl RedDBRuntime {
                                         let kind = match &err {
                                             crate::replication::logical::LogicalApplyError::Gap { .. } => "stalled_gap",
                                             crate::replication::logical::LogicalApplyError::Divergence { .. } => "divergence",
+                                            // Issue #835 — a stale-term record from a
+                                            // returning ex-primary was fenced. The
+                                            // replica stays put (no apply, no watermark
+                                            // advance) until the legitimate primary's
+                                            // current-term stream resumes.
+                                            crate::replication::logical::LogicalApplyError::StaleTermFenced { .. } => "stale_term_fenced",
                                             _ => "apply_error",
                                         };
                                         self.persist_replication_health(
@@ -5317,7 +5323,7 @@ impl RedDBRuntime {
     /// `apply_miss` kind for deletes against a missing target.
     pub fn replica_apply_error_counts(
         &self,
-    ) -> [(crate::replication::logical::ApplyErrorKind, u64); 5] {
+    ) -> [(crate::replication::logical::ApplyErrorKind, u64); 6] {
         self.inner.replica_apply_metrics.snapshot()
     }
 


### PR DESCRIPTION
## What

Fences a former primary that rejoins on a **stale term** after a failover, so its term-stamped writes and stream handshakes are rejected until it re-syncs and adopts the new term (PRD #819, ADR 0030). Closes #835.

Builds on the consensus core from #834 (term framing / election that establishes the new term) and #821.

## Acceptance criteria

- [x] **Replicas reject records and stream handshakes carrying a term behind the current term** — at both the apply and the handshake boundary.
- [x] **The writer lease generation is tied to the term so a stale holder fails closed.**
- [x] **A returning ex-primary cannot advance any watermark or apply on replicas until it adopts the new term.**
- [x] **Tests cover stale-term rejection at the apply and handshake boundaries.**

## How

**Apply boundary (live on the replica apply path).** `LogicalChangeApplier::apply` now rejects a record whose `term` is behind the replica's adopted term (`last_applied_term`) with a new `LogicalApplyError::StaleTermFenced`, *before* the LSN state machine runs. Fail-closed: no apply, and the LSN/term chain **and** received frontier do not advance — so a returning ex-primary cannot move any watermark. A same-term record is admitted; a higher term is adopted (new primary's timeline). Counted as `ApplyErrorKind::Fenced` and surfaced through replication health as `stale_term_fenced`. This mirrors the election-side `RefusalReason::StaleTerm` on the data path.

**Handshake boundary.** New `replication::fence` module: `TermFence` over a durable `TermStore` (`MemoryTermStore` + `FileTermStore`, using the same atomic temp-file + rename + parent-dir fsync discipline as `FileLastVoteStore`). `admit_record` / `admit_handshake` classify an incoming term as **Admit** (==), **Adopt** (>, persisted durably), or **Fenced** (<); `classify()` is the pure, non-mutating read.

**Writer-lease term tie.** `WriterLease` now carries a `term` (back-compat: legacy lease JSON without the field decodes as `DEFAULT_REPLICATION_TERM`). `LeaseStore::try_acquire_for_term` stamps it and **fences** a contender whose term is behind the published lease's term — even when the lease has expired and would otherwise be poachable, so a deposed primary can never re-take the writer slot on its old term. `refresh_for_term` fails closed once the term advances, so a deposed holder's keep-alive stops before it touches the backend. New `LeaseError::Fenced`, plus `WriterLease::fenced_by_term` / `fencing_token`.

## Scope / staging

Consistent with how the consensus family (#833 failover, #834 election, rollback) landed: the apply-boundary fence is **live** on the real replica apply loop; the handshake `TermFence` and the term-stamped lease acquire are the reusable primitives + API, exercised by tests, ready for the transport/runtime wiring that bumps the live term on failover (the election `bump_term` / failover handover are likewise still behind their injected transports).

## Tests

`cargo test -p reddb-io-server --lib replication::` green (158 passed). New tests:
- `fence`: stale rejection + admit + durable adopt at **both** boundaries, end-to-end returning-ex-primary, `classify` purity, file-store round-trip across a restart.
- `logical`: `apply_fences_stale_term_record` (fail-closed, no watermark/frontier advance, metrics trail), `apply_admits_same_term_and_adopts_higher_term`.
- `lease`: stale-term contender fenced even when expired, same/higher term may poach, `refresh_for_term` fails closed once term advances, term stamping + back-compat default.

`cargo fmt --check` clean; `cargo clippy` clean on touched files (one pre-existing unrelated s3.rs warning).

⚠️ High-risk consensus family — **please review; do not admin-merge.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783036674&installation_id=129708444&pr_number=944&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F944&signature=c72a9f575722c480afe2d7b24f4ac3e3cf2cb8e4fd3cc2a44448d3f6865cb979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced stale-term fencing mechanism at replication boundaries to prevent acceptance of outdated replication terms from returning nodes
  * Added term-aware lease acquisition with automatic fencing for operations using stale terms
  * Enhanced replication metrics to track and monitor stale-term fenced operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->