### PR TITLE
merge: #1021 Move-range snapshot catch-up tracer

### DIFF
--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -31,6 +31,7 @@ pub mod fence;
 pub mod flow_control;
 pub mod lease;
 pub mod logical;
+pub mod move_range;
 pub mod primary;
 pub mod quorum;
 pub mod replica;
@@ -64,6 +65,10 @@ pub use fence::{
 };
 pub use flow_control::{Admission, FlowController};
 pub use lease::{LeaseError, LeaseStore, WriterLease};
+pub use move_range::{
+    MoveRangeCatchUp, MoveRangeCutover, MoveRangeError, MoveRangeRequest, MoveRangeTargetState,
+    MoveRangeTracer, RangeIndexedRecord, RangeOwnership,
+};
 pub use quorum::{QuorumConfig, QuorumCoordinator, QuorumError};
 pub use rollback::{
     DivergentTail, RollbackCoordinator, RollbackError, RollbackEvent, RollbackOutcome,

--- a/crates/reddb-server/src/replication/move_range.rs
+++ b/crates/reddb-server/src/replication/move_range.rs
@@ -1,0 +1,236 @@
+//! Move-range snapshot catch-up tracer (issue #1021).
+//!
+//! This module models the first range move flow over the storage pieces that
+//! already exist: a physical range-directory checkpoint plus range-stamped
+//! logical WAL batches. Live cluster transport can wrap these primitives later.
+
+use std::io;
+use std::path::Path;
+
+use crate::storage::wal::{WalReader, WalRecord};
+use crate::storage::{RangeMetadata, RangeSnapshot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeIndexedRecord {
+    pub lsn: u64,
+    pub range_id: String,
+    pub actions: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveRangeRequest {
+    pub range_id: String,
+    pub required_watermark_lsn: u64,
+    pub source_owner_epoch: u64,
+    pub target_owner_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveRangeTargetState {
+    pub range_id: String,
+    pub owner_epoch: u64,
+    pub snapshot_lsn: u64,
+    pub applied_lsn: u64,
+    pub metadata: RangeMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveRangeCatchUp {
+    pub range_id: String,
+    pub started_after_lsn: u64,
+    pub applied_lsn: u64,
+    pub applied_batches: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoveRangeCutover {
+    pub range_id: String,
+    pub owner_epoch: u64,
+    pub reached_lsn: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeOwnership {
+    pub range_id: String,
+    pub owner_node_id: String,
+    pub owner_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MoveRangeError {
+    WrongRange {
+        expected: String,
+        actual: String,
+    },
+    StaleTargetSnapshot {
+        range_id: String,
+        snapshot_epoch: u64,
+        required_epoch: u64,
+    },
+    CatchUpRequired {
+        range_id: String,
+        reached_lsn: u64,
+        required_lsn: u64,
+    },
+    StaleOwnerEpoch {
+        range_id: String,
+        attempted_epoch: u64,
+        current_epoch: u64,
+    },
+}
+
+impl std::fmt::Display for MoveRangeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongRange { expected, actual } => {
+                write!(f, "range move expected {expected}, got {actual}")
+            }
+            Self::StaleTargetSnapshot {
+                range_id,
+                snapshot_epoch,
+                required_epoch,
+            } => write!(
+                f,
+                "range {range_id} target snapshot epoch {snapshot_epoch} is stale; required {required_epoch}",
+            ),
+            Self::CatchUpRequired {
+                range_id,
+                reached_lsn,
+                required_lsn,
+            } => write!(
+                f,
+                "range {range_id} cutover blocked at LSN {reached_lsn}; required {required_lsn}",
+            ),
+            Self::StaleOwnerEpoch {
+                range_id,
+                attempted_epoch,
+                current_epoch,
+            } => write!(
+                f,
+                "range {range_id} write epoch {attempted_epoch} is stale; current owner epoch {current_epoch}",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MoveRangeError {}
+
+impl MoveRangeTargetState {
+    pub fn from_installed_snapshot(snapshot: &RangeSnapshot, metadata: RangeMetadata) -> Self {
+        Self {
+            range_id: metadata.logical_range_id.clone(),
+            owner_epoch: snapshot.owner_epoch,
+            snapshot_lsn: snapshot.snapshot_lsn,
+            applied_lsn: snapshot.snapshot_lsn,
+            metadata,
+        }
+    }
+}
+
+impl RangeOwnership {
+    pub fn new(
+        range_id: impl Into<String>,
+        owner_node_id: impl Into<String>,
+        owner_epoch: u64,
+    ) -> Self {
+        Self {
+            range_id: range_id.into(),
+            owner_node_id: owner_node_id.into(),
+            owner_epoch,
+        }
+    }
+
+    pub fn check_write_epoch(&self, attempted_epoch: u64) -> Result<(), MoveRangeError> {
+        if attempted_epoch == self.owner_epoch {
+            Ok(())
+        } else {
+            Err(MoveRangeError::StaleOwnerEpoch {
+                range_id: self.range_id.clone(),
+                attempted_epoch,
+                current_epoch: self.owner_epoch,
+            })
+        }
+    }
+}
+
+pub struct MoveRangeTracer;
+
+impl MoveRangeTracer {
+    pub fn read_range_indexed_wal(
+        wal_path: impl AsRef<Path>,
+        range_id: &str,
+        since_lsn: u64,
+    ) -> io::Result<Vec<RangeIndexedRecord>> {
+        let reader = WalReader::open(wal_path)?;
+        let mut records = Vec::new();
+        for entry in reader.iter() {
+            let (lsn, record) = entry?;
+            let WalRecord::RangeCommitBatch {
+                range_id: record_range_id,
+                actions,
+                ..
+            } = record
+            else {
+                continue;
+            };
+            if record_range_id == range_id && lsn > since_lsn {
+                records.push(RangeIndexedRecord {
+                    lsn,
+                    range_id: record_range_id,
+                    actions,
+                });
+            }
+        }
+        Ok(records)
+    }
+
+    pub fn catch_up_from_wal(
+        target: &mut MoveRangeTargetState,
+        wal_path: impl AsRef<Path>,
+        required_watermark_lsn: u64,
+    ) -> io::Result<MoveRangeCatchUp> {
+        let started_after_lsn = target.applied_lsn;
+        let records = Self::read_range_indexed_wal(wal_path, &target.range_id, target.applied_lsn)?;
+        for record in &records {
+            target.applied_lsn = target.applied_lsn.max(record.lsn);
+        }
+        target.applied_lsn = target.applied_lsn.min(required_watermark_lsn);
+        Ok(MoveRangeCatchUp {
+            range_id: target.range_id.clone(),
+            started_after_lsn,
+            applied_lsn: target.applied_lsn,
+            applied_batches: records.len(),
+        })
+    }
+
+    pub fn cutover(
+        req: &MoveRangeRequest,
+        target: &MoveRangeTargetState,
+    ) -> Result<MoveRangeCutover, MoveRangeError> {
+        if target.range_id != req.range_id {
+            return Err(MoveRangeError::WrongRange {
+                expected: req.range_id.clone(),
+                actual: target.range_id.clone(),
+            });
+        }
+        if target.owner_epoch != req.source_owner_epoch {
+            return Err(MoveRangeError::StaleTargetSnapshot {
+                range_id: req.range_id.clone(),
+                snapshot_epoch: target.owner_epoch,
+                required_epoch: req.source_owner_epoch,
+            });
+        }
+        if target.applied_lsn < req.required_watermark_lsn {
+            return Err(MoveRangeError::CatchUpRequired {
+                range_id: req.range_id.clone(),
+                reached_lsn: target.applied_lsn,
+                required_lsn: req.required_watermark_lsn,
+            });
+        }
+        Ok(MoveRangeCutover {
+            range_id: req.range_id.clone(),
+            owner_epoch: req.target_owner_epoch,
+            reached_lsn: target.applied_lsn,
+        })
+    }
+}

--- a/crates/reddb-server/src/storage/cluster_layout.rs
+++ b/crates/reddb-server/src/storage/cluster_layout.rs
@@ -26,6 +26,14 @@ pub struct RangeMetadata {
     pub append_segment_file: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeSnapshot {
+    pub metadata: RangeMetadata,
+    pub checkpoint_dir: PathBuf,
+    pub snapshot_lsn: u64,
+    pub owner_epoch: u64,
+}
+
 impl ClusterRangeLayout {
     pub fn new(support_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -63,7 +71,38 @@ impl ClusterRangeLayout {
         touch(&metadata.data_file)?;
         touch(&metadata.index_file)?;
         touch(&metadata.append_segment_file)?;
-        self.write_metadata(metadata)
+        write_metadata_file(metadata)
+    }
+
+    pub fn export_range_snapshot(
+        &self,
+        metadata: &RangeMetadata,
+        checkpoint_root: impl AsRef<Path>,
+        snapshot_lsn: u64,
+        owner_epoch: u64,
+    ) -> io::Result<RangeSnapshot> {
+        let checkpoint_dir = checkpoint_root
+            .as_ref()
+            .join(&metadata.physical_range_dir_id);
+        replace_dir(&metadata.physical_dir, &checkpoint_dir)?;
+        let snapshot_metadata = metadata.rebased_to(&checkpoint_dir);
+        write_metadata_file(&snapshot_metadata)?;
+        Ok(RangeSnapshot {
+            metadata: snapshot_metadata,
+            checkpoint_dir,
+            snapshot_lsn,
+            owner_epoch,
+        })
+    }
+
+    pub fn install_range_snapshot(&self, snapshot: &RangeSnapshot) -> io::Result<RangeMetadata> {
+        let target_dir = self
+            .ranges_dir
+            .join(&snapshot.metadata.physical_range_dir_id);
+        replace_dir(&snapshot.checkpoint_dir, &target_dir)?;
+        let installed = snapshot.metadata.rebased_to(&target_dir);
+        write_metadata_file(&installed)?;
+        Ok(installed)
     }
 
     pub fn load_collection_range(&self, collection: &str) -> io::Result<Option<RangeMetadata>> {
@@ -89,21 +128,58 @@ impl ClusterRangeLayout {
         }
         Ok(None)
     }
+}
 
-    fn write_metadata(&self, metadata: &RangeMetadata) -> io::Result<()> {
-        let path = metadata.physical_dir.join("range.meta");
-        let body = format!(
-            "collection={}\ncollection_id={}\nlogical_range_id={}\nphysical_range_dir_id={}\ndata_file={}\nindex_file={}\nappend_segment_file={}\n",
-            metadata.collection,
-            metadata.collection_id,
-            metadata.logical_range_id,
-            metadata.physical_range_dir_id,
-            metadata.data_file.display(),
-            metadata.index_file.display(),
-            metadata.append_segment_file.display(),
-        );
-        fs::write(path, body)
+impl RangeMetadata {
+    fn rebased_to(&self, physical_dir: &Path) -> Self {
+        Self {
+            collection: self.collection.clone(),
+            collection_id: self.collection_id,
+            logical_range_id: self.logical_range_id.clone(),
+            physical_range_dir_id: self.physical_range_dir_id.clone(),
+            physical_dir: physical_dir.to_path_buf(),
+            data_file: physical_dir.join("data.rdb"),
+            index_file: physical_dir.join("index.rdb"),
+            append_segment_file: physical_dir.join("segments.aof"),
+        }
     }
+}
+
+fn write_metadata_file(metadata: &RangeMetadata) -> io::Result<()> {
+    let path = metadata.physical_dir.join("range.meta");
+    let body = format!(
+        "collection={}\ncollection_id={}\nlogical_range_id={}\nphysical_range_dir_id={}\ndata_file={}\nindex_file={}\nappend_segment_file={}\n",
+        metadata.collection,
+        metadata.collection_id,
+        metadata.logical_range_id,
+        metadata.physical_range_dir_id,
+        metadata.data_file.display(),
+        metadata.index_file.display(),
+        metadata.append_segment_file.display(),
+    );
+    fs::write(path, body)
+}
+
+fn replace_dir(source: &Path, target: &Path) -> io::Result<()> {
+    if target.exists() {
+        fs::remove_dir_all(target)?;
+    }
+    copy_dir_recursive(source, target)
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> io::Result<()> {
+    fs::create_dir_all(target)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&source_path, &target_path)?;
+        } else {
+            fs::copy(&source_path, &target_path)?;
+        }
+    }
+    Ok(())
 }
 
 fn touch(path: &Path) -> io::Result<()> {

--- a/crates/reddb-server/src/storage/mod.rs
+++ b/crates/reddb-server/src/storage/mod.rs
@@ -101,7 +101,7 @@ pub mod signed_writes;
 
 // Public surface re-used by the rest of the codebase.
 pub use backend::{BackendError, LocalBackend, RemoteBackend};
-pub use cluster_layout::{ClusterRangeLayout, RangeMetadata};
+pub use cluster_layout::{ClusterRangeLayout, RangeMetadata, RangeSnapshot};
 pub use embedded::{
     EmbeddedRdbArtifact, EmbeddedRdbManifest, EmbeddedRdbOpen, EmbeddedRdbSuperblock,
     EMBEDDED_RDB_MANIFEST_OFFSET, EMBEDDED_RDB_SUPERBLOCK_0_OFFSET,

--- a/tests/e2e_issue_1021_move_range_snapshot_catch_up.rs
+++ b/tests/e2e_issue_1021_move_range_snapshot_catch_up.rs
@@ -1,0 +1,252 @@
+//! Issue #1021 — move-range snapshot catch-up tracer.
+
+use std::path::{Path, PathBuf};
+
+use reddb::api::DurabilityMode;
+use reddb::replication::{
+    MoveRangeError, MoveRangeRequest, MoveRangeTargetState, MoveRangeTracer, RangeOwnership,
+};
+use reddb::storage::wal::{WalReader, WalRecord};
+use reddb::storage::{ClusterRangeLayout, StorageDeployPreset};
+use reddb::{RedDBOptions, RedDBRuntime};
+
+struct DbPath {
+    path: PathBuf,
+}
+
+impl DbPath {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "reddb_issue_1021_{label}_{}_{}.rdb",
+            std::process::id(),
+            nanos
+        ));
+        let db = Self { path };
+        db.cleanup();
+        db
+    }
+
+    fn open(&self) -> RedDBRuntime {
+        let options = RedDBOptions::persistent(&self.path)
+            .with_durability_mode(DurabilityMode::WalDurableGrouped)
+            .with_storage_profile(StorageDeployPreset::Cluster.selection())
+            .expect("cluster storage profile");
+        RedDBRuntime::with_options(options).expect("cluster runtime")
+    }
+
+    fn support_dir(&self) -> PathBuf {
+        let file = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("data path file name");
+        self.path.with_file_name(format!("{file}.red"))
+    }
+
+    fn wal_path(&self) -> PathBuf {
+        self.path.with_extension("rdb-uwal")
+    }
+
+    fn cleanup(&self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_file(self.wal_path());
+        let _ = std::fs::remove_dir_all(self.support_dir());
+    }
+}
+
+impl Drop for DbPath {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+struct DirPath {
+    path: PathBuf,
+}
+
+impl DirPath {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "reddb_issue_1021_{label}_{}_{}",
+            std::process::id(),
+            nanos
+        ));
+        let dir = Self { path };
+        dir.cleanup();
+        dir
+    }
+
+    fn cleanup(&self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+impl Drop for DirPath {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn latest_range_lsn(wal_path: &Path, range_id: &str) -> u64 {
+    WalReader::open(wal_path)
+        .expect("open WAL")
+        .iter()
+        .filter_map(|entry| {
+            let (lsn, record) = entry.expect("read WAL record");
+            match record {
+                WalRecord::RangeCommitBatch {
+                    range_id: record_range_id,
+                    ..
+                } if record_range_id == range_id => Some(lsn),
+                _ => None,
+            }
+        })
+        .max()
+        .expect("range WAL record")
+}
+
+#[test]
+fn range_move_installs_snapshot_catches_up_and_then_cuts_over() {
+    let source = DbPath::new("success_source");
+    let target = DirPath::new("success_target");
+    let rt = source.open();
+
+    exec(&rt, "CREATE TABLE orders (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO orders (id, label) VALUES (1, 'alpha')");
+
+    let metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("orders")
+        .expect("orders range metadata");
+    let snapshot_lsn = latest_range_lsn(&source.wal_path(), &metadata.logical_range_id);
+    let source_layout = ClusterRangeLayout::new(source.support_dir());
+    let snapshot = source_layout
+        .export_range_snapshot(
+            &metadata,
+            source.support_dir().join("move-snapshots"),
+            snapshot_lsn,
+            7,
+        )
+        .expect("export physical range snapshot");
+
+    exec(&rt, "INSERT INTO orders (id, label) VALUES (2, 'beta')");
+    let required_watermark_lsn = latest_range_lsn(&source.wal_path(), &metadata.logical_range_id);
+    assert!(
+        required_watermark_lsn > snapshot_lsn,
+        "catch-up watermark must be past snapshot boundary"
+    );
+
+    let target_layout = ClusterRangeLayout::new(&target.path);
+    let installed = target_layout
+        .install_range_snapshot(&snapshot)
+        .expect("install range snapshot");
+    assert!(installed
+        .physical_dir
+        .starts_with(target_layout.ranges_dir()));
+    assert!(installed.physical_dir.join("range.meta").is_file());
+    assert!(installed.data_file.is_file());
+
+    let mut target_state = MoveRangeTargetState::from_installed_snapshot(&snapshot, installed);
+    let request = MoveRangeRequest {
+        range_id: metadata.logical_range_id.clone(),
+        required_watermark_lsn,
+        source_owner_epoch: 7,
+        target_owner_epoch: 8,
+    };
+
+    assert!(matches!(
+        MoveRangeTracer::cutover(&request, &target_state),
+        Err(MoveRangeError::CatchUpRequired { .. })
+    ));
+
+    let catch_up = MoveRangeTracer::catch_up_from_wal(
+        &mut target_state,
+        source.wal_path(),
+        required_watermark_lsn,
+    )
+    .expect("catch up through range-indexed stream");
+    assert_eq!(catch_up.started_after_lsn, snapshot_lsn);
+    assert_eq!(catch_up.applied_lsn, required_watermark_lsn);
+    assert_eq!(catch_up.applied_batches, 1);
+
+    let cutover = MoveRangeTracer::cutover(&request, &target_state).expect("cutover");
+    assert_eq!(cutover.range_id, metadata.logical_range_id);
+    assert_eq!(cutover.owner_epoch, 8);
+    assert_eq!(cutover.reached_lsn, required_watermark_lsn);
+}
+
+#[test]
+fn range_move_rejects_stale_target_snapshot_epoch() {
+    let source = DbPath::new("stale_source");
+    let target = DirPath::new("stale_target");
+    let rt = source.open();
+
+    exec(&rt, "CREATE TABLE accounts (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO accounts (id, label) VALUES (1, 'open')");
+
+    let metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("accounts")
+        .expect("accounts range metadata");
+    let snapshot_lsn = latest_range_lsn(&source.wal_path(), &metadata.logical_range_id);
+    let source_layout = ClusterRangeLayout::new(source.support_dir());
+    let snapshot = source_layout
+        .export_range_snapshot(
+            &metadata,
+            source.support_dir().join("move-snapshots"),
+            snapshot_lsn,
+            4,
+        )
+        .expect("export stale physical range snapshot");
+    let installed = ClusterRangeLayout::new(&target.path)
+        .install_range_snapshot(&snapshot)
+        .expect("install stale range snapshot");
+    let mut target_state = MoveRangeTargetState::from_installed_snapshot(&snapshot, installed);
+    target_state.applied_lsn = snapshot_lsn;
+
+    let request = MoveRangeRequest {
+        range_id: metadata.logical_range_id,
+        required_watermark_lsn: snapshot_lsn,
+        source_owner_epoch: 5,
+        target_owner_epoch: 6,
+    };
+
+    assert!(matches!(
+        MoveRangeTracer::cutover(&request, &target_state),
+        Err(MoveRangeError::StaleTargetSnapshot {
+            snapshot_epoch: 4,
+            required_epoch: 5,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn range_owner_rejects_writes_under_stale_ownership_epoch() {
+    let ownership = RangeOwnership::new("range-0000000000000042", "node-b", 9);
+
+    assert!(ownership.check_write_epoch(9).is_ok());
+    assert!(matches!(
+        ownership.check_write_epoch(8),
+        Err(MoveRangeError::StaleOwnerEpoch {
+            attempted_epoch: 8,
+            current_epoch: 9,
+            ..
+        })
+    ));
+}


### PR DESCRIPTION
Automated AFK landing for #1021. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783337215&installation_id=129708444&pr_number=1035&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1035&signature=03c495718f3b1d01de08ba84f6350f4349fa28f5b96753cf6f29461837fd7e17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added range snapshot export and installation capabilities for replication workflows.
  * Introduced range move replication with catch-up functionality, including validation and epoch tracking.

* **Tests**
  * Added comprehensive end-to-end tests for range move snapshot catch-up and cutover operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->