### PR TITLE
feat(timeseries): columnar migration read-bridge for existing row data (#861)

### DIFF
--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -234,25 +234,9 @@ impl RedDBRuntime {
             let end = meta.end_ns_exclusive;
 
             // Materialise (ts, value) for rows whose time-column value
-            // lands in this chunk's `[start, end)` window.
-            let mut points: Vec<(u64, f64)> = manager
-                .query_all(|entity| {
-                    entity
-                        .data
-                        .as_row()
-                        .and_then(|row| row.get_field(&time_col))
-                        .and_then(field_as_u64)
-                        .is_some_and(|ts| ts >= start && ts < end)
-                })
-                .iter()
-                .filter_map(|entity| {
-                    let row = entity.data.as_row()?;
-                    let ts = row.get_field(&time_col).and_then(field_as_u64)?;
-                    let value = row.get_field("value").and_then(field_as_f64).unwrap_or(0.0);
-                    Some((ts, value))
-                })
-                .collect();
-            points.sort_by_key(|(ts, _)| *ts);
+            // lands in this chunk's `[start, end)` window — the same
+            // entity/row reader the read-bridge serves row chunks from.
+            let points = materialize_row_points(&manager, &time_col, start, end);
 
             let mut chunk = crate::storage::timeseries::TimeSeriesChunk::with_max_points(
                 collection.to_string(),
@@ -325,6 +309,135 @@ impl RedDBRuntime {
                 .collect(),
         )
     }
+
+    /// Read-bridge (#861): read every point of `collection` in the
+    /// inclusive range `[start_ns, end_ns]`, dispatching **per chunk** on
+    /// its storage format so row-stored and columnar (`RDCC`) chunks
+    /// coexist after `COLUMNAR` is enabled — with no mass rewrite of the
+    /// pre-existing row data.
+    ///
+    /// Each chunk's [`ChunkMeta::format`](crate::storage::timeseries::ChunkMeta::format)
+    /// is the format-version gate:
+    /// - [`ChunkFormat::ColumnarV1`] → decode the chunk's RDCC `ColumnBlock`
+    ///   through the granule-pruned column-block range scan, after
+    ///   confirming the block's embedded `format_version` is one this build
+    ///   understands ([`peek_column_block_version`]).
+    /// - [`ChunkFormat::Row`] → materialise the chunk's rows from the
+    ///   entity/row store, the same reader the seal sources from.
+    ///
+    /// Points come back merged and timestamp-ordered, so a caller sees one
+    /// logical series regardless of how each chunk is physically stored.
+    /// Chunk windows are disjoint, so a columnar chunk is read only through
+    /// its RDCC block and never double-counted via the row path.
+    pub fn read_bridge_points(
+        &self,
+        collection: &str,
+        start_ns: u64,
+        end_ns: u64,
+    ) -> RedDBResult<Vec<(u64, f64)>> {
+        use crate::storage::timeseries::ChunkFormat;
+        use crate::storage::unified::column_block::{
+            peek_column_block_version, COLUMN_BLOCK_VERSION_V1,
+        };
+
+        let registry = self.inner.db.hypertables();
+        let Some(spec) = registry.get(collection) else {
+            return Ok(Vec::new());
+        };
+        let time_col = spec.time_column.clone();
+        let store = self.inner.db.store();
+
+        let mut out: Vec<(u64, f64)> = Vec::new();
+        for meta in registry.show_chunks(collection) {
+            // Skip chunks whose observed window cannot intersect the query.
+            // An empty chunk has min_ts_ns == u64::MAX, so it is skipped.
+            if meta.max_ts_ns < start_ns || meta.min_ts_ns > end_ns {
+                continue;
+            }
+            match meta.format() {
+                ChunkFormat::ColumnarV1 => {
+                    // RDCC reader. Bytes may be absent post-restart (pending
+                    // the durable page-write bridge); nothing to read then.
+                    let Some(bytes) = registry.columnar_block(&meta.id) else {
+                        continue;
+                    };
+                    // Format-version gate: reject a block this build cannot
+                    // read rather than mis-decode it.
+                    match peek_column_block_version(&bytes) {
+                        Some(COLUMN_BLOCK_VERSION_V1) => {}
+                        Some(v) => {
+                            return Err(RedDBError::Internal(format!(
+                                "chunk {} @ {} carries unsupported columnar format version {v}",
+                                meta.id.hypertable, meta.id.start_ns
+                            )));
+                        }
+                        None => {
+                            return Err(RedDBError::Internal(format!(
+                                "chunk {} @ {} is flagged columnar but its block is not RDCC",
+                                meta.id.hypertable, meta.id.start_ns
+                            )));
+                        }
+                    }
+                    let scan = crate::storage::timeseries::chunk::query_column_block_range(
+                        &bytes, start_ns, end_ns,
+                    )
+                    .map_err(|err| {
+                        RedDBError::Internal(format!("columnar read-bridge decode failed: {err:?}"))
+                    })?;
+                    out.extend(scan.points.iter().map(|p| (p.timestamp_ns, p.value)));
+                }
+                ChunkFormat::Row => {
+                    // Row reader: materialise the chunk window, then filter
+                    // to the inclusive query range (mirrors the columnar
+                    // scan's `[start_ns, end_ns]` contract).
+                    let Some(manager) = store.get_collection(collection) else {
+                        continue;
+                    };
+                    let chunk_start = meta.id.start_ns;
+                    let chunk_end = meta.end_ns_exclusive;
+                    out.extend(
+                        materialize_row_points(&manager, &time_col, chunk_start, chunk_end)
+                            .into_iter()
+                            .filter(|(ts, _)| *ts >= start_ns && *ts <= end_ns),
+                    );
+                }
+            }
+        }
+        out.sort_by_key(|(ts, _)| *ts);
+        Ok(out)
+    }
+}
+
+/// Materialise `(timestamp_ns, value)` rows from the entity/row store for
+/// the half-open chunk window `[start, end)`, timestamp-ordered. This is
+/// the shared row reader: the columnar seal sources its chunk from it, and
+/// the read-bridge serves row-stored chunks through it (#861). `time_col`
+/// names the time axis; the value column follows the `value` convention.
+fn materialize_row_points(
+    manager: &crate::storage::unified::SegmentManager,
+    time_col: &str,
+    start: u64,
+    end: u64,
+) -> Vec<(u64, f64)> {
+    let mut points: Vec<(u64, f64)> = manager
+        .query_all(|entity| {
+            entity
+                .data
+                .as_row()
+                .and_then(|row| row.get_field(time_col))
+                .and_then(field_as_u64)
+                .is_some_and(|ts| ts >= start && ts < end)
+        })
+        .iter()
+        .filter_map(|entity| {
+            let row = entity.data.as_row()?;
+            let ts = row.get_field(time_col).and_then(field_as_u64)?;
+            let value = row.get_field("value").and_then(field_as_f64).unwrap_or(0.0);
+            Some((ts, value))
+        })
+        .collect();
+    points.sort_by_key(|(ts, _)| *ts);
+    points
 }
 
 /// Read a row field as a non-negative `u64` timestamp, accepting the

--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -120,6 +120,23 @@ pub struct ChunkId {
     pub start_ns: u64,
 }
 
+/// On-disk storage format of a chunk — the **read-bridge dispatch key**
+/// (PRD #850 Phase 1, #861). After `COLUMNAR` is enabled on a collection
+/// that already holds row data, pre-existing chunks stay `Row` and new
+/// chunks seal `ColumnarV1`; the two coexist in the same collection and a
+/// read dispatches on this discriminant — `Row` to the entity/row reader,
+/// `ColumnarV1` to the RDCC column-block reader — with no mass rewrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkFormat {
+    /// Legacy row-stored chunk (`columnar_page == None`): it predates the
+    /// columnar seal, or sealed while the collection was non-columnar. Its
+    /// rows are served from the entity/row path.
+    Row,
+    /// Columnar `RDCC` chunk, format version 1 (`columnar_page == Some`).
+    /// Its rows decode from the recorded `ColumnBlock`.
+    ColumnarV1,
+}
+
 /// Metadata tracked per child chunk. Physical storage lives in
 /// `TimeSeriesChunk` keyed by `(hypertable, start_ns)`.
 #[derive(Debug, Clone)]
@@ -158,6 +175,24 @@ impl ChunkMeta {
             ttl_override_ns: None,
             columnar_page: None,
         }
+    }
+
+    /// The chunk's storage format — the read-bridge dispatch key (#861).
+    /// Derived from the migration discriminant `columnar_page`: a recorded
+    /// RDCC `ColumnBlock` location means [`ChunkFormat::ColumnarV1`], its
+    /// absence means the legacy [`ChunkFormat::Row`] form. This is the
+    /// format-version gate that lets old row chunks and new columnar chunks
+    /// coexist in one collection without a rewrite.
+    pub fn format(&self) -> ChunkFormat {
+        match self.columnar_page {
+            Some(_) => ChunkFormat::ColumnarV1,
+            None => ChunkFormat::Row,
+        }
+    }
+
+    /// True when this chunk is stored in the columnar `RDCC` form.
+    pub fn is_columnar(&self) -> bool {
+        matches!(self.format(), ChunkFormat::ColumnarV1)
     }
 
     pub fn observe(&mut self, ts_ns: u64) {
@@ -1053,6 +1088,29 @@ mod tests {
             "only in-window columnar chunk kept"
         );
         assert!(chunks.iter().all(|c| c.columnar_page.is_some()));
+    }
+
+    /// Read-bridge dispatch key (#861): `ChunkMeta::format()` classifies a
+    /// chunk purely from the `columnar_page` migration discriminant, so a
+    /// pre-existing row chunk and a newly columnar-sealed chunk in the same
+    /// registry are disambiguated by format version — the gate the read
+    /// path dispatches on.
+    #[test]
+    fn chunk_format_dispatches_on_columnar_page_discriminant() {
+        let reg = HypertableRegistry::new();
+        reg.register(HypertableSpec::new("m", "ts", DAY_NS));
+        // A row chunk (allocated by a write) and a columnar chunk coexist.
+        reg.route("m", 0).unwrap();
+        reg.restore_chunk(columnar_chunk("m", DAY_NS, DAY_NS));
+
+        let chunks = reg.show_chunks("m");
+        let row = chunks.iter().find(|c| c.id.start_ns == 0).unwrap();
+        let col = chunks.iter().find(|c| c.id.start_ns == DAY_NS).unwrap();
+
+        assert_eq!(row.format(), ChunkFormat::Row);
+        assert!(!row.is_columnar());
+        assert_eq!(col.format(), ChunkFormat::ColumnarV1);
+        assert!(col.is_columnar());
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/timeseries/mod.rs
+++ b/crates/reddb-server/src/storage/timeseries/mod.rs
@@ -26,7 +26,7 @@ pub use continuous_aggregate::{
     BucketState, ContinuousAggregateColumn, ContinuousAggregateEngine, ContinuousAggregateSource,
     ContinuousAggregateSpec, ContinuousAggregateState, RefreshPoint,
 };
-pub use hypertable::{ChunkId, ChunkMeta, HypertableRegistry, HypertableSpec};
+pub use hypertable::{ChunkFormat, ChunkId, ChunkMeta, HypertableRegistry, HypertableSpec};
 pub use log_pipeline::{LogIngestStats, LogLine, LogPipeline, LogSeverity};
 pub use retention::{
     RetentionBackend, RetentionDaemonHandle, RetentionPolicy, RetentionRegistry, RetentionStats,

--- a/crates/reddb-server/src/storage/unified/column_block.rs
+++ b/crates/reddb-server/src/storage/unified/column_block.rs
@@ -656,6 +656,27 @@ pub fn write_column_block(
     Ok(out)
 }
 
+/// Peek the RDCC **format version** from a column-block buffer without
+/// decoding it. Returns `Some(version)` when `bytes` opens with the `RDCC`
+/// magic, or `None` when it does not (too short, or the leading magic is
+/// not `RDCC` — i.e. the buffer is not the columnar form at all).
+///
+/// This is the read-bridge's format detector (#861): a chunk's stored
+/// bytes are classified — and a columnar chunk's version gated — before
+/// dispatching to the columnar reader, so an unknown future layout is
+/// rejected rather than misread. It touches only the 6-byte magic+version
+/// prefix; no CRC, directory, or stream work.
+pub fn peek_column_block_version(bytes: &[u8]) -> Option<u16> {
+    if bytes.len() < HEADER_LEN + FOOTER_LEN {
+        return None;
+    }
+    let magic: [u8; 4] = bytes[0..4].try_into().unwrap();
+    if magic != COLUMN_BLOCK_MAGIC {
+        return None;
+    }
+    Some(u16::from_le_bytes([bytes[4], bytes[5]]))
+}
+
 /// Decode a v1 `RDCC` block: verify both magics, the version, and the
 /// CRC, then decode each column stream back to its raw bytes.
 pub fn read_column_block(bytes: &[u8]) -> Result<DecodedColumnBlock, ColumnBlockError> {
@@ -1022,6 +1043,31 @@ mod tests {
         // Empty (zero-column) block still decodes.
         let decoded = read_column_block(&block).unwrap();
         assert!(decoded.columns.is_empty());
+    }
+
+    #[test]
+    fn peek_version_classifies_rdcc_and_rejects_non_rdcc() {
+        // A real block peeks as v1 without a full decode.
+        let block = write_column_block(1, 0, 0, 0, 0, 0, &[]).unwrap();
+        assert_eq!(
+            peek_column_block_version(&block),
+            Some(COLUMN_BLOCK_VERSION_V1)
+        );
+        // The peek reads the raw version word — even a future version the
+        // full reader rejects is reported here, so the read-bridge can gate.
+        let mut future = block.clone();
+        future[4..6].copy_from_slice(&(COLUMN_BLOCK_VERSION_V1 + 7).to_le_bytes());
+        assert_eq!(
+            peek_column_block_version(&future),
+            Some(COLUMN_BLOCK_VERSION_V1 + 7)
+        );
+        // Non-RDCC bytes (wrong magic) → not the columnar form.
+        let mut wrong_magic = block.clone();
+        wrong_magic[0] = b'X';
+        assert_eq!(peek_column_block_version(&wrong_magic), None);
+        // Row-form / arbitrary short bytes → not a column block.
+        assert_eq!(peek_column_block_version(b"row-stored bytes"), None);
+        assert_eq!(peek_column_block_version(&[]), None);
     }
 
     #[test]

--- a/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
+++ b/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
@@ -1,0 +1,148 @@
+//! #861 — columnar migration read-bridge, end-to-end.
+//!
+//! The migration/compat path under the chunk model: when `COLUMNAR` is
+//! enabled on a collection that ALREADY holds row-stored data, the
+//! pre-existing row chunks keep serving through the row path and only NEW
+//! chunks seal columnar (`RDCC`). The two coexist in one collection,
+//! disambiguated by format version (`ChunkMeta.format()` /
+//! `ChunkMeta.columnar_page`), and a read bridges across the boundary so
+//! no prior data is lost or stranded — with no mass rewrite.
+//!
+//! This pins the three acceptance criteria:
+//!   1. After enabling columnar, all prior row-stored data stays readable.
+//!   2. New chunks seal columnar; old row + new columnar coexist,
+//!      disambiguated by format version.
+//!   3. No data is lost or stranded across the upgrade.
+
+use reddb_server::catalog::AnalyticalStorageConfig;
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+/// 1-hour chunk interval, in nanoseconds — matches `CHUNK_INTERVAL '1h'`.
+const HOUR_NS: u64 = 3_600 * 1_000_000_000;
+
+/// Pre-existing (row-stored) data: lands wholly in the chunk starting at 0.
+const OLD_ROW: &[(u64, i64)] = &[
+    (1_000_000_000, 10),
+    (2_000_000_000, 20),
+    (3_000_000_000, 30),
+];
+
+/// Post-upgrade data: lands in the SECOND chunk (`[1h, 2h)`), sealed
+/// columnar after `COLUMNAR` is turned on.
+const NEW_COLUMNAR: &[(u64, i64)] = &[(HOUR_NS + 1_000_000_000, 40), (HOUR_NS + 2_000_000_000, 50)];
+
+fn insert(rt: &RedDBRuntime, collection: &str, rows: &[(u64, i64)]) {
+    for (ts, value) in rows {
+        rt.execute_query(&format!(
+            "INSERT INTO {collection} (ts, value) VALUES ({ts}, {value})"
+        ))
+        .unwrap_or_else(|e| panic!("insert ({ts}, {value}): {e}"));
+    }
+}
+
+/// Flip an existing collection's contract to columnar — the "enable
+/// COLUMNAR on a collection that already has data" operator action.
+fn enable_columnar(rt: &RedDBRuntime, collection: &str, time_key: &str) {
+    let db = rt.db();
+    let mut contract = db
+        .collection_contract(collection)
+        .expect("collection has a contract");
+    contract.analytical_storage = Some(AnalyticalStorageConfig {
+        columnar: true,
+        time_key: time_key.to_string(),
+        order_by_key: None,
+    });
+    db.save_collection_contract(contract)
+        .expect("save columnar-enabled contract");
+}
+
+fn want(rows: &[(u64, i64)]) -> Vec<(u64, f64)> {
+    rows.iter().map(|(ts, v)| (*ts, *v as f64)).collect()
+}
+
+#[test]
+fn read_bridge_serves_row_and_columnar_chunks_after_enabling_columnar() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+
+    // --- Before the upgrade: a plain (non-columnar) hypertable with data ---
+    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+        .expect("create hypertable");
+    insert(&rt, "cpu", OLD_ROW);
+
+    // Seal the existing chunk row-oriented (no columnar flag yet).
+    assert_eq!(
+        rt.seal_hypertable_chunks("cpu").expect("seal row"),
+        0,
+        "without the flag nothing seals columnar"
+    );
+    assert_eq!(
+        rt.columnar_chunk_count("cpu"),
+        0,
+        "pre-upgrade chunk is row-stored"
+    );
+
+    // --- Enable COLUMNAR on the collection that already holds data ---
+    enable_columnar(&rt, "cpu", "ts");
+
+    // New data lands in a NEW chunk and seals columnar.
+    insert(&rt, "cpu", NEW_COLUMNAR);
+    assert_eq!(
+        rt.seal_hypertable_chunks("cpu").expect("seal columnar"),
+        1,
+        "the new chunk seals columnar; the pre-existing row chunk is skipped"
+    );
+
+    // Criterion 2: old row + new columnar coexist, disambiguated by format.
+    let chunks = rt.db().hypertables().show_chunks("cpu");
+    assert_eq!(chunks.len(), 2, "two chunks: one row, one columnar");
+    let row_chunks = chunks.iter().filter(|c| !c.is_columnar()).count();
+    let col_chunks = chunks.iter().filter(|c| c.is_columnar()).count();
+    assert_eq!(row_chunks, 1, "pre-existing chunk stays row-stored");
+    assert_eq!(col_chunks, 1, "new chunk is columnar (RDCC)");
+    assert_eq!(rt.columnar_chunk_count("cpu"), 1);
+
+    // No rewrite: the old chunk (start 0) carries no columnar_page.
+    let old = chunks.iter().find(|c| c.id.start_ns == 0).unwrap();
+    assert!(
+        old.columnar_page.is_none(),
+        "enabling columnar must NOT rewrite the pre-existing row chunk"
+    );
+
+    // Criterion 1 + 3: the read-bridge returns ALL data, both formats,
+    // merged in timestamp order — nothing lost or stranded.
+    let all = rt
+        .read_bridge_points("cpu", 0, u64::MAX)
+        .expect("read bridge");
+    let mut expected = want(OLD_ROW);
+    expected.extend(want(NEW_COLUMNAR));
+    assert_eq!(
+        all, expected,
+        "every prior + new point is readable, in order"
+    );
+}
+
+#[test]
+fn read_bridge_prunes_chunks_outside_the_query_range() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+        .expect("create hypertable");
+
+    insert(&rt, "cpu", OLD_ROW);
+    rt.seal_hypertable_chunks("cpu").expect("seal row");
+    enable_columnar(&rt, "cpu", "ts");
+    insert(&rt, "cpu", NEW_COLUMNAR);
+    rt.seal_hypertable_chunks("cpu").expect("seal columnar");
+
+    // A window covering only the first (row) chunk returns only its points.
+    let only_row = rt
+        .read_bridge_points("cpu", 0, HOUR_NS - 1)
+        .expect("read bridge");
+    assert_eq!(only_row, want(OLD_ROW), "row chunk served alone");
+
+    // A window covering only the second (columnar) chunk returns only its
+    // points — proving the columnar reader is exercised in isolation too.
+    let only_col = rt
+        .read_bridge_points("cpu", HOUR_NS, u64::MAX)
+        .expect("read bridge");
+    assert_eq!(only_col, want(NEW_COLUMNAR), "columnar chunk served alone");
+}


### PR DESCRIPTION
## Summary
Implements the **read-bridge** migration/compat path for #861 (PRD #850 Phase 1). When `COLUMNAR` is enabled on a collection that already holds row-stored data, the pre-existing chunks keep serving through a format-version-gated read path and only **new** chunks seal RDCC — old row and new columnar chunks coexist in one collection, with **no mass rewrite** (the HITL-resolved approach, 2026-06-03).

## What changed
- **`column_block.rs`** — `peek_column_block_version()` classifies a buffer as RDCC and reports its version without a full decode: the read-bridge's format detector / version gate.
- **`hypertable.rs`** — `ChunkFormat { Row, ColumnarV1 }` + `ChunkMeta::format()` / `is_columnar()` derive the storage form from the `columnar_page` migration discriminant — the per-chunk dispatch key.
- **`impl_timeseries.rs`** — `read_bridge_points()` reads a collection across the format boundary, dispatching each chunk (`ColumnarV1` → granule-pruned RDCC range scan after a version-gate check; `Row` → entity/row reader) and merging in timestamp order. Chunk windows are disjoint, so a columnar chunk is read only through its RDCC block and never double-counted via the row path. Row materialization extracted into a shared helper the columnar seal also sources from.

## Acceptance criteria
- [x] After enabling columnar, all prior row-stored data remains readable.
- [x] New chunks seal columnar; old row + new RDCC coexist, disambiguated by format version.
- [x] No data lost or stranded; round-trip lossless on both paths; pre-existing chunk is **not** rewritten.

## Tests
- `column_block`: peek-version classification (RDCC v1, future version, non-RDCC, empty).
- `hypertable`: `ChunkMeta::format()` dispatch on the columnar_page discriminant.
- `tests/columnar_read_bridge_e2e.rs`: enable columnar on a collection with existing data → row + columnar coexist; read-bridge returns all prior + new data in order; range pruning serves each format in isolation; old chunk carries no `columnar_page` (no rewrite).

All timeseries lib tests (110) + columnar e2e suites (4) pass. Out of scope: one-shot rewrite, compaction (#857), columnar read-speed redesign (#943).

Closes #861.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783056240&installation_id=129708444&pr_number=950&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F950&signature=10ca30884947b8bc30f37d6aeb7227221d6603c9f5962f2a1f0dc2040125d26d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added timeseries read-bridge to transparently query mixed storage formats—seamlessly combine row-based and columnar chunks without requiring data migration or rewrites.

* **Tests**
  * Added integration tests validating mixed-format coexistence, query range filtering, and correct point merging across different chunk types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->