### PR TITLE
feat(replication): witness member — vote-only, holds no data (#836)

### DIFF
--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -36,6 +36,7 @@ pub mod rollback;
 pub mod scheduler;
 pub mod swap_db;
 pub mod topology_advertiser;
+pub mod witness;
 
 pub use bookmark::{BookmarkDecodeError, CausalBookmark};
 pub use commit_policy::CommitPolicy;
@@ -62,6 +63,7 @@ pub use topology_advertiser::{
     LagConfig, TopologyAdvertiser, TopologyAuthGate, DEFAULT_REPLICA_TIMEOUT_MS,
     TOPOLOGY_READ_CAPABILITY,
 };
+pub use witness::{RuntimeProfile, WitnessSupervisor};
 
 pub const DEFAULT_REPLICATION_TERM: u64 = 1;
 pub const DEFAULT_SLOT_RETENTION_MAX_LAG_LSN: u64 = 100_000;

--- a/crates/reddb-server/src/replication/witness.rs
+++ b/crates/reddb-server/src/replication/witness.rs
@@ -1,0 +1,169 @@
+//! Witness runtime profile (issue #836, PRD #819, ADR 0030).
+//!
+//! A **witness** is a node that runs *only* the control-plane supervisor —
+//! the vote path of the [election core](super::election) — and boots **no
+//! data plane** (no storage engine, no WAL, no replication streaming). It
+//! holds no data and can never be promoted to primary, but its vote counts
+//! toward the election quorum. This makes `2 data nodes + 1 witness` a valid
+//! HA shape (the Mongo "arbiter" idea), so an operator gets automatic
+//! failover without standing up a third *data* replica.
+//!
+//! ADR 0030 fixes the shape: "*The supervisor is therefore a module every
+//! node runs; a witness is a node that runs only that module.*" and
+//! "*Witness members require a build/runtime profile that excludes the data
+//! plane.*" This module is that profile.
+//!
+//! ## What a witness is, structurally
+//!
+//! * [`RuntimeProfile`] — the boot-time choice between a data-bearing node
+//!   ([`RuntimeProfile::Data`], supervisor + data plane) and a witness
+//!   ([`RuntimeProfile::Witness`], supervisor only). `boots_data_plane()` is
+//!   the one bit the boot pipeline branches on.
+//! * [`WitnessSupervisor`] — a booted witness. It is exactly a durable
+//!   [`Voter`](super::election::Voter) plus the node's shared
+//!   [`NodeIdentity`](crate::cluster::NodeIdentity); there is, by
+//!   construction, nothing else. The absence of a data-plane field *is* the
+//!   guarantee — a witness cannot accidentally serve a read or accept a
+//!   write because it holds no engine to do so.
+//!
+//! ## Shared identity, not a second namespace
+//!
+//! A witness authenticates with the **same per-node mTLS identity** a data
+//! member uses: [`NodeIdentity`](crate::cluster::NodeIdentity) is the
+//! validated X.509 subject of the node certificate, and the same type backs
+//! both [`ReplicationPeerIdentity`](crate::cluster::ReplicationPeerIdentity)
+//! and [`ClusterVoterIdentity`](crate::cluster::ClusterVoterIdentity). The
+//! witness's membership id is that identity's subject, so its votes land in
+//! the same identity namespace as every data member's acks — a witness is
+//! not a second-class peer with a parallel auth path.
+
+use std::path::PathBuf;
+
+use crate::cluster::NodeIdentity;
+
+use super::election::{
+    FileLastVoteStore, LastVoteError, LastVoteStore, Member, MemberKind, VoteDecision, VoteRequest,
+    Voter,
+};
+
+/// Which planes a node boots.
+///
+/// Every node runs the control-plane supervisor (the vote path). The profile
+/// decides whether the *data plane* — storage engine, WAL, replication
+/// streaming — is constructed alongside it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeProfile {
+    /// A data-bearing node: supervisor **and** data plane. Holds data,
+    /// streams WAL, and can be promoted to primary.
+    Data,
+    /// A witness: the supervisor / vote path **only**. Holds no data, boots
+    /// no data plane, and can never be promoted (ADR 0030).
+    Witness,
+}
+
+impl RuntimeProfile {
+    /// Does this profile boot the data plane (storage engine + WAL +
+    /// replication streaming)? Only [`RuntimeProfile::Data`] does — a witness
+    /// is supervisor-only.
+    pub fn boots_data_plane(self) -> bool {
+        matches!(self, RuntimeProfile::Data)
+    }
+
+    /// The supervisor module runs on *every* profile — that is the whole
+    /// point of the decoupled control plane (ADR 0030). A witness is the
+    /// degenerate node that runs nothing else.
+    pub fn boots_supervisor(self) -> bool {
+        true
+    }
+
+    /// The membership kind this profile presents to the election quorum.
+    pub fn member_kind(self) -> MemberKind {
+        match self {
+            RuntimeProfile::Data => MemberKind::Data,
+            RuntimeProfile::Witness => MemberKind::Witness,
+        }
+    }
+}
+
+/// A booted witness node: the control-plane supervisor with no data plane.
+///
+/// A witness is a [`Voter`] over a durable last-vote store plus the node's
+/// shared [`NodeIdentity`] — and nothing else. There is intentionally no
+/// engine, no WAL, and no replication handle on this struct: a witness
+/// *cannot* serve data because it holds none.
+///
+/// The store type is generic so production uses the durable
+/// [`FileLastVoteStore`] (ADR 0030: "the supervisor needs durable per-node
+/// vote state to prevent double-voting across restarts") while tests use an
+/// in-memory store.
+pub struct WitnessSupervisor<S: LastVoteStore> {
+    identity: NodeIdentity,
+    voter: Voter<S>,
+}
+
+impl<S: LastVoteStore> WitnessSupervisor<S> {
+    /// Boot a witness supervisor over `store`, identified by the shared
+    /// per-node `identity`. The voter id is the identity's certificate
+    /// subject, so the witness votes under the same identity a data member
+    /// would replicate under.
+    pub fn new(identity: NodeIdentity, store: S) -> Self {
+        let voter = Voter::new(identity.as_str(), store);
+        Self { identity, voter }
+    }
+
+    /// A witness always runs the witness profile.
+    pub fn profile(&self) -> RuntimeProfile {
+        RuntimeProfile::Witness
+    }
+
+    /// A witness never boots a data plane — invariant by construction, stated
+    /// here so callers (and the boot pipeline) can assert it without reaching
+    /// into the profile.
+    pub fn boots_data_plane(&self) -> bool {
+        false
+    }
+
+    /// The shared per-node identity this witness authenticates with — the
+    /// same [`NodeIdentity`](crate::cluster::NodeIdentity) type a data member
+    /// presents over mTLS.
+    pub fn identity(&self) -> &NodeIdentity {
+        &self.identity
+    }
+
+    /// This witness's entry in the supervisor's membership view: a vote-only
+    /// [`MemberKind::Witness`], always [`VotingState::Voting`](super::election::VotingState::Voting).
+    /// It counts toward quorum but is never electable.
+    pub fn member(&self) -> Member {
+        Member::witness(self.identity.as_str())
+    }
+
+    /// Consider a candidate's vote request against the current commit
+    /// watermark — the only control-plane action a witness performs. The
+    /// watermark rule and the durable double-vote guard live in the
+    /// [`Voter`], so a witness applies the exact same safety rule a data
+    /// voter does.
+    pub fn consider_vote(
+        &self,
+        req: &VoteRequest,
+        commit_watermark: u64,
+    ) -> Result<VoteDecision, LastVoteError> {
+        self.voter.consider(req, commit_watermark)
+    }
+
+    /// The highest term this witness has durably recorded.
+    pub fn current_term(&self) -> Result<u64, LastVoteError> {
+        self.voter.current_term()
+    }
+}
+
+impl WitnessSupervisor<FileLastVoteStore> {
+    /// Boot a witness with a durable, on-disk last-vote store at
+    /// `last_vote_path` — the production constructor. Survives a restart so a
+    /// witness that crashes mid-term never double-votes (ADR 0030).
+    pub fn with_durable_store(identity: NodeIdentity, last_vote_path: impl Into<PathBuf>) -> Self {
+        Self::new(identity, FileLastVoteStore::new(last_vote_path))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/reddb-server/src/replication/witness/tests.rs
+++ b/crates/reddb-server/src/replication/witness/tests.rs
@@ -1,0 +1,198 @@
+//! Unit tests for the witness runtime profile (issue #836).
+//!
+//! These pin the structural guarantees: a witness boots no data plane, is a
+//! vote-only member that counts toward quorum but cannot stand for election,
+//! votes through the same durable last-vote rule a data voter uses, and
+//! authenticates with the shared per-node [`NodeIdentity`].
+
+use super::*;
+use crate::replication::election::{
+    quorum_threshold, LastVote, MemoryLastVoteStore, RefusalReason, VotingState,
+};
+
+fn identity(subject: &str) -> NodeIdentity {
+    NodeIdentity::from_certificate_subject(subject).expect("non-empty subject")
+}
+
+fn witness(subject: &str) -> WitnessSupervisor<MemoryLastVoteStore> {
+    WitnessSupervisor::new(identity(subject), MemoryLastVoteStore::new())
+}
+
+// ---------------------------------------------------------------
+// RuntimeProfile: the data-plane branch
+// ---------------------------------------------------------------
+
+#[test]
+fn data_profile_boots_data_plane_witness_does_not() {
+    assert!(RuntimeProfile::Data.boots_data_plane());
+    assert!(!RuntimeProfile::Witness.boots_data_plane());
+    // Every profile runs the supervisor — that is the decoupled control plane.
+    assert!(RuntimeProfile::Data.boots_supervisor());
+    assert!(RuntimeProfile::Witness.boots_supervisor());
+}
+
+#[test]
+fn profile_maps_to_its_member_kind() {
+    assert_eq!(RuntimeProfile::Data.member_kind(), MemberKind::Data);
+    assert_eq!(RuntimeProfile::Witness.member_kind(), MemberKind::Witness);
+}
+
+// ---------------------------------------------------------------
+// WitnessSupervisor: supervisor-only, no data plane
+// ---------------------------------------------------------------
+
+#[test]
+fn witness_supervisor_boots_no_data_plane() {
+    let w = witness("CN=witness-1");
+    assert_eq!(w.profile(), RuntimeProfile::Witness);
+    assert!(!w.boots_data_plane(), "a witness holds no data plane");
+}
+
+#[test]
+fn witness_member_is_vote_only_and_not_electable() {
+    let w = witness("CN=witness-1");
+    let m = w.member();
+    assert_eq!(m.kind, MemberKind::Witness);
+    assert_eq!(m.state, VotingState::Voting, "a witness always votes");
+    assert!(m.is_voter(), "a witness counts toward quorum");
+    assert!(
+        !m.is_electable(),
+        "a witness holds no data, so it can never be primary",
+    );
+}
+
+#[test]
+fn witness_vote_counts_toward_quorum_denominator() {
+    // 2 data + 1 witness → the witness is in the denominator, so the strict
+    // majority is 2, the whole point of the HA shape.
+    let members = vec![
+        Member::data_voting("CN=data-a"),
+        Member::data_voting("CN=data-b"),
+        witness("CN=witness-1").member(),
+    ];
+    assert_eq!(quorum_threshold(&members), 2);
+}
+
+// ---------------------------------------------------------------
+// WitnessSupervisor: applies the real vote rule
+// ---------------------------------------------------------------
+
+#[test]
+fn witness_grants_a_covering_candidate() {
+    let w = witness("CN=witness-1");
+    // Candidate frontier 150 covers watermark 100.
+    let decision = w
+        .consider_vote(&VoteRequest::real("CN=data-a", 5, 150), 100)
+        .unwrap();
+    assert_eq!(decision, VoteDecision::Granted);
+    // A real grant advanced the witness's durable term.
+    assert_eq!(w.current_term().unwrap(), 5);
+}
+
+#[test]
+fn witness_refuses_a_candidate_below_the_watermark() {
+    let w = witness("CN=witness-1");
+    // Frontier 90 does not cover watermark 100 — the safety core refuses,
+    // exactly as a data voter would.
+    let decision = w
+        .consider_vote(&VoteRequest::real("CN=data-a", 5, 90), 100)
+        .unwrap();
+    assert_eq!(
+        decision,
+        VoteDecision::Refused(RefusalReason::WatermarkNotCovered {
+            candidate_lsn: 90,
+            watermark: 100,
+        }),
+    );
+}
+
+#[test]
+fn witness_does_not_double_vote_in_a_term() {
+    let w = witness("CN=witness-1");
+    assert!(w
+        .consider_vote(&VoteRequest::real("CN=data-a", 7, 200), 100)
+        .unwrap()
+        .is_granted());
+    // A second candidate in the same term is refused — already voted.
+    assert_eq!(
+        w.consider_vote(&VoteRequest::real("CN=data-b", 7, 200), 100)
+            .unwrap(),
+        VoteDecision::Refused(RefusalReason::AlreadyVoted {
+            term: 7,
+            voted_for: "CN=data-a".to_string(),
+        }),
+    );
+}
+
+#[test]
+fn witness_probe_does_not_advance_its_term() {
+    let w = witness("CN=witness-1");
+    assert!(w
+        .consider_vote(&VoteRequest::probe("CN=data-a", 9, 200), 100)
+        .unwrap()
+        .is_granted());
+    // A dry-run probe is observation only — no term advance, no persisted vote.
+    assert_eq!(w.current_term().unwrap(), 0);
+}
+
+// ---------------------------------------------------------------
+// Shared per-node identity
+// ---------------------------------------------------------------
+
+#[test]
+fn witness_authenticates_with_the_shared_node_identity() {
+    let id = identity("CN=node-7,O=reddb");
+    let w = WitnessSupervisor::new(id.clone(), MemoryLastVoteStore::new());
+    // The witness's identity is the same NodeIdentity type a data member
+    // presents over mTLS — same namespace, not a parallel one.
+    assert_eq!(w.identity(), &id);
+    // Its membership id is the certificate subject, so its votes land under
+    // the same identity its acks would.
+    assert_eq!(w.member().id, "CN=node-7,O=reddb");
+}
+
+#[test]
+fn durable_witness_does_not_double_vote_across_restart() {
+    let dir = std::env::temp_dir().join(format!(
+        "reddb-witness-{}-{}",
+        std::process::id(),
+        crate::utils::now_unix_nanos()
+    ));
+    let path = dir.join("witness.lastvote.json");
+    let id = identity("CN=witness-1");
+
+    // Boot a durable witness, grant "data-a" in term 7.
+    {
+        let w = WitnessSupervisor::with_durable_store(id.clone(), &path);
+        assert!(w
+            .consider_vote(&VoteRequest::real("CN=data-a", 7, 200), 100)
+            .unwrap()
+            .is_granted());
+    }
+    // The witness process restarts: a fresh supervisor over the same file
+    // refuses a different candidate in term 7, read back from disk.
+    {
+        let w = WitnessSupervisor::with_durable_store(id, &path);
+        assert_eq!(
+            w.consider_vote(&VoteRequest::real("CN=data-b", 7, 200), 100)
+                .unwrap(),
+            VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                term: 7,
+                voted_for: "CN=data-a".to_string(),
+            }),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn seeded_store_reports_its_recorded_term() {
+    let w = WitnessSupervisor::new(
+        identity("CN=witness-1"),
+        MemoryLastVoteStore::seeded(LastVote {
+            term: 4,
+            voted_for: Some("CN=data-a".to_string()),
+        }),
+    );
+    assert_eq!(w.current_term().unwrap(), 4);
+}

--- a/crates/reddb-server/tests/witness_failover_e2e.rs
+++ b/crates/reddb-server/tests/witness_failover_e2e.rs
@@ -1,0 +1,295 @@
+//! End-to-end acceptance test for the witness runtime profile
+//! (issue #836, PRD #819, ADR 0030).
+//!
+//! Deploys `2 data nodes + 1 witness`, kills the primary, and asserts the
+//! surviving data node is elected **with the witness's vote** — the exact
+//! HA shape the witness profile exists to enable. The witness here is the
+//! real [`WitnessSupervisor`]: it boots no data plane, holds no data, and
+//! authenticates with the shared per-node [`NodeIdentity`]. The data voters
+//! are real durable [`Voter`]s and the candidate side is the real
+//! [`ElectionCoordinator`] — only the clock and reachability are injected,
+//! so the assertions are deterministic with no clock and no network.
+//!
+//! Acceptance criteria covered (issue #836):
+//!   * a witness profile boots the supervisor/vote path only, no data plane;
+//!   * a witness vote counts toward election quorum;
+//!   * `2 data + 1 witness` elects correctly on primary loss;
+//!   * the witness authenticates with the shared per-node identity;
+//!   * this integration test covers the `2 data + 1 witness` failover.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use reddb_server::cluster::NodeIdentity;
+use reddb_server::replication::election::MemoryLastVoteStore;
+use reddb_server::replication::{
+    randomized_election_timeout, ElectionCoordinator, ElectionOutcome, ElectionRequest,
+    ElectionTransport, FileLastVoteStore, Member, RefusalReason, RuntimeProfile, VoteDecision,
+    VoteRequest, Voter, WitnessSupervisor,
+};
+
+const LONG: Duration = Duration::from_secs(60);
+
+// Shared per-node mTLS identities — the witness and the data members draw
+// from the *same* identity type (X.509 subject), not separate namespaces.
+const DATA_A: &str = "CN=data-a,O=reddb";
+const DATA_B: &str = "CN=data-b,O=reddb";
+const WITNESS: &str = "CN=witness-1,O=reddb";
+
+fn identity(subject: &str) -> NodeIdentity {
+    NodeIdentity::from_certificate_subject(subject).expect("non-empty subject")
+}
+
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "reddb-witness-e2e-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A `2 data + 1 witness` cluster. The two data members vote through durable
+/// file-backed [`Voter`]s; the witness votes through the real
+/// [`WitnessSupervisor`] (no data plane). A `reachable` flag models a node
+/// being killed or partitioned away.
+struct WitnessCluster {
+    dir: std::path::PathBuf,
+    members: Vec<Member>,
+    /// data member id -> (durable last-vote path, reachable)
+    data: HashMap<String, (std::path::PathBuf, bool)>,
+    /// the single witness supervisor + its reachability
+    witness: WitnessSupervisor<MemoryLastVoteStore>,
+    witness_reachable: bool,
+    watermark: u64,
+    elapsed: Arc<Mutex<Duration>>,
+    tick: Duration,
+    bumped: Vec<u64>,
+    promoted: Option<u64>,
+}
+
+impl WitnessCluster {
+    fn new(dir: std::path::PathBuf, watermark: u64) -> Self {
+        let members = vec![
+            Member::data_voting(DATA_A),
+            Member::data_voting(DATA_B),
+            Member::witness(WITNESS),
+        ];
+        let mut data = HashMap::new();
+        for id in [DATA_A, DATA_B] {
+            data.insert(
+                id.to_string(),
+                (dir.join(format!("{id}.lastvote.json")), true),
+            );
+        }
+        let witness = WitnessSupervisor::new(identity(WITNESS), MemoryLastVoteStore::new());
+        Self {
+            dir,
+            members,
+            data,
+            witness,
+            witness_reachable: true,
+            watermark,
+            elapsed: Arc::new(Mutex::new(Duration::ZERO)),
+            tick: Duration::from_millis(10),
+            bumped: Vec::new(),
+            promoted: None,
+        }
+    }
+
+    /// Kill / partition away a node so the candidate can no longer reach it.
+    fn kill(&mut self, id: &str) {
+        if id == WITNESS {
+            self.witness_reachable = false;
+        } else if let Some(entry) = self.data.get_mut(id) {
+            entry.1 = false;
+        }
+    }
+}
+
+impl ElectionTransport for WitnessCluster {
+    fn members(&self) -> Vec<Member> {
+        self.members.clone()
+    }
+
+    fn request_vote(&mut self, peer_id: &str, req: &VoteRequest) -> VoteDecision {
+        // The witness votes through its real supervisor — no data plane.
+        if peer_id == self.witness.member().id {
+            if !self.witness_reachable {
+                return unreachable_refusal(req);
+            }
+            return self
+                .witness
+                .consider_vote(req, self.watermark)
+                .expect("memory store infallible");
+        }
+        // A data member votes through its durable file-backed voter.
+        let (path, reachable) = self.data.get(peer_id).expect("known data peer");
+        if !reachable {
+            return unreachable_refusal(req);
+        }
+        let voter = Voter::new(peer_id, FileLastVoteStore::new(path));
+        voter.consider(req, self.watermark).expect("durable store")
+    }
+
+    fn elapsed(&self) -> Duration {
+        let mut e = self.elapsed.lock().unwrap();
+        let now = *e;
+        *e += self.tick;
+        now
+    }
+
+    fn bump_term(&mut self, new_term: u64) {
+        self.bumped.push(new_term);
+    }
+
+    fn promote(&mut self, new_term: u64) {
+        self.promoted = Some(new_term);
+    }
+}
+
+/// An unreachable peer surfaces to the candidate as a no-grant; its durable
+/// store is never touched.
+fn unreachable_refusal(req: &VoteRequest) -> VoteDecision {
+    VoteDecision::Refused(RefusalReason::StaleTerm {
+        candidate_term: req.term,
+        voter_term: u64::MAX,
+    })
+}
+
+fn surviving_candidate(id: &str, current_term: u64, lsn: u64, watermark: u64) -> ElectionRequest {
+    ElectionRequest {
+        candidate: Member::data_voting(id),
+        current_term,
+        last_log_lsn: lsn,
+        commit_watermark: watermark,
+    }
+}
+
+fn cleanup(c: &WitnessCluster) {
+    let _ = std::fs::remove_dir_all(&c.dir);
+}
+
+// The headline acceptance test: 2 data + 1 witness, primary killed, the
+// surviving data node is elected with the witness's vote.
+#[test]
+fn two_data_plus_witness_elects_surviving_node_on_primary_loss() {
+    let dir = temp_dir("failover");
+    let mut cluster = WitnessCluster::new(dir, 100);
+
+    // data-a was the primary; it is killed. data-b survives and stands.
+    cluster.kill(DATA_A);
+    // data-b covers the commit watermark (frontier 150 >= 100).
+    let req = surviving_candidate(DATA_B, 4, 150, 100);
+
+    let timeout =
+        randomized_election_timeout(Duration::from_millis(150), Duration::from_millis(150), 3);
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, timeout);
+
+    // data-b self-vote + the witness vote = 2 = strict majority of 3.
+    assert_eq!(
+        outcome,
+        ElectionOutcome::Elected {
+            term: 5,
+            votes: 2,
+            needed: 2,
+        },
+        "the witness vote completes the majority after primary loss",
+    );
+    assert_eq!(
+        cluster.promoted,
+        Some(5),
+        "the surviving data node is promoted"
+    );
+    assert_eq!(
+        cluster.bumped,
+        vec![5],
+        "the real election bumped exactly one term"
+    );
+    cleanup(&cluster);
+}
+
+// The witness genuinely holds no data plane and can never be the one promoted.
+#[test]
+fn witness_holds_no_data_and_is_never_electable() {
+    let witness = WitnessSupervisor::new(identity(WITNESS), MemoryLastVoteStore::new());
+    assert_eq!(witness.profile(), RuntimeProfile::Witness);
+    assert!(!witness.boots_data_plane(), "a witness boots no data plane");
+    assert!(
+        !witness.member().is_electable(),
+        "a witness can never be promoted to primary",
+    );
+    // It still counts as a voter toward quorum.
+    assert!(witness.member().is_voter());
+    // And it authenticates with the shared per-node identity.
+    assert_eq!(witness.identity(), &identity(WITNESS));
+}
+
+// Without the witness the two-data cluster cannot form a majority once the
+// primary dies — this is exactly the gap the witness closes.
+#[test]
+fn two_data_alone_cannot_elect_when_the_witness_is_also_down() {
+    let dir = temp_dir("no-witness");
+    let mut cluster = WitnessCluster::new(dir, 100);
+
+    // Primary data-a is killed AND the witness is unreachable: data-b reaches
+    // only itself = 1 < majority 2. No promotion — the cluster correctly
+    // refuses to elect a minority primary.
+    cluster.kill(DATA_A);
+    cluster.kill(WITNESS);
+    let req = surviving_candidate(DATA_B, 4, 150, 100);
+
+    let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
+
+    assert!(
+        matches!(
+            outcome,
+            ElectionOutcome::ProbeFailed {
+                votes: 1,
+                needed: 2
+            }
+        ),
+        "no majority without the witness, got {outcome:?}",
+    );
+    assert!(cluster.bumped.is_empty(), "a failed probe burns no term");
+    assert_eq!(cluster.promoted, None, "no minority primary");
+    cleanup(&cluster);
+}
+
+// The witness vote is durable: once it grants the surviving node a term, a
+// restart of the witness must not grant a competing candidate the same term.
+#[test]
+fn witness_vote_is_durable_across_restart() {
+    let dir = temp_dir("durable");
+    let path = dir.join("witness.lastvote.json");
+    let id = identity(WITNESS);
+
+    // The witness grants data-b in term 5 and the grant is persisted.
+    {
+        let witness = WitnessSupervisor::with_durable_store(id.clone(), &path);
+        assert!(witness
+            .consider_vote(&VoteRequest::real(DATA_B, 5, 150), 100)
+            .unwrap()
+            .is_granted());
+    }
+    // The witness restarts (fresh supervisor, same file). A competing
+    // candidate asking for term 5 is refused from disk — no second primary.
+    {
+        let witness = WitnessSupervisor::with_durable_store(id, &path);
+        assert_eq!(
+            witness
+                .consider_vote(&VoteRequest::real(DATA_A, 5, 150), 100)
+                .unwrap(),
+            VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                term: 5,
+                voted_for: DATA_B.to_string(),
+            }),
+        );
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## What

A **witness runtime profile**: a node that boots *only* the control-plane supervisor (the election vote path) and **no data plane** — no storage engine, no WAL, no replication streaming. It holds no data and can never be promoted to primary, but its vote counts toward election quorum. This makes `2 data + 1 witness` a valid HA shape (ADR 0030, PRD #819).

Closes #836.

## How

- `RuntimeProfile{Data,Witness}` — `boots_data_plane()` is the one bit the boot pipeline branches on; the supervisor runs on every profile (ADR 0030).
- `WitnessSupervisor` — a durable `Voter` plus the shared per-node `NodeIdentity`, and nothing else. The absence of a data-plane field *is* the guarantee: a witness cannot serve a read or accept a write because it holds no engine.
- **Shared identity:** a witness authenticates with the same per-node mTLS `NodeIdentity` a data member uses; its votes land in the same identity namespace as data acks — not a parallel auth path.
- Reuses the #834 election core unchanged (watermark rule + durable double-vote guard live in `Voter`), so a witness applies the exact same safety rule a data voter does.

## Acceptance criteria

- [x] Witness boots the supervisor/vote path only, no data plane.
- [x] A witness vote counts toward election quorum.
- [x] `2 data + 1 witness` elects correctly on primary loss.
- [x] Witness authenticates with the shared per-node identity.
- [x] Integration test covers the `2 data + 1 witness` failover.

## Tests

- Witness unit tests (12): no data plane, vote-only / non-electable, durable no-double-vote across restart, shared identity. `cargo test -p reddb-io-server --lib replication::witness` ✓
- `2 data + 1 witness` failover e2e (4): primary killed → surviving data node elected with the witness's vote; minority-without-witness correctly refuses to elect. `cargo test -p reddb-io-server --test witness_failover_e2e` ✓
- `cargo fmt --check` and clippy clean on all new files. (Pre-existing clippy errors elsewhere in the crate — tdigest/csv/parser — are unrelated to this change.)

## Process

PRD #819 consensus family (design approved via #834). **HITL — for human review, not admin-merge.**

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783039699&installation_id=129708444&pr_number=945&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F945&signature=23f9a2193d89eb63bc222f9e877b07a8542e5e6a675d0112c059f492f0b7e319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added witness node support enabling lightweight cluster participants that vote in elections without storing data, improving failover resilience and cluster quorum management.

* **Tests**
  * Added comprehensive test coverage for witness node behavior and failover scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->