### PR TITLE
merge: #1020 Cluster range directory layout tracer

### DIFF
--- a/crates/reddb-server/src/storage/cluster_layout.rs
+++ b/crates/reddb-server/src/storage/cluster_layout.rs
@@ -1,0 +1,150 @@
+//! Cluster range-directory layout tracer.
+//!
+//! This is deliberately a small physical-layout tracer: it records the mapping
+//! from logical collection/range identity to an on-disk range directory and
+//! creates the per-range data/index/append-only segment files. The existing
+//! pager remains the storage engine for this slice.
+
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterRangeLayout {
+    ranges_dir: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeMetadata {
+    pub collection: String,
+    pub collection_id: u64,
+    pub logical_range_id: String,
+    pub physical_range_dir_id: String,
+    pub physical_dir: PathBuf,
+    pub data_file: PathBuf,
+    pub index_file: PathBuf,
+    pub append_segment_file: PathBuf,
+}
+
+impl ClusterRangeLayout {
+    pub fn new(support_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            ranges_dir: support_dir.into().join("ranges"),
+        }
+    }
+
+    pub fn ranges_dir(&self) -> &Path {
+        &self.ranges_dir
+    }
+
+    pub fn metadata_for(
+        &self,
+        collection: &str,
+        collection_id: u64,
+        physical_file_id: &str,
+    ) -> RangeMetadata {
+        let logical_range_id = format!("range-{collection_id:016x}");
+        let physical_range_dir_id = format!("{physical_file_id}-range");
+        let physical_dir = self.ranges_dir.join(&physical_range_dir_id);
+        RangeMetadata {
+            collection: collection.to_string(),
+            collection_id,
+            logical_range_id,
+            physical_range_dir_id,
+            data_file: physical_dir.join("data.rdb"),
+            index_file: physical_dir.join("index.rdb"),
+            append_segment_file: physical_dir.join("segments.aof"),
+            physical_dir,
+        }
+    }
+
+    pub fn prepare_range(&self, metadata: &RangeMetadata) -> io::Result<()> {
+        fs::create_dir_all(&metadata.physical_dir)?;
+        touch(&metadata.data_file)?;
+        touch(&metadata.index_file)?;
+        touch(&metadata.append_segment_file)?;
+        self.write_metadata(metadata)
+    }
+
+    pub fn load_collection_range(&self, collection: &str) -> io::Result<Option<RangeMetadata>> {
+        if !self.ranges_dir.exists() {
+            return Ok(None);
+        }
+        for entry in fs::read_dir(&self.ranges_dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let path = entry.path().join("range.meta");
+            if !path.exists() {
+                continue;
+            }
+            let raw = fs::read_to_string(&path)?;
+            let Some(metadata) = parse_metadata(&raw) else {
+                continue;
+            };
+            if metadata.collection == collection {
+                return Ok(Some(metadata));
+            }
+        }
+        Ok(None)
+    }
+
+    fn write_metadata(&self, metadata: &RangeMetadata) -> io::Result<()> {
+        let path = metadata.physical_dir.join("range.meta");
+        let body = format!(
+            "collection={}\ncollection_id={}\nlogical_range_id={}\nphysical_range_dir_id={}\ndata_file={}\nindex_file={}\nappend_segment_file={}\n",
+            metadata.collection,
+            metadata.collection_id,
+            metadata.logical_range_id,
+            metadata.physical_range_dir_id,
+            metadata.data_file.display(),
+            metadata.index_file.display(),
+            metadata.append_segment_file.display(),
+        );
+        fs::write(path, body)
+    }
+}
+
+fn touch(path: &Path) -> io::Result<()> {
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .map(|_| ())
+}
+
+fn parse_metadata(raw: &str) -> Option<RangeMetadata> {
+    let mut collection = None;
+    let mut collection_id = None;
+    let mut logical_range_id = None;
+    let mut physical_range_dir_id = None;
+    let mut data_file = None;
+    let mut index_file = None;
+    let mut append_segment_file = None;
+    for line in raw.lines() {
+        let (key, value) = line.split_once('=')?;
+        match key {
+            "collection" => collection = Some(value.to_string()),
+            "collection_id" => collection_id = value.parse::<u64>().ok(),
+            "logical_range_id" => logical_range_id = Some(value.to_string()),
+            "physical_range_dir_id" => physical_range_dir_id = Some(value.to_string()),
+            "data_file" => data_file = Some(PathBuf::from(value)),
+            "index_file" => index_file = Some(PathBuf::from(value)),
+            "append_segment_file" => append_segment_file = Some(PathBuf::from(value)),
+            _ => {}
+        }
+    }
+    let data_file = data_file?;
+    let physical_dir = data_file.parent()?.to_path_buf();
+    Some(RangeMetadata {
+        collection: collection?,
+        collection_id: collection_id?,
+        logical_range_id: logical_range_id?,
+        physical_range_dir_id: physical_range_dir_id?,
+        physical_dir,
+        data_file,
+        index_file: index_file?,
+        append_segment_file: append_segment_file?,
+    })
+}

--- a/crates/reddb-server/src/storage/mod.rs
+++ b/crates/reddb-server/src/storage/mod.rs
@@ -77,6 +77,9 @@ pub mod layout;
 // Storage/deploy profile selection contract.
 pub mod profile;
 
+// Cluster range-directory layout tracer.
+pub mod cluster_layout;
+
 // Embedded single-file `.rdb` artifact skeleton.
 pub mod embedded;
 
@@ -97,6 +100,7 @@ pub mod signed_writes;
 
 // Public surface re-used by the rest of the codebase.
 pub use backend::{BackendError, LocalBackend, RemoteBackend};
+pub use cluster_layout::{ClusterRangeLayout, RangeMetadata};
 pub use embedded::{
     EmbeddedRdbArtifact, EmbeddedRdbManifest, EmbeddedRdbOpen, EmbeddedRdbSuperblock,
     EMBEDDED_RDB_MANIFEST_OFFSET, EMBEDDED_RDB_SUPERBLOCK_0_OFFSET,

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -21,6 +21,12 @@ fn store_config_from_options(options: &RedDBOptions) -> UnifiedStoreConfig {
         .with_durability_mode(options.durability_mode)
         .with_group_commit(options.group_commit);
     config.auto_index_id = options.auto_index_id;
+    if options.storage_profile.deploy_profile == crate::storage::profile::DeployProfile::Cluster {
+        if let Some((_, paths)) = options.resolve_tiered_layout() {
+            config.cluster_range_layout =
+                Some(crate::storage::ClusterRangeLayout::new(paths.support_dir));
+        }
+    }
 
     if let Ok(value) = std::env::var("REDDB_DURABILITY") {
         if let Some(mode) = DurabilityMode::from_str(&value) {

--- a/crates/reddb-server/src/storage/unified/store.rs
+++ b/crates/reddb-server/src/storage/unified/store.rs
@@ -42,6 +42,7 @@ use crate::storage::engine::pager::PagerError;
 use crate::storage::engine::{BTree, BTreeError, Pager, PagerConfig, PhysicalFileHeader};
 use crate::storage::primitives::encoding::{read_varu32, read_varu64, write_varu32, write_varu64};
 use crate::storage::schema::types::Value;
+use crate::storage::{ClusterRangeLayout, RangeMetadata};
 
 const STORE_MAGIC: &[u8; 4] = b"RDST";
 const STORE_VERSION_V1: u32 = 1;
@@ -286,6 +287,9 @@ pub struct UnifiedStoreConfig {
     pub group_commit: GroupCommitOptions,
     /// Data directory path
     pub data_dir: Option<std::path::PathBuf>,
+    /// Cluster range-directory tracer layout. `None` keeps embedded /
+    /// primary-replica storage on the existing single-store physical layout.
+    pub cluster_range_layout: Option<ClusterRangeLayout>,
 }
 
 impl Default for UnifiedStoreConfig {
@@ -301,6 +305,7 @@ impl Default for UnifiedStoreConfig {
             durability_mode: DurabilityMode::WalDurableGrouped,
             group_commit: GroupCommitOptions::default(),
             data_dir: None,
+            cluster_range_layout: None,
         }
     }
 }
@@ -511,6 +516,9 @@ pub struct UnifiedStore {
     /// rebuilt state is byte-deterministic against the pre-restart
     /// state under a fixed codec seed.
     pub(crate) replayed_turbo_inserts: parking_lot::Mutex<HashMap<String, Vec<(u64, Vec<f32>)>>>,
+    /// Logical collection/range ownership metadata for the cluster
+    /// range-directory tracer.
+    collection_ranges: RwLock<HashMap<String, RangeMetadata>>,
 }
 
 mod builder;

--- a/crates/reddb-server/src/storage/unified/store/commit.rs
+++ b/crates/reddb-server/src/storage/unified/store/commit.rs
@@ -136,6 +136,26 @@ fn take_deferred_store_wal_capture() -> DeferredStoreWalActions {
 }
 
 impl StoreWalAction {
+    fn collection_name(&self) -> Option<&str> {
+        match self {
+            Self::CreateCollection { name, .. } => Some(name),
+            Self::DropCollection { name } => Some(name),
+            Self::UpsertEntityRecord { collection, .. }
+            | Self::DeleteEntityRecord { collection, .. }
+            | Self::BulkUpsertEntityRecords { collection, .. }
+            | Self::RefreshCollection { collection, .. } => Some(collection),
+        }
+    }
+
+    fn create_collection_range_id(&self) -> Option<String> {
+        match self {
+            Self::CreateCollection { collection_id, .. } => {
+                Some(format!("range-{collection_id:016x}"))
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn upsert_entity(
         collection: &str,
         entity: &UnifiedEntity,
@@ -312,6 +332,17 @@ impl StoreWalAction {
 
 fn legacy_collection_physical_file_id(name: &str) -> String {
     format!("legacy-collection-{name}")
+}
+
+fn commit_batch_record(tx_id: u64, actions: Vec<Vec<u8>>, range_id: Option<&str>) -> WalRecord {
+    match range_id {
+        Some(range_id) => WalRecord::RangeCommitBatch {
+            tx_id,
+            range_id: range_id.to_string(),
+            actions,
+        },
+        None => WalRecord::TxCommitBatch { tx_id, actions },
+    }
 }
 
 #[derive(Debug)]
@@ -550,7 +581,11 @@ impl StoreCommitCoordinator {
         self.fsync_count.load(Ordering::Relaxed)
     }
 
-    pub(crate) fn append_actions(&self, actions: &[StoreWalAction]) -> io::Result<()> {
+    pub(crate) fn append_actions(
+        &self,
+        actions: &[StoreWalAction],
+        range_id: Option<&str>,
+    ) -> io::Result<()> {
         if actions.is_empty() {
             return Ok(());
         }
@@ -564,10 +599,11 @@ impl StoreCommitCoordinator {
         if matches!(self.mode, DurabilityMode::Strict) {
             let commit_lsn = {
                 let mut wal = self.wal.lock();
-                wal.append(&WalRecord::TxCommitBatch {
+                wal.append(&commit_batch_record(
                     tx_id,
-                    actions: actions.iter().map(StoreWalAction::encode).collect(),
-                })?;
+                    actions.iter().map(StoreWalAction::encode).collect(),
+                    range_id,
+                ))?;
                 wal.current_lsn()
             };
             self.force_sync()?;
@@ -582,11 +618,7 @@ impl StoreCommitCoordinator {
         let wal_bytes = encoded_actions.iter().fold(0u64, |total, payload| {
             total.saturating_add(payload.len() as u64)
         });
-        let blob = WalRecord::TxCommitBatch {
-            tx_id,
-            actions: encoded_actions,
-        }
-        .encode();
+        let blob = commit_batch_record(tx_id, encoded_actions, range_id).encode();
 
         let commit_lsn = self.queue.enqueue(blob);
         self.wait_until_durable(commit_lsn, wal_bytes)?;
@@ -680,6 +712,14 @@ impl StoreCommitCoordinator {
             };
             match record {
                 WalRecord::TxCommitBatch { actions, .. } => {
+                    for payload in actions {
+                        let action = StoreWalAction::decode(&payload)?;
+                        store.apply_replayed_action(&action).map_err(|err| {
+                            io::Error::other(format!("failed to replay store wal action: {err}"))
+                        })?;
+                    }
+                }
+                WalRecord::RangeCommitBatch { actions, .. } => {
                     for payload in actions {
                         let action = StoreWalAction::decode(&payload)?;
                         store.apply_replayed_action(&action).map_err(|err| {
@@ -914,8 +954,9 @@ impl UnifiedStore {
             DurabilityMode::Strict => self.flush_paged_state(),
             DurabilityMode::WalDurableGrouped | DurabilityMode::Async => {
                 if let Some(commit) = &self.commit {
+                    let range_id = self.range_id_for_actions(&actions.actions);
                     commit
-                        .append_actions(&actions.actions)
+                        .append_actions(&actions.actions, range_id.as_deref())
                         .map_err(StoreError::Io)
                 } else {
                     self.flush_paged_state()
@@ -965,7 +1006,10 @@ impl UnifiedStore {
             DurabilityMode::Strict => self.flush_paged_state(),
             DurabilityMode::WalDurableGrouped | DurabilityMode::Async => {
                 if let Some(commit) = &self.commit {
-                    commit.append_actions(&actions).map_err(StoreError::Io)?;
+                    let range_id = self.range_id_for_actions(&actions);
+                    commit
+                        .append_actions(&actions, range_id.as_deref())
+                        .map_err(StoreError::Io)?;
                     Ok(())
                 } else {
                     self.flush_paged_state()
@@ -974,17 +1018,35 @@ impl UnifiedStore {
         }
     }
 
+    fn range_id_for_actions(&self, actions: &[StoreWalAction]) -> Option<String> {
+        let Some(_) = &self.config.cluster_range_layout else {
+            return None;
+        };
+        for action in actions {
+            if let Some(range_id) = action.create_collection_range_id() {
+                return Some(range_id);
+            }
+            if let Some(collection) = action.collection_name() {
+                if let Some(metadata) = self.collection_range_metadata(collection) {
+                    return Some(metadata.logical_range_id);
+                }
+            }
+        }
+        None
+    }
+
     pub(crate) fn apply_replayed_action(&self, action: &StoreWalAction) -> Result<(), StoreError> {
         match action {
             StoreWalAction::CreateCollection {
                 name,
                 collection_id,
-                physical_file_id: _,
+                physical_file_id,
             } => {
                 self.register_collection_id(*collection_id);
                 if self.get_collection(name).is_none() {
                     let _ = self.create_collection_in_memory(name);
                 }
+                let _ = self.register_collection_range(name, *collection_id, physical_file_id)?;
                 Ok(())
             }
             StoreWalAction::DropCollection { name } => self.drop_collection_in_memory(name),
@@ -1501,7 +1563,7 @@ mod tests {
                     physical_file_id: format!("collection-test-c{tx}"),
                 };
                 coord_c
-                    .append_actions(std::slice::from_ref(&action))
+                    .append_actions(std::slice::from_ref(&action), None)
                     .expect("append_actions");
             }));
         }
@@ -1555,7 +1617,7 @@ mod tests {
                     physical_file_id: format!("collection-test-z{tx}"),
                 };
                 coord_c
-                    .append_actions(std::slice::from_ref(&action))
+                    .append_actions(std::slice::from_ref(&action), None)
                     .expect("append_actions");
             }));
         }

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -247,6 +247,7 @@ impl UnifiedStore {
 
         let collection_id = self.next_collection_id();
         let physical_file_id = format!("collection-{collection_id:016x}");
+        self.register_collection_range(&name, collection_id, &physical_file_id)?;
         self.mark_paged_registry_dirty();
         self.finish_paged_write([StoreWalAction::CreateCollection {
             name,
@@ -285,6 +286,35 @@ impl UnifiedStore {
     /// Get a collection
     pub fn get_collection(&self, name: &str) -> Option<Arc<SegmentManager>> {
         self.collections.read().get(name).map(Arc::clone)
+    }
+
+    pub(crate) fn register_collection_range(
+        &self,
+        collection: &str,
+        collection_id: u64,
+        physical_file_id: &str,
+    ) -> Result<Option<RangeMetadata>, StoreError> {
+        let Some(layout) = &self.config.cluster_range_layout else {
+            return Ok(None);
+        };
+        let metadata = layout.metadata_for(collection, collection_id, physical_file_id);
+        layout.prepare_range(&metadata)?;
+        self.collection_ranges
+            .write()
+            .insert(collection.to_string(), metadata.clone());
+        Ok(Some(metadata))
+    }
+
+    pub fn collection_range_metadata(&self, collection: &str) -> Option<RangeMetadata> {
+        if let Some(metadata) = self.collection_ranges.read().get(collection).cloned() {
+            return Some(metadata);
+        }
+        let layout = self.config.cluster_range_layout.as_ref()?;
+        let metadata = layout.load_collection_range(collection).ok().flatten()?;
+        self.collection_ranges
+            .write()
+            .insert(collection.to_string(), metadata.clone());
+        Some(metadata)
     }
 
     /// Get the context index for cross-structure search.

--- a/crates/reddb-server/src/storage/unified/store/impl_pages.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_pages.rs
@@ -330,6 +330,7 @@ impl UnifiedStore {
             commit: None,
             unindex_cross_refs_fast_path: AtomicU64::new(0),
             replayed_turbo_inserts: parking_lot::Mutex::new(HashMap::new()),
+            collection_ranges: RwLock::new(HashMap::new()),
         }
     }
 
@@ -404,6 +405,7 @@ impl UnifiedStore {
             commit,
             unindex_cross_refs_fast_path: AtomicU64::new(0),
             replayed_turbo_inserts: parking_lot::Mutex::new(HashMap::new()),
+            collection_ranges: RwLock::new(HashMap::new()),
         };
 
         // Load existing data from pages if database exists

--- a/crates/reddb-server/src/storage/wal/checkpoint.rs
+++ b/crates/reddb-server/src/storage/wal/checkpoint.rs
@@ -193,6 +193,10 @@ impl Checkpointer {
                     // Store-level logical commit batches are replayed by
                     // UnifiedStore, not by the pager page checkpoint path.
                 }
+                WalRecord::RangeCommitBatch { .. } => {
+                    // Store-level logical commit batches are replayed by
+                    // UnifiedStore, not by the pager page checkpoint path.
+                }
                 WalRecord::VectorInsert { .. } => {
                     // Vector-turbo logical inserts are replayed by the
                     // vector index layer, not by page checkpointing.

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -71,6 +71,8 @@ pub enum RecordType {
     FullPageImage = 8,
     /// Logical vector insert for vector-turbo WAL replay.
     VectorInsert = 9,
+    /// Cluster range-scoped logical commit batch.
+    RangeCommitBatch = 10,
 }
 
 impl RecordType {
@@ -85,6 +87,7 @@ impl RecordType {
             7 => Some(RecordType::TxCommitBatch),
             8 => Some(RecordType::FullPageImage),
             9 => Some(RecordType::VectorInsert),
+            10 => Some(RecordType::RangeCommitBatch),
             _ => None,
         }
     }
@@ -109,6 +112,12 @@ pub enum WalRecord {
     /// Atomic logical commit batch. Recovery applies all actions in
     /// order iff this complete record and checksum are present.
     TxCommitBatch { tx_id: u64, actions: Vec<Vec<u8>> },
+    /// Atomic logical commit batch stamped with the owning range.
+    RangeCommitBatch {
+        tx_id: u64,
+        range_id: String,
+        actions: Vec<Vec<u8>>,
+    },
     /// Full-page image — pristine page bytes captured before the first
     /// modification per checkpoint cycle. Recovery applies these before
     /// redo so torn writes are healed without the `-dwb` sidecar.
@@ -242,6 +251,22 @@ impl WalRecord {
                 buf.push(RecordType::TxCommitBatch as u8);
                 buf.extend_from_slice(&term.to_le_bytes());
                 buf.extend_from_slice(&tx_id.to_le_bytes());
+                buf.extend_from_slice(&(actions.len() as u32).to_le_bytes());
+                for action in actions {
+                    buf.extend_from_slice(&(action.len() as u32).to_le_bytes());
+                    buf.extend_from_slice(action);
+                }
+            }
+            WalRecord::RangeCommitBatch {
+                tx_id,
+                range_id,
+                actions,
+            } => {
+                buf.push(RecordType::RangeCommitBatch as u8);
+                buf.extend_from_slice(&term.to_le_bytes());
+                buf.extend_from_slice(&tx_id.to_le_bytes());
+                buf.extend_from_slice(&(range_id.len() as u32).to_le_bytes());
+                buf.extend_from_slice(range_id.as_bytes());
                 buf.extend_from_slice(&(actions.len() as u32).to_le_bytes());
                 for action in actions {
                     buf.extend_from_slice(&(action.len() as u32).to_le_bytes());
@@ -467,6 +492,51 @@ impl WalRecord {
 
                 WalRecord::TxCommitBatch { tx_id, actions }
             }
+            RecordType::RangeCommitBatch => {
+                let mut tx_buf = [0u8; 8];
+                reader.read_exact(&mut tx_buf)?;
+                running_crc = crc32_update(running_crc, &tx_buf);
+                let tx_id = u64::from_le_bytes(tx_buf);
+
+                let mut range_len_buf = [0u8; 4];
+                reader.read_exact(&mut range_len_buf)?;
+                running_crc = crc32_update(running_crc, &range_len_buf);
+                let range_len = u32::from_le_bytes(range_len_buf) as usize;
+
+                let mut range_buf = vec![0u8; range_len];
+                reader.read_exact(&mut range_buf)?;
+                running_crc = crc32_update(running_crc, &range_buf);
+                let range_id = String::from_utf8(range_buf).map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid range id utf8: {err}"),
+                    )
+                })?;
+
+                let mut count_buf = [0u8; 4];
+                reader.read_exact(&mut count_buf)?;
+                running_crc = crc32_update(running_crc, &count_buf);
+                let count = u32::from_le_bytes(count_buf) as usize;
+
+                let mut actions = Vec::with_capacity(count);
+                for _ in 0..count {
+                    let mut len_buf = [0u8; 4];
+                    reader.read_exact(&mut len_buf)?;
+                    running_crc = crc32_update(running_crc, &len_buf);
+                    let len = u32::from_le_bytes(len_buf) as usize;
+
+                    let mut action = vec![0u8; len];
+                    reader.read_exact(&mut action)?;
+                    running_crc = crc32_update(running_crc, &action);
+                    actions.push(action);
+                }
+
+                WalRecord::RangeCommitBatch {
+                    tx_id,
+                    range_id,
+                    actions,
+                }
+            }
             RecordType::VectorInsert => {
                 let mut len_buf = [0u8; 4];
                 reader.read_exact(&mut len_buf)?;
@@ -585,12 +655,13 @@ mod tests {
         assert_eq!(RecordType::from_u8(7), Some(RecordType::TxCommitBatch));
         assert_eq!(RecordType::from_u8(8), Some(RecordType::FullPageImage));
         assert_eq!(RecordType::from_u8(9), Some(RecordType::VectorInsert));
+        assert_eq!(RecordType::from_u8(10), Some(RecordType::RangeCommitBatch));
     }
 
     #[test]
     fn test_record_type_invalid() {
         assert_eq!(RecordType::from_u8(0), None);
-        assert_eq!(RecordType::from_u8(10), None);
+        assert_eq!(RecordType::from_u8(11), None);
         assert_eq!(RecordType::from_u8(255), None);
     }
 
@@ -671,6 +742,18 @@ mod tests {
         let encoded = record.encode();
 
         assert_eq!(encoded[0], RecordType::TxCommitBatch as u8);
+    }
+
+    #[test]
+    fn test_encode_range_commit_batch() {
+        let record = WalRecord::RangeCommitBatch {
+            tx_id: 7,
+            range_id: "range-0000000000000007".to_string(),
+            actions: vec![b"insert".to_vec(), b"update".to_vec()],
+        };
+        let encoded = record.encode();
+
+        assert_eq!(encoded[0], RecordType::RangeCommitBatch as u8);
     }
 
     // ==================== WalRecord::read Tests ====================
@@ -768,6 +851,21 @@ mod tests {
     fn test_read_tx_commit_batch_roundtrip() {
         let original = WalRecord::TxCommitBatch {
             tx_id: 42,
+            actions: vec![b"old-version".to_vec(), b"new-version".to_vec()],
+        };
+        let encoded = original.encode();
+
+        let mut cursor = Cursor::new(encoded);
+        let decoded = WalRecord::read(&mut cursor).unwrap().unwrap();
+
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_read_range_commit_batch_roundtrip() {
+        let original = WalRecord::RangeCommitBatch {
+            tx_id: 42,
+            range_id: "range-000000000000002a".to_string(),
             actions: vec![b"old-version".to_vec(), b"new-version".to_vec()],
         };
         let encoded = original.encode();
@@ -980,6 +1078,11 @@ mod tests {
             },
             WalRecord::TxCommitBatch {
                 tx_id: 7,
+                actions: vec![b"insert".to_vec(), b"update".to_vec()],
+            },
+            WalRecord::RangeCommitBatch {
+                tx_id: 8,
+                range_id: "range-0000000000000008".to_string(),
                 actions: vec![b"insert".to_vec(), b"update".to_vec()],
             },
             WalRecord::FullPageImage {

--- a/tests/e2e_issue_1020_cluster_range_layout.rs
+++ b/tests/e2e_issue_1020_cluster_range_layout.rs
@@ -1,0 +1,132 @@
+//! Issue #1020 — cluster range-directory layout tracer.
+
+use std::path::PathBuf;
+
+use reddb::api::DurabilityMode;
+use reddb::storage::schema::Value;
+use reddb::storage::wal::{WalReader, WalRecord};
+use reddb::storage::StorageDeployPreset;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+struct DbPath {
+    path: PathBuf,
+}
+
+impl DbPath {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "reddb_issue_1020_{label}_{}_{}.rdb",
+            std::process::id(),
+            nanos
+        ));
+        let db = Self { path };
+        db.cleanup();
+        db
+    }
+
+    fn open(&self) -> RedDBRuntime {
+        let options = RedDBOptions::persistent(&self.path)
+            .with_durability_mode(DurabilityMode::WalDurableGrouped)
+            .with_storage_profile(StorageDeployPreset::Cluster.selection())
+            .expect("cluster storage profile");
+        RedDBRuntime::with_options(options).expect("cluster runtime")
+    }
+
+    fn support_dir(&self) -> PathBuf {
+        let file = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("data path file name");
+        self.path.with_file_name(format!("{file}.red"))
+    }
+
+    fn wal_path(&self) -> PathBuf {
+        self.path.with_extension("rdb-uwal")
+    }
+
+    fn cleanup(&self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_file(self.wal_path());
+        let _ = std::fs::remove_dir_all(self.support_dir());
+    }
+}
+
+impl Drop for DbPath {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+#[test]
+fn cluster_profile_creates_range_directory_metadata_and_range_wal_identity() {
+    let db = DbPath::new("range_layout");
+    let rt = db.open();
+
+    exec(&rt, "CREATE TABLE orders (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO orders (id, label) VALUES (1, 'alpha')");
+
+    let metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("orders")
+        .expect("orders range metadata");
+    assert_eq!(metadata.collection, "orders");
+    let expected_range_id = format!("range-{:016x}", metadata.collection_id);
+    let expected_physical_dir_id = format!("collection-{:016x}-range", metadata.collection_id);
+    assert_eq!(metadata.logical_range_id, expected_range_id);
+    assert_eq!(metadata.physical_range_dir_id, expected_physical_dir_id);
+    assert!(metadata.physical_dir.is_dir());
+    assert!(metadata.data_file.is_file());
+    assert!(metadata.index_file.is_file());
+    assert!(metadata.append_segment_file.is_file());
+    assert!(metadata.physical_dir.join("range.meta").is_file());
+
+    let wal_records = WalReader::open(db.wal_path())
+        .expect("open store wal")
+        .iter()
+        .collect::<std::io::Result<Vec<_>>>()
+        .expect("read store wal");
+    let range_batches: Vec<_> = wal_records
+        .iter()
+        .filter_map(|(_, record)| match record {
+            WalRecord::RangeCommitBatch {
+                range_id, actions, ..
+            } => Some((range_id, actions.len())),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        range_batches
+            .iter()
+            .any(|(range_id, _)| range_id.as_str() == metadata.logical_range_id),
+        "expected range-stamped WAL batch for {}",
+        metadata.logical_range_id
+    );
+
+    drop(rt);
+    let reopened = db.open();
+    let reopened_metadata = reopened
+        .db()
+        .store()
+        .collection_range_metadata("orders")
+        .expect("orders range metadata after replay");
+    assert_eq!(reopened_metadata, metadata);
+
+    let selected = reopened
+        .execute_query("SELECT label FROM orders WHERE id = 1")
+        .expect("select through range-owned collection");
+    assert_eq!(
+        selected.result.records[0].get("label"),
+        Some(&Value::text("alpha"))
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #1020. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783329718&installation_id=129708444&pr_number=1033&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1033&signature=b6a7433ff8f3d33d0ec9c352d8633a68314fae49d62b54b4242f9c0ffbdc3ecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster range layout infrastructure to support distributed data organization across cluster deployments.
  * Enhanced write-ahead logging with range-scoped commit batching for improved reliability in clustered environments.

* **Tests**
  * Added end-to-end test verifying cluster range directory structure and data persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->