### PR TITLE
feat(leaderboard): approximate tail rank via per-(collection,score) sketch (#923)

### DIFF
--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1379,6 +1379,7 @@ pub(crate) mod retention_sweeper;
 pub(crate) mod scalar_evaluator;
 pub mod schema_diff;
 pub mod schema_vocabulary;
+pub(crate) mod score_sketch;
 pub(crate) mod sessionize;
 pub mod signed_chain;
 pub mod signed_writes_kind;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -367,6 +367,110 @@ impl RedDBRuntime {
         Ok(Some(strictly_better + 1))
     }
 
+    /// `APPROX RANK OF <id> IN <name>` — the *approximate tail* read
+    /// (issue #923 / ADR 0035). Serves an explicitly-approximate
+    /// percentile / rank for an entry below the exact top-K head from a
+    /// per-`(table, column)` score sketch.
+    ///
+    /// The result is always labeled approximate (`approximate = true`,
+    /// distinct from the exact `RANK OF` surface which returns only a bare
+    /// `rank`) so a caller never reads a tail estimate as an exact head
+    /// position. An invisible / non-existent row yields no row, exactly
+    /// like the exact surface.
+    fn execute_approx_rank_of(
+        &self,
+        raw_query: &str,
+        req: super::ranking_descriptor_catalog::ApproxRankOfRequest,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let store = self.inner.db.store();
+        let descriptor = super::ranking_descriptor_catalog::get(store.as_ref(), &req.ranking)
+            .ok_or_else(|| {
+                RedDBError::Query(format!("ranking '{}' does not exist", req.ranking))
+            })?;
+
+        let approx = self.compute_approx_rank(&descriptor, req.entity_id)?;
+        let columns = vec![
+            "rank".to_string(),
+            "percentile".to_string(),
+            "approximate".to_string(),
+        ];
+        let rows = match approx {
+            Some(approx) => vec![vec![
+                ("rank".to_string(), Value::UnsignedInteger(approx.rank)),
+                ("percentile".to_string(), Value::Float(approx.percentile)),
+                ("approximate".to_string(), Value::Boolean(true)),
+            ]],
+            None => Vec::new(),
+        };
+        Ok(RuntimeQueryResult::ok_records(
+            raw_query.to_string(),
+            columns,
+            rows,
+            "select",
+        ))
+    }
+
+    /// Refresh the per-`(table, column)` score sketch from the rows visible
+    /// to the current snapshot and return the target's approximate rank, or
+    /// `None` if the target row is invisible to this snapshot / tenant.
+    ///
+    /// The sketch is rebuilt from the live column on each read and persisted
+    /// back to `red_config` keyed by `(table, column)` — so it is maintained
+    /// per `(collection, score column)` and stays current as scores change
+    /// (criterion 4). The scan runs through `execute_query_inner`, inheriting
+    /// the same MVCC snapshot, RLS/tenant scope, and policy as ordinary
+    /// reads. The *approximation* is the histogram bucketing in
+    /// [`super::score_sketch::ScoreSketch`], not the data freshness, so the
+    /// estimate carries the documented error band even though it is built
+    /// from a full scan in this v0 (incremental maintenance is an ADR-0035
+    /// implementation detail, left open and reversible).
+    fn compute_approx_rank(
+        &self,
+        descriptor: &super::ranking_descriptor_catalog::RankingDescriptor,
+        target_id: u64,
+    ) -> RedDBResult<Option<super::score_sketch::ApproxRank>> {
+        let table = &descriptor.table;
+        let column = &descriptor.column;
+
+        // Scan the visible rows once: it both feeds the sketch and locates
+        // the target's score under the same snapshot/tenant/policy frame.
+        let scan_sql = format!("SELECT * FROM {table}");
+        let scan = self.execute_query_inner(&scan_sql)?;
+        let records = &scan.result.records;
+
+        let mut scores: Vec<f64> = Vec::with_capacity(records.len());
+        let mut target_score: Option<f64> = None;
+        for rec in records {
+            let Some(score) = record_column_f64(rec, column) else {
+                continue;
+            };
+            scores.push(score);
+            let rid = match rec.get("rid") {
+                Some(Value::UnsignedInteger(n)) => Some(*n),
+                Some(Value::Integer(n)) if *n >= 0 => Some(*n as u64),
+                _ => None,
+            };
+            if rid == Some(target_id) {
+                target_score = Some(score);
+            }
+        }
+
+        let sketch = super::score_sketch::ScoreSketch::from_scores(&scores);
+        // Persist the refreshed sketch per (table, column).
+        super::ranking_descriptor_catalog::save_sketch(
+            self.inner.db.store().as_ref(),
+            table,
+            column,
+            &sketch,
+        );
+
+        let Some(target_score) = target_score else {
+            // Not visible to this snapshot/tenant ⇒ no rank (matches exact).
+            return Ok(None);
+        };
+        Ok(sketch.approx_rank(target_score, descriptor.descending))
+    }
+
     fn execute_alter_metric(
         &self,
         raw_query: &str,
@@ -6365,6 +6469,9 @@ impl RedDBRuntime {
         }
         if super::ranking_descriptor_catalog::parse_show_rankings(query) {
             return self.execute_show_rankings(query);
+        }
+        if let Some(parsed) = super::ranking_descriptor_catalog::parse_approx_rank_of(query) {
+            return self.execute_approx_rank_of(query, parsed?);
         }
         if let Some(parsed) = super::ranking_descriptor_catalog::parse_rank_of(query) {
             return self.execute_rank_of(query, parsed?);

--- a/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
+++ b/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
@@ -68,6 +68,15 @@ pub struct RankOfRequest {
     pub ranking: String,
 }
 
+/// Parsed `APPROX RANK OF <id> IN <name>` read request — the approximate
+/// *tail* read (issue #923). Distinct statement head from the exact
+/// `RANK OF`, so the exact head surface (#918) is untouched.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApproxRankOfRequest {
+    pub entity_id: u64,
+    pub ranking: String,
+}
+
 fn now_ms() -> u128 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -253,9 +262,50 @@ pub fn parse_rank_of(sql: &str) -> Option<RedDBResult<RankOfRequest>> {
     Some(result)
 }
 
+/// Parse `APPROX RANK OF <id> IN <name>` (also `APPROXIMATE RANK OF …`).
+///
+/// Returns `None` unless the statement starts with `APPROX[IMATE] RANK OF`,
+/// so it never shadows the exact `RANK OF` head. A malformed tail returns
+/// `Some(Err(..))` for a targeted error.
+pub fn parse_approx_rank_of(sql: &str) -> Option<RedDBResult<ApproxRankOfRequest>> {
+    let tokens = tokenize(sql);
+    let approx = tokens
+        .first()
+        .is_some_and(|t| eq(t, "APPROX") || eq(t, "APPROXIMATE"));
+    if !approx
+        || !tokens.get(1).is_some_and(|t| eq(t, "RANK"))
+        || !tokens.get(2).is_some_and(|t| eq(t, "OF"))
+    {
+        return None;
+    }
+    let err = || {
+        RedDBError::Query(
+            "invalid APPROX RANK OF: expected APPROX RANK OF <id> IN <ranking-name>".to_string(),
+        )
+    };
+    let result = (|| {
+        let id_str = tokens.get(3).ok_or_else(err)?;
+        let entity_id = id_str.parse::<u64>().map_err(|_| err())?;
+        if !tokens.get(4).is_some_and(|t| eq(t, "IN")) {
+            return Err(err());
+        }
+        let ranking = tokens.get(5).ok_or_else(err)?;
+        if tokens.get(6).is_some() {
+            return Err(err());
+        }
+        Ok(ApproxRankOfRequest {
+            entity_id,
+            ranking: ranking.clone(),
+        })
+    })();
+    Some(result)
+}
+
 // ───────────────────────── persistence ─────────────────────────
 
-fn read_latest_registry_json(store: &UnifiedStore) -> Option<String> {
+/// Read the latest persisted `value` Text for an arbitrary `red_config`
+/// key (most-recent entity wins, mirroring the WAL-as-log-of-writes shape).
+fn read_latest_config_value(store: &UnifiedStore, key: &str) -> Option<String> {
     let manager = store.get_collection("red_config")?;
     let mut all = manager.query_all(|_| true);
     all.sort_by_key(|entity| std::cmp::Reverse(entity.id.raw()));
@@ -266,7 +316,7 @@ fn read_latest_registry_json(store: &UnifiedStore) -> Option<String> {
         let Some(named) = &row.named else { continue };
         let matches = matches!(
             named.get("key"),
-            Some(Value::Text(value)) if value.as_ref() == REGISTRY_KEY
+            Some(Value::Text(value)) if value.as_ref() == key
         );
         if matches {
             if let Some(Value::Text(value)) = named.get("value") {
@@ -275,6 +325,40 @@ fn read_latest_registry_json(store: &UnifiedStore) -> Option<String> {
         }
     }
     None
+}
+
+fn read_latest_registry_json(store: &UnifiedStore) -> Option<String> {
+    read_latest_config_value(store, REGISTRY_KEY)
+}
+
+/// `red_config` key for the approximate score sketch of `(table, column)`.
+/// The sketch is keyed per `(collection, score column)` (criterion 4), not
+/// per ranking name, so two rankings over the same column share one sketch.
+fn sketch_key(table: &str, column: &str) -> String {
+    format!("red.ranking.sketch.{table}.{column}")
+}
+
+/// Persist the approximate score sketch for `(table, column)`.
+pub fn save_sketch(
+    store: &UnifiedStore,
+    table: &str,
+    column: &str,
+    sketch: &super::score_sketch::ScoreSketch,
+) {
+    store.set_config_tree(
+        &sketch_key(table, column),
+        &crate::serde_json::Value::String(sketch.to_json().to_string()),
+    );
+}
+
+/// Load the persisted approximate score sketch for `(table, column)`, if any.
+pub fn load_sketch(
+    store: &UnifiedStore,
+    table: &str,
+    column: &str,
+) -> Option<super::score_sketch::ScoreSketch> {
+    let raw = read_latest_config_value(store, &sketch_key(table, column))?;
+    super::score_sketch::ScoreSketch::from_json_str(&raw)
 }
 
 fn load(store: &UnifiedStore) -> Vec<RankingDescriptor> {
@@ -443,6 +527,45 @@ mod tests {
         assert!(parse_rank_of("SELECT 1").is_none());
         // `RANK() OVER (...)` is a window projection, not the RANK OF read.
         assert!(parse_rank_of("SELECT RANK() OVER (ORDER BY s DESC) FROM t").is_none());
+    }
+
+    #[test]
+    fn parse_approx_rank_of_full() {
+        let req = parse_approx_rank_of("APPROX RANK OF 7 IN top_players")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(
+            req,
+            ApproxRankOfRequest {
+                entity_id: 7,
+                ranking: "top_players".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_approx_rank_of_accepts_long_keyword_and_is_case_insensitive() {
+        let req = parse_approx_rank_of("approximate rank of 9 in r")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(req.entity_id, 9);
+        assert_eq!(req.ranking, "r");
+    }
+
+    #[test]
+    fn parse_approx_rank_of_does_not_shadow_exact_rank_of() {
+        // The exact `RANK OF` head must not be mistaken for the approx tail.
+        assert!(parse_approx_rank_of("RANK OF 1 IN r").is_none());
+        // And the exact parser must ignore the approx head.
+        assert!(parse_rank_of("APPROX RANK OF 1 IN r").is_none());
+    }
+
+    #[test]
+    fn parse_approx_rank_of_rejects_non_numeric_id() {
+        let err = parse_approx_rank_of("APPROX RANK OF xyz IN r")
+            .expect("recognised")
+            .expect_err("bad id");
+        assert!(err.to_string().contains("APPROX RANK OF"), "{err}");
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/score_sketch.rs
+++ b/crates/reddb-server/src/runtime/score_sketch.rs
@@ -1,0 +1,334 @@
+//! Approximate score sketch for leaderboard rank — the *tail* half of the
+//! hybrid rank (issue #923 / ADR 0035).
+//!
+//! The exact, MVCC-correct rank is served only for the bounded top-K head
+//! (`ranking_descriptor_catalog` + `impl_core::compute_exact_head_rank`).
+//! For an entry below that head a leaderboard wants "you're in the top X%",
+//! not an exact position — and an exact global rank under MVCC is either
+//! wrong-semantics or expensive (ADR 0035). This module is the explicitly
+//! *approximate* aggregate that fills that gap.
+//!
+//! ## Engine: equi-width histogram
+//!
+//! ADR 0035 deliberately leaves the sketch engine (t-digest vs equi-depth
+//! histogram vs count-min) open. We pick the simplest structure that gives
+//! a *documented, testable* error band: a fixed-resolution **equi-width
+//! histogram** over `[min, max]` with [`DEFAULT_BUCKETS`] buckets.
+//!
+//! Each bucket holds the count of scores that fell in its half-open slice
+//! `[min + i·w, min + (i+1)·w)` (the top bucket is inclusive of `max`),
+//! where `w = (max − min) / B`. An approximate rank for score `s` sums the
+//! buckets strictly beyond `s`'s bucket and interpolates linearly *within*
+//! `s`'s bucket (assuming a uniform spread across the bucket width).
+//!
+//! ## Error band (documented — criterion 3)
+//!
+//! The only loss is the within-bucket interpolation, so the absolute rank
+//! error is bounded by the population of the bucket the target lands in,
+//! and therefore by the largest bucket:
+//!
+//! ```text
+//! |approx_rank(s) − exact_rank(s)|  ≤  max_i counts[i]  ≤  total
+//! ```
+//!
+//! For a distribution spread across all `B` buckets the largest bucket is
+//! ≈ `total / B`, so the error band tightens to roughly `total / B`. See
+//! [`ScoreSketch::max_bucket_count`] for the live bound and the unit tests
+//! for the empirical check against a uniform distribution.
+
+use crate::utils::json::{parse_json, JsonValue};
+
+/// Default number of histogram buckets. 256 keeps the error band at
+/// ≈ `total / 256` for a spread distribution while staying tiny to persist.
+pub const DEFAULT_BUCKETS: usize = 256;
+
+/// An approximate score distribution as an equi-width histogram.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoreSketch {
+    /// Lowest observed score.
+    min: f64,
+    /// Highest observed score.
+    max: f64,
+    /// Per-bucket counts, `counts.len()` == bucket resolution.
+    counts: Vec<u64>,
+    /// Total number of scores folded in (`sum(counts)`).
+    total: u64,
+}
+
+/// An approximate position within the ranking, derived from the sketch.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ApproxRank {
+    /// 1-based approximate rank (1 == best). Always labeled approximate by
+    /// the surface — never presented as an exact head position.
+    pub rank: u64,
+    /// Share of the population this entry ranks at-or-ahead of, in `0..=100`.
+    /// Higher means nearer the top of the board.
+    pub percentile: f64,
+}
+
+impl ScoreSketch {
+    /// Build a sketch from raw scores with [`DEFAULT_BUCKETS`] resolution.
+    pub fn from_scores(scores: &[f64]) -> Self {
+        Self::from_scores_with_buckets(scores, DEFAULT_BUCKETS)
+    }
+
+    /// Build a sketch with an explicit bucket resolution (≥ 1).
+    pub fn from_scores_with_buckets(scores: &[f64], buckets: usize) -> Self {
+        let buckets = buckets.max(1);
+        let clean: Vec<f64> = scores.iter().copied().filter(|s| s.is_finite()).collect();
+        if clean.is_empty() {
+            return Self {
+                min: 0.0,
+                max: 0.0,
+                counts: vec![0; buckets],
+                total: 0,
+            };
+        }
+        let mut min = clean[0];
+        let mut max = clean[0];
+        for &s in &clean[1..] {
+            if s < min {
+                min = s;
+            }
+            if s > max {
+                max = s;
+            }
+        }
+        let mut counts = vec![0u64; buckets];
+        for &s in &clean {
+            counts[Self::bucket_index(min, max, buckets, s)] += 1;
+        }
+        Self {
+            min,
+            max,
+            counts,
+            total: clean.len() as u64,
+        }
+    }
+
+    /// Bucket index a score falls in, clamped to `[0, buckets - 1]`.
+    fn bucket_index(min: f64, max: f64, buckets: usize, score: f64) -> usize {
+        if max <= min {
+            return 0;
+        }
+        let width = (max - min) / buckets as f64;
+        let raw = ((score - min) / width).floor();
+        if raw < 0.0 {
+            0
+        } else if raw as usize >= buckets {
+            buckets - 1
+        } else {
+            raw as usize
+        }
+    }
+
+    /// Total scores folded into the sketch.
+    pub fn total(&self) -> u64 {
+        self.total
+    }
+
+    /// The largest single-bucket population — the live absolute rank-error
+    /// bound (see the module-level error-band note).
+    pub fn max_bucket_count(&self) -> u64 {
+        self.counts.iter().copied().max().unwrap_or(0)
+    }
+
+    /// Estimated number of scores strictly *better* than `score`, where
+    /// "better" follows `descending` (higher-is-better when `true`). Sums
+    /// the buckets fully beyond `score`'s bucket and interpolates the
+    /// fraction of `score`'s own bucket that lies beyond it.
+    fn estimate_better(&self, score: f64, descending: bool) -> f64 {
+        if self.total == 0 {
+            return 0.0;
+        }
+        let buckets = self.counts.len();
+        if self.max <= self.min {
+            // Degenerate distribution: every score is equal, nobody is
+            // strictly better.
+            return 0.0;
+        }
+        let idx = Self::bucket_index(self.min, self.max, buckets, score);
+        let width = (self.max - self.min) / buckets as f64;
+        let bucket_low = self.min + idx as f64 * width;
+        let bucket_high = bucket_low + width;
+
+        let mut better = 0.0;
+        if descending {
+            // Higher is better: buckets above idx, plus the slice of idx's
+            // bucket above `score`.
+            for &c in &self.counts[idx + 1..] {
+                better += c as f64;
+            }
+            let frac_above = ((bucket_high - score) / width).clamp(0.0, 1.0);
+            better += self.counts[idx] as f64 * frac_above;
+        } else {
+            // Lower is better: buckets below idx, plus the slice below.
+            for &c in &self.counts[..idx] {
+                better += c as f64;
+            }
+            let frac_below = ((score - bucket_low) / width).clamp(0.0, 1.0);
+            better += self.counts[idx] as f64 * frac_below;
+        }
+        better
+    }
+
+    /// Approximate rank + percentile for `score`. `None` when the sketch is
+    /// empty. RANK semantics: `rank = 1 + round(scores strictly better)`,
+    /// so the best score is rank 1.
+    pub fn approx_rank(&self, score: f64, descending: bool) -> Option<ApproxRank> {
+        if self.total == 0 {
+            return None;
+        }
+        let better = self.estimate_better(score, descending).round();
+        let better = better.clamp(0.0, (self.total - 1) as f64) as u64;
+        let rank = better + 1;
+        // Share of the population this entry ranks at-or-ahead of: everyone
+        // except those strictly better. 100 == top of the board.
+        let at_or_ahead = self.total - better;
+        let percentile = (at_or_ahead as f64 / self.total as f64) * 100.0;
+        Some(ApproxRank { rank, percentile })
+    }
+
+    // ───────────────────────── persistence ─────────────────────────
+
+    /// Serialize to the compact JSON shape persisted in `red_config`.
+    pub fn to_json(&self) -> crate::serde_json::Value {
+        let mut obj = crate::serde_json::Map::new();
+        obj.insert(
+            "min".to_string(),
+            crate::serde_json::Value::Number(self.min),
+        );
+        obj.insert(
+            "max".to_string(),
+            crate::serde_json::Value::Number(self.max),
+        );
+        obj.insert(
+            "total".to_string(),
+            crate::serde_json::Value::Number(self.total as f64),
+        );
+        obj.insert(
+            "counts".to_string(),
+            crate::serde_json::Value::Array(
+                self.counts
+                    .iter()
+                    .map(|c| crate::serde_json::Value::Number(*c as f64))
+                    .collect(),
+            ),
+        );
+        crate::serde_json::Value::Object(obj)
+    }
+
+    /// Parse a sketch from its persisted JSON string. Returns `None` for
+    /// malformed input so a corrupt record degrades to "no sketch" rather
+    /// than poisoning a read.
+    pub fn from_json_str(raw: &str) -> Option<Self> {
+        let parsed = parse_json(raw).ok()?;
+        let obj = parsed.as_object()?;
+        let lookup = |k: &str| obj.iter().find(|(key, _)| key == k).map(|(_, v)| v);
+        let min = lookup("min").and_then(JsonValue::as_f64)?;
+        let max = lookup("max").and_then(JsonValue::as_f64)?;
+        let total = lookup("total").and_then(JsonValue::as_f64)? as u64;
+        let counts: Vec<u64> = lookup("counts")
+            .and_then(JsonValue::as_array)?
+            .iter()
+            .filter_map(|v| v.as_f64().map(|n| n as u64))
+            .collect();
+        if counts.is_empty() {
+            return None;
+        }
+        Some(Self {
+            min,
+            max,
+            counts,
+            total,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_sketch_has_no_rank() {
+        let sketch = ScoreSketch::from_scores(&[]);
+        assert_eq!(sketch.total(), 0);
+        assert!(sketch.approx_rank(10.0, true).is_none());
+    }
+
+    #[test]
+    fn degenerate_all_equal_ranks_first() {
+        let sketch = ScoreSketch::from_scores(&[50.0; 20]);
+        let r = sketch.approx_rank(50.0, true).expect("rank");
+        assert_eq!(r.rank, 1, "nobody is strictly better in a flat field");
+        assert!((r.percentile - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn descending_best_is_rank_one_worst_is_last() {
+        // Scores 1..=100, higher is better.
+        let scores: Vec<f64> = (1..=100).map(|n| n as f64).collect();
+        let sketch = ScoreSketch::from_scores(&scores);
+
+        let best = sketch.approx_rank(100.0, true).expect("rank");
+        assert_eq!(best.rank, 1);
+        assert!(best.percentile > 99.0, "top score sits near 100%");
+
+        let worst = sketch.approx_rank(1.0, true).expect("rank");
+        assert_eq!(worst.rank, 100, "lowest score ranks last of 100");
+    }
+
+    #[test]
+    fn ascending_lower_is_better() {
+        // Latency-style: lower is better.
+        let scores: Vec<f64> = (1..=100).map(|n| n as f64).collect();
+        let sketch = ScoreSketch::from_scores(&scores);
+        let fastest = sketch.approx_rank(1.0, false).expect("rank");
+        assert_eq!(fastest.rank, 1, "lowest score ranks first when ascending");
+        let slowest = sketch.approx_rank(100.0, false).expect("rank");
+        assert_eq!(slowest.rank, 100);
+    }
+
+    /// Criterion 3 — the estimate falls inside the documented error band
+    /// against a known (uniform) distribution.
+    #[test]
+    fn uniform_distribution_within_documented_error_band() {
+        let n = 1000u64;
+        let scores: Vec<f64> = (1..=n).map(|v| v as f64).collect();
+        let sketch = ScoreSketch::from_scores(&scores); // 256 buckets
+
+        // Documented bound: |approx − exact| ≤ max bucket population.
+        let band = sketch.max_bucket_count();
+        assert!(
+            band <= (n / DEFAULT_BUCKETS as u64) + 2,
+            "spread distribution should keep the largest bucket near total/B; got {band}"
+        );
+
+        // Check every score: exact descending rank of score v (1..=n) is
+        // (n - v + 1). The sketch estimate must stay within the band.
+        for v in 1..=n {
+            let exact = n - v + 1;
+            let approx = sketch.approx_rank(v as f64, true).expect("rank").rank;
+            let delta = exact.abs_diff(approx);
+            assert!(
+                delta <= band,
+                "score {v}: approx {approx} vs exact {exact} exceeds band {band}"
+            );
+        }
+    }
+
+    #[test]
+    fn json_round_trips() {
+        let scores: Vec<f64> = (1..=50).map(|n| n as f64 * 2.0).collect();
+        let sketch = ScoreSketch::from_scores(&scores);
+        let encoded = sketch.to_json().to_string();
+        let decoded = ScoreSketch::from_json_str(&encoded).expect("round-trip");
+        assert_eq!(decoded, sketch);
+    }
+
+    #[test]
+    fn corrupt_json_degrades_to_none() {
+        assert!(ScoreSketch::from_json_str("not json").is_none());
+        assert!(ScoreSketch::from_json_str("{\"min\":0}").is_none());
+    }
+}

--- a/crates/reddb-server/tests/leaderboard_rank_e2e.rs
+++ b/crates/reddb-server/tests/leaderboard_rank_e2e.rs
@@ -50,6 +50,40 @@ fn rank_of(rt: &RedDBRuntime, sql: &str) -> Option<u64> {
         })
 }
 
+/// An `APPROX RANK OF …` row, or `None` when the read returned no row.
+struct ApproxRow {
+    rank: u64,
+    percentile: f64,
+    approximate: bool,
+}
+
+fn approx_rank_of(rt: &RedDBRuntime, sql: &str) -> Option<ApproxRow> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  -> {e}"));
+    let rec = result.result.records.first()?;
+    let rank = match rec.get("rank") {
+        Some(Value::UnsignedInteger(n)) => *n,
+        Some(Value::Integer(n)) => *n as u64,
+        other => panic!("rank missing/typed wrong: {other:?}"),
+    };
+    let percentile = match rec.get("percentile") {
+        Some(Value::Float(f)) => *f,
+        Some(Value::Integer(n)) => *n as f64,
+        Some(Value::UnsignedInteger(n)) => *n as f64,
+        other => panic!("percentile missing/typed wrong: {other:?}"),
+    };
+    let approximate = match rec.get("approximate") {
+        Some(Value::Boolean(b)) => *b,
+        other => panic!("approximate missing/typed wrong: {other:?}"),
+    };
+    Some(ApproxRow {
+        rank,
+        percentile,
+        approximate,
+    })
+}
+
 /// Entity id (`rid`) of the row whose `name` column matches.
 fn rid_of(rt: &RedDBRuntime, table: &str, name: &str) -> u64 {
     let result = rt
@@ -305,6 +339,125 @@ fn rank_reads_honor_tenant_rls() {
         rank_of(&rt, &format!("WITHIN TENANT 'globex' RANK OF {alice} IN r")),
         None,
         "a row hidden by RLS has no rank for that tenant"
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Issue #923 — approximate tail: percentile/rank for entries below the
+// exact top-K head, served from a per-(collection, score column) sketch.
+// ══════════════════════════════════════════════════════════════════════
+
+/// Seed `n` players with score == their index (1..=n), a known uniform
+/// distribution the error band can be checked against.
+fn seed_uniform(rt: &RedDBRuntime, n: u64) {
+    exec(rt, "CREATE TABLE players (name TEXT, score INT)");
+    for v in 1..=n {
+        exec(
+            rt,
+            &format!("INSERT INTO players (name, score) VALUES ('p{v}', {v})"),
+        );
+    }
+}
+
+// ── #923 criteria 1 & 2: tail entry gets an approximate, labeled rank ──
+
+#[test]
+fn tail_entry_below_head_gets_a_labeled_approximate_rank() {
+    let rt = runtime();
+    seed_uniform(&rt, 100);
+    // Exact head of just 5: everything below rank 5 is the approximate tail.
+    exec(&rt, "CREATE RANKING r ON players (score DESC) TOP 5");
+
+    // p50 (score 50) ranks 51 exactly (50 higher scores) — well into the
+    // tail. The exact surface serves no rank for it…
+    let p50 = rid_of(&rt, "players", "p50");
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {p50} IN r")),
+        None,
+        "an entry below the top-K head has no exact rank"
+    );
+
+    // …but the approximate surface does, explicitly labeled approximate.
+    let approx = approx_rank_of(&rt, &format!("APPROX RANK OF {p50} IN r"))
+        .expect("approximate tail rank is served");
+    assert!(
+        approx.approximate,
+        "tail result must be labeled approximate, not presented as exact"
+    );
+    assert!(
+        approx.rank >= 49 && approx.rank <= 53,
+        "approx rank {} should sit near the exact 51",
+        approx.rank
+    );
+    // Percentile: ~half the field ranks at or below p50.
+    assert!(
+        (40.0..=60.0).contains(&approx.percentile),
+        "percentile {} should sit near the middle",
+        approx.percentile
+    );
+
+    // A non-existent / invisible row yields no approximate row either.
+    assert!(approx_rank_of(&rt, "APPROX RANK OF 999999 IN r").is_none());
+}
+
+// ── #923 criterion 3: estimate within the documented error band ───────
+
+#[test]
+fn approx_rank_stays_within_documented_error_band() {
+    let rt = runtime();
+    let n = 500u64;
+    seed_uniform(&rt, n);
+    exec(&rt, "CREATE RANKING r ON players (score DESC) TOP 10");
+
+    // The sketch uses 256 equi-width buckets; the documented bound is
+    // |approx − exact| ≤ max bucket population, which for this spread
+    // distribution is ≈ total/256. Allow a small slack for rounding.
+    let band = (n / 256) + 3;
+    for v in (20..=n).step_by(37) {
+        let exact = n - v + 1; // descending: v higher scores beat score v
+        let id = rid_of(&rt, "players", &format!("p{v}"));
+        let approx = approx_rank_of(&rt, &format!("APPROX RANK OF {id} IN r"))
+            .expect("approx rank")
+            .rank;
+        let delta = exact.abs_diff(approx);
+        assert!(
+            delta <= band,
+            "score {v}: approx {approx} vs exact {exact} exceeds band {band}"
+        );
+    }
+}
+
+// ── #923 criterion 4: sketch is per-(table,column) & tracks score changes ──
+
+#[test]
+fn approx_rank_tracks_score_changes() {
+    let rt = runtime();
+    seed_uniform(&rt, 100);
+    exec(&rt, "CREATE RANKING r ON players (score DESC) TOP 5");
+
+    let p50 = rid_of(&rt, "players", "p50");
+    let before = approx_rank_of(&rt, &format!("APPROX RANK OF {p50} IN r"))
+        .expect("approx rank before")
+        .rank;
+    assert!(
+        (49..=53).contains(&before),
+        "baseline approx rank {before} near 51"
+    );
+
+    // Insert 100 new players that all outscore p50. The per-(table,column)
+    // sketch must reflect the new scores: p50 drops far down the board.
+    for k in 1..=100 {
+        exec(
+            &rt,
+            &format!("INSERT INTO players (name, score) VALUES ('hi{k}', 1000)"),
+        );
+    }
+    let after = approx_rank_of(&rt, &format!("APPROX RANK OF {p50} IN r"))
+        .expect("approx rank after")
+        .rank;
+    assert!(
+        after >= before + 80,
+        "after adding 100 higher scores p50 must drop sharply: {before} -> {after}"
     );
 }
 


### PR DESCRIPTION
Closes #923.

Salvages worker `w94GB`'s substantive attempt (+720) that hit a merge-conflict when main moved under it (PRD-916 leaderboard rank). The branch was re-merged onto current main (clean 3-way; the god-file overlaps in `impl_core.rs`/`ranking_descriptor_catalog.rs` auto-resolved) and revalidated.

Adds the approximate tail to leaderboard rank: entries below the exact top-K head get an approximate percentile/rank from a per-`(collection, score column)` sketch (`score_sketch.rs`), explicitly labeled approximate so callers don't present an estimate as exact.

## Validation (against current main)
- `cargo test -p reddb-io-server --test leaderboard_rank_e2e` → **9 passed, 0 failed**:
  - tail_entry_below_head_gets_a_labeled_approximate_rank
  - approx_rank_stays_within_documented_error_band
  - approx_rank_tracks_score_changes
  - rows_beyond_the_top_k_head_return_no_exact_rank
  - uncommitted_row_in_another_transaction_does_not_shift_rank (MVCC sidestep)
  - rank_reads_honor_tenant_rls
  - rank_of_row_agrees_with_order_by_and_window_rank
  - ranking_is_declared_as_a_catalog_capability
  - top_n_order_by_limit_is_unchanged
- `cargo fmt -p reddb-io-server -- --check` ✓

Files: `score_sketch.rs` (+334, sketch engine), `ranking_descriptor_catalog.rs` (+127), `impl_core.rs` (+107), `leaderboard_rank_e2e.rs` (+153 test), `runtime.rs` (+1).

HITL-resolved 2026-06-03: salvage over re-queue (sketch engine + e2e already written, conflict was resolvable).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783094976&installation_id=129708444&pr_number=963&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F963&signature=1d1ebb2250b1883875d2ef90a0c9fb494b3403ca38fb0844d728e5e7108eb66f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `APPROX RANK OF <id> IN <name>` SQL syntax for approximate ranking queries.
  * Returns approximate rank, percentile, and approximation indicator for entries outside top K result sets.
  * Approximate rankings update dynamically as underlying data changes.

* **Tests**
  * Added end-to-end tests validating approximate rank accuracy, error bounds, and real-time updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->