### PR TITLE
merge: #1024 Storage profile documentation and ADR cross-links

### DIFF
--- a/.red/adr/0003-disk-format-v1.md
+++ b/.red/adr/0003-disk-format-v1.md
@@ -6,6 +6,10 @@
 **Superseded by:** —
 **Related issues:** [#39](https://github.com/reddb-io/reddb/issues/39)
 
+Operator map: [Storage Profiles](../../docs/deployment/storage-profiles.md)
+links this stable byte-format contract to the embedded `single-file` profile
+and the first offline embedded-to-operational migration path.
+
 ## Context
 
 RedDB is pre-1.0. The CHANGELOG explicitly says "format may change at

--- a/.red/adr/0018-tiered-storage-layout.md
+++ b/.red/adr/0018-tiered-storage-layout.md
@@ -4,6 +4,10 @@ Status: Proposed (2026-05-14)
 
 Related: [ADR 0003: On-disk format v1.0 stable contract](0003-disk-format-v1.md)
 
+Operator map: [Storage Profiles](../../docs/deployment/storage-profiles.md)
+links these layout presets to `single-file`, `operational-directory`,
+serverless segment packs, and cluster `range-directory` packaging.
+
 ## Context
 
 RedDB currently derives sidecar files directly at individual callsites. WAL,

--- a/.red/adr/0030-replication-consistency-and-failover-model.md
+++ b/.red/adr/0030-replication-consistency-and-failover-model.md
@@ -2,6 +2,10 @@
 
 Status: proposed
 
+Operator map: [Storage Profiles](../../docs/deployment/storage-profiles.md)
+links this consistency and failover contract to the primary-replica operational
+layout and its backup/WAL retention boundary.
+
 RedDB today does single-primary, multi-replica replication with async-by-default
 commit (`local` policy), region-aware quorum (`QuorumMode::Regions`), a CAS writer
 lease for serverless single-writer fencing, and **manual** failover — there is no

--- a/.red/adr/0031-causal-consistency-bookmarks-and-ttl-replication.md
+++ b/.red/adr/0031-causal-consistency-bookmarks-and-ttl-replication.md
@@ -2,6 +2,10 @@
 
 Status: proposed
 
+Operator map: [Storage Profiles](../../docs/deployment/storage-profiles.md)
+links this bookmark and TTL replication contract to the primary-replica recovery
+boundary that depends on ADR 0030 and ADR 0032.
+
 RedDB replicas are eventually consistent and expose an LSN, but a client has no way
 to carry causality from a write to a later read, so read-your-writes across the
 primary/replica boundary is not guaranteed. Separately, TTL/expiry is evaluated

--- a/.red/adr/0032-wal-source-of-truth-and-term-framing.md
+++ b/.red/adr/0032-wal-source-of-truth-and-term-framing.md
@@ -2,6 +2,10 @@
 
 Status: proposed
 
+Operator map: [Storage Profiles](../../docs/deployment/storage-profiles.md)
+links this WAL source-of-truth decision to backup/PITR, replica catch-up, and
+cluster range-stamped WAL boundaries.
+
 RedDB keeps two logs: the storage-engine physical WAL (`storage/wal/`) for crash
 recovery, and a separate logical replication spool (`LogicalWalSpool`, v2 framing)
 that drives replication and PITR. Today they are written in parallel via a CDC hook

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -187,6 +187,7 @@
 
 - **Deployment**
   - [Embedded Mode](/deployment/embedded.md)
+  - [Storage Profiles](/deployment/storage-profiles.md)
   - [Server Mode](/deployment/server.md)
   - [Serverless Mode](/deployment/serverless.md)
   - [Docker](/deployment/docker.md)

--- a/docs/deployment/embedded.md
+++ b/docs/deployment/embedded.md
@@ -44,6 +44,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 | Persistence | In-memory or file-backed |
 | Operational shape | Application-owned lifecycle |
 
+Embedded mode uses the `embedded` storage profile with `single-file`
+packaging. See [Storage Profiles](storage-profiles.md#embedded-single-file)
+for the backup boundary and ADR links behind that physical contract.
+
 ## Maintenance
 
 Embedded mode does not have a long-running RedDB server process to trigger maintenance on your behalf. Call it from your application where appropriate:

--- a/docs/deployment/replication.md
+++ b/docs/deployment/replication.md
@@ -70,6 +70,10 @@ That is the stepping stone toward a more Turso-like design later. The
 current architecture still runs the database locally per instance and
 uses remote storage for snapshot/WAL persistence and replay.
 
+For the storage profile presets that decide when primary-replica
+deployments must use `operational-directory` packaging, see
+[Storage Profiles](storage-profiles.md#primary-replica-operational-layout).
+
 ## Monitoring
 
 ### Replication Status

--- a/docs/deployment/serverless.md
+++ b/docs/deployment/serverless.md
@@ -185,9 +185,14 @@ deployments use S3-compatible storage so the writer lease has a
 home. See [Remote Backends](backends.md) for the full matrix and
 the conditional-write contract.
 
+For the physical storage boundary, including checkpointed segment
+packs versus backup/WAL restore, see
+[Storage Profiles](storage-profiles.md#serverless-segment-pack).
+
 ## See also
 
 - [Backends](backends.md) — `RED_BACKEND` matrix, CAS contract
+- [Storage Profiles](storage-profiles.md) — physical packaging and migration boundaries
 - [Replication](replication.md) — commit policy, writer lease
 - [Operator Runbook](../operations/runbook.md) — full deploy / DR playbook
 - [Metrics Spec](../spec/metrics.md) — every gauge / counter named above

--- a/docs/deployment/storage-profiles.md
+++ b/docs/deployment/storage-profiles.md
@@ -1,0 +1,141 @@
+# Storage Profiles
+
+Storage profiles describe the physical packaging RedDB uses for a deployment.
+They are separate from the query API and transport mode: the same logical
+collections can run in embedded, serverless, primary-replica, or cluster shape,
+but the files operators must back up, retain, and move are different.
+
+Runtime selection is visible through `SHOW CONFIG`:
+
+```sql
+SHOW CONFIG storage.deploy.profile;
+SHOW CONFIG storage.deploy.packaging;
+SHOW CONFIG storage.deploy.preset;
+SHOW CONFIG storage.deploy.managed_backup;
+SHOW CONFIG storage.deploy.wal_retention;
+```
+
+## Profile Matrix
+
+| Deployment profile | Packaging | Physical shape | Recovery boundary |
+|---|---|---|---|
+| `embedded` | `single-file` | One canonical `.rdb` opened by the application. Required local durability sidecars, such as WAL, stay adjacent to the data file when enabled. | Local file backup or snapshot plus the adjacent WAL needed for crash recovery. |
+| `serverless` | `operational-directory` plus segment pack artifacts | A local hydrated `.rdb` for serving, remote snapshots/WAL for cold restore, and immutable segment packs for checkpointed byte distribution. | Segment packs currently declare `recovery_boundary.kind = "checkpointed-rdb"` and `wal_segments_required = 0`; remote restore uses the backup manifest and WAL archive. |
+| `primary-replica` | `single-file` for dev/small presets, `operational-directory` for production backup, WAL retention, or more than one replica | Primary and each replica keep local data files plus logical WAL spool and replication metadata. Production presets move toward an operational directory so snapshots, WAL, and metadata are explicit. | Primary snapshot plus retained WAL/logical spool. Replicas rebootstrap from a snapshot, then catch up from retained logical WAL records. |
+| `cluster` | `operational-directory` | Range-directory layout under the support directory. Each collection range has stable logical range identity, range metadata, and per-range data/index/append segment files. | Range snapshots plus range-stamped WAL records. Full online range movement and rebalancing remain roadmap work. |
+
+## Embedded Single-File
+
+Embedded mode is the default profile and preserves the v1 single-file contract:
+`RedDB::open("./data.rdb")` owns the canonical data file. This is the packaging
+operators should choose for local-first applications, CLIs, desktop apps, and
+single-process services that want the smallest artifact set.
+
+The file format stability and migration rules are governed by
+[ADR 0003](../../.red/adr/0003-disk-format-v1.md). Tiered path derivation and
+support directory naming are defined by
+[ADR 0018](../../.red/adr/0018-tiered-storage-layout.md). ADR 0018 does not move
+every callsite by itself; it defines the layout vocabulary that later runtime
+wiring consumes.
+
+## Serverless Segment Pack
+
+Serverless deployments serve from a local hydrated file but treat remote storage
+as the durability and cold-start boundary. The remote backend stores snapshots,
+WAL segments, `MANIFEST.json`, and the writer lease when CAS is available. See
+[Remote Backends](backends.md) for the conditional-write contract.
+
+Segment packs are a separate distribution artifact for checkpointed `.rdb`
+bytes. A pack contains immutable `parts/` plus `manifest.json`, with checksums
+for every part and a recovery boundary that currently requires no WAL replay
+beyond the checkpointed source file. Hydration validates the manifest and parts
+before writing the destination `.rdb`.
+
+Do not treat segment packs as an online compaction or PITR mechanism. They are a
+checkpointed byte packaging format for serverless cold-start distribution. PITR
+still depends on the backup manifest and WAL archive.
+
+## Primary-Replica Operational Layout
+
+Primary-replica deployments are timeline-oriented, not just "copy the file to
+another node." The primary writes the local physical WAL and exposes logical WAL
+records for replicas. Replicas bootstrap from a snapshot, then apply logical WAL
+records until they catch the primary's advertised frontier.
+
+The current presets intentionally allow `single-file` for development and small
+topologies, but production shapes that enable managed backup, WAL retention, or
+more than one replica require `operational-directory`. That keeps the snapshot,
+WAL, and replication metadata boundary visible to operators.
+
+The consistency and failover contract is defined by
+[ADR 0030](../../.red/adr/0030-replication-consistency-and-failover-model.md).
+Causal read bookmarks depend on the same commit watermark in
+[ADR 0031](../../.red/adr/0031-causal-consistency-bookmarks-and-ttl-replication.md).
+The physical WAL is the source of truth for derived logical replication records
+per [ADR 0032](../../.red/adr/0032-wal-source-of-truth-and-term-framing.md).
+
+## Cluster Range Layout
+
+Cluster profile uses `operational-directory` packaging and creates a
+`range-directory` layout under the data file support directory. The layout gives
+each collection range a logical range id, a physical range directory id,
+`range.meta`, `data.rdb`, `index.rdb`, and `segments.aof`.
+
+This is the physical packaging foundation for future cluster range ownership and
+movement. The current supported surface is range metadata, range-stamped WAL
+identity, and snapshot install/catch-up plumbing. Automatic shard balancing,
+multi-region consensus, and arbitrary online conversion from local stores to a
+running cluster are out of scope for the current profile contract.
+
+## Migration Paths
+
+The first supported storage-profile migration is offline embedded single-file to
+operational directory:
+
+```rust
+use reddb::RedDBOptions;
+use reddb::storage::operational_migration::migrate_embedded_to_operational;
+
+migrate_embedded_to_operational("./data.rdb", "./data-operational")?;
+let options = RedDBOptions::operational_directory("./data-operational");
+```
+
+This is a closed source file export. The migrator takes the same exclusive lock
+as the embedded runtime, validates the checkpoint header and page checksums,
+writes `MANIFEST.json`, and copies stable file identities under `files/`.
+
+Unsupported directions in the current contract:
+
+- Operational directory back to embedded single-file.
+- Online conversion while the source database is open.
+- Primary-replica to embedded rollback, except by restoring the original backup
+  or preserved source `.rdb`.
+- Serverless segment pack as a replacement for backup/PITR WAL replay.
+- Embedded or primary-replica store converted directly into a live cluster range
+  layout.
+
+## Backup, Restore, and WAL Retention
+
+For local and primary-replica stores, backup safety is bounded by the latest
+validated snapshot plus every WAL segment needed to reach the requested restore
+point. Restore validates snapshot checksums and the WAL hash chain; a missing,
+corrupt, or reordered segment fails restore rather than producing a partial
+database.
+
+For primary-replica deployments, WAL retention is also a replication health
+boundary. A replica that falls behind the retained WAL window reports a gap and
+must be re-bootstrapped from a snapshot that covers the missing range. Widen
+retention before maintenance windows that may pause replicas.
+
+For serverless segment packs, the manifest's recovery boundary is narrower:
+checkpointed bytes only, with `wal_segments_required = 0`. Use remote backup and
+WAL archive restore for PITR or crash recovery beyond that checkpoint.
+
+## See Also
+
+- [Embedded Mode](embedded.md)
+- [Serverless Mode](serverless.md)
+- [Replication](replication.md)
+- [Remote Backends](backends.md)
+- [Operator Runbook](../operations/runbook.md)
+- [Native Migrations](../migrations/overview.md#offline-storage-profile-migration)

--- a/docs/migrations/commands.md
+++ b/docs/migrations/commands.md
@@ -58,7 +58,9 @@ must be closed; the migrator refuses an open source by taking the embedded
 runtime's exclusive file lock. It validates the checkpoint header and page
 checksums before exporting, then writes `MANIFEST.json` plus physical files under
 `files/` with stable logical file identities. Keep the original `.rdb` as the
-rollback artifact.
+rollback artifact. See
+[Storage Profiles](../deployment/storage-profiles.md#migration-paths) for the
+supported and unsupported storage-profile directions.
 
 ---
 

--- a/docs/migrations/overview.md
+++ b/docs/migrations/overview.md
@@ -55,7 +55,9 @@ under `files/`.
 
 The first contract is intentionally one-way: keep the original `.rdb` as your
 rollback artifact, and open the migrated directory with the operational
-directory profile after validation.
+directory profile after validation. For the full profile matrix and unsupported
+reverse or online directions, see
+[Storage Profiles](../deployment/storage-profiles.md#migration-paths).
 
 ### One language, one system
 

--- a/tests/docs_storage_profiles.rs
+++ b/tests/docs_storage_profiles.rs
@@ -1,0 +1,90 @@
+const STORAGE_PROFILES_DOC: &str = include_str!("../docs/deployment/storage-profiles.md");
+const SIDEBAR: &str = include_str!("../docs/_sidebar.md");
+const EMBEDDED_DOC: &str = include_str!("../docs/deployment/embedded.md");
+const SERVERLESS_DOC: &str = include_str!("../docs/deployment/serverless.md");
+const REPLICATION_DOC: &str = include_str!("../docs/deployment/replication.md");
+const MIGRATIONS_OVERVIEW: &str = include_str!("../docs/migrations/overview.md");
+const MIGRATIONS_COMMANDS: &str = include_str!("../docs/migrations/commands.md");
+const ADR_0003: &str = include_str!("../.red/adr/0003-disk-format-v1.md");
+const ADR_0018: &str = include_str!("../.red/adr/0018-tiered-storage-layout.md");
+const ADR_0030: &str =
+    include_str!("../.red/adr/0030-replication-consistency-and-failover-model.md");
+const ADR_0031: &str =
+    include_str!("../.red/adr/0031-causal-consistency-bookmarks-and-ttl-replication.md");
+const ADR_0032: &str = include_str!("../.red/adr/0032-wal-source-of-truth-and-term-framing.md");
+
+#[test]
+fn storage_profile_docs_cover_supported_packaging_and_boundaries() {
+    for needle in [
+        "embedded",
+        "single-file",
+        "serverless",
+        "segment pack",
+        "primary-replica",
+        "operational-directory",
+        "cluster",
+        "range-directory",
+        "wal_segments_required = 0",
+        "Online conversion while the source database is open",
+        "Operational directory back to embedded single-file",
+        "backup manifest and WAL archive",
+    ] {
+        assert!(
+            STORAGE_PROFILES_DOC.contains(needle),
+            "storage profile docs must mention {needle:?}"
+        );
+    }
+}
+
+#[test]
+fn storage_profile_docs_cross_link_relevant_adrs() {
+    for adr in [
+        "../../.red/adr/0003-disk-format-v1.md",
+        "../../.red/adr/0018-tiered-storage-layout.md",
+        "../../.red/adr/0030-replication-consistency-and-failover-model.md",
+        "../../.red/adr/0031-causal-consistency-bookmarks-and-ttl-replication.md",
+        "../../.red/adr/0032-wal-source-of-truth-and-term-framing.md",
+    ] {
+        assert!(
+            STORAGE_PROFILES_DOC.contains(adr),
+            "storage profile docs must link {adr}"
+        );
+    }
+}
+
+#[test]
+fn storage_profile_adrs_link_back_to_operator_docs() {
+    for (name, adr) in [
+        ("ADR 0003", ADR_0003),
+        ("ADR 0018", ADR_0018),
+        ("ADR 0030", ADR_0030),
+        ("ADR 0031", ADR_0031),
+        ("ADR 0032", ADR_0032),
+    ] {
+        assert!(
+            adr.contains("../../docs/deployment/storage-profiles.md"),
+            "{name} must link back to storage profile docs"
+        );
+    }
+}
+
+#[test]
+fn storage_profile_entry_points_are_discoverable() {
+    assert!(
+        SIDEBAR.contains("[Storage Profiles](/deployment/storage-profiles.md)"),
+        "sidebar must expose storage profiles"
+    );
+
+    for (name, doc) in [
+        ("embedded", EMBEDDED_DOC),
+        ("serverless", SERVERLESS_DOC),
+        ("replication", REPLICATION_DOC),
+        ("migrations overview", MIGRATIONS_OVERVIEW),
+        ("migrations commands", MIGRATIONS_COMMANDS),
+    ] {
+        assert!(
+            doc.contains("storage-profiles.md"),
+            "{name} docs must link to the storage profile entry point"
+        );
+    }
+}


### PR DESCRIPTION
Automated AFK landing for #1024. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783338854&installation_id=129708444&pr_number=1037&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1037&signature=abd8f8ad3229e89e6350808adfd6a56f574da2eb6e4bec90484c8b6809dc7c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Storage Profiles documentation covering deployment modes (embedded, serverless, primary-replica, cluster), packaging formats, offline migration paths, backup/restore boundaries, and WAL retention rules.
  * Enhanced deployment and architecture documentation with cross-references and operator maps linking to Storage Profiles for operational guidance.

* **Tests**
  * Added documentation validation tests ensuring consistency across Storage Profiles and related documentation pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->