### PR TITLE
feat(server): per-principal in-flight cap + structured refusal (#934)

### DIFF
--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -392,6 +392,11 @@ fn server_flags() -> Vec<FlagSchema> {
              red_config: red.http.retry_after_secs; clamped to [1, 30])",
             )
             .with_default("5"),
+        FlagSchema::new("http-max-inflight-per-principal").with_description(
+            "Max concurrent in-flight HTTP requests per principal; over-cap requests \
+             get a structured 429 (env: REDDB_HTTP_MAX_INFLIGHT_PER_PRINCIPAL; \
+             red_config: red.http.max_inflight_per_principal; 0 disables; default: 64)",
+        ),
     ]
 }
 

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -134,6 +134,7 @@ pub mod header_escape_guard;
 pub mod http_connection_limiter;
 pub mod http_handler_metrics;
 pub mod http_limits;
+pub mod http_principal_limiter;
 pub mod ingest_pipeline;
 pub mod output_stream;
 mod patch_support;
@@ -158,6 +159,7 @@ use self::http_handler_metrics::{HttpHandlerMetrics, HttpRejectReason, HttpTrans
 pub use self::http_limits::{
     HttpLimitsCliInput, HttpLimitsResolved, DEFAULT_HANDLER_TIMEOUT_MS, DEFAULT_RETRY_AFTER_SECS,
 };
+use self::http_principal_limiter::PrincipalConnectionLimiter;
 use self::patch_support::*;
 use self::request_body::*;
 use self::routing::*;
@@ -260,6 +262,14 @@ pub struct RedDBServer {
     /// capacity-reject 503 path (issue #574 slice 5). Read on the reject
     /// path in `axum_edge`.
     retry_after_secs: u64,
+    /// Issue #934 / PRD #930 — per-principal concurrent in-flight cap. The
+    /// global `http_limiter` bounds *total* in-flight work (async
+    /// backpressure); this bounds any *single* principal's share so one
+    /// abusive caller can't drain the whole global cap and starve the rest.
+    /// Consulted at the async edge after global admission; a principal over
+    /// its cap gets a structured 429 refusal. Shared via `Arc` (inside the
+    /// limiter) so cloned server handles enforce one set of counters.
+    principal_limiter: PrincipalConnectionLimiter,
     /// Issue #761 / S2 — process-wide output-stream capacity registry.
     /// Shared via `Arc` so cloned server handles (e.g.
     /// `serve_in_background`) all enforce against one set of counters.
@@ -383,6 +393,9 @@ impl RedDBServer {
             slow_inject_ms: Arc::new(AtomicU64::new(0)),
             http_metrics: HttpHandlerMetrics::new(),
             retry_after_secs: DEFAULT_RETRY_AFTER_SECS,
+            principal_limiter: PrincipalConnectionLimiter::new(
+                http_limits::DEFAULT_MAX_INFLIGHT_PER_PRINCIPAL,
+            ),
             stream_capacity: output_stream::StreamCapacityRegistry::new(),
             lease_registry: output_stream::LeaseRegistry::new(),
             cursor_registry: output_stream::CursorRegistry::new(),
@@ -427,7 +440,23 @@ impl RedDBServer {
         self.http_limiter = HttpConnectionLimiter::new(limits.max_handlers);
         self.handler_timeout = Duration::from_millis(limits.handler_timeout_ms);
         self.retry_after_secs = limits.retry_after_secs;
+        self.principal_limiter = PrincipalConnectionLimiter::new(limits.max_inflight_per_principal);
         self
+    }
+
+    /// Visible for tests. Override the per-principal concurrent in-flight
+    /// cap (issue #934) so the integration test can saturate one principal
+    /// and observe the structured 429 refusal without standing up hundreds
+    /// of real sockets. `0` disables the per-principal cap.
+    #[doc(hidden)]
+    pub fn with_principal_inflight_cap(mut self, cap: usize) -> Self {
+        self.principal_limiter = PrincipalConnectionLimiter::new(cap);
+        self
+    }
+
+    #[doc(hidden)]
+    pub fn principal_limiter(&self) -> &PrincipalConnectionLimiter {
+        &self.principal_limiter
     }
 
     #[doc(hidden)]

--- a/crates/reddb-server/src/server/axum_edge.rs
+++ b/crates/reddb-server/src/server/axum_edge.rs
@@ -39,6 +39,7 @@ use hyper_util::service::TowerToHyperService;
 
 use super::http_connection_limiter::HttpConnectionPermit;
 use super::http_handler_metrics::{HttpRejectReason, HttpTransport};
+use super::http_principal_limiter::{PrincipalCapExceeded, PrincipalInflightPermit};
 use super::transport::{
     find_header_end, json_error, parse_query_string, HttpRequest, HttpResponse, CORS_HEADER_PAIRS,
 };
@@ -212,6 +213,18 @@ impl RedDBServer {
         // Admission control is now per in-flight request, not per
         // connection: an idle keep-alive connection holds no slot, so the
         // cap no longer bounds connection count (issue #931 / AC #4).
+        //
+        // Two gates, in order:
+        //   1. Global cap — bounds *total* in-flight work (async
+        //      backpressure). Exhaustion is a server-wide 503; it hits
+        //      every caller equally, which is the backpressure signal.
+        //   2. Per-principal cap (issue #934) — bounds any *single*
+        //      caller's share so one abusive principal can't drain the
+        //      global cap and starve the rest. Over-cap is a structured
+        //      429 carrying the principal's limit/current so it can back
+        //      off precisely. Checked second: there is no point telling a
+        //      caller "you're over your share" when the server has no room
+        //      for anyone.
         let permit = match self.http_limiter.try_acquire() {
             Some(permit) => permit,
             None => {
@@ -221,10 +234,24 @@ impl RedDBServer {
             }
         };
 
+        let principal = super::routing::principal_for(&request.headers);
+        let principal_permit = match self.principal_limiter.try_acquire(&principal) {
+            Ok(principal_permit) => principal_permit,
+            Err(err) => {
+                // Drop the global permit before returning so the slot this
+                // refused caller briefly held is freed immediately.
+                drop(permit);
+                self.http_metrics
+                    .record_reject(transport, HttpRejectReason::PrincipalCapExhausted);
+                return self.reject_principal_response(&err);
+            }
+        };
+
         let response = if self.is_streaming_request(&request) {
-            self.serve_streaming_request(request, permit).await
+            self.serve_streaming_request(request, permit, principal_permit)
+                .await
         } else {
-            self.serve_buffered_request(request, permit, transport)
+            self.serve_buffered_request(request, permit, principal_permit, transport)
                 .await
         };
         self.http_metrics
@@ -238,13 +265,29 @@ impl RedDBServer {
         &self,
         request: HttpRequest,
         permit: HttpConnectionPermit,
+        principal_permit: PrincipalInflightPermit,
         transport: HttpTransport,
     ) -> Response {
         let server = self.clone();
         let join = tokio::task::spawn_blocking(move || {
-            // Permit is held for the duration of the engine call and
-            // released when this closure returns.
+            // Both the global and per-principal permits are held for the
+            // duration of the engine call and released when this closure
+            // returns — so the per-principal slot is occupied for exactly
+            // as long as the request is in flight.
             let _permit = permit;
+            let _principal_permit = principal_permit;
+            // Test-only hook (shared with the retired sync path): a slow
+            // injection keeps the request in flight while it sleeps, so an
+            // integration test can saturate the per-principal cap with a
+            // handful of concurrent requests instead of racing real load.
+            // The atomic is 0 in production, so this is a single relaxed
+            // load on the hot path.
+            let inject_ms = server
+                .slow_inject_ms
+                .load(std::sync::atomic::Ordering::Relaxed);
+            if inject_ms > 0 {
+                std::thread::sleep(std::time::Duration::from_millis(inject_ms));
+            }
             server.route(request)
         });
         match tokio::time::timeout(self.handler_timeout, join).await {
@@ -269,11 +312,16 @@ impl RedDBServer {
         &self,
         request: HttpRequest,
         permit: HttpConnectionPermit,
+        principal_permit: PrincipalInflightPermit,
     ) -> Response {
         let (head_tx, head_rx) = oneshot::channel::<EdgeStreamResponse>();
         let server = self.clone();
         tokio::task::spawn_blocking(move || {
+            // Held for the whole stream lifetime (head + body): the
+            // per-principal slot is released only when the synchronous
+            // streaming handler returns, matching the global permit.
             let _permit = permit;
+            let _principal_permit = principal_permit;
             let mut sink = StreamSink::new(head_tx);
             // Errors here are connection-level (client gone / broken
             // pipe); the sync handler already wrote what it could.
@@ -286,6 +334,18 @@ impl RedDBServer {
             // complete response head — surface a 500 rather than hang.
             Err(_) => internal_error_response(),
         }
+    }
+
+    /// Structured 429 emitted when a principal is over its per-principal
+    /// concurrent in-flight cap (issue #934). The body shape is built by
+    /// [`super::routing::principal_inflight_refusal_response`] — shared with
+    /// the stream-capacity refusal so clients branch on `error.code` — and
+    /// converted here, which applies the canonical CORS posture and any
+    /// guard-validated headers (the `Retry-After`).
+    fn reject_principal_response(&self, err: &PrincipalCapExceeded) -> Response {
+        let response =
+            super::routing::principal_inflight_refusal_response(err, self.retry_after_secs);
+        buffered_response_to_axum(response)
     }
 
     /// 503 emitted when the in-flight-request admission cap is exhausted.

--- a/crates/reddb-server/src/server/http_handler_metrics.rs
+++ b/crates/reddb-server/src/server/http_handler_metrics.rs
@@ -54,13 +54,21 @@ impl HttpTransport {
 pub enum HttpRejectReason {
     CapExhausted,
     HandlerTimeout,
+    /// Issue #934 — a principal hit its per-principal concurrent in-flight
+    /// cap (the global cap still had room; this caller did not).
+    PrincipalCapExhausted,
 }
+
+/// Number of distinct [`HttpRejectReason`] variants — array width for the
+/// per-transport rejection counters.
+const REJECT_REASONS: usize = 3;
 
 impl HttpRejectReason {
     fn label(self) -> &'static str {
         match self {
             HttpRejectReason::CapExhausted => "cap_exhausted",
             HttpRejectReason::HandlerTimeout => "handler_timeout",
+            HttpRejectReason::PrincipalCapExhausted => "principal_cap_exhausted",
         }
     }
 
@@ -68,7 +76,17 @@ impl HttpRejectReason {
         match self {
             HttpRejectReason::CapExhausted => 0,
             HttpRejectReason::HandlerTimeout => 1,
+            HttpRejectReason::PrincipalCapExhausted => 2,
         }
+    }
+
+    /// All variants, for render-time iteration.
+    fn all() -> [HttpRejectReason; REJECT_REASONS] {
+        [
+            HttpRejectReason::CapExhausted,
+            HttpRejectReason::HandlerTimeout,
+            HttpRejectReason::PrincipalCapExhausted,
+        ]
     }
 }
 
@@ -125,8 +143,13 @@ impl TransportHistogram {
 
 #[derive(Debug)]
 struct Inner {
-    rejected: [[AtomicU64; 2]; 2],
+    rejected: [[AtomicU64; REJECT_REASONS]; 2],
     duration: [TransportHistogram; 2],
+}
+
+/// One fresh zeroed rejection-counter row (`REJECT_REASONS` wide).
+fn zeroed_reject_row() -> [AtomicU64; REJECT_REASONS] {
+    std::array::from_fn(|_| AtomicU64::new(0))
 }
 
 #[derive(Debug, Clone)]
@@ -138,10 +161,7 @@ impl HttpHandlerMetrics {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Inner {
-                rejected: [
-                    [AtomicU64::new(0), AtomicU64::new(0)],
-                    [AtomicU64::new(0), AtomicU64::new(0)],
-                ],
+                rejected: [zeroed_reject_row(), zeroed_reject_row()],
                 duration: [TransportHistogram::new(), TransportHistogram::new()],
             }),
         }
@@ -214,10 +234,7 @@ impl HttpHandlerMetrics {
         );
         let _ = writeln!(body, "# TYPE http_handler_rejected_total counter");
         for transport in [HttpTransport::Http, HttpTransport::Https] {
-            for reason in [
-                HttpRejectReason::CapExhausted,
-                HttpRejectReason::HandlerTimeout,
-            ] {
+            for reason in HttpRejectReason::all() {
                 let _ = writeln!(
                     body,
                     "http_handler_rejected_total{{transport=\"{}\",reason=\"{}\"}} {}",
@@ -362,7 +379,11 @@ mod tests {
         let mut body = String::new();
         m.render(&mut body, &limiter);
         for transport in ["http", "https"] {
-            for reason in ["cap_exhausted", "handler_timeout"] {
+            for reason in [
+                "cap_exhausted",
+                "handler_timeout",
+                "principal_cap_exhausted",
+            ] {
                 let expected = format!(
                     "http_handler_rejected_total{{transport=\"{transport}\",reason=\"{reason}\"}} 0"
                 );

--- a/crates/reddb-server/src/server/http_limits.rs
+++ b/crates/reddb-server/src/server/http_limits.rs
@@ -9,6 +9,7 @@
 //!   - max_handlers      = (2 * num_cpus).clamp(8, 256)
 //!   - handler_timeout   = 30_000 ms
 //!   - retry_after_secs  = 5
+//!   - max_inflight_per_principal = 64   (issue #934; 0 disables)
 //!
 //! Each knob is validated at parse time and at resolution time so a
 //! stale red_config value cannot corrupt the running server.
@@ -34,12 +35,31 @@ pub fn default_max_handlers() -> usize {
 pub const DEFAULT_HANDLER_TIMEOUT_MS: u64 = 30_000;
 pub const DEFAULT_RETRY_AFTER_SECS: u64 = 5;
 
+/// Built-in default for `max_inflight_per_principal` (issue #934). Bounds
+/// any single principal's concurrent in-flight requests at the async edge so
+/// one caller can't drain the whole global handler cap and starve the rest.
+/// `0` disables the per-principal cap entirely; a single-tenant deployment
+/// can set it there to pay nothing. Chosen below the typical multi-core
+/// global cap (256) so it provides real fairness headroom, while sitting
+/// above the global cap on tiny boxes (where there is no abuse pressure) so
+/// it never trips spuriously.
+pub const DEFAULT_MAX_INFLIGHT_PER_PRINCIPAL: usize = 64;
+
 /// Validate a `max_handlers` candidate from any source. Returns the
 /// value unchanged on success.
 pub fn validate_max_handlers(value: usize) -> Result<usize, String> {
     if value == 0 {
         return Err("http max_handlers must be >= 1".to_string());
     }
+    Ok(value)
+}
+
+/// Validate a `max_inflight_per_principal` candidate (issue #934). Every
+/// `usize` is acceptable: a positive value caps each principal's concurrent
+/// in-flight requests, and `0` disables the per-principal cap. Present for
+/// symmetry with the other knobs so the CLI parser can run all four through
+/// the same validated-parse helper.
+pub fn validate_max_inflight_per_principal(value: usize) -> Result<usize, String> {
     Ok(value)
 }
 
@@ -73,6 +93,8 @@ pub struct HttpLimitsCliInput {
     pub handler_timeout_ms_env: Option<u64>,
     pub retry_after_secs_flag: Option<u64>,
     pub retry_after_secs_env: Option<u64>,
+    pub max_inflight_per_principal_flag: Option<usize>,
+    pub max_inflight_per_principal_env: Option<usize>,
 }
 
 /// Resolved values after applying the full precedence chain. Stamped
@@ -82,6 +104,8 @@ pub struct HttpLimitsResolved {
     pub max_handlers: usize,
     pub handler_timeout_ms: u64,
     pub retry_after_secs: u64,
+    /// Per-principal concurrent in-flight cap (issue #934). `0` disables.
+    pub max_inflight_per_principal: usize,
 }
 
 impl HttpLimitsResolved {
@@ -90,6 +114,7 @@ impl HttpLimitsResolved {
             max_handlers: default_max_handlers(),
             handler_timeout_ms: DEFAULT_HANDLER_TIMEOUT_MS,
             retry_after_secs: DEFAULT_RETRY_AFTER_SECS,
+            max_inflight_per_principal: DEFAULT_MAX_INFLIGHT_PER_PRINCIPAL,
         }
     }
 }
@@ -136,10 +161,21 @@ where
         .or(input.retry_after_secs_env)
         .unwrap_or(defaults.retry_after_secs);
 
+    let max_inflight_per_principal = input
+        .max_inflight_per_principal_flag
+        .or_else(|| {
+            config_lookup("red.http.max_inflight_per_principal")
+                .and_then(|raw| raw.parse::<usize>().ok())
+                .and_then(|v| validate_max_inflight_per_principal(v).ok())
+        })
+        .or(input.max_inflight_per_principal_env)
+        .unwrap_or(defaults.max_inflight_per_principal);
+
     HttpLimitsResolved {
         max_handlers,
         handler_timeout_ms,
         retry_after_secs,
+        max_inflight_per_principal,
     }
 }
 
@@ -272,5 +308,69 @@ mod tests {
     fn default_max_handlers_in_bounds() {
         let cap = default_max_handlers();
         assert!((8..=256).contains(&cap));
+    }
+
+    #[test]
+    fn max_inflight_per_principal_follows_precedence_chain() {
+        // default
+        let resolved = resolve_http_limits(&HttpLimitsCliInput::default(), no_config());
+        assert_eq!(
+            resolved.max_inflight_per_principal,
+            DEFAULT_MAX_INFLIGHT_PER_PRINCIPAL
+        );
+
+        // env over default
+        let input = HttpLimitsCliInput {
+            max_inflight_per_principal_env: Some(17),
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_http_limits(&input, no_config()).max_inflight_per_principal,
+            17
+        );
+
+        // red_config over env
+        let input = HttpLimitsCliInput {
+            max_inflight_per_principal_env: Some(17),
+            ..Default::default()
+        };
+        let lookup = map_lookup(HashMap::from([(
+            "red.http.max_inflight_per_principal",
+            "9",
+        )]));
+        assert_eq!(
+            resolve_http_limits(&input, lookup).max_inflight_per_principal,
+            9
+        );
+
+        // flag over everything
+        let input = HttpLimitsCliInput {
+            max_inflight_per_principal_flag: Some(3),
+            max_inflight_per_principal_env: Some(17),
+            ..Default::default()
+        };
+        let lookup = map_lookup(HashMap::from([(
+            "red.http.max_inflight_per_principal",
+            "9",
+        )]));
+        assert_eq!(
+            resolve_http_limits(&input, lookup).max_inflight_per_principal,
+            3
+        );
+    }
+
+    #[test]
+    fn max_inflight_per_principal_zero_disables_and_is_honored() {
+        // 0 is a legal value (disables the per-principal cap) and must
+        // survive the resolve chain rather than being treated as unset.
+        let lookup = map_lookup(HashMap::from([(
+            "red.http.max_inflight_per_principal",
+            "0",
+        )]));
+        assert_eq!(
+            resolve_http_limits(&HttpLimitsCliInput::default(), lookup).max_inflight_per_principal,
+            0
+        );
+        assert!(validate_max_inflight_per_principal(0).is_ok());
     }
 }

--- a/crates/reddb-server/src/server/http_principal_limiter.rs
+++ b/crates/reddb-server/src/server/http_principal_limiter.rs
@@ -1,0 +1,287 @@
+//! Per-principal in-flight admission for the async HTTP edge (issue #934,
+//! PRD #930).
+//!
+//! The thread-per-connection cap retired in #931 used to bound *both*
+//! total concurrency and any single caller's share of it as a side effect
+//! — one greedy client could only ever hold as many slots as it held OS
+//! threads, and the global `(2*num_cpus).clamp(8,256)` ceiling capped
+//! that. The async edge removed the OS-thread coupling: an idle keep-alive
+//! connection is now a parked future, and admission is per in-flight
+//! request against a single global [`HttpConnectionLimiter`]. That global
+//! cap bounds *total* in-flight work (async backpressure) but no longer
+//! bounds any single principal's share — one abusive caller can drain the
+//! whole global cap and starve everyone else.
+//!
+//! This limiter restores the per-caller bound as a first-class control: a
+//! small `AtomicUsize`-per-principal in-flight counter consulted at the
+//! edge *after* global admission. A principal over its own cap gets a
+//! structured 429 refusal (see [`PrincipalCapExceeded`]) carrying the
+//! limit, the live count, and the principal label so a well-behaved client
+//! can back off without guessing. It is the concurrency sibling of the
+//! per-principal QPS quota ([`crate::runtime::quota_bucket::QuotaBucket`],
+//! which bounds *rate*) and the per-principal stream cap (ADR 0029 /
+//! `StreamCapacityRegistry`, which bounds concurrent *streams*).
+//!
+//! A `cap` of `0` disables the limiter entirely (every acquire succeeds) so
+//! operators can opt out and so small single-tenant deployments pay nothing.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Refusal returned by [`PrincipalConnectionLimiter::try_acquire`] when a
+/// principal is already at its concurrent in-flight cap. Carries the values
+/// a client needs to back off intelligently: its own cap, the live count it
+/// hit, and the principal label the server bucketed it under.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrincipalCapExceeded {
+    pub principal: String,
+    pub limit: usize,
+    pub current: usize,
+}
+
+/// Stable machine-readable refusal code embedded in the structured body so
+/// clients branch on it without parsing prose.
+pub const PRINCIPAL_INFLIGHT_CODE: &str = "principal_inflight_exhausted";
+
+#[derive(Debug)]
+struct Inner {
+    /// Per-principal concurrent in-flight ceiling. `0` disables the
+    /// limiter (every acquire succeeds, no map mutation).
+    cap: usize,
+    /// `principal -> live in-flight count`. An entry exists only while a
+    /// principal holds at least one permit; it is removed when its count
+    /// returns to zero so the map can't grow unbounded under churn.
+    in_use: Mutex<HashMap<String, usize>>,
+    /// Total refusals since process start, surfaced to `/metrics`.
+    rejected: AtomicU64,
+}
+
+/// Permit handle — owns one in-flight slot for a single principal. Dropping
+/// the permit decrements that principal's count (and evicts the entry at
+/// zero). Intentionally `!Clone` so slot accounting can't drift.
+#[derive(Debug)]
+pub struct PrincipalInflightPermit {
+    inner: Arc<Inner>,
+    principal: String,
+}
+
+impl Drop for PrincipalInflightPermit {
+    fn drop(&mut self) {
+        let mut map = self.inner.in_use.lock().expect("principal limiter mutex");
+        if let Some(count) = map.get_mut(&self.principal) {
+            *count -= 1;
+            if *count == 0 {
+                map.remove(&self.principal);
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PrincipalConnectionLimiter {
+    inner: Arc<Inner>,
+}
+
+impl PrincipalConnectionLimiter {
+    /// Build a limiter with the given per-principal concurrent in-flight
+    /// cap. `0` disables enforcement.
+    pub fn new(cap: usize) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                cap,
+                in_use: Mutex::new(HashMap::new()),
+                rejected: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    /// The configured per-principal cap. `0` means disabled.
+    pub fn cap(&self) -> usize {
+        self.inner.cap
+    }
+
+    /// `true` when enforcement is active (cap > 0).
+    pub fn is_enforced(&self) -> bool {
+        self.inner.cap > 0
+    }
+
+    /// Live in-flight count for a single principal (`0` if it holds none).
+    /// Observability only.
+    pub fn current_for(&self, principal: &str) -> usize {
+        let map = self.inner.in_use.lock().expect("principal limiter mutex");
+        map.get(principal).copied().unwrap_or(0)
+    }
+
+    /// Number of principals currently holding at least one permit.
+    pub fn tracked_principals(&self) -> usize {
+        let map = self.inner.in_use.lock().expect("principal limiter mutex");
+        map.len()
+    }
+
+    /// Total refusals issued since construction. Surfaced via
+    /// `reddb_http_principal_inflight_rejected_total`.
+    pub fn rejected_total(&self) -> u64 {
+        self.inner.rejected.load(Ordering::Relaxed)
+    }
+
+    /// Admit one in-flight request for `principal`. Returns `Ok(permit)`
+    /// when the principal is under its cap (slot reserved, released on
+    /// permit drop) or `Err(PrincipalCapExceeded)` when it is already at
+    /// the cap. A disabled limiter (cap `0`) always admits and never
+    /// touches the map.
+    pub fn try_acquire(
+        &self,
+        principal: &str,
+    ) -> Result<PrincipalInflightPermit, PrincipalCapExceeded> {
+        if self.inner.cap == 0 {
+            return Ok(PrincipalInflightPermit {
+                inner: Arc::clone(&self.inner),
+                principal: principal.to_string(),
+            });
+        }
+        let mut map = self.inner.in_use.lock().expect("principal limiter mutex");
+        let count = map.entry(principal.to_string()).or_insert(0);
+        if *count >= self.inner.cap {
+            let current = *count;
+            // Drop the lock before bumping the (Relaxed) counter — keep the
+            // critical section to the map mutation only.
+            drop(map);
+            self.inner.rejected.fetch_add(1, Ordering::Relaxed);
+            return Err(PrincipalCapExceeded {
+                principal: principal.to_string(),
+                limit: self.inner.cap,
+                current,
+            });
+        }
+        *count += 1;
+        Ok(PrincipalInflightPermit {
+            inner: Arc::clone(&self.inner),
+            principal: principal.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::thread;
+
+    #[test]
+    fn disabled_cap_admits_everything_without_tracking() {
+        let limiter = PrincipalConnectionLimiter::new(0);
+        assert!(!limiter.is_enforced());
+        let mut permits = Vec::new();
+        for _ in 0..1_000 {
+            permits.push(limiter.try_acquire("alice").expect("disabled admits"));
+        }
+        // cap==0 short-circuits before the map, so nothing is tracked.
+        assert_eq!(limiter.tracked_principals(), 0);
+        assert_eq!(limiter.rejected_total(), 0);
+    }
+
+    #[test]
+    fn admits_up_to_cap_then_refuses_with_structured_detail() {
+        let limiter = PrincipalConnectionLimiter::new(3);
+        let p1 = limiter.try_acquire("alice").expect("slot 1");
+        let p2 = limiter.try_acquire("alice").expect("slot 2");
+        let p3 = limiter.try_acquire("alice").expect("slot 3");
+        assert_eq!(limiter.current_for("alice"), 3);
+
+        let err = limiter.try_acquire("alice").expect_err("over cap");
+        assert_eq!(
+            err,
+            PrincipalCapExceeded {
+                principal: "alice".to_string(),
+                limit: 3,
+                current: 3,
+            }
+        );
+        assert_eq!(limiter.rejected_total(), 1);
+        drop((p1, p2, p3));
+    }
+
+    #[test]
+    fn dropping_a_permit_frees_a_slot() {
+        let limiter = PrincipalConnectionLimiter::new(1);
+        let p = limiter.try_acquire("bob").expect("first slot");
+        assert!(limiter.try_acquire("bob").is_err());
+        drop(p);
+        // Entry evicted at zero, then re-acquirable.
+        assert_eq!(limiter.current_for("bob"), 0);
+        assert_eq!(limiter.tracked_principals(), 0);
+        let _p = limiter.try_acquire("bob").expect("reacquire after drop");
+        assert_eq!(limiter.current_for("bob"), 1);
+    }
+
+    #[test]
+    fn principals_are_isolated() {
+        let limiter = PrincipalConnectionLimiter::new(1);
+        let _alice = limiter.try_acquire("alice").expect("alice slot");
+        // alice is saturated, but bob has his own independent budget.
+        assert!(limiter.try_acquire("alice").is_err());
+        let _bob = limiter.try_acquire("bob").expect("bob unaffected");
+        assert_eq!(limiter.tracked_principals(), 2);
+    }
+
+    #[test]
+    fn entry_evicted_when_last_permit_drops() {
+        let limiter = PrincipalConnectionLimiter::new(4);
+        let a = limiter.try_acquire("carol").expect("1");
+        let b = limiter.try_acquire("carol").expect("2");
+        assert_eq!(limiter.tracked_principals(), 1);
+        drop(a);
+        assert_eq!(limiter.current_for("carol"), 1);
+        assert_eq!(limiter.tracked_principals(), 1);
+        drop(b);
+        assert_eq!(limiter.tracked_principals(), 0);
+    }
+
+    #[test]
+    fn concurrent_acquire_never_over_issues_per_principal() {
+        // Many threads race the same principal; the high-water count
+        // must never exceed the cap and successes must equal the cap.
+        let cap = 8;
+        let limiter = PrincipalConnectionLimiter::new(cap);
+        let success = Arc::new(AtomicUsize::new(0));
+        let denied = Arc::new(AtomicUsize::new(0));
+        let held: Arc<Mutex<Vec<PrincipalInflightPermit>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let mut handles = Vec::new();
+        for _ in 0..64 {
+            let l = limiter.clone();
+            let s = Arc::clone(&success);
+            let d = Arc::clone(&denied);
+            let h = Arc::clone(&held);
+            handles.push(thread::spawn(move || match l.try_acquire("storm") {
+                Ok(p) => {
+                    s.fetch_add(1, Ordering::Relaxed);
+                    h.lock().unwrap().push(p);
+                }
+                Err(_) => {
+                    d.fetch_add(1, Ordering::Relaxed);
+                }
+            }));
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_eq!(success.load(Ordering::Relaxed), cap);
+        assert_eq!(denied.load(Ordering::Relaxed), 64 - cap);
+        assert_eq!(limiter.current_for("storm"), cap);
+        assert_eq!(limiter.rejected_total() as usize, 64 - cap);
+
+        held.lock().unwrap().clear();
+        assert_eq!(limiter.current_for("storm"), 0);
+    }
+
+    #[test]
+    fn clone_shares_state() {
+        let a = PrincipalConnectionLimiter::new(2);
+        let b = a.clone();
+        let _p = a.try_acquire("dave").unwrap();
+        assert_eq!(b.current_for("dave"), 1);
+        assert_eq!(b.cap(), 2);
+    }
+}

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -2213,6 +2213,53 @@ mod tests {
     }
 
     #[test]
+    fn principal_inflight_refusal_has_structured_backoff_shape() {
+        use crate::server::http_principal_limiter::PrincipalCapExceeded;
+
+        let err = PrincipalCapExceeded {
+            // Embed a quote-bearing principal so the test also proves the
+            // tainted-field path escapes hostile header-derived labels.
+            principal: "replica:ev\"il".to_string(),
+            limit: 64,
+            current: 64,
+        };
+        let response = principal_inflight_refusal_response(&err, 5);
+        assert_eq!(response.status, 429);
+        assert_eq!(response.content_type, "application/json");
+
+        // `Retry-After: 5` rides as a guard-validated header so clients
+        // with only header-level backoff still get a hint.
+        assert!(
+            response
+                .extra_headers
+                .iter()
+                .any(|(name, value)| name.eq_ignore_ascii_case("Retry-After")
+                    && value.to_str().ok() == Some("5")),
+            "expected Retry-After: 5, got {:?}",
+            response.extra_headers
+        );
+
+        let body: crate::json::Value =
+            crate::json::from_slice(&response.body).expect("refusal body is valid JSON");
+        assert_eq!(body["ok"], crate::json::Value::Bool(false));
+        assert_eq!(body["retry_after_secs"], crate::json::Value::Number(5.0));
+        let error = &body["error"];
+        assert_eq!(
+            error["code"],
+            crate::json::Value::String(
+                crate::server::http_principal_limiter::PRINCIPAL_INFLIGHT_CODE.to_string()
+            )
+        );
+        assert_eq!(error["limit"], crate::json::Value::Number(64.0));
+        assert_eq!(error["current"], crate::json::Value::Number(64.0));
+        // The principal round-trips intact through the tainted-field escape.
+        assert_eq!(
+            error["principal"],
+            crate::json::Value::String("replica:ev\"il".to_string())
+        );
+    }
+
+    #[test]
     fn fresh_server_health_is_ready_when_query_endpoint_works() {
         let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
         let server = RedDBServer::new(runtime);
@@ -4816,6 +4863,55 @@ pub(crate) fn stream_capacity_refusal_response(
     if let Ok(retry_after) =
         crate::server::header_escape_guard::HeaderEscapeGuard::header_value("1")
     {
+        response = response.with_header("Retry-After", retry_after);
+    }
+    response
+}
+
+/// Issue #934 / PRD #930 — structured refusal for a request rejected by the
+/// per-principal concurrent in-flight cap at the async edge. Shares the
+/// `{"ok":false,"error":{code,limit,current,principal}}` shape with the
+/// stream-capacity refusal so a client can branch on `error.code` without
+/// re-parsing prose, and carries a `Retry-After` header for clients with
+/// only header-level backoff. The principal label is emitted through the
+/// tainted-field path so a hostile `x-reddb-replica-id` header can't break
+/// out of the JSON string.
+pub(crate) fn principal_inflight_refusal_response(
+    err: &crate::server::http_principal_limiter::PrincipalCapExceeded,
+    retry_after_secs: u64,
+) -> HttpResponse {
+    use crate::json::{Map, Value as JsonValue};
+
+    let mut error_obj = Map::new();
+    error_obj.insert(
+        "code".to_string(),
+        JsonValue::String(
+            crate::server::http_principal_limiter::PRINCIPAL_INFLIGHT_CODE.to_string(),
+        ),
+    );
+    error_obj.insert(
+        "message".to_string(),
+        JsonValue::String("per-principal in-flight request cap exceeded".to_string()),
+    );
+    error_obj.insert(
+        "principal".to_string(),
+        crate::json_field::SerializedJsonField::tainted(&err.principal),
+    );
+    error_obj.insert("limit".to_string(), JsonValue::Number(err.limit as f64));
+    error_obj.insert("current".to_string(), JsonValue::Number(err.current as f64));
+
+    let mut root = Map::new();
+    root.insert("ok".to_string(), JsonValue::Bool(false));
+    root.insert("error".to_string(), JsonValue::Object(error_obj));
+    root.insert(
+        "retry_after_secs".to_string(),
+        JsonValue::Number(retry_after_secs as f64),
+    );
+
+    let mut response = json_response(429, JsonValue::Object(root));
+    if let Ok(retry_after) = crate::server::header_escape_guard::HeaderEscapeGuard::header_value(
+        &retry_after_secs.to_string(),
+    ) {
         response = response.with_header("Retry-After", retry_after);
     }
     response

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -2517,6 +2517,7 @@ fn apply_http_limits(
         max_handlers = resolved.max_handlers,
         handler_timeout_ms = resolved.handler_timeout_ms,
         retry_after_secs = resolved.retry_after_secs,
+        max_inflight_per_principal = resolved.max_inflight_per_principal,
         "http_limits resolved"
     );
     server.with_http_limits(resolved)

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -2888,7 +2888,8 @@ fn build_http_limits_cli_input(
     flags: &HashMap<String, FlagValue>,
 ) -> Result<reddb::server::HttpLimitsCliInput, String> {
     use reddb::server::http_limits::{
-        validate_handler_timeout_ms, validate_max_handlers, validate_retry_after_secs,
+        validate_handler_timeout_ms, validate_max_handlers, validate_max_inflight_per_principal,
+        validate_retry_after_secs,
     };
 
     fn parse_usize_validated<V>(
@@ -2962,6 +2963,17 @@ fn build_http_limits_cli_input(
         validate_retry_after_secs,
     )?;
 
+    let max_inflight_per_principal_flag = parse_usize_validated(
+        "--http-max-inflight-per-principal",
+        flag_string(flags, "http-max-inflight-per-principal").filter(|v| !v.is_empty()),
+        validate_max_inflight_per_principal,
+    )?;
+    let max_inflight_per_principal_env = parse_usize_validated(
+        "REDDB_HTTP_MAX_INFLIGHT_PER_PRINCIPAL",
+        env_string("REDDB_HTTP_MAX_INFLIGHT_PER_PRINCIPAL"),
+        validate_max_inflight_per_principal,
+    )?;
+
     Ok(reddb::server::HttpLimitsCliInput {
         max_handlers_flag,
         max_handlers_env,
@@ -2969,6 +2981,8 @@ fn build_http_limits_cli_input(
         handler_timeout_ms_env,
         retry_after_secs_flag,
         retry_after_secs_env,
+        max_inflight_per_principal_flag,
+        max_inflight_per_principal_env,
     })
 }
 

--- a/tests/http_principal_inflight_cap.rs
+++ b/tests/http_principal_inflight_cap.rs
@@ -1,0 +1,143 @@
+//! Integration test for issue #934 (PRD #930): the async HTTP edge must
+//! bound any *single* principal's concurrent in-flight requests and refuse
+//! over-cap requests with a structured `429` that a client can back off on
+//! — while leaving the global cap (total backpressure) and other principals
+//! untouched.
+//!
+//! Determinism: a per-principal cap of 1 plus a slow-inject hook (the same
+//! test hook the deadline test uses) holds one request in flight long enough
+//! to fire follow-up requests against a parked permit, so no real load race
+//! is needed.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+use reddb::server::RedDBServer;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+/// Send one buffered `POST /query` carrying `Authorization: Bearer <token>`
+/// and return the full raw response text. The body is a trivial `SELECT 1`
+/// so the engine call is cheap; the slow-inject hook (not the query) is what
+/// keeps the request in flight.
+fn post_query(addr: &str, token: &str) -> String {
+    let mut tcp = TcpStream::connect(addr).expect("connect");
+    tcp.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    tcp.set_write_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let body = br#"{"query":"SELECT 1"}"#;
+    let request = format!(
+        "POST /query HTTP/1.1\r\nHost: localhost\r\nAuthorization: Bearer {token}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    tcp.write_all(request.as_bytes()).unwrap();
+    tcp.write_all(body).unwrap();
+    tcp.flush().unwrap();
+    let mut buf = Vec::new();
+    let _ = tcp.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).to_string()
+}
+
+fn boot(cap: usize, slow_ms: u64) -> (String, RedDBServer) {
+    let opts = RedDBOptions::in_memory();
+    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+    let server = RedDBServer::new(runtime).with_principal_inflight_cap(cap);
+    server.set_test_slow_inject_ms(slow_ms);
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap().to_string();
+    let bg = server.clone();
+    bg.serve_in_background_on(listener);
+    thread::sleep(Duration::from_millis(80));
+    (addr, server)
+}
+
+#[test]
+fn over_cap_principal_gets_structured_429_others_unaffected_then_recovers() {
+    // cap=1 per principal; each request parks ~700ms in flight.
+    let (addr, server) = boot(1, 700);
+
+    // Fire request A for principal `alice` in the background; it acquires
+    // the single per-principal slot and holds it while the slow-inject
+    // sleeps inside the engine call.
+    let addr_a = addr.clone();
+    let a = thread::spawn(move || post_query(&addr_a, "alice-token"));
+
+    // Wait until A is actually in flight (its permit is held). One
+    // principal tracked == A occupies its slot.
+    let mut in_flight = false;
+    for _ in 0..200 {
+        if server.principal_limiter().tracked_principals() >= 1 {
+            in_flight = true;
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(in_flight, "request A should be in flight holding its slot");
+
+    // Request B for the SAME principal must be refused: alice is at her
+    // cap of 1. Structured 429 with Retry-After and the backoff fields.
+    let b = post_query(&addr, "alice-token");
+    assert!(
+        b.starts_with("HTTP/1.1 429"),
+        "over-cap same-principal request must be 429, got: {b:?}"
+    );
+    assert!(
+        b.to_ascii_lowercase().contains("retry-after:"),
+        "refusal must carry Retry-After, got: {b:?}"
+    );
+    assert!(
+        b.contains("principal_inflight_exhausted"),
+        "refusal must carry the structured code, got: {b:?}"
+    );
+    assert!(
+        b.contains("\"limit\":1"),
+        "refusal must report the principal's limit, got: {b:?}"
+    );
+
+    // Request C for a DIFFERENT principal shares no budget with alice and
+    // must be admitted (it routes normally — any non-429 from the limiter).
+    let c = post_query(&addr, "bob-token");
+    assert!(
+        !c.starts_with("HTTP/1.1 429"),
+        "a different principal must not be throttled by alice's cap, got: {c:?}"
+    );
+
+    // A completes; alice's slot frees. The metric counter saw exactly the
+    // one refusal (B) — C and D were admitted, not refused.
+    let _ = a.join().unwrap();
+    assert_eq!(
+        server.principal_limiter().rejected_total(),
+        1,
+        "exactly one over-cap refusal expected"
+    );
+
+    // Recovery: with alice's slot drained, a fresh alice request is
+    // admitted again (not a limiter 429).
+    let d = post_query(&addr, "alice-token");
+    assert!(
+        !d.starts_with("HTTP/1.1 429"),
+        "alice should be admitted again after her slot drained, got: {d:?}"
+    );
+}
+
+#[test]
+fn disabled_cap_admits_unlimited_concurrency_per_principal() {
+    // cap=0 disables the per-principal gate entirely; many concurrent
+    // requests for one principal all get through (bounded only by the
+    // global cap, which is the default and far above this handful).
+    let (addr, _server) = boot(0, 300);
+
+    let mut handles = Vec::new();
+    for _ in 0..6 {
+        let addr = addr.clone();
+        handles.push(thread::spawn(move || post_query(&addr, "same-token")));
+    }
+    for h in handles {
+        let resp = h.join().unwrap();
+        assert!(
+            !resp.starts_with("HTTP/1.1 429"),
+            "disabled per-principal cap must not throttle, got: {resp:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Issue
Closes #934 — Abuse defense: per-principal caps + async backpressure (replace 256 thread cap). Parent PRD #930.

## What changed
#931 retired the thread-per-connection HTTP backend and its `(2*num_cpus).clamp(8,256)` cap. That cap had bounded **both** total concurrency **and** any single caller's share of it (a greedy client could only hold as many slots as it held OS threads). The async edge admits per in-flight request against one global `HttpConnectionLimiter` — that bounds *total* in-flight work (async backpressure) but no longer bounds any *single* principal's share, so one abusive caller could drain the global cap and starve everyone.

This PR restores the per-caller bound as a first-class control:

- **`PrincipalConnectionLimiter`** (`http_principal_limiter.rs`): `AtomicU64`-counted per-principal in-flight tracking, O(1) acquire/release via an RAII permit, map entry evicted at zero (no unbounded growth under churn), rejection counter. `cap=0` disables it (single-tenant opt-out, zero map traffic).
- **Edge enforcement** (`axum_edge`): global admission first (server-wide 503 backpressure), then per-principal admission keyed by `principal_for()`. Over-cap callers get a structured **429** carrying `{code, message, limit, current, principal}` + `Retry-After` so clients back off precisely. Shares the refusal shape with the stream-capacity refusal; principal label emitted through the tainted-field escape so a hostile header can't break out of the JSON string.
- **Operator knob** `max_inflight_per_principal` wired through flag > red_config > env > default (default 64); new `http_handler_rejected_total{reason="principal_cap_exhausted"}` metric series.

The per-principal **rate** cap (`QuotaBucket`) and async backpressure already landed; this adds the missing per-principal **connection** cap. ADR 0029 stream caps (ADR 0035) still apply.

## Acceptance criteria
- [x] Per-principal connection/rate caps enforced; over-cap connections get a structured refusal.
- [x] Async backpressure bounds in-flight work without an OS-thread cap.
- [x] Tests cover cap enforcement and structured refusal.

## Tests
- 7 limiter unit (disabled-cap, admit-to-cap, drop-frees-slot, isolation, eviction, concurrent-race never over-issues, clone-shares-state) — pass
- 10 `http_limits` resolve + refusal-shape unit (structured backoff shape, tainted-principal escape) — pass
- 2 edge integration (`http_principal_inflight_cap`): over-cap 429 / isolation / recovery; disabled-cap passthrough — pass
- `cargo fmt --check` clean on all changed files.

Note: pre-existing crate-wide clippy debt (`erasing_op` in `integration_turboquant_blocked_layout`, `f64::consts::PI` in tdigest/csv/expr) is unrelated to this change — none of the touched files are implicated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783061574&installation_id=129708444&pr_number=953&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F953&signature=84dbcf47a4492c6e6a29c9079055181e7c1473ee7965870fd95936373301acb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-principal concurrent in-flight HTTP request rate limiting to prevent resource exhaustion. Configurable via `--http-max-inflight-per-principal` CLI flag, `REDDB_HTTP_MAX_INFLIGHT_PER_PRINCIPAL` environment variable, or configuration file (default: 64 requests per principal; set to 0 to disable). Requests exceeding the limit receive HTTP 429 responses with structured retry guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->