### PR TITLE
merge: #1016 Replica-aware read routing freshness tracer

### DIFF
--- a/crates/reddb-client/src/bookmark_routing.rs
+++ b/crates/reddb-client/src/bookmark_routing.rs
@@ -138,6 +138,9 @@ impl ReadEndpoint {
 /// Why a causal read landed on the endpoint it did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteKind {
+    /// Eventual read routed to a healthy replica without a freshness
+    /// requirement.
+    EventualReplica,
     /// The chosen target replica's snapshot frontier already covered
     /// the bookmark — no wait was needed.
     EligibleTarget,
@@ -291,6 +294,59 @@ impl RoutingTable {
         self.replicas
             .iter()
             .position(|r| r.healthy && !r.rebootstrapping)
+    }
+
+    /// Pick a replica for an ordinary eventual read.
+    ///
+    /// Eventual reads have no required LSN, so any healthy replica is
+    /// eligible. Re-bootstrapping replicas are included here: they may
+    /// keep serving their old snapshot for non-causal reads while
+    /// rebuilding, but they remain excluded from freshness-required
+    /// routes.
+    pub fn route_eventual_read(&self, preferred_region: Option<&str>) -> RouteDecision {
+        let replica = preferred_region
+            .and_then(|region| {
+                self.replicas
+                    .iter()
+                    .find(|r| r.healthy && r.region == region)
+            })
+            .or_else(|| self.replicas.iter().find(|r| r.healthy));
+
+        match replica {
+            Some(r) => RouteDecision {
+                endpoint: Endpoint {
+                    addr: r.addr.clone(),
+                    region: r.region.clone(),
+                },
+                kind: RouteKind::EventualReplica,
+                waited: Duration::ZERO,
+            },
+            None => RouteDecision {
+                endpoint: self.write.endpoint(),
+                kind: RouteKind::FallbackPrimary,
+                waited: Duration::ZERO,
+            },
+        }
+    }
+
+    /// Resolve a freshness-required read using a required contiguous
+    /// applied LSN rather than an opaque bookmark token.
+    ///
+    /// This is the same routing rule causal bookmarks use after the
+    /// token is decoded: only replicas whose contiguous applied
+    /// frontier reaches `required_lsn` may serve the read; the chosen
+    /// target gets a bounded chance to catch up before fallback.
+    pub fn route_required_lsn_read(
+        &self,
+        required_lsn: u64,
+        opts: &CausalReadOptions,
+        waiter: &mut dyn BookmarkWaiter,
+    ) -> RouteDecision {
+        self.route_causal_read(
+            BookmarkTarget::new(self.write.term, required_lsn),
+            opts,
+            waiter,
+        )
     }
 
     /// Resolve a causal read with bounded-wait-then-fallback.

--- a/crates/reddb-client/tests/read_routing_freshness.rs
+++ b/crates/reddb-client/tests/read_routing_freshness.rs
@@ -1,0 +1,127 @@
+//! Issue #1016 — replica-aware read routing freshness tracer.
+
+use std::time::Duration;
+
+use reddb_client::bookmark_routing::{BookmarkWaiter, CausalReadOptions, RouteKind, RoutingTable};
+use reddb_client::topology::ClusterMembership;
+use reddb_wire::topology::{Endpoint, ReplicaInfo};
+
+fn primary() -> Endpoint {
+    Endpoint {
+        addr: "primary:5050".into(),
+        region: "us-east-1".into(),
+    }
+}
+
+fn replica(addr: &str, region: &str, healthy: bool, last_applied_lsn: u64) -> ReplicaInfo {
+    ReplicaInfo {
+        addr: addr.into(),
+        region: region.into(),
+        healthy,
+        lag_ms: if healthy { 5 } else { u32::MAX },
+        last_applied_lsn,
+        rebootstrapping: false,
+    }
+}
+
+fn table(replicas: Vec<ReplicaInfo>) -> RoutingTable {
+    RoutingTable::from_membership(
+        ClusterMembership {
+            primary: primary(),
+            replicas,
+            epoch: 1016,
+        },
+        1,
+    )
+}
+
+struct ScriptedWaiter {
+    frontiers: Vec<u64>,
+    idx: usize,
+    tick: Duration,
+    elapsed: Duration,
+    polled: Vec<String>,
+}
+
+impl ScriptedWaiter {
+    fn new(frontiers: Vec<u64>, tick: Duration) -> Self {
+        Self {
+            frontiers,
+            idx: 0,
+            tick,
+            elapsed: Duration::ZERO,
+            polled: Vec::new(),
+        }
+    }
+}
+
+impl BookmarkWaiter for ScriptedWaiter {
+    fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    fn poll(&mut self, target_addr: &str) -> u64 {
+        self.polled.push(target_addr.to_string());
+        self.elapsed += self.tick;
+        let frontier = self
+            .frontiers
+            .get(self.idx)
+            .copied()
+            .or_else(|| self.frontiers.last().copied())
+            .unwrap_or(0);
+        self.idx += 1;
+        frontier
+    }
+}
+
+#[test]
+fn eventual_read_routes_to_healthy_replica_without_waiting() {
+    let table = table(vec![
+        replica("down:5050", "us-east-1", false, 900),
+        replica("healthy:5050", "us-east-1", true, 10),
+    ]);
+
+    let decision = table.route_eventual_read(None);
+
+    assert_eq!(decision.kind, RouteKind::EventualReplica);
+    assert_eq!(decision.endpoint.addr, "healthy:5050");
+    assert_eq!(decision.waited, Duration::ZERO);
+}
+
+#[test]
+fn required_lsn_read_avoids_stale_replica_and_uses_caught_up_peer() {
+    let table = table(vec![
+        replica("stale:5050", "us-east-1", true, 80),
+        replica("caught-up:5050", "us-west-2", true, 120),
+    ]);
+    let mut waiter = ScriptedWaiter::new(vec![80, 85, 90], Duration::from_millis(10));
+
+    let decision = table.route_required_lsn_read(
+        100,
+        &CausalReadOptions::with_deadline(Duration::from_millis(25)).prefer_region("us-east-1"),
+        &mut waiter,
+    );
+
+    assert_eq!(decision.kind, RouteKind::FallbackReplica);
+    assert_eq!(decision.endpoint.addr, "caught-up:5050");
+    assert!(waiter.polled.iter().all(|addr| addr == "stale:5050"));
+}
+
+#[test]
+fn required_lsn_read_falls_back_to_primary_after_bounded_wait() {
+    let table = table(vec![
+        replica("stale-a:5050", "us-east-1", true, 40),
+        replica("stale-b:5050", "us-west-2", true, 60),
+    ]);
+    let mut waiter = ScriptedWaiter::new(vec![50, 70, 90], Duration::from_millis(10));
+
+    let decision = table.route_required_lsn_read(
+        100,
+        &CausalReadOptions::with_deadline(Duration::from_millis(25)),
+        &mut waiter,
+    );
+
+    assert_eq!(decision.kind, RouteKind::FallbackPrimary);
+    assert_eq!(decision.endpoint.addr, "primary:5050");
+    assert!(decision.waited >= Duration::from_millis(25));
+}


### PR DESCRIPTION
Automated AFK landing for #1016. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783328479&installation_id=129708444&pr_number=1030&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1030&signature=0e00c9de4c134edff83cf5d2203705393db3182479c241d28e4e8245ec9553e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replica-aware read routing supporting two strategies: immediate eventual reads and LSN-based freshness-required reads
  * Intelligent replica selection with optional region preference and automatic fallback to primary when freshness deadlines are exceeded

* **Tests**
  * Added comprehensive test suite validating replica selection, freshness guarantees, and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->