### PR TITLE
merge: #919 RedWire live queue wait: timeout outcome + server max-wait cap

### DIFF
--- a/crates/reddb-client/src/redwire/codec.rs
+++ b/crates/reddb-client/src/redwire/codec.rs
@@ -125,4 +125,19 @@ mod tests {
         assert_eq!(n, bytes.len());
         assert_eq!(decoded, f);
     }
+
+    #[test]
+    fn decodes_live_queue_wait_timeout_kind() {
+        let f = Frame::new(MessageKind::QueueWaitTimeout, 42, Vec::new()).with_stream(9);
+        let bytes = encode_frame(&f);
+
+        assert_eq!(bytes[4], 0x30, "wire kind byte is pinned");
+        let (decoded, n) = decode_frame(&bytes).unwrap();
+
+        assert_eq!(n, bytes.len());
+        assert_eq!(decoded.kind, MessageKind::QueueWaitTimeout);
+        assert_eq!(decoded.stream_id, 9);
+        assert_eq!(decoded.correlation_id, 42);
+        assert!(decoded.payload.is_empty());
+    }
 }

--- a/crates/reddb-client/src/redwire/frame.rs
+++ b/crates/reddb-client/src/redwire/frame.rs
@@ -65,6 +65,7 @@ pub enum MessageKind {
     Get = 0x19,
     Delete = 0x1A,
     DeleteOk = 0x1B,
+    QueueWaitTimeout = 0x30,
 }
 
 impl MessageKind {
@@ -91,6 +92,7 @@ impl MessageKind {
             0x19 => Some(Self::Get),
             0x1A => Some(Self::Delete),
             0x1B => Some(Self::DeleteOk),
+            0x30 => Some(Self::QueueWaitTimeout),
             _ => None,
         }
     }

--- a/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
+++ b/crates/reddb-server/tests/queue_read_wait_redwire_smoke.rs
@@ -685,6 +685,14 @@ async fn wait_times_out_with_distinct_frame() {
         MessageKind::Pong,
         "session must stay responsive after a timed-out wait"
     );
+    assert_eq!(
+        server
+            .runtime
+            .queue_wait_registry()
+            .live_waiters("", "jobs"),
+        0,
+        "expired wait must release its registry slot reference"
+    );
 
     let metrics = scrape_metrics(&server.runtime);
     assert_metric_line(


### PR DESCRIPTION
Automated AFK landing for #919. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783133144&installation_id=129708444&pr_number=978&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F978&signature=bf42344c7568523eb345ea26ba1e99a2bf80afabe7fe85fa228446b22e5d0d68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for queue wait timeout handling in the wire protocol, enabling operations to terminate gracefully when queue wait operations exceed their time limits.

* **Tests**
  * Added unit test for timeout message decoding.
  * Enhanced integration tests to verify proper cleanup of timed-out queue wait operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->