### PR TITLE
feat(server): skip Double-Write Buffer on CoW filesystems (ZFS/btrfs), crash-injection gated (#895)

### DIFF
--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -40,10 +40,15 @@ use fs2::FileExt;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
 /// Default cache size (pages)
 const DEFAULT_CACHE_SIZE: usize = 10_000;
+
+#[cfg(test)]
+static COW_ATOMIC_WRITE_TEST_OVERRIDE: AtomicU8 = AtomicU8::new(0);
 
 /// Pager error types
 #[derive(Debug)]
@@ -286,6 +291,11 @@ impl Drop for Pager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(target_os = "linux")]
+    use pager_impl::parse_mountinfo_options_for_path;
+    use pager_impl::{
+        classify_cow_filesystem, CowFilesystemKind, BTRFS_SUPER_MAGIC, FS_NOCOW_FL, ZFS_SUPER_MAGIC,
+    };
     use std::fs;
     use std::io::Write;
 
@@ -318,6 +328,26 @@ mod tests {
         PathBuf::from(dwb)
     }
 
+    static COW_ATOMIC_WRITE_OVERRIDE_GUARD: Mutex<()> = Mutex::new(());
+
+    struct CowAtomicWriteOverrideGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for CowAtomicWriteOverrideGuard {
+        fn drop(&mut self) {
+            COW_ATOMIC_WRITE_TEST_OVERRIDE.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn cow_atomic_write_override(value: bool) -> CowAtomicWriteOverrideGuard {
+        let guard = COW_ATOMIC_WRITE_OVERRIDE_GUARD
+            .lock()
+            .unwrap_or_else(|err| err.into_inner());
+        COW_ATOMIC_WRITE_TEST_OVERRIDE.store(if value { 1 } else { 2 }, Ordering::Relaxed);
+        CowAtomicWriteOverrideGuard { _guard: guard }
+    }
+
     fn write_dwb_fixture(path: &Path, pages: &[(u32, Page)]) {
         let entry_size = 4 + PAGE_SIZE;
         let header_len = 12;
@@ -341,6 +371,25 @@ mod tests {
         let dwb_path = dwb_path_for(path);
         let mut file = fs::File::create(&dwb_path).unwrap();
         file.write_all(&buf).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    fn write_page_bytes(path: &Path, page_id: u32, page: &Page) {
+        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        file.seek(SeekFrom::Start(page_id as u64 * PAGE_SIZE as u64))
+            .unwrap();
+        file.write_all(page.as_bytes()).unwrap();
+        file.sync_all().unwrap();
+    }
+
+    fn write_torn_page_bytes(path: &Path, page_id: u32, before: &Page, after: &Page) {
+        let mut torn = *before.as_bytes();
+        torn[..PAGE_SIZE / 2].copy_from_slice(&after.as_bytes()[..PAGE_SIZE / 2]);
+
+        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        file.seek(SeekFrom::Start(page_id as u64 * PAGE_SIZE as u64))
+            .unwrap();
+        file.write_all(&torn).unwrap();
         file.sync_all().unwrap();
     }
 
@@ -557,6 +606,252 @@ mod tests {
             assert_eq!(fs::metadata(&dwb_path).unwrap().len(), 0);
         }
 
+        cleanup(&path);
+    }
+
+    #[test]
+    fn cow_probe_classification_fails_closed_for_btrfs_nodatacow() {
+        assert_eq!(
+            classify_cow_filesystem(ZFS_SUPER_MAGIC, None, None),
+            Some(CowFilesystemKind::Zfs),
+            "ZFS is always CoW"
+        );
+        assert_eq!(
+            classify_cow_filesystem(BTRFS_SUPER_MAGIC, Some("rw,relatime"), Some(0)),
+            Some(CowFilesystemKind::BtrfsDataCow),
+            "btrfs qualifies only when datacow remains enabled"
+        );
+        assert_eq!(
+            classify_cow_filesystem(BTRFS_SUPER_MAGIC, Some("rw,nodatacow"), Some(0)),
+            None,
+            "btrfs nodatacow mount option must reject DWB skip"
+        );
+        assert_eq!(
+            classify_cow_filesystem(BTRFS_SUPER_MAGIC, Some("rw"), Some(FS_NOCOW_FL)),
+            None,
+            "btrfs chattr +C / NOCOW inode flag must reject DWB skip"
+        );
+        assert_eq!(
+            classify_cow_filesystem(BTRFS_SUPER_MAGIC, Some("rw"), None),
+            None,
+            "missing btrfs inode flags are uncertain and must fail closed"
+        );
+        assert_eq!(
+            classify_cow_filesystem(BTRFS_SUPER_MAGIC, None, Some(0)),
+            None,
+            "missing btrfs mount options are uncertain and must fail closed"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn mountinfo_parser_uses_longest_cow_mount_and_rejects_nodatacow() {
+        let mountinfo = "\
+24 18 0:21 / / rw,relatime - ext4 /dev/root rw\n\
+35 24 0:42 /subvol /mnt/reddb rw,relatime - btrfs /dev/sdb rw,space_cache=v2\n\
+36 35 0:43 /nocow /mnt/reddb/nocow rw,relatime - btrfs /dev/sdb rw,nodatacow\n\
+";
+
+        assert_eq!(
+            parse_mountinfo_options_for_path(mountinfo, Path::new("/mnt/reddb/data.rdb"))
+                .as_deref(),
+            Some("rw,relatime,rw,space_cache=v2")
+        );
+        assert_eq!(
+            parse_mountinfo_options_for_path(mountinfo, Path::new("/mnt/reddb/nocow/data.rdb"))
+                .as_deref(),
+            Some("rw,relatime,rw,nodatacow")
+        );
+    }
+
+    #[test]
+    fn double_write_false_keeps_dwb_when_cow_probe_denies() {
+        let _override = cow_atomic_write_override(false);
+        let path = temp_db_path();
+        cleanup(&path);
+
+        {
+            let config = PagerConfig {
+                double_write: false,
+                ..Default::default()
+            };
+            let pager = Pager::open(&path, config).unwrap();
+            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            pager.write_page(page.page_id(), page).unwrap();
+            pager.flush().unwrap();
+        }
+
+        assert!(
+            dwb_path_for(&path).exists(),
+            "DWB must stay enabled when double_write=false is not proven safe"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn double_write_false_skips_dwb_when_cow_probe_allows() {
+        let _override = cow_atomic_write_override(true);
+        let path = temp_db_path();
+        cleanup(&path);
+
+        {
+            let config = PagerConfig {
+                double_write: false,
+                ..Default::default()
+            };
+            let pager = Pager::open(&path, config).unwrap();
+            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            pager.write_page(page.page_id(), page).unwrap();
+            pager.flush().unwrap();
+        }
+
+        assert!(
+            !dwb_path_for(&path).exists(),
+            "DWB may be skipped only after the CoW probe allows it"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn double_write_false_on_cow_replays_then_removes_existing_dwb() {
+        let _override = cow_atomic_write_override(true);
+        let path = temp_db_path();
+        cleanup(&path);
+
+        let page_id;
+        {
+            let pager = Pager::open(&path, PagerConfig::default()).unwrap();
+            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            page_id = page.page_id();
+            pager.sync().unwrap();
+        }
+
+        let mut recovered_page = Page::new(PageType::BTreeLeaf, page_id);
+        recovered_page.insert_cell(b"key", b"value").unwrap();
+        write_dwb_fixture(&path, &[(page_id, recovered_page)]);
+
+        {
+            let config = PagerConfig {
+                double_write: false,
+                ..Default::default()
+            };
+            let pager = Pager::open(&path, config).unwrap();
+            let read_page = pager.read_page(page_id).unwrap();
+            let (key, value) = read_page.read_cell(0).unwrap();
+            assert_eq!(key, b"key");
+            assert_eq!(value, b"value");
+        }
+
+        assert!(
+            !dwb_path_for(&path).exists(),
+            "CoW DWB-skip must replay any existing DWB before removing the sidecar"
+        );
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn simulated_cow_mid_write_leaves_a_whole_consistent_page_without_dwb() {
+        let _override = cow_atomic_write_override(true);
+        let path = temp_db_path();
+        cleanup(&path);
+
+        let config = PagerConfig {
+            double_write: false,
+            ..Default::default()
+        };
+
+        let page_id;
+        let before;
+        let after;
+        {
+            let pager = Pager::open(&path, config.clone()).unwrap();
+            let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            page_id = page.page_id();
+            page.insert_cell(b"phase", b"before").unwrap();
+            pager.write_page(page_id, page).unwrap();
+            pager.sync().unwrap();
+            before = pager.read_page(page_id).unwrap();
+
+            let mut page = before.clone();
+            page.insert_cell(b"phase2", b"after").unwrap();
+            pager.write_page(page_id, page).unwrap();
+            pager.flush().unwrap();
+            after = pager.read_page(page_id).unwrap();
+        }
+
+        // CoW crash model: the interrupted write leaves either the old full
+        // page or the new full page, never a torn mix. Exercise both outcomes.
+        for (whole_page, expected_cells) in [(&before, 1), (&after, 2)] {
+            write_page_bytes(&path, page_id, whole_page);
+
+            let pager = Pager::open(&path, config.clone()).unwrap();
+            let recovered = pager.read_page(page_id).unwrap();
+            assert_eq!(recovered.cell_count(), expected_cells);
+            let (key, value) = recovered.read_cell(0).unwrap();
+            assert_eq!(key, b"phase");
+            assert_eq!(value, b"before");
+            if expected_cells == 2 {
+                let (key, value) = recovered.read_cell(1).unwrap();
+                assert_eq!(key, b"phase2");
+                assert_eq!(value, b"after");
+            }
+            drop(pager);
+        }
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn same_mid_write_without_cow_recovers_from_dwb() {
+        let _override = cow_atomic_write_override(false);
+        let path = temp_db_path();
+        cleanup(&path);
+
+        let config = PagerConfig {
+            double_write: false,
+            ..Default::default()
+        };
+
+        let page_id;
+        let before;
+        let after;
+        {
+            let pager = Pager::open(&path, config.clone()).unwrap();
+            let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            page_id = page.page_id();
+            page.insert_cell(b"phase", b"before").unwrap();
+            pager.write_page(page_id, page).unwrap();
+            pager.sync().unwrap();
+            before = pager.read_page(page_id).unwrap();
+
+            let mut page = before.clone();
+            page.insert_cell(b"phase2", b"after").unwrap();
+            pager.write_page(page_id, page).unwrap();
+            pager.flush().unwrap();
+            after = pager.read_page(page_id).unwrap();
+        }
+
+        write_dwb_fixture(&path, &[(page_id, after.clone())]);
+        write_torn_page_bytes(&path, page_id, &before, &after);
+
+        {
+            let pager = Pager::open(&path, config).unwrap();
+            let recovered = pager.read_page(page_id).unwrap();
+            assert_eq!(recovered.cell_count(), 2);
+
+            let (key, value) = recovered.read_cell(0).unwrap();
+            assert_eq!(key, b"phase");
+            assert_eq!(value, b"before");
+
+            let (key, value) = recovered.read_cell(1).unwrap();
+            assert_eq!(key, b"phase2");
+            assert_eq!(value, b"after");
+        }
+
+        assert_eq!(fs::metadata(dwb_path_for(&path)).unwrap().len(), 0);
         cleanup(&path);
     }
 

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -2,10 +2,142 @@ use super::*;
 
 /// DWB file magic: "RDDW"
 const DWB_MAGIC: [u8; 4] = [0x52, 0x44, 0x44, 0x57];
+pub(super) const BTRFS_SUPER_MAGIC: i64 = 0x9123_683e;
+pub(super) const ZFS_SUPER_MAGIC: i64 = 0x2fc1_2fc1;
+pub(super) const FS_NOCOW_FL: u64 = 0x0080_0000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CowFilesystemKind {
+    Zfs,
+    BtrfsDataCow,
+    TestOverride,
+}
+
+pub(super) fn classify_cow_filesystem(
+    fs_type: i64,
+    mount_options: Option<&str>,
+    inode_flags: Option<u64>,
+) -> Option<CowFilesystemKind> {
+    match fs_type {
+        ZFS_SUPER_MAGIC => Some(CowFilesystemKind::Zfs),
+        BTRFS_SUPER_MAGIC => {
+            let mount_options = mount_options?;
+            if mount_options.split(',').any(|option| option == "nodatacow") {
+                return None;
+            }
+
+            let inode_flags = inode_flags?;
+            if inode_flags & FS_NOCOW_FL != 0 {
+                return None;
+            }
+
+            Some(CowFilesystemKind::BtrfsDataCow)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_fstatfs_type(file: &File) -> Option<i64> {
+    use std::mem::MaybeUninit;
+    use std::os::fd::AsRawFd;
+
+    let mut stat = MaybeUninit::<libc::statfs>::uninit();
+    let rc = unsafe { libc::fstatfs(file.as_raw_fd(), stat.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+    let stat = unsafe { stat.assume_init() };
+    Some(stat.f_type as i64)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_inode_flags(file: &File) -> Option<u64> {
+    use std::os::fd::AsRawFd;
+
+    let mut flags: libc::c_long = 0;
+    let rc = unsafe { libc::ioctl(file.as_raw_fd(), libc::FS_IOC_GETFLAGS, &mut flags) };
+    if rc != 0 {
+        return None;
+    }
+    Some(flags as u64)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_mount_options_for_path(path: &Path) -> Option<String> {
+    let path = path.canonicalize().ok()?;
+    let mountinfo = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
+    parse_mountinfo_options_for_path(&mountinfo, &path)
+}
+
+#[cfg(target_os = "linux")]
+pub(super) fn parse_mountinfo_options_for_path(mountinfo: &str, path: &Path) -> Option<String> {
+    let mut best: Option<(usize, String)> = None;
+
+    for line in mountinfo.lines() {
+        let fields: Vec<&str> = line.split(' ').collect();
+        if fields.len() < 10 {
+            continue;
+        }
+
+        let Some(separator) = fields.iter().position(|field| *field == "-") else {
+            continue;
+        };
+        if separator + 3 >= fields.len() || separator < 6 {
+            continue;
+        }
+
+        let mount_point = mountinfo_unescape_path(fields[4]);
+        if !path.starts_with(&mount_point) {
+            continue;
+        }
+
+        let fs_type = fields[separator + 1];
+        if fs_type != "btrfs" && fs_type != "zfs" {
+            continue;
+        }
+
+        let mount_options = fields[5];
+        let super_options = fields[separator + 3];
+        let options = format!("{mount_options},{super_options}");
+        let depth = mount_point.components().count();
+        if best
+            .as_ref()
+            .map(|(best_depth, _)| depth > *best_depth)
+            .unwrap_or(true)
+        {
+            best = Some((depth, options));
+        }
+    }
+
+    best.map(|(_, options)| options)
+}
+
+#[cfg(target_os = "linux")]
+fn mountinfo_unescape_path(value: &str) -> PathBuf {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let octal = &value[i + 1..i + 4];
+            if let Ok(byte) = u8::from_str_radix(octal, 8) {
+                out.push(byte);
+                i += 4;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+
+    PathBuf::from(String::from_utf8_lossy(&out).into_owned())
+}
 
 impl Pager {
     /// Open or create a database file
-    pub fn open<P: AsRef<Path>>(path: P, config: PagerConfig) -> Result<Self, PagerError> {
+    pub fn open<P: AsRef<Path>>(path: P, mut config: PagerConfig) -> Result<Self, PagerError> {
         let path = path.as_ref().to_path_buf();
         let exists = path.exists();
 
@@ -72,7 +204,25 @@ impl Pager {
         // suppressed — torn pages are healed by replaying FullPageImage WAL
         // records during recovery. Any pre-existing `-dwb` is removed so a
         // flipped flag cannot leave a stale sidecar on disk.
+        //
+        // gh-895: an explicit `double_write = false` request is honored only
+        // when the already-open data file is proven to live on a filesystem
+        // with atomic CoW page writes. Unknown and non-CoW filesystems fail
+        // closed by keeping the DWB sidecar.
         let fold_dwb = crate::physical::fold_dwb_into_wal_enabled();
+        if !config.double_write && !config.read_only && !fold_dwb {
+            let skip_dwb_on_cow =
+                Self::cow_filesystem_has_atomic_page_writes(&path, &file).is_some();
+            if !skip_dwb_on_cow {
+                tracing::warn!(
+                    path = %path.display(),
+                    "double_write=false requested, but the data file is not proven to be on \
+                     ZFS or btrfs datacow; keeping the double-write buffer enabled"
+                );
+                config.double_write = true;
+            }
+        }
+
         let dwb_file = if config.double_write && !config.read_only && !fold_dwb {
             let f = Self::open_dwb_file(&path)?;
             Some(Mutex::new(f))
@@ -100,6 +250,9 @@ impl Pager {
         if exists {
             // Recover from double-write buffer if needed
             pager.recover_from_dwb()?;
+            if !pager.config.double_write && !pager.config.read_only {
+                let _ = std::fs::remove_file(Self::dwb_path(&pager.path));
+            }
             // Load existing database (with header shadow fallback)
             pager.load_header()?;
             pager.bind_encryption_for_existing()?;
@@ -120,6 +273,49 @@ impl Pager {
     /// Pure function with no I/O so the warn decision is unit-testable.
     pub(crate) fn page_size_misaligned_with_block(page_size: usize, fs_block_size: u64) -> bool {
         fs_block_size != 0 && !(page_size as u64).is_multiple_of(fs_block_size)
+    }
+
+    #[cfg(test)]
+    fn cow_filesystem_test_override() -> Option<bool> {
+        match COW_ATOMIC_WRITE_TEST_OVERRIDE.load(Ordering::Relaxed) {
+            1 => Some(true),
+            2 => Some(false),
+            _ => None,
+        }
+    }
+
+    #[cfg(not(test))]
+    fn cow_filesystem_test_override() -> Option<bool> {
+        None
+    }
+
+    fn cow_filesystem_has_atomic_page_writes(
+        path: &Path,
+        file: &File,
+    ) -> Option<CowFilesystemKind> {
+        if let Some(allowed) = Self::cow_filesystem_test_override() {
+            return allowed.then_some(CowFilesystemKind::TestOverride);
+        }
+        Self::probe_cow_filesystem(path, file)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn probe_cow_filesystem(path: &Path, file: &File) -> Option<CowFilesystemKind> {
+        let fs_type = linux_fstatfs_type(file)?;
+        match fs_type {
+            ZFS_SUPER_MAGIC => Some(CowFilesystemKind::Zfs),
+            BTRFS_SUPER_MAGIC => {
+                let mount_options = linux_mount_options_for_path(path)?;
+                let inode_flags = linux_inode_flags(file)?;
+                classify_cow_filesystem(fs_type, Some(&mount_options), Some(inode_flags))
+            }
+            _ => None,
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn probe_cow_filesystem(_path: &Path, _file: &File) -> Option<CowFilesystemKind> {
+        None
     }
 
     /// Inspect page 0 for the `RDBE` encryption marker, then resolve

--- a/crates/reddb-server/src/storage/unified/store/impl_pages.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_pages.rs
@@ -361,11 +361,11 @@ impl UnifiedStore {
         let mut pager_config = PagerConfig::default();
         // Tunables via env — experimental, used by the benchmark harness
         // to compare durability profiles head-to-head with Postgres.
-        // REDDB_DOUBLE_WRITE=0 disables the double-write buffer, which
-        // otherwise adds two fsyncs per pager flush (one on DWB, one
-        // on the main file). With DWB off the pager behaves more like
-        // Postgres + full_page_writes=off — we trade torn-page
-        // protection for ingest throughput.
+        // REDDB_DOUBLE_WRITE=0 requests skipping the double-write buffer,
+        // which otherwise adds two fsyncs per pager flush (one on DWB, one
+        // on the main file). The pager honors this only when the actual
+        // data file is proven to live on a CoW filesystem with atomic page
+        // writes; otherwise it fails closed and keeps DWB enabled.
         if matches!(
             std::env::var("REDDB_DOUBLE_WRITE").ok().as_deref(),
             Some("0") | Some("false") | Some("off")


### PR DESCRIPTION
Closes #895.

Operator opt-in to skip the redundant double-write buffer on copy-on-write filesystems (page writes are already atomic there), while still replaying + removing a valid `-dwb` sidecar left by a pre-opt-in crash so recovery ordering is preserved. Includes a regression test beside the existing pager DWB recovery tests.

**Provenance:** salvaged from an AFK **codex** attempt that completed the implementation and passed `cargo check` + `cargo fmt` (and locally `cargo check` re-confirmed green on salvage), but was false-stalled by the commit-anchored progress guard before it could commit — the bug fixed in red-skills ADR 0051. Full Rust gates left to CI/review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783120775&installation_id=129708444&pr_number=976&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F976&signature=e6c483f8f41956f8250afce41da5831f77e7c8f9ac99c6ed2f062b3d54eee3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filesystem classification to detect whether the database storage supports atomic copy-on-write (CoW) operations on ZFS or btrfs.

* **Improvements**
  * Database now automatically enables double-write buffer protection when atomic CoW is not confirmed, ensuring data safety through a "fails closed" approach.

* **Documentation**
  * Updated REDDB_DOUBLE_WRITE environment variable documentation to clarify behavior when CoW filesystem detection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->