### PR TITLE
feat(replication): operator observability surface — leader, per-replica lag, resync counter (#839)

### DIFF
--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -2840,6 +2840,19 @@ impl RedDb for GrpcRuntime {
             }
             crate::replication::ReplicationRole::Primary => {
                 map.insert("role".into(), JsonValue::String("primary".into()));
+                // Leader identity + resync counters (issue #839) — mirror
+                // the HTTP `/replication/status` surface so a gRPC consumer
+                // sees the same observability fields.
+                map.insert("is_leader".into(), JsonValue::Bool(true));
+                map.insert("leader".into(), JsonValue::String(self.runtime.node_id()));
+                map.insert(
+                    "full_resync_count".into(),
+                    JsonValue::Number(self.runtime.replication_full_resync_count() as f64),
+                );
+                map.insert(
+                    "partial_resync_count".into(),
+                    JsonValue::Number(self.runtime.replication_partial_resync_count() as f64),
+                );
                 if let Some(ref repl) = db.replication {
                     let lsn = repl
                         .logical_wal_spool
@@ -2855,6 +2868,42 @@ impl RedDb for GrpcRuntime {
                         "replica_count".into(),
                         JsonValue::Number(repl.replica_count() as f64),
                     );
+                    // Per-replica lag in LSN-offset and wall-clock (#839).
+                    let head_lsn = repl.current_logical_lsn();
+                    let now_ms = crate::utils::now_unix_millis() as u128;
+                    let replicas = repl
+                        .replica_snapshots()
+                        .into_iter()
+                        .map(|replica| {
+                            let mut replica_json = crate::json::Map::new();
+                            replica_json.insert("id".into(), JsonValue::String(replica.id.clone()));
+                            replica_json.insert(
+                                "last_acked_lsn".into(),
+                                JsonValue::Number(replica.last_acked_lsn as f64),
+                            );
+                            replica_json.insert(
+                                "last_sent_lsn".into(),
+                                JsonValue::Number(replica.last_sent_lsn as f64),
+                            );
+                            replica_json.insert(
+                                "lag_lsn".into(),
+                                JsonValue::Number(
+                                    head_lsn.saturating_sub(replica.last_acked_lsn) as f64,
+                                ),
+                            );
+                            let lag_ms = now_ms.saturating_sub(replica.last_seen_at_unix_ms);
+                            replica_json.insert(
+                                "lag_seconds".into(),
+                                JsonValue::Number((lag_ms as f64) / 1000.0),
+                            );
+                            replica_json.insert(
+                                "rebootstrapping".into(),
+                                JsonValue::Bool(replica.rebootstrapping),
+                            );
+                            JsonValue::Object(replica_json)
+                        })
+                        .collect();
+                    map.insert("replicas".into(), JsonValue::Array(replicas));
                     if let Some(progress) = repl.replication_progress() {
                         map.insert(
                             "replication_lag_lsn".into(),
@@ -2914,6 +2963,8 @@ impl RedDb for GrpcRuntime {
             }
             crate::replication::ReplicationRole::Replica { primary_addr } => {
                 map.insert("role".into(), JsonValue::String("replica".into()));
+                map.insert("is_leader".into(), JsonValue::Bool(false));
+                map.insert("leader".into(), JsonValue::String(primary_addr.clone()));
                 map.insert(
                     "primary_addr".into(),
                     JsonValue::String(primary_addr.clone()),

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -1085,6 +1085,13 @@ pub struct PrimaryReplication {
     /// replication metric so a brief disconnect that recovers via
     /// partial resync is observable.
     partial_resync_count: std::sync::atomic::AtomicU64,
+    /// Count of pulls that forced a full re-bootstrap — the replica's
+    /// retained WAL no longer covers its requested position, so it must
+    /// discard its dataset and reload a fresh snapshot (issue #839).
+    /// This is the primary alert signal: a healthy cluster re-bootstraps
+    /// rarely, so any sustained rise means slots are being invalidated
+    /// faster than replicas can keep up.
+    full_resync_count: std::sync::atomic::AtomicU64,
 }
 
 /// How a replica's pull should be served, decided from its slot state.
@@ -1142,6 +1149,7 @@ impl PrimaryReplication {
             commit_waiter: Arc::new(crate::replication::commit_waiter::CommitWaiter::new()),
             topology_epoch: std::sync::atomic::AtomicU64::new(0),
             partial_resync_count: std::sync::atomic::AtomicU64::new(0),
+            full_resync_count: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -1573,6 +1581,8 @@ impl PrimaryReplication {
         if let Some(cause) =
             self.slot_rebootstrap_reason(id, requested_since_lsn, oldest_available_lsn)
         {
+            self.full_resync_count
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             return ResumeMode::FullRebootstrap { cause };
         }
         let resume_lsn = self
@@ -1590,6 +1600,14 @@ impl PrimaryReplication {
     /// Surfaced in the replication metrics/status payload (issue #832).
     pub fn partial_resync_count(&self) -> u64 {
         self.partial_resync_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Number of pulls that forced a full re-bootstrap since process
+    /// start (issue #839). Surfaced as `reddb_replication_full_resync_total`
+    /// and in `/replication/status` — the primary operator alert signal.
+    pub fn full_resync_count(&self) -> u64 {
+        self.full_resync_count
             .load(std::sync::atomic::Ordering::Relaxed)
     }
 
@@ -2095,6 +2113,11 @@ mod tests {
             before + 1,
             "partial resync must be observable via the metric"
         );
+        assert_eq!(
+            within.full_resync_count(),
+            0,
+            "a partial resync must not bump the full-resync counter"
+        );
 
         // A slot driven past the retention cap is invalidated and must
         // re-bootstrap — and that decision must NOT count as a partial
@@ -2109,6 +2132,7 @@ mod tests {
         }
         past_cap.enforce_retention_limits(0);
         let before_full = past_cap.partial_resync_count();
+        let before_full_count = past_cap.full_resync_count();
         match past_cap.plan_replica_resume("slow", 0, past_cap.wal_buffer.oldest_lsn()) {
             ResumeMode::FullRebootstrap { cause } => {
                 assert_eq!(cause, SlotInvalidationCause::Horizon)
@@ -2119,6 +2143,11 @@ mod tests {
             past_cap.partial_resync_count(),
             before_full,
             "a full re-bootstrap must not be counted as a partial resync"
+        );
+        assert_eq!(
+            past_cap.full_resync_count(),
+            before_full_count + 1,
+            "a full re-bootstrap must bump the full-resync alert counter (issue #839)"
         );
     }
 

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -5279,6 +5279,49 @@ impl RedDBRuntime {
             .unwrap_or_default()
     }
 
+    /// Issue #839 — the primary's current logical-WAL head LSN, used as
+    /// the reference point for per-replica lag. `0` on non-primary
+    /// instances or before the logical spool has any records.
+    pub fn primary_logical_head_lsn(&self) -> u64 {
+        self.inner
+            .db
+            .replication
+            .as_ref()
+            .map(|repl| repl.current_logical_lsn())
+            .unwrap_or(0)
+    }
+
+    /// Issue #839 — count of pulls that forced a full re-bootstrap since
+    /// process start. The primary operator alert signal; always `0` on a
+    /// non-primary instance.
+    pub fn replication_full_resync_count(&self) -> u64 {
+        self.inner
+            .db
+            .replication
+            .as_ref()
+            .map(|repl| repl.full_resync_count())
+            .unwrap_or(0)
+    }
+
+    /// Issue #839 — count of pulls served as a partial (incremental)
+    /// resync since process start. Always `0` on a non-primary instance.
+    pub fn replication_partial_resync_count(&self) -> u64 {
+        self.inner
+            .db
+            .replication
+            .as_ref()
+            .map(|repl| repl.partial_resync_count())
+            .unwrap_or(0)
+    }
+
+    /// Issue #839 — this node's stable identity, surfaced as the leader
+    /// identity in `/replication/status` when the node is the primary.
+    /// Reuses the same persisted id a replica advertises to the primary,
+    /// so a cluster has one stable name per node regardless of role.
+    pub fn node_id(&self) -> String {
+        self.resolve_replica_id()
+    }
+
     /// Issue #826 — re-evaluate write-admission flow control from the
     /// live primary replica registry and return the resulting throttle
     /// state. Computes the max lag across in-quorum replicas (async

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -1323,6 +1323,36 @@ impl RedDBServer {
             flow.observed_lag_lsn()
         );
 
+        // Issue #839 — full-resync / re-bootstrap counter is the primary
+        // operator alert signal. A healthy cluster re-bootstraps rarely;
+        // any sustained rise means slots are invalidated faster than
+        // replicas keep up. The partial-resync counter is emitted beside
+        // it so an alert can distinguish a benign reconnect storm (partial
+        // climbing, full flat) from genuine slot loss.
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_full_resync_total Pulls that forced a replica full re-bootstrap since process start."
+        );
+        let _ = writeln!(body, "# TYPE reddb_replication_full_resync_total counter");
+        let _ = writeln!(
+            body,
+            "reddb_replication_full_resync_total {}",
+            self.runtime.replication_full_resync_count()
+        );
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_partial_resync_total Pulls served as an incremental partial resync since process start."
+        );
+        let _ = writeln!(
+            body,
+            "# TYPE reddb_replication_partial_resync_total counter"
+        );
+        let _ = writeln!(
+            body,
+            "reddb_replication_partial_resync_total {}",
+            self.runtime.replication_partial_resync_count()
+        );
+
         // PLAN.md Phase 11.5 — replica apply error counters and
         // current health label. Counters are global across the
         // instance lifetime; the health label reflects whatever the
@@ -3697,6 +3727,33 @@ mod tests {
             "reddb_cache_blob_version_mismatch_total{namespace=\"runtime.result_cache\"}",
         ] {
             assert!(body.contains(needle), "missing metric line for {needle}");
+        }
+    }
+
+    #[test]
+    fn metrics_expose_replication_resync_alert_counters() {
+        // Issue #839 — the full-resync counter must be scrapeable as an
+        // alerting metric; the partial counter rides alongside for context.
+        let runtime = crate::runtime::RedDBRuntime::with_options(
+            crate::api::RedDBOptions::in_memory()
+                .with_replication(crate::replication::ReplicationConfig::primary()),
+        )
+        .expect("runtime");
+
+        let server = RedDBServer::new(runtime);
+        let response = server.handle_metrics();
+        let body = String::from_utf8(response.body).expect("utf8 metrics");
+
+        for needle in [
+            "# TYPE reddb_replication_full_resync_total counter",
+            "reddb_replication_full_resync_total 0",
+            "# TYPE reddb_replication_partial_resync_total counter",
+            "reddb_replication_partial_resync_total 0",
+        ] {
+            assert!(
+                body.contains(needle),
+                "missing metric line for {needle}\n{body}"
+            );
         }
     }
 

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -23,6 +23,27 @@ impl RedDBServer {
             }
             crate::replication::ReplicationRole::Primary => {
                 object.insert("role".to_string(), JsonValue::String("primary".to_string()));
+                // Leader identity (issue #839). A primary is the leader of
+                // its own term, so the leader is this node. Operators read
+                // `leader` alongside `current_term` to confirm who carries
+                // the term without cross-referencing the election log.
+                object.insert("is_leader".to_string(), JsonValue::Bool(true));
+                object.insert(
+                    "leader".to_string(),
+                    JsonValue::String(self.runtime.node_id()),
+                );
+                // Full-resync / partial-resync counters (issue #839). The
+                // full-resync counter is the primary alert signal; the
+                // partial counter contextualises it (brief disconnects that
+                // recovered incrementally are healthy).
+                object.insert(
+                    "full_resync_count".to_string(),
+                    JsonValue::Number(self.runtime.replication_full_resync_count() as f64),
+                );
+                object.insert(
+                    "partial_resync_count".to_string(),
+                    JsonValue::Number(self.runtime.replication_partial_resync_count() as f64),
+                );
                 if let Some(ref primary) = db.replication {
                     let wal_lsn = primary
                         .logical_wal_spool
@@ -49,6 +70,49 @@ impl RedDBServer {
                         "replica_count".to_string(),
                         JsonValue::Number(primary.replica_count() as f64),
                     );
+                    // Per-replica lag in both LSN-offset and wall-clock
+                    // (issue #839). `lag_lsn` is the record distance from
+                    // the primary's logical head to the replica's last ack;
+                    // `lag_seconds` is the wall-clock age since the primary
+                    // last heard from the replica. The two together tell a
+                    // replica that is behind-but-pulling (high lag_lsn, low
+                    // lag_seconds) apart from one that has gone silent.
+                    let head_lsn = primary.current_logical_lsn();
+                    let now_ms = crate::utils::now_unix_millis() as u128;
+                    let replicas = primary
+                        .replica_snapshots()
+                        .into_iter()
+                        .map(|replica| {
+                            let mut replica_json = Map::new();
+                            replica_json
+                                .insert("id".to_string(), JsonValue::String(replica.id.clone()));
+                            replica_json.insert(
+                                "last_acked_lsn".to_string(),
+                                JsonValue::Number(replica.last_acked_lsn as f64),
+                            );
+                            replica_json.insert(
+                                "last_sent_lsn".to_string(),
+                                JsonValue::Number(replica.last_sent_lsn as f64),
+                            );
+                            replica_json.insert(
+                                "lag_lsn".to_string(),
+                                JsonValue::Number(
+                                    head_lsn.saturating_sub(replica.last_acked_lsn) as f64
+                                ),
+                            );
+                            let lag_ms = now_ms.saturating_sub(replica.last_seen_at_unix_ms);
+                            replica_json.insert(
+                                "lag_seconds".to_string(),
+                                JsonValue::Number((lag_ms as f64) / 1000.0),
+                            );
+                            replica_json.insert(
+                                "rebootstrapping".to_string(),
+                                JsonValue::Bool(replica.rebootstrapping),
+                            );
+                            JsonValue::Object(replica_json)
+                        })
+                        .collect();
+                    object.insert("replicas".to_string(), JsonValue::Array(replicas));
                     if let Some(progress) = primary.replication_progress() {
                         object.insert(
                             "replication_lag_lsn".to_string(),
@@ -97,6 +161,15 @@ impl RedDBServer {
             }
             crate::replication::ReplicationRole::Replica { primary_addr } => {
                 object.insert("role".to_string(), JsonValue::String("replica".to_string()));
+                object.insert("is_leader".to_string(), JsonValue::Bool(false));
+                // Leader identity (issue #839). From a replica's vantage the
+                // leader is the primary it streams from; surfaced under the
+                // same `leader` key the primary uses so dashboards read one
+                // field regardless of which node they scrape.
+                object.insert(
+                    "leader".to_string(),
+                    JsonValue::String(primary_addr.clone()),
+                );
                 object.insert(
                     "primary_addr".to_string(),
                     JsonValue::String(primary_addr.clone()),
@@ -196,5 +269,71 @@ mod tests {
             body.contains(r#""invalidation_reason":"horizon""#),
             "{body}"
         );
+    }
+
+    #[test]
+    fn replication_status_surfaces_term_leader_watermark_and_resync_counters() {
+        // Issue #839 acceptance: the operator-facing surface carries the
+        // current term, a leader identity, the commit watermark, and the
+        // full-resync alert counter.
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory().with_replication(ReplicationConfig::primary().with_term(7)),
+        )
+        .expect("runtime");
+
+        let server = RedDBServer::new(runtime);
+        let response = server.handle_replication_status();
+        let body = String::from_utf8(response.body).expect("status body is utf8");
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains(r#""role":"primary""#), "{body}");
+        assert!(body.contains(r#""current_term":7"#), "{body}");
+        assert!(body.contains(r#""is_leader":true"#), "{body}");
+        // A primary is the leader of its own term, so `leader` is this
+        // node's stable id — present and non-empty.
+        assert!(body.contains(r#""leader":""#), "{body}");
+        assert!(!body.contains(r#""leader":"""#), "{body}");
+        assert!(body.contains(r#""commit_watermark":"#), "{body}");
+        assert!(body.contains(r#""full_resync_count":0"#), "{body}");
+        assert!(body.contains(r#""partial_resync_count":0"#), "{body}");
+    }
+
+    #[test]
+    fn replication_status_surfaces_per_replica_lag_offset_and_wall_clock() {
+        // Issue #839 acceptance: per-replica lag in both LSN-offset and
+        // wall-clock appears in the status payload.
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory().with_replication(ReplicationConfig::primary()),
+        )
+        .expect("runtime");
+        let db = runtime.db();
+        let primary = db.replication.as_ref().expect("primary replication");
+        primary.register_replica("r1".to_string());
+        // Advance the primary head to LSN 5, tell it the replica was sent
+        // through 5 but has only acked through 2 — a 3-record offset lag.
+        let spool = primary
+            .logical_wal_spool
+            .as_ref()
+            .expect("logical WAL spool");
+        for lsn in 1..=5 {
+            spool
+                .append_with_term_and_timestamp(1, lsn, lsn, &[lsn as u8])
+                .expect("append logical WAL");
+        }
+        primary.note_replica_pull("r1", 5);
+        primary.ack_replica("r1", 2);
+
+        let server = RedDBServer::new(runtime);
+        let response = server.handle_replication_status();
+        let body = String::from_utf8(response.body).expect("status body is utf8");
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains(r#""replicas":["#), "{body}");
+        assert!(body.contains(r#""id":"r1""#), "{body}");
+        assert!(body.contains(r#""last_acked_lsn":2"#), "{body}");
+        assert!(body.contains(r#""lag_lsn":3"#), "{body}");
+        // Wall-clock lag is surfaced as `lag_seconds`; the replica was just
+        // acked, so the value is small but the field must be present.
+        assert!(body.contains(r#""lag_seconds":"#), "{body}");
     }
 }


### PR DESCRIPTION
## What

Completes the operator-facing replication observability surface (PRD #819, issue #839). Closes #839.

End-to-end, an operator can now see **term, leader, commit watermark, per-node lag (offset + time), and the resync counter** via both `/replication/status` and `/metrics`.

## Changes

**Full-resync / re-bootstrap counter (the primary alert signal)**
- New `full_resync_count` atomic on `PrimaryReplication`, bumped on every `FullRebootstrap` decision in `plan_replica_resume`.
- Exposed as `reddb_replication_full_resync_total` (with `reddb_replication_partial_resync_total` alongside for context — a benign reconnect storm shows partial climbing / full flat).

**`/replication/status` payload**
- **Leader identity**: `is_leader` + `leader` (the node's stable id on a primary; the `primary_addr` on a replica — one key regardless of which node you scrape).
- **Resync counters**: `full_resync_count`, `partial_resync_count`.
- **Per-replica lag array** (`replicas`): each entry carries `last_acked_lsn`, `last_sent_lsn`, `lag_lsn` (LSN-offset from the logical head) and `lag_seconds` (wall-clock since last contact), plus `rebootstrapping`.
- Mirrored in the gRPC `replication_status` so both transports agree.

`current_term` and `commit_watermark` were already surfaced; per-replica lag *metrics* (`reddb_replica_lag_records` / `reddb_replica_lag_seconds`) already existed. This PR adds the status-payload view of per-replica lag and the resync alert metric.

**Runtime accessors**: `node_id()`, `primary_logical_head_lsn()`, `replication_full_resync_count()`, `replication_partial_resync_count()`.

## Acceptance criteria
- [x] Per-replica lag exposed in both LSN-offset and wall-clock (status `replicas[].lag_lsn` / `lag_seconds`; metrics `reddb_replica_lag_records` / `_seconds`).
- [x] Full-resync / re-bootstrap counter as an alertable metric (`reddb_replication_full_resync_total`).
- [x] Current term, leader identity, commit watermark in `/replication/status`.
- [x] Tests assert the surfaced fields.

## Tests
- `plan_replica_resume_partial_within_window_full_past_cap` extended: full-resync counter increments on rebootstrap, never on partial.
- `replication_status_surfaces_term_leader_watermark_and_resync_counters`
- `replication_status_surfaces_per_replica_lag_offset_and_wall_clock`
- `metrics_expose_replication_resync_alert_counters`

`cargo fmt --check` clean, `cargo clippy --lib` clean. Additive only (319 insertions, 0 deletions).

## Process
PRD #819 consensus family (design approved via #834). **Land via human review — do not admin-merge.** The election coordinator is still a staged primitive, so leader identity is derived from the running node's own role/identity rather than live election state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783045304&installation_id=129708444&pr_number=947&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F947&signature=aa9a173ebe87da5a0e33015b5a445ebf757c5f7a900c9e68916269cbf477823f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced replication status endpoint with leader identification and per-replica observability, including lag measurements (latency and LSN-based) and resync tracking
  * Added Prometheus metrics counters for full and partial resyncs to improve operational visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->