### PR TITLE
merge: #970 Enforce: an agent-closed issue's claimed tests exist in the diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,34 @@ jobs:
       - name: Doc-generation tooling contract test
         run: node --test scripts/docs_matrix_contract.test.mjs
 
+  afk-validation-sidecar:
+    # Issue #970 — machine-check AFK's structured validation sidecar against
+    # the actual merged diff. The contract test always runs; the live diff
+    # check activates when an AFK/CI caller supplies RED_AFK_VALIDATION_SIDECAR.
+    name: AFK Validation Sidecar
+    needs: gate
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+      - name: Sidecar tooling contract test
+        run: node --test scripts/check-afk-validation-diff.test.mjs
+      - name: Check supplied AFK validation sidecar against diff
+        run: |
+          if [ -z "${RED_AFK_VALIDATION_SIDECAR:-}" ]; then
+            echo "No RED_AFK_VALIDATION_SIDECAR supplied; contract test covered the gate."
+            exit 0
+          fi
+          node scripts/check-afk-validation-diff.mjs \
+            --sidecar "$RED_AFK_VALIDATION_SIDECAR" \
+            --base "${RED_AFK_VALIDATION_BASE:-origin/main}" \
+            --head "${RED_AFK_VALIDATION_HEAD:-HEAD}"
+
   quality:
     name: Quality (fmt, check, clippy)
     needs: gate

--- a/scripts/check-afk-validation-diff.mjs
+++ b/scripts/check-afk-validation-diff.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const SCHEMA = "red.afk.validation.v1";
+
+function usage() {
+  return `Usage: node scripts/check-afk-validation-diff.mjs --sidecar PATH [--base REF] [--head REF] [--repo DIR] [--allow-missing-sidecar]
+
+Checks that passed test claims from the ${SCHEMA} JSONL sidecar have matching
+test evidence in the git diff.`;
+}
+
+function parseArgs(argv) {
+  const args = {
+    sidecar: process.env.RED_AFK_VALIDATION_SIDECAR || "",
+    base: process.env.RED_AFK_VALIDATION_BASE || "origin/main",
+    head: process.env.RED_AFK_VALIDATION_HEAD || "HEAD",
+    repo: process.cwd(),
+    allowMissingSidecar: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    } else if (arg === "--sidecar") {
+      args.sidecar = argv[++i] || "";
+    } else if (arg === "--base") {
+      args.base = argv[++i] || "";
+    } else if (arg === "--head") {
+      args.head = argv[++i] || "";
+    } else if (arg === "--repo") {
+      args.repo = argv[++i] || "";
+    } else if (arg === "--allow-missing-sidecar") {
+      args.allowMissingSidecar = true;
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function loadValidationRecords(sidecarPath) {
+  const text = fs.readFileSync(sidecarPath, "utf8");
+  const records = [];
+  const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "");
+
+  for (const [index, line] of lines.entries()) {
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch (err) {
+      throw new Error(`invalid JSON on sidecar line ${index + 1}: ${err.message}`);
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`sidecar line ${index + 1} is not a JSON object`);
+    }
+    if (parsed.schema !== SCHEMA) {
+      throw new Error(`sidecar line ${index + 1} has schema ${JSON.stringify(parsed.schema)}, expected ${SCHEMA}`);
+    }
+    records.push(parsed);
+  }
+
+  if (records.length === 0) {
+    throw new Error(`sidecar ${sidecarPath} contains no ${SCHEMA} records`);
+  }
+
+  return records;
+}
+
+function shellWords(command) {
+  if (!command) return [];
+  return command
+    .match(/"[^"]*"|'[^']*'|\S+/g)
+    ?.map((word) => word.replace(/^['"]|['"]$/g, ""))
+    ?? [];
+}
+
+function commandLooksLikeTest(command) {
+  return /\b(cargo\s+test|node\s+--test|pnpm\b[^\n;]*\btest\b|npm\b[^\n;]*\btest\b|yarn\b[^\n;]*\btest\b|pytest\b|go\s+test\b|vitest\b|jest\b)/.test(
+    command || "",
+  );
+}
+
+function testPathPattern(filePath) {
+  const normalized = filePath.replace(/\\/g, "/");
+  return (
+    /(^|\/)(tests?|__tests__|spec)\//.test(normalized) ||
+    /(^|\/)[^/]+[._-](test|spec)\.(cjs|mjs|js|jsx|ts|tsx|rs|py|go|java|kt|rb|php|zig|dart)$/.test(normalized) ||
+    /(^|\/)test_[^/]+\.(py|rs)$/.test(normalized) ||
+    /(^|\/)[^/]+_test\.go$/.test(normalized)
+  );
+}
+
+function extractExplicitTestPaths(record) {
+  const values = [record.name, ...shellWords(record.command)].filter(Boolean);
+  return values
+    .map((value) => value.replace(/^\.?\//, ""))
+    .filter((value) => value.includes("/") || /\.[a-z0-9]+$/i.test(value))
+    .filter(testPathPattern);
+}
+
+function extractTestClaims(records) {
+  return records
+    .filter((record) => record.status === "passed")
+    .filter((record) => {
+      const name = typeof record.name === "string" ? record.name : "";
+      return name.startsWith("test:") || commandLooksLikeTest(String(record.command || ""));
+    })
+    .map((record) => {
+      const name = String(record.name || "");
+      const rawScope = name.startsWith("test:") ? name.slice("test:".length) : "root";
+      const scope = rawScope === "" || rawScope === "root" || rawScope === "no-package" ? "." : rawScope;
+      return {
+        name,
+        scope,
+        command: String(record.command || ""),
+        explicitPaths: extractExplicitTestPaths(record),
+      };
+    });
+}
+
+function gitOutput(repo, args) {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+}
+
+function diffArgs(base, head) {
+  return [`${base}...${head}`];
+}
+
+function readDiff(repo, base, head) {
+  try {
+    return {
+      files: gitOutput(repo, ["diff", "--name-only", "--diff-filter=ACMR", ...diffArgs(base, head)])
+        .split(/\r?\n/)
+        .filter(Boolean),
+      patch: gitOutput(repo, ["diff", "--unified=0", "--no-ext-diff", ...diffArgs(base, head)]),
+    };
+  } catch {
+    return {
+      files: gitOutput(repo, ["diff", "--name-only", "--diff-filter=ACMR", base, head])
+        .split(/\r?\n/)
+        .filter(Boolean),
+      patch: gitOutput(repo, ["diff", "--unified=0", "--no-ext-diff", base, head]),
+    };
+  }
+}
+
+function addedInlineTestPaths(patch) {
+  const paths = new Set();
+  let current = "";
+  for (const line of patch.split(/\r?\n/)) {
+    if (line.startsWith("+++ b/")) {
+      current = line.slice("+++ b/".length);
+      continue;
+    }
+    if (!line.startsWith("+") || line.startsWith("+++")) continue;
+    if (
+      /#\[(tokio::)?test\]/.test(line) ||
+      /#\[cfg\(test\)\]/.test(line) ||
+      /\bmod tests\b/.test(line) ||
+      /^\+\s*(test|it|describe)\s*\(/.test(line) ||
+      /^\+\s*@Test\b/.test(line) ||
+      /^\+\s*func Test[A-Z_]/.test(line)
+    ) {
+      if (current) paths.add(current);
+    }
+  }
+  return paths;
+}
+
+function buildTestEvidence(diff) {
+  const evidence = new Set(diff.files.filter(testPathPattern));
+  for (const filePath of addedInlineTestPaths(diff.patch)) evidence.add(filePath);
+  return evidence;
+}
+
+function pathMatchesScope(filePath, scope) {
+  if (scope === ".") return true;
+  const normalized = scope.replace(/\\/g, "/").replace(/^\.?\//, "").replace(/\/$/, "");
+  return filePath === normalized || filePath.startsWith(`${normalized}/`);
+}
+
+function hasEvidenceForClaim(claim, evidence) {
+  if (claim.explicitPaths.length > 0) {
+    return claim.explicitPaths.some((explicitPath) => evidence.has(explicitPath));
+  }
+  return [...evidence].some((filePath) => pathMatchesScope(filePath, claim.scope));
+}
+
+function checkValidationDiff({ records, diff }) {
+  const claims = extractTestClaims(records);
+  const evidence = buildTestEvidence(diff);
+  const violations = claims.filter((claim) => !hasEvidenceForClaim(claim, evidence));
+  return { claims, evidence: [...evidence].sort(), violations };
+}
+
+function ghaError(message) {
+  if (process.env.GITHUB_ACTIONS === "true") {
+    console.error(`::error::${message}`);
+  } else {
+    console.error(`ERROR: ${message}`);
+  }
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    ghaError(err.message);
+    console.error(usage());
+    return 2;
+  }
+
+  if (args.help) {
+    console.log(usage());
+    return 0;
+  }
+
+  if (!args.sidecar) {
+    if (args.allowMissingSidecar) {
+      console.log("AFK validation diff check skipped: no sidecar path supplied");
+      return 0;
+    }
+    ghaError("missing --sidecar PATH or RED_AFK_VALIDATION_SIDECAR");
+    return 2;
+  }
+
+  const sidecarPath = path.resolve(args.repo, args.sidecar);
+  if (!fs.existsSync(sidecarPath)) {
+    if (args.allowMissingSidecar) {
+      console.log(`AFK validation diff check skipped: sidecar not found at ${sidecarPath}`);
+      return 0;
+    }
+    ghaError(`sidecar not found: ${sidecarPath}`);
+    return 2;
+  }
+
+  try {
+    const records = loadValidationRecords(sidecarPath);
+    const diff = readDiff(args.repo, args.base, args.head);
+    const result = checkValidationDiff({ records, diff });
+
+    if (result.claims.length === 0) {
+      console.log(`AFK validation diff check passed: ${SCHEMA} sidecar contains no passed test claims`);
+      return 0;
+    }
+
+    if (result.violations.length > 0) {
+      for (const violation of result.violations) {
+        ghaError(
+          `${SCHEMA} sidecar claims passed test ${JSON.stringify(violation.name)} but no matching test file or inline test addition exists in diff ${args.base}...${args.head}`,
+        );
+      }
+      if (result.evidence.length === 0) {
+        console.error("No test evidence paths were found in the diff.");
+      } else {
+        console.error(`Test evidence paths found: ${result.evidence.join(", ")}`);
+      }
+      return 1;
+    }
+
+    console.log(
+      `AFK validation diff check passed: ${result.claims.length} passed test claim(s), ${result.evidence.length} diff test evidence path(s)`,
+    );
+    return 0;
+  } catch (err) {
+    ghaError(err.message);
+    return 2;
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}
+
+export {
+  SCHEMA,
+  buildTestEvidence,
+  checkValidationDiff,
+  extractTestClaims,
+  loadValidationRecords,
+  testPathPattern,
+};

--- a/scripts/check-afk-validation-diff.test.mjs
+++ b/scripts/check-afk-validation-diff.test.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  SCHEMA,
+  checkValidationDiff,
+  extractTestClaims,
+  loadValidationRecords,
+  testPathPattern,
+} from "./check-afk-validation-diff.mjs";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const CHECKER = "scripts/check-afk-validation-diff.mjs";
+
+function git(repo, args) {
+  return execFileSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+}
+
+function write(repo, relativePath, contents) {
+  const fullPath = path.join(repo, relativePath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, contents);
+}
+
+function makeRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), "afk-validation-diff-"));
+  git(repo, ["init", "-q"]);
+  git(repo, ["config", "user.email", "test@example.invalid"]);
+  git(repo, ["config", "user.name", "Test User"]);
+  write(repo, "src/lib.rs", "pub fn value() -> u32 { 1 }\n");
+  git(repo, ["add", "."]);
+  git(repo, ["commit", "-qm", "base"]);
+  return repo;
+}
+
+function sidecar(repo, records) {
+  const sidecarPath = path.join(repo, "validation.jsonl");
+  fs.writeFileSync(sidecarPath, records.map((record) => JSON.stringify(record)).join("\n") + "\n");
+  return sidecarPath;
+}
+
+function passedTestRecord(overrides = {}) {
+  return {
+    schema: SCHEMA,
+    name: "test:root",
+    command: "pnpm -C /repo test",
+    status: "passed",
+    durationMs: 12,
+    summary: "command exited 0",
+    ...overrides,
+  };
+}
+
+function runChecker(repo, sidecarPath) {
+  return execFileSync("node", [CHECKER, "--repo", repo, "--sidecar", sidecarPath, "--base", "HEAD~1", "--head", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+test("test path matcher covers repo test file conventions", () => {
+  for (const filePath of [
+    "tests/e2e_meta_json_sidecar_policy.rs",
+    "scripts/check-afk-validation-diff.test.mjs",
+    "drivers/js/test/smoke.test.mjs",
+    "drivers/python/tests/test_params.py",
+    "crates/reddb-wire/tests/parser_table.rs",
+  ]) {
+    assert.equal(testPathPattern(filePath), true, `${filePath} should be test evidence`);
+  }
+  assert.equal(testPathPattern("src/runtime.rs"), false);
+});
+
+test("loads only structured red.afk.validation.v1 sidecar records", () => {
+  const repo = makeRepo();
+  try {
+    const sidecarPath = sidecar(repo, [passedTestRecord()]);
+    const records = loadValidationRecords(sidecarPath);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].schema, SCHEMA);
+
+    const badPath = path.join(repo, "bad-validation.jsonl");
+    fs.writeFileSync(badPath, JSON.stringify({ schema: "not-prose", name: "test:root" }) + "\n");
+    assert.throws(() => loadValidationRecords(badPath), /expected red\.afk\.validation\.v1/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("extracts passed test claims from structured test records", () => {
+  const claims = extractTestClaims([
+    passedTestRecord({ name: "test:root" }),
+    passedTestRecord({ name: "typecheck:root", command: "cargo check", status: "passed" }),
+    passedTestRecord({ name: "test:root", status: "failed" }),
+  ]);
+  assert.equal(claims.length, 1);
+  assert.equal(claims[0].name, "test:root");
+});
+
+test("flags a passed test claim when no tests are present in the diff", () => {
+  const repo = makeRepo();
+  try {
+    write(repo, "src/lib.rs", "pub fn value() -> u32 { 2 }\n");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "code only"]);
+    const sidecarPath = sidecar(repo, [passedTestRecord()]);
+
+    assert.throws(() => runChecker(repo, sidecarPath), /no matching test file or inline test addition exists/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("passes when a claimed root test has a test file in the diff", () => {
+  const repo = makeRepo();
+  try {
+    write(repo, "scripts/check-afk-validation-diff.test.mjs", "import { test } from 'node:test';\n");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "add test"]);
+    const sidecarPath = sidecar(repo, [passedTestRecord()]);
+
+    assert.match(runChecker(repo, sidecarPath), /AFK validation diff check passed/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("passes when a claimed root test adds inline Rust test evidence", () => {
+  const repo = makeRepo();
+  try {
+    write(
+      repo,
+      "src/lib.rs",
+      "pub fn value() -> u32 { 2 }\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn value_is_two() {\n        assert_eq!(super::value(), 2);\n    }\n}\n",
+    );
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-qm", "add inline test"]);
+    const sidecarPath = sidecar(repo, [passedTestRecord()]);
+
+    assert.match(runChecker(repo, sidecarPath), /AFK validation diff check passed/);
+  } finally {
+    fs.rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("does not parse free-form validation prose as a test claim", () => {
+  const result = checkValidationDiff({
+    records: [
+      {
+        schema: SCHEMA,
+        name: "typecheck:root",
+        command: "cargo check --workspace --locked",
+        status: "passed",
+      },
+    ],
+    diff: {
+      files: ["agent-notes.md"],
+      patch: "+I validated scripts/check-afk-validation-diff.test.mjs\n",
+    },
+  });
+  assert.equal(result.claims.length, 0);
+  assert.equal(result.violations.length, 0);
+});
+
+test("CI runs the AFK validation sidecar contract test and optional diff check", () => {
+  const ci = fs.readFileSync(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  assert.match(ci, /afk-validation-sidecar:/);
+  assert.match(ci, /node --test scripts\/check-afk-validation-diff\.test\.mjs/);
+  assert.match(ci, /RED_AFK_VALIDATION_SIDECAR/);
+});


### PR DESCRIPTION
Automated AFK landing for #970. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783189683&installation_id=129708444&pr_number=982&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F982&signature=5ed5d1a039ca72cda07d60641d3ae0744fd39f4aab0318bd77ee8b3b53b5e9f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated AFK sidecar validation into CI/CD workflow to automatically verify test claims
  * Enables conditional validation when sidecar tooling is provided

* **Tests**
  * Added comprehensive test suite covering validation logic, test-path matching, and record loading
  * Tests verify claim validation against repository changes and inline code additions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->