### PR TITLE
merge: #1015 Operational WAL retention floor

### DIFF
--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -1416,11 +1416,17 @@ impl PrimaryReplication {
     }
 
     pub fn prune_retained_wal_through(&self, archived_lsn: u64) -> io::Result<u64> {
+        self.prune_retained_wal(crate::storage::wal::WalPruneBoundary::new(archived_lsn))
+    }
+
+    pub fn prune_retained_wal(
+        &self,
+        boundary: crate::storage::wal::WalPruneBoundary,
+    ) -> io::Result<u64> {
         self.enforce_retention_limits(crate::utils::now_unix_millis() as u128);
-        let prune_lsn = self
-            .retention_floor_lsn()
-            .map(|floor| floor.min(archived_lsn))
-            .unwrap_or(archived_lsn);
+        let prune_lsn = boundary
+            .with_replica_restart_lsn(self.retention_floor_lsn())
+            .prune_through_lsn();
         if prune_lsn > 0 {
             if let Some(spool) = &self.logical_wal_spool {
                 spool.prune_through(prune_lsn)?;
@@ -1895,6 +1901,65 @@ mod tests {
             .map(|(lsn, _)| lsn)
             .collect();
         assert_eq!(retained, vec![6]);
+    }
+
+    #[test]
+    fn backup_floor_limits_wal_pruning_without_replicas() {
+        let primary = PrimaryReplication::new(None);
+        for lsn in 1..=6 {
+            primary.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+
+        let boundary = crate::storage::wal::WalPruneBoundary::new(6).with_backup_floor_lsn(Some(3));
+
+        assert_eq!(primary.prune_retained_wal(boundary).unwrap(), 3);
+        let retained: Vec<_> = primary
+            .wal_buffer
+            .read_since(0, usize::MAX)
+            .into_iter()
+            .map(|(lsn, _)| lsn)
+            .collect();
+        assert_eq!(
+            retained,
+            vec![4, 5, 6],
+            "backup/PITR floor keeps WAL needed after the retained checkpoint"
+        );
+    }
+
+    #[test]
+    fn combined_backup_and_replica_floors_choose_conservative_boundary() {
+        let primary = PrimaryReplication::new(None);
+        primary.register_replica("fast".to_string());
+        primary.register_replica("slow".to_string());
+        for lsn in 1..=8 {
+            primary.wal_buffer.append(lsn, vec![lsn as u8]);
+        }
+        primary.ack_replica_lsn("fast", 8, 8);
+        primary.ack_replica_lsn("slow", 3, 2);
+
+        let backup_floor =
+            crate::storage::wal::WalPruneBoundary::new(8).with_backup_floor_lsn(Some(6));
+        assert_eq!(
+            primary.prune_retained_wal(backup_floor).unwrap(),
+            2,
+            "slowest replica restart LSN beats the newer backup floor"
+        );
+
+        primary.ack_replica_lsn("slow", 8, 8);
+        let older_backup =
+            crate::storage::wal::WalPruneBoundary::new(8).with_backup_floor_lsn(Some(4));
+        assert_eq!(
+            primary.prune_retained_wal(older_backup).unwrap(),
+            4,
+            "older retained backup checkpoint beats caught-up replicas"
+        );
+        let retained: Vec<_> = primary
+            .wal_buffer
+            .read_since(0, usize::MAX)
+            .into_iter()
+            .map(|(lsn, _)| lsn)
+            .collect();
+        assert_eq!(retained, vec![5, 6, 7, 8]);
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -5960,7 +5960,14 @@ impl RedDBRuntime {
                     )
                     .map_err(|err| RedDBError::Internal(err.to_string()))?
                     {
-                        let _ = primary.prune_retained_wal_through(meta.lsn_end);
+                        let backup_floor_lsn = crate::storage::wal::backup_wal_retention_floor_lsn(
+                            backend.as_ref(),
+                            &snapshot_prefix,
+                        )
+                        .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                        let boundary = crate::storage::wal::WalPruneBoundary::new(meta.lsn_end)
+                            .with_backup_floor_lsn(backup_floor_lsn);
+                        let _ = primary.prune_retained_wal(boundary);
                         // Advance the chain head so the next archive call
                         // links to this segment's hash. If the segment has
                         // no sha256 (legacy / hashing failed) we leave the

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -62,6 +62,45 @@ pub struct SnapshotManifest {
     pub snapshot_sha256: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WalPruneBoundary {
+    pub archived_lsn: u64,
+    pub backup_floor_lsn: Option<u64>,
+    pub replica_restart_lsn: Option<u64>,
+}
+
+impl WalPruneBoundary {
+    pub fn new(archived_lsn: u64) -> Self {
+        Self {
+            archived_lsn,
+            backup_floor_lsn: None,
+            replica_restart_lsn: None,
+        }
+    }
+
+    pub fn with_backup_floor_lsn(mut self, floor_lsn: Option<u64>) -> Self {
+        self.backup_floor_lsn = floor_lsn;
+        self
+    }
+
+    pub fn with_replica_restart_lsn(mut self, restart_lsn: Option<u64>) -> Self {
+        self.replica_restart_lsn = restart_lsn;
+        self
+    }
+
+    pub fn prune_through_lsn(self) -> u64 {
+        [
+            Some(self.archived_lsn),
+            self.backup_floor_lsn,
+            self.replica_restart_lsn,
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .unwrap_or(0)
+    }
+}
+
 impl BackupHead {
     pub fn to_json_value(&self) -> JsonValue {
         let mut object = Map::new();
@@ -140,6 +179,10 @@ impl BackupHead {
 }
 
 impl SnapshotManifest {
+    pub fn wal_retention_floor_lsn(&self) -> u64 {
+        self.base_lsn
+    }
+
     pub fn to_json_value(&self) -> JsonValue {
         let mut object = Map::new();
         object.insert(
@@ -335,7 +378,7 @@ impl WalArchiver {
         self.backend.download(segment_key, dest)
     }
 
-    /// Delete archived segments older than the given LSN.
+    /// Delete archived segments fully covered by the given LSN.
     /// Returns the number of segments deleted.
     pub fn cleanup_before(&self, lsn: u64) -> Result<usize, BackendError> {
         let keys = self.backend.list(&self.prefix)?;
@@ -345,17 +388,18 @@ impl WalArchiver {
             let Some(file_name) = path.file_name().and_then(|s| s.to_str()) else {
                 continue;
             };
-            let Some((start, _end)) = file_name
+            let Some((start, end)) = file_name
                 .strip_suffix(".wal")
                 .and_then(|base| base.split_once('-'))
             else {
                 continue;
             };
-            let Ok(lsn_start) = start.parse::<u64>() else {
+            let (Ok(_lsn_start), Ok(lsn_end)) = (start.parse::<u64>(), end.parse::<u64>()) else {
                 continue;
             };
-            if lsn_start < lsn {
+            if lsn_end <= lsn {
                 self.backend.delete(&key)?;
+                let _ = self.backend.delete(&wal_segment_manifest_key(&key));
                 deleted += 1;
             }
         }
@@ -935,6 +979,16 @@ pub fn load_snapshot_manifest(
     Ok(Some(SnapshotManifest::from_json_value(&value)?))
 }
 
+pub fn backup_wal_retention_floor_lsn(
+    backend: &dyn RemoteBackend,
+    snapshot_prefix: &str,
+) -> Result<Option<u64>, BackendError> {
+    Ok(collect_unified_snapshots(backend, snapshot_prefix)?
+        .into_iter()
+        .map(|snapshot| snapshot.lsn)
+        .min())
+}
+
 pub fn archive_change_records(
     backend: &dyn RemoteBackend,
     prefix: &str,
@@ -1399,6 +1453,76 @@ mod tests {
         assert!(s1.prev_hash.is_none(), "first segment has no prev_hash");
         assert_eq!(s2.prev_hash, m1.sha256, "seg 2 links to seg 1 sha256");
         assert_eq!(s3.prev_hash, m2.sha256, "seg 3 links to seg 2 sha256");
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn backup_manifest_floor_uses_oldest_retained_snapshot_lsn() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("reddb_backup_floor_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let backend = LocalBackend;
+        let prefix = format!("{}/snapshots/", temp_dir.to_string_lossy());
+        std::fs::create_dir_all(&prefix).unwrap();
+
+        for (snapshot_id, base_lsn) in [(1, 10), (2, 30)] {
+            let snapshot_key = format!("{prefix}{snapshot_id:012}.snapshot");
+            std::fs::write(&snapshot_key, b"snapshot").unwrap();
+            publish_snapshot_manifest(
+                &backend,
+                &SnapshotManifest {
+                    timeline_id: "main".to_string(),
+                    snapshot_key,
+                    snapshot_id,
+                    snapshot_time: snapshot_id * 100,
+                    base_lsn,
+                    schema_version: crate::api::REDDB_FORMAT_VERSION,
+                    format_version: crate::api::REDDB_FORMAT_VERSION,
+                    snapshot_sha256: None,
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(
+            backup_wal_retention_floor_lsn(&backend, &prefix).unwrap(),
+            Some(10),
+            "oldest retained snapshot base_lsn is the PITR WAL floor"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn cleanup_before_keeps_segment_crossing_retention_floor() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("reddb_archive_cleanup_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let backend = Arc::new(LocalBackend);
+        let prefix = format!("{}/wal/", temp_dir.to_string_lossy());
+        let archiver = WalArchiver::new(backend.clone(), prefix.clone());
+
+        let wal_path = temp_dir.join("segment.wal");
+        std::fs::write(&wal_path, b"segment-1").unwrap();
+        let old = archiver.archive_segment(&wal_path, 1, 3, None).unwrap();
+        std::fs::write(&wal_path, b"segment-2").unwrap();
+        let crossing = archiver
+            .archive_segment(&wal_path, 4, 6, old.sha256.clone())
+            .unwrap();
+
+        assert_eq!(archiver.cleanup_before(5).unwrap(), 1);
+        assert!(!backend.exists(&old.key).unwrap());
+        assert!(
+            !backend.exists(&wal_segment_manifest_key(&old.key)).unwrap(),
+            "cleanup removes sidecar with deleted segment"
+        );
+        assert!(
+            backend.exists(&crossing.key).unwrap(),
+            "segment containing WAL after the restore floor must remain"
+        );
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/crates/reddb-server/src/storage/wal/mod.rs
+++ b/crates/reddb-server/src/storage/wal/mod.rs
@@ -23,12 +23,13 @@ pub mod writer;
 
 pub use append_coordinator::WalAppendCoordinator;
 pub use archiver::{
-    archive_change_records, archive_snapshot, load_archived_change_records, load_backup_head,
-    load_snapshot_manifest, load_unified_manifest, load_wal_segment_manifest, publish_backup_head,
-    publish_snapshot_manifest, publish_unified_manifest, publish_unified_manifest_for_prefix,
-    publish_wal_segment_manifest, sha256_bytes_hex, sha256_file_hex, snapshot_manifest_key,
-    unified_manifest_key, wal_segment_manifest_key, BackupHead, SnapshotManifest, UnifiedManifest,
-    UnifiedSnapshotEntry, UnifiedWalEntry, WalArchiver, WalSegmentManifest, WalSegmentMeta,
+    archive_change_records, archive_snapshot, backup_wal_retention_floor_lsn,
+    load_archived_change_records, load_backup_head, load_snapshot_manifest, load_unified_manifest,
+    load_wal_segment_manifest, publish_backup_head, publish_snapshot_manifest,
+    publish_unified_manifest, publish_unified_manifest_for_prefix, publish_wal_segment_manifest,
+    sha256_bytes_hex, sha256_file_hex, snapshot_manifest_key, unified_manifest_key,
+    wal_segment_manifest_key, BackupHead, SnapshotManifest, UnifiedManifest, UnifiedSnapshotEntry,
+    UnifiedWalEntry, WalArchiver, WalPruneBoundary, WalSegmentManifest, WalSegmentMeta,
 };
 pub use checkpoint::{CheckpointError, CheckpointMode, CheckpointResult, Checkpointer};
 pub use group_commit::GroupCommit;

--- a/crates/reddb-server/src/storage/wal/operational.rs
+++ b/crates/reddb-server/src/storage/wal/operational.rs
@@ -33,6 +33,7 @@ pub struct OperationalBackupFile {
 pub struct OperationalBackupManifest {
     pub version: u32,
     pub checkpoint_lsn: u64,
+    pub wal_retention_floor_lsn: u64,
     pub wal_start_lsn: u64,
     pub current_lsn: u64,
     pub files: Vec<OperationalBackupFile>,
@@ -122,6 +123,7 @@ pub fn create_operational_backup(
     let manifest = OperationalBackupManifest {
         version: 1,
         checkpoint_lsn,
+        wal_retention_floor_lsn: wal_start_lsn,
         wal_start_lsn,
         current_lsn,
         files,
@@ -303,6 +305,10 @@ fn read_manifest(path: &Path) -> Result<OperationalBackupManifest, BackendError>
 }
 
 impl OperationalBackupManifest {
+    pub fn wal_retention_floor_lsn(&self) -> u64 {
+        self.wal_retention_floor_lsn
+    }
+
     fn to_json_value(&self) -> JsonValue {
         let mut object = Map::new();
         object.insert(
@@ -312,6 +318,10 @@ impl OperationalBackupManifest {
         object.insert(
             "checkpoint_lsn".to_string(),
             JsonValue::Number(self.checkpoint_lsn as f64),
+        );
+        object.insert(
+            "wal_retention_floor_lsn".to_string(),
+            JsonValue::Number(self.wal_retention_floor_lsn as f64),
         );
         object.insert(
             "wal_start_lsn".to_string(),
@@ -351,6 +361,15 @@ impl OperationalBackupManifest {
                 .and_then(JsonValue::as_u64)
                 .ok_or_else(|| {
                     BackendError::Internal("backup manifest missing checkpoint_lsn".to_string())
+                })?,
+            wal_retention_floor_lsn: value
+                .get("wal_retention_floor_lsn")
+                .and_then(JsonValue::as_u64)
+                .or_else(|| value.get("wal_start_lsn").and_then(JsonValue::as_u64))
+                .ok_or_else(|| {
+                    BackendError::Internal(
+                        "backup manifest missing wal_retention_floor_lsn".to_string(),
+                    )
                 })?,
             wal_start_lsn: value
                 .get("wal_start_lsn")

--- a/tests/e2e_operational_backup_restore.rs
+++ b/tests/e2e_operational_backup_restore.rs
@@ -113,6 +113,12 @@ fn checkpoint_backup_records_boundary_manifest_and_file_checksums() {
         manifest.get("checkpoint_lsn").and_then(JsonValue::as_u64),
         Some(backup.checkpoint_lsn)
     );
+    assert_eq!(
+        manifest
+            .get("wal_retention_floor_lsn")
+            .and_then(JsonValue::as_u64),
+        Some(backup.wal_start_lsn)
+    );
     let files = manifest
         .get("files")
         .and_then(JsonValue::as_array)


### PR DESCRIPTION
Automated AFK landing for #1015. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783328597&installation_id=129708444&pr_number=1031&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1031&signature=d8152c07a5b9b07e6a3625acfc84df446aa8a961b92a393bd35d801fbabeca64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced WAL pruning to properly account for backup and replica retention requirements, ensuring no data loss.
  * WAL cleanup now uses conservative logic to preserve segments spanning retention boundaries.

* **Tests**
  * Added tests validating retention floor calculations and segment cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->