### PR TITLE
feat(leaderboard): add rank range reads

### DIFF
--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -86,6 +86,19 @@ fn record_column_f64(
     }
 }
 
+fn record_rid_u64(rec: &crate::storage::query::unified::UnifiedRecord) -> Option<u64> {
+    match rec.get("rid") {
+        Some(Value::UnsignedInteger(n)) => Some(*n),
+        Some(Value::Integer(n)) if *n >= 0 => Some(*n as u64),
+        _ => None,
+    }
+}
+
+struct RankedHeadEntry {
+    rank: u64,
+    record: crate::storage::query::unified::UnifiedRecord,
+}
+
 fn secret_sql_value_to_string(value: &Value) -> RedDBResult<String> {
     match value {
         Value::Text(s) => Ok(s.to_string()),
@@ -298,6 +311,56 @@ impl RedDBRuntime {
         ))
     }
 
+    /// `RANK RANGE <lo> TO <hi> IN <name>` — exact, MVCC-correct entries
+    /// occupying a contiguous rank range within the bounded top-K head.
+    ///
+    /// The output is in leaderboard order and includes `rank` plus the
+    /// row columns returned by the canonical exact-head SQL read.
+    fn execute_rank_range(
+        &self,
+        raw_query: &str,
+        req: super::ranking_descriptor_catalog::RankRangeRequest,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let store = self.inner.db.store();
+        let descriptor = super::ranking_descriptor_catalog::get(store.as_ref(), &req.ranking)
+            .ok_or_else(|| {
+                RedDBError::Query(format!("ranking '{}' does not exist", req.ranking))
+            })?;
+        let (head_columns, entries) = self.compute_ranked_head_entries(&descriptor)?;
+
+        let mut columns = Vec::with_capacity(head_columns.len() + 1);
+        columns.push("rank".to_string());
+        for column in &head_columns {
+            if column != "rank" {
+                columns.push(column.clone());
+            }
+        }
+
+        let rows = entries
+            .into_iter()
+            .filter(|entry| entry.rank >= req.lo && entry.rank <= req.hi)
+            .map(|entry| {
+                let mut row = Vec::with_capacity(columns.len());
+                row.push(("rank".to_string(), Value::UnsignedInteger(entry.rank)));
+                for column in &head_columns {
+                    if column == "rank" {
+                        continue;
+                    }
+                    if let Some(value) = entry.record.get(column) {
+                        row.push((column.clone(), value.clone()));
+                    }
+                }
+                row
+            })
+            .collect();
+        Ok(RuntimeQueryResult::ok_records(
+            raw_query.to_string(),
+            columns,
+            rows,
+            "select",
+        ))
+    }
+
     /// Compute the exact rank of `target_id` within the descriptor's
     /// bounded top-K head, or `None` if the row is invisible to the
     /// querying snapshot or beyond the exact head.
@@ -316,6 +379,18 @@ impl RedDBRuntime {
         descriptor: &super::ranking_descriptor_catalog::RankingDescriptor,
         target_id: u64,
     ) -> RedDBResult<Option<u64>> {
+        let (_columns, entries) = self.compute_ranked_head_entries(descriptor)?;
+        Ok(entries
+            .into_iter()
+            .find(|entry| record_rid_u64(&entry.record) == Some(target_id))
+            .map(|entry| entry.rank))
+    }
+
+    /// Return the exact head rows in deterministic rank order.
+    fn compute_ranked_head_entries(
+        &self,
+        descriptor: &super::ranking_descriptor_catalog::RankingDescriptor,
+    ) -> RedDBResult<(Vec<String>, Vec<RankedHeadEntry>)> {
         let table = &descriptor.table;
         let column = &descriptor.column;
 
@@ -327,44 +402,32 @@ impl RedDBRuntime {
         // makes the rank honor policy/tenant scope (criterion 5).
         let dir = if descriptor.descending { "DESC" } else { "ASC" };
         let head_sql = format!(
-            "SELECT * FROM {table} ORDER BY {column} {dir} LIMIT {}",
+            "SELECT * FROM {table} ORDER BY {column} {dir}, rid ASC LIMIT {}",
             descriptor.top_k
         );
         let head_result = self.execute_query_inner(&head_sql)?;
-        let head = &head_result.result.records;
 
-        // Locate the target inside the head. Not present ⇒ either invisible
-        // to this snapshot/tenant, or beyond the exact head — both correctly
-        // yield "no exact rank" (the approximate tail is a separate slice).
-        let target_score = head.iter().find_map(|rec| {
-            let rid = match rec.get("rid") {
-                Some(Value::UnsignedInteger(n)) => *n,
-                Some(Value::Integer(n)) if *n >= 0 => *n as u64,
-                _ => return None,
-            };
-            (rid == target_id).then(|| record_column_f64(rec, column))?
-        });
-        let Some(target_score) = target_score else {
-            return Ok(None);
-        };
-
-        // RANK semantics: tied scores share a rank, so the rank is
-        // 1 + (number of strictly-better visible rows in the head).
-        let mut strictly_better = 0u64;
-        for rec in head {
+        let mut entries = Vec::with_capacity(head_result.result.records.len());
+        let mut row_position = 0u64;
+        let mut current_rank = 0u64;
+        let mut previous_score: Option<f64> = None;
+        for rec in &head_result.result.records {
             let Some(score) = record_column_f64(rec, column) else {
                 continue;
             };
-            let better = if descriptor.descending {
-                score > target_score
+            row_position += 1;
+            current_rank = if previous_score == Some(score) {
+                current_rank
             } else {
-                score < target_score
+                row_position
             };
-            if better {
-                strictly_better += 1;
-            }
+            previous_score = Some(score);
+            entries.push(RankedHeadEntry {
+                rank: current_rank,
+                record: rec.clone(),
+            });
         }
-        Ok(Some(strictly_better + 1))
+        Ok((head_result.result.columns, entries))
     }
 
     /// `APPROX RANK OF <id> IN <name>` — the *approximate tail* read
@@ -6540,6 +6603,9 @@ impl RedDBRuntime {
         }
         if super::ranking_descriptor_catalog::parse_show_rankings(query) {
             return self.execute_show_rankings(query);
+        }
+        if let Some(parsed) = super::ranking_descriptor_catalog::parse_rank_range(query) {
+            return self.execute_rank_range(query, parsed?);
         }
         if let Some(parsed) = super::ranking_descriptor_catalog::parse_approx_rank_of(query) {
             return self.execute_approx_rank_of(query, parsed?);

--- a/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
+++ b/crates/reddb-server/src/runtime/ranking_descriptor_catalog.rs
@@ -68,6 +68,14 @@ pub struct RankOfRequest {
     pub ranking: String,
 }
 
+/// Parsed `RANK RANGE <lo> TO <hi> IN <name>` read request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankRangeRequest {
+    pub lo: u64,
+    pub hi: u64,
+    pub ranking: String,
+}
+
 /// Parsed `APPROX RANK OF <id> IN <name>` read request — the approximate
 /// *tail* read (issue #923). Distinct statement head from the exact
 /// `RANK OF`, so the exact head surface (#918) is untouched.
@@ -256,6 +264,50 @@ pub fn parse_rank_of(sql: &str) -> Option<RedDBResult<RankOfRequest>> {
         }
         Ok(RankOfRequest {
             entity_id,
+            ranking: ranking.clone(),
+        })
+    })();
+    Some(result)
+}
+
+/// Parse `RANK RANGE <lo> TO <hi> IN <name>`.
+///
+/// Returns `None` unless the statement starts with `RANK RANGE`. A malformed
+/// tail returns `Some(Err(..))` for a targeted error.
+pub fn parse_rank_range(sql: &str) -> Option<RedDBResult<RankRangeRequest>> {
+    let tokens = tokenize(sql);
+    if tokens.len() < 2 || !eq(&tokens[0], "RANK") || !eq(&tokens[1], "RANGE") {
+        return None;
+    }
+    let err = || {
+        RedDBError::Query(
+            "invalid RANK RANGE: expected RANK RANGE <lo> TO <hi> IN <ranking-name>".to_string(),
+        )
+    };
+    let result = (|| {
+        let lo_str = tokens.get(2).ok_or_else(err)?;
+        let lo = lo_str.parse::<u64>().map_err(|_| err())?;
+        if lo == 0 {
+            return Err(err());
+        }
+        if !tokens.get(3).is_some_and(|t| eq(t, "TO")) {
+            return Err(err());
+        }
+        let hi_str = tokens.get(4).ok_or_else(err)?;
+        let hi = hi_str.parse::<u64>().map_err(|_| err())?;
+        if hi < lo {
+            return Err(err());
+        }
+        if !tokens.get(5).is_some_and(|t| eq(t, "IN")) {
+            return Err(err());
+        }
+        let ranking = tokens.get(6).ok_or_else(err)?;
+        if tokens.get(7).is_some() {
+            return Err(err());
+        }
+        Ok(RankRangeRequest {
+            lo,
+            hi,
             ranking: ranking.clone(),
         })
     })();
@@ -527,6 +579,50 @@ mod tests {
         assert!(parse_rank_of("SELECT 1").is_none());
         // `RANK() OVER (...)` is a window projection, not the RANK OF read.
         assert!(parse_rank_of("SELECT RANK() OVER (ORDER BY s DESC) FROM t").is_none());
+    }
+
+    #[test]
+    fn parse_rank_range_full() {
+        let req = parse_rank_range("RANK RANGE 100 TO 110 IN top_players")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(
+            req,
+            RankRangeRequest {
+                lo: 100,
+                hi: 110,
+                ranking: "top_players".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_rank_range_is_case_insensitive() {
+        let req = parse_rank_range("rank range 1 to 5 in r")
+            .expect("recognised")
+            .expect("valid");
+        assert_eq!(req.lo, 1);
+        assert_eq!(req.hi, 5);
+        assert_eq!(req.ranking, "r");
+    }
+
+    #[test]
+    fn parse_rank_range_rejects_bad_bounds() {
+        let err = parse_rank_range("RANK RANGE 0 TO 5 IN r")
+            .expect("recognised")
+            .expect_err("zero lower bound");
+        assert!(err.to_string().contains("RANK RANGE"), "{err}");
+
+        let err = parse_rank_range("RANK RANGE 5 TO 4 IN r")
+            .expect("recognised")
+            .expect_err("inverted bounds");
+        assert!(err.to_string().contains("RANK RANGE"), "{err}");
+    }
+
+    #[test]
+    fn parse_rank_range_does_not_shadow_exact_rank_of() {
+        assert!(parse_rank_range("RANK OF 1 IN r").is_none());
+        assert!(parse_rank_of("RANK RANGE 1 TO 2 IN r").is_none());
     }
 
     #[test]

--- a/crates/reddb-server/tests/leaderboard_rank_e2e.rs
+++ b/crates/reddb-server/tests/leaderboard_rank_e2e.rs
@@ -50,6 +50,35 @@ fn rank_of(rt: &RedDBRuntime, sql: &str) -> Option<u64> {
         })
 }
 
+/// `(rank, rid, name)` rows from a `RANK RANGE …` read.
+fn rank_range_rows(rt: &RedDBRuntime, sql: &str) -> Vec<(u64, u64, String)> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  -> {e}"));
+    result
+        .result
+        .records
+        .iter()
+        .map(|rec| {
+            let rank = match rec.get("rank") {
+                Some(Value::UnsignedInteger(n)) => *n,
+                Some(Value::Integer(n)) => *n as u64,
+                other => panic!("rank missing/typed wrong: {other:?}"),
+            };
+            let rid = match rec.get("rid") {
+                Some(Value::UnsignedInteger(n)) => *n,
+                Some(Value::Integer(n)) => *n as u64,
+                other => panic!("rid missing/typed wrong: {other:?}"),
+            };
+            let name = match rec.get("name") {
+                Some(Value::Text(t)) => t.to_string(),
+                other => panic!("name missing/typed wrong: {other:?}"),
+            };
+            (rank, rid, name)
+        })
+        .collect()
+}
+
 /// An `APPROX RANK OF …` row, or `None` when the read returned no row.
 struct ApproxRow {
     rank: u64,
@@ -339,6 +368,111 @@ fn rank_reads_honor_tenant_rls() {
         rank_of(&rt, &format!("WITHIN TENANT 'globex' RANK OF {alice} IN r")),
         None,
         "a row hidden by RLS has no rank for that tenant"
+    );
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Issue #924 — exact head range-by-rank reads for position pagination.
+// ══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn rank_range_returns_entries_in_rank_order() {
+    let rt = runtime();
+    seed_players(
+        &rt,
+        &[
+            ("alice", 100),
+            ("bob", 80),
+            ("eve", 80),
+            ("carol", 60),
+            ("dave", 40),
+        ],
+    );
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+
+    let rows = rank_range_rows(&rt, "RANK RANGE 2 TO 4 IN r");
+    let projected: Vec<(u64, String)> = rows
+        .into_iter()
+        .map(|(rank, _rid, name)| (rank, name))
+        .collect();
+    assert_eq!(
+        projected,
+        vec![
+            (2, "bob".to_string()),
+            (2, "eve".to_string()),
+            (4, "carol".to_string()),
+        ],
+        "range read must return entries in rank order, including tied rank rows"
+    );
+}
+
+#[test]
+fn rank_range_pages_are_gap_free_on_a_stable_snapshot() {
+    let rt = runtime();
+    seed_uniform(&rt, 6);
+    exec(&rt, "CREATE RANKING r ON players (score DESC)");
+
+    set_current_connection_id(1);
+    exec(&rt, "BEGIN");
+    let page1 = rank_range_rows(&rt, "RANK RANGE 1 TO 2 IN r");
+
+    set_current_connection_id(2);
+    exec(&rt, "BEGIN");
+    exec(
+        &rt,
+        "INSERT INTO players (name, score) VALUES ('late_winner', 1000)",
+    );
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(1);
+    let page2 = rank_range_rows(&rt, "RANK RANGE 3 TO 4 IN r");
+    let page3 = rank_range_rows(&rt, "RANK RANGE 5 TO 6 IN r");
+    exec(&rt, "COMMIT");
+    clear_current_connection_id();
+
+    let names: Vec<String> = page1
+        .into_iter()
+        .chain(page2)
+        .chain(page3)
+        .map(|(_rank, _rid, name)| name)
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "p6".to_string(),
+            "p5".to_string(),
+            "p4".to_string(),
+            "p3".to_string(),
+            "p2".to_string(),
+            "p1".to_string(),
+        ],
+        "stable-snapshot pages must not overlap, leave gaps, or shift after a later commit"
+    );
+}
+
+#[test]
+fn rank_range_ties_are_deterministic_and_match_rank_of() {
+    let rt = runtime();
+    seed_players(&rt, &[("a", 100), ("b", 100), ("c", 100), ("d", 90)]);
+    exec(&rt, "CREATE RANKING r ON players (score DESC) TOP 2");
+
+    let a = rid_of(&rt, "players", "a");
+    let b = rid_of(&rt, "players", "b");
+    let c = rid_of(&rt, "players", "c");
+
+    let rows = rank_range_rows(&rt, "RANK RANGE 1 TO 1 IN r");
+    let projected: Vec<(u64, u64, String)> = rows;
+    assert_eq!(
+        projected,
+        vec![(1, a, "a".to_string()), (1, b, "b".to_string())],
+        "equal scores inside the bounded head must be ordered by rid"
+    );
+    assert_eq!(rank_of(&rt, &format!("RANK OF {a} IN r")), Some(1));
+    assert_eq!(rank_of(&rt, &format!("RANK OF {b} IN r")), Some(1));
+    assert_eq!(
+        rank_of(&rt, &format!("RANK OF {c} IN r")),
+        None,
+        "the same deterministic TOP k boundary applies to RANK OF"
     );
 }
 


### PR DESCRIPTION
Implements #924.

Changes:
- Add `RANK RANGE <lo> TO <hi> IN <ranking>` parser support.
- Execute rank-range reads via the existing exact-head ranking path.
- Share deterministic score/rid tie ordering with `RANK OF`.
- Add leaderboard e2e coverage for rank order, stable pagination, and tie determinism.

Verification:
- `cargo test -p reddb-io-server runtime::ranking_descriptor_catalog::tests -- --nocapture`
- `cargo test -p reddb-io-server --test leaderboard_rank_e2e -- --nocapture`
- `cargo check -p reddb-io-server`
- `cargo fmt --all --check`
- `git diff --check`

Closes #924

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783134756&installation_id=129708444&pr_number=979&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F979&signature=fc86ad31679f4b8eccc4100bdaf0f6d66a91ac6dac49bd88bb12a4f8e882622b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Leaderboards now support querying exact rank ranges, enabling efficient retrieval and pagination of ranked entries within specified rank boundaries. Results are returned in deterministic rank order with consistent tie-handling for entries with equal scores, providing stable and predictable pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->