### PR TITLE
merge: #1017 Replica auxiliary index boundary

### DIFF
--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -10547,13 +10547,13 @@ impl RedDBRuntime {
         }
         self.inner
             .index_store
-            .register(super::index_store::RegisteredIndex {
-                name: index_name,
-                collection: table.to_string(),
+            .register(super::index_store::RegisteredIndex::replicated(
+                index_name,
+                table.to_string(),
                 columns,
-                method: super::index_store::IndexMethodKind::Hash,
-                unique: false,
-            });
+                super::index_store::IndexMethodKind::Hash,
+                false,
+            ));
         self.invalidate_plan_cache();
     }
 

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -1426,13 +1426,13 @@ impl RedDBRuntime {
         // Register metadata
         self.inner
             .index_store
-            .register(super::index_store::RegisteredIndex {
-                name: query.name.clone(),
-                collection: query.table.clone(),
-                columns: query.columns.clone(),
-                method: method_kind,
-                unique: query.unique,
-            });
+            .register(super::index_store::RegisteredIndex::replicated(
+                query.name.clone(),
+                query.table.clone(),
+                query.columns.clone(),
+                method_kind,
+                query.unique,
+            ));
         // Issue #120 — surface the index name + indexed columns in
         // the schema-vocabulary so AskPipeline (#121) can resolve
         // "the email index" back to its collection.

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1107,6 +1107,7 @@ pub struct RegisteredIndex {
     pub columns: Vec<String>,
     pub method: IndexMethodKind,
     pub unique: bool,
+    pub scope: IndexScope,
 }
 
 impl RegisteredIndex {
@@ -1124,6 +1125,46 @@ impl RegisteredIndex {
             }
         }
     }
+
+    pub fn replicated(
+        name: String,
+        collection: String,
+        columns: Vec<String>,
+        method: IndexMethodKind,
+        unique: bool,
+    ) -> Self {
+        Self {
+            name,
+            collection,
+            columns,
+            method,
+            unique,
+            scope: IndexScope::Replicated,
+        }
+    }
+
+    pub fn auxiliary(
+        name: String,
+        collection: String,
+        columns: Vec<String>,
+        method: IndexMethodKind,
+        unique: bool,
+    ) -> Self {
+        Self {
+            name,
+            collection,
+            columns,
+            method,
+            unique,
+            scope: IndexScope::Auxiliary,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexScope {
+    Replicated,
+    Auxiliary,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1280,6 +1321,60 @@ impl IndexStore {
         registry.insert((info.collection.clone(), info.name.clone()), info);
     }
 
+    pub fn create_auxiliary_index(
+        &self,
+        name: &str,
+        collection: &str,
+        columns: &[String],
+        method: IndexMethodKind,
+        unique: bool,
+        entities: &[(EntityId, Vec<(String, Value)>)],
+    ) -> Result<usize, String> {
+        let indexed = self.create_index(name, collection, columns, method, unique, entities)?;
+        self.register(RegisteredIndex::auxiliary(
+            name.to_string(),
+            collection.to_string(),
+            columns.to_vec(),
+            method,
+            unique,
+        ));
+        Ok(indexed)
+    }
+
+    pub fn create_auxiliary_hash_index(
+        &self,
+        name: &str,
+        collection: &str,
+        column: &str,
+    ) -> Result<usize, String> {
+        self.create_auxiliary_index(
+            name,
+            collection,
+            &[column.to_string()],
+            IndexMethodKind::Hash,
+            false,
+            &[],
+        )
+    }
+
+    pub fn discard_auxiliary_indices(&self) {
+        let indices = {
+            let registry = read_unpoisoned(&self.registry);
+            registry
+                .values()
+                .filter(|idx| idx.scope == IndexScope::Auxiliary)
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        for index in indices {
+            self.drop_index(&index.name, &index.collection);
+        }
+    }
+
+    pub fn discard_auxiliary_indices_for_promotion(&self) {
+        self.discard_auxiliary_indices();
+    }
+
     /// Lookup entity IDs via hash index for a collection.column = value
     pub fn hash_lookup(
         &self,
@@ -1343,6 +1438,15 @@ impl IndexStore {
         registry
             .values()
             .filter(|idx| idx.collection == collection)
+            .cloned()
+            .collect()
+    }
+
+    pub fn list_replicated_indices(&self, collection: &str) -> Vec<RegisteredIndex> {
+        let registry = read_unpoisoned(&self.registry);
+        registry
+            .values()
+            .filter(|idx| idx.collection == collection && idx.scope == IndexScope::Replicated)
             .cloned()
             .collect()
     }
@@ -1871,13 +1975,13 @@ mod tests {
     #[test]
     fn test_index_entity_insert_errors_when_registered_hash_index_is_missing() {
         let store = IndexStore::new();
-        store.register(RegisteredIndex {
-            name: "idx_email".to_string(),
-            collection: "users".to_string(),
-            columns: vec!["email".to_string()],
-            method: IndexMethodKind::Hash,
-            unique: false,
-        });
+        store.register(RegisteredIndex::replicated(
+            "idx_email".to_string(),
+            "users".to_string(),
+            vec!["email".to_string()],
+            IndexMethodKind::Hash,
+            false,
+        ));
 
         let err = store
             .index_entity_insert(
@@ -1905,13 +2009,13 @@ mod tests {
                 &[],
             )
             .unwrap();
-        store.register(RegisteredIndex {
-            name: "idx_city_age".to_string(),
-            collection: "users".to_string(),
-            columns: columns.clone(),
-            method: IndexMethodKind::BTree,
-            unique: false,
-        });
+        store.register(RegisteredIndex::replicated(
+            "idx_city_age".to_string(),
+            "users".to_string(),
+            columns.clone(),
+            IndexMethodKind::BTree,
+            false,
+        ));
 
         let rows = vec![
             (
@@ -1967,13 +2071,13 @@ mod tests {
                 &[],
             )
             .unwrap();
-        store.register(RegisteredIndex {
-            name: "idx_email".to_string(),
-            collection: "users".to_string(),
-            columns: vec!["email".to_string()],
-            method: IndexMethodKind::Hash,
-            unique: false,
-        });
+        store.register(RegisteredIndex::replicated(
+            "idx_email".to_string(),
+            "users".to_string(),
+            vec!["email".to_string()],
+            IndexMethodKind::Hash,
+            false,
+        ));
     }
 
     #[test]
@@ -2005,13 +2109,13 @@ mod tests {
         // No backing hash index exists — delete must still return Ok
         // (deleting from a dropped index is a non-fatal no-op).
         let store = IndexStore::new();
-        store.register(RegisteredIndex {
-            name: "idx_email".to_string(),
-            collection: "users".to_string(),
-            columns: vec!["email".to_string()],
-            method: IndexMethodKind::Hash,
-            unique: false,
-        });
+        store.register(RegisteredIndex::replicated(
+            "idx_email".to_string(),
+            "users".to_string(),
+            vec!["email".to_string()],
+            IndexMethodKind::Hash,
+            false,
+        ));
         store
             .index_entity_delete(
                 "users",

--- a/crates/reddb-server/src/runtime/mutation.rs
+++ b/crates/reddb-server/src/runtime/mutation.rs
@@ -445,13 +445,13 @@ impl<'rt> MutationEngine<'rt> {
             );
             return;
         }
-        index_store.register(super::index_store::RegisteredIndex {
-            name: "idx_id".to_string(),
-            collection: collection.to_string(),
+        index_store.register(super::index_store::RegisteredIndex::replicated(
+            "idx_id".to_string(),
+            collection.to_string(),
             columns,
-            method: super::index_store::IndexMethodKind::Hash,
-            unique: false,
-        });
+            super::index_store::IndexMethodKind::Hash,
+            false,
+        ));
         // Plan-cache invalidation so subsequent SELECT/UPDATE/DELETE
         // pickers see the new index when planning. Mirrors the explicit
         // `CREATE INDEX` path in `impl_ddl::execute_create_index`.

--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -1757,7 +1757,10 @@ fn indices_snapshot(
         if !visible_collections.is_none_or(|visible| visible.contains(&collection.name)) {
             continue;
         }
-        for index in runtime.index_store_ref().list_indices(&collection.name) {
+        for index in runtime
+            .index_store_ref()
+            .list_replicated_indices(&collection.name)
+        {
             let key = (Some(index.collection.clone()), index.name.clone());
             if !seen.insert(key) {
                 continue;
@@ -1800,7 +1803,10 @@ fn show_indexes_snapshot(
         if !collection_is_visible(&collection.name, visible_collections) {
             continue;
         }
-        for index in runtime.index_store_ref().list_indices(&collection.name) {
+        for index in runtime
+            .index_store_ref()
+            .list_replicated_indices(&collection.name)
+        {
             let entries_indexed = runtime.index_store_ref().entries_indexed(&index);
             rows.push(UnifiedRecord::with_schema(
                 Arc::clone(&schema),

--- a/tests/e2e_issue_813_replica_repull_idempotent.rs
+++ b/tests/e2e_issue_813_replica_repull_idempotent.rs
@@ -312,7 +312,7 @@ fn repull_with_updates_converges_to_primary_live_set() {
 }
 
 #[test]
-fn logical_stream_replay_maintains_declared_replica_indexes() {
+fn logical_stream_replay_maintains_official_replicated_indexes() {
     let primary_path = temp_path("primary-indexed");
     let replica_path = temp_path("replica-indexed");
 
@@ -345,6 +345,12 @@ fn logical_stream_replay_maintains_declared_replica_indexes() {
     replica
         .execute_query("CREATE INDEX idx_age ON users (age) USING BTREE")
         .unwrap();
+    let official = replica.index_store_ref().list_replicated_indices("users");
+    assert_eq!(
+        official.len(),
+        2,
+        "CREATE INDEX must register official replicated indexes"
+    );
 
     replay_from_zero_with_indexes(&replica, &records);
 
@@ -373,10 +379,166 @@ fn logical_stream_replay_maintains_declared_replica_indexes() {
         1,
         "replica BTree replay must maintain the equality helper for age=35"
     );
+    let catalog = replica
+        .execute_query(
+            "SELECT * FROM red.indices WHERE collection = 'users' AND name IN ('idx_city', 'idx_age')",
+        )
+        .expect("red.indices query");
+    assert_eq!(
+        catalog.result.records.len(),
+        2,
+        "official indexes must remain visible in replicated catalog views"
+    );
 
     drop(replica);
     cleanup(&primary_path);
     cleanup(&replica_path);
+}
+
+#[test]
+fn auxiliary_indexes_are_local_and_do_not_enter_catalog_state() {
+    let primary_path = temp_path("primary-aux");
+    let replica_path = temp_path("replica-aux");
+
+    let (records, _) = drive_primary(
+        &primary_path,
+        "users",
+        &[
+            "CREATE TABLE users (id INTEGER, city TEXT)",
+            "INSERT INTO users (id, city) VALUES (1, 'NYC')",
+            "INSERT INTO users (id, city) VALUES (2, 'NYC')",
+            "INSERT INTO users (id, city) VALUES (3, 'LA')",
+        ],
+    );
+
+    let replica = RedDBRuntime::with_options(RedDBOptions::persistent(
+        &replica_path.to_string_lossy().to_string(),
+    ))
+    .expect("open replica runtime");
+    replica
+        .execute_query("CREATE TABLE users (id INTEGER, city TEXT)")
+        .unwrap();
+    replica
+        .index_store_ref()
+        .create_auxiliary_hash_index("aux_city", "users", "city")
+        .expect("create local auxiliary index");
+
+    assert_eq!(
+        replica.index_store_ref().list_indices("users").len(),
+        1,
+        "auxiliary index must exist in local runtime registry"
+    );
+    assert!(
+        replica
+            .index_store_ref()
+            .list_replicated_indices("users")
+            .is_empty(),
+        "auxiliary index must not be classified as official replicated state"
+    );
+
+    let before_catalog = replica
+        .execute_query("SELECT * FROM red.indices WHERE collection = 'users' AND name = 'aux_city'")
+        .expect("red.indices query");
+    assert!(
+        before_catalog.result.records.is_empty(),
+        "auxiliary index must not appear in replicated catalog views"
+    );
+
+    replay_from_zero_with_indexes(&replica, &records);
+
+    let nyc_ids = replica
+        .index_store_ref()
+        .hash_lookup("users", "aux_city", b"NYC")
+        .expect("auxiliary hash lookup");
+    assert_eq!(
+        nyc_ids.len(),
+        2,
+        "local auxiliary index must still be maintained during replica row replay"
+    );
+    assert!(
+        replica
+            .index_store_ref()
+            .list_replicated_indices("users")
+            .is_empty(),
+        "replica row replay must not promote auxiliary indexes to official state"
+    );
+    let after_catalog = replica
+        .execute_query("SELECT * FROM red.indices WHERE collection = 'users' AND name = 'aux_city'")
+        .expect("red.indices query");
+    assert!(
+        after_catalog.result.records.is_empty(),
+        "auxiliary index must remain absent from catalog after replay"
+    );
+
+    drop(replica);
+    cleanup(&primary_path);
+    cleanup(&replica_path);
+}
+
+#[test]
+fn promotion_discards_auxiliary_indexes_without_promoting_them() {
+    let path = temp_path("promotion-aux");
+    let replica = RedDBRuntime::with_options(RedDBOptions::persistent(
+        &path.to_string_lossy().to_string(),
+    ))
+    .expect("open replica runtime");
+    replica
+        .execute_query("CREATE TABLE users (id INTEGER, city TEXT)")
+        .unwrap();
+    replica
+        .execute_query("CREATE INDEX idx_city ON users (city) USING HASH")
+        .unwrap();
+    replica
+        .index_store_ref()
+        .create_auxiliary_hash_index("aux_city", "users", "city")
+        .expect("create local auxiliary index");
+
+    assert_eq!(replica.index_store_ref().list_indices("users").len(), 2);
+    assert_eq!(
+        replica
+            .index_store_ref()
+            .list_replicated_indices("users")
+            .len(),
+        1,
+        "only the official index should be eligible to survive promotion"
+    );
+
+    replica
+        .index_store_ref()
+        .discard_auxiliary_indices_for_promotion();
+
+    let remaining = replica.index_store_ref().list_indices("users");
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining[0].name, "idx_city");
+    assert_eq!(
+        replica
+            .index_store_ref()
+            .list_replicated_indices("users")
+            .len(),
+        1,
+        "promotion discard must leave official replicated indexes intact"
+    );
+    assert!(
+        replica
+            .index_store_ref()
+            .hash_lookup("users", "aux_city", b"NYC")
+            .is_err(),
+        "auxiliary backing index must be removed during promotion discard"
+    );
+
+    let catalog = replica
+        .execute_query(
+            "SELECT * FROM red.indices WHERE collection = 'users' AND name IN ('idx_city', 'aux_city')",
+        )
+        .expect("red.indices query");
+    assert_eq!(
+        catalog.result.records.len(),
+        1,
+        "discarded auxiliary index must not become catalog-visible after promotion"
+    );
+
+    drop(replica);
+    cleanup(&path);
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1017. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783336510&installation_id=129708444&pr_number=1034&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1034&signature=694812412b3d3d7d12883ee2606dd66b448d56323a96ebf4ed8d496c11cc7d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated index registration system to explicitly distinguish between replicated and auxiliary indexes, improving replica synchronization and index lifecycle management. Auxiliary indexes are now properly isolated from replicated catalog state.

* **Tests**
  * Added comprehensive test coverage for auxiliary index behavior and replica index promotion scenarios to ensure correct index replication and lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->