### PR TITLE
merge: #965 Test-DB auto-cleanup harness (TempDir-backed, drops on panic)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,6 +2245,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "snap",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,8 @@ tokio-stream = "0.1"
 rcgen = "0.14"
 # IAM policy property tests at the umbrella integration-test layer.
 proptest = "1"
+# TempDir-backed integration-test database cleanup harness.
+tempfile = "3"
 
 # ---------------------------------------------------------------------
 # Build profile tuning — trades runtime perf for build wall time

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -3,6 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use tempfile::TempDir;
+
 pub mod mock_ai_provider;
 pub mod prometheus;
 
@@ -23,6 +25,54 @@ use reddb::{CatalogUseCases, HealthState, RedDBOptions, RedDBRuntime};
 const ACCOUNTS_TTL_MS: u64 = 86_400_000;
 const METRICS_RETENTION_MS: u64 = 7 * 86_400_000;
 const FIVE_MINUTES_NS: u64 = 300_000_000_000;
+
+#[derive(Debug)]
+pub struct TestDb {
+    dir: TempDir,
+    path: PathBuf,
+}
+
+impl TestDb {
+    pub fn new() -> Self {
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-test-db-")
+            .tempdir()
+            .expect("temp test db dir");
+        let path = dir.path().join("data.rdb");
+        Self { dir, path }
+    }
+
+    pub fn dir(&self) -> &Path {
+        self.dir.path()
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn open_runtime(&self) -> RedDBRuntime {
+        RedDBRuntime::with_options(RedDBOptions::persistent(&self.path)).unwrap_or_else(|err| {
+            panic!(
+                "failed to open persistent runtime at {}: {err:?}",
+                self.path.display()
+            )
+        })
+    }
+
+    pub fn into_parts(self) -> (TempDir, PathBuf) {
+        (self.dir, self.path)
+    }
+}
+
+impl Default for TestDb {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn temp_db() -> (TempDir, PathBuf) {
+    TestDb::new().into_parts()
+}
 
 #[derive(Debug)]
 pub struct PersistentDbPath {

--- a/tests/temp_db_cleanup_harness.rs
+++ b/tests/temp_db_cleanup_harness.rs
@@ -1,0 +1,77 @@
+mod support;
+
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use reddb::RedDBRuntime;
+use support::{temp_db, TestDb};
+
+fn create_db(path: &Path) {
+    let rt = RedDBRuntime::with_options(reddb::RedDBOptions::persistent(path)).expect("open db");
+    rt.execute_query("CREATE TABLE cleanup_harness (id INT)")
+        .expect("create table");
+    rt.execute_query("INSERT INTO cleanup_harness (id) VALUES (1)")
+        .expect("insert row");
+    drop(rt);
+}
+
+#[test]
+fn temp_db_returns_unique_isolated_paths() {
+    let (first_dir, first_path) = temp_db();
+    let (second_dir, second_path) = temp_db();
+
+    assert_ne!(first_dir.path(), second_dir.path());
+    assert_ne!(first_path, second_path);
+    assert!(first_path.starts_with(first_dir.path()));
+    assert!(second_path.starts_with(second_dir.path()));
+}
+
+#[test]
+fn test_db_guard_removes_dir_on_success() {
+    let dir = {
+        let db = TestDb::new();
+        let dir = db.dir().to_path_buf();
+        create_db(db.path());
+        assert!(dir.exists(), "test DB dir should exist before guard drop");
+        assert!(
+            std::fs::read_dir(&dir)
+                .expect("read test DB dir")
+                .next()
+                .is_some(),
+            "DB creation should leave artifacts before guard drop"
+        );
+        dir
+    };
+
+    assert!(
+        !dir.exists(),
+        "TempDir-backed test DB guard should remove its directory on drop"
+    );
+}
+
+#[test]
+fn test_db_guard_removes_dir_during_panic_unwind() {
+    let created_dir = Arc::new(Mutex::new(None));
+    let created_dir_for_panic = Arc::clone(&created_dir);
+
+    let result = std::panic::catch_unwind(move || {
+        let db = TestDb::new();
+        let dir = db.dir().to_path_buf();
+        *created_dir_for_panic.lock().expect("record created dir") = Some(dir.clone());
+
+        create_db(db.path());
+        assert!(dir.exists(), "test DB dir should exist before panic");
+        panic!("exercise TestDb cleanup during unwind");
+    });
+
+    assert!(result.is_err(), "test closure should panic");
+    let dir = created_dir
+        .lock()
+        .expect("created dir lock")
+        .clone()
+        .expect("created dir recorded");
+    assert!(
+        !dir.exists(),
+        "TempDir-backed test DB guard should remove its directory during panic unwind"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #965. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783211348&installation_id=129708444&pr_number=985&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F985&signature=4f0548c6b248e8bd29b5831c64a1de8161dc0219ae97a54951918adb7f1f1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added temporary database utilities and cleanup validation test harness.

* **Chores**
  * Added `tempfile` dependency for test infrastructure support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->