### PR TITLE
merge: #1013 Primary-replica logical stream tracer

### DIFF
--- a/crates/reddb-server/src/replication/failover.rs
+++ b/crates/reddb-server/src/replication/failover.rs
@@ -40,6 +40,61 @@
 
 use std::time::Duration;
 
+use crate::replication::CommitPolicy;
+
+/// Promotion-time view of the local replica's durable progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PromotionProgress {
+    /// Highest logical stream LSN applied and durably checkpointed locally.
+    pub durable_lsn: u64,
+    /// Primary frontier the replica must cover before normal promotion.
+    pub required_lsn: u64,
+    /// Commit policy active for the cluster.
+    pub policy: CommitPolicy,
+}
+
+/// Why a normal replica promotion is unsafe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromotionRefusal {
+    BelowRequiredDurableWatermark(PromotionProgress),
+}
+
+impl std::fmt::Display for PromotionRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BelowRequiredDurableWatermark(progress) => write!(
+                f,
+                "promotion refused: replica durable_lsn {} is below required {} for commit policy {}",
+                progress.durable_lsn,
+                progress.required_lsn,
+                progress.policy.label()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for PromotionRefusal {}
+
+/// Normal promotion is only safe when the replica has durably applied
+/// the primary frontier it is being asked to assume. The frontier is a
+/// semantic logical-stream LSN, not a physical page/file WAL offset.
+pub fn check_promotion_watermark(
+    durable_lsn: u64,
+    required_lsn: u64,
+    policy: CommitPolicy,
+) -> Result<PromotionProgress, PromotionRefusal> {
+    let progress = PromotionProgress {
+        durable_lsn,
+        required_lsn,
+        policy,
+    };
+    if durable_lsn < required_lsn {
+        Err(PromotionRefusal::BelowRequiredDurableWatermark(progress))
+    } else {
+        Ok(progress)
+    }
+}
+
 /// The replication role a node plays after a failover step.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NodeRole {
@@ -534,5 +589,27 @@ mod tests {
         assert!(!outcome.forced);
         assert_eq!(outcome.skipped_lsn, 0);
         assert!(outcome.is_zero_rpo());
+    }
+
+    #[test]
+    fn normal_promotion_rejects_replica_below_required_durable_watermark() {
+        let err =
+            check_promotion_watermark(41, 42, CommitPolicy::AckN(1)).expect_err("must reject");
+        match err {
+            PromotionRefusal::BelowRequiredDurableWatermark(progress) => {
+                assert_eq!(progress.durable_lsn, 41);
+                assert_eq!(progress.required_lsn, 42);
+                assert_eq!(progress.policy, CommitPolicy::AckN(1));
+            }
+        }
+    }
+
+    #[test]
+    fn normal_promotion_accepts_replica_at_required_durable_watermark() {
+        let progress =
+            check_promotion_watermark(42, 42, CommitPolicy::Quorum).expect("must accept");
+        assert_eq!(progress.durable_lsn, 42);
+        assert_eq!(progress.required_lsn, 42);
+        assert_eq!(progress.policy, CommitPolicy::Quorum);
     }
 }

--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -6,6 +6,7 @@ use std::sync::{Condvar, Mutex};
 use crate::api::{RedDBError, RedDBResult};
 use crate::application::entity::metadata_from_json;
 use crate::replication::cdc::{ChangeOperation, ChangeRecord};
+use crate::runtime::index_store::IndexStore;
 use crate::storage::{EntityId, EntityKind, RedDB, UnifiedStore};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -348,6 +349,30 @@ impl LogicalChangeApplier {
         record: &ChangeRecord,
         mode: ApplyMode,
     ) -> Result<ApplyOutcome, LogicalApplyError> {
+        self.apply_inner(db, None, record, mode)
+    }
+
+    /// Apply one logical change record and maintain the runtime secondary
+    /// indexes declared on the replica. Restore/PITR callers should use
+    /// [`Self::apply`], because they may not have a live runtime index
+    /// store during recovery.
+    pub fn apply_with_index_store(
+        &self,
+        db: &RedDB,
+        index_store: &IndexStore,
+        record: &ChangeRecord,
+        mode: ApplyMode,
+    ) -> Result<ApplyOutcome, LogicalApplyError> {
+        self.apply_inner(db, Some(index_store), record, mode)
+    }
+
+    fn apply_inner(
+        &self,
+        db: &RedDB,
+        index_store: Option<&IndexStore>,
+        record: &ChangeRecord,
+        mode: ApplyMode,
+    ) -> Result<ApplyOutcome, LogicalApplyError> {
         let last = self.last_applied_lsn.load(Ordering::Acquire);
         let last_term = self.last_applied_term.load(Ordering::Acquire);
 
@@ -373,7 +398,7 @@ impl LogicalChangeApplier {
             .fetch_max(record.lsn, Ordering::AcqRel);
 
         if last == 0 && record.lsn > 0 {
-            self.do_apply(db, record, mode)?;
+            self.do_apply(db, index_store, record, mode)?;
             self.last_applied_term.store(record.term, Ordering::Release);
             self.last_applied_lsn.store(record.lsn, Ordering::Release);
             *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
@@ -405,7 +430,7 @@ impl LogicalChangeApplier {
             });
         }
 
-        self.do_apply(db, record, mode)?;
+        self.do_apply(db, index_store, record, mode)?;
         self.last_applied_term.store(record.term, Ordering::Release);
         self.last_applied_lsn.store(record.lsn, Ordering::Release);
         *self.last_payload_hash.lock().expect("payload hash mutex") = Some(payload_hash);
@@ -416,15 +441,15 @@ impl LogicalChangeApplier {
     fn do_apply(
         &self,
         db: &RedDB,
+        index_store: Option<&IndexStore>,
         record: &ChangeRecord,
         mode: ApplyMode,
     ) -> Result<(), LogicalApplyError> {
-        Self::apply_record_with_metrics(db, record, mode, &self.metrics).map_err(|err| {
-            LogicalApplyError::Apply {
+        Self::apply_record_with_metrics_and_indexes(db, index_store, record, mode, &self.metrics)
+            .map_err(|err| LogicalApplyError::Apply {
                 lsn: record.lsn,
                 source: err,
-            }
-        })
+            })
     }
 
     /// Stateless apply — applies the record without monotonicity
@@ -447,6 +472,16 @@ impl LogicalChangeApplier {
     /// rather than being swallowed by the old `let _ =`.
     pub fn apply_record_with_metrics(
         db: &RedDB,
+        record: &ChangeRecord,
+        _mode: ApplyMode,
+        metrics: &ReplicaApplyMetrics,
+    ) -> RedDBResult<()> {
+        Self::apply_record_with_metrics_and_indexes(db, None, record, _mode, metrics)
+    }
+
+    pub fn apply_record_with_metrics_and_indexes(
+        db: &RedDB,
+        index_store: Option<&IndexStore>,
         record: &ChangeRecord,
         _mode: ApplyMode,
         metrics: &ReplicaApplyMetrics,
@@ -514,6 +549,7 @@ impl LogicalChangeApplier {
                 };
                 let entity = UnifiedStore::deserialize_entity(bytes, store.format_version())
                     .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                let prior_entity = store.get(&record.collection, EntityId::new(record.entity_id));
 
                 // Issue #813 — MVCC table-row supersession on the replica.
                 //
@@ -577,6 +613,26 @@ impl LogicalChangeApplier {
                         .set_metadata(&record.collection, entity.id, metadata)
                         .map_err(|err| RedDBError::Internal(err.to_string()))?;
                 }
+                if let Some(index_store) = index_store {
+                    let new_fields = entity_index_fields(&entity);
+                    if !new_fields.is_empty() {
+                        if let Some(old) = prior_entity.as_ref() {
+                            let old_fields = entity_index_fields(old);
+                            index_store
+                                .index_entity_update(
+                                    &record.collection,
+                                    entity.id,
+                                    &old_fields,
+                                    &new_fields,
+                                )
+                                .map_err(RedDBError::Internal)?;
+                        } else {
+                            index_store
+                                .index_entity_insert(&record.collection, entity.id, &new_fields)
+                                .map_err(RedDBError::Internal)?;
+                        }
+                    }
+                }
                 store
                     .context_index()
                     .index_entity(&record.collection, &entity);
@@ -584,6 +640,17 @@ impl LogicalChangeApplier {
         }
         Ok(())
     }
+}
+
+fn entity_index_fields(
+    entity: &crate::storage::unified::entity::UnifiedEntity,
+) -> Vec<(String, crate::storage::schema::Value)> {
+    let Some(row) = entity.data.as_row() else {
+        return Vec::new();
+    };
+    row.iter_fields()
+        .map(|(name, value)| (name.to_string(), value.clone()))
+        .collect()
 }
 
 fn record_payload_hash(record: &ChangeRecord) -> [u8; 32] {

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -54,8 +54,9 @@ pub use election::{
     VotingState,
 };
 pub use failover::{
-    FailoverCoordinator, FailoverError, FailoverMode, FailoverNode, FailoverOutcome,
-    FailoverRequest, FailoverTransport, NodeRole, RoleAssignment,
+    check_promotion_watermark, FailoverCoordinator, FailoverError, FailoverMode, FailoverNode,
+    FailoverOutcome, FailoverRequest, FailoverTransport, NodeRole, PromotionProgress,
+    PromotionRefusal, RoleAssignment,
 };
 pub use fence::{
     FenceBoundary, FenceVerdict, FileTermStore, MemoryTermStore, StaleTermFenced, TermFence,

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1356,7 +1356,7 @@ mod impl_search;
 mod impl_timeseries;
 mod impl_tree;
 mod impl_vcs;
-mod index_store;
+pub(crate) mod index_store;
 pub mod integrity_tombstone;
 mod join_filter;
 mod keyed_spine;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4276,7 +4276,8 @@ impl RedDBRuntime {
         self.inner.db.store().set_config_tree(
             "red.replication",
             &crate::json!({
-                "last_applied_lsn": lsn
+                "last_applied_lsn": lsn,
+                "last_durable_lsn": lsn
             }),
         );
     }
@@ -5241,8 +5242,9 @@ impl RedDBRuntime {
                                     );
                                     continue;
                                 };
-                                match applier.apply(
+                                match applier.apply_with_index_store(
                                     self.inner.db.as_ref(),
+                                    self.index_store_ref(),
                                     &change,
                                     ApplyMode::Replica,
                                 ) {
@@ -5567,6 +5569,22 @@ impl RedDBRuntime {
     /// `Local` — current behavior, no replica blocking.
     pub fn commit_policy(&self) -> crate::replication::CommitPolicy {
         crate::replication::CommitPolicy::from_env()
+    }
+
+    /// Replica-side durable logical-stream progress. The current apply
+    /// loop persists this immediately after applying an LSN and before
+    /// acking the primary, so it is the local promotion safety watermark.
+    pub fn replica_durable_lsn(&self) -> u64 {
+        self.config_u64(
+            "red.replication.last_durable_lsn",
+            self.config_u64("red.replication.last_applied_lsn", 0),
+        )
+    }
+
+    /// Primary frontier most recently observed by this replica while
+    /// pulling the semantic logical stream.
+    pub fn replica_required_promotion_lsn(&self) -> u64 {
+        self.config_u64("red.replication.last_seen_primary_lsn", 0)
     }
 
     /// PLAN.md Phase 11.5 — accessor for replica-side apply error

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -2736,6 +2736,39 @@ impl RedDBServer {
             return json_error(409, reason);
         }
 
+        let durable_lsn = self.runtime.replica_durable_lsn();
+        let required_lsn = self.runtime.replica_required_promotion_lsn();
+        let policy = self.runtime.commit_policy();
+        if let Err(err) =
+            crate::replication::check_promotion_watermark(durable_lsn, required_lsn, policy)
+        {
+            let reason = err.to_string();
+            if let Err(emit_err) = self.runtime.emit_control_event(
+                crate::runtime::control_events::EventKind::ReplicationSafety,
+                crate::runtime::control_events::Outcome::Denied,
+                "promotion_refused",
+                Some("replication:durable_watermark".to_string()),
+                Some(reason.clone()),
+                vec![
+                    (
+                        "durable_lsn".to_string(),
+                        crate::runtime::control_events::Sensitivity::raw(durable_lsn.to_string()),
+                    ),
+                    (
+                        "required_lsn".to_string(),
+                        crate::runtime::control_events::Sensitivity::raw(required_lsn.to_string()),
+                    ),
+                    (
+                        "commit_policy".to_string(),
+                        crate::runtime::control_events::Sensitivity::raw(policy.label()),
+                    ),
+                ],
+            ) {
+                return json_error(500, emit_err.to_string());
+            }
+            return json_error(409, reason);
+        }
+
         // Body parsing.
         let (holder_id, ttl_ms) = if body.is_empty() {
             (default_holder_id(), 60_000u64)

--- a/tests/e2e_issue_813_replica_repull_idempotent.rs
+++ b/tests/e2e_issue_813_replica_repull_idempotent.rs
@@ -170,6 +170,20 @@ fn replay_from_zero(replica: &RedDB, records: &[ChangeRecord]) {
     }
 }
 
+fn replay_from_zero_with_indexes(replica: &RedDBRuntime, records: &[ChangeRecord]) {
+    let applier = LogicalChangeApplier::new(0);
+    for record in records {
+        applier
+            .apply_with_index_store(
+                replica.db().as_ref(),
+                replica.index_store_ref(),
+                record,
+                ApplyMode::Replica,
+            )
+            .unwrap_or_else(|err| panic!("apply lsn={} failed: {err}", record.lsn));
+    }
+}
+
 /// Pure inserts: a 5-row table replayed from LSN 0, then re-pulled from
 /// LSN 0 (cursor wiped), must not inflate the replica's entity count.
 #[test]
@@ -295,4 +309,102 @@ fn repull_with_updates_converges_to_primary_live_set() {
     drop(replica);
     cleanup(&primary_path);
     cleanup(&replica_path);
+}
+
+#[test]
+fn logical_stream_replay_maintains_declared_replica_indexes() {
+    let primary_path = temp_path("primary-indexed");
+    let replica_path = temp_path("replica-indexed");
+
+    let (records, _) = drive_primary(
+        &primary_path,
+        "users",
+        &[
+            "CREATE TABLE users (id INTEGER, age INTEGER, city TEXT)",
+            "INSERT INTO users (id, age, city) VALUES (1, 31, 'NYC')",
+            "INSERT INTO users (id, age, city) VALUES (2, 29, 'NYC')",
+            "INSERT INTO users (id, age, city) VALUES (3, 44, 'LA')",
+            "UPDATE users SET city = 'SF', age = 35 WHERE id = 2",
+        ],
+    );
+    assert!(
+        records.iter().all(|record| record.entity_bytes.is_some()),
+        "replication stream must carry semantic entity records, not physical WAL frames"
+    );
+
+    let replica = RedDBRuntime::with_options(RedDBOptions::persistent(
+        &replica_path.to_string_lossy().to_string(),
+    ))
+    .expect("open replica runtime");
+    replica
+        .execute_query("CREATE TABLE users (id INTEGER, age INTEGER, city TEXT)")
+        .unwrap();
+    replica
+        .execute_query("CREATE INDEX idx_city ON users (city) USING HASH")
+        .unwrap();
+    replica
+        .execute_query("CREATE INDEX idx_age ON users (age) USING BTREE")
+        .unwrap();
+
+    replay_from_zero_with_indexes(&replica, &records);
+
+    let live = live_rows(&replica.db().store(), "users");
+    assert!(
+        live.values().any(|fields| fields
+            .iter()
+            .any(|(name, value)| name == "city" && value.contains("SF"))),
+        "semantic replay must install the updated SF row before index lookup; live={live:?}"
+    );
+    let sf_ids = replica
+        .index_store_ref()
+        .hash_lookup("users", "idx_city", b"SF")
+        .expect("idx_city hash lookup");
+    assert_eq!(
+        sf_ids.len(),
+        1,
+        "replica index replay must populate idx_city for SF exactly once; live={live:?}"
+    );
+    let age_35_ids = replica
+        .index_store_ref()
+        .hash_lookup("users", "idx_age_hash", &35i64.to_le_bytes())
+        .expect("idx_age_hash lookup");
+    assert_eq!(
+        age_35_ids.len(),
+        1,
+        "replica BTree replay must maintain the equality helper for age=35"
+    );
+
+    drop(replica);
+    cleanup(&primary_path);
+    cleanup(&replica_path);
+}
+
+#[test]
+fn replica_progress_exposes_applied_and_durable_promotion_watermarks() {
+    let replica = RedDBRuntime::with_options(
+        RedDBOptions::in_memory()
+            .with_replication(ReplicationConfig::replica("http://primary:50051")),
+    )
+    .expect("open replica runtime");
+
+    replica.db().store().set_config_tree(
+        "red.replication",
+        &reddb::json!({
+            "last_applied_lsn": 40,
+            "last_durable_lsn": 39,
+            "last_seen_primary_lsn": 42
+        }),
+    );
+
+    assert_eq!(replica.replica_durable_lsn(), 39);
+    assert_eq!(replica.replica_required_promotion_lsn(), 42);
+    assert!(
+        reddb::replication::check_promotion_watermark(
+            replica.replica_durable_lsn(),
+            replica.replica_required_promotion_lsn(),
+            reddb::replication::CommitPolicy::AckN(1),
+        )
+        .is_err(),
+        "normal promotion must reject a replica below the durable target"
+    );
 }


### PR DESCRIPTION
Automated AFK landing for #1013. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783327381&installation_id=129708444&pr_number=1029&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1029&signature=eeab6ae8496387f127d43fa4a3d00afabd3595cf9a05b39607bdd995aed012a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added promotion safety validation to prevent unsafe replica promotions
  * Extended replica recovery to maintain secondary indexes during replication playback

* **Bug Fixes**
  * Added safety gate to promotion endpoint that denies unsafe promotion requests with appropriate error responses

* **Tests**
  * Added end-to-end tests validating secondary index maintenance during replica recovery
  * Added end-to-end tests verifying promotion safety checks and progress watermarks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->