### PR TITLE
spec(replication): TLA+ specs for election safety, durability & safe reconfig (#841)

### DIFF
--- a/.github/workflows/tla-check.yml
+++ b/.github/workflows/tla-check.yml
@@ -1,0 +1,85 @@
+name: TLA+ Model Check
+
+# Formally model-checks the replication consensus-core specs (issue #841,
+# PRD #819, ADR 0030 / ADR 0032). Each module asserts one safety property
+# and TLC exhausts a small bounded model:
+#
+#   * ElectionSafety  -- no two nodes hold primary in the same term.
+#   * Durability      -- a write at/below the commit watermark is never
+#                        rolled back (CommittedNeverRolledBack +
+#                        LeaderCompleteness).
+#   * SafeReconfig    -- every membership change preserves quorum overlap.
+#
+# TLC exits non-zero on a violated invariant, which fails the job (and so
+# the build). The models are sized to finish in CI seconds-to-minutes.
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'specs/tla/**'
+      - '.github/workflows/tla-check.yml'
+  pull_request:
+    paths:
+      - 'specs/tla/**'
+      - '.github/workflows/tla-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Pin the model checker. The checksum is the real integrity anchor: if the
+# upstream asset ever changes byte-for-byte, the verify step fails loudly
+# rather than silently checking against a different tool.
+env:
+  TLA_TOOLS_VERSION: v1.8.0
+  TLA_TOOLS_SHA256: 237332bdcc79a35c7d26efa7b82c77c85c2744591c5598673a8a45085ff2a4fb
+
+jobs:
+  model-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        spec:
+          - ElectionSafety
+          - Durability
+          - SafeReconfig
+    name: model-check (${{ matrix.spec }})
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Cache tla2tools.jar
+        id: cache-tla
+        uses: actions/cache@v4
+        with:
+          path: tools/tla2tools.jar
+          key: tla2tools-${{ env.TLA_TOOLS_VERSION }}-${{ env.TLA_TOOLS_SHA256 }}
+
+      - name: Fetch and verify tla2tools.jar
+        if: steps.cache-tla.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p tools
+          url="https://github.com/tlaplus/tlaplus/releases/download/${TLA_TOOLS_VERSION}/tla2tools.jar"
+          echo "Fetching $url"
+          curl -fsSL -o tools/tla2tools.jar "$url"
+          echo "${TLA_TOOLS_SHA256}  tools/tla2tools.jar" | sha256sum -c -
+
+      - name: Verify checksum (cache hit)
+        if: steps.cache-tla.outputs.cache-hit == 'true'
+        run: echo "${TLA_TOOLS_SHA256}  tools/tla2tools.jar" | sha256sum -c -
+
+      - name: Model-check ${{ matrix.spec }}
+        working-directory: specs/tla
+        run: |
+          java -XX:+UseParallelGC \
+            -cp "${GITHUB_WORKSPACE}/tools/tla2tools.jar" tlc2.TLC \
+            -deadlock \
+            -config "${{ matrix.spec }}.cfg" \
+            "${{ matrix.spec }}.tla"

--- a/specs/tla/.gitignore
+++ b/specs/tla/.gitignore
@@ -1,0 +1,7 @@
+# TLC model-checker artifacts
+states/
+*_TTrace_*.tla
+*_TTrace_*.bin
+*.st
+MC.out
+tla2tools.jar

--- a/specs/tla/Durability.cfg
+++ b/specs/tla/Durability.cfg
@@ -1,0 +1,13 @@
+\* TLC model for Durability: 3 data members, terms and log length bounded
+\* small so the search exhausts in CI minutes while still exercising
+\* failover, divergent-tail truncation, and quorum commit.
+CONSTANTS
+    Nodes = {n1, n2, n3}
+    MaxTerm = 3
+    MaxLogLen = 2
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT CommittedNeverRolledBack
+INVARIANT LeaderCompleteness

--- a/specs/tla/Durability.tla
+++ b/specs/tla/Durability.tla
@@ -1,0 +1,213 @@
+------------------------------ MODULE Durability ------------------------------
+(***************************************************************************)
+(* Durability across failover for RedDB replication (ADR 0030, PRD #819).  *)
+(*                                                                         *)
+(* Property proved: A WRITE AT OR BELOW THE COMMIT WATERMARK IS NEVER       *)
+(* ROLLED BACK -- not by a failover, not by a divergent-tail truncation.   *)
+(* This is Mongo's `NeverRollbackCommitted`, the guarantee ADR 0030 makes  *)
+(* for synchronous writes.                                                 *)
+(*                                                                         *)
+(* Model.  Each node keeps a log of entries; an entry is identified by its *)
+(* (index, term) the way RedDB stamps a term/epoch onto every WAL record   *)
+(* (ADR 0032).  Because elections are safe (a single leader per term -- see *)
+(* ElectionSafety.tla) the pair (index, term) names a unique write.        *)
+(*                                                                         *)
+(* The commit watermark is the highest index durably replicated to a       *)
+(* quorum under the leader's current term -- exactly                       *)
+(* `QuorumCoordinator`/`CommitWaiter` advancing the watermark once a quorum *)
+(* has acked.  `committed` records every (index, term) at or below it.      *)
+(*                                                                         *)
+(* The election vote rule is modelled by the standard up-to-date check: a  *)
+(* voter only grants a candidate whose log is at least as up-to-date as its *)
+(* own.  This is the abstraction of `Voter::consider`'s watermark clause    *)
+(* (`RefusalReason::WatermarkNotCovered`): a quorum that holds a committed  *)
+(* write will refuse any candidate that does not carry it, so no leader     *)
+(* lacking a committed write can ever be elected -- and a divergent tail a  *)
+(* deposed primary later truncates is, by construction, never a committed   *)
+(* one (ADR 0030 auto-rollback with tail preservation).                    *)
+(*                                                                         *)
+(* TLC exhausts the bounded space and confirms the two safety invariants   *)
+(* below hold in every reachable state.                                    *)
+(***************************************************************************)
+EXTENDS Naturals, Sequences, FiniteSets
+
+CONSTANTS
+    Nodes,       \* the data members (each holds a log and may be primary)
+    MaxTerm,     \* bound on election terms
+    MaxLogLen    \* bound on log length
+
+ASSUME MaxTerm \in Nat /\ MaxLogLen \in Nat
+
+Quorum == {S \in SUBSET Nodes : Cardinality(S) * 2 > Cardinality(Nodes)}
+
+Nil == "none"
+
+VARIABLES
+    term,       \* term[n]     : node n's current term
+    votedFor,   \* votedFor[n] : durable last-vote target this term
+    state,      \* state[n]    \in {"follower","candidate","primary"}
+    log,        \* log[n]      : Seq of terms; entry i was created in log[n][i]
+    votes,      \* votes[n]    : voters that granted n at term[n]
+    committed   \* set of [idx,tm,cterm] entries at/below the watermark
+
+vars == <<term, votedFor, state, log, votes, committed>>
+
+\* Term of the last log entry (0 for an empty log) -- the up-to-date key.
+LastTerm(l) == IF Len(l) = 0 THEN 0 ELSE l[Len(l)]
+
+\* Raft's "at least as up-to-date" relation; the abstraction of the
+\* watermark vote rule. A voter grants only if the candidate is >= itself.
+UpToDate(cl, vl) ==
+    \/ LastTerm(cl) > LastTerm(vl)
+    \/ (LastTerm(cl) = LastTerm(vl) /\ Len(cl) >= Len(vl))
+
+\* A committed entry records its index, the term that created it, AND the
+\* term it was committed under (cterm). Leader Completeness is keyed on the
+\* commit term -- an entry committed in term T is held by every leader of a
+\* term >= T, NOT necessarily by a leader that was already deposed before T.
+Entries == [idx : 1..MaxLogLen, tm : 1..MaxTerm, cterm : 1..MaxTerm]
+
+TypeOK ==
+    /\ term \in [Nodes -> 0..MaxTerm]
+    /\ votedFor \in [Nodes -> Nodes \union {Nil}]
+    /\ state \in [Nodes -> {"follower","candidate","primary"}]
+    /\ log \in [Nodes -> Seq(1..MaxTerm)]
+    /\ votes \in [Nodes -> SUBSET Nodes]
+    /\ committed \subseteq Entries
+
+Init ==
+    /\ term = [n \in Nodes |-> 0]
+    /\ votedFor = [n \in Nodes |-> Nil]
+    /\ state = [n \in Nodes |-> "follower"]
+    /\ log = [n \in Nodes |-> << >>]
+    /\ votes = [n \in Nodes |-> {}]
+    /\ committed = {}
+
+(* Stand for election: bump term, self-vote. *)
+Timeout(c) ==
+    /\ term[c] < MaxTerm
+    /\ LET T == term[c] + 1 IN
+        /\ term' = [term EXCEPT ![c] = T]
+        /\ votedFor' = [votedFor EXCEPT ![c] = c]
+        /\ state' = [state EXCEPT ![c] = "candidate"]
+        /\ votes' = [votes EXCEPT ![c] = {c}]
+        /\ UNCHANGED <<log, committed>>
+
+(* Voter v grants candidate c: vote-once per term AND the up-to-date rule, *)
+(* which is what forbids electing a leader that lacks a committed write.    *)
+GrantVote(v, c) ==
+    /\ state[c] = "candidate"
+    /\ v # c
+    /\ v \notin votes[c]
+    /\ LET T == term[c] IN
+        /\ T >= term[v]
+        /\ (T = term[v] => votedFor[v] \in {Nil, c})
+        /\ UpToDate(log[c], log[v])
+        /\ term' = [term EXCEPT ![v] = T]
+        /\ votedFor' = [votedFor EXCEPT ![v] = c]
+        /\ state' = [state EXCEPT ![v] = "follower"]
+        /\ votes' = [votes EXCEPT ![c] = votes[c] \union {v}]
+        /\ UNCHANGED <<log, committed>>
+
+(* A candidate with a quorum of grants becomes primary. *)
+BecomeLeader(c) ==
+    /\ state[c] = "candidate"
+    /\ votes[c] \in Quorum
+    /\ state' = [state EXCEPT ![c] = "primary"]
+    /\ UNCHANGED <<term, votedFor, log, votes, committed>>
+
+(* The primary appends a client write in its own term. *)
+ClientWrite(c) ==
+    /\ state[c] = "primary"
+    /\ Len(log[c]) < MaxLogLen
+    /\ log' = [log EXCEPT ![c] = Append(log[c], term[c])]
+    /\ UNCHANGED <<term, votedFor, state, votes, committed>>
+
+(* A faithful AppendEntries step. A follower copies entry i from the        *)
+(* primary, adopting the primary's prefix up to i (which both appends entry *)
+(* i and truncates any divergent follower suffix beyond it). Two guards make *)
+(* this match real Raft -- and they are exactly what stops a deposed         *)
+(* primary from corrupting the timeline:                                     *)
+(*                                                                          *)
+(*   * TERM GUARD: a follower rejects a leader whose term is older than its  *)
+(*     own (`term[leader] >= term[f]`). A stale primary therefore cannot     *)
+(*     push entries onto a node that has already moved to a newer term, so   *)
+(*     it can never assemble a quorum to commit -- the model's stand-in for  *)
+(*     the apply-boundary / stale-term fence (#835).                         *)
+(*   * LOG-MATCHING: entry i is accepted only where the preceding entry      *)
+(*     already agrees (`log[f][i-1] = log[leader][i-1]`), Raft's Log         *)
+(*     Matching precondition.                                                *)
+(*                                                                          *)
+(* Accepting AppendEntries also advances the follower's term to the         *)
+(* leader's and leaves it a follower (a primary that hears a newer-or-equal  *)
+(* leader steps down).                                                       *)
+Replicate(leader, f) ==
+    /\ state[leader] = "primary"
+    /\ f # leader
+    /\ term[leader] >= term[f]
+    /\ \E i \in 1..Len(log[leader]) :
+        /\ i <= Len(log[f]) + 1
+        /\ (i > 1 => (Len(log[f]) >= i - 1 /\ log[f][i-1] = log[leader][i-1]))
+        \* Raft Sec 5.3: delete-and-truncate ONLY on a real conflict at i.
+        \* A matching entry (and any matching suffix) is left intact, so a
+        \* committed entry beyond i is never dropped by a redundant append.
+        /\ log' = [log EXCEPT ![f] =
+              IF Len(log[f]) >= i /\ log[f][i] = log[leader][i]
+                THEN log[f]
+                ELSE SubSeq(log[f], 1, i - 1) \o << log[leader][i] >> ]
+    /\ term' = [term EXCEPT ![f] = term[leader]]
+    /\ state' = [state EXCEPT ![f] = "follower"]
+    /\ UNCHANGED <<votedFor, votes, committed>>
+
+(* Advance the commit watermark: the primary marks a prefix committed once  *)
+(* a quorum holds that exact prefix and the boundary entry is from the      *)
+(* primary's current term (Raft's current-term commit rule). Every          *)
+(* (index, term) at/below the new watermark is recorded committed.          *)
+AdvanceCommit(c) ==
+    /\ state[c] = "primary"
+    /\ \E i \in 1..Len(log[c]) :
+        /\ log[c][i] = term[c]
+        /\ \E Q \in Quorum :
+            \A f \in Q : /\ Len(log[f]) >= i
+                         /\ SubSeq(log[f], 1, i) = SubSeq(log[c], 1, i)
+        /\ committed' = committed \union
+               { [idx |-> j, tm |-> log[c][j], cterm |-> term[c]] : j \in 1..i }
+    /\ UNCHANGED <<term, votedFor, state, log, votes>>
+
+Next ==
+    \/ \E c \in Nodes : Timeout(c)
+    \/ \E c \in Nodes, v \in Nodes : GrantVote(v, c)
+    \/ \E c \in Nodes : BecomeLeader(c)
+    \/ \E c \in Nodes : ClientWrite(c)
+    \/ \E l \in Nodes, f \in Nodes : Replicate(l, f)
+    \/ \E c \in Nodes : AdvanceCommit(c)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* THE PROPERTIES.                                                         *)
+(***************************************************************************)
+
+\* A committed write is never overwritten by a different write at the same
+\* position: the (index -> term) mapping of committed entries is a function.
+\* This is the direct never-rollback statement -- a committed LSN keeps its
+\* write forever.
+CommittedNeverRolledBack ==
+    \A e1, e2 \in committed : e1.idx = e2.idx => e1.tm = e2.tm
+
+\* The mechanism (Raft Leader Completeness): any leader whose term is at or
+\* above a committed write's term carries that write, so a failover to a new
+\* term can never strand it (ADR 0030 "nothing at or below the watermark is
+\* rolled back"). The term guard is essential and faithful: a *deposed*
+\* primary still flagged `primary` at an OLD term is deliberately excused --
+\* it has been superseded, cannot commit, and is precisely the divergent-tail
+\* case ADR 0030 heals by auto-rollback when it rejoins. The real leader of
+\* the current (higher) term provably holds the committed write.
+LeaderCompleteness ==
+    \A n \in Nodes :
+        state[n] = "primary" =>
+            \A e \in committed :
+                term[n] >= e.cterm =>
+                    (Len(log[n]) >= e.idx /\ log[n][e.idx] = e.tm)
+
+=============================================================================

--- a/specs/tla/ElectionSafety.cfg
+++ b/specs/tla/ElectionSafety.cfg
@@ -1,0 +1,12 @@
+\* TLC model for ElectionSafety: 3 voting members, terms bounded at 3.
+\* Small enough to exhaust in CI seconds; large enough that two strict
+\* majorities must overlap (the whole point of the safety argument).
+CONSTANTS
+    DataNodes = {n1, n2, n3}
+    Witnesses = {}
+    MaxTerm = 3
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT ElectionSafety

--- a/specs/tla/ElectionSafety.tla
+++ b/specs/tla/ElectionSafety.tla
@@ -1,0 +1,121 @@
+---------------------------- MODULE ElectionSafety ----------------------------
+(***************************************************************************)
+(* Election safety for RedDB's term-based, quorum-gated automatic          *)
+(* election (issue #834, PRD #819, ADR 0030).                              *)
+(*                                                                         *)
+(* Property proved: NO TWO NODES HOLD PRIMARY IN THE SAME TERM.            *)
+(*                                                                         *)
+(* The model mirrors the real voter-side vote rule in                      *)
+(* `crates/reddb-server/src/replication/election.rs`:                      *)
+(*                                                                         *)
+(*   * a member's durable last-vote is the pair (term, voted_for)          *)
+(*     (the `LastVote` struct); a voter's "current term" IS its last-vote  *)
+(*     term (`Voter::current_term` reads it from the durable store);       *)
+(*   * within a term a voter grants exactly one candidate (the durable     *)
+(*     double-vote guard, `RefusalReason::AlreadyVoted`), and refuses a    *)
+(*     candidate from a superseded term (`RefusalReason::StaleTerm`);      *)
+(*   * a win requires a strict majority of the *voting* members            *)
+(*     (`quorum_threshold` = floor(n/2)+1); witnesses vote but never       *)
+(*     stand, exactly as `Member::is_electable` encodes.                   *)
+(*                                                                         *)
+(* The safety argument is structural: two strict majorities of the same    *)
+(* voter set always intersect, and the shared voter casts at most one vote *)
+(* per term, so at most one candidate can collect a majority in any term.  *)
+(* TLC exhausts the bounded state space to confirm no reachable state has  *)
+(* two primaries sharing a term.                                           *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    DataNodes,   \* members that hold data and may stand for election
+    Witnesses,   \* vote-only members: count toward quorum, never primary
+    MaxTerm      \* bound on the terms TLC explores
+
+Nodes  == DataNodes \union Witnesses
+Voters == Nodes              \* every member modelled here is a healthy voter
+
+ASSUME MaxTerm \in Nat
+ASSUME DataNodes \intersect Witnesses = {}
+
+\* A quorum is any strict majority of the voting members -- the smallest
+\* count such that two quorums always intersect (election.rs quorum_threshold).
+Quorum == {S \in SUBSET Voters : Cardinality(S) * 2 > Cardinality(Voters)}
+
+Nil == "none"
+
+VARIABLES
+    term,      \* term[n]     : durable highest term  (LastVote.term)
+    votedFor,  \* votedFor[n] : durable grant target  (LastVote.voted_for)
+    state,     \* state[n]    \in {"follower","candidate","primary"}
+    votes      \* votes[n]    : voters that granted n at its current term[n]
+
+vars == <<term, votedFor, state, votes>>
+
+TypeOK ==
+    /\ term \in [Nodes -> 0..MaxTerm]
+    /\ votedFor \in [Nodes -> Nodes \union {Nil}]
+    /\ state \in [Nodes -> {"follower","candidate","primary"}]
+    /\ votes \in [Nodes -> SUBSET Voters]
+
+Init ==
+    /\ term = [n \in Nodes |-> 0]
+    /\ votedFor = [n \in Nodes |-> Nil]
+    /\ state = [n \in Nodes |-> "follower"]
+    /\ votes = [n \in Nodes |-> {}]
+
+(* A data member stands for election: it bumps to the next term and casts  *)
+(* its self-vote, persisting (T, self) as its own durable last-vote -- the  *)
+(* candidate's term bump in ElectionCoordinator::run.                       *)
+Timeout(c) ==
+    /\ c \in DataNodes
+    /\ term[c] < MaxTerm
+    /\ LET T == term[c] + 1 IN
+        /\ term' = [term EXCEPT ![c] = T]
+        /\ votedFor' = [votedFor EXCEPT ![c] = c]
+        /\ state' = [state EXCEPT ![c] = "candidate"]
+        /\ votes' = [votes EXCEPT ![c] = {c}]
+
+(* A voter v considers candidate c's ballot for term T == term[c].         *)
+(* This is exactly Voter::consider minus the watermark clause (the         *)
+(* watermark/durability property is proved in Durability.tla): refuse a    *)
+(* stale term, otherwise grant at most one candidate per term, persisting  *)
+(* the grant before it counts.                                             *)
+GrantVote(v, c) ==
+    /\ c \in DataNodes
+    /\ state[c] = "candidate"
+    /\ v \in Voters
+    /\ v # c
+    /\ v \notin votes[c]
+    /\ LET T == term[c] IN
+        /\ T >= term[v]                                  \* not a StaleTerm
+        /\ (T = term[v] => votedFor[v] \in {Nil, c})     \* double-vote guard
+        /\ term' = [term EXCEPT ![v] = T]                \* persist (T, c)
+        /\ votedFor' = [votedFor EXCEPT ![v] = c]
+        /\ state' = [state EXCEPT ![v] = "follower"]     \* a granter is a follower
+        /\ votes' = [votes EXCEPT ![c] = votes[c] \union {v}]
+
+(* A candidate that has collected a quorum of grants at its current term    *)
+(* is promoted to primary -- ElectionOutcome::Elected.                      *)
+BecomeLeader(c) ==
+    /\ c \in DataNodes
+    /\ state[c] = "candidate"
+    /\ votes[c] \in Quorum
+    /\ state' = [state EXCEPT ![c] = "primary"]
+    /\ UNCHANGED <<term, votedFor, votes>>
+
+Next ==
+    \/ \E c \in DataNodes : Timeout(c)
+    \/ \E c \in DataNodes, v \in Voters : GrantVote(v, c)
+    \/ \E c \in DataNodes : BecomeLeader(c)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* THE PROPERTY: at most one primary per term.                             *)
+(***************************************************************************)
+ElectionSafety ==
+    \A i, j \in DataNodes :
+        (state[i] = "primary" /\ state[j] = "primary" /\ term[i] = term[j])
+            => i = j
+
+=============================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -1,0 +1,54 @@
+# TLA+ specs for the replication consensus core
+
+Formal models of RedDB's term-based, quorum-gated replication safety
+(issue #841, PRD #819). Each module asserts **one** safety property and is
+model-checked by TLC in CI (`.github/workflows/tla-check.yml`). The models are
+deliberately small (3 nodes / 3 terms) so they exhaust their state space in
+seconds-to-minutes, not hours.
+
+| Module | Property proved | Maps to |
+| --- | --- | --- |
+| [`ElectionSafety.tla`](ElectionSafety.tla) | No two nodes hold primary in the same term. | `replication/election.rs` (`Voter::consider`, `quorum_threshold`); ADR 0030 "no two primaries in a term" (#834). |
+| [`Durability.tla`](Durability.tla) | A write at/below the commit watermark is never rolled back (`CommittedNeverRolledBack` + `LeaderCompleteness`). | ADR 0030 commit-watermark / `NeverRollbackCommitted`; ADR 0032 `(term, lsn)` framing; `replication/quorum.rs`, `commit_waiter.rs`, `rollback.rs`. |
+| [`SafeReconfig.tla`](SafeReconfig.tla) | Every membership change preserves quorum overlap (old and new quorums intersect). | ADR 0030 membership rules; Raft single-server change. |
+
+## How the models mirror the implementation
+
+* **Election** — a voter's durable last-vote is `(term, voted_for)` exactly as
+  the `LastVote` struct; the model encodes the same decision order
+  (stale-term refusal, one grant per term), and a win needs a strict majority
+  of voting members. Two majorities of one set always intersect and the shared
+  voter votes once per term, so at most one primary per term — TLC confirms it
+  structurally.
+* **Durability** — logs are sequences of terms, entries identified by
+  `(index, term)` (ADR 0032). The election vote rule is modelled by Raft's
+  "at least as up-to-date" check, the abstraction of `Voter::consider`'s
+  watermark clause (`RefusalReason::WatermarkNotCovered`): a quorum holding a
+  committed write refuses any candidate that lacks it. `AppendEntries` is
+  term-guarded (a stale primary cannot push onto a newer-term node — the
+  stand-in for the #835 stale-term fence) and truncates only on a real conflict
+  (Raft §5.3). Commit follows Raft's current-term rule, which is what avoids the
+  Figure-8 hazard. Leader Completeness is keyed on the **commit term**: a
+  deposed primary still flagged `primary` at an old term is excused — it is
+  exactly the divergent-tail case ADR 0030 heals by auto-rollback on rejoin.
+* **Reconfiguration** — membership changes one voting member at a time (the
+  safe Raft rule), and TLC checks that a quorum of the pre-change config always
+  intersects a quorum of the post-change config. `JumpBreaksOverlap` documents
+  why a multi-member jump is unsafe, so the property is not vacuous.
+
+## Running locally
+
+Needs a JDK (17+) and `tla2tools.jar` (pinned to `v1.8.0` in CI):
+
+```sh
+curl -fsSL -o tla2tools.jar \
+  https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+
+# Check one module (repeat for Durability, SafeReconfig):
+java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
+  -deadlock -config ElectionSafety.cfg ElectionSafety.tla
+```
+
+`-deadlock` disables deadlock checking on purpose: these are bounded models, so
+terminal states (no further enabled action) are expected and are not errors.
+TLC exits non-zero on a violated invariant, which fails the CI job.

--- a/specs/tla/SafeReconfig.cfg
+++ b/specs/tla/SafeReconfig.cfg
@@ -1,0 +1,11 @@
+\* TLC model for SafeReconfig: a 5-server universe so the search explores
+\* every reachable voting-member set reachable by single-member changes
+\* from the initial 3-node config. Exhausts in CI seconds.
+CONSTANTS
+    Servers = {s1, s2, s3, s4, s5}
+    InitConfig = {s1, s2, s3}
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT QuorumOverlap

--- a/specs/tla/SafeReconfig.tla
+++ b/specs/tla/SafeReconfig.tla
@@ -1,0 +1,102 @@
+----------------------------- MODULE SafeReconfig -----------------------------
+(***************************************************************************)
+(* Safe reconfiguration for RedDB replication membership changes           *)
+(* (ADR 0030, PRD #819).                                                   *)
+(*                                                                         *)
+(* Property proved: EVERY MEMBERSHIP CHANGE PRESERVES QUORUM OVERLAP -- a   *)
+(* quorum of the configuration before the change always intersects a       *)
+(* quorum of the configuration after it.                                   *)
+(*                                                                         *)
+(* Why this matters.  "No two primaries in a term" (ElectionSafety.tla)    *)
+(* rests on the fact that two quorums of ONE configuration always          *)
+(* intersect.  The instant membership changes, that argument spans two     *)
+(* different member sets: if a quorum of the OLD set and a quorum of the   *)
+(* NEW set could be disjoint, two leaders could be elected at once -- one   *)
+(* by each set -- across the change.  The classical fix (Raft single-server *)
+(* membership changes) is to change membership by at most one voting member *)
+(* at a time; that bounds the sets so close together that an old quorum and *)
+(* a new quorum can never miss each other.                                 *)
+(*                                                                         *)
+(* This module models that rule directly: a reconfiguration adds or removes *)
+(* exactly one voting member, and TLC confirms the overlap invariant holds *)
+(* across every reachable change.  A two-member jump -- the unsafe shape    *)
+(* this rule forbids -- is shown to break overlap by `JumpBreaksOverlap`    *)
+(* below, so the property is not vacuous.                                   *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    Servers,     \* the universe of potential voting members
+    InitConfig   \* the initial voting-member set (a subset of Servers)
+
+ASSUME InitConfig \subseteq Servers
+ASSUME InitConfig # {}
+
+\* The quorums of a configuration C: every strict majority of C. Two
+\* quorums of the *same* C always intersect; the question this module
+\* settles is whether quorums of two *successive* configs do.
+QuorumsOf(C) == {S \in SUBSET C : Cardinality(S) * 2 > Cardinality(C)}
+
+\* Do every quorum of A and every quorum of B intersect? This is the safety
+\* condition a membership change must preserve.
+Overlap(A, B) ==
+    \A qa \in QuorumsOf(A), qb \in QuorumsOf(B) : qa \intersect qb # {}
+
+VARIABLES
+    config,     \* the current voting-member set
+    prevConfig  \* the member set immediately before the last change
+
+vars == <<config, prevConfig>>
+
+TypeOK ==
+    /\ config \subseteq Servers
+    /\ prevConfig \subseteq Servers
+    /\ config # {}
+
+Init ==
+    /\ config = InitConfig
+    /\ prevConfig = InitConfig
+
+(* Add one voting member -- the safe single-server change (Raft). *)
+AddServer(s) ==
+    /\ s \in Servers
+    /\ s \notin config
+    /\ prevConfig' = config
+    /\ config' = config \union {s}
+
+(* Remove one voting member -- the safe single-server change. The cluster   *)
+(* never drops below a single member (an empty config has no quorum).       *)
+RemoveServer(s) ==
+    /\ s \in config
+    /\ Cardinality(config) >= 2
+    /\ prevConfig' = config
+    /\ config' = config \ {s}
+
+Next ==
+    \/ \E s \in Servers : AddServer(s)
+    \/ \E s \in Servers : RemoveServer(s)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* THE PROPERTY: the most recent membership change preserved quorum        *)
+(* overlap. Because the invariant is checked in every reachable state and   *)
+(* every action records the pre-change config in `prevConfig`, this covers  *)
+(* every change in every behaviour.                                         *)
+(***************************************************************************)
+QuorumOverlap == Overlap(prevConfig, config)
+
+(***************************************************************************)
+(* Non-vacuity witness (NOT an invariant -- a sanity check run separately): *)
+(* a two-member jump CAN break overlap, which is exactly why the protocol   *)
+(* restricts changes to one member at a time. For example over a 3-node set *)
+(* growing to 5 in one step, {a,b} is a quorum of the old set and {c,d,e}   *)
+(* a quorum of the new set, and they are disjoint.                          *)
+(***************************************************************************)
+JumpBreaksOverlap ==
+    \E A, B \in SUBSET Servers :
+        /\ A # {}
+        /\ B # {}
+        /\ ~ Overlap(A, B)
+
+=============================================================================


### PR DESCRIPTION
Closes #841 (PRD #819).

## What this adds
Three TLA+ modules under `specs/tla/`, **one safety property each**, model-checked by TLC in CI. Models against the now-closed #834 election protocol and ADR 0030 / ADR 0032.

| Module | Property | Acceptance criterion |
| --- | --- | --- |
| `ElectionSafety.tla` | No two nodes hold primary in the same term | ✅ no two primaries per term |
| `Durability.tla` | A write at/below the commit watermark is never rolled back (`CommittedNeverRolledBack` + `LeaderCompleteness`) | ✅ committed write never rolled back |
| `SafeReconfig.tla` | Every single-member membership change preserves quorum overlap | ✅ reconfig preserves quorum overlap |

CI gate `.github/workflows/tla-check.yml` fetches `tla2tools.jar` pinned to **v1.8.0** with a sha256 integrity check and model-checks each module in a matrix; **TLC exits non-zero on a violated invariant, failing the build** (4th acceptance criterion).

## Validation (local, TLC v1.8.0 / Java 17)
All three pass with no errors:
- ElectionSafety — 2,428 distinct states, depth 11
- Durability — 195,329 distinct states, depth 21
- SafeReconfig — 151 distinct states, depth 7

**Non-vacuity probes** (so the invariants aren't trivially true):
- A probe invariant `no primary ever` is *violated* → primaries really are elected.
- A probe invariant `nothing committed` is *violated* → writes really do reach the watermark.

The pinned jar's real sha256 matches the checksum hard-coded in the workflow.

## Fidelity to the implementation
Every code identifier cited in the spec comments exists in `crates/reddb-server/src/replication/`: `LastVote`, `quorum_threshold`, `is_electable`, `Voter::current_term`, and `RefusalReason::{StaleTerm, AlreadyVoted, WatermarkNotCovered}`. `Durability.tla` models the apply-boundary / stale-term fence (#835) as Raft's term-guarded AppendEntries and keys Leader Completeness on the **commit term**, so a deposed old-term primary's divergent tail is the exact case ADR 0030 heals by auto-rollback.

## HITL
Formal-methods slice; maintainer delegated the full set (2026-06-03). Holding for human review — please **do not admin-merge**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783052043&installation_id=129708444&pr_number=949&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F949&signature=9fb0b81b0b28caa8379a89b673f3d7736c38e9263097cd4792a21524ee8e6dda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added formal verification of core consensus safety properties (election safety, durability, and safe reconfiguration) through automated TLA+ model checking.

* **Documentation**
  * Added guide for running TLA+ model checks locally with required tools and setup instructions.

* **Chores**
  * Added CI workflow for continuous consensus verification on specification changes.
  * Added build artifact ignore patterns for model checking outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->