### PR TITLE
merge: #1022 Range repair rebootstrap tracer

### DIFF
--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -34,6 +34,7 @@ pub mod logical;
 pub mod move_range;
 pub mod primary;
 pub mod quorum;
+pub mod range_repair;
 pub mod replica;
 pub mod rollback;
 pub mod scheduler;
@@ -70,6 +71,10 @@ pub use move_range::{
     MoveRangeTracer, RangeIndexedRecord, RangeOwnership,
 };
 pub use quorum::{QuorumConfig, QuorumCoordinator, QuorumError};
+pub use range_repair::{
+    RangeRepairError, RangeRepairOutcome, RangeRepairReason, RangeRepairRequest, RangeRepairTracer,
+    RangeReplicaHealth, RangeReplicaRepairState,
+};
 pub use rollback::{
     DivergentTail, RollbackCoordinator, RollbackError, RollbackEvent, RollbackOutcome,
     RollbackPlan, RollbackRequest, RollbackTransport, TailRecord,

--- a/crates/reddb-server/src/replication/range_repair.rs
+++ b/crates/reddb-server/src/replication/range_repair.rs
@@ -1,0 +1,258 @@
+//! Full-rebootstrap range repair tracer (issue #1022).
+//!
+//! A damaged local range copy is quarantined before replacement. The repair
+//! then installs a physical range snapshot from a healthy owner and catches up
+//! through the range-indexed logical WAL stream before reporting the replica
+//! healthy again.
+
+use std::io;
+use std::path::Path;
+
+use crate::replication::{
+    MoveRangeCatchUp, MoveRangeError, MoveRangeRequest, MoveRangeTargetState, MoveRangeTracer,
+};
+use crate::storage::{ClusterRangeLayout, RangeMetadata, RangeQuarantine, RangeSnapshot};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RangeRepairReason {
+    Corrupt {
+        detail: String,
+    },
+    TooStale {
+        local_lsn: u64,
+        retention_floor_lsn: u64,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RangeReplicaHealth {
+    Healthy { owner_epoch: u64, applied_lsn: u64 },
+    RepairRequired { reason: RangeRepairReason },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeReplicaRepairState {
+    pub range_id: String,
+    pub metadata: RangeMetadata,
+    pub owner_epoch: u64,
+    pub applied_lsn: u64,
+    pub health: RangeReplicaHealth,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeRepairRequest {
+    pub range_id: String,
+    pub required_watermark_lsn: u64,
+    pub source_owner_epoch: u64,
+    pub repaired_owner_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeRepairOutcome {
+    pub range_id: String,
+    pub quarantine: RangeQuarantine,
+    pub installed_metadata: RangeMetadata,
+    pub catch_up: MoveRangeCatchUp,
+    pub healthy: RangeReplicaHealth,
+}
+
+#[derive(Debug)]
+pub enum RangeRepairError {
+    NotMarkedForRepair {
+        range_id: String,
+    },
+    WrongLocalRange {
+        expected: String,
+        actual: String,
+    },
+    WrongSnapshotRange {
+        expected: String,
+        actual: String,
+    },
+    Quarantine(io::Error),
+    InstallSnapshot {
+        quarantine: RangeQuarantine,
+        source: io::Error,
+    },
+    CatchUp {
+        quarantine: RangeQuarantine,
+        source: io::Error,
+    },
+    Cutover {
+        quarantine: RangeQuarantine,
+        source: MoveRangeError,
+    },
+}
+
+impl std::fmt::Display for RangeRepairError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotMarkedForRepair { range_id } => {
+                write!(f, "range {range_id} is not marked for repair")
+            }
+            Self::WrongLocalRange { expected, actual } => {
+                write!(f, "range repair expected local {expected}, got {actual}")
+            }
+            Self::WrongSnapshotRange { expected, actual } => {
+                write!(
+                    f,
+                    "range repair expected snapshot for {expected}, got {actual}"
+                )
+            }
+            Self::Quarantine(err) => write!(f, "failed to quarantine range: {err}"),
+            Self::InstallSnapshot { source, .. } => {
+                write!(f, "failed to install repair snapshot: {source}")
+            }
+            Self::CatchUp { source, .. } => {
+                write!(f, "failed to catch up repaired range: {source}")
+            }
+            Self::Cutover { source, .. } => {
+                write!(f, "failed to mark repaired range healthy: {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RangeRepairError {}
+
+pub struct RangeRepairTracer;
+
+impl RangeRepairTracer {
+    pub fn mark_corrupt(
+        metadata: RangeMetadata,
+        owner_epoch: u64,
+        applied_lsn: u64,
+        detail: impl Into<String>,
+    ) -> RangeReplicaRepairState {
+        Self::mark_for_repair(
+            metadata,
+            owner_epoch,
+            applied_lsn,
+            RangeRepairReason::Corrupt {
+                detail: detail.into(),
+            },
+        )
+    }
+
+    pub fn mark_too_stale(
+        metadata: RangeMetadata,
+        owner_epoch: u64,
+        local_lsn: u64,
+        retention_floor_lsn: u64,
+    ) -> RangeReplicaRepairState {
+        Self::mark_for_repair(
+            metadata,
+            owner_epoch,
+            local_lsn,
+            RangeRepairReason::TooStale {
+                local_lsn,
+                retention_floor_lsn,
+            },
+        )
+    }
+
+    pub fn repair_from_healthy_owner(
+        target_layout: &ClusterRangeLayout,
+        state: &mut RangeReplicaRepairState,
+        snapshot: &RangeSnapshot,
+        source_wal_path: impl AsRef<Path>,
+        request: RangeRepairRequest,
+    ) -> Result<RangeRepairOutcome, RangeRepairError> {
+        if !matches!(state.health, RangeReplicaHealth::RepairRequired { .. }) {
+            return Err(RangeRepairError::NotMarkedForRepair {
+                range_id: state.range_id.clone(),
+            });
+        }
+        if state.range_id != request.range_id {
+            return Err(RangeRepairError::WrongLocalRange {
+                expected: request.range_id.clone(),
+                actual: state.range_id.clone(),
+            });
+        }
+        if snapshot.metadata.logical_range_id != request.range_id {
+            return Err(RangeRepairError::WrongSnapshotRange {
+                expected: request.range_id.clone(),
+                actual: snapshot.metadata.logical_range_id.clone(),
+            });
+        }
+
+        let reason = match &state.health {
+            RangeReplicaHealth::RepairRequired { reason } => reason.quarantine_label(),
+            RangeReplicaHealth::Healthy { .. } => unreachable!(),
+        };
+        let quarantine = target_layout
+            .quarantine_range(&state.metadata, reason)
+            .map_err(RangeRepairError::Quarantine)?;
+        let installed_metadata =
+            target_layout
+                .install_range_snapshot(snapshot)
+                .map_err(|source| RangeRepairError::InstallSnapshot {
+                    quarantine: quarantine.clone(),
+                    source,
+                })?;
+        let mut target_state =
+            MoveRangeTargetState::from_installed_snapshot(snapshot, installed_metadata.clone());
+        let catch_up = MoveRangeTracer::catch_up_from_wal(
+            &mut target_state,
+            source_wal_path,
+            request.required_watermark_lsn,
+        )
+        .map_err(|source| RangeRepairError::CatchUp {
+            quarantine: quarantine.clone(),
+            source,
+        })?;
+        MoveRangeTracer::cutover(
+            &MoveRangeRequest {
+                range_id: request.range_id.clone(),
+                required_watermark_lsn: request.required_watermark_lsn,
+                source_owner_epoch: request.source_owner_epoch,
+                target_owner_epoch: request.repaired_owner_epoch,
+            },
+            &target_state,
+        )
+        .map_err(|source| RangeRepairError::Cutover {
+            quarantine: quarantine.clone(),
+            source,
+        })?;
+
+        state.metadata = installed_metadata.clone();
+        state.owner_epoch = request.repaired_owner_epoch;
+        state.applied_lsn = target_state.applied_lsn;
+        state.health = RangeReplicaHealth::Healthy {
+            owner_epoch: request.repaired_owner_epoch,
+            applied_lsn: target_state.applied_lsn,
+        };
+
+        Ok(RangeRepairOutcome {
+            range_id: request.range_id,
+            quarantine,
+            installed_metadata,
+            catch_up,
+            healthy: state.health.clone(),
+        })
+    }
+
+    fn mark_for_repair(
+        metadata: RangeMetadata,
+        owner_epoch: u64,
+        applied_lsn: u64,
+        reason: RangeRepairReason,
+    ) -> RangeReplicaRepairState {
+        RangeReplicaRepairState {
+            range_id: metadata.logical_range_id.clone(),
+            metadata,
+            owner_epoch,
+            applied_lsn,
+            health: RangeReplicaHealth::RepairRequired { reason },
+        }
+    }
+}
+
+impl RangeRepairReason {
+    fn quarantine_label(&self) -> &'static str {
+        match self {
+            Self::Corrupt { .. } => "corrupt",
+            Self::TooStale { .. } => "too-stale",
+        }
+    }
+}

--- a/crates/reddb-server/src/storage/cluster_layout.rs
+++ b/crates/reddb-server/src/storage/cluster_layout.rs
@@ -8,6 +8,7 @@
 use std::fs::{self, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClusterRangeLayout {
@@ -32,6 +33,14 @@ pub struct RangeSnapshot {
     pub checkpoint_dir: PathBuf,
     pub snapshot_lsn: u64,
     pub owner_epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RangeQuarantine {
+    pub range_id: String,
+    pub original_dir: PathBuf,
+    pub quarantine_dir: PathBuf,
+    pub reason: String,
 }
 
 impl ClusterRangeLayout {
@@ -105,6 +114,31 @@ impl ClusterRangeLayout {
         Ok(installed)
     }
 
+    pub fn quarantine_range(
+        &self,
+        metadata: &RangeMetadata,
+        reason: impl AsRef<str>,
+    ) -> io::Result<RangeQuarantine> {
+        let reason = sanitize_quarantine_reason(reason.as_ref());
+        let quarantine_root = self.ranges_dir.join("quarantine");
+        fs::create_dir_all(&quarantine_root)?;
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let quarantine_dir = quarantine_root.join(format!(
+            "{}.{}.{}",
+            metadata.physical_range_dir_id, reason, suffix
+        ));
+        fs::rename(&metadata.physical_dir, &quarantine_dir)?;
+        Ok(RangeQuarantine {
+            range_id: metadata.logical_range_id.clone(),
+            original_dir: metadata.physical_dir.clone(),
+            quarantine_dir,
+            reason,
+        })
+    }
+
     pub fn load_collection_range(&self, collection: &str) -> io::Result<Option<RangeMetadata>> {
         if !self.ranges_dir.exists() {
             return Ok(None);
@@ -168,8 +202,9 @@ fn replace_dir(source: &Path, target: &Path) -> io::Result<()> {
 }
 
 fn copy_dir_recursive(source: &Path, target: &Path) -> io::Result<()> {
+    let entries = fs::read_dir(source)?;
     fs::create_dir_all(target)?;
-    for entry in fs::read_dir(source)? {
+    for entry in entries {
         let entry = entry?;
         let source_path = entry.path();
         let target_path = target.join(entry.file_name());
@@ -188,6 +223,24 @@ fn touch(path: &Path) -> io::Result<()> {
         .append(true)
         .open(path)
         .map(|_| ())
+}
+
+fn sanitize_quarantine_reason(reason: &str) -> String {
+    let sanitized: String = reason
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "repair".to_string()
+    } else {
+        sanitized
+    }
 }
 
 fn parse_metadata(raw: &str) -> Option<RangeMetadata> {

--- a/crates/reddb-server/src/storage/mod.rs
+++ b/crates/reddb-server/src/storage/mod.rs
@@ -102,7 +102,7 @@ pub mod signed_writes;
 
 // Public surface re-used by the rest of the codebase.
 pub use backend::{BackendError, LocalBackend, RemoteBackend};
-pub use cluster_layout::{ClusterRangeLayout, RangeMetadata, RangeSnapshot};
+pub use cluster_layout::{ClusterRangeLayout, RangeMetadata, RangeQuarantine, RangeSnapshot};
 pub use embedded::{
     EmbeddedRdbArtifact, EmbeddedRdbManifest, EmbeddedRdbOpen, EmbeddedRdbSuperblock,
     EMBEDDED_RDB_MANIFEST_OFFSET, EMBEDDED_RDB_SUPERBLOCK_0_OFFSET,

--- a/tests/e2e_issue_1022_range_repair_rebootstrap.rs
+++ b/tests/e2e_issue_1022_range_repair_rebootstrap.rs
@@ -1,0 +1,294 @@
+//! Issue #1022 — range repair as full rebootstrap tracer.
+
+use std::path::{Path, PathBuf};
+
+use reddb::api::DurabilityMode;
+use reddb::replication::{
+    RangeRepairError, RangeRepairRequest, RangeRepairTracer, RangeReplicaHealth,
+};
+use reddb::storage::wal::{WalReader, WalRecord};
+use reddb::storage::{ClusterRangeLayout, StorageDeployPreset};
+use reddb::{RedDBOptions, RedDBRuntime};
+
+struct DbPath {
+    path: PathBuf,
+}
+
+impl DbPath {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "reddb_issue_1022_{label}_{}_{}.rdb",
+            std::process::id(),
+            nanos
+        ));
+        let db = Self { path };
+        db.cleanup();
+        db
+    }
+
+    fn open(&self) -> RedDBRuntime {
+        let options = RedDBOptions::persistent(&self.path)
+            .with_durability_mode(DurabilityMode::WalDurableGrouped)
+            .with_storage_profile(StorageDeployPreset::Cluster.selection())
+            .expect("cluster storage profile");
+        RedDBRuntime::with_options(options).expect("cluster runtime")
+    }
+
+    fn support_dir(&self) -> PathBuf {
+        let file = self
+            .path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("data path file name");
+        self.path.with_file_name(format!("{file}.red"))
+    }
+
+    fn wal_path(&self) -> PathBuf {
+        self.path.with_extension("rdb-uwal")
+    }
+
+    fn cleanup(&self) {
+        let _ = std::fs::remove_file(&self.path);
+        let _ = std::fs::remove_file(self.wal_path());
+        let _ = std::fs::remove_dir_all(self.support_dir());
+    }
+}
+
+impl Drop for DbPath {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+struct DirPath {
+    path: PathBuf,
+}
+
+impl DirPath {
+    fn new(label: &str) -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "reddb_issue_1022_{label}_{}_{}",
+            std::process::id(),
+            nanos
+        ));
+        let dir = Self { path };
+        dir.cleanup();
+        dir
+    }
+
+    fn cleanup(&self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+impl Drop for DirPath {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn latest_range_lsn(wal_path: &Path, range_id: &str) -> u64 {
+    WalReader::open(wal_path)
+        .expect("open WAL")
+        .iter()
+        .filter_map(|entry| {
+            let (lsn, record) = entry.expect("read WAL record");
+            match record {
+                WalRecord::RangeCommitBatch {
+                    range_id: record_range_id,
+                    ..
+                } if record_range_id == range_id => Some(lsn),
+                _ => None,
+            }
+        })
+        .max()
+        .expect("range WAL record")
+}
+
+#[test]
+fn corrupt_range_repair_quarantines_installs_snapshot_catches_up_and_marks_healthy() {
+    let source = DbPath::new("corrupt_source");
+    let target = DirPath::new("corrupt_target");
+    let rt = source.open();
+
+    exec(&rt, "CREATE TABLE orders (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO orders (id, label) VALUES (1, 'alpha')");
+
+    let source_metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("orders")
+        .expect("orders range metadata");
+    let snapshot_lsn = latest_range_lsn(&source.wal_path(), &source_metadata.logical_range_id);
+    let source_layout = ClusterRangeLayout::new(source.support_dir());
+    let snapshot = source_layout
+        .export_range_snapshot(
+            &source_metadata,
+            source.support_dir().join("repair-snapshots"),
+            snapshot_lsn,
+            11,
+        )
+        .expect("export physical range snapshot");
+
+    let target_layout = ClusterRangeLayout::new(&target.path);
+    let local_metadata = target_layout
+        .install_range_snapshot(&snapshot)
+        .expect("seed stale local range copy");
+    std::fs::write(&local_metadata.data_file, b"corrupt local bytes").expect("mark local data");
+
+    exec(&rt, "INSERT INTO orders (id, label) VALUES (2, 'beta')");
+    let required_watermark_lsn =
+        latest_range_lsn(&source.wal_path(), &source_metadata.logical_range_id);
+    assert!(required_watermark_lsn > snapshot_lsn);
+
+    let mut state =
+        RangeRepairTracer::mark_corrupt(local_metadata, 11, snapshot_lsn, "checksum mismatch");
+    assert!(matches!(
+        state.health,
+        RangeReplicaHealth::RepairRequired { .. }
+    ));
+
+    let outcome = RangeRepairTracer::repair_from_healthy_owner(
+        &target_layout,
+        &mut state,
+        &snapshot,
+        source.wal_path(),
+        RangeRepairRequest {
+            range_id: source_metadata.logical_range_id.clone(),
+            required_watermark_lsn,
+            source_owner_epoch: 11,
+            repaired_owner_epoch: 12,
+        },
+    )
+    .expect("repair range from healthy owner");
+
+    assert!(outcome.quarantine.quarantine_dir.is_dir());
+    assert_eq!(
+        std::fs::read(outcome.quarantine.quarantine_dir.join("data.rdb")).expect("quarantine data"),
+        b"corrupt local bytes"
+    );
+    assert!(outcome.installed_metadata.data_file.is_file());
+    assert_eq!(outcome.catch_up.started_after_lsn, snapshot_lsn);
+    assert_eq!(outcome.catch_up.applied_lsn, required_watermark_lsn);
+    assert_eq!(outcome.catch_up.applied_batches, 1);
+    assert_eq!(
+        state.health,
+        RangeReplicaHealth::Healthy {
+            owner_epoch: 12,
+            applied_lsn: required_watermark_lsn
+        }
+    );
+}
+
+#[test]
+fn too_stale_range_can_be_marked_for_rebootstrap() {
+    let source = DbPath::new("stale_mark_source");
+    let target = DirPath::new("stale_mark_target");
+    let rt = source.open();
+
+    exec(&rt, "CREATE TABLE accounts (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO accounts (id, label) VALUES (1, 'open')");
+
+    let source_metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("accounts")
+        .expect("accounts range metadata");
+    let snapshot_lsn = latest_range_lsn(&source.wal_path(), &source_metadata.logical_range_id);
+    let snapshot = ClusterRangeLayout::new(source.support_dir())
+        .export_range_snapshot(
+            &source_metadata,
+            source.support_dir().join("repair-snapshots"),
+            snapshot_lsn,
+            3,
+        )
+        .expect("export snapshot");
+    let local_metadata = ClusterRangeLayout::new(&target.path)
+        .install_range_snapshot(&snapshot)
+        .expect("seed local range copy");
+
+    let state = RangeRepairTracer::mark_too_stale(local_metadata, 3, 7, 42);
+
+    assert!(matches!(
+        state.health,
+        RangeReplicaHealth::RepairRequired { .. }
+    ));
+    assert_eq!(state.applied_lsn, 7);
+}
+
+#[test]
+fn failed_repair_leaves_quarantined_data_available_for_inspection() {
+    let source = DbPath::new("failed_source");
+    let target = DirPath::new("failed_target");
+    let rt = source.open();
+
+    exec(&rt, "CREATE TABLE invoices (id INTEGER, label TEXT)");
+    exec(&rt, "INSERT INTO invoices (id, label) VALUES (1, 'sent')");
+
+    let source_metadata = rt
+        .db()
+        .store()
+        .collection_range_metadata("invoices")
+        .expect("invoices range metadata");
+    let snapshot_lsn = latest_range_lsn(&source.wal_path(), &source_metadata.logical_range_id);
+    let source_layout = ClusterRangeLayout::new(source.support_dir());
+    let snapshot = source_layout
+        .export_range_snapshot(
+            &source_metadata,
+            source.support_dir().join("repair-snapshots"),
+            snapshot_lsn,
+            5,
+        )
+        .expect("export snapshot");
+
+    let target_layout = ClusterRangeLayout::new(&target.path);
+    let local_metadata = target_layout
+        .install_range_snapshot(&snapshot)
+        .expect("seed local range copy");
+    std::fs::write(&local_metadata.data_file, b"inspect me").expect("local inspection marker");
+    std::fs::remove_dir_all(&snapshot.checkpoint_dir)
+        .expect("break healthy-owner snapshot transfer");
+
+    let mut state = RangeRepairTracer::mark_corrupt(local_metadata, 5, snapshot_lsn, "bad page");
+    let err = RangeRepairTracer::repair_from_healthy_owner(
+        &target_layout,
+        &mut state,
+        &snapshot,
+        source.wal_path(),
+        RangeRepairRequest {
+            range_id: source_metadata.logical_range_id,
+            required_watermark_lsn: snapshot_lsn,
+            source_owner_epoch: 5,
+            repaired_owner_epoch: 6,
+        },
+    )
+    .expect_err("broken snapshot install must fail");
+
+    let quarantine = match err {
+        RangeRepairError::InstallSnapshot { quarantine, .. } => quarantine,
+        other => panic!("expected install failure, got {other:?}"),
+    };
+    assert!(quarantine.quarantine_dir.is_dir());
+    assert_eq!(
+        std::fs::read(quarantine.quarantine_dir.join("data.rdb")).expect("quarantined data"),
+        b"inspect me"
+    );
+    assert!(!quarantine.original_dir.exists());
+    assert!(matches!(
+        state.health,
+        RangeReplicaHealth::RepairRequired { .. }
+    ));
+}


### PR DESCRIPTION
Automated AFK landing for #1022. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339903&installation_id=129708444&pr_number=1038&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1038&signature=41eccfdcbf9bfbe36d2800fb46859271d192e86a263a6aa55b805547e52ac9c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added range repair functionality to automatically restore corrupted or stale database ranges by quarantining damaged data, installing snapshots from healthy sources, and synchronizing via write-ahead logs.
  * Corrupted ranges can now be marked for repair and restored to a healthy state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->