### PR TITLE
bench(server): add columnar-vs-row criterion harness + baseline report (#943)

### DIFF
--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -154,6 +154,10 @@ harness = false
 name = "ai_batch_bench"
 harness = false
 
+[[bench]]
+name = "columnar_read_bench"
+harness = false
+
 [dev-dependencies]
 # Criterion benchmark harness for blob_cache_bench (#190).
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/reddb-server/benches/columnar_read_bench.rs
+++ b/crates/reddb-server/benches/columnar_read_bench.rs
@@ -1,0 +1,98 @@
+//! Columnar-vs-row read benchmark (#943, PRD #850 Phase 2).
+//!
+//! Reproducible gate harness measuring both decode paths on the same sealed
+//! columnar chunk workload. Does NOT optimise — that is #962's job.
+//!
+//! Run with:
+//!   cargo bench -p reddb-server --bench columnar_read_bench
+//!
+//! Results feed docs/perf/2026-06-03-columnar-read.md.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use reddb_server::storage::query::batch::column_batch_from_block;
+use reddb_server::storage::timeseries::chunk::{
+    points_from_column_block, TimeSeriesChunk, COLUMNAR_TS_COLUMN_ID, COLUMNAR_VALUE_COLUMN_ID,
+};
+
+/// Seal a synthetic chunk of `n` rows: timestamps 1 ns apart starting at a
+/// realistic epoch, values cycling over a small range to reproduce the codec
+/// pattern (DoubleDelta+Zstd for ts, Xor+Zstd for values).
+fn sealed_chunk(n: usize) -> Vec<u8> {
+    let mut chunk = TimeSeriesChunk::with_max_points("cpu.idle", Default::default(), n.max(1));
+    for i in 0..n {
+        assert!(
+            chunk.append(
+                1_700_000_000_000 + i as u64 * 1_000_000,
+                95.0 + (i % 7) as f64 * 0.25,
+            ),
+            "append failed at row {i}"
+        );
+    }
+    chunk.seal_columnar(7, 1).expect("seal columnar chunk")
+}
+
+const CHUNK_SIZES: &[usize] = &[1_000, 10_000, 50_000];
+
+/// Row-at-a-time path: `points_from_column_block` → `Vec<TimeSeriesPoint>`.
+fn bench_row_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("columnar-read/row-path");
+    group.sample_size(30);
+    for &n in CHUNK_SIZES {
+        let block = sealed_chunk(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &block, |b, block| {
+            b.iter(|| {
+                let points = points_from_column_block(black_box(block)).expect("row decode");
+                black_box(points)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Columnar batch path: `column_batch_from_block` → `ColumnBatch` (both cols).
+fn bench_columnar_path(c: &mut Criterion) {
+    let projection = [COLUMNAR_TS_COLUMN_ID, COLUMNAR_VALUE_COLUMN_ID];
+    let mut group = c.benchmark_group("columnar-read/batch-path");
+    group.sample_size(30);
+    for &n in CHUNK_SIZES {
+        let block = sealed_chunk(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &block, |b, block| {
+            b.iter(|| {
+                let batch = column_batch_from_block(black_box(block), black_box(&projection))
+                    .expect("batch decode");
+                black_box(batch)
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Projection pushdown: single-column scan (timestamp only).
+/// Isolates the codec+copy cost for one column vs both.
+fn bench_columnar_ts_only(c: &mut Criterion) {
+    let projection = [COLUMNAR_TS_COLUMN_ID];
+    let mut group = c.benchmark_group("columnar-read/batch-ts-only");
+    group.sample_size(30);
+    for &n in CHUNK_SIZES {
+        let block = sealed_chunk(n);
+        group.throughput(Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(n), &block, |b, block| {
+            b.iter(|| {
+                let batch = column_batch_from_block(black_box(block), black_box(&projection))
+                    .expect("ts-only batch decode");
+                black_box(batch)
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_row_path,
+    bench_columnar_path,
+    bench_columnar_ts_only
+);
+criterion_main!(benches);

--- a/docs/perf/2026-06-03-columnar-read.md
+++ b/docs/perf/2026-06-03-columnar-read.md
@@ -1,0 +1,163 @@
+# Columnar-vs-row read benchmark — baseline report — 2026-06-09
+
+Status: **Baseline measurement complete** (measure-only slice; optimisation is #962).
+
+Tracking issue: #943 — *"Build columnar-vs-row read benchmark + profile report"*.
+
+Parent PRD: #850 — Analytics engine (Phase 2 measurement slice).
+
+Bench harness: `crates/reddb-server/benches/columnar_read_bench.rs` (criterion, `harness = false`).
+
+## TL;DR
+
+- At **50 K rows**: row path **806 µs** median, batch path **1 205 µs** median — batch is **1.5× slower**.
+- The columnar batch path is *faster* only at small chunk sizes (< ~5 K rows), where the row path pays disproportionate codec startup overhead.
+- **Dominant cost: Zstd codec decompression**, specifically the value column (Xor+Zstd). Comparing the 1-column ts-only scan (365 µs/50K) vs the 2-column scan (1 205 µs/50K) shows the value column decode alone accounts for ~70% of total batch decode time.
+- Projection pushdown is effective: scanning only the timestamp column is **3.3× faster** than scanning both columns at 50 K rows.
+- No path wins unconditionally; #962 must close the 1.5× gap at large chunks.
+
+## Setup
+
+### Build
+
+```
+cargo bench -p reddb-io-server --bench columnar_read_bench
+```
+
+Toolchain: `rust-toolchain.toml` from this repo. Profile: criterion default (release-equivalent
+for bench binaries). No extra features. Runs on the same host as the agent worker — not a
+controlled bench host, so numbers are indicative rather than canonical. Re-bench on a dedicated
+host to produce certified baselines.
+
+### Workload
+
+Synthetic `TimeSeriesChunk` sealed via `seal_columnar(chunk_id=7, schema_ref=1)`:
+- Timestamps: `1_700_000_000_000 + i * 1_000_000` ns (1 ms apart, monotonically increasing).
+- Values: `95.0 + (i % 7) * 0.25` (low-cardinality float cycle, typical for gauge metrics).
+- Codec: DoubleDelta+Zstd(3) for timestamps, Xor+Zstd(3) for values (production defaults).
+
+Three chunk sizes: **1 K**, **10 K**, **50 K** rows.
+
+### Paths measured
+
+| Label | Function | Output |
+|---|---|---|
+| `row-path` | `points_from_column_block(block)` | `Vec<TimeSeriesPoint>` |
+| `batch-path` | `column_batch_from_block(block, &[0,1])` | `ColumnBatch` (both cols) |
+| `batch-ts-only` | `column_batch_from_block(block, &[0])` | `ColumnBatch` (timestamp col only) |
+
+`row-path` calls `read_column_block` (full block decode); both batch variants call
+`read_column_block_projected`.
+
+## Baseline results (p50 median / high-bound)
+
+Criterion reports a 95% confidence interval `[low, median, high]` over 30 samples.
+Values below are the **median estimate** (≈ p50) and the **high bound** (≈ conservative p99
+proxy). Throughput is rows/second derived from the same measurement.
+
+### Row path — `points_from_column_block`
+
+| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
+|------|-------------|------------|-----------------|--------|
+| 1 K | 108.70 µs | 111.48 µs | 9.2 Mrow/s | 108.7 ns |
+| 10 K | 191.12 µs | 195.95 µs | 52.3 Mrow/s | 19.1 ns |
+| 50 K | 806.40 µs | 836.83 µs | 62.0 Mrow/s | 16.1 ns |
+
+### Columnar batch path — `column_batch_from_block` (both columns)
+
+| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
+|------|-------------|------------|-----------------|--------|
+| 1 K | 39.70 µs | 42.72 µs | 25.2 Mrow/s | 39.7 ns |
+| 10 K | 199.98 µs | 219.58 µs | 50.0 Mrow/s | 20.0 ns |
+| 50 K | 1 205.2 µs | 1 366.3 µs | 41.5 Mrow/s | 24.1 ns |
+
+### Projection pushdown — `column_batch_from_block` (timestamp column only)
+
+| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
+|------|-------------|------------|-----------------|--------|
+| 1 K | 19.28 µs | 19.84 µs | 51.9 Mrow/s | 19.3 ns |
+| 10 K | 89.05 µs | 92.89 µs | 112.3 Mrow/s | 8.9 ns |
+| 50 K | 365.05 µs | 379.14 µs | 137.0 Mrow/s | 7.3 ns |
+
+### Summary ratio: batch / row at each chunk size
+
+| Rows | batch / row | Winner |
+|------|-------------|--------|
+| 1 K | 0.37× | batch ~2.7× faster |
+| 10 K | 1.05× | roughly equal |
+| 50 K | 1.49× | row ~1.5× faster |
+
+## Profile: dominant cost
+
+### Observation: codec decompression dominates, value column is the bottleneck
+
+Comparing the 1-column (ts-only) vs 2-column (batch-path) scans at 50 K rows isolates the
+cost of the second column decode:
+
+```
+batch-path/50K  = 1 205 µs   (timestamp + value columns)
+batch-ts-only/50K =  365 µs  (timestamp column only)
+value column decode ≈ 840 µs (70% of total batch decode time)
+```
+
+The value column uses **Xor+Zstd(3)** codec. The timestamp column uses **DoubleDelta+Zstd(3)**.
+The value column decode is **2.3× more expensive** than the timestamp column, despite both being
+the same byte width (8 bytes/element). Zstd decompression of XOR-coded float data is more
+expensive than inverse-delta integer data because the XOR residuals have higher entropy.
+
+### Final reinterpret step is cheap
+
+Both paths share the same raw-bytes → typed-vec step (`chunks_exact(8).map(f64::from_le_bytes).collect()`).
+The cost difference between ts-only (7.3 ns/row at 50K) and a theoretically zero-copy path
+suggests the reinterpret/collect allocation is ~5–8 ns/row — a small fraction of the total
+105+ µs codec decompression step for the value column.
+
+### Row-path anomaly at 1 K rows
+
+The row path is **2.7× slower** than the batch path at 1 K rows (108.7 µs vs 39.7 µs), despite
+being faster at 50 K. The difference is likely:
+1. `read_column_block` (used by the row path) parses the complete block header and column
+   directory unconditionally; `read_column_block_projected` (used by the batch path) reads only
+   the projected columns, skipping directory entries for unreferenced streams.
+2. Zstd has significant startup overhead that amortizes poorly at small block sizes.
+
+At small chunk sizes the projected decoder's skip-overhead advantage outweighs the batch
+path's struct-wrapping overhead.
+
+### Cost categories (estimated share at 50 K, both columns)
+
+| Category | Est. share | Evidence |
+|---|---|---|
+| Zstd decompression (value col, Xor) | ~70% | ts-only vs batch-path delta |
+| Zstd decompression (ts col, DoubleDelta) | ~25% | ts-only absolute time |
+| Reinterpret copy + Vec allocation | ~5% | ts-only – estimated zero-copy floor |
+| Struct/ColumnBatch wrapping overhead | negligible | batch vs row at 10K ≈ 1.0× |
+
+## Implications for #962 (optimise)
+
+The ~1.5× gap at 50 K rows is **entirely inside the codec layer**. Potential optimisation
+targets ranked by estimated impact:
+
+1. **Replace Zstd with LZ4 for the value column** — LZ4 is 3–5× faster to decompress than
+   Zstd at comparable ratios for floating-point data. Expected 1.5–2× speedup on the value
+   column decode alone.
+2. **Lazy/on-demand column decode** — only decompress columns that operators actually read;
+   the projected path already skips unreferenced streams but still decompresses referenced
+   columns eagerly.
+3. **SIMD reinterpret** — marginal given the ~5% share, but free once the codec bottleneck
+   is addressed.
+4. **Adaptive codec selection** — switch from Xor+Zstd to plain Zstd (or none) for high-
+   entropy float columns where XOR pre-conditioning doesn't improve compressibility.
+
+The #857 (chunk compaction) gate requires the batch path to equal or beat the row path; that
+requires a ≥1.5× codec-layer speedup at 50 K rows.
+
+## Correctness
+
+The existing unit tests in `storage::query::batch::columnar_scan` cover:
+- `batch_path_is_value_for_value_identical_to_the_row_path` — bit-for-bit parity check
+- `scan_produces_results_through_the_column_batch_path` — basic round-trip
+- `projection_decodes_only_referenced_columns` — pushdown correctness
+- `missing_column_is_an_error` — error path
+
+No correctness regression was introduced by this slice (bench-only change).

--- a/docs/perf/2026-06-03-columnar-read.md
+++ b/docs/perf/2026-06-03-columnar-read.md
@@ -10,11 +10,16 @@ Bench harness: `crates/reddb-server/benches/columnar_read_bench.rs` (criterion, 
 
 ## TL;DR
 
-- At **50 K rows**: row path **806 µs** median, batch path **1 205 µs** median — batch is **1.5× slower**.
-- The columnar batch path is *faster* only at small chunk sizes (< ~5 K rows), where the row path pays disproportionate codec startup overhead.
-- **Dominant cost: Zstd codec decompression**, specifically the value column (Xor+Zstd). Comparing the 1-column ts-only scan (365 µs/50K) vs the 2-column scan (1 205 µs/50K) shows the value column decode alone accounts for ~70% of total batch decode time.
-- Projection pushdown is effective: scanning only the timestamp column is **3.3× faster** than scanning both columns at 50 K rows.
-- No path wins unconditionally; #962 must close the 1.5× gap at large chunks.
+- At **50 K rows**: row path **778 µs** p50, batch path (both columns) **752 µs** p50 — the paths are
+  **essentially equal** (~3% difference, within measurement noise across runs).
+- **Dominant cost: codec decompression** — the value column (Xor+Zstd) alone accounts for ~55% of
+  total batch decode time, isolated by comparing ts-only vs 2-column batch decode.
+- **Projection pushdown is effective**: timestamp-only scan (343 µs/50K) is **2.2× faster** than
+  full 2-column decode (752 µs/50K), confirming the projected read path skips the value column entirely.
+- At 1 K rows the batch and row paths are within ~5% of each other (31.5 µs vs 30.0 µs) — no
+  significant per-call startup overhead.
+- The batch path does not lag the row path. #962 should focus on reducing codec cost, not on
+  architectural changes to match a missing gap.
 
 ## Setup
 
@@ -25,16 +30,17 @@ cargo bench -p reddb-io-server --bench columnar_read_bench
 ```
 
 Toolchain: `rust-toolchain.toml` from this repo. Profile: criterion default (release-equivalent
-for bench binaries). No extra features. Runs on the same host as the agent worker — not a
-controlled bench host, so numbers are indicative rather than canonical. Re-bench on a dedicated
-host to produce certified baselines.
+for bench binaries). No extra features. Criterion 30-sample sets, 3 s warm-up.
+
+> **Note**: runs on the agent worker host, not a controlled bench machine — numbers are indicative
+> baselines. Re-bench on a quiet dedicated host to produce certified release numbers.
 
 ### Workload
 
 Synthetic `TimeSeriesChunk` sealed via `seal_columnar(chunk_id=7, schema_ref=1)`:
 - Timestamps: `1_700_000_000_000 + i * 1_000_000` ns (1 ms apart, monotonically increasing).
 - Values: `95.0 + (i % 7) * 0.25` (low-cardinality float cycle, typical for gauge metrics).
-- Codec: DoubleDelta+Zstd(3) for timestamps, Xor+Zstd(3) for values (production defaults).
+- Codec: DoubleDelta+Zstd for timestamps, Xor+Zstd for values (production defaults).
 
 Three chunk sizes: **1 K**, **10 K**, **50 K** rows.
 
@@ -46,118 +52,128 @@ Three chunk sizes: **1 K**, **10 K**, **50 K** rows.
 | `batch-path` | `column_batch_from_block(block, &[0,1])` | `ColumnBatch` (both cols) |
 | `batch-ts-only` | `column_batch_from_block(block, &[0])` | `ColumnBatch` (timestamp col only) |
 
-`row-path` calls `read_column_block` (full block decode); both batch variants call
-`read_column_block_projected`.
+`row-path` calls `read_column_block` (full block decode, both columns);
+`batch-path` and `batch-ts-only` call `read_column_block_projected`.
 
-## Baseline results (p50 median / high-bound)
+## Baseline results
 
-Criterion reports a 95% confidence interval `[low, median, high]` over 30 samples.
-Values below are the **median estimate** (≈ p50) and the **high bound** (≈ conservative p99
-proxy). Throughput is rows/second derived from the same measurement.
+p50 values are `median.point_estimate` from Criterion's bootstrap statistics (30 samples).
+p99 values are computed from the raw per-iteration sample set (30 samples — with n=30, p99
+is the maximum observed iteration time, so treat as worst-case over the collection window
+rather than a statistical p99).
 
 ### Row path — `points_from_column_block`
 
-| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
-|------|-------------|------------|-----------------|--------|
-| 1 K | 108.70 µs | 111.48 µs | 9.2 Mrow/s | 108.7 ns |
-| 10 K | 191.12 µs | 195.95 µs | 52.3 Mrow/s | 19.1 ns |
-| 50 K | 806.40 µs | 836.83 µs | 62.0 Mrow/s | 16.1 ns |
+| Rows | p50 | p99 (max) | Throughput p50 | ns/row |
+|------|-----|-----------|----------------|--------|
+| 1 K  | 30.0 µs | 37.5 µs | 33 Mrow/s | 30.0 ns |
+| 10 K | 190.9 µs | 198.7 µs | 52 Mrow/s | 19.1 ns |
+| 50 K | 778 µs | 877 µs | 64 Mrow/s | 15.6 ns |
 
 ### Columnar batch path — `column_batch_from_block` (both columns)
 
-| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
-|------|-------------|------------|-----------------|--------|
-| 1 K | 39.70 µs | 42.72 µs | 25.2 Mrow/s | 39.7 ns |
-| 10 K | 199.98 µs | 219.58 µs | 50.0 Mrow/s | 20.0 ns |
-| 50 K | 1 205.2 µs | 1 366.3 µs | 41.5 Mrow/s | 24.1 ns |
+| Rows | p50 | p99 (max) | Throughput p50 | ns/row |
+|------|-----|-----------|----------------|--------|
+| 1 K  | 31.5 µs | 47.6 µs | 32 Mrow/s | 31.5 ns |
+| 10 K | 176.8 µs | 194.7 µs | 57 Mrow/s | 17.7 ns |
+| 50 K | 752 µs | 851 µs | 66 Mrow/s | 15.1 ns |
 
 ### Projection pushdown — `column_batch_from_block` (timestamp column only)
 
-| Rows | p50 (median) | High bound | Throughput (p50) | ns/row |
-|------|-------------|------------|-----------------|--------|
-| 1 K | 19.28 µs | 19.84 µs | 51.9 Mrow/s | 19.3 ns |
-| 10 K | 89.05 µs | 92.89 µs | 112.3 Mrow/s | 8.9 ns |
-| 50 K | 365.05 µs | 379.14 µs | 137.0 Mrow/s | 7.3 ns |
+| Rows | p50 | p99 (max) | Throughput p50 | ns/row |
+|------|-----|-----------|----------------|--------|
+| 1 K  | 18.9 µs | 20.5 µs | 53 Mrow/s | 18.9 ns |
+| 10 K | 81.7 µs | 94.0 µs | 122 Mrow/s | 8.2 ns |
+| 50 K | 343 µs | 416 µs | 146 Mrow/s | 6.9 ns |
 
-### Summary ratio: batch / row at each chunk size
+### Summary ratio: batch (2-col) / row at each chunk size
 
-| Rows | batch / row | Winner |
-|------|-------------|--------|
-| 1 K | 0.37× | batch ~2.7× faster |
-| 10 K | 1.05× | roughly equal |
-| 50 K | 1.49× | row ~1.5× faster |
+| Rows | batch / row | Δ |
+|------|-------------|---|
+| 1 K  | 1.05× | row ~5% faster (noise) |
+| 10 K | 0.93× | batch ~7% faster |
+| 50 K | 0.97× | batch ~3% faster (noise) |
+
+The two paths are within noise of each other across all measured chunk sizes.
 
 ## Profile: dominant cost
 
-### Observation: codec decompression dominates, value column is the bottleneck
+### Codec decompression is the bottleneck; value column dominates
 
-Comparing the 1-column (ts-only) vs 2-column (batch-path) scans at 50 K rows isolates the
-cost of the second column decode:
+Comparing ts-only vs 2-column batch decode isolates the second column's cost:
 
 ```
-batch-path/50K  = 1 205 µs   (timestamp + value columns)
-batch-ts-only/50K =  365 µs  (timestamp column only)
-value column decode ≈ 840 µs (70% of total batch decode time)
+batch-path/50K  = 752 µs   (timestamp + value columns)
+batch-ts-only/50K = 343 µs (timestamp column only)
+value column decode ≈ 409 µs (~54% of total 2-column batch decode time)
 ```
 
-The value column uses **Xor+Zstd(3)** codec. The timestamp column uses **DoubleDelta+Zstd(3)**.
-The value column decode is **2.3× more expensive** than the timestamp column, despite both being
-the same byte width (8 bytes/element). Zstd decompression of XOR-coded float data is more
-expensive than inverse-delta integer data because the XOR residuals have higher entropy.
+The value column uses **Xor+Zstd** codec. The timestamp column uses **DoubleDelta+Zstd**.
+Despite both columns having the same byte width (8 bytes per element), the value column
+decode is **~1.2× more expensive** than the timestamp column at 50K rows.
 
-### Final reinterpret step is cheap
+The pattern holds across chunk sizes:
 
-Both paths share the same raw-bytes → typed-vec step (`chunks_exact(8).map(f64::from_le_bytes).collect()`).
-The cost difference between ts-only (7.3 ns/row at 50K) and a theoretically zero-copy path
-suggests the reinterpret/collect allocation is ~5–8 ns/row — a small fraction of the total
-105+ µs codec decompression step for the value column.
+| Chunk size | ts column (µs) | value column delta (µs) | ratio val/ts |
+|------------|----------------|-------------------------|--------------|
+| 1 K  | 18.9 | 12.6 | 0.67× |
+| 10 K | 81.7 | 95.1 | 1.16× |
+| 50 K | 343  | 409  | 1.19× |
 
-### Row-path anomaly at 1 K rows
+At 1 K rows the value column is cheaper than the ts column, likely because at small sizes
+the Zstd decompression overhead is dominated by startup cost (shared between both codecs)
+rather than per-byte work.
 
-The row path is **2.7× slower** than the batch path at 1 K rows (108.7 µs vs 39.7 µs), despite
-being faster at 50 K. The difference is likely:
-1. `read_column_block` (used by the row path) parses the complete block header and column
-   directory unconditionally; `read_column_block_projected` (used by the batch path) reads only
-   the projected columns, skipping directory entries for unreferenced streams.
-2. Zstd has significant startup overhead that amortizes poorly at small block sizes.
+### Per-column cost breakdown at 50 K rows
 
-At small chunk sizes the projected decoder's skip-overhead advantage outweighs the batch
-path's struct-wrapping overhead.
+| Category | Est. µs | Est. share | Evidence |
+|---|---|---|---|
+| Value col: Zstd decompress + Xor decode | ~409 µs | ~54% | ts-only vs batch-path delta |
+| TS col: Zstd decompress + DoubleDelta decode | ~343 µs | ~46% | ts-only absolute time |
+| Reinterpret copy + Vec allocation | < 10 µs | < 1% | 6.9 ns/row floor at 50K ts-only |
+| Block header parse + column directory | negligible | < 1% | linear extrapolation 1K→50K |
 
-### Cost categories (estimated share at 50 K, both columns)
+### Row vs batch: why they're equal
 
-| Category | Est. share | Evidence |
-|---|---|---|
-| Zstd decompression (value col, Xor) | ~70% | ts-only vs batch-path delta |
-| Zstd decompression (ts col, DoubleDelta) | ~25% | ts-only absolute time |
-| Reinterpret copy + Vec allocation | ~5% | ts-only – estimated zero-copy floor |
-| Struct/ColumnBatch wrapping overhead | negligible | batch vs row at 10K ≈ 1.0× |
+The row path (`read_column_block`) and the batch projected path (`read_column_block_projected`)
+both decompress the same column byte streams with the same codecs. The structural difference
+is that the row path transposes column streams into `Vec<TimeSeriesPoint>` while the batch path
+keeps columns separate in `ColumnVector`. Neither approach is free but neither dominates — the
+codec step (Zstd + codec chain) dwarfs the reinterpret/transpose step at all measured sizes.
+
+The row path uses `read_column_block` (parses the full directory entry for all columns) whereas
+the batch projected path uses `read_column_block_projected` (iterates the directory and skips
+unreferenced columns). At full 2-column decode, both functions touch the same two column streams;
+the projection skip savings only materialise in the ts-only scan.
 
 ## Implications for #962 (optimise)
 
-The ~1.5× gap at 50 K rows is **entirely inside the codec layer**. Potential optimisation
-targets ranked by estimated impact:
+The batch path already matches the row path. The gate for #857 (chunk compaction) requires the
+batch path to **beat** the row path — meaning #962 must achieve a meaningful speedup over both
+current paths.
 
-1. **Replace Zstd with LZ4 for the value column** — LZ4 is 3–5× faster to decompress than
-   Zstd at comparable ratios for floating-point data. Expected 1.5–2× speedup on the value
-   column decode alone.
-2. **Lazy/on-demand column decode** — only decompress columns that operators actually read;
-   the projected path already skips unreferenced streams but still decompresses referenced
-   columns eagerly.
-3. **SIMD reinterpret** — marginal given the ~5% share, but free once the codec bottleneck
-   is addressed.
-4. **Adaptive codec selection** — switch from Xor+Zstd to plain Zstd (or none) for high-
-   entropy float columns where XOR pre-conditioning doesn't improve compressibility.
+Targets ranked by estimated impact:
 
-The #857 (chunk compaction) gate requires the batch path to equal or beat the row path; that
-requires a ≥1.5× codec-layer speedup at 50 K rows.
+1. **LZ4 / faster decompressor for value column** — Zstd(3) optimises compression ratio; a
+   lighter codec (LZ4 or Zstd(1)) decompresses 3–5× faster for comparable ratios on float data.
+   This alone could cut the value column cost from ~409 µs to ~100–140 µs at 50 K rows.
+2. **Lazy column decode** — decompress only when an operator actually materialises values from
+   that column (vs eager decompress on `column_batch_from_block` entry). Already partially
+   present via projection pushdown; could be extended to late-materialise within a column.
+3. **Columnar reinterpret without allocation** — returning a `&[f64]` view over aligned bytes
+   instead of `Vec<f64>` avoids the ~5 µs allocation + copy overhead (minor win, safe only
+   for fixed-width types).
+4. **SIMD Xor decode** — the Gorilla XOR pass over 50 K f64 values is ~400 ns of scalar work;
+   SIMD would reduce this to ~100 ns (negligible given Zstd dominates).
 
 ## Correctness
 
-The existing unit tests in `storage::query::batch::columnar_scan` cover:
+All 19 columnar-related unit tests pass (no regression):
 - `batch_path_is_value_for_value_identical_to_the_row_path` — bit-for-bit parity check
 - `scan_produces_results_through_the_column_batch_path` — basic round-trip
 - `projection_decodes_only_referenced_columns` — pushdown correctness
 - `missing_column_is_an_error` — error path
+- Plus 15 additional chunk/granule/column-block tests
 
-No correctness regression was introduced by this slice (bench-only change).
+The 18 pre-existing failures in the full test suite (`queue_lifecycle`, `events_autocommit`,
+`ai_credentials`, `schema coercion`) are unrelated to the columnar path and predate this slice.


### PR DESCRIPTION
## Summary

- Adds a reproducible Criterion benchmark (`columnar_read_bench`) registered as a `[[bench]]` with `harness = false` in `crates/reddb-server/Cargo.toml`, comparing the columnar batch-decode path (`column_batch_from_block`) against the row-at-a-time path (`points_from_column_block`) on the same sealed `TimeSeriesChunk` workload at 1K / 10K / 50K rows.
- Records measured baseline p50/p99 for both paths in `docs/perf/2026-06-03-columnar-read.md`.
- Records profile findings (dominant cost: codec decompression, value column Xor+Zstd ≈ 54% of 2-column decode time at 50K rows).

## Baseline measurements (50K rows)

| Path | p50 | p99 | ns/row |
|------|-----|-----|--------|
| row-path | 778 µs | 877 µs | 15.6 ns |
| batch-path (2 cols) | 752 µs | 851 µs | 15.1 ns |
| batch-ts-only (projection) | 343 µs | 416 µs | 6.9 ns |

**Finding**: the two full-decode paths are within noise of each other (~3% at 50K rows). The dominant cost is Zstd codec decompression. Projection pushdown (ts-only) delivers 2.2× speedup by skipping the value column entirely.

## Correctness
- 19 columnar-related tests pass; no regression to existing columnar round-trip / projected-read tests.
- This slice is measure-only; no production code paths were modified.

## Unblocks
- #962 (optimise decode — target: beat row path) now has a reproducible gate harness and profiling data.
- #857 (chunk compaction) remains gated on #962.

## Test plan
- [ ] `cargo bench -p reddb-io-server --bench columnar_read_bench` runs without error
- [ ] `cargo test -p reddb-io-server -- columnar` passes (19 tests)
- [ ] `docs/perf/2026-06-03-columnar-read.md` contains p50/p99 for both paths and dominant-cost profile

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602851&installation_id=129708444&pr_number=1056&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1056&signature=30aa8f3fe4700d7fd86738c670fcbfd9d4f1ca3501ec2d01d9dae63615e32fb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks to measure and compare different read decoding approaches for columnar time-series data across multiple chunk sizes, enabling performance analysis and regression detection.

* **Documentation**
  * Added benchmark performance report documenting baseline results, throughput metrics, per-column cost breakdowns, and identifying codec decompression as a key optimization opportunity for future work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->