### PR TITLE
merge: #969 Remediate coverage-theater tests in critical paths

### DIFF
--- a/crates/reddb-server/src/storage/btree/gc.rs
+++ b/crates/reddb-server/src/storage/btree/gc.rs
@@ -346,6 +346,7 @@ impl GcHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::storage::btree::version::Snapshot;
     use crate::storage::btree::{BPlusTree, BTreeConfig};
     use crate::storage::primitives::ids::TxnId;
 
@@ -391,16 +392,40 @@ mod tests {
 
     #[test]
     fn test_gc_incremental() {
-        let gc = GarbageCollector::new(GcConfig::new().with_batch_size(2));
+        let gc = GarbageCollector::new(
+            GcConfig::new()
+                .with_min_age(Timestamp(0))
+                .with_batch_size(2),
+        );
         let tree: BPlusTree<i32, String> = BPlusTree::new(BTreeConfig::new().with_order(4));
 
         for i in 1..=20 {
-            tree.insert(i, format!("v{}", i), TxnId(1));
+            tree.insert(i, format!("v1_{}", i), TxnId(1));
+            tree.insert(i, format!("v2_{}", i), TxnId(2));
+            tree.insert(i, format!("v3_{}", i), TxnId(3));
         }
 
-        // Run incremental - should return continuation point
+        assert!(tree.stats().leaf_nodes > 2);
+
         let next = gc.run_incremental(&tree, None);
-        // May or may not be done depending on tree structure
+        assert!(next.is_some(), "first batch should return a continuation");
+
+        let next_after_second_batch = gc.run_incremental(&tree, next);
+        assert_ne!(next_after_second_batch, next);
+
+        let mut next = next_after_second_batch;
+        while next.is_some() {
+            next = gc.run_incremental(&tree, next);
+        }
+
+        let stats_after_completion = gc.stats();
+        assert!(stats_after_completion.nodes_visited > 0);
+        assert!(stats_after_completion.versions_collected > 0);
+
+        let snapshot = Snapshot::new(TxnId(99), current_timestamp());
+        for i in 1..=20 {
+            assert_eq!(tree.get(&i, &snapshot), Some(format!("v3_{}", i)));
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/transaction/coordinator.rs
+++ b/crates/reddb-server/src/storage/transaction/coordinator.rs
@@ -781,8 +781,23 @@ mod tests {
         // Rollback to savepoint
         tm.rollback_to_savepoint(handle.id, "sp1").unwrap();
 
+        {
+            let txns = recover_read_guard(&tm.transactions);
+            let state = txns.get(&handle.id).unwrap();
+            assert_eq!(state.write_set.len(), 1);
+            assert_eq!(state.write_set[0].key, b"key1");
+            assert_eq!(state.write_set[0].new_value.as_deref(), Some(&b"v1"[..]));
+            assert!(!state.savepoints.exists("sp1"));
+        }
+
         // Should be able to commit
         tm.commit(handle.id).unwrap();
+        assert_eq!(tm.get_state(handle.id), Some(TxnState::Committed));
+
+        let committed = recover_read_guard(&tm.committed_ts);
+        assert!(committed.contains_key(&b"key1".to_vec()));
+        assert!(!committed.contains_key(&b"key2".to_vec()));
+        assert!(!committed.contains_key(&b"key3".to_vec()));
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #969. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783211359&installation_id=129708444&pr_number=986&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F986&signature=6801bbf6c6e495022a39a28da8f533806305b8522011969051f6296ad4ddcdb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced garbage collection test suite with multi-version scenarios and snapshot-based validation
  * Improved transaction savepoint rollback tests with comprehensive state verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->