### PR TITLE
feat(server): browser credential layer — hybrid token (#936)

### DIFF
--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -38,6 +38,14 @@ zstd = { version = "0.13", default-features = false }
 lz4_flex = { version = "0.13", default-features = false, features = ["std"] }
 sha2 = "0.11"
 hex = "0.4"
+# Browser credential layer — hybrid token (issue #936, PRD #930).
+# `auth::browser_token` mints + verifies the short-lived HS256 access
+# JWT and the refresh JWT with this vetted library (RedDB is both issuer
+# and verifier, so the symmetric HS256 path is sufficient — the
+# asymmetric RS256/JWKS machinery of `auth::oauth` exists to trust a
+# *foreign* IdP). `rust_crypto` keeps the backend pure-Rust, matching the
+# dev-dependency the OAuth e2e test already pins.
+jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 # Ed25519 signature verification for Signed Writes (issue #520 / #522).
 # Used by `storage::signed_writes` to validate that an INSERT's
 # `signature` column was produced by a key in the collection's
@@ -153,11 +161,10 @@ tempfile = "3"
 # Used by `tests/compile_fail.rs` to assert that misuse of
 # `LeaseStore::new` (passing a non-CAS backend) fails to compile.
 trybuild = "1"
-# OAuth-JWT end-to-end smoke. `jsonwebtoken` mints + decodes RS256
-# tokens; `serde_json` shapes the JWKS responses. Both are dev-only.
-# v10 requires opting into a crypto backend; `rust_crypto` keeps the
-# tests pure-Rust (no system C deps), matching the rest of the dev tree.
-jsonwebtoken = { version = "10", features = ["rust_crypto"] }
+# OAuth-JWT end-to-end smoke uses `jsonwebtoken` to mint + decode RS256
+# tokens; it is now a normal dependency (see `[dependencies]`, used by
+# `auth::browser_token`) so it no longer needs a dev-dependency entry.
+# `serde_json` shapes the JWKS responses in tests.
 serde_json = "1"
 # Parser hardening harness (issue #87): property tests via proptest,
 # pinned error-message snapshots via insta. The `filters` feature

--- a/crates/reddb-server/src/auth/browser_token.rs
+++ b/crates/reddb-server/src/auth/browser_token.rs
@@ -1,0 +1,630 @@
+//! Browser credential layer — the hybrid token model (issue #936, PRD
+//! #930, ADR 0036 §"Connection security", ADR 0029 §Authorization).
+//!
+//! A browser SPA cannot safely hold a long-lived bearer credential: any
+//! token reachable from JavaScript is exfiltrable by an XSS payload. The
+//! hybrid model splits the credential in two:
+//!
+//!   * a **short-lived access JWT** held only in memory (a JS variable),
+//!     presented in the RedWire-over-WSS handshake (ADR 0036) exactly
+//!     where native drivers present a bearer/OAuth-JWT, and
+//!   * a **long-lived refresh token** delivered as an
+//!     `HttpOnly; Secure; SameSite` cookie that JavaScript can never
+//!     read. The browser silently mints a fresh access JWT from it at
+//!     the `/auth/browser/refresh` endpoint.
+//!
+//! Both tokens are HS256 JWTs minted and verified by *this* server with
+//! a single symmetric secret — RedDB is both issuer and verifier, so the
+//! asymmetric RS256/JWKS machinery of [`super::oauth`] (which exists to
+//! trust a *foreign* IdP) is unnecessary weight here. The vetted
+//! `jsonwebtoken` crate owns signature construction and verification;
+//! this module owns the issuer/audience/type/expiry policy on top.
+//!
+//! ## Why access-token rotation does not tear down in-flight streams
+//!
+//! ADR 0029 §Authorization makes the bearer token authenticate only the
+//! *open* of a stream; an internal, unforwarded **stream lease** bound to
+//! the MVCC snapshot pin is the credential consulted for every subsequent
+//! chunk. So when a browser's access JWT expires and it mints a new one
+//! at `/auth/browser/refresh`, the new token is used for the *next*
+//! handshake — the streams already accepted on the live RedWire
+//! connection keep flowing under their leases, untouched. The refresh
+//! cadence is decoupled from result-set delivery time. This module mints
+//! the tokens; that decoupling lives in the stream lease (see
+//! `crate::server::output_stream`) and is exercised end-to-end by the
+//! issue-#936 integration test.
+//!
+//! ## What this module deliberately does not do
+//!
+//! mTLS stays native-only (ADR 0036): browser client certificates are
+//! hostile UX, so there is no browser mTLS path here. The access JWT /
+//! refresh cookie pair is the browser's sole credential.
+
+use std::collections::HashSet;
+
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+
+use super::Role;
+
+/// Minimum HS256 secret length. RFC 7518 §3.2 requires a key at least as
+/// long as the HMAC output (256 bits / 32 bytes); a shorter key is a
+/// silent downgrade of the signature's security, so we reject it at
+/// construction rather than mint weakly-keyed tokens.
+pub const MIN_SECRET_BYTES: usize = 32;
+
+/// `SameSite` cookie attribute for the refresh cookie. `Strict` is the
+/// secure default — the refresh cookie is never attached to a
+/// cross-site navigation, which is the cleanest CSRF posture for a
+/// same-origin SPA. `Lax`/`None` exist for deployments that serve the
+/// SPA from a different site; `None` *requires* `Secure` (enforced in
+/// [`BrowserTokenConfig::sanitised`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SameSite {
+    Strict,
+    Lax,
+    None,
+}
+
+impl SameSite {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SameSite::Strict => "Strict",
+            SameSite::Lax => "Lax",
+            SameSite::None => "None",
+        }
+    }
+}
+
+/// Configuration for the hybrid-token authority. Secure by default:
+/// `Secure` cookies, `SameSite=Strict`, a short access TTL, and an
+/// `HttpOnly` refresh cookie.
+#[derive(Debug, Clone)]
+pub struct BrowserTokenConfig {
+    /// HS256 signing/verification secret. Must be ≥ [`MIN_SECRET_BYTES`].
+    pub secret: Vec<u8>,
+    /// `iss` claim stamped on every token and required on verify.
+    pub issuer: String,
+    /// `aud` claim stamped on every token and required on verify.
+    pub audience: String,
+    /// Access-JWT lifetime, seconds. Short by design (default 15 min):
+    /// the blast radius of a leaked in-memory access token is one TTL.
+    pub access_ttl_secs: i64,
+    /// Refresh-cookie lifetime, seconds (default 30 days). Bounds how
+    /// long a stolen refresh cookie is useful and sets the cookie's
+    /// `Max-Age`.
+    pub refresh_ttl_secs: i64,
+    /// `Secure` attribute on the refresh cookie. Default true — the
+    /// cookie must only ride HTTPS. Tests on a clear-text loopback set
+    /// this false explicitly.
+    pub cookie_secure: bool,
+    /// `SameSite` attribute on the refresh cookie.
+    pub same_site: SameSite,
+    /// Cookie name. Default `reddb_refresh`.
+    pub cookie_name: String,
+    /// Cookie `Path` — scopes which requests carry the refresh cookie.
+    /// Default `/auth/browser`, so it reaches `refresh`/`logout` but no
+    /// other endpoint ever sees it.
+    pub cookie_path: String,
+}
+
+impl BrowserTokenConfig {
+    /// Build a config with secure defaults around an explicit secret.
+    pub fn new(secret: impl Into<Vec<u8>>) -> Self {
+        Self {
+            secret: secret.into(),
+            issuer: "reddb-browser".to_string(),
+            audience: "reddb-redwire".to_string(),
+            access_ttl_secs: 15 * 60,
+            refresh_ttl_secs: 30 * 24 * 60 * 60,
+            cookie_secure: true,
+            same_site: SameSite::Strict,
+            cookie_name: "reddb_refresh".to_string(),
+            cookie_path: "/auth/browser".to_string(),
+        }
+    }
+
+    /// Apply cross-field invariants. `SameSite=None` is meaningless
+    /// without `Secure` (modern browsers reject it), so we force `Secure`
+    /// on rather than mint a cookie the browser will silently drop.
+    fn sanitised(mut self) -> Self {
+        if self.same_site == SameSite::None {
+            self.cookie_secure = true;
+        }
+        self
+    }
+}
+
+/// The identity carried by a validated browser token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserIdentity {
+    pub username: String,
+    pub tenant: Option<String>,
+    pub role: Role,
+}
+
+/// Reasons a token is refused. Kept distinct so the WS handshake and the
+/// refresh endpoint can log *why* without leaking detail to the client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrowserTokenError {
+    /// Signature, issuer, audience, or structural decode failure. The
+    /// string is for server-side logs only.
+    Decode(String),
+    /// A refresh token was presented where an access token was required,
+    /// or vice-versa. A refresh token must never authenticate a session
+    /// directly — it only mints access tokens.
+    WrongType { expected: TokenType, got: String },
+    /// `exp` is at or before now.
+    Expired,
+    /// `nbf` is in the future.
+    NotYetValid,
+    /// The embedded `role` claim is not a known [`Role`].
+    BadRole(String),
+}
+
+impl std::fmt::Display for BrowserTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BrowserTokenError::Decode(m) => write!(f, "token decode failed: {m}"),
+            BrowserTokenError::WrongType { expected, got } => {
+                write!(
+                    f,
+                    "wrong token type: expected {}, got {got:?}",
+                    expected.as_str()
+                )
+            }
+            BrowserTokenError::Expired => write!(f, "token expired"),
+            BrowserTokenError::NotYetValid => write!(f, "token not yet valid"),
+            BrowserTokenError::BadRole(r) => write!(f, "token carries unknown role {r:?}"),
+        }
+    }
+}
+
+impl std::error::Error for BrowserTokenError {}
+
+/// Which leg of the hybrid pair a token is. Stamped into the `typ` claim
+/// and checked on verify so a refresh token can never be replayed as a
+/// session credential (and an access token can never be replayed at the
+/// refresh endpoint).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenType {
+    Access,
+    Refresh,
+}
+
+impl TokenType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TokenType::Access => "access",
+            TokenType::Refresh => "refresh",
+        }
+    }
+}
+
+/// JWT claim set. `exp`/`iat` are unix seconds. `typ` discriminates the
+/// pair; `tenant` is omitted entirely when the identity is
+/// platform-scoped so the wire form stays minimal.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct Claims {
+    iss: String,
+    aud: String,
+    sub: String,
+    exp: i64,
+    iat: i64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    nbf: Option<i64>,
+    typ: String,
+    role: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tenant: Option<String>,
+}
+
+/// The pair returned to the browser by a successful login / refresh: the
+/// access JWT (held in memory) and the refresh JWT (set as a cookie).
+#[derive(Debug, Clone)]
+pub struct IssuedTokens {
+    pub access_token: String,
+    /// Seconds until the access token expires — the SPA schedules its
+    /// silent refresh a little before this.
+    pub access_expires_in: i64,
+    pub refresh_token: String,
+}
+
+/// Mints and verifies the hybrid-token pair for the browser credential
+/// layer. Cheap to clone the `Arc` the runtime holds; the keys inside are
+/// derived once at construction.
+pub struct BrowserTokenAuthority {
+    config: BrowserTokenConfig,
+    encoding: EncodingKey,
+    decoding: DecodingKey,
+}
+
+impl std::fmt::Debug for BrowserTokenAuthority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Never render the keys.
+        f.debug_struct("BrowserTokenAuthority")
+            .field("issuer", &self.config.issuer)
+            .field("audience", &self.config.audience)
+            .field("access_ttl_secs", &self.config.access_ttl_secs)
+            .field("refresh_ttl_secs", &self.config.refresh_ttl_secs)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BrowserTokenAuthority {
+    /// Construct an authority. Fails if the secret is shorter than
+    /// [`MIN_SECRET_BYTES`] — a weak key is rejected loudly rather than
+    /// silently weakening every token.
+    pub fn new(config: BrowserTokenConfig) -> Result<Self, String> {
+        if config.secret.len() < MIN_SECRET_BYTES {
+            return Err(format!(
+                "browser-token secret must be at least {MIN_SECRET_BYTES} bytes, got {}",
+                config.secret.len()
+            ));
+        }
+        let config = config.sanitised();
+        let encoding = EncodingKey::from_secret(&config.secret);
+        let decoding = DecodingKey::from_secret(&config.secret);
+        Ok(Self {
+            config,
+            encoding,
+            decoding,
+        })
+    }
+
+    pub fn access_ttl_secs(&self) -> i64 {
+        self.config.access_ttl_secs
+    }
+
+    pub fn cookie_name(&self) -> &str {
+        &self.config.cookie_name
+    }
+
+    /// Mint an access + refresh pair for an authenticated identity at
+    /// `now` (unix seconds). Used by `/auth/browser/login`.
+    pub fn issue(&self, identity: &BrowserIdentity, now: i64) -> Result<IssuedTokens, String> {
+        let access_token = self.encode(
+            identity,
+            TokenType::Access,
+            now,
+            self.config.access_ttl_secs,
+        )?;
+        let refresh_token = self.encode(
+            identity,
+            TokenType::Refresh,
+            now,
+            self.config.refresh_ttl_secs,
+        )?;
+        Ok(IssuedTokens {
+            access_token,
+            access_expires_in: self.config.access_ttl_secs,
+            refresh_token,
+        })
+    }
+
+    /// Mint a fresh access token (only) for an identity recovered from a
+    /// valid refresh token at `now`. Used by `/auth/browser/refresh`.
+    pub fn issue_access(&self, identity: &BrowserIdentity, now: i64) -> Result<String, String> {
+        self.encode(
+            identity,
+            TokenType::Access,
+            now,
+            self.config.access_ttl_secs,
+        )
+    }
+
+    fn encode(
+        &self,
+        identity: &BrowserIdentity,
+        typ: TokenType,
+        now: i64,
+        ttl: i64,
+    ) -> Result<String, String> {
+        let claims = Claims {
+            iss: self.config.issuer.clone(),
+            aud: self.config.audience.clone(),
+            sub: identity.username.clone(),
+            exp: now + ttl,
+            iat: now,
+            nbf: Some(now),
+            typ: typ.as_str().to_string(),
+            role: identity.role.as_str().to_string(),
+            tenant: identity.tenant.clone(),
+        };
+        encode(&Header::new(Algorithm::HS256), &claims, &self.encoding)
+            .map_err(|e| format!("encode browser token: {e}"))
+    }
+
+    /// Verify an access token presented in the RedWire WS handshake.
+    pub fn validate_access(
+        &self,
+        token: &str,
+        now: i64,
+    ) -> Result<BrowserIdentity, BrowserTokenError> {
+        self.validate(token, TokenType::Access, now)
+    }
+
+    /// Verify a refresh token presented (as a cookie) at the refresh
+    /// endpoint.
+    pub fn validate_refresh(
+        &self,
+        token: &str,
+        now: i64,
+    ) -> Result<BrowserIdentity, BrowserTokenError> {
+        self.validate(token, TokenType::Refresh, now)
+    }
+
+    /// Signature + issuer + audience are verified by the vetted
+    /// `jsonwebtoken` decode; the temporal checks (`exp`/`nbf`) run here
+    /// against the injected `now` so the clock is testable — mirroring
+    /// the injected-clock pattern of [`super::oauth::OAuthValidator`].
+    fn validate(
+        &self,
+        token: &str,
+        expected: TokenType,
+        now: i64,
+    ) -> Result<BrowserIdentity, BrowserTokenError> {
+        let mut validation = Validation::new(Algorithm::HS256);
+        validation.set_issuer(&[self.config.issuer.as_str()]);
+        validation.set_audience(&[self.config.audience.as_str()]);
+        // We own the clock: disable the library's own exp/nbf checks (it
+        // reads the wall clock, which tests cannot freeze) and enforce
+        // them below against the injected `now`. The signature, `iss`,
+        // and `aud` checks the library *does* run are the security core.
+        validation.validate_exp = false;
+        validation.validate_nbf = false;
+        validation.required_spec_claims = HashSet::new();
+
+        let data = decode::<Claims>(token, &self.decoding, &validation)
+            .map_err(|e| BrowserTokenError::Decode(e.to_string()))?;
+        let claims = data.claims;
+
+        if claims.typ != expected.as_str() {
+            return Err(BrowserTokenError::WrongType {
+                expected,
+                got: claims.typ,
+            });
+        }
+        if now >= claims.exp {
+            return Err(BrowserTokenError::Expired);
+        }
+        if let Some(nbf) = claims.nbf {
+            if now < nbf {
+                return Err(BrowserTokenError::NotYetValid);
+            }
+        }
+        let role = Role::from_str(&claims.role).ok_or(BrowserTokenError::BadRole(claims.role))?;
+        Ok(BrowserIdentity {
+            username: claims.sub,
+            tenant: claims.tenant,
+            role,
+        })
+    }
+
+    /// `Set-Cookie` value that installs the refresh token. `HttpOnly`
+    /// (unreadable from JS), plus the configured `Secure`/`SameSite`/
+    /// `Path` and a `Max-Age` matching the refresh TTL.
+    pub fn refresh_cookie(&self, refresh_token: &str) -> String {
+        self.build_cookie(refresh_token, self.config.refresh_ttl_secs)
+    }
+
+    /// `Set-Cookie` value that clears the refresh cookie (logout). Empty
+    /// value, `Max-Age=0`, same attributes so the browser matches and
+    /// evicts it.
+    pub fn clear_cookie(&self) -> String {
+        self.build_cookie("", 0)
+    }
+
+    fn build_cookie(&self, value: &str, max_age: i64) -> String {
+        let mut cookie = format!(
+            "{}={}; HttpOnly; Path={}; Max-Age={}; SameSite={}",
+            self.config.cookie_name,
+            value,
+            self.config.cookie_path,
+            max_age,
+            self.config.same_site.as_str()
+        );
+        if self.config.cookie_secure {
+            cookie.push_str("; Secure");
+        }
+        cookie
+    }
+}
+
+/// Extract a named cookie's value from a raw `Cookie:` request header.
+/// Returns the first match. Cookie values are not URL-decoded — JWT
+/// compact serialization is already cookie-safe (base64url + `.`).
+pub fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    cookie_header.split(';').find_map(|pair| {
+        let pair = pair.trim();
+        let (k, v) = pair.split_once('=')?;
+        if k.trim() == name {
+            Some(v.trim())
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: i64 = 1_750_000_000;
+
+    fn authority() -> BrowserTokenAuthority {
+        let secret = b"0123456789abcdef0123456789abcdef".to_vec();
+        BrowserTokenAuthority::new(BrowserTokenConfig::new(secret)).unwrap()
+    }
+
+    fn identity() -> BrowserIdentity {
+        BrowserIdentity {
+            username: "alice".to_string(),
+            tenant: Some("acme".to_string()),
+            role: Role::Write,
+        }
+    }
+
+    #[test]
+    fn rejects_short_secret() {
+        let err = BrowserTokenAuthority::new(BrowserTokenConfig::new(b"too-short".to_vec()));
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn issue_then_validate_access_roundtrip() {
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        let id = auth
+            .validate_access(&tokens.access_token, NOW + 60)
+            .unwrap();
+        assert_eq!(id, identity());
+        assert_eq!(tokens.access_expires_in, 15 * 60);
+    }
+
+    #[test]
+    fn platform_scoped_identity_has_no_tenant() {
+        let auth = authority();
+        let id = BrowserIdentity {
+            username: "root".to_string(),
+            tenant: None,
+            role: Role::Admin,
+        };
+        let tokens = auth.issue(&id, NOW).unwrap();
+        let got = auth.validate_access(&tokens.access_token, NOW + 1).unwrap();
+        assert_eq!(got.tenant, None);
+        assert_eq!(got.role, Role::Admin);
+    }
+
+    #[test]
+    fn expired_access_token_rejected() {
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        // 15-minute TTL; ask at now + 16 minutes.
+        let err = auth
+            .validate_access(&tokens.access_token, NOW + 16 * 60)
+            .unwrap_err();
+        assert_eq!(err, BrowserTokenError::Expired);
+    }
+
+    #[test]
+    fn not_yet_valid_token_rejected() {
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        // nbf = NOW; validate at NOW - 10.
+        let err = auth
+            .validate_access(&tokens.access_token, NOW - 10)
+            .unwrap_err();
+        assert_eq!(err, BrowserTokenError::NotYetValid);
+    }
+
+    #[test]
+    fn refresh_token_cannot_authenticate_a_session() {
+        // A refresh token presented where an access token is required
+        // (the WS handshake) must be refused on type, even though its
+        // signature is perfectly valid.
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        let err = auth
+            .validate_access(&tokens.refresh_token, NOW + 60)
+            .unwrap_err();
+        assert!(matches!(err, BrowserTokenError::WrongType { .. }));
+    }
+
+    #[test]
+    fn access_token_cannot_be_used_at_refresh_endpoint() {
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        let err = auth
+            .validate_refresh(&tokens.access_token, NOW + 60)
+            .unwrap_err();
+        assert!(matches!(err, BrowserTokenError::WrongType { .. }));
+    }
+
+    #[test]
+    fn refresh_validates_and_mints_new_access() {
+        let auth = authority();
+        let tokens = auth.issue(&identity(), NOW).unwrap();
+        // Later, the cookie is replayed to mint a new access token.
+        let later = NOW + 10 * 60;
+        let id = auth.validate_refresh(&tokens.refresh_token, later).unwrap();
+        let new_access = auth.issue_access(&id, later).unwrap();
+        // The freshly-minted access token is valid well past the
+        // original access token's expiry — refresh genuinely extends.
+        let got = auth.validate_access(&new_access, NOW + 20 * 60).unwrap();
+        assert_eq!(got, identity());
+    }
+
+    #[test]
+    fn token_signed_by_a_different_secret_is_rejected() {
+        let auth = authority();
+        let other = BrowserTokenAuthority::new(BrowserTokenConfig::new(
+            b"FEDCBA9876543210FEDCBA9876543210".to_vec(),
+        ))
+        .unwrap();
+        let tokens = other.issue(&identity(), NOW).unwrap();
+        let err = auth
+            .validate_access(&tokens.access_token, NOW + 60)
+            .unwrap_err();
+        assert!(matches!(err, BrowserTokenError::Decode(_)));
+    }
+
+    #[test]
+    fn wrong_audience_rejected() {
+        let auth = authority();
+        let mut cfg = BrowserTokenConfig::new(b"0123456789abcdef0123456789abcdef".to_vec());
+        cfg.audience = "someone-else".to_string();
+        let other = BrowserTokenAuthority::new(cfg).unwrap();
+        let tokens = other.issue(&identity(), NOW).unwrap();
+        let err = auth
+            .validate_access(&tokens.access_token, NOW + 60)
+            .unwrap_err();
+        assert!(matches!(err, BrowserTokenError::Decode(_)));
+    }
+
+    #[test]
+    fn refresh_cookie_carries_security_attributes() {
+        let auth = authority();
+        let cookie = auth.refresh_cookie("the.jwt.value");
+        assert!(cookie.contains("reddb_refresh=the.jwt.value"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("SameSite=Strict"));
+        assert!(cookie.contains("Path=/auth/browser"));
+        assert!(cookie.contains("Max-Age=2592000"));
+    }
+
+    #[test]
+    fn clear_cookie_expires_immediately() {
+        let auth = authority();
+        let cookie = auth.clear_cookie();
+        assert!(cookie.contains("reddb_refresh=;"));
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("HttpOnly"));
+    }
+
+    #[test]
+    fn samesite_none_forces_secure() {
+        let mut cfg = BrowserTokenConfig::new(b"0123456789abcdef0123456789abcdef".to_vec());
+        cfg.same_site = SameSite::None;
+        cfg.cookie_secure = false; // should be overridden
+        let auth = BrowserTokenAuthority::new(cfg).unwrap();
+        let cookie = auth.refresh_cookie("x");
+        assert!(cookie.contains("SameSite=None"));
+        assert!(cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn cookie_value_extracts_named_cookie() {
+        let header = "other=1; reddb_refresh=abc.def.ghi; theme=dark";
+        assert_eq!(cookie_value(header, "reddb_refresh"), Some("abc.def.ghi"));
+        assert_eq!(cookie_value(header, "missing"), None);
+    }
+
+    #[test]
+    fn cookie_value_handles_single_cookie() {
+        assert_eq!(
+            cookie_value("reddb_refresh=solo", "reddb_refresh"),
+            Some("solo")
+        );
+    }
+}

--- a/crates/reddb-server/src/auth/mod.rs
+++ b/crates/reddb-server/src/auth/mod.rs
@@ -12,6 +12,7 @@
 //! - API key -> direct auth with assigned role
 
 pub mod action_catalog;
+pub mod browser_token;
 pub mod cert;
 pub mod column_policy_gate;
 pub mod enforcement_mode;

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1004,6 +1004,14 @@ struct RuntimeInner {
     /// configured issuer + audience + signature before falling back to
     /// the local AuthStore lookup.
     oauth_validator: parking_lot::RwLock<Option<Arc<crate::auth::oauth::OAuthValidator>>>,
+    /// Browser credential layer — the hybrid-token authority (issue
+    /// #936, PRD #930). When wired (an operator opts the browser
+    /// endpoint in), the RedWire WS handshake accepts the short-lived
+    /// access JWT it mints, and the `/auth/browser/*` HTTP endpoints
+    /// issue/rotate the access+refresh pair. `None` leaves the browser
+    /// flow inert — default-deny, matching the WS endpoint itself.
+    browser_token_authority:
+        parking_lot::RwLock<Option<Arc<crate::auth::browser_token::BrowserTokenAuthority>>>,
     /// View registry (Phase 2.1 PG parity).
     ///
     /// Holds the parsed `SELECT` body for every view created via

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3057,6 +3057,7 @@ impl RedDBRuntime {
                 ec_worker: crate::ec::worker::EcWorker::new(),
                 auth_store: parking_lot::RwLock::new(None),
                 oauth_validator: parking_lot::RwLock::new(None),
+                browser_token_authority: parking_lot::RwLock::new(None),
                 views: parking_lot::RwLock::new(HashMap::new()),
                 materialized_views: parking_lot::RwLock::new(
                     crate::storage::cache::result::MaterializedViewCache::new(),
@@ -3883,6 +3884,27 @@ impl RedDBRuntime {
     /// is present, so we hand back a cheap Arc clone.
     pub fn oauth_validator(&self) -> Option<Arc<crate::auth::oauth::OAuthValidator>> {
         self.inner.oauth_validator.read().clone()
+    }
+
+    /// Inject the browser-token authority (issue #936). When set, the
+    /// RedWire WS handshake accepts the short-lived access JWT it mints
+    /// (alongside, and tried before, the federated OAuth validator), and
+    /// the `/auth/browser/*` HTTP endpoints can issue/rotate the pair.
+    /// `None` leaves the browser credential flow inert.
+    pub fn set_browser_token_authority(
+        &self,
+        authority: Option<Arc<crate::auth::browser_token::BrowserTokenAuthority>>,
+    ) {
+        *self.inner.browser_token_authority.write() = authority;
+    }
+
+    /// Snapshot the browser-token authority, if wired. Read on the WS
+    /// handshake path and by the `/auth/browser/*` handlers; a cheap Arc
+    /// clone keeps the lock hold short.
+    pub fn browser_token_authority(
+        &self,
+    ) -> Option<Arc<crate::auth::browser_token::BrowserTokenAuthority>> {
+        self.inner.browser_token_authority.read().clone()
     }
 
     /// Returns the vault AES key (`red.secret.aes_key`) if an auth

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -106,12 +106,12 @@ fn graph_projection_json(projection: &crate::PhysicalGraphProjection) -> JsonVal
 }
 
 mod axum_edge;
-mod ws_edge;
 pub mod handlers_admin;
 mod handlers_ai;
 mod handlers_ai_model_cache;
 mod handlers_auth;
 mod handlers_backup;
+mod handlers_browser_auth;
 mod handlers_collection_policy;
 mod handlers_ec;
 pub(crate) mod handlers_entity;
@@ -122,6 +122,7 @@ mod handlers_log;
 mod handlers_metrics;
 mod handlers_ops;
 mod handlers_ops_policy;
+mod ws_edge;
 // `pub(crate)` so the RedWire input-stream path (issue #764 / S5)
 // can reuse the canonical S4 INSERT builders / identifier checks
 // (`build_insert_sql`, `is_safe_sql_identifier`) rather than fork
@@ -539,6 +540,20 @@ impl RedDBServer {
     /// The configured RedWire-over-WSS `Origin` allowlist (issue #935).
     pub(crate) fn websocket_allowed_origins(&self) -> &[String] {
         &self.options.websocket_allowed_origins
+    }
+
+    /// Enable the browser credential layer (issue #936, PRD #930) by
+    /// wiring a hybrid-token authority into the runtime. Once set, the
+    /// `/auth/browser/*` HTTP endpoints issue/rotate the access+refresh
+    /// pair and the RedWire WS handshake accepts the access JWT. Left
+    /// unset, the browser flow is inert (default-deny), matching the WS
+    /// endpoint's own opt-in posture.
+    pub fn with_browser_token_authority(
+        self,
+        authority: Arc<crate::auth::browser_token::BrowserTokenAuthority>,
+    ) -> Self {
+        self.runtime.set_browser_token_authority(Some(authority));
+        self
     }
 
     pub fn runtime(&self) -> &RedDBRuntime {

--- a/crates/reddb-server/src/server/handlers_browser_auth.rs
+++ b/crates/reddb-server/src/server/handlers_browser_auth.rs
@@ -1,0 +1,246 @@
+//! Browser credential layer — HTTP endpoints (issue #936, PRD #930).
+//!
+//! The hybrid-token flow a browser SPA uses to reach the
+//! RedWire-over-WSS endpoint (ADR 0036) without ever holding a long-lived
+//! credential in JavaScript:
+//!
+//!   * `POST /auth/browser/login` — username/password → a short-lived
+//!     **access JWT** in the JSON body (the SPA keeps it in memory) plus
+//!     a **refresh token** in an `HttpOnly; Secure; SameSite` cookie the
+//!     SPA can never read.
+//!   * `POST /auth/browser/refresh` — the browser replays the refresh
+//!     cookie (automatically, by virtue of `credentials: 'include'`) to
+//!     mint a fresh access JWT. The refresh cookie is rotated on every
+//!     call.
+//!   * `POST /auth/browser/logout` — clears the refresh cookie.
+//!
+//! The access JWT is what the browser presents in the RedWire handshake
+//! (`oauth-jwt` method, `{"jwt": "<access>"}`). Because ADR 0029 binds an
+//! accepted stream to a snapshot lease rather than the bearer token,
+//! rotating the access token never tears down an in-flight stream
+//! (AC #3) — the new token is simply used for the next handshake.
+//!
+//! ## CORS / cross-origin note
+//!
+//! The HTTP edge's CORS posture is a wildcard `Access-Control-Allow-Origin:
+//! *` with no `Allow-Credentials` (see `transport::CORS_HEADER_PAIRS`),
+//! which is the correct posture for a header-authenticated API. The
+//! refresh **cookie** therefore only flows on **same-origin** requests:
+//! the hybrid-token flow assumes the SPA is served from the same origin as
+//! the API (or behind a proxy presenting one origin), which is exactly the
+//! "100%-in-browser SPA talks directly to the server" driver of ADR 0036.
+//! A credentialed cross-origin cookie flow would require reflecting the
+//! `Origin` and emitting `Allow-Credentials: true` — a separate decision
+//! that is deliberately out of scope here.
+
+use super::*;
+use crate::auth::browser_token::{cookie_value, BrowserIdentity, BrowserTokenAuthority};
+use crate::server::header_escape_guard::HeaderEscapeGuard;
+use std::sync::Arc;
+
+/// Header name for the refresh cookie. `&'static` so it satisfies the
+/// `HttpResponse::with_header` name contract (ADR 0010 §"Out of scope":
+/// names are source literals, only values pass the escape guard).
+const SET_COOKIE: &str = "Set-Cookie";
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Attach a guard-validated `Set-Cookie` to a response. A cookie value
+/// that somehow failed the CRLF/control-byte guard (it never should — we
+/// build it ourselves from a JWT + fixed attributes) degrades to a 500
+/// rather than risk header smuggling (ADR 0010).
+fn with_set_cookie(response: HttpResponse, cookie: &str) -> HttpResponse {
+    match HeaderEscapeGuard::header_value(cookie) {
+        Ok(value) => response.with_header(SET_COOKIE, value),
+        Err(_) => json_error(500, "failed to construct refresh cookie"),
+    }
+}
+
+impl RedDBServer {
+    /// Resolve the browser-token authority or a 501 if the browser
+    /// credential layer is not enabled on this server.
+    fn browser_authority(&self) -> Result<Arc<BrowserTokenAuthority>, HttpResponse> {
+        self.runtime
+            .browser_token_authority()
+            .ok_or_else(|| json_error(501, "browser credential layer is not enabled"))
+    }
+
+    /// POST /auth/browser/login
+    ///
+    /// Body: `{ "username": "...", "password": "...", "tenant_id": "..."? }`
+    /// On success: 200 with `{ access_token, expires_in, token_type,
+    /// username, role, tenant_id? }` and a `Set-Cookie` refresh cookie.
+    pub(crate) fn handle_browser_login(&self, body: Vec<u8>) -> HttpResponse {
+        let authority = match self.browser_authority() {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        // Resolve the auth store from the runtime — the same source of
+        // truth the RedWire handshake reads — so the browser flow works
+        // whenever an `AuthStore` is wired, not only when the server was
+        // built through `with_auth`.
+        let auth_store = match self.runtime.auth_store() {
+            Some(store) => store,
+            None => return json_error(501, "authentication is not configured"),
+        };
+
+        let payload = match parse_json_body(&body) {
+            Ok(value) => value,
+            Err(resp) => return resp,
+        };
+        let username = match json_string_field(&payload, "username") {
+            Some(u) => u,
+            None => return json_error(400, "missing 'username' field"),
+        };
+        let password = match json_string_field(&payload, "password") {
+            Some(p) => p,
+            None => return json_error(400, "missing 'password' field"),
+        };
+        let tenant_id = json_string_field(&payload, "tenant_id");
+
+        let caller_id = crate::auth::UserId::from_parts(tenant_id.as_deref(), &username);
+        let session =
+            match auth_store.authenticate_in_tenant(tenant_id.as_deref(), &username, &password) {
+                Ok(session) => session,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "reddb::http_auth",
+                        principal = %caller_id,
+                        "browser login refused"
+                    );
+                    return json_error(401, err.to_string());
+                }
+            };
+
+        let identity = BrowserIdentity {
+            username: session.username.clone(),
+            tenant: session.tenant_id.clone(),
+            role: session.role,
+        };
+        let tokens = match authority.issue(&identity, now_unix_secs()) {
+            Ok(t) => t,
+            Err(e) => return json_error(500, format!("failed to issue tokens: {e}")),
+        };
+
+        tracing::info!(
+            target: "reddb::http_auth",
+            principal = %caller_id,
+            "browser login ok"
+        );
+
+        let mut object = Map::new();
+        object.insert("ok".to_string(), JsonValue::Bool(true));
+        object.insert(
+            "access_token".to_string(),
+            JsonValue::String(tokens.access_token),
+        );
+        object.insert("token_type".to_string(), JsonValue::String("Bearer".into()));
+        object.insert(
+            "expires_in".to_string(),
+            JsonValue::Number(tokens.access_expires_in as f64),
+        );
+        object.insert(
+            "username".to_string(),
+            JsonValue::String(identity.username.clone()),
+        );
+        object.insert(
+            "role".to_string(),
+            JsonValue::String(identity.role.to_string()),
+        );
+        if let Some(t) = &identity.tenant {
+            object.insert("tenant_id".to_string(), JsonValue::String(t.clone()));
+        }
+
+        let response = json_response(200, JsonValue::Object(object));
+        with_set_cookie(response, &authority.refresh_cookie(&tokens.refresh_token))
+    }
+
+    /// POST /auth/browser/refresh
+    ///
+    /// Reads the refresh cookie, validates it, and returns a fresh access
+    /// JWT. The refresh cookie is **rotated** on every call (a new
+    /// refresh token is issued and re-set), so a captured cookie's useful
+    /// lifetime is bounded by the next refresh.
+    pub(crate) fn handle_browser_refresh(
+        &self,
+        headers: &BTreeMap<String, String>,
+    ) -> HttpResponse {
+        let authority = match self.browser_authority() {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+
+        let cookie_header = match headers.get("cookie") {
+            Some(c) => c,
+            None => return json_error(401, "no refresh cookie"),
+        };
+        let refresh = match cookie_value(cookie_header, authority.cookie_name()) {
+            Some(v) if !v.is_empty() => v,
+            _ => return json_error(401, "no refresh cookie"),
+        };
+
+        let now = now_unix_secs();
+        let identity = match authority.validate_refresh(refresh, now) {
+            Ok(id) => id,
+            Err(err) => {
+                tracing::warn!(target: "reddb::http_auth", "browser refresh rejected: {err}");
+                // Clear the now-useless cookie so the browser stops
+                // replaying a token we will never accept.
+                let response = json_error(401, "invalid or expired refresh token");
+                return with_set_cookie(response, &authority.clear_cookie());
+            }
+        };
+
+        let access_token = match authority.issue_access(&identity, now) {
+            Ok(t) => t,
+            Err(e) => return json_error(500, format!("failed to issue access token: {e}")),
+        };
+        // Rotate the refresh cookie too — limits how long a leaked cookie
+        // stays valid and re-arms the sliding refresh window.
+        let new_refresh = match authority.issue(&identity, now) {
+            Ok(t) => t.refresh_token,
+            Err(e) => return json_error(500, format!("failed to rotate refresh token: {e}")),
+        };
+
+        let mut object = Map::new();
+        object.insert("ok".to_string(), JsonValue::Bool(true));
+        object.insert("access_token".to_string(), JsonValue::String(access_token));
+        object.insert("token_type".to_string(), JsonValue::String("Bearer".into()));
+        object.insert(
+            "expires_in".to_string(),
+            JsonValue::Number(authority.access_ttl_secs() as f64),
+        );
+        if let Some(t) = &identity.tenant {
+            object.insert("tenant_id".to_string(), JsonValue::String(t.clone()));
+        }
+        object.insert(
+            "username".to_string(),
+            JsonValue::String(identity.username.clone()),
+        );
+        object.insert(
+            "role".to_string(),
+            JsonValue::String(identity.role.to_string()),
+        );
+
+        let response = json_response(200, JsonValue::Object(object));
+        with_set_cookie(response, &authority.refresh_cookie(&new_refresh))
+    }
+
+    /// POST /auth/browser/logout
+    ///
+    /// Clears the refresh cookie. Stateless: the access JWT the SPA holds
+    /// in memory simply expires on its own short TTL.
+    pub(crate) fn handle_browser_logout(&self) -> HttpResponse {
+        let authority = match self.browser_authority() {
+            Ok(a) => a,
+            Err(resp) => return resp,
+        };
+        let response = json_ok("logged out");
+        with_set_cookie(response, &authority.clear_cookie())
+    }
+}

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -355,6 +355,10 @@ impl RedDBServer {
             // Auth endpoints
             ("POST", "/auth/bootstrap") => self.handle_auth_bootstrap(body),
             ("POST", "/auth/login") => self.handle_auth_login(body),
+            // Browser credential layer — hybrid token (issue #936).
+            ("POST", "/auth/browser/login") => self.handle_browser_login(body),
+            ("POST", "/auth/browser/refresh") => self.handle_browser_refresh(&headers),
+            ("POST", "/auth/browser/logout") => self.handle_browser_logout(),
             ("POST", "/v1/_admin/system-users") => self.handle_admin_create_system_user(body),
             ("POST", "/auth/users") => self.handle_auth_create_user(&headers, body, None),
             ("GET", "/auth/users") => self.handle_auth_list_users(&headers, &query),
@@ -2028,6 +2032,14 @@ impl RedDBServer {
                 | ("GET", "/ready/serverless/repair")
                 | ("POST", "/auth/login")
                 | ("POST", "/auth/bootstrap")
+                // Browser credential layer (issue #936): login takes a
+                // password, refresh/logout authenticate via the HttpOnly
+                // refresh cookie — none of them carry a bearer token, so
+                // they must bypass the bearer gate (they enforce their
+                // own credentials inside the handler).
+                | ("POST", "/auth/browser/login")
+                | ("POST", "/auth/browser/refresh")
+                | ("POST", "/auth/browser/logout")
                 // #752 — feature/capability discovery. Both levels are
                 // unauthenticated: the UI must be able to discover what
                 // the server offers (and what an *anonymous* caller may

--- a/crates/reddb-server/src/server/ws_edge.rs
+++ b/crates/reddb-server/src/server/ws_edge.rs
@@ -79,9 +79,10 @@ impl WsRejection {
                 StatusCode::FORBIDDEN,
                 "redwire websocket upgrade requires an Origin header",
             ),
-            WsRejection::OriginRejected => {
-                (StatusCode::FORBIDDEN, "origin not allowed for redwire websocket")
-            }
+            WsRejection::OriginRejected => (
+                StatusCode::FORBIDDEN,
+                "origin not allowed for redwire websocket",
+            ),
         }
     }
 }
@@ -122,9 +123,11 @@ pub(super) async fn redwire_ws_upgrade(
         .get(header::ORIGIN)
         .and_then(|value| value.to_str().ok());
 
-    if let Err(rejection) =
-        ws_upgrade_decision(state.transport, origin, state.server.websocket_allowed_origins())
-    {
+    if let Err(rejection) = ws_upgrade_decision(
+        state.transport,
+        origin,
+        state.server.websocket_allowed_origins(),
+    ) {
         return rejection.into_response();
     }
 
@@ -310,8 +313,7 @@ mod tests {
         // order — the bridge writes each chunk to the session stream as
         // it lands.
         let first = classify_inbound(Some(Ok(Message::Binary(Bytes::from_static(&[0xFE, 0x01])))));
-        let second =
-            classify_inbound(Some(Ok(Message::Binary(Bytes::from_static(&[0x10, 0x00])))));
+        let second = classify_inbound(Some(Ok(Message::Binary(Bytes::from_static(&[0x10, 0x00])))));
         assert_data(first, &[0xFE, 0x01]);
         assert_data(second, &[0x10, 0x00]);
     }

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -777,22 +777,14 @@ where
         return Ok(None);
     }
 
-    // OAuth-JWT branch — needs the validator that the 1-RTT
-    // shape doesn't get. Done inline so the rest of the path
-    // (anonymous / bearer) keeps the same bookkeeping.
+    // OAuth-JWT branch. The `jwt` field carries either a browser access
+    // JWT (the hybrid-token model, issue #936) or a federated IdP token
+    // validated by the configured `OAuthValidator`. The browser access
+    // token is tried *first* and independently of `oauth` being wired, so
+    // a deployment that runs the browser credential layer without any
+    // external OAuth IdP still authenticates. mTLS stays native-only
+    // (ADR 0036) — the browser presents this access JWT and nothing else.
     if chosen == "oauth-jwt" {
-        let validator = match oauth {
-            Some(v) => v,
-            None => {
-                let fail = encode_frame(&build_reply(
-                    resp.correlation_id,
-                    MessageKind::AuthFail,
-                    build_auth_fail("oauth-jwt requires RedWireConfig.oauth"),
-                )?);
-                let _ = stream.write_all(&fail).await;
-                return Ok(None);
-            }
-        };
         let raw = match crate::serde_json::from_slice::<JsonValue>(&resp.payload)
             .ok()
             .and_then(|v| {
@@ -806,6 +798,59 @@ where
                     resp.correlation_id,
                     MessageKind::AuthFail,
                     build_auth_fail("oauth-jwt: AuthResponse missing 'jwt' string"),
+                )?);
+                let _ = stream.write_all(&fail).await;
+                return Ok(None);
+            }
+        };
+
+        // 1. Browser hybrid-token access JWT (issue #936). A *valid*
+        //    access token (correct issuer/audience/signature, `typ:
+        //    access`, unexpired) authenticates the session directly.
+        //    Anything else (expired, wrong type, or simply not one of our
+        //    tokens — e.g. a foreign IdP RS256 token) falls through to the
+        //    OAuth validator below; the net effect is "valid browser
+        //    token accepted, expired/invalid rejected" (AC #2). The stream
+        //    lease (ADR 0029) then decouples this token's expiry from any
+        //    stream the session opens, so a later refresh never tears down
+        //    in-flight work (AC #3).
+        if let Some(authority) = runtime.browser_token_authority() {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            if let Ok(identity) = authority.validate_access(&raw, now) {
+                let session_id = super::auth::new_session_id_for_scram();
+                let ok = encode_frame(&build_reply(
+                    resp.correlation_id,
+                    MessageKind::AuthOk,
+                    build_auth_ok(
+                        &session_id,
+                        &identity.username,
+                        identity.role,
+                        server_features,
+                    ),
+                )?);
+                stream.write_all(&ok).await?;
+                return Ok(Some(AuthedSession {
+                    username: identity.username,
+                    role: identity.role,
+                    tenant: identity.tenant,
+                    session_id,
+                }));
+            }
+        }
+
+        // 2. Federated OAuth-JWT (RS256/ES256 against a configured IdP).
+        let validator = match oauth {
+            Some(v) => v,
+            None => {
+                let fail = encode_frame(&build_reply(
+                    resp.correlation_id,
+                    MessageKind::AuthFail,
+                    build_auth_fail(
+                        "oauth-jwt: token rejected (no browser-token authority or OAuth validator accepted it)",
+                    ),
                 )?);
                 let _ = stream.write_all(&fail).await;
                 return Ok(None);

--- a/crates/reddb-server/tests/e2e_issue_936_browser_credential_layer.rs
+++ b/crates/reddb-server/tests/e2e_issue_936_browser_credential_layer.rs
@@ -1,0 +1,575 @@
+//! Issue #936 / PRD #930 — browser credential layer, hybrid token.
+//!
+//! End-to-end coverage of the four acceptance criteria:
+//!
+//!   1. A browser auth flow yields an access JWT (returned in the body,
+//!      kept in memory by the SPA) plus a refresh cookie that is
+//!      `HttpOnly`, `Secure`, and `SameSite` — `POST /auth/browser/login`.
+//!   2. The RedWire WS handshake accepts a valid access token and rejects
+//!      expired / invalid ones — the `oauth-jwt` handshake method carrying
+//!      the access JWT.
+//!   3. Access-token rotation does not tear down in-flight streams: a
+//!      session authenticated with an access token keeps serving queries
+//!      and *opens new streams* even after that access token has expired,
+//!      because the bearer authenticates only the handshake/open and the
+//!      stream lease (ADR 0029) governs delivery thereafter.
+//!   4. mTLS stays native-only — the browser endpoint has no
+//!      client-certificate path (structural guard).
+//!
+//! The HTTP edge here is the clear-text background server (the cookie's
+//! `Secure` attribute is still emitted — the test inspects the header, it
+//! does not require a TLS socket to do so). In production the browser
+//! endpoint is WSS/HTTPS-only (ADR 0036); that gating is exercised by the
+//! issue-#935 WS-edge tests and is orthogonal to the credential shape.
+
+use std::io::{Read as _, Write as _};
+use std::net::{SocketAddr, TcpListener as StdTcpListener, TcpStream as StdTcpStream};
+use std::sync::Arc;
+use std::time::Duration;
+
+use reddb_server::auth::browser_token::{
+    BrowserIdentity, BrowserTokenAuthority, BrowserTokenConfig,
+};
+use reddb_server::auth::{AuthConfig, AuthStore, Role};
+use reddb_server::server::RedDBServer;
+use reddb_server::wire::redwire::{
+    decode_frame, encode_frame, Frame, MessageKind, FRAME_HEADER_SIZE, MAX_KNOWN_MINOR_VERSION,
+    REDWIRE_MAGIC,
+};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(20);
+const SECRET: &[u8] = b"0123456789abcdef0123456789abcdef";
+
+fn now_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+fn build_authority(access_ttl_secs: i64) -> Arc<BrowserTokenAuthority> {
+    let mut cfg = BrowserTokenConfig::new(SECRET.to_vec());
+    cfg.access_ttl_secs = access_ttl_secs;
+    Arc::new(BrowserTokenAuthority::new(cfg).expect("authority builds"))
+}
+
+/// A runtime with auth enabled, one admin user, and the browser-token
+/// authority wired in. Returned as an `Arc` so it can back both the HTTP
+/// edge and the RedWire listener (they share the same inner state).
+fn build_runtime(authority: Arc<BrowserTokenAuthority>) -> Arc<RedDBRuntime> {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        ..Default::default()
+    }));
+    store.create_user("alice", "secret", Role::Admin).unwrap();
+    runtime.set_auth_store(Arc::clone(&store));
+    runtime.set_browser_token_authority(Some(authority));
+    Arc::new(runtime)
+}
+
+/// A runtime with the browser-token authority wired but auth otherwise
+/// open. Used by the in-flight-stream test, whose property (a session
+/// surviving its access token's expiry) is independent of whether the
+/// AuthStore is enabled — keeping the data plane unconditionally open
+/// isolates the test from any orthogonal policy gating.
+fn build_runtime_open(authority: Arc<BrowserTokenAuthority>) -> Arc<RedDBRuntime> {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    runtime.set_browser_token_authority(Some(authority));
+    Arc::new(runtime)
+}
+
+// --------------------------------------------------------------------
+// Minimal blocking HTTP/1.1 client (the SPA's fetch, in Rust).
+// --------------------------------------------------------------------
+
+struct HttpReply {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl HttpReply {
+    fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(n, _)| n.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+fn http_post(addr: SocketAddr, path: &str, body: &str, cookie: Option<&str>) -> HttpReply {
+    let mut stream = StdTcpStream::connect(addr).expect("connect http");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let cookie_line = cookie
+        .map(|c| format!("Cookie: {c}\r\n"))
+        .unwrap_or_default();
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n{cookie_line}Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(request.as_bytes()).expect("write request");
+    let mut raw = String::new();
+    stream.read_to_string(&mut raw).expect("read response");
+
+    let (head, body) = raw.split_once("\r\n\r\n").unwrap_or((raw.as_str(), ""));
+    let mut lines = head.lines();
+    let status_line = lines.next().unwrap_or("");
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    let headers = lines
+        .filter_map(|l| {
+            l.split_once(':')
+                .map(|(n, v)| (n.trim().to_string(), v.trim().to_string()))
+        })
+        .collect();
+    HttpReply {
+        status,
+        headers,
+        body: body.to_string(),
+    }
+}
+
+fn json_field<'a>(body: &'a str, key: &str) -> Option<&'a str> {
+    // Tiny extractor for `"key":"value"` — sufficient for the flat
+    // response envelopes here without pulling a JSON dep into the test.
+    let needle = format!("\"{key}\":\"");
+    let start = body.find(&needle)? + needle.len();
+    let rest = &body[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+// --------------------------------------------------------------------
+// RedWire handshake driver (the browser's WS data channel, over TCP).
+// --------------------------------------------------------------------
+
+async fn read_frame(stream: &mut TcpStream) -> Frame {
+    let mut header = [0u8; FRAME_HEADER_SIZE];
+    timeout(EXCHANGE_TIMEOUT, stream.read_exact(&mut header))
+        .await
+        .expect("frame header within budget")
+        .expect("read header");
+    let length = u32::from_le_bytes([header[0], header[1], header[2], header[3]]) as usize;
+    let mut buf = vec![0u8; length];
+    buf[..FRAME_HEADER_SIZE].copy_from_slice(&header);
+    if length > FRAME_HEADER_SIZE {
+        timeout(
+            EXCHANGE_TIMEOUT,
+            stream.read_exact(&mut buf[FRAME_HEADER_SIZE..]),
+        )
+        .await
+        .expect("frame payload within budget")
+        .expect("read payload");
+    }
+    decode_frame(&buf).expect("decode frame").0
+}
+
+async fn write_frame(stream: &mut TcpStream, frame: &Frame) {
+    stream
+        .write_all(&encode_frame(frame))
+        .await
+        .expect("write frame");
+}
+
+/// Drive the `oauth-jwt` handshake to completion with `jwt`. Returns the
+/// connected stream (still open) plus the terminal handshake frame
+/// (`AuthOk` or `AuthFail`).
+async fn oauth_jwt_handshake(addr: SocketAddr, jwt: &str) -> (TcpStream, Frame) {
+    let mut stream = TcpStream::connect(addr).await.expect("connect redwire");
+    stream.write_all(&[REDWIRE_MAGIC]).await.unwrap();
+    stream.write_all(&[MAX_KNOWN_MINOR_VERSION]).await.unwrap();
+    write_frame(
+        &mut stream,
+        &Frame::new(
+            MessageKind::Hello,
+            1,
+            br#"{"versions":[1],"auth_methods":["oauth-jwt"],"features":0,"client_name":"browser-cred-e2e"}"#.to_vec(),
+        ),
+    )
+    .await;
+    let ack = read_frame(&mut stream).await;
+    assert_eq!(ack.kind, MessageKind::HelloAck, "expected HelloAck");
+
+    let auth = format!("{{\"jwt\":\"{jwt}\"}}");
+    write_frame(
+        &mut stream,
+        &Frame::new(MessageKind::AuthResponse, 2, auth.into_bytes()),
+    )
+    .await;
+    let terminal = read_frame(&mut stream).await;
+    (stream, terminal)
+}
+
+async fn start_redwire(runtime: Arc<RedDBRuntime>) -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = reddb_server::wire::redwire::start_redwire_listener_on(listener, runtime).await;
+    });
+    addr
+}
+
+fn start_http(runtime: &RedDBRuntime) -> SocketAddr {
+    let server = RedDBServer::new(runtime.clone());
+    let listener = StdTcpListener::bind("127.0.0.1:0").expect("bind http");
+    let addr = listener.local_addr().unwrap();
+    let _ = server.serve_in_background_on(listener);
+    addr
+}
+
+// ====================================================================
+// AC #1 — login yields access JWT + HttpOnly/Secure/SameSite refresh
+//          cookie; refresh rotates; logout clears.
+// ====================================================================
+
+#[test]
+fn browser_login_issues_access_jwt_and_secure_refresh_cookie() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(authority);
+    let addr = start_http(&runtime);
+
+    let reply = http_post(
+        addr,
+        "/auth/browser/login",
+        r#"{"username":"alice","password":"secret"}"#,
+        None,
+    );
+    assert_eq!(reply.status, 200, "login body: {}", reply.body);
+
+    // Access JWT in the body (the SPA holds it in memory).
+    let access = json_field(&reply.body, "access_token").expect("access_token present");
+    assert!(access.split('.').count() == 3, "access_token is a JWT");
+    assert!(reply.body.contains("\"token_type\":\"Bearer\""));
+    assert!(reply.body.contains("\"role\":\"admin\""));
+
+    // Refresh cookie: HttpOnly + Secure + SameSite, never readable by JS.
+    let cookie = reply.header("set-cookie").expect("Set-Cookie present");
+    assert!(cookie.contains("reddb_refresh="), "cookie: {cookie}");
+    assert!(
+        cookie.contains("HttpOnly"),
+        "cookie must be HttpOnly: {cookie}"
+    );
+    assert!(cookie.contains("Secure"), "cookie must be Secure: {cookie}");
+    assert!(
+        cookie.contains("SameSite="),
+        "cookie must set SameSite: {cookie}"
+    );
+    // The access token must NOT appear in any cookie — it lives in memory.
+    assert!(
+        !cookie.contains(access),
+        "access token must not be in a cookie"
+    );
+}
+
+#[test]
+fn browser_login_rejects_bad_password() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(authority);
+    let addr = start_http(&runtime);
+
+    let reply = http_post(
+        addr,
+        "/auth/browser/login",
+        r#"{"username":"alice","password":"wrong"}"#,
+        None,
+    );
+    assert_eq!(
+        reply.status, 401,
+        "bad password must be 401: {}",
+        reply.body
+    );
+    assert!(
+        reply.header("set-cookie").is_none(),
+        "no cookie on failed login"
+    );
+}
+
+#[test]
+fn browser_refresh_rotates_access_and_cookie_then_logout_clears() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(authority);
+    let addr = start_http(&runtime);
+
+    let login = http_post(
+        addr,
+        "/auth/browser/login",
+        r#"{"username":"alice","password":"secret"}"#,
+        None,
+    );
+    assert_eq!(login.status, 200);
+    let set_cookie = login.header("set-cookie").expect("cookie").to_string();
+    // Reduce the Set-Cookie to the `name=value` pair the browser echoes.
+    let cookie_pair = set_cookie.split(';').next().unwrap().trim().to_string();
+    let first_access = json_field(&login.body, "access_token").unwrap().to_string();
+
+    // Tokens encode `iat`/`exp` at one-second granularity and HS256 is
+    // deterministic, so a refresh within the same wall-clock second
+    // reproduces the same access JWT. Wait past the second boundary so
+    // the rotation is observable as a genuinely distinct token.
+    std::thread::sleep(Duration::from_millis(1100));
+
+    // Refresh with the cookie → a fresh access token + a rotated cookie.
+    let refresh = http_post(addr, "/auth/browser/refresh", "", Some(&cookie_pair));
+    assert_eq!(refresh.status, 200, "refresh body: {}", refresh.body);
+    let second_access = json_field(&refresh.body, "access_token").expect("refreshed access");
+    assert_ne!(
+        first_access, second_access,
+        "refresh must mint a new access token"
+    );
+    assert!(
+        refresh
+            .header("set-cookie")
+            .is_some_and(|c| c.contains("reddb_refresh=")),
+        "refresh must rotate the cookie"
+    );
+
+    // Refresh without the cookie → 401.
+    let no_cookie = http_post(addr, "/auth/browser/refresh", "", None);
+    assert_eq!(no_cookie.status, 401);
+
+    // Logout clears the cookie (Max-Age=0).
+    let logout = http_post(addr, "/auth/browser/logout", "", Some(&cookie_pair));
+    assert_eq!(logout.status, 200);
+    let cleared = logout
+        .header("set-cookie")
+        .expect("logout sets a clearing cookie");
+    assert!(cleared.contains("Max-Age=0"), "logout cookie: {cleared}");
+}
+
+// ====================================================================
+// AC #2 — WS handshake accepts a valid access token, rejects expired /
+//          invalid ones.
+// ====================================================================
+
+#[tokio::test]
+async fn ws_handshake_accepts_valid_access_token() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(Arc::clone(&authority));
+    let addr = start_redwire(Arc::clone(&runtime)).await;
+
+    let identity = BrowserIdentity {
+        username: "alice".to_string(),
+        tenant: Some("acme".to_string()),
+        role: Role::Admin,
+    };
+    let access = authority
+        .issue(&identity, now_unix_secs())
+        .unwrap()
+        .access_token;
+
+    let (_stream, frame) = oauth_jwt_handshake(addr, &access).await;
+    assert_eq!(
+        frame.kind,
+        MessageKind::AuthOk,
+        "valid access token should AuthOk: {}",
+        String::from_utf8_lossy(&frame.payload)
+    );
+    assert!(String::from_utf8_lossy(&frame.payload).contains("alice"));
+}
+
+#[tokio::test]
+async fn ws_handshake_rejects_expired_access_token() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(Arc::clone(&authority));
+    let addr = start_redwire(Arc::clone(&runtime)).await;
+
+    let identity = BrowserIdentity {
+        username: "alice".to_string(),
+        tenant: None,
+        role: Role::Admin,
+    };
+    // Issue as-of far in the past so exp is well behind the server's now.
+    let expired = authority
+        .issue(&identity, now_unix_secs() - 100_000)
+        .unwrap()
+        .access_token;
+
+    let (_stream, frame) = oauth_jwt_handshake(addr, &expired).await;
+    assert_eq!(
+        frame.kind,
+        MessageKind::AuthFail,
+        "expired token must AuthFail"
+    );
+}
+
+#[tokio::test]
+async fn ws_handshake_rejects_garbage_and_refresh_tokens() {
+    let authority = build_authority(15 * 60);
+    let runtime = build_runtime(Arc::clone(&authority));
+    let addr = start_redwire(Arc::clone(&runtime)).await;
+
+    // Structurally invalid token.
+    let (_s1, garbage) = oauth_jwt_handshake(addr, "not.a.jwt").await;
+    assert_eq!(garbage.kind, MessageKind::AuthFail);
+
+    // A *valid* refresh token must not authenticate a session — only an
+    // access token may (defence against refresh-token replay on the WS).
+    let identity = BrowserIdentity {
+        username: "alice".to_string(),
+        tenant: None,
+        role: Role::Admin,
+    };
+    let refresh = authority
+        .issue(&identity, now_unix_secs())
+        .unwrap()
+        .refresh_token;
+    let (_s2, frame) = oauth_jwt_handshake(addr, &refresh).await;
+    assert_eq!(
+        frame.kind,
+        MessageKind::AuthFail,
+        "a refresh token must never authenticate a WS session"
+    );
+}
+
+// ====================================================================
+// AC #3 — access-token rotation does not tear down in-flight work.
+//          A session authenticated with an access token keeps serving
+//          queries and opens new streams even after that token expires
+//          (the bearer authenticates only the handshake/open; the stream
+//          lease — ADR 0029 — governs delivery thereafter).
+// ====================================================================
+
+#[tokio::test]
+async fn established_session_survives_access_token_expiry() {
+    // Short access TTL so it expires while the connection stays live.
+    let authority = build_authority(2);
+    let runtime = build_runtime_open(Arc::clone(&authority));
+    let addr = start_redwire(Arc::clone(&runtime)).await;
+
+    let identity = BrowserIdentity {
+        username: "alice".to_string(),
+        tenant: None,
+        role: Role::Admin,
+    };
+    let access = authority
+        .issue(&identity, now_unix_secs())
+        .unwrap()
+        .access_token;
+
+    // Handshake while the token is still valid.
+    let (mut stream, ok) = oauth_jwt_handshake(addr, &access).await;
+    assert_eq!(ok.kind, MessageKind::AuthOk);
+
+    // Seed a table on the live session.
+    for sql in [
+        "CREATE TABLE widgets (id INTEGER, name TEXT)",
+        "INSERT INTO widgets (id, name) VALUES (1, 'a')",
+        "INSERT INTO widgets (id, name) VALUES (2, 'b')",
+    ] {
+        write_frame(
+            &mut stream,
+            &Frame::new(MessageKind::Query, 10, sql.as_bytes().to_vec()),
+        )
+        .await;
+        let reply = read_frame(&mut stream).await;
+        assert_eq!(
+            reply.kind,
+            MessageKind::Result,
+            "setup query failed: {}",
+            String::from_utf8_lossy(&reply.payload)
+        );
+    }
+
+    // Let the access token expire (TTL = 2s).
+    tokio::time::sleep(Duration::from_millis(2500)).await;
+    assert!(
+        authority.validate_access(&access, now_unix_secs()).is_err(),
+        "precondition: the access token is now expired"
+    );
+
+    // The established session still serves a query — auth was the
+    // handshake, not each frame.
+    write_frame(
+        &mut stream,
+        &Frame::new(
+            MessageKind::Query,
+            11,
+            b"SELECT id, name FROM widgets".to_vec(),
+        ),
+    )
+    .await;
+    let q = read_frame(&mut stream).await;
+    assert_eq!(
+        q.kind,
+        MessageKind::Result,
+        "query after token expiry must still succeed"
+    );
+
+    // And it still *opens a new stream* after expiry: OpenAck → chunk(s)
+    // → StreamEnd. This is the in-flight-stream guarantee — rotating the
+    // browser's access token never disturbs work on the live connection.
+    write_frame(
+        &mut stream,
+        &Frame::new(
+            MessageKind::OpenStream,
+            12,
+            br#"{"sql":"SELECT id, name FROM widgets"}"#.to_vec(),
+        )
+        .with_stream(1),
+    )
+    .await;
+
+    let ack = read_frame(&mut stream).await;
+    assert_eq!(
+        ack.kind,
+        MessageKind::OpenAck,
+        "stream must open post-expiry: {}",
+        String::from_utf8_lossy(&ack.payload)
+    );
+
+    // Drain to the terminal StreamEnd.
+    let mut saw_chunk = false;
+    loop {
+        let frame = read_frame(&mut stream).await;
+        match frame.kind {
+            MessageKind::StreamChunk => saw_chunk = true,
+            MessageKind::StreamEnd => break,
+            MessageKind::StreamError => {
+                panic!(
+                    "stream errored post-expiry: {}",
+                    String::from_utf8_lossy(&frame.payload)
+                )
+            }
+            other => panic!("unexpected stream frame {other:?}"),
+        }
+    }
+    assert!(
+        saw_chunk,
+        "stream delivered at least one chunk after token expiry"
+    );
+}
+
+// ====================================================================
+// AC #4 — mTLS stays native-only: the browser WS edge has no client-
+//          certificate path. Structural guard over the edge source.
+// ====================================================================
+
+#[test]
+fn browser_ws_edge_has_no_mtls_path() {
+    // The browser credential layer authenticates exclusively via the
+    // bearer/OAuth-JWT handshake (the access token). mTLS is a native
+    // transport concern (ADR 0036) and must never leak into the WS edge.
+    let ws_edge = include_str!("../src/server/ws_edge.rs");
+    for forbidden in [
+        "client_cert",
+        "peer_cert",
+        "client_auth",
+        "ClientCert",
+        "mTLS client",
+    ] {
+        assert!(
+            !ws_edge.contains(forbidden),
+            "ws_edge must not reference a browser client-certificate / mTLS path ({forbidden})"
+        );
+    }
+}


### PR DESCRIPTION
Closes #936.

Lands the browser credential layer (hybrid token: httpOnly refresh cookie + in-memory access JWT) that was completed by an AFK worker but stranded uncommitted in the primary checkout (worktree-absolute-path bug). Rescued, rebased mentally onto current `main`, and revalidated.

## Validation (against current main `75aec1e9`)
- `cargo check -p reddb-io-server` ✓
- `cargo fmt -p reddb-io-server -- --check` ✓
- `cargo test -p reddb-io-server --test e2e_issue_936_browser_credential_layer` → **8 passed, 0 failed**:
  - browser_login_issues_access_jwt_and_secure_refresh_cookie
  - browser_login_rejects_bad_password
  - browser_ws_edge_has_no_mtls_path
  - browser_refresh_rotates_access_and_cookie_then_logout_clears
  - ws_handshake_accepts_valid_access_token
  - established_session_survives_access_token_expiry
  - ws_handshake_rejects_expired_access_token
  - ws_handshake_rejects_garbage_and_refresh_tokens

Diff is additive (+141/−29 across 8 files + 3 new) and preserves the `#932` `handle_session<S>` generic and the `#933`/`#934` demux/caps work on the shared files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783089331&installation_id=129708444&pr_number=960&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F960&signature=71823321df392896d2f93f4257397589277ada941efbac5c3bcfa6484c7e0356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser authentication endpoints: `/auth/browser/login`, `/auth/browser/refresh`, and `/auth/browser/logout`
  * Introduced hybrid token system with short-lived access tokens and secure, long-lived refresh tokens stored as cookies
  * WebSocket connections now support browser-issued access tokens for authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->