### PR TITLE
feat(server): in-process protocol demux — collapse the service_router loopback proxy (#933)

### DIFF
--- a/crates/reddb-server/src/grpc.rs
+++ b/crates/reddb-server/src/grpc.rs
@@ -258,6 +258,30 @@ impl RedDBGrpcServer {
         Ok(())
     }
 
+    /// Serve gRPC over a stream of already-accepted connections fed by the
+    /// in-process protocol demux (issue #933). The demux classifies each
+    /// inbound connection on the shared port and hands the HTTP/2 ones
+    /// straight in through `rx` — there is no loopback socket and no
+    /// `copy_bidirectional` hop. The server runs until `rx` closes (the
+    /// demux acceptor dropped its sender) and all in-flight RPCs drain.
+    pub(crate) async fn serve_router_demux(
+        &self,
+        rx: tokio::sync::mpsc::Receiver<tokio::net::TcpStream>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use tokio_stream::StreamExt;
+        let incoming = tokio_stream::wrappers::ReceiverStream::new(rx).map(Ok::<_, std::io::Error>);
+        let mut builder = tonic::transport::Server::builder();
+        if let Some(tls) = &self.options.tls {
+            log_grpc_tls_identity(tls);
+            builder = builder.tls_config(tls.to_tonic_config()?)?;
+        }
+        builder
+            .add_service(Self::configured_service(self.grpc_runtime()))
+            .serve_with_incoming(incoming)
+            .await?;
+        Ok(())
+    }
+
     fn configured_service(runtime: GrpcRuntime) -> RedDbServer<GrpcRuntime> {
         // Advertise zstd + gzip so clients can opt in. Server compresses
         // outbound replies with zstd; sticking to a single send codec keeps

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use crate::auth::store::AuthStore;
 use crate::replication::ReplicationConfig;
 use crate::runtime::RedDBRuntime;
-use crate::service_router::{serve_tcp_router, TcpProtocolRouterConfig};
+use crate::service_router::{serve_tcp_router, InProcessRouterConfig};
 use crate::{
     GrpcServerOptions, RedDBGrpcServer, RedDBOptions, RedDBServer, ServerOptions, StorageMode,
 };
@@ -1413,27 +1413,26 @@ fn run_routed_server(config: ServerCommandConfig, router_bind_addr: String) -> R
 
     spawn_admin_metrics_listeners(&runtime, &auth_store);
 
-    let http_listener = std::net::TcpListener::bind("127.0.0.1:0")
-        .map_err(|err| format!("bind internal HTTP listener: {err}"))?;
-    let http_backend = http_listener
-        .local_addr()
-        .map_err(|err| format!("inspect internal HTTP listener: {err}"))?;
+    // Issue #933: collapse the loopback proxy. All three transports are
+    // served from one in-process acceptor that shares the single tokio
+    // runtime (ADR 0035) — no internal HTTP/gRPC/wire listeners, no
+    // `copy_bidirectional` hop. We build the handler objects here and hand
+    // them to the demux, which classifies each connection and dispatches.
     let http_server = build_http_server(
         runtime.clone(),
         auth_store.clone(),
-        http_backend.to_string(),
+        router_bind_addr.clone(),
     );
     let http_server = apply_http_limits(http_server, &config, &runtime);
-    let http_handle = http_server.serve_in_background_on(http_listener);
 
-    thread::sleep(Duration::from_millis(100));
-    if http_handle.is_finished() {
-        return match http_handle.join() {
-            Ok(Ok(())) => Err("HTTP backend exited unexpectedly".to_string()),
-            Ok(Err(err)) => Err(err.to_string()),
-            Err(_) => Err("HTTP backend thread panicked".to_string()),
-        };
-    }
+    let grpc_server = RedDBGrpcServer::with_options(
+        runtime.clone(),
+        GrpcServerOptions {
+            bind_addr: router_bind_addr.clone(),
+            tls: None,
+        },
+        auth_store,
+    );
 
     let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -1443,54 +1442,20 @@ fn run_routed_server(config: ServerCommandConfig, router_bind_addr: String) -> R
         .map_err(|err| format!("tokio runtime: {err}"))?;
 
     let signal_runtime = runtime.clone();
+    let wire_runtime = Arc::new(runtime);
     tokio_runtime.block_on(async move {
         spawn_lifecycle_signal_handler(signal_runtime).await;
-        let grpc_listener = std::net::TcpListener::bind("127.0.0.1:0")
-            .map_err(|err| format!("bind internal gRPC listener: {err}"))?;
-        let grpc_backend = grpc_listener
-            .local_addr()
-            .map_err(|err| format!("inspect internal gRPC listener: {err}"))?;
-        let grpc_server = RedDBGrpcServer::with_options(
-            runtime.clone(),
-            GrpcServerOptions {
-                bind_addr: grpc_backend.to_string(),
-                tls: None,
-            },
-            auth_store,
-        );
-        tokio::spawn(async move {
-            if let Err(err) = grpc_server.serve_on(grpc_listener).await {
-                tracing::error!(err = %err, "gRPC backend error");
-            }
-        });
-
-        let wire_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .map_err(|err| format!("bind internal wire listener: {err}"))?;
-        let wire_backend = wire_listener
-            .local_addr()
-            .map_err(|err| format!("inspect internal wire listener: {err}"))?;
-        let wire_rt = Arc::new(runtime);
-        tokio::spawn(async move {
-            if let Err(err) =
-                crate::wire::redwire::listener::start_redwire_listener_on(wire_listener, wire_rt)
-                    .await
-            {
-                tracing::error!(err = %err, "redwire backend error");
-            }
-        });
-
         tracing::info!(
             bind = %router_bind_addr,
             cpus = rt_config.available_cpus,
             workers = worker_threads,
             "router bootstrapping"
         );
-        serve_tcp_router(TcpProtocolRouterConfig {
+        serve_tcp_router(InProcessRouterConfig {
             bind_addr: router_bind_addr,
-            grpc_backend,
-            http_backend,
-            wire_backend,
+            http_server,
+            grpc_server,
+            wire_runtime,
         })
         .await
         .map_err(|err| err.to_string())

--- a/crates/reddb-server/src/service_router/mod.rs
+++ b/crates/reddb-server/src/service_router/mod.rs
@@ -1,47 +1,93 @@
-//! TCP protocol router.
+//! In-process protocol demux (issue #933, PRD #930, ADR 0035).
 //!
-//! Accepts an inbound TCP connection, peeks the first bytes to decide whether
-//! it's gRPC (HTTP/2), HTTP/1.x, or the proprietary Wire protocol, and proxies
-//! to the matching backend. Detection is pluggable: each protocol is a
-//! `ProtocolDetector` impl in the `detector` submodule, and the `Router`
-//! composes them in order.
+//! A single async acceptor owns the shared public port. For each inbound
+//! connection it peeks the first bytes, classifies the protocol (gRPC
+//! HTTP/2 preface / HTTP/1.x / RedWire `0xFE` magic), and dispatches to the
+//! matching handler **in-process** — there is no loopback backend socket
+//! and no `copy_bidirectional` proxy hop. All transports share the one
+//! tokio runtime the acceptor runs on.
+//!
+//! Peeking (not reading) is the load-bearing trick: the classified bytes
+//! stay in the socket buffer, so the chosen handler re-reads the
+//! connection from byte zero exactly as if it had accepted it directly —
+//! the HTTP edge reads its request line, hyper reads the HTTP/2 preface,
+//! and the RedWire session reads its magic byte.
+//!
+//! Detection is pluggable: each protocol is a `ProtocolDetector` impl in
+//! the `detector` submodule, and the `Router` composes them in order.
 
 pub(crate) mod detector;
 pub(crate) mod router;
 
-use std::net::SocketAddr;
+use std::sync::Arc;
 
 use tokio::io;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
 
 pub(crate) use detector::Protocol;
 use router::Router;
 
-#[derive(Debug, Clone)]
-pub(crate) struct TcpProtocolRouterConfig {
+use crate::grpc::RedDBGrpcServer;
+use crate::runtime::RedDBRuntime;
+use crate::server::RedDBServer;
+
+/// Depth of the bounded channel feeding classified gRPC connections into
+/// the in-process tonic server. A connection sits here only for the brief
+/// window between classification and tonic accepting it; the bound keeps a
+/// burst of gRPC dials from growing the queue without limit.
+const GRPC_DEMUX_CHANNEL_DEPTH: usize = 128;
+
+/// Handler dependencies the demux dispatches into. Each transport is the
+/// same server object the standalone single-transport runners use, so the
+/// served surface on the shared port matches the dedicated ports exactly.
+pub(crate) struct InProcessRouterConfig {
     pub bind_addr: String,
-    pub grpc_backend: SocketAddr,
-    pub http_backend: SocketAddr,
-    pub wire_backend: SocketAddr,
+    pub http_server: RedDBServer,
+    pub grpc_server: RedDBGrpcServer,
+    pub wire_runtime: Arc<RedDBRuntime>,
 }
 
 pub(crate) async fn serve_tcp_router(
-    config: TcpProtocolRouterConfig,
+    config: InProcessRouterConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let listener = TcpListener::bind(&config.bind_addr).await?;
+    let InProcessRouterConfig {
+        bind_addr,
+        http_server,
+        grpc_server,
+        wire_runtime,
+    } = config;
+
+    let listener = TcpListener::bind(&bind_addr).await?;
     tracing::info!(
         transport = "router",
-        bind = %config.bind_addr,
+        bind = %bind_addr,
         protocols = "grpc/http/wire",
-        "listener online"
+        "in-process demux online"
     );
 
+    // One long-lived tonic server, fed classified connections over a
+    // channel instead of its own listener. Dropping every `grpc_tx` (only
+    // on acceptor exit) closes the stream and drains the server.
+    let (grpc_tx, grpc_rx) = mpsc::channel::<TcpStream>(GRPC_DEMUX_CHANNEL_DEPTH);
+    tokio::spawn(async move {
+        if let Err(err) = grpc_server.serve_router_demux(grpc_rx).await {
+            tracing::error!(transport = "router", err = %err, "in-process gRPC server exited");
+        }
+    });
+
+    let router = Arc::new(Router::default_tcp());
     loop {
         let (stream, peer) = listener.accept().await?;
-        let router = config.clone();
+        let router = router.clone();
+        let http_server = http_server.clone();
+        let grpc_tx = grpc_tx.clone();
+        let wire_runtime = wire_runtime.clone();
         let peer_str = peer.to_string();
         tokio::spawn(async move {
-            if let Err(err) = proxy_routed_connection(stream, router).await {
+            if let Err(err) =
+                dispatch_connection(stream, &router, http_server, grpc_tx, wire_runtime).await
+            {
                 tracing::warn!(
                     transport = "router",
                     peer = %peer_str,
@@ -53,18 +99,100 @@ pub(crate) async fn serve_tcp_router(
     }
 }
 
-async fn proxy_routed_connection(
-    mut inbound: TcpStream,
-    config: TcpProtocolRouterConfig,
+/// Classify one accepted connection and hand it to the matching handler
+/// in-process. The peeked bytes remain buffered on the socket, so each
+/// handler reads the connection from the start.
+async fn dispatch_connection(
+    stream: TcpStream,
+    router: &Router,
+    http_server: RedDBServer,
+    grpc_tx: mpsc::Sender<TcpStream>,
+    wire_runtime: Arc<RedDBRuntime>,
 ) -> io::Result<()> {
-    let router = Router::default_tcp();
-    let backend = match router.detect(&inbound).await? {
-        Protocol::Grpc => config.grpc_backend,
-        Protocol::Http => config.http_backend,
-        Protocol::Wire => config.wire_backend,
-    };
-
-    let mut outbound = TcpStream::connect(backend).await?;
-    tokio::io::copy_bidirectional(&mut inbound, &mut outbound).await?;
+    match router.detect(&stream).await? {
+        Protocol::Http => http_server.serve_edge_one(stream).await,
+        Protocol::Grpc => {
+            // The only failure here is the tonic server task having exited;
+            // surface it rather than dropping the connection silently.
+            if grpc_tx.send(stream).await.is_err() {
+                return Err(io::Error::other("in-process gRPC server unavailable"));
+            }
+        }
+        Protocol::Wire => {
+            crate::wire::redwire::listener::handle_router_connection(stream, wire_runtime).await?;
+        }
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::detector::HTTP_2_PREFACE;
+    use super::router::Router;
+    use super::Protocol;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// Drive the real peek path the demux uses: a client writes a
+    /// protocol's opening bytes, the server accepts and classifies. This
+    /// proves classification works end-to-end over a socket (peek, not
+    /// read) for each protocol the shared port serves.
+    async fn classify_opening_bytes(opening: &[u8]) -> Protocol {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        let opening = opening.to_vec();
+        let client = tokio::spawn(async move {
+            let mut stream = TcpStream::connect(addr).await.expect("connect");
+            stream.write_all(&opening).await.expect("write");
+            stream.flush().await.expect("flush");
+            // Hold the connection open so the peeked bytes are not lost to
+            // a half-close racing the server's classification.
+            stream
+        });
+
+        let (server_stream, _peer) = listener.accept().await.expect("accept");
+        let protocol = Router::default_tcp()
+            .detect(&server_stream)
+            .await
+            .expect("detect");
+        let _client = client.await.expect("client task");
+        protocol
+    }
+
+    #[tokio::test]
+    async fn demux_classifies_h2_preface_as_grpc() {
+        assert_eq!(classify_opening_bytes(HTTP_2_PREFACE).await, Protocol::Grpc);
+    }
+
+    #[tokio::test]
+    async fn demux_classifies_http_request_line_as_http() {
+        assert_eq!(
+            classify_opening_bytes(b"POST /query HTTP/1.1\r\n").await,
+            Protocol::Http
+        );
+        assert_eq!(
+            classify_opening_bytes(b"GET /health HTTP/1.1\r\n").await,
+            Protocol::Http
+        );
+    }
+
+    #[tokio::test]
+    async fn demux_classifies_redwire_magic_as_wire() {
+        // 0xFE magic followed by a handshake frame prefix.
+        assert_eq!(
+            classify_opening_bytes(&[0xFE, 0x00, 0x01, 0x02]).await,
+            Protocol::Wire
+        );
+    }
+
+    #[tokio::test]
+    async fn demux_falls_back_to_wire_for_unknown_binary() {
+        // No detector matches a bare binary frame → Wire fallback, matching
+        // the previous router's reachability for native RedWire clients.
+        assert_eq!(
+            classify_opening_bytes(&[0x10, 0x00, 0x00, 0x00, 0x01, b'S', b'E', b'L']).await,
+            Protocol::Wire
+        );
+    }
 }

--- a/crates/reddb-server/src/wire/redwire/listener.rs
+++ b/crates/reddb-server/src/wire/redwire/listener.rs
@@ -1,9 +1,10 @@
 //! TCP / TLS / Unix listeners for the RedWire protocol.
 //!
 //! Each accepted connection spawns a `handle_session` task. The
-//! first byte off the wire (the RedWire magic, `0xFE`) is consumed
-//! by the service-router detector before reaching this listener;
-//! when the listener runs standalone it reads the magic itself.
+//! RedWire magic (`0xFE`) is always read here off the wire: the
+//! standalone listeners read it before the session loop, and the
+//! in-process demux (issue #933) only *peeks* to classify, so the
+//! magic is still buffered when `handle_router_connection` reads it.
 
 use std::io;
 use std::sync::Arc;
@@ -48,10 +49,10 @@ pub async fn start_redwire_listener(
     serve_redwire_tcp(listener, runtime, config.auth_store, config.oauth).await
 }
 
-/// Start a RedWire listener on an already-bound TCP listener (used
-/// by the service router which owns the public socket and proxies
-/// to a loopback redwire backend, and by service_cli's spawn_wire_listeners
-/// when binding the user-facing wire port directly).
+/// Start a RedWire listener on an already-bound TCP listener (used by
+/// service_cli's spawn_wire_listeners when binding the user-facing wire
+/// port directly; the shared-port demux instead dispatches per connection
+/// through [`handle_router_connection`]).
 ///
 /// Pulls the auth store off the runtime so bearer tokens issued by the
 /// HTTP `/auth/login` endpoint are honoured on the wire transport too —
@@ -151,6 +152,19 @@ pub async fn start_redwire_tls_listener(
             }
         });
     }
+}
+
+/// In-process demux entry (issue #933): serve one RedWire connection the
+/// protocol router classified on the shared port. The router peeks — it
+/// does not consume — so the `0xFE` magic is still on the wire and is
+/// read here exactly as in the standalone path. The auth store is pulled
+/// off the runtime so bearer tokens minted over HTTP are honoured here too.
+pub async fn handle_router_connection(
+    stream: TcpStream,
+    runtime: Arc<RedDBRuntime>,
+) -> io::Result<()> {
+    let auth_store = runtime.auth_store();
+    handle_standalone(stream, runtime, auth_store, None).await
 }
 
 /// Standalone entry: consume the magic byte ourselves before the


### PR DESCRIPTION
## What & why

Closes #933 (parent PRD #930, ADR 0035).

Collapses the `service_router` loopback proxy. Previously the routed server bound **four** TCP listeners — one public router plus three internal loopback backends (HTTP, gRPC, RedWire) — and forwarded every connection with `tokio::io::copy_bidirectional` after classifying it. This replaces that with a single in-process acceptor that peeks, classifies, and dispatches straight into the matching handler. No loopback sockets, no copy hop, one shared tokio runtime.

## How

The load-bearing trick is that classification **peeks** (`TcpStream::peek`) rather than reads, so the opening bytes stay buffered on the socket and each handler reads the connection from byte zero exactly as if it had accepted it directly:

- **HTTP/1.x** → `RedDBServer::serve_edge_one(stream)` (the async axum/hyper edge from #931).
- **gRPC (HTTP/2 preface)** → fed into one long-lived tonic server over a bounded mpsc channel (`serve_router_demux`); the accepted stream is handed straight in — no listener, no proxy. The server drains when the acceptor drops its sender.
- **RedWire (`0xFE`)** → `handle_router_connection(stream, runtime)`, which reads the magic byte itself (peek left it on the wire).

`run_routed_server` now builds the three handler objects and hands them to the demux via `InProcessRouterConfig`; the internal loopback listeners and the 100 ms HTTP-backend health probe are gone.

## Acceptance criteria

- [x] All transports served from one in-process acceptor, no loopback proxy hop (`copy_bidirectional` removed entirely).
- [x] Protocol classification covered by byte-pattern tests — existing detector/router unit tests plus new socket-level `detect()` tests for gRPC preface, HTTP request lines, RedWire magic, and binary→Wire fallback.
- [x] Reachability on the shared port matches the previous router — same fallback-to-Wire semantics, same handler objects as the standalone single-transport runners.

## Tests

- `cargo test -p reddb-io-server --lib service_router` → 16 passed
- Transport regression smoke (standalone paths untouched): gRPC 4 passed, RedWire + HTTP 15 passed
- `cargo clippy --lib` clean, `cargo fmt --check` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783050541&installation_id=129708444&pr_number=948&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F948&signature=ca1af487921fdf72d5bacc867e4cd9cf6a43732f370a4dbeceacf5c7a7cd17e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured server's protocol routing to operate in-process instead of through TCP proxying, improving performance and reducing latency in request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->