### PR TITLE
merge: #980 Fix local JSON object macro clippy warning

### DIFF
--- a/crates/reddb-server/src/serde_json.rs
+++ b/crates/reddb-server/src/serde_json.rs
@@ -646,6 +646,9 @@ macro_rules! json {
     ([ $( $elem:expr ),* $(,)? ]) => {
         $crate::serde_json::Value::Array(vec![ $( $crate::json!($elem) ),* ])
     };
+    ({}) => {
+        $crate::serde_json::Value::Object($crate::serde_json::Map::new())
+    };
     ({ $( $key:literal : $value:expr ),* $(,)? }) => {{
         let mut map = $crate::serde_json::Map::new();
         $( map.insert($key.to_string(), $crate::json!($value)); )*
@@ -657,3 +660,21 @@ macro_rules! json {
 }
 
 pub use crate::json;
+
+#[cfg(test)]
+mod json_macro_tests {
+    use super::Value;
+    use crate::json::json;
+
+    #[test]
+    fn object_macro_supports_empty_and_non_empty_objects() {
+        assert_eq!(json!({}), Value::Object(Default::default()));
+
+        let value = json!({ "name": "reddb", "ok": true });
+        let Value::Object(map) = value else {
+            panic!("non-empty object macro should produce an object");
+        };
+        assert_eq!(map.get("name"), Some(&Value::String("reddb".to_string())));
+        assert_eq!(map.get("ok"), Some(&Value::Bool(true)));
+    }
+}

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -48,7 +48,7 @@ fn linux_fstatfs_type(file: &File) -> Option<i64> {
         return None;
     }
     let stat = unsafe { stat.assume_init() };
-    Some(stat.f_type as i64)
+    Some(stat.f_type)
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Automated AFK landing for #980. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783188553&installation_id=129708444&pr_number=981&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F981&signature=cf42deb68c8f231ab27fb6ceeede6d404bed8c3913afc8a1536faab0a28e518d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for empty JSON object literals in macro syntax.

* **Bug Fixes**
  * Improved filesystem type value handling in storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->