### PR TITLE
merge: #971 Migrate DB-touching tests to the auto-cleanup harness + fix the cwd ./wal/ writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "rustls-pemfile",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -2299,6 +2300,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
  "toml",
  "zstd",
 ]

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -114,6 +114,7 @@ async-trait = "0.1"
 # convergence and inverse-RTT weighted distribution.
 proptest = "1"
 prost = "0.14"
+tempfile = "3"
 
 [[bin]]
 name = "red_client"

--- a/crates/reddb-client/tests/conformance.rs
+++ b/crates/reddb-client/tests/conformance.rs
@@ -538,7 +538,7 @@ mod client_transport {
     use super::*;
     use std::net::TcpListener;
     use std::process::{Command, Stdio};
-    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant};
 
     #[tokio::test]
     async fn client_transport_conformance_suite() {
@@ -557,15 +557,13 @@ mod client_transport {
         };
 
         let port = pick_free_port().expect("pick port");
-        let data_dir = std::env::temp_dir().join(format!(
-            "reddb-rust-conformance-{}-{}",
-            std::process::id(),
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock")
-                .as_nanos()
-        ));
-        std::fs::create_dir_all(&data_dir).expect("scratch dir");
+        // Held for the whole test: the TempDir guard removes the scratch DB
+        // directory on drop (incl. panic), after the server is killed below.
+        let data_dir_guard = tempfile::Builder::new()
+            .prefix("reddb-test-rust-conformance-")
+            .tempdir()
+            .expect("scratch dir");
+        let data_dir = data_dir_guard.path();
 
         let mut server = Command::new(&bin)
             .arg("server")
@@ -583,7 +581,6 @@ mod client_transport {
 
         let _ = server.kill();
         let _ = server.wait();
-        let _ = std::fs::remove_dir_all(&data_dir);
 
         result.expect("client-transport conformance suite");
     }

--- a/crates/reddb-client/tests/embedded_bulk_insert.rs
+++ b/crates/reddb-client/tests/embedded_bulk_insert.rs
@@ -11,32 +11,44 @@
 //! a single batch grows by one record's worth of framing plus the
 //! row payloads.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use reddb_client::embedded::EmbeddedClient;
 use reddb_client::JsonValue;
 
-fn unique_db_path(label: &str) -> PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    std::env::temp_dir().join(format!(
-        "reddb-bulk-{}-{}-{}.rdb",
-        label,
-        std::process::id(),
-        nanos
-    ))
+/// Auto-cleaning DB path: holds the [`tempfile::TempDir`] guard so the temp
+/// directory and the `.rdb` (plus its `.rdb-uwal` sidecar) are removed on drop,
+/// including on panic. Derefs to `&Path` for the helpers below; callers keep the
+/// binding alive for the whole test.
+struct TempDbPath {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl std::ops::Deref for TempDbPath {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn unique_db_path(label: &str) -> TempDbPath {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-bulk-{label}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join(format!("reddb-bulk-{label}.rdb"));
+    TempDbPath { _dir: dir, path }
 }
 
 /// WAL filename mirrors `StoreCommitCoordinator::wal_path_for_db` —
 /// `<data_path>.rdb-uwal`. Building it from the data path keeps the
 /// test independent of the engine's internal path helpers.
-fn wal_path_for(data_path: &PathBuf) -> PathBuf {
+fn wal_path_for(data_path: &Path) -> PathBuf {
     data_path.with_extension("rdb-uwal")
 }
 
-fn wal_size(data_path: &PathBuf) -> u64 {
+fn wal_size(data_path: &Path) -> u64 {
     std::fs::metadata(wal_path_for(data_path))
         .map(|m| m.len())
         .unwrap_or(0)
@@ -69,7 +81,7 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
     // exactly the per-batch-vs-per-row bytes we want to compare.
     let bulk_path = unique_db_path("bulk");
     let bulk_size = {
-        let db = EmbeddedClient::open(bulk_path.clone()).expect("open bulk db");
+        let db = EmbeddedClient::open(bulk_path.to_path_buf()).expect("open bulk db");
         let inserted = db.bulk_insert("users", &rows(N)).expect("bulk insert");
         assert_eq!(
             inserted.affected, N as u64,
@@ -90,7 +102,7 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
     // same engine config.
     let perrow_path = unique_db_path("perrow");
     let perrow_size = {
-        let db = EmbeddedClient::open(perrow_path.clone()).expect("open perrow db");
+        let db = EmbeddedClient::open(perrow_path.to_path_buf()).expect("open perrow db");
         for i in 0..N {
             let sql = format!(
                 "INSERT INTO users (name, age) VALUES ('user_{i}', {})",
@@ -102,10 +114,6 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
         drop(db);
         after
     };
-
-    // Cleanup so a panic still leaves /tmp clean.
-    cleanup_db(&bulk_path);
-    cleanup_db(&perrow_path);
 
     eprintln!(
         "WAL size for {N} rows: bulk_insert={bulk_size} bytes, per-row={perrow_size} bytes (ratio {:.1}×)",
@@ -133,26 +141,10 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
     );
 }
 
-fn cleanup_db(path: &PathBuf) {
-    if let Some(parent) = path.parent() {
-        if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-            if let Ok(rd) = std::fs::read_dir(parent) {
-                for entry in rd.flatten() {
-                    let name = entry.file_name();
-                    let name_str = name.to_string_lossy();
-                    if name_str.starts_with(stem) {
-                        let _ = std::fs::remove_file(entry.path());
-                    }
-                }
-            }
-        }
-    }
-}
-
 #[test]
 fn bulk_insert_round_trip() {
     let path = unique_db_path("round-trip");
-    let db = EmbeddedClient::open(path.clone()).expect("open db");
+    let db = EmbeddedClient::open(path.to_path_buf()).expect("open db");
 
     let inserted = db
         .bulk_insert(
@@ -182,7 +174,6 @@ fn bulk_insert_round_trip() {
     assert_eq!(result.rows.len(), 3, "expected 3 rows back from select");
 
     drop(db);
-    cleanup_db(&path);
 }
 
 #[test]
@@ -191,7 +182,7 @@ fn bulk_insert_heterogeneous_payloads_still_work() {
     // the implementation to fall back to the per-row path. Pin
     // that this still inserts every row.
     let path = unique_db_path("hetero");
-    let db = EmbeddedClient::open(path.clone()).expect("open db");
+    let db = EmbeddedClient::open(path.to_path_buf()).expect("open db");
 
     let inserted = db
         .bulk_insert(
@@ -213,18 +204,16 @@ fn bulk_insert_heterogeneous_payloads_still_work() {
     assert_eq!(result.rows.len(), 2);
 
     drop(db);
-    cleanup_db(&path);
 }
 
 #[test]
 fn bulk_insert_empty_is_noop() {
     let path = unique_db_path("empty");
-    let db = EmbeddedClient::open(path.clone()).expect("open db");
+    let db = EmbeddedClient::open(path.to_path_buf()).expect("open db");
     let inserted = db.bulk_insert("anything", &[]).expect("empty bulk");
     assert_eq!(inserted.affected, 0);
     assert!(inserted.ids.is_empty());
     drop(db);
-    cleanup_db(&path);
 }
 
 /// Pins #111: `EmbeddedClient::insert` routes through the same
@@ -239,7 +228,7 @@ fn insert_emits_one_wal_record_per_call() {
     // Run 1: a single `insert` of one row.
     let insert_path = unique_db_path("insert-one");
     let insert_size = {
-        let db = EmbeddedClient::open(insert_path.clone()).expect("open insert db");
+        let db = EmbeddedClient::open(insert_path.to_path_buf()).expect("open insert db");
         let res = db
             .insert(
                 "users",
@@ -261,7 +250,7 @@ fn insert_emits_one_wal_record_per_call() {
     // hitting the same port with the same row.
     let bulk_path = unique_db_path("bulk-one");
     let bulk_size = {
-        let db = EmbeddedClient::open(bulk_path.clone()).expect("open bulk db");
+        let db = EmbeddedClient::open(bulk_path.to_path_buf()).expect("open bulk db");
         let inserted = db
             .bulk_insert(
                 "users",
@@ -284,17 +273,13 @@ fn insert_emits_one_wal_record_per_call() {
     // below the SQL path).
     let sql_path = unique_db_path("insert-sql");
     let sql_size = {
-        let db = EmbeddedClient::open(sql_path.clone()).expect("open sql db");
+        let db = EmbeddedClient::open(sql_path.to_path_buf()).expect("open sql db");
         db.query("INSERT INTO users (name, age) VALUES ('solo', 42)")
             .expect("sql insert");
         let after = wal_size(&sql_path);
         drop(db);
         after
     };
-
-    cleanup_db(&insert_path);
-    cleanup_db(&bulk_path);
-    cleanup_db(&sql_path);
 
     eprintln!(
         "WAL size for 1 row: insert={insert_size} bytes, bulk_insert(1)={bulk_size} bytes, query(SQL)={sql_size} bytes"
@@ -328,7 +313,7 @@ fn insert_emits_one_wal_record_per_call() {
 #[test]
 fn insert_round_trip() {
     let path = unique_db_path("insert-round-trip");
-    let db = EmbeddedClient::open(path.clone()).expect("open db");
+    let db = EmbeddedClient::open(path.to_path_buf()).expect("open db");
 
     let res = db
         .insert(
@@ -353,5 +338,4 @@ fn insert_round_trip() {
     assert_eq!(rid, returned_rid);
 
     drop(db);
-    cleanup_db(&path);
 }

--- a/crates/reddb-client/tests/redwire_query_with_live.rs
+++ b/crates/reddb-client/tests/redwire_query_with_live.rs
@@ -2,7 +2,7 @@
 
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use reddb_client::redwire::{Auth, ConnectOptions, RedWireClient};
 use reddb_client::{Value, ValueOut};
@@ -22,13 +22,12 @@ async fn redwire_query_with_params_against_live_server() -> Result<(), Box<dyn s
     };
 
     let port = pick_free_port()?;
-    let data_dir = std::env::temp_dir().join(format!(
-        "reddb-rust-redwire-{}-{}",
-        std::process::id(),
-        SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
-    ));
-    std::fs::create_dir_all(&data_dir)?;
-    let data_path = data_dir.join("data.db");
+    // Held for the whole test: the TempDir guard removes the scratch DB
+    // directory on drop (incl. panic), after the server is stopped below.
+    let data_dir = tempfile::Builder::new()
+        .prefix("reddb-test-rust-redwire-")
+        .tempdir()?;
+    let data_path = data_dir.path().join("data.db");
 
     let mut server = Command::new(&bin)
         .arg("server")
@@ -42,7 +41,7 @@ async fn redwire_query_with_params_against_live_server() -> Result<(), Box<dyn s
 
     let test_result = run_live_query_with(port).await;
     stop_server(&mut server);
-    let _ = std::fs::remove_dir_all(data_dir);
+    drop(data_dir);
     test_result
 }
 

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -27,3 +27,4 @@ zstd = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 toml = "1.1"
+tempfile = "3"

--- a/crates/reddb-file/tests/embedded_rdb_artifact.rs
+++ b/crates/reddb-file/tests/embedded_rdb_artifact.rs
@@ -7,18 +7,14 @@ use reddb_file::{
     EMBEDDED_RDB_SUPERBLOCK_1_OFFSET,
 };
 
-fn temp_dir(label: &str) -> PathBuf {
-    let unique = format!(
-        "reddb_embedded_rdb_{label}_{}_{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    );
-    let dir = std::env::temp_dir().join(unique);
-    fs::create_dir_all(&dir).unwrap();
-    dir
+/// Auto-cleaning temp dir: the returned [`tempfile::TempDir`] guard removes the
+/// directory and all `.rdb` artifacts under it on drop, including on panic. The
+/// caller keeps the binding alive and reads paths via `dir.path()`.
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-embedded-rdb-{label}-"))
+        .tempdir()
+        .expect("temp dir")
 }
 
 fn artifact_names(dir: &Path) -> Vec<String> {
@@ -52,7 +48,7 @@ fn run_crash_child(test_name: &str, path: &Path, op: &str, point: &str) {
 #[test]
 fn create_open_embedded_rdb_uses_one_required_artifact() {
     let dir = temp_dir("create_open");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
 
     let created = EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
     assert_eq!(created.selected_superblock.copy_index, 1);
@@ -70,15 +66,13 @@ fn create_open_embedded_rdb_uses_one_required_artifact() {
     assert_eq!(reopened.selected_superblock.copy_index, 1);
     assert_eq!(reopened.selected_superblock.generation, 2);
     assert_eq!(reopened.manifest.checksum, created.manifest.checksum);
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
-
-    fs::remove_dir_all(dir).unwrap();
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
 }
 
 #[test]
 fn open_falls_back_to_older_superblock_when_newer_copy_is_invalid() {
     let dir = temp_dir("superblock_fallback");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
 
     let mut file = OpenOptions::new()
@@ -94,14 +88,12 @@ fn open_falls_back_to_older_superblock_when_newer_copy_is_invalid() {
     let reopened = EmbeddedRdbArtifact::open(&path).expect("open falls back");
     assert_eq!(reopened.selected_superblock.copy_index, 0);
     assert_eq!(reopened.selected_superblock.generation, 1);
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn open_validates_manifest_checksum_from_selected_superblock() {
     let dir = temp_dir("manifest_checksum");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
 
     let mut file = OpenOptions::new()
@@ -125,14 +117,12 @@ fn open_validates_manifest_checksum_from_selected_superblock() {
 
     let recovered = EmbeddedRdbArtifact::open(&path).expect("open recovers from superblock");
     assert_eq!(recovered.manifest.wal_region_offset, 12288);
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_wal_frames_are_versioned_ordered_and_chained() {
     let dir = temp_dir("wal_chain");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
 
     EmbeddedRdbArtifact::append_wal_payloads(
@@ -165,14 +155,12 @@ fn embedded_wal_frames_are_versioned_ordered_and_chained() {
     let payloads =
         EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read valid wal prefix");
     assert_eq!(payloads, vec![b"first".to_vec()]);
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_wal_recovery_ignores_corrupt_or_truncated_tail_frame() {
     let dir = temp_dir("wal_tail");
-    let corrupt_path = dir.join("corrupt.rdb");
+    let corrupt_path = dir.path().join("corrupt.rdb");
     EmbeddedRdbArtifact::create(&corrupt_path).expect("create corrupt artifact");
     EmbeddedRdbArtifact::append_wal_payloads(
         &corrupt_path,
@@ -196,7 +184,7 @@ fn embedded_wal_recovery_ignores_corrupt_or_truncated_tail_frame() {
         EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read valid wal prefix");
     assert_eq!(payloads, vec![b"durable".to_vec()]);
 
-    let truncated_path = dir.join("truncated.rdb");
+    let truncated_path = dir.path().join("truncated.rdb");
     EmbeddedRdbArtifact::create(&truncated_path).expect("create truncated artifact");
     EmbeddedRdbArtifact::append_wal_payloads(
         &truncated_path,
@@ -217,8 +205,6 @@ fn embedded_wal_recovery_ignores_corrupt_or_truncated_tail_frame() {
     let payloads =
         EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read valid wal prefix");
     assert_eq!(payloads, vec![b"durable".to_vec()]);
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
@@ -241,7 +227,7 @@ fn embedded_wal_crash_injection_preserves_last_published_prefix() {
         "wal_after_frame_sync",
         "wal_after_superblock_write",
     ] {
-        let path = dir.join(format!("{point}.rdb"));
+        let path = dir.path().join(format!("{point}.rdb"));
         EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
         EmbeddedRdbArtifact::append_wal_payloads(&path, &[b"base".to_vec()])
             .expect("append base frame");
@@ -268,14 +254,12 @@ fn embedded_wal_crash_injection_preserves_last_published_prefix() {
             "base frame lost after {point}: {payloads:?}"
         );
     }
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_wal_serializes_concurrent_appenders() {
     let dir = temp_dir("wal_concurrent");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
 
     let mut handles = Vec::new();
@@ -299,14 +283,12 @@ fn embedded_wal_serializes_concurrent_appenders() {
     seen.sort();
     seen.dedup();
     assert_eq!(seen.len(), 200);
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_snapshot_checkpoint_is_copy_on_write_until_superblock_publish() {
     let dir = temp_dir("snapshot_cow");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     let v1 = b"RDST-v1";
     let v2 = b"RDST-v2-new-checkpoint";
     let created = EmbeddedRdbArtifact::create_with_snapshot(&path, v1).expect("create snapshot");
@@ -342,14 +324,12 @@ fn embedded_snapshot_checkpoint_is_copy_on_write_until_superblock_publish() {
             .unwrap(),
         v1
     );
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_open_skips_newer_superblock_when_snapshot_checksum_fails() {
     let dir = temp_dir("snapshot_checksum_fallback");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     let v1 = b"RDST-good";
     let v2 = b"RDST-bad-checkpoint";
     EmbeddedRdbArtifact::create_with_snapshot(&path, v1).expect("create snapshot");
@@ -372,8 +352,6 @@ fn embedded_open_skips_newer_superblock_when_snapshot_checksum_fails() {
             .unwrap(),
         v1
     );
-
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
@@ -397,7 +375,7 @@ fn embedded_snapshot_crash_injection_preserves_published_snapshot() {
         "snapshot_after_manifest_write",
         "snapshot_after_superblock_write",
     ] {
-        let path = dir.join(format!("{point}.rdb"));
+        let path = dir.path().join(format!("{point}.rdb"));
         EmbeddedRdbArtifact::create_with_snapshot(&path, b"RDST-base")
             .expect("create base snapshot");
 
@@ -421,6 +399,4 @@ fn embedded_snapshot_crash_injection_preserves_published_snapshot() {
             b"RDST-after-crash".to_vec()
         );
     }
-
-    fs::remove_dir_all(dir).unwrap();
 }

--- a/crates/reddb-file/tests/primary_replica_basebackup_crash.rs
+++ b/crates/reddb-file/tests/primary_replica_basebackup_crash.rs
@@ -25,7 +25,7 @@ fn basebackup_parts_publish_survives_crash_without_manifest() {
         "basebackup_after_parts_dir_rename",
     ] {
         let root = temp_root(point);
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         let backup = backup_plan();
 
         let child = Command::new(std::env::current_exe().expect("current test exe"))
@@ -33,7 +33,7 @@ fn basebackup_parts_publish_survives_crash_without_manifest() {
             .arg("primary_replica_basebackup_crash_child")
             .arg("--nocapture")
             .env(CHILD_ENV, "1")
-            .env(ROOT_ENV, &root)
+            .env(ROOT_ENV, root.path())
             .env(CRASH_ENV, point)
             .status()
             .expect("run crash child");
@@ -53,8 +53,6 @@ fn basebackup_parts_publish_survives_crash_without_manifest() {
                 "final parts dir must not be visible before directory publish at {point}"
             );
         }
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -65,7 +63,7 @@ fn basebackup_retry_crash_preserves_existing_parts() {
     }
 
     let root = temp_root("retry");
-    let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+    let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
     let backup = backup_plan();
     let manifest = plan
         .write_basebackup_snapshot_parts(backup.clone(), b"original-snapshot", 8)
@@ -91,8 +89,6 @@ fn basebackup_retry_crash_preserves_existing_parts() {
         .read_snapshot_parts(plan.basebackup_dir())
         .expect("existing parts still verify");
     assert_eq!(restored, b"original-snapshot");
-
-    let _ = std::fs::remove_dir_all(root);
 }
 
 #[test]
@@ -108,7 +104,7 @@ fn basebackup_manifest_publish_survives_atomic_crash_points() {
         "atomic_after_dir_sync",
     ] {
         let root = temp_root(&format!("manifest-{point}"));
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         let backup = backup_plan();
         let manifest = plan
             .write_basebackup_snapshot_parts(backup.clone(), b"manifest-snapshot", 8)
@@ -119,7 +115,7 @@ fn basebackup_manifest_publish_survives_atomic_crash_points() {
             .arg("primary_replica_basebackup_crash_child")
             .arg("--nocapture")
             .env(CHILD_ENV, "1")
-            .env(ROOT_ENV, &root)
+            .env(ROOT_ENV, root.path())
             .env(MODE_ENV, "manifest")
             .env(CRASH_ENV, point)
             .status()
@@ -143,8 +139,6 @@ fn basebackup_manifest_publish_survives_atomic_crash_points() {
                 .verify_snapshot_parts(plan.basebackup_dir())
                 .expect("unpublished basebackup chunks remain valid");
         }
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -219,13 +213,13 @@ fn crc32(bytes: &[u8]) -> u32 {
     hasher.finalize()
 }
 
-fn temp_root(label: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-file-primary-basebackup-crash-{label}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+/// Auto-cleaning temp root: the returned [`tempfile::TempDir`] guard removes the
+/// directory and all artifacts under it on drop, including on panic. The caller
+/// keeps the binding alive across the crash child + assertions and reads the
+/// path via `root.path()`.
+fn temp_root(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-primary-basebackup-crash-{label}-"))
+        .tempdir()
+        .expect("temp dir")
 }

--- a/crates/reddb-file/tests/primary_replica_relay_timeline_crash.rs
+++ b/crates/reddb-file/tests/primary_replica_relay_timeline_crash.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitCode};
 
 use reddb_file::{
@@ -19,12 +19,12 @@ fn relay_manifest_write_survives_atomic_crash_points() {
 
     for point in crash_points() {
         let root = temp_root("relay", point);
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         initial_relay()
             .write_to_path(plan.relay_manifest_path("replica-a"))
             .expect("write initial relay manifest");
 
-        run_child(&root, "relay", point);
+        run_child(root.path(), "relay", point);
 
         let manifest =
             ReplicaRelayLogManifest::read_from_path(plan.relay_manifest_path("replica-a"))
@@ -35,8 +35,6 @@ fn relay_manifest_write_survives_atomic_crash_points() {
             manifest.flushed_lsn
         );
         assert_eq!(manifest.applied_lsn, manifest.flushed_lsn);
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -48,7 +46,7 @@ fn relay_segment_write_survives_atomic_crash_points() {
 
     for point in crash_points() {
         let root = temp_root("relay-segment", point);
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         let segment_path = plan
             .relay_dir("replica-a")
             .join("relay-00000000000000000001-00000000000000000010.redwal");
@@ -56,7 +54,7 @@ fn relay_segment_write_survives_atomic_crash_points() {
             .write_to_path(&segment_path)
             .expect("write initial relay segment");
 
-        run_child(&root, "relay-segment", point);
+        run_child(root.path(), "relay-segment", point);
 
         let segment =
             ReplicaRelayLogSegment::read_from_path(&segment_path).expect("relay segment decodes");
@@ -72,8 +70,6 @@ fn relay_segment_write_survives_atomic_crash_points() {
             assert_eq!(segment.records.len(), 2);
             assert_eq!(segment.records[1].payload, b"new".to_vec());
         }
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -85,12 +81,12 @@ fn timeline_history_write_survives_atomic_crash_points() {
 
     for point in crash_points() {
         let root = temp_root("timeline", point);
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         TimelineHistory::new(1)
             .write_to_path(plan.timeline_history_path())
             .expect("write initial timeline history");
 
-        run_child(&root, "timeline", point);
+        run_child(root.path(), "timeline", point);
 
         let history =
             TimelineHistory::read_from_path(plan.timeline_history_path()).expect("history decodes");
@@ -102,8 +98,6 @@ fn timeline_history_write_survives_atomic_crash_points() {
         if history.current() == Some(TimelineId(2)) {
             assert_eq!(history.ancestor_lsn(TimelineId(2)), Some(80));
         }
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -132,7 +126,7 @@ fn primary_replica_atomic_crash_child() -> ExitCode {
     ExitCode::from(1)
 }
 
-fn run_child(root: &PathBuf, artifact: &str, point: &str) {
+fn run_child(root: &Path, artifact: &str, point: &str) {
     let child = Command::new(std::env::current_exe().expect("current test exe"))
         .arg("--exact")
         .arg("primary_replica_atomic_crash_child")
@@ -204,13 +198,13 @@ fn updated_timeline() -> TimelineHistory {
     history
 }
 
-fn temp_root(artifact: &str, point: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-file-primary-{artifact}-crash-{point}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+/// Auto-cleaning temp root: the returned [`tempfile::TempDir`] guard removes the
+/// directory and all artifacts under it on drop, including on panic. The caller
+/// keeps the binding alive across the crash child + assertions and reads the
+/// path via `root.path()`.
+fn temp_root(artifact: &str, point: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-primary-{artifact}-crash-{point}-"))
+        .tempdir()
+        .expect("temp dir")
 }

--- a/crates/reddb-file/tests/primary_replica_slot_catalog_crash.rs
+++ b/crates/reddb-file/tests/primary_replica_slot_catalog_crash.rs
@@ -22,7 +22,7 @@ fn slot_catalog_write_survives_atomic_crash_points() {
         "atomic_after_dir_sync",
     ] {
         let root = temp_root(point);
-        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1));
+        let plan = PrimaryReplicaFilePlan::new(root.path(), TimelineId(1));
         initial_catalog()
             .write_to_path(plan.slots_path())
             .expect("write initial slot catalog");
@@ -32,7 +32,7 @@ fn slot_catalog_write_survives_atomic_crash_points() {
             .arg("primary_replica_slot_catalog_crash_child")
             .arg("--nocapture")
             .env(CHILD_ENV, "1")
-            .env(ROOT_ENV, &root)
+            .env(ROOT_ENV, root.path())
             .env(CRASH_ENV, point)
             .status()
             .expect("run crash child");
@@ -55,8 +55,6 @@ fn slot_catalog_write_survives_atomic_crash_points() {
             slot.confirmed_flush_lsn
         );
         assert_eq!(slot.confirmed_flush_lsn, slot.confirmed_apply_lsn);
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -91,13 +89,13 @@ fn updated_catalog() -> ReplicationSlotCatalog {
     catalog
 }
 
-fn temp_root(label: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-file-primary-slot-crash-{label}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+/// Auto-cleaning temp root: the returned [`tempfile::TempDir`] guard removes the
+/// directory and all artifacts under it on drop, including on panic. The caller
+/// keeps the binding alive across the crash child + assertions and reads the
+/// path via `root.path()`.
+fn temp_root(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-primary-slot-crash-{label}-"))
+        .tempdir()
+        .expect("temp dir")
 }

--- a/crates/reddb-file/tests/serverless_current_pointer_crash.rs
+++ b/crates/reddb-file/tests/serverless_current_pointer_crash.rs
@@ -22,7 +22,7 @@ fn current_pointer_publish_survives_crash_points() {
         "current_pointer_after_dir_sync",
     ] {
         let root = temp_root(point);
-        let first = ServerlessFilePlan::new(&root, "db", 1);
+        let first = ServerlessFilePlan::new(root.path(), "db", 1);
         let first_pointer = first
             .publish_core_generation(&extent_index(1, b"first"), b"first", b"secondary")
             .expect("publish first generation");
@@ -32,7 +32,7 @@ fn current_pointer_publish_survives_crash_points() {
             .arg("serverless_current_pointer_crash_child")
             .arg("--nocapture")
             .env(CHILD_ENV, "1")
-            .env(ROOT_ENV, &root)
+            .env(ROOT_ENV, root.path())
             .env(CRASH_ENV, point)
             .status()
             .expect("run crash child");
@@ -53,15 +53,13 @@ fn current_pointer_publish_survives_crash_points() {
         if current.generation == 1 {
             assert_eq!(current, first_pointer);
         } else {
-            let second = ServerlessFilePlan::new(&root, "db", 2);
+            let second = ServerlessFilePlan::new(root.path(), "db", 2);
             let manifest =
                 ServerlessManifest::read_from_path(second.manifest_path()).expect("read manifest");
             second
                 .validate_complete_generation(&manifest)
                 .expect("new generation is complete when pointer advanced");
         }
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -78,7 +76,7 @@ fn generation_pack_publish_does_not_advance_current_on_crash() {
         "serverless_pack_after_dir_sync",
     ] {
         let root = temp_root(point);
-        let first = ServerlessFilePlan::new(&root, "db", 1);
+        let first = ServerlessFilePlan::new(root.path(), "db", 1);
         let first_pointer = first
             .publish_core_generation(&extent_index(1, b"first"), b"first", b"secondary")
             .expect("publish first generation");
@@ -88,7 +86,7 @@ fn generation_pack_publish_does_not_advance_current_on_crash() {
             .arg("serverless_current_pointer_crash_child")
             .arg("--nocapture")
             .env(CHILD_ENV, "1")
-            .env(ROOT_ENV, &root)
+            .env(ROOT_ENV, root.path())
             .env(CRASH_ENV, point)
             .status()
             .expect("run crash child");
@@ -105,8 +103,6 @@ fn generation_pack_publish_does_not_advance_current_on_crash() {
             current, first_pointer,
             "pack crash at {point} must not advance CURRENT"
         );
-
-        let _ = std::fs::remove_dir_all(root);
     }
 }
 
@@ -138,13 +134,13 @@ fn extent_index(generation: u64, payload: &[u8]) -> ServerlessExtentIndex {
     index
 }
 
-fn temp_root(label: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-file-serverless-current-crash-{label}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+/// Auto-cleaning temp root: the returned [`tempfile::TempDir`] guard removes the
+/// directory and all artifacts under it on drop, including on panic. The caller
+/// keeps the binding alive across the crash child + assertions and reads the
+/// path via `root.path()`.
+fn temp_root(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-serverless-current-crash-{label}-"))
+        .tempdir()
+        .expect("temp dir")
 }

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -462,8 +462,13 @@ mod tests {
 
     #[test]
     fn test_archive_and_download() {
-        let temp_dir = std::env::temp_dir().join("reddb_archiver_test");
-        let _ = std::fs::create_dir_all(&temp_dir);
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-archiver-test-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend_dir = temp_dir.join("backend");
         let _ = std::fs::create_dir_all(&backend_dir);
 
@@ -471,8 +476,7 @@ mod tests {
         // Anchor the archive prefix inside the temp dir. `backup_wal_prefix("")`
         // yields a cwd-relative `wal/` directory, which leaks archived segments
         // into the working tree (`crates/reddb-server/wal/`) and is never cleaned.
-        let wal_prefix =
-            reddb_file::backup_wal_prefix(&format!("{}/", temp_dir.to_string_lossy()));
+        let wal_prefix = reddb_file::backup_wal_prefix(&format!("{}/", temp_dir.to_string_lossy()));
         let archiver = WalArchiver::new(backend, &wal_prefix);
 
         // Create a fake WAL file
@@ -505,8 +509,7 @@ mod tests {
         assert!(found);
         assert!(dest.exists());
 
-        // Cleanup
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -468,7 +468,11 @@ mod tests {
         let _ = std::fs::create_dir_all(&backend_dir);
 
         let backend = Arc::new(LocalBackend);
-        let wal_prefix = reddb_file::backup_wal_prefix("");
+        // Anchor the archive prefix inside the temp dir. `backup_wal_prefix("")`
+        // yields a cwd-relative `wal/` directory, which leaks archived segments
+        // into the working tree (`crates/reddb-server/wal/`) and is never cleaned.
+        let wal_prefix =
+            reddb_file::backup_wal_prefix(&format!("{}/", temp_dir.to_string_lossy()));
         let archiver = WalArchiver::new(backend, &wal_prefix);
 
         // Create a fake WAL file

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -514,8 +514,13 @@ mod tests {
 
     #[test]
     fn test_backup_head_roundtrip() {
-        let temp_dir = std::env::temp_dir().join("reddb_backup_head_test");
-        let _ = std::fs::create_dir_all(&temp_dir);
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-backup-head-test-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend = LocalBackend;
         let root_prefix = format!("{}/", temp_dir.to_string_lossy());
         let head_key = reddb_file::backup_head_key(&root_prefix);
@@ -540,13 +545,18 @@ mod tests {
             .expect("head");
         assert_eq!(loaded, head);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]
     fn test_snapshot_manifest_roundtrip() {
-        let temp_dir = std::env::temp_dir().join("reddb_snapshot_manifest_test");
-        let _ = std::fs::create_dir_all(&temp_dir);
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-snapshot-manifest-test-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend = LocalBackend;
         let root_prefix = format!("{}/", temp_dir.to_string_lossy());
         let manifest = SnapshotManifest {
@@ -570,14 +580,18 @@ mod tests {
             .expect("manifest");
         assert_eq!(loaded, manifest);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]
     fn test_archived_change_records_roundtrip() {
-        let temp_dir = std::env::temp_dir().join("reddb_archived_change_records_test");
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-archived-change-records-test-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend = LocalBackend;
         let root_prefix = format!("{}/", temp_dir.to_string_lossy());
         let prefix = reddb_file::backup_wal_prefix(&root_prefix);
@@ -602,15 +616,18 @@ mod tests {
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].lsn, 7);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]
     fn archive_change_records_writes_sidecar_with_sha256() {
-        let temp_dir =
-            std::env::temp_dir().join(format!("reddb_archiver_sidecar_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-archiver-sidecar-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend = LocalBackend;
         let root_prefix = format!("{}/", temp_dir.to_string_lossy());
         let prefix = reddb_file::backup_wal_prefix(&root_prefix);
@@ -644,7 +661,7 @@ mod tests {
             load_archived_change_records_with_sha256(&backend, &meta.key).unwrap();
         assert_eq!(computed, meta.sha256, "computed sha must match sidecar");
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]
@@ -703,10 +720,13 @@ mod tests {
 
     #[test]
     fn unified_manifest_publish_load_roundtrip() {
-        let temp_dir =
-            std::env::temp_dir().join(format!("reddb_unified_manifest_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-unified-manifest-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let prefix = temp_dir.to_string_lossy().to_string();
 
         let backend = LocalBackend;
@@ -718,15 +738,18 @@ mod tests {
         assert_eq!(loaded.version, "1.0");
         assert_eq!(loaded.latest_lsn, 0);
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]
     fn archive_change_records_chains_prev_hash() {
-        let temp_dir =
-            std::env::temp_dir().join(format!("reddb_archive_chain_{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        std::fs::create_dir_all(&temp_dir).unwrap();
+        // Auto-cleaning temp dir: removed on drop (incl. panic), so the test
+        // leaves no residue even if an assertion fails.
+        let dir = tempfile::Builder::new()
+            .prefix("reddb-archive-chain-")
+            .tempdir()
+            .unwrap();
+        let temp_dir = dir.path().to_path_buf();
         let backend = LocalBackend;
         let root_prefix = format!("{}/", temp_dir.to_string_lossy());
         let prefix = reddb_file::backup_wal_prefix(&root_prefix);
@@ -780,7 +803,7 @@ mod tests {
         assert_eq!(s2.prev_hash, m1.sha256, "seg 2 links to seg 1 sha256");
         assert_eq!(s3.prev_hash, m2.sha256, "seg 3 links to seg 2 sha256");
 
-        let _ = std::fs::remove_dir_all(&temp_dir);
+        // `dir` (TempDir) auto-removes the whole tree on drop.
     }
 
     #[test]

--- a/crates/reddb-server/tests/cascade_replication_e2e.rs
+++ b/crates/reddb-server/tests/cascade_replication_e2e.rs
@@ -46,7 +46,7 @@ fn temp_data_path(name: &str) -> TempDataPath {
         .prefix(&format!("reddb-test-cascade-e2e-{name}-"))
         .tempdir()
         .expect("temp dir");
-    let path = dir.path().join(format!("reddb_cascade_e2e_{name}.rdb"));
+    let path = dir.path().join(format!("cascade_e2e_{name}.rdb"));
     TempDataPath { _dir: dir, path }
 }
 

--- a/crates/reddb-server/tests/cascade_replication_e2e.rs
+++ b/crates/reddb-server/tests/cascade_replication_e2e.rs
@@ -20,19 +20,34 @@
 //! values the transport would carry.
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb_server::replication::primary::PrimaryReplication;
 use reddb_server::replication::{
     CascadeRefusal, CascadeRelay, CausalBookmark, ReplicaClass, ReplicationConfig, UpstreamChoice,
 };
 
-fn temp_data_path(name: &str) -> std::path::PathBuf {
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_cascade_e2e_{name}_{suffix}.rdb"))
+/// Auto-cleaning data path: the returned guard holds a [`tempfile::TempDir`],
+/// so the directory and all artifacts are removed on drop (incl. panic). Keep
+/// the binding alive for the whole test.
+struct TempDataPath {
+    _dir: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl std::ops::Deref for TempDataPath {
+    type Target = std::path::Path;
+    fn deref(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+fn temp_data_path(name: &str) -> TempDataPath {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-cascade-e2e-{name}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join(format!("reddb_cascade_e2e_{name}.rdb"));
+    TempDataPath { _dir: dir, path }
 }
 
 const TERM: u64 = 1;
@@ -151,8 +166,6 @@ fn cascaded_leaf_syncs_through_intermediate_and_frontier_propagates() {
     assert_eq!(chain_frontier, 10);
     primary.ack_replica_lsn("inter-a", chain_frontier, chain_frontier);
     assert_eq!(primary.retention_floor_lsn(), Some(10));
-
-    let _ = std::fs::remove_file(&path);
 }
 
 #[test]
@@ -180,8 +193,6 @@ fn bookmark_read_routes_by_visible_frontier_through_the_chain() {
     let inter_bookmark = relay.upstream_confirmed_bookmark(TERM);
     assert_eq!(inter_bookmark.commit_lsn(), 6); // pinned by the leaf
     assert_eq!(inter_bookmark.term(), TERM);
-
-    let _ = std::fs::remove_file(&path);
 }
 
 #[test]
@@ -214,8 +225,6 @@ fn intermediate_fan_out_is_one_stream_at_the_primary() {
     assert_eq!(relay.upstream_confirmed_lsn(), 12);
     primary.ack_replica_lsn("inter-a", 12, 12);
     assert_eq!(primary.retention_floor_lsn(), Some(12));
-
-    let _ = std::fs::remove_file(&path);
 }
 
 /// Sanity that the shared `Arc<[u8]>` fan-out path the production transport
@@ -238,6 +247,4 @@ fn forwarding_works_over_shared_payload_handles() {
         vec![1, 2, 3],
         "the intermediate withholds records it has not yet applied"
     );
-
-    let _ = std::fs::remove_file(&path);
 }

--- a/crates/reddb-server/tests/election_consensus_e2e.rs
+++ b/crates/reddb-server/tests/election_consensus_e2e.rs
@@ -30,18 +30,15 @@ use reddb_server::replication::{
 
 const LONG: Duration = Duration::from_secs(60);
 
-/// Unique temp dir for one test's per-node durable last-vote files.
-fn temp_cluster_dir(tag: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-election-e2e-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
+/// Auto-cleaning temp dir for one test's per-node durable last-vote files.
+/// The returned [`tempfile::TempDir`] guard removes the directory (and every
+/// last-vote file under it) on drop, including on panic; the caller binds it to
+/// a local and keeps it alive for the whole test.
+fn temp_cluster_dir(tag: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-election-e2e-{tag}-"))
+        .tempdir()
+        .expect("temp dir")
 }
 
 struct PeerState {
@@ -54,6 +51,9 @@ struct PeerState {
 /// Black-box cluster: each peer is a real durable [`Voter`]; the candidate is
 /// the real coordinator. Clock advances a fixed tick per RPC.
 struct Cluster {
+    // Retained for construction symmetry; the TempDir guard in the test owns
+    // cleanup now, so this field is no longer read.
+    #[allow(dead_code)]
     dir: std::path::PathBuf,
     members: Vec<Member>,
     peers: HashMap<String, PeerState>,
@@ -128,10 +128,6 @@ impl ElectionTransport for Cluster {
     }
 }
 
-fn cleanup(c: &Cluster) {
-    let _ = std::fs::remove_dir_all(&c.dir);
-}
-
 fn candidate(id: &str, current_term: u64, lsn: u64, watermark: u64) -> ElectionRequest {
     ElectionRequest {
         candidate: Member::data_voting(id),
@@ -150,7 +146,7 @@ fn covering_replica_is_elected_by_majority_within_timeout() {
         Member::data_voting("r2"),
         Member::data_voting("r3"),
     ];
-    let mut cluster = Cluster::new(dir, members, 100);
+    let mut cluster = Cluster::new(dir.path().to_path_buf(), members, 100);
     // The old primary is gone; replica r1 covers the watermark (frontier 150).
     let req = candidate("r1", 4, 150, 100);
 
@@ -163,7 +159,6 @@ fn covering_replica_is_elected_by_majority_within_timeout() {
         "got {outcome:?}",
     );
     assert_eq!(cluster.promoted, Some(5));
-    cleanup(&cluster);
 }
 
 // Criterion 2: a candidate below the watermark cannot win.
@@ -175,7 +170,7 @@ fn candidate_below_watermark_cannot_win() {
         Member::data_voting("r2"),
         Member::data_voting("r3"),
     ];
-    let mut cluster = Cluster::new(dir, members, 100);
+    let mut cluster = Cluster::new(dir.path().to_path_buf(), members, 100);
     // r1's frontier 90 does not cover watermark 100.
     let req = candidate("r1", 4, 90, 100);
 
@@ -184,14 +179,13 @@ fn candidate_below_watermark_cannot_win() {
     assert_eq!(outcome, ElectionOutcome::NotElectable);
     assert!(cluster.bumped.is_empty(), "no term burned");
     assert_eq!(cluster.promoted, None);
-    cleanup(&cluster);
 }
 
 // Criterion 3: durable last-vote survives restart — no double-vote.
 #[test]
 fn restarted_voter_does_not_double_vote() {
     let dir = temp_cluster_dir("restart");
-    let path = dir.join("r2.lastvote.json");
+    let path = dir.path().join("r2.lastvote.json");
 
     // r2 grants candidate "alpha" in term 5, persisted to disk.
     {
@@ -215,7 +209,6 @@ fn restarted_voter_does_not_double_vote() {
             }),
         );
     }
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // Criterion 4a: a failed dry-run probe does not bump the term.
@@ -227,7 +220,7 @@ fn failed_probe_does_not_bump_term() {
         Member::data_voting("r2"),
         Member::data_voting("r3"),
     ];
-    let mut cluster = Cluster::new(dir, members, 100);
+    let mut cluster = Cluster::new(dir.path().to_path_buf(), members, 100);
     cluster.partition_away("r2");
     cluster.partition_away("r3");
     let req = candidate("r1", 4, 150, 100);
@@ -242,7 +235,6 @@ fn failed_probe_does_not_bump_term() {
         cluster.bumped.is_empty(),
         "dry-run probe must not bump the term"
     );
-    cleanup(&cluster);
 }
 
 // Criterion 4b: a witness vote counts toward quorum.
@@ -254,7 +246,7 @@ fn witness_completes_the_quorum() {
         Member::data_voting("r2"),
         Member::witness("w1"),
     ];
-    let mut cluster = Cluster::new(dir, members, 100);
+    let mut cluster = Cluster::new(dir.path().to_path_buf(), members, 100);
     cluster.partition_away("r2"); // only candidate + witness reachable
     let req = candidate("r1", 4, 150, 100);
 
@@ -271,7 +263,6 @@ fn witness_completes_the_quorum() {
         ),
         "witness vote should complete the majority, got {outcome:?}",
     );
-    cleanup(&cluster);
 }
 
 // Criterion 4c: a catching-up replica is non-voting and out of the denominator.
@@ -283,7 +274,7 @@ fn catching_up_replica_is_non_voting() {
         Member::data_voting("r2"),
         Member::data_catching_up("r3"), // syncing — excluded
     ];
-    let mut cluster = Cluster::new(dir, members, 100);
+    let mut cluster = Cluster::new(dir.path().to_path_buf(), members, 100);
     let req = candidate("r1", 4, 150, 100);
 
     let outcome = ElectionCoordinator::run(&req, &mut cluster, LONG);
@@ -300,7 +291,6 @@ fn catching_up_replica_is_non_voting() {
         ),
         "got {outcome:?}",
     );
-    cleanup(&cluster);
 }
 
 // Criterion 5: no two primaries in a term, under partition. Two candidates on
@@ -314,7 +304,7 @@ fn no_two_primaries_in_a_term_under_partition() {
 
     // Both partitions read/write the SAME per-node durable files (one disk
     // per node). Build two clusters pointed at the same dir.
-    let mut majority = Cluster::new(dir.clone(), members.clone(), 100);
+    let mut majority = Cluster::new(dir.path().to_path_buf(), members.clone(), 100);
     majority.partition_away("a");
     majority.partition_away("b");
     let c_outcome = ElectionCoordinator::run(&candidate("c", 4, 150, 100), &mut majority, LONG);
@@ -331,7 +321,7 @@ fn no_two_primaries_in_a_term_under_partition() {
     );
     assert_eq!(majority.promoted, Some(5));
 
-    let mut minority = Cluster::new(dir.clone(), members, 100);
+    let mut minority = Cluster::new(dir.path().to_path_buf(), members, 100);
     minority.partition_away("c");
     minority.partition_away("d");
     minority.partition_away("e");
@@ -344,7 +334,7 @@ fn no_two_primaries_in_a_term_under_partition() {
 
     // Durable barrier: a voter d, which granted c in term 5, refuses a in 5
     // even across a process restart (fresh Voter over the same file).
-    let d_path = dir.join("d.lastvote.json");
+    let d_path = dir.path().join("d.lastvote.json");
     let d = Voter::new("d", FileLastVoteStore::new(&d_path));
     assert_eq!(
         d.consider(&VoteRequest::real("a", 5, 150), 100).unwrap(),
@@ -353,5 +343,4 @@ fn no_two_primaries_in_a_term_under_partition() {
             voted_for: "c".to_string(),
         }),
     );
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -57,7 +57,6 @@ fn embedded_runtime_persists_table_data_inside_single_rdb_file() {
     }
 
     assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
-
 }
 
 #[test]
@@ -110,7 +109,6 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
     );
     assert!(checkpointed.manifest.snapshot_bytes > 0);
     assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
-
 }
 
 #[test]
@@ -152,5 +150,4 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
 
     let frames = EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read wal payloads");
     assert!(!frames.is_empty(), "expected retried wal frame");
-
 }

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -1,23 +1,19 @@
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use reddb_file::EmbeddedRdbArtifact;
 use reddb_server::storage::schema::Value;
 use reddb_server::storage::{EntityId, UnifiedStore, UnifiedStoreConfig};
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
-fn temp_dir(label: &str) -> PathBuf {
-    let unique = format!(
-        "reddb_embedded_rdb_{label}_{}_{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    );
-    let dir = std::env::temp_dir().join(unique);
-    fs::create_dir_all(&dir).unwrap();
-    dir
+/// Auto-cleaning temp dir: the returned [`tempfile::TempDir`] guard removes the
+/// directory and the `.rdb` artifact (incl. internal WAL) on drop, including on
+/// panic. The caller keeps the binding alive and reads paths via `dir.path()`.
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-embedded-rdb-{label}-"))
+        .tempdir()
+        .expect("temp dir")
 }
 
 fn artifact_names(dir: &Path) -> Vec<String> {
@@ -32,7 +28,7 @@ fn artifact_names(dir: &Path) -> Vec<String> {
 #[test]
 fn embedded_runtime_persists_table_data_inside_single_rdb_file() {
     let dir = temp_dir("runtime_single_file");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
 
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("open runtime");
@@ -43,7 +39,7 @@ fn embedded_runtime_persists_table_data_inside_single_rdb_file() {
         rt.flush().expect("flush embedded artifact");
     }
 
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
     let artifact = EmbeddedRdbArtifact::open(&path).expect("open embedded artifact");
     assert_eq!(artifact.manifest.snapshot_bytes > 0, true);
     assert!(EmbeddedRdbArtifact::read_snapshot(&artifact)
@@ -60,9 +56,8 @@ fn embedded_runtime_persists_table_data_inside_single_rdb_file() {
         rt.flush().expect("flush reopened artifact");
     }
 
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
 
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
@@ -78,7 +73,7 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
     }
 
     let dir = temp_dir("internal_wal_replay");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     let output = std::process::Command::new(std::env::current_exe().unwrap())
         .arg("--exact")
         .arg("embedded_runtime_replays_internal_wal_without_flush_or_drop")
@@ -93,7 +88,7 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
     let artifact = EmbeddedRdbArtifact::open(&path).expect("open embedded artifact");
     assert_eq!(artifact.manifest.snapshot_bytes, 0);
     assert!(
@@ -114,15 +109,14 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
         checkpointed.manifest.wal_region_offset
     );
     assert!(checkpointed.manifest.snapshot_bytes > 0);
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
 
-    fs::remove_dir_all(dir).unwrap();
 }
 
 #[test]
 fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
     let dir = temp_dir("internal_wal_expand");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
 
     EmbeddedRdbArtifact::create(&path).expect("create embedded artifact");
     let store =
@@ -147,7 +141,7 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
         .insert_auto("blobs", entity)
         .expect("insert large row");
 
-    assert_eq!(artifact_names(&dir), vec!["data.rdb"]);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
     let artifact = EmbeddedRdbArtifact::open(&path).expect("open embedded artifact");
     assert!(artifact.manifest.snapshot_bytes > 0);
     assert!(artifact.manifest.wal_region_bytes > 64 * 1024);
@@ -159,5 +153,4 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
     let frames = EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read wal payloads");
     assert!(!frames.is_empty(), "expected retried wal frame");
 
-    fs::remove_dir_all(dir).unwrap();
 }

--- a/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
+++ b/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
@@ -152,7 +152,6 @@ fn turbo_collection_recovers_partial_block_tail_after_restart() {
         runtime_contents, oracle_contents,
         "runtime ordering must match scalar oracle after boot rebuild",
     );
-
 }
 
 /// Determinism contract: two independent restarts of the same
@@ -201,5 +200,4 @@ fn turbo_recovery_is_deterministic_across_restarts() {
     let a = run();
     let b = run();
     assert_eq!(a, b, "two restarts produce identical recovery state");
-
 }

--- a/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
+++ b/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
@@ -7,8 +7,6 @@
 //! the pre-restart state exactly — same block/lane placement, same
 //! encoded codes, same scale, same search results.
 
-use std::path::Path;
-
 use reddb_server::runtime::vector_turbo_kind::TURBO_CODEC_SEED;
 use reddb_server::storage::engine::distance::DistanceMetric;
 use reddb_server::storage::engine::turboquant::index::TurboQuantIndex;
@@ -16,20 +14,36 @@ use reddb_server::storage::engine::turboquant::storage::BLOCK_LANES;
 use reddb_server::storage::EntityId;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
-fn db_path(tag: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-turbo-boot-rebuild-{}-{tag}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("reddb.rdb")
+/// Auto-cleaning DB path: holds the [`tempfile::TempDir`] guard so the temp
+/// directory and the `.rdb` (plus every sidecar artifact) are removed on drop,
+/// including on panic. Derefs/coerces to `&Path`, so callers keep using
+/// `&path` / `RedDBOptions::persistent(&path)` unchanged while the directory
+/// lives for the whole test.
+struct TempDb {
+    _dir: tempfile::TempDir,
+    path: std::path::PathBuf,
 }
 
-fn cleanup(path: &Path) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::remove_dir_all(parent);
+impl std::ops::Deref for TempDb {
+    type Target = std::path::Path;
+    fn deref(&self) -> &std::path::Path {
+        &self.path
     }
+}
+
+impl From<&TempDb> for std::path::PathBuf {
+    fn from(value: &TempDb) -> std::path::PathBuf {
+        value.path.clone()
+    }
+}
+
+fn db_path(tag: &str) -> TempDb {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-turbo-boot-rebuild-{tag}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("reddb.rdb");
+    TempDb { _dir: dir, path }
 }
 
 fn synth_vector(i: usize) -> Vec<f32> {
@@ -139,7 +153,6 @@ fn turbo_collection_recovers_partial_block_tail_after_restart() {
         "runtime ordering must match scalar oracle after boot rebuild",
     );
 
-    cleanup(&path);
 }
 
 /// Determinism contract: two independent restarts of the same
@@ -189,5 +202,4 @@ fn turbo_recovery_is_deterministic_across_restarts() {
     let b = run();
     assert_eq!(a, b, "two restarts produce identical recovery state");
 
-    cleanup(&path);
 }

--- a/crates/reddb-server/tests/integration_turbo_crash_inject.rs
+++ b/crates/reddb-server/tests/integration_turbo_crash_inject.rs
@@ -26,11 +26,33 @@
 
 #![cfg(feature = "turbo-crash-inject")]
 
-use std::path::Path;
 use std::sync::Arc;
 
 use reddb_server::runtime::turbo_crash_inject::{install, InjectionPoint, TurboCrashInjector};
 use reddb_server::{RedDBOptions, RedDBRuntime};
+
+/// Auto-cleaning DB path: holds the [`tempfile::TempDir`] guard so the temp
+/// directory and the `.rdb` (plus every sidecar artifact) are removed on drop,
+/// including on panic. Derefs/coerces to `&Path` so callers keep using `&path`
+/// / `RedDBOptions::persistent(&path)` unchanged while the directory lives for
+/// the whole test.
+struct TempDb {
+    _dir: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl std::ops::Deref for TempDb {
+    type Target = std::path::Path;
+    fn deref(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl From<&TempDb> for std::path::PathBuf {
+    fn from(value: &TempDb) -> std::path::PathBuf {
+        value.path.clone()
+    }
+}
 
 /// Process-global lock — the injector slot is global, so every
 /// kill-point scenario in this file must serialise against every
@@ -45,20 +67,13 @@ fn injector_test_lock() -> &'static parking_lot::Mutex<()> {
     LOCK.get_or_init(|| parking_lot::Mutex::new(()))
 }
 
-fn db_path(tag: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-turbo-crash-inject-{}-{tag}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("reddb.rdb")
-}
-
-fn cleanup(path: &Path) {
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::remove_dir_all(parent);
-    }
+fn db_path(tag: &str) -> TempDb {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-turbo-crash-inject-{tag}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("reddb.rdb");
+    TempDb { _dir: dir, path }
 }
 
 /// Injector that panics the first time `target` is fired and
@@ -197,7 +212,6 @@ fn crash_before_wal_fsync_leaves_no_partial_state() {
     // `content` field). The "no half-visible lane" contract is
     // enforced by construction — partial-block tail recovery is
     // proven by `crash_in_partial_tail_recovers_to_clean_boundary`.
-    cleanup(&path);
 }
 
 /// After a kill at `BeforeIndexCommit`, recovery via WAL replay must
@@ -226,7 +240,6 @@ fn crash_before_index_commit_recovers_via_wal_replay() {
         hits.iter().any(|c| c == "recovered"),
         "INSERT WAL-fsync'd before crash must be recovered: {hits:?}"
     );
-    cleanup(&path);
 }
 
 /// After a kill at `BeforeExtentFsync`, the in-memory index update
@@ -257,7 +270,6 @@ fn crash_before_extent_fsync_recovers_via_wal_replay() {
         hits.iter().any(|c| c == "recovered"),
         "INSERT WAL-fsync'd before crash must be recovered: {hits:?}"
     );
-    cleanup(&path);
 }
 
 /// Kill mid-checkpoint: the WAL is intact and recovery resumes from
@@ -295,7 +307,6 @@ fn crash_mid_checkpoint_does_not_lose_acked_inserts() {
             "INSERT acked before checkpoint must survive ({want}): {hits:?}"
         );
     }
-    cleanup(&path);
 }
 
 /// Partial-block tail crash safety (PRD #688, ADR 0024): a kill mid-
@@ -342,5 +353,4 @@ fn crash_in_partial_tail_recovers_to_clean_boundary() {
         // no panic, no NOT_READY — the search above already proved
         // that.
     }
-    cleanup(&path);
 }

--- a/crates/reddb-server/tests/integration_turbo_snapshot.rs
+++ b/crates/reddb-server/tests/integration_turbo_snapshot.rs
@@ -84,7 +84,6 @@ fn standard_layout_writes_tv_snapshot_at_checkpoint() {
         ".tv snapshot should exist at {} after checkpoint",
         snap.display()
     );
-
 }
 
 #[test]
@@ -120,7 +119,6 @@ fn minimal_layout_writes_no_tv_snapshot() {
         "Minimal layout must not write a .tv anywhere — found {} on disk",
         standard_path.display()
     );
-
 }
 
 #[test]
@@ -184,7 +182,6 @@ fn deleting_tv_snapshot_falls_back_to_rebuild() {
         !hits.result.records.is_empty(),
         "rebuild fallback path must surface the inserted vectors"
     );
-
 }
 
 #[test]
@@ -237,5 +234,4 @@ fn corrupt_tv_snapshot_is_ignored_on_boot() {
         !hits.result.records.is_empty(),
         "boot must succeed and rebuild from extent when .tv is corrupt"
     );
-
 }

--- a/crates/reddb-server/tests/integration_turbo_snapshot.rs
+++ b/crates/reddb-server/tests/integration_turbo_snapshot.rs
@@ -19,16 +19,14 @@ use reddb_server::storage::engine::turboquant::storage::BLOCK_LANES;
 use reddb_server::storage::layout::{LayoutOverrides, StorageLayout, TieredLayoutPaths};
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
-fn db_dir(tag: &str) -> PathBuf {
-    let dir =
-        std::env::temp_dir().join(format!("reddb-turbo-snapshot-{}-{tag}", std::process::id()));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
-}
-
-fn cleanup(dir: &Path) {
-    let _ = std::fs::remove_dir_all(dir);
+/// Auto-cleaning DB directory: the returned [`tempfile::TempDir`] guard removes
+/// the directory and all `.rdb`/`.tv` artifacts on drop (incl. panic). Callers
+/// keep the binding alive for the whole test and read paths via `dir.path()`.
+fn db_dir(tag: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-turbo-snapshot-{tag}-"))
+        .tempdir()
+        .expect("temp dir")
 }
 
 fn synth_vector(i: usize) -> Vec<f32> {
@@ -60,8 +58,8 @@ fn snapshot_path_for(dir: &Path, layout: StorageLayout, collection: &str) -> Opt
 #[test]
 fn standard_layout_writes_tv_snapshot_at_checkpoint() {
     let dir = db_dir("standard-writes");
-    let path = dir.join("data.rdb");
-    let snap = snapshot_path_for(&dir, StorageLayout::Standard, "turbo_snap")
+    let path = dir.path().join("data.rdb");
+    let snap = snapshot_path_for(dir.path(), StorageLayout::Standard, "turbo_snap")
         .expect("standard layout produces a snapshot path");
 
     {
@@ -87,17 +85,16 @@ fn standard_layout_writes_tv_snapshot_at_checkpoint() {
         snap.display()
     );
 
-    cleanup(&dir);
 }
 
 #[test]
 fn minimal_layout_writes_no_tv_snapshot() {
     let dir = db_dir("minimal-omits");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
 
-    let standard_path = snapshot_path_for(&dir, StorageLayout::Standard, "turbo_min")
+    let standard_path = snapshot_path_for(dir.path(), StorageLayout::Standard, "turbo_min")
         .expect("standard layout has a snapshot path");
-    let minimal_path = snapshot_path_for(&dir, StorageLayout::Minimal, "turbo_min");
+    let minimal_path = snapshot_path_for(dir.path(), StorageLayout::Minimal, "turbo_min");
     assert!(
         minimal_path.is_none(),
         "Minimal layout must not advertise a snapshot path"
@@ -124,13 +121,12 @@ fn minimal_layout_writes_no_tv_snapshot() {
         standard_path.display()
     );
 
-    cleanup(&dir);
 }
 
 #[test]
 fn deleting_tv_snapshot_falls_back_to_rebuild() {
     let dir = db_dir("delete-fallback");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     let n = BLOCK_LANES + 5;
     let vectors: Vec<Vec<f32>> = (0..n).map(synth_vector).collect();
 
@@ -149,7 +145,7 @@ fn deleting_tv_snapshot_falls_back_to_rebuild() {
         rt.checkpoint().expect("checkpoint succeeds");
     }
 
-    let snap = snapshot_path_for(&dir, StorageLayout::Standard, "turbo_del").unwrap();
+    let snap = snapshot_path_for(dir.path(), StorageLayout::Standard, "turbo_del").unwrap();
     assert!(snap.exists(), "precondition: .tv exists after checkpoint");
 
     // Wipe every .tv file under the support tree before restarting. The
@@ -167,7 +163,7 @@ fn deleting_tv_snapshot_falls_back_to_rebuild() {
             }
         }
     }
-    rm_tv(&dir);
+    rm_tv(dir.path());
     assert!(!snap.exists(), ".tv should be gone after manual deletion");
 
     let rt = RedDBRuntime::with_options(
@@ -189,13 +185,12 @@ fn deleting_tv_snapshot_falls_back_to_rebuild() {
         "rebuild fallback path must surface the inserted vectors"
     );
 
-    cleanup(&dir);
 }
 
 #[test]
 fn corrupt_tv_snapshot_is_ignored_on_boot() {
     let dir = db_dir("corrupt-fallback");
-    let path = dir.join("data.rdb");
+    let path = dir.path().join("data.rdb");
     let n = BLOCK_LANES + 2;
     let vectors: Vec<Vec<f32>> = (0..n).map(synth_vector).collect();
 
@@ -214,7 +209,7 @@ fn corrupt_tv_snapshot_is_ignored_on_boot() {
         rt.checkpoint().expect("checkpoint succeeds");
     }
 
-    let snap = snapshot_path_for(&dir, StorageLayout::Standard, "turbo_corrupt").unwrap();
+    let snap = snapshot_path_for(dir.path(), StorageLayout::Standard, "turbo_corrupt").unwrap();
     assert!(snap.exists(), "precondition: .tv exists after checkpoint");
     // Overwrite the magic bytes so the loader rejects the file and the
     // runtime falls back to extent/WAL rebuild.
@@ -243,5 +238,4 @@ fn corrupt_tv_snapshot_is_ignored_on_boot() {
         "boot must succeed and rebuild from extent when .tv is corrupt"
     );
 
-    cleanup(&dir);
 }

--- a/crates/reddb-server/tests/primary_replica_slot_catalog.rs
+++ b/crates/reddb-server/tests/primary_replica_slot_catalog.rs
@@ -39,7 +39,7 @@ fn temp_data_path(name: &str) -> TempDataPath {
         .prefix(&format!("reddb-test-{name}-"))
         .tempdir()
         .expect("temp dir");
-    let path = dir.path().join(format!("reddb_{name}.rdb"));
+    let path = dir.path().join(format!("{name}.rdb"));
     TempDataPath { _dir: dir, path }
 }
 

--- a/crates/reddb-server/tests/primary_replica_slot_catalog.rs
+++ b/crates/reddb-server/tests/primary_replica_slot_catalog.rs
@@ -1,12 +1,11 @@
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::{Command, ExitCode};
 use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb_server::replication::primary::PrimaryReplication;
 use reddb_server::{RedDBOptions, RedDBRuntime, RedDBServer, ReplicationConfig};
@@ -15,12 +14,33 @@ const SLOT_CRASH_CHILD_ENV: &str = "REDDB_PRIMARY_REPLICA_SLOT_RUNTIME_CRASH_CHI
 const SLOT_CRASH_DATA_PATH_ENV: &str = "REDDB_PRIMARY_REPLICA_SLOT_RUNTIME_CRASH_DATA_PATH";
 const PRIMARY_REPLICA_CRASH_ENV: &str = "REDDB_PRIMARY_REPLICA_CRASH_AT";
 
-fn temp_data_path(name: &str) -> PathBuf {
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{suffix}.rdb"))
+/// Auto-cleaning data path: holds the [`tempfile::TempDir`] guard so the temp
+/// directory and all WAL/sidecar artifacts are removed on drop (incl. panic).
+struct TempDataPath {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl std::ops::Deref for TempDataPath {
+    type Target = std::path::Path;
+    fn deref(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl AsRef<std::ffi::OsStr> for TempDataPath {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.path.as_os_str()
+    }
+}
+
+fn temp_data_path(name: &str) -> TempDataPath {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-{name}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join(format!("reddb_{name}.rdb"));
+    TempDataPath { _dir: dir, path }
 }
 
 fn env_lock() -> &'static Mutex<()> {
@@ -54,19 +74,6 @@ impl Drop for EnvGuard {
             }
         }
     }
-}
-
-fn cleanup(data_path: &Path) {
-    let _ = fs::remove_file(data_path);
-    let _ = fs::remove_file(PrimaryReplication::slot_path_for(data_path));
-    let _ =
-        fs::remove_file(reddb_server::replication::primary::LogicalWalSpool::path_for(data_path));
-    let _ = fs::remove_dir_all(PrimaryReplication::primary_replica_root_for(data_path));
-    let _ = fs::remove_dir_all(reddb_file::layout::rebootstrap_staging_root(data_path));
-    let _ = fs::remove_file(reddb_file::layout::rebootstrap_pending_path(data_path));
-    let _ = fs::remove_file(reddb_file::layout::rebootstrap_ready_marker_path(data_path));
-    let _ = fs::remove_file(reddb_file::layout::rebootstrap_intent_log_path(data_path));
-    let _ = fs::remove_file(reddb_file::layout::rebootstrap_previous_path(data_path));
 }
 
 fn post_query_once(runtime: &RedDBRuntime, sql: &str) -> (u16, String) {
@@ -144,7 +151,6 @@ fn scrape_metrics(runtime: &RedDBRuntime) -> String {
 #[test]
 fn primary_persists_reddb_file_replication_slot_catalog() {
     let data_path = temp_data_path("primary_replica_slot_catalog");
-    cleanup(&data_path);
 
     {
         let primary = PrimaryReplication::new(Some(&data_path));
@@ -166,8 +172,6 @@ fn primary_persists_reddb_file_replication_slot_catalog() {
     assert_eq!(slot.confirmed_flush_lsn, 8);
     assert_eq!(slot.confirmed_apply_lsn, 8);
     assert!(slot.active);
-
-    cleanup(&data_path);
 }
 
 #[test]
@@ -183,7 +187,6 @@ fn primary_runtime_slot_catalog_write_survives_atomic_crash_points() {
         "atomic_after_dir_sync",
     ] {
         let data_path = temp_data_path(&format!("primary_replica_slot_runtime_crash_{point}"));
-        cleanup(&data_path);
 
         {
             let primary = PrimaryReplication::new(Some(&data_path));
@@ -232,8 +235,6 @@ fn primary_runtime_slot_catalog_write_survives_atomic_crash_points() {
             resume == 8 || resume == 80,
             "reopened primary should resume from old or new durable slot after {point}, got {resume}"
         );
-
-        cleanup(&data_path);
     }
 }
 
@@ -251,7 +252,6 @@ fn primary_runtime_slot_catalog_crash_child() -> ExitCode {
 #[test]
 fn primary_can_reopen_slots_from_binary_catalog_without_legacy_json() {
     let data_path = temp_data_path("primary_replica_slot_catalog_binary_only");
-    cleanup(&data_path);
 
     {
         let primary = PrimaryReplication::new(Some(&data_path));
@@ -269,14 +269,11 @@ fn primary_can_reopen_slots_from_binary_catalog_without_legacy_json() {
     assert_eq!(slot.restart_lsn, 13);
     assert_eq!(slot.confirmed_lsn(), 17);
     assert_eq!(reopened.register_replica("replica-a".to_string()), 13);
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn primary_falls_back_to_legacy_slots_when_binary_catalog_is_corrupt() {
     let data_path = temp_data_path("primary_replica_slot_catalog_corrupt_binary");
-    cleanup(&data_path);
 
     {
         let primary = PrimaryReplication::new(Some(&data_path));
@@ -298,14 +295,11 @@ fn primary_falls_back_to_legacy_slots_when_binary_catalog_is_corrupt() {
     assert_eq!(slot.restart_lsn, 14);
     assert_eq!(slot.confirmed_lsn(), 21);
     assert_eq!(reopened.register_replica("replica-a".to_string()), 14);
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn primary_runtime_materializes_reddb_file_wal_segments_for_commits() {
     let data_path = temp_data_path("primary_replica_redwal_runtime");
-    cleanup(&data_path);
 
     let runtime = RedDBRuntime::with_options(
         RedDBOptions::persistent(&data_path).with_replication(ReplicationConfig::primary()),
@@ -335,8 +329,6 @@ fn primary_runtime_materializes_reddb_file_wal_segments_for_commits() {
         segment.records.len() >= 2,
         "two commits should append to the same redwal segment"
     );
-
-    cleanup(&data_path);
 }
 
 #[test]
@@ -348,7 +340,6 @@ fn http_mutation_ack_n_commit_policy_fails_closed_without_replica_ack() {
         ("RED_COMMIT_FAIL_ON_TIMEOUT", "true"),
     ]);
     let data_path = temp_data_path("primary_replica_http_ack_n_timeout");
-    cleanup(&data_path);
 
     let runtime = RedDBRuntime::with_options(
         RedDBOptions::persistent(&data_path).with_replication(ReplicationConfig::primary()),
@@ -371,14 +362,11 @@ fn http_mutation_ack_n_commit_policy_fails_closed_without_replica_ack() {
         runtime.cdc_current_lsn() > 0,
         "local mutation should have advanced CDC before the response failed"
     );
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn primary_runtime_writes_redwal_to_promoted_timeline() {
     let data_path = temp_data_path("primary_replica_redwal_promoted_timeline");
-    cleanup(&data_path);
 
     let runtime = RedDBRuntime::with_options(
         RedDBOptions::persistent(&data_path).with_replication(ReplicationConfig::primary()),
@@ -430,14 +418,11 @@ fn primary_runtime_writes_redwal_to_promoted_timeline() {
             .any(|record| record.lsn == head_lsn),
         "post-promotion commit must not append to initial timeline"
     );
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn runtime_reports_primary_replica_wal_retention_plan_from_slot_catalog() {
     let data_path = temp_data_path("primary_replica_wal_retention_plan");
-    cleanup(&data_path);
 
     let runtime =
         RedDBRuntime::with_options(RedDBOptions::persistent(&data_path)).expect("runtime boots");
@@ -478,14 +463,11 @@ fn runtime_reports_primary_replica_wal_retention_plan_from_slot_catalog() {
     assert_eq!(pruned.retained_bytes_after_prune, 7);
     assert!(pruned.removed_segments.is_empty());
     assert!(wal_path.exists());
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn metrics_exports_primary_replica_wal_retention_plan() {
     let data_path = temp_data_path("primary_replica_wal_retention_metrics");
-    cleanup(&data_path);
 
     let runtime =
         RedDBRuntime::with_options(RedDBOptions::persistent(&data_path)).expect("runtime boots");
@@ -513,14 +495,11 @@ fn metrics_exports_primary_replica_wal_retention_plan() {
     assert!(metrics.contains("reddb_primary_replica_wal_oldest_required_lsn 0"));
     assert!(metrics.contains("reddb_primary_replica_wal_removable_segments 0"));
     assert!(metrics.contains("reddb_primary_replica_wal_retention_error 0"));
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn metrics_surfaces_primary_replica_wal_retention_errors() {
     let data_path = temp_data_path("primary_replica_wal_retention_metrics_error");
-    cleanup(&data_path);
 
     let runtime =
         RedDBRuntime::with_options(RedDBOptions::persistent(&data_path)).expect("runtime boots");
@@ -537,14 +516,11 @@ fn metrics_surfaces_primary_replica_wal_retention_errors() {
         metrics.contains("reddb_primary_replica_wal_retention_error 1"),
         "metrics should surface retention computation errors, got {metrics}"
     );
-
-    cleanup(&data_path);
 }
 
 #[test]
 fn runtime_prunes_primary_replica_redwal_segments_after_replica_ack() {
     let data_path = temp_data_path("primary_replica_wal_prune_on_ack");
-    cleanup(&data_path);
 
     let runtime = RedDBRuntime::with_options(
         RedDBOptions::persistent(&data_path).with_replication(ReplicationConfig::primary()),
@@ -581,6 +557,4 @@ fn runtime_prunes_primary_replica_redwal_segments_after_replica_ack() {
             "segment {index} should remain inside the minimum retention window"
         );
     }
-
-    cleanup(&data_path);
 }

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -667,16 +667,11 @@ fn config_reference_compares_stored_value_without_reparsing_sql() {
 
 #[test]
 fn secret_reference_compares_vault_value_without_reparsing_sql() {
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "reddb-runtime-secret-test-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    ));
-    let _ = std::fs::remove_file(&path);
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-test-runtime-secret-")
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("runtime-secret-test.rdb");
 
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime boots");
     let pager = rt
@@ -716,7 +711,6 @@ fn secret_reference_compares_vault_value_without_reparsing_sql() {
     assert_eq!(int_at(&matched, 0, "id"), 1);
 
     drop(rt);
-    let _ = std::fs::remove_file(path);
 }
 
 // ── Issue #299 conformance: queue full → DLQ routing ─────────────────────────
@@ -1201,12 +1195,11 @@ fn vector_turbo_collection_searches_with_inner_product_and_cosine() {
 
 #[test]
 fn vector_turbo_collection_reopens_without_tv_snapshot() {
-    let path = std::env::temp_dir().join(format!(
-        "reddb-vector-turbo-reopen-{}.db",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::layout::unified_wal_path(&path));
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-test-vector-turbo-reopen-")
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("reddb-vector-turbo-reopen.db");
 
     {
         let rt =
@@ -1225,9 +1218,6 @@ fn vector_turbo_collection_reopens_without_tv_snapshot() {
         .expect("search after reopen");
     assert_eq!(text_at(&result, 0, "content"), "persisted");
     assert!(!path.with_extension("tv").exists());
-
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::layout::unified_wal_path(&path));
 }
 
 /// Acceptance check for issue #693 — `vector.turbo` SEARCH must
@@ -2252,16 +2242,11 @@ fn first_user_entity_id_is_one_hundred_and_two() {
 
 #[test]
 fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
-    let mut path = std::env::temp_dir();
-    path.push(format!(
-        "reddb-first-user-entity-id-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("clock")
-            .as_nanos()
-    ));
-    let _ = std::fs::remove_file(&path);
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-test-first-user-entity-id-")
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("first-user-entity-id.rdb");
 
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime boots");
     let res = rt
@@ -2271,7 +2256,6 @@ fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
         .expect("first persistent user insert");
     let id = u64_at(&res, 0, "red_entity_id");
     drop(rt);
-    let _ = std::fs::remove_file(&path);
 
     assert_eq!(
         id, 102,

--- a/crates/reddb-server/tests/support/primary_replica_file.rs
+++ b/crates/reddb-server/tests/support/primary_replica_file.rs
@@ -43,18 +43,16 @@ impl AsRef<OsStr> for TempDataPath {
     }
 }
 
-impl From<&TempDataPath> for PathBuf {
-    fn from(value: &TempDataPath) -> PathBuf {
-        value.path.clone()
-    }
-}
+// `From<&TempDataPath> for PathBuf` is provided by std's blanket
+// `impl<T: AsRef<OsStr>> From<&T> for PathBuf` via the `AsRef<OsStr>` impl above,
+// so an explicit impl would conflict (E0119).
 
 pub fn temp_data_path(name: &str) -> TempDataPath {
     let dir = tempfile::Builder::new()
         .prefix(&format!("reddb-test-{name}-"))
         .tempdir()
         .expect("temp dir");
-    let path = dir.path().join(format!("reddb_{name}.rdb"));
+    let path = dir.path().join(format!("{name}.rdb"));
     TempDataPath { _dir: dir, path }
 }
 

--- a/crates/reddb-server/tests/support/primary_replica_file.rs
+++ b/crates/reddb-server/tests/support/primary_replica_file.rs
@@ -1,18 +1,64 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb_server::replication::primary::PrimaryReplication;
 use reddb_server::RedDBRuntime;
 
-pub fn temp_data_path(name: &str) -> PathBuf {
-    let suffix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{suffix}.rdb"))
+/// Auto-cleaning data path for primary/replica file tests.
+///
+/// Holds the backing [`tempfile::TempDir`] guard so the temp directory and
+/// every WAL/sidecar artifact under it are removed on drop — including when a
+/// test panics. The value derefs/coerces to a `&Path`, so callers can keep
+/// passing `&data_path` where a `&Path` (or `&OsStr`, or `Into<PathBuf>`) is
+/// expected and the directory still lives for the whole test.
+pub struct TempDataPath {
+    _dir: tempfile::TempDir,
+    path: PathBuf,
 }
 
+impl TempDataPath {
+    #[allow(dead_code)]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl std::ops::Deref for TempDataPath {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for TempDataPath {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsRef<OsStr> for TempDataPath {
+    fn as_ref(&self) -> &OsStr {
+        self.path.as_os_str()
+    }
+}
+
+impl From<&TempDataPath> for PathBuf {
+    fn from(value: &TempDataPath) -> PathBuf {
+        value.path.clone()
+    }
+}
+
+pub fn temp_data_path(name: &str) -> TempDataPath {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-test-{name}-"))
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join(format!("reddb_{name}.rdb"));
+    TempDataPath { _dir: dir, path }
+}
+
+#[allow(dead_code)]
 pub fn cleanup(data_path: &Path) {
     let _ = fs::remove_file(data_path);
     let _ = fs::remove_file(PrimaryReplication::slot_path_for(data_path));

--- a/crates/reddb-server/tests/witness_failover_e2e.rs
+++ b/crates/reddb-server/tests/witness_failover_e2e.rs
@@ -41,17 +41,15 @@ fn identity(subject: &str) -> NodeIdentity {
     NodeIdentity::from_certificate_subject(subject).expect("non-empty subject")
 }
 
-fn temp_dir(tag: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-witness-e2e-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
+/// Auto-cleaning temp dir for one test's per-node durable last-vote files. The
+/// returned [`tempfile::TempDir`] guard removes the directory and all files
+/// under it on drop (incl. panic); the caller keeps the binding alive for the
+/// whole test.
+fn temp_dir(tag: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-witness-e2e-{tag}-"))
+        .tempdir()
+        .expect("temp dir")
 }
 
 /// A `2 data + 1 witness` cluster. The two data members vote through durable
@@ -59,6 +57,9 @@ fn temp_dir(tag: &str) -> std::path::PathBuf {
 /// [`WitnessSupervisor`] (no data plane). A `reachable` flag models a node
 /// being killed or partitioned away.
 struct WitnessCluster {
+    // Retained for construction symmetry; the TempDir guard in the test owns
+    // cleanup now, so this field is no longer read.
+    #[allow(dead_code)]
     dir: std::path::PathBuf,
     members: Vec<Member>,
     /// data member id -> (durable last-vote path, reachable)
@@ -171,16 +172,12 @@ fn surviving_candidate(id: &str, current_term: u64, lsn: u64, watermark: u64) ->
     }
 }
 
-fn cleanup(c: &WitnessCluster) {
-    let _ = std::fs::remove_dir_all(&c.dir);
-}
-
 // The headline acceptance test: 2 data + 1 witness, primary killed, the
 // surviving data node is elected with the witness's vote.
 #[test]
 fn two_data_plus_witness_elects_surviving_node_on_primary_loss() {
     let dir = temp_dir("failover");
-    let mut cluster = WitnessCluster::new(dir, 100);
+    let mut cluster = WitnessCluster::new(dir.path().to_path_buf(), 100);
 
     // data-a was the primary; it is killed. data-b survives and stands.
     cluster.kill(DATA_A);
@@ -211,7 +208,6 @@ fn two_data_plus_witness_elects_surviving_node_on_primary_loss() {
         vec![5],
         "the real election bumped exactly one term"
     );
-    cleanup(&cluster);
 }
 
 // The witness genuinely holds no data plane and can never be the one promoted.
@@ -235,7 +231,7 @@ fn witness_holds_no_data_and_is_never_electable() {
 #[test]
 fn two_data_alone_cannot_elect_when_the_witness_is_also_down() {
     let dir = temp_dir("no-witness");
-    let mut cluster = WitnessCluster::new(dir, 100);
+    let mut cluster = WitnessCluster::new(dir.path().to_path_buf(), 100);
 
     // Primary data-a is killed AND the witness is unreachable: data-b reaches
     // only itself = 1 < majority 2. No promotion — the cluster correctly
@@ -258,7 +254,6 @@ fn two_data_alone_cannot_elect_when_the_witness_is_also_down() {
     );
     assert!(cluster.bumped.is_empty(), "a failed probe burns no term");
     assert_eq!(cluster.promoted, None, "no minority primary");
-    cleanup(&cluster);
 }
 
 // The witness vote is durable: once it grants the surviving node a term, a
@@ -266,7 +261,7 @@ fn two_data_alone_cannot_elect_when_the_witness_is_also_down() {
 #[test]
 fn witness_vote_is_durable_across_restart() {
     let dir = temp_dir("durable");
-    let path = dir.join("witness.lastvote.json");
+    let path = dir.path().join("witness.lastvote.json");
     let id = identity(WITNESS);
 
     // The witness grants data-b in term 5 and the grant is persisted.
@@ -291,5 +286,4 @@ fn witness_vote_is_durable_across_restart() {
             }),
         );
     }
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/audit_query_endpoint.rs
+++ b/tests/audit_query_endpoint.rs
@@ -4,6 +4,9 @@
 //! runtime's `AuditLogger`, then issues filtered HTTP requests and
 //! confirms the response matches the in-memory expectation.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
@@ -15,18 +18,7 @@ use reddb::{RedDBOptions, RedDBRuntime};
 
 /// Unique per-test data path so the audit logger doesn't share
 /// `<tmp>/.audit.log` across parallel tests.
-fn isolated_runtime(tag: &str) -> RedDBRuntime {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-audit-endpoint-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn isolated_runtime(dir: &support::TempDataDir) -> RedDBRuntime {
     let opts = RedDBOptions::in_memory().with_data_path(dir.join("data.rdb"));
     RedDBRuntime::with_options(opts).expect("runtime")
 }
@@ -105,7 +97,8 @@ fn seed_events(rt: &RedDBRuntime) {
 
 #[test]
 fn query_by_principal_returns_only_alice_events() {
-    let rt = isolated_runtime("seed");
+    let dir = support::temp_data_dir("audit-endpoint-principal");
+    let rt = isolated_runtime(&dir);
     seed_events(&rt);
     let addr = spawn_http(rt);
 
@@ -118,7 +111,8 @@ fn query_by_principal_returns_only_alice_events() {
 
 #[test]
 fn query_by_action_prefix_filters_correctly() {
-    let rt = isolated_runtime("seed");
+    let dir = support::temp_data_dir("audit-endpoint-action");
+    let rt = isolated_runtime(&dir);
     seed_events(&rt);
     let addr = spawn_http(rt);
 
@@ -132,7 +126,8 @@ fn query_by_action_prefix_filters_correctly() {
 
 #[test]
 fn query_by_outcome_denied_returns_eve_only() {
-    let rt = isolated_runtime("seed");
+    let dir = support::temp_data_dir("audit-endpoint-outcome");
+    let rt = isolated_runtime(&dir);
     seed_events(&rt);
     let addr = spawn_http(rt);
 
@@ -144,7 +139,8 @@ fn query_by_outcome_denied_returns_eve_only() {
 
 #[test]
 fn query_jsonl_format_returns_ndjson() {
-    let rt = isolated_runtime("seed");
+    let dir = support::temp_data_dir("audit-endpoint-jsonl");
+    let rt = isolated_runtime(&dir);
     seed_events(&rt);
     let addr = spawn_http(rt);
 
@@ -161,7 +157,8 @@ fn query_jsonl_format_returns_ndjson() {
 
 #[test]
 fn invalid_outcome_returns_400() {
-    let rt = isolated_runtime("seed");
+    let dir = support::temp_data_dir("audit-endpoint-400");
+    let rt = isolated_runtime(&dir);
     seed_events(&rt);
     let addr = spawn_http(rt);
 

--- a/tests/audit_rotation.rs
+++ b/tests/audit_rotation.rs
@@ -6,25 +6,17 @@
 //! the active file and the rotated archives; that is verified in
 //! `audit_query_endpoint.rs`.
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::PathBuf;
 use std::time::Duration;
 
 use reddb::runtime::audit_log::{AuditEvent, AuditLogger};
 use reddb::runtime::audit_query::{run_query, AuditQuery};
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-audit-rotation-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 #[test]

--- a/tests/audit_structured.rs
+++ b/tests/audit_structured.rs
@@ -5,25 +5,15 @@
 //! parses one event must be able to parse all events without
 //! per-site exceptions.
 
-use std::path::PathBuf;
+#[allow(dead_code)]
+mod support;
+
 use std::time::Duration;
 
 use reddb::runtime::audit_log::{AuditAuthSource, AuditEvent, AuditLogger, Outcome};
 
-fn temp_path(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-audit-structured-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p.push("data.rdb");
-    p
+fn temp_path(tag: &str) -> support::TempDbFile {
+    support::temp_db_file(tag)
 }
 
 #[test]

--- a/tests/chaos_backend_unavailable_restore.rs
+++ b/tests/chaos_backend_unavailable_restore.rs
@@ -7,23 +7,15 @@
 //! crash, not silently produce an empty DB. This is the exact case
 //! a freshly-rotated bucket or misconfigured `RED_BACKEND` would hit.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::storage::backend::{BackendError, LocalBackend};
 use reddb::storage::wal::PointInTimeRecovery;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-chaos-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 #[test]
@@ -60,8 +52,6 @@ fn restore_against_empty_backend_fails_with_not_found() {
         !restore_path.exists(),
         "no destination DB must be created when restore fails"
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }
 
 #[test]
@@ -93,6 +83,4 @@ fn restore_against_missing_prefix_fails_with_not_found_or_transport() {
         other => panic!("expected NotFound or Transport, got {other:?}"),
     }
     assert!(!restore_path.exists());
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/chaos_concurrent_lease_acquire.rs
+++ b/tests/chaos_concurrent_lease_acquire.rs
@@ -9,29 +9,18 @@
 //! `current()` returns one canonical holder + generation, and a
 //! refresh from the winner still works.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::replication::lease::{LeaseError, LeaseStore};
 use reddb::storage::backend::LocalBackend;
-use std::path::PathBuf;
 use std::sync::{Arc, Barrier};
 use std::thread;
 
-fn temp_prefix(tag: &str) -> String {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-chaos-lease-race-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p.to_string_lossy().to_string()
-}
-
 #[test]
 fn n_threads_racing_for_one_lease_yield_exactly_one_winner() {
-    let prefix = temp_prefix("race");
+    let dir = support::temp_data_dir("chaos-lease-race");
+    let prefix = dir.to_string_lossy().to_string();
     let store = Arc::new(LeaseStore::new(Arc::new(LocalBackend)).with_prefix(prefix.clone()));
 
     const CONTENDERS: usize = 8;
@@ -89,6 +78,4 @@ fn n_threads_racing_for_one_lease_yield_exactly_one_winner() {
         "current() must return the same holder we recorded as the winner"
     );
     assert_eq!(observed.generation, 1, "first acquire seeds generation 1");
-
-    let _ = std::fs::remove_dir_all(&prefix);
 }

--- a/tests/chaos_migration_sigkill_resume.rs
+++ b/tests/chaos_migration_sigkill_resume.rs
@@ -27,9 +27,11 @@
 
 #![cfg(unix)]
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use reddb::client::RedDBClient;
@@ -43,33 +45,6 @@ fn pick_port() -> u16 {
     let port = listener.local_addr().expect("local_addr").port();
     drop(listener);
     port
-}
-
-/// Counter so concurrent test runs (rare, but possible) get distinct
-/// temp dirs without colliding.
-static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Deterministic per-run temp dir under `/tmp/reddb-chaos-<pid>-<n>/`.
-struct TempDir(PathBuf);
-
-impl TempDir {
-    fn new() -> Self {
-        let pid = std::process::id();
-        let n = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!("reddb-chaos-{pid}-{n}"));
-        std::fs::create_dir_all(&path).expect("create temp dir");
-        Self(path)
-    }
-
-    fn path(&self) -> &PathBuf {
-        &self.0
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.0);
-    }
 }
 
 /// Spawn a `red server` child bound to `127.0.0.1:<port>` over gRPC
@@ -117,8 +92,8 @@ fn wait_until_ready(port: u16) -> Result<(), String> {
 #[test]
 #[ignore = "spawns a real red server subprocess; run with --ignored"]
 fn sigkill_mid_batched_migration_resumes_without_double_apply() {
-    let temp = TempDir::new();
-    let data_path = temp.path().join("data.rdb");
+    let temp = support::temp_data_dir("chaos-sigkill-migration");
+    let data_path = temp.join("data.rdb");
     let port = pick_port();
 
     let mut child = spawn_server(port, &data_path);

--- a/tests/chaos_promote_refused_when_lease_held.rs
+++ b/tests/chaos_promote_refused_when_lease_held.rs
@@ -8,28 +8,17 @@
 //! so the operator sees who's blocking the takeover instead of a
 //! generic 409.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::replication::lease::{LeaseError, LeaseStore};
 use reddb::storage::backend::LocalBackend;
-use std::path::PathBuf;
 use std::sync::Arc;
-
-fn temp_prefix(tag: &str) -> String {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-chaos-promote-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p.to_string_lossy().to_string()
-}
 
 #[test]
 fn second_promoter_is_refused_while_first_lease_alive() {
-    let prefix = temp_prefix("contended");
+    let dir = support::temp_data_dir("chaos-promote-contended");
+    let prefix = dir.to_string_lossy().to_string();
     let store = LeaseStore::new(Arc::new(LocalBackend)).with_prefix(prefix.clone());
 
     // Holder A acquires a 60s lease.
@@ -56,13 +45,12 @@ fn second_promoter_is_refused_while_first_lease_alive() {
     let refreshed = store.refresh(&lease_a, 60_000).expect("refresh");
     assert_eq!(refreshed.generation, 1);
     assert!(refreshed.expires_at_ms >= lease_a.expires_at_ms);
-
-    let _ = std::fs::remove_dir_all(&prefix);
 }
 
 #[test]
 fn promote_after_lease_expiry_bumps_generation() {
-    let prefix = temp_prefix("expired-takeover");
+    let dir = support::temp_data_dir("chaos-promote-expired");
+    let prefix = dir.to_string_lossy().to_string();
     let store = LeaseStore::new(Arc::new(LocalBackend)).with_prefix(prefix.clone());
 
     // Original holder takes a 1ms lease; we sleep past expiry.
@@ -78,6 +66,4 @@ fn promote_after_lease_expiry_bumps_generation() {
         .expect("expired lease must be poachable");
     assert_eq!(lease_b.holder_id, "writer-b");
     assert_eq!(lease_b.generation, lease_a.generation + 1);
-
-    let _ = std::fs::remove_dir_all(&prefix);
 }

--- a/tests/chaos_replica_apply_divergence.rs
+++ b/tests/chaos_replica_apply_divergence.rs
@@ -9,20 +9,12 @@ use reddb::replication::logical::{
     ApplyMode, ApplyOutcome, LogicalApplyError, LogicalChangeApplier,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_path(prefix: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-chaos-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
@@ -32,7 +24,6 @@ fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
 #[test]
 fn replica_applier_fails_closed_on_lsn_collision_diff_payload() {
     let path = temp_path("divergence");
-    let _ = std::fs::remove_file(&path);
     let db = RedDB::open(&path).unwrap();
     let applier = LogicalChangeApplier::new(0);
 
@@ -65,6 +56,4 @@ fn replica_applier_fails_closed_on_lsn_collision_diff_payload() {
             .unwrap(),
         ApplyOutcome::Idempotent
     );
-
-    let _ = std::fs::remove_file(&path);
 }

--- a/tests/chaos_replica_apply_gap.rs
+++ b/tests/chaos_replica_apply_gap.rs
@@ -11,20 +11,12 @@ use reddb::replication::logical::{
     ApplyMode, ApplyOutcome, LogicalApplyError, LogicalChangeApplier,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_path(prefix: &str) -> PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-chaos-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
@@ -34,7 +26,6 @@ fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
 #[test]
 fn replica_applier_returns_gap_when_record_skips_lsn() {
     let path = temp_path("apply-gap");
-    let _ = std::fs::remove_file(&path);
     let db = RedDB::open(&path).unwrap();
     let applier = LogicalChangeApplier::new(0);
 
@@ -65,6 +56,4 @@ fn replica_applier_returns_gap_when_record_skips_lsn() {
         1,
         "applier must stay at 1 after Gap; advancing would silently swallow corruption"
     );
-
-    let _ = std::fs::remove_file(&path);
 }

--- a/tests/chaos_wal_chain_break.rs
+++ b/tests/chaos_wal_chain_break.rs
@@ -11,22 +11,13 @@ use reddb::storage::wal::{
     publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("reddb-chaos-{prefix}-{pid}-{nanos}"));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> reddb::replication::cdc::ChangeRecord {
@@ -99,6 +90,4 @@ fn restore_fails_closed_when_wal_chain_is_broken() {
         msg.to_lowercase().contains("chain"),
         "error must mention chain; got: {msg}"
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/chaos_wal_segment_corruption.rs
+++ b/tests/chaos_wal_segment_corruption.rs
@@ -11,24 +11,13 @@ use reddb::storage::wal::{
     publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-chaos-{prefix}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> reddb::replication::cdc::ChangeRecord {
@@ -99,6 +88,4 @@ fn restore_fails_closed_on_segment_sha256_mismatch() {
         msg.contains("integrity") || msg.contains("sha256"),
         "error must mention integrity/sha256; got: {msg}"
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/chaos_wal_segment_missing.rs
+++ b/tests/chaos_wal_segment_missing.rs
@@ -11,24 +11,13 @@ use reddb::storage::wal::{
     PointInTimeRecovery, SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-chaos-{prefix}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> reddb::replication::cdc::ChangeRecord {
@@ -99,6 +88,4 @@ fn restore_fails_closed_on_missing_middle_segment() {
         msg.contains("chain"),
         "error must mention chain; got: {msg}"
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/cli_bootstrap.rs
+++ b/tests/cli_bootstrap.rs
@@ -3,29 +3,15 @@
 //! so they exercise the full main() path including the boot-time
 //! secret expansion.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 fn red_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_red"))
-}
-
-/// Per-test scratch dir under /tmp. Pid + nanos suffix dodges
-/// collision when the test binary runs in parallel.
-fn scratch_dir(label: &str) -> PathBuf {
-    let now_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-cli-bootstrap-{}-{}-{}",
-        label,
-        std::process::id(),
-        now_ns
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
 }
 
 /// Run `red bootstrap ...` with a short-lived REDDB_VAULT_KEY env var
@@ -62,7 +48,7 @@ fn run_bootstrap(args: &[&str], password: Option<&str>, vault_key: &str) -> (i32
 
 #[test]
 fn bootstrap_succeeds_and_prints_certificate() {
-    let dir = scratch_dir("ok");
+    let dir = support::temp_data_dir("cli-bootstrap-ok");
     let path = dir.join("x.rdb");
     let path_str = path.display().to_string();
 
@@ -93,12 +79,11 @@ fn bootstrap_succeeds_and_prints_certificate() {
         cert.chars().all(|c| c.is_ascii_hexdigit()),
         "certificate not hex: {cert:?}"
     );
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn bootstrap_fails_when_already_bootstrapped() {
-    let dir = scratch_dir("rerun");
+    let dir = support::temp_data_dir("cli-bootstrap-rerun");
     let path = dir.join("x.rdb");
     let path_str = path.display().to_string();
 
@@ -139,12 +124,11 @@ fn bootstrap_fails_when_already_bootstrapped() {
         stderr2.to_lowercase().contains("bootstrap") || stderr2.to_lowercase().contains("already"),
         "stderr should mention re-bootstrap; got: {stderr2}"
     );
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn bootstrap_json_output_has_required_keys() {
-    let dir = scratch_dir("json");
+    let dir = support::temp_data_dir("cli-bootstrap-json");
     let path = dir.join("x.rdb");
     let path_str = path.display().to_string();
 
@@ -172,12 +156,11 @@ fn bootstrap_json_output_has_required_keys() {
     assert!(line.contains("\"username\":\"admin\""), "got: {line}");
     assert!(line.contains("\"token\":\""), "got: {line}");
     assert!(line.contains("\"certificate\":\""), "got: {line}");
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn bootstrap_requires_vault_flag() {
-    let dir = scratch_dir("novault");
+    let dir = support::temp_data_dir("cli-bootstrap-novault");
     let path = dir.join("x.rdb");
     let path_str = path.display().to_string();
 
@@ -198,7 +181,6 @@ fn bootstrap_requires_vault_flag() {
         stderr.contains("--vault") || stderr.contains("vault"),
         "stderr should mention vault: {stderr}"
     );
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
@@ -208,7 +190,7 @@ fn password_file_env_expanded_into_password_var() {
     // and run bootstrap WITHOUT --password-stdin or --password.
     // Bootstrap should pull the password out of REDDB_PASSWORD,
     // which was filled by the boot-time expander.
-    let dir = scratch_dir("file-expand");
+    let dir = support::temp_data_dir("cli-bootstrap-file-expand");
     let path = dir.join("x.rdb");
     let path_str = path.display().to_string();
     let pwfile = dir.join("pw");
@@ -246,14 +228,13 @@ fn password_file_env_expanded_into_password_var() {
     );
     let cert = stdout.trim();
     assert_eq!(cert.len(), 64, "expected 64-hex cert, got {cert:?}");
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]
 fn password_file_and_password_var_conflict_fails_boot() {
     // When both REDDB_PASSWORD and REDDB_PASSWORD_FILE are set the
     // process must refuse to start (exit 2 from main).
-    let dir = scratch_dir("conflict");
+    let dir = support::temp_data_dir("cli-bootstrap-conflict");
     let pwfile = dir.join("pw");
     std::fs::write(&pwfile, "from-file").unwrap();
 
@@ -277,5 +258,4 @@ fn password_file_and_password_var_conflict_fails_boot() {
         stderr.contains("REDDB_PASSWORD") || stderr.contains("_FILE"),
         "expected conflict message; got: {stderr}"
     );
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/cli_migrate_from_redis.rs
+++ b/tests/cli_migrate_from_redis.rs
@@ -2,6 +2,9 @@
 //! These tests spawn the real `red` binary so help text, flag parsing,
 //! exit status, and JSON envelopes stay wired through main().
 
+#[allow(dead_code)]
+mod support;
+
 use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -9,21 +12,6 @@ use std::thread;
 
 fn red_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_red"))
-}
-
-fn scratch_path(label: &str) -> PathBuf {
-    let now_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-cli-migrate-{}-{}-{}",
-        label,
-        std::process::id(),
-        now_ns
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("data.rdb")
 }
 
 fn one_shot_tcp_listener() -> String {
@@ -55,7 +43,7 @@ fn migrate_from_redis_help_declares_cli_status() {
 #[test]
 fn migrate_from_redis_dry_run_validates_connectivity_without_writes() {
     let redis_url = one_shot_tcp_listener();
-    let path = scratch_path("dry-run");
+    let path = support::temp_db_file("cli-migrate-dry-run");
     let output = Command::new(red_binary())
         .args([
             "migrate-from-redis",
@@ -89,7 +77,7 @@ fn migrate_from_redis_dry_run_validates_connectivity_without_writes() {
 
 #[test]
 fn migrate_from_redis_dual_write_mode_points_to_application_helper() {
-    let path = scratch_path("dual-write");
+    let path = support::temp_db_file("cli-migrate-dual-write");
     let output = Command::new(red_binary())
         .args([
             "migrate-from-redis",

--- a/tests/cli_query_param.rs
+++ b/tests/cli_query_param.rs
@@ -8,6 +8,9 @@
 //!   - the legacy no-param path still works
 //!   - arity errors surface clearly
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -15,22 +18,7 @@ fn red() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_red"))
 }
 
-fn scratch_db(label: &str) -> PathBuf {
-    let now_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-cli-param-{}-{}-{}",
-        label,
-        std::process::id(),
-        now_ns
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("data.rdb")
-}
-
-fn run_query(path: &PathBuf, sql: &str, extra: &[&str]) -> (String, String, i32) {
+fn run_query(path: &std::path::Path, sql: &str, extra: &[&str]) -> (String, String, i32) {
     let path_str = path.display().to_string();
     let mut args: Vec<&str> = vec!["query", "--path", &path_str, sql];
     args.extend_from_slice(extra);
@@ -47,7 +35,7 @@ fn run_query(path: &PathBuf, sql: &str, extra: &[&str]) -> (String, String, i32)
     )
 }
 
-fn seed(path: &PathBuf) {
+fn seed(path: &std::path::Path) {
     let (_o, e, c) = run_query(path, "CREATE TABLE t (id INTEGER, name TEXT)", &["--json"]);
     assert_eq!(c, 0, "create: {e}");
     for (id, name) in [(1, "alice"), (2, "bob"), (3, "carol")] {
@@ -59,7 +47,7 @@ fn seed(path: &PathBuf) {
 
 #[test]
 fn legacy_no_param_select_still_works() {
-    let path = scratch_db("legacy");
+    let path = support::temp_db_file("cli-param-legacy");
     seed(&path);
     let (stdout, stderr, code) = run_query(&path, "SELECT * FROM t", &["--json"]);
     assert_eq!(code, 0, "stderr={stderr}");
@@ -68,7 +56,7 @@ fn legacy_no_param_select_still_works() {
 
 #[test]
 fn single_int_param_binds_dollar_one() {
-    let path = scratch_db("int");
+    let path = support::temp_db_file("cli-param-int");
     seed(&path);
     let (stdout, stderr, code) = run_query(
         &path,
@@ -82,7 +70,7 @@ fn single_int_param_binds_dollar_one() {
 
 #[test]
 fn auto_typed_string_param_falls_back_to_text() {
-    let path = scratch_db("text");
+    let path = support::temp_db_file("cli-param-text");
     seed(&path);
     let (stdout, stderr, code) = run_query(
         &path,
@@ -96,7 +84,7 @@ fn auto_typed_string_param_falls_back_to_text() {
 
 #[test]
 fn multiple_params_bind_positional_order() {
-    let path = scratch_db("multi");
+    let path = support::temp_db_file("cli-param-multi");
     seed(&path);
     let (stdout, stderr, code) = run_query(
         &path,
@@ -110,7 +98,7 @@ fn multiple_params_bind_positional_order() {
 
 #[test]
 fn param_type_text_keeps_numeric_string_as_text() {
-    let path = scratch_db("ty-text");
+    let path = support::temp_db_file("cli-param-ty-text");
     seed(&path);
     // Insert a row whose name is the digit string "42".
     let (_o, e, c) = run_query(
@@ -134,7 +122,7 @@ fn param_type_text_keeps_numeric_string_as_text() {
 
 #[test]
 fn param_at_file_loads_json_content() {
-    let path = scratch_db("file");
+    let path = support::temp_db_file("cli-param-file");
     seed(&path);
     // Drop the value into a JSON file (`@file` form).
     let pf = path.parent().unwrap().join("val.json");
@@ -151,7 +139,7 @@ fn param_at_file_loads_json_content() {
 
 #[test]
 fn arity_mismatch_is_a_clear_error() {
-    let path = scratch_db("arity");
+    let path = support::temp_db_file("cli-param-arity");
     seed(&path);
     let (_stdout, stderr, code) = run_query(
         &path,

--- a/tests/cross_binary_smoke.rs
+++ b/tests/cross_binary_smoke.rs
@@ -7,9 +7,12 @@
 //! Both binaries are reached through Cargo's `CARGO_BIN_EXE_*`
 //! env vars so the test never duplicates path knowledge.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{ErrorKind, Read};
 use std::net::TcpStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::{Mutex, MutexGuard};
 use std::time::{Duration, Instant};
@@ -55,21 +58,6 @@ fn pick_port() -> u16 {
     let p = l.local_addr().unwrap().port();
     drop(l);
     p
-}
-
-fn scratch_path(label: &str) -> PathBuf {
-    let now_ns = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-cross-smoke-{}-{}-{}",
-        label,
-        std::process::id(),
-        now_ns
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("data.rdb")
 }
 
 /// Block until `host:port` accepts a TCP connection or the deadline
@@ -122,8 +110,7 @@ impl Drop for ServerHandle {
     }
 }
 
-fn boot_red_grpc(port: u16) -> Result<ServerHandle, String> {
-    let path = scratch_path("grpc");
+fn boot_red_grpc(port: u16, data_path: &Path) -> Result<ServerHandle, String> {
     let bind = format!("127.0.0.1:{port}");
     let mut cmd = Command::new(red_binary());
     cmd.args([
@@ -132,7 +119,7 @@ fn boot_red_grpc(port: u16) -> Result<ServerHandle, String> {
         "--grpc-bind",
         &bind,
         "--path",
-        path.to_str().unwrap(),
+        data_path.to_str().unwrap(),
     ])
     .stdout(Stdio::piped())
     .stderr(Stdio::piped());
@@ -140,8 +127,7 @@ fn boot_red_grpc(port: u16) -> Result<ServerHandle, String> {
     Ok(ServerHandle { child })
 }
 
-fn boot_red_http(port: u16) -> Result<ServerHandle, String> {
-    let path = scratch_path("http");
+fn boot_red_http(port: u16, data_path: &Path) -> Result<ServerHandle, String> {
     let bind = format!("127.0.0.1:{port}");
     let grpc_port = pick_port();
     let grpc_bind = format!("127.0.0.1:{grpc_port}");
@@ -154,7 +140,7 @@ fn boot_red_http(port: u16) -> Result<ServerHandle, String> {
         "--grpc-bind",
         &grpc_bind,
         "--path",
-        path.to_str().unwrap(),
+        data_path.to_str().unwrap(),
     ])
     .stdout(Stdio::piped())
     .stderr(Stdio::piped());
@@ -162,8 +148,7 @@ fn boot_red_http(port: u16) -> Result<ServerHandle, String> {
     Ok(ServerHandle { child })
 }
 
-fn boot_red_wire(port: u16) -> Result<ServerHandle, String> {
-    let path = scratch_path("wire");
+fn boot_red_wire(port: u16, data_path: &Path) -> Result<ServerHandle, String> {
     let bind = format!("127.0.0.1:{port}");
     // The server boots a default-port gRPC listener even when only
     // --wire-bind is requested. Pin it to a free port so parallel
@@ -178,7 +163,7 @@ fn boot_red_wire(port: u16) -> Result<ServerHandle, String> {
         "--grpc-bind",
         &grpc_bind,
         "--path",
-        path.to_str().unwrap(),
+        data_path.to_str().unwrap(),
     ])
     .stdout(Stdio::piped())
     .stderr(Stdio::piped());
@@ -209,7 +194,8 @@ fn red_client_round_trips_against_red_over_grpc() {
     };
     let _guard = lock_boot();
     let port = pick_port();
-    let mut server = match boot_red_grpc(port) {
+    let _dir = support::temp_data_dir("cross-smoke-grpc");
+    let mut server = match boot_red_grpc(port, &_dir.join("data.rdb")) {
         Ok(h) => h,
         Err(e) => panic!("could not start `red server`: {e}"),
     };
@@ -250,7 +236,8 @@ fn red_client_round_trips_against_red_over_redwire() {
     };
     let _guard = lock_boot();
     let port = pick_port();
-    let mut server = match boot_red_wire(port) {
+    let _dir = support::temp_data_dir("cross-smoke-redwire");
+    let mut server = match boot_red_wire(port, &_dir.join("data.rdb")) {
         Ok(h) => h,
         Err(e) => panic!("could not start `red server` (wire): {e}"),
     };
@@ -290,7 +277,8 @@ fn red_client_round_trips_against_red_over_http() {
     };
     let _guard = lock_boot();
     let port = pick_port();
-    let mut server = match boot_red_http(port) {
+    let _dir = support::temp_data_dir("cross-smoke-http");
+    let mut server = match boot_red_http(port, &_dir.join("data.rdb")) {
         Ok(h) => h,
         Err(e) => panic!("could not start `red server` (http): {e}"),
     };
@@ -364,7 +352,8 @@ fn red_client_red_scheme_routes_to_default_port() {
     drop(probe);
 
     let _guard = lock_boot();
-    let mut server = match boot_red_wire(port) {
+    let _dir = support::temp_data_dir("cross-smoke-default-port");
+    let mut server = match boot_red_wire(port, &_dir.join("data.rdb")) {
         Ok(h) => h,
         Err(e) => panic!("could not start `red server` (wire): {e}"),
     };

--- a/tests/drill_backup_restore_round_trip.rs
+++ b/tests/drill_backup_restore_round_trip.rs
@@ -22,24 +22,13 @@ use reddb::storage::wal::{
     publish_unified_manifest_for_prefix, PointInTimeRecovery, SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-drill-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
@@ -137,6 +126,4 @@ fn round_trip_restore_replays_full_wal_history() {
         "recovered LSN must reach the last archived LSN"
     );
     assert!(restore_path.exists(), "restored DB file must be on disk");
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/drill_pitr_byte_identical.rs
+++ b/tests/drill_pitr_byte_identical.rs
@@ -22,24 +22,13 @@ use reddb::storage::wal::{
 };
 use reddb::storage::RedDB;
 use std::collections::BTreeSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-drill-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 /// Snapshot of every collection's name and entity count. Sorted to
@@ -138,6 +127,4 @@ fn snapshot_and_restored_db_have_same_collection_inventory() {
         snap_sha, snap_sha_again,
         "snapshot SHA-256 must be deterministic across reads"
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/drill_pitr_chain_break_within_window.rs
+++ b/tests/drill_pitr_chain_break_within_window.rs
@@ -25,24 +25,13 @@ use reddb::storage::wal::{
     publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-drill-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 fn record_at(lsn: u64, ts: u64, payload: &[u8]) -> ChangeRecord {
@@ -137,6 +126,4 @@ fn pitr_within_window_fails_closed_on_chain_break_in_a_covered_segment() {
         // claims about the file's existence — only that the API
         // surfaced the error.
     }
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/drill_pitr_target_time.rs
+++ b/tests/drill_pitr_target_time.rs
@@ -15,24 +15,13 @@ use reddb::storage::wal::{
     SnapshotManifest,
 };
 use reddb::storage::RedDB;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[allow(dead_code)]
 mod support;
 
-fn temp_dir(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-drill-{tag}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(tag: &str) -> support::TempDataDir {
+    support::temp_data_dir(tag)
 }
 
 fn record_at(lsn: u64, ts: u64, payload: &[u8]) -> ChangeRecord {
@@ -122,6 +111,4 @@ fn restore_to_target_time_skips_records_after_t() {
         result.recovered_to_time,
         target_time
     );
-
-    let _ = std::fs::remove_dir_all(&work);
 }

--- a/tests/e2e_audit_slow_routing.rs
+++ b/tests/e2e_audit_slow_routing.rs
@@ -26,7 +26,7 @@ static TIER_GUARD: Mutex<()> = Mutex::new(());
 fn performance_tier_creates_slow_log_file_under_support_dir() {
     let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
     let data = support::temp_db_file("audit-slow-perf");
-    let options = RedDBOptions::persistent(&data).with_layout(StorageLayout::Performance);
+    let options = RedDBOptions::persistent(data.path()).with_layout(StorageLayout::Performance);
     let _rt = RedDBRuntime::with_options(options).expect("runtime opens");
 
     let (audit_dest, slow_dest) = tier_wiring::current_log_destinations();
@@ -87,7 +87,7 @@ fn syslog_override_falls_back_without_panicking() {
         },
         ..LayoutOverrides::default()
     };
-    let options = RedDBOptions::persistent(&data)
+    let options = RedDBOptions::persistent(data.path())
         .with_layout(StorageLayout::Performance)
         .with_layout_overrides(overrides);
     let _rt = RedDBRuntime::with_options(options).expect("runtime opens with syslog override");

--- a/tests/e2e_audit_slow_routing.rs
+++ b/tests/e2e_audit_slow_routing.rs
@@ -7,31 +7,25 @@
 //! closes the loop: the runtime *consumes* that destination, so the
 //! actual log files exist on disk after `RedDBRuntime::with_options`.
 
-use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use reddb::{
     tier_wiring, LayoutOverrides, LogDestination, LogRoutingOverrides, RedDBOptions, RedDBRuntime,
     StorageLayout,
 };
 
+#[allow(dead_code)]
+mod support;
+
 // Tier toggles + global audit sink are process-globals — serialise the
 // two routing tests so they don't observe each other's state.
 static TIER_GUARD: Mutex<()> = Mutex::new(());
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_audit_slow_{prefix}_{unique}.rdb"))
-}
-
 #[test]
 fn performance_tier_creates_slow_log_file_under_support_dir() {
     let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = persistent_path("perf");
+    let data = support::temp_db_file("audit-slow-perf");
     let options = RedDBOptions::persistent(&data).with_layout(StorageLayout::Performance);
     let _rt = RedDBRuntime::with_options(options).expect("runtime opens");
 
@@ -85,7 +79,7 @@ fn syslog_override_falls_back_without_panicking() {
     // panicking even when the resolved destination is Syslog. The audit
     // / slow sinks fall back to a file-on-disk so events still survive.
     let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = persistent_path("syslog");
+    let data = support::temp_db_file("audit-slow-syslog");
     let overrides = LayoutOverrides {
         logs: LogRoutingOverrides {
             audit_log: Some(LogDestination::Syslog),

--- a/tests/e2e_backup_restore.rs
+++ b/tests/e2e_backup_restore.rs
@@ -11,6 +11,9 @@
 //!   4. Manifests written before the checksum field was introduced
 //!      (`snapshot_sha256: None`) still restore — backward compat.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery, SnapshotManifest,
@@ -20,16 +23,8 @@ use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-fn temp_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("reddb-backup-{prefix}-{pid}-{nanos}"));
-    std::fs::create_dir_all(&p).unwrap();
-    p
+fn temp_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 fn write_dummy_snapshot(dir: &std::path::Path, name: &str, body: &[u8]) -> PathBuf {

--- a/tests/e2e_collection_retention_policy.rs
+++ b/tests/e2e_collection_retention_policy.rs
@@ -14,21 +14,15 @@
 //!    (four contract columns + three sweeper observability columns
 //!    added in slice 12).
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::ExecuteQueryInput;
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 
-fn unique_dir(prefix: &str) -> PathBuf {
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let mut path = std::env::temp_dir();
-    path.push(format!("reddb-{prefix}-{pid}-{nanos}"));
-    std::fs::create_dir_all(&path).unwrap();
-    path
+fn unique_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 #[test]
@@ -187,6 +181,4 @@ fn retention_policy_persists_across_restart() {
             other => panic!("expected integer estimate, got {other:?}"),
         }
     }
-
-    let _ = std::fs::remove_dir_all(&dir);
 }

--- a/tests/e2e_compound_assignment.rs
+++ b/tests/e2e_compound_assignment.rs
@@ -1,7 +1,9 @@
+#[allow(dead_code)]
+mod support;
+
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
@@ -48,16 +50,6 @@ fn read_event_payload(rt: &RedDBRuntime, queue: &str) -> serde_json::Value {
         }
         other => panic!("expected Json payload, got {other:?}"),
     }
-}
-
-fn unique_data_dir(prefix: &str) -> PathBuf {
-    let mut path = std::env::temp_dir();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    path.push(format!("reddb-{prefix}-{}-{nanos}", std::process::id()));
-    path
 }
 
 #[test]
@@ -189,7 +181,8 @@ fn update_compound_rejects_zero_division_modulo_and_overflow() {
 
 #[test]
 fn update_compound_refreshes_indexes_events_and_persists_materialized_value() {
-    let path = unique_data_dir("compound-assignment");
+    let dir = support::temp_data_dir("e2e-compound-assignment");
+    let path = dir.join("data.rdb");
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
             .expect("persistent runtime");
@@ -229,5 +222,4 @@ fn update_compound_refreshes_indexes_events_and_persists_materialized_value() {
         .expect("reopened persistent runtime");
     let reopened = exec(&rt, "SELECT score FROM compound_materialized WHERE id = 1");
     assert_eq!(int_field(only_record(&reopened), "score"), 15);
-    let _ = std::fs::remove_dir_all(path);
 }

--- a/tests/e2e_config_matrix.rs
+++ b/tests/e2e_config_matrix.rs
@@ -4,6 +4,9 @@
 //! `SHOW CONFIG <key>` (populated into red_config if absent). Tier B
 //! keys stay silent until a user `SET CONFIG` writes them.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{RedDBOptions, RedDBRuntime};
 
 fn open_runtime() -> RedDBRuntime {
@@ -190,14 +193,8 @@ fn config_file_overlay_seeds_missing_keys() {
     // overlay, so the file's value must NOT overwrite the matrix
     // default — write-if-absent semantics. The test asserts that
     // exact property: SHOW CONFIG still reports the matrix default.
-    let mut tmp = std::env::temp_dir();
-    tmp.push(format!(
-        "reddb-overlay-{}.json",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or_default()
-    ));
+    let tmp_dir = support::temp_data_dir("e2e-config-overlay");
+    let tmp = tmp_dir.join("overlay.json");
     {
         let mut f = std::fs::File::create(&tmp).unwrap();
         f.write_all(
@@ -234,7 +231,6 @@ fn config_file_overlay_seeds_missing_keys() {
     unsafe {
         std::env::remove_var("REDDB_CONFIG_FILE");
     }
-    let _ = std::fs::remove_file(&tmp);
 }
 
 #[test]

--- a/tests/e2e_config_secret_ref.rs
+++ b/tests/e2e_config_secret_ref.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -7,13 +7,8 @@ use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identit
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn temp_db_path(name: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
+#[allow(dead_code)]
+mod support;
 
 fn unique_ident(prefix: &str) -> String {
     let unique = SystemTime::now()
@@ -21,27 +16,6 @@ fn unique_ident(prefix: &str) -> String {
         .unwrap_or_default()
         .as_nanos();
     format!("{prefix}_{unique}")
-}
-
-fn cleanup_related(path: &Path) {
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    let Some(stem) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    if let Ok(entries) = std::fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let entry_path = entry.path();
-            let Some(name) = entry_path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if name == stem || name.starts_with(&format!("{stem}-")) {
-                let _ = std::fs::remove_file(&entry_path);
-                let _ = std::fs::remove_dir_all(&entry_path);
-            }
-        }
-    }
 }
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
@@ -98,11 +72,10 @@ fn secret_ref_test_lock() -> &'static Mutex<()> {
 #[test]
 fn config_secret_ref_get_is_reference_and_resolve_is_explicit_authorized_and_audited() {
     let _guard = secret_ref_test_lock().lock().unwrap();
-    let path = temp_db_path("config_secret_ref_326");
-    cleanup_related(&path);
+    let path = support::temp_db_file("config-secret-ref-326");
 
     let secret = "vault_plaintext_probe_326";
-    let (rt, auth) = open_runtime_with_vault(&path, "vault-pass-326");
+    let (rt, auth) = open_runtime_with_vault(path.path(), "vault-pass-326");
     let app = unique_ident("app");
     let secrets = unique_ident("secrets");
     let alice = unique_ident("alice");
@@ -224,8 +197,6 @@ fn config_secret_ref_get_is_reference_and_resolve_is_explicit_authorized_and_aud
     assert!(audit_body.contains(&format!("{app}.api_key")));
     assert!(audit_body.contains(&format!("{secrets}.api_key")));
     assert!(!audit_body.contains(secret));
-
-    cleanup_related(&path);
 }
 
 /// `SecretRefGuard` — depth-2 chains must be rejected at config write time
@@ -235,10 +206,9 @@ fn config_secret_ref_get_is_reference_and_resolve_is_explicit_authorized_and_aud
 #[test]
 fn secret_ref_guard_rejects_depth_two_chain_at_write() {
     let _guard = secret_ref_test_lock().lock().unwrap();
-    let path = temp_db_path("secret_ref_guard_708_depth2");
-    cleanup_related(&path);
+    let path = support::temp_db_file("secret-ref-guard-708-depth2");
 
-    let (rt, _auth) = open_runtime_with_vault(&path, "vault-pass-708-d2");
+    let (rt, _auth) = open_runtime_with_vault(path.path(), "vault-pass-708-d2");
     let app = unique_ident("app");
     let secrets = unique_ident("secrets");
 
@@ -271,8 +241,6 @@ fn secret_ref_guard_rejects_depth_two_chain_at_write() {
         msg.contains(&format!("{secrets}.chain")),
         "missing target key: {msg}"
     );
-
-    cleanup_related(&path);
 }
 
 /// `SecretRefGuard` — a cyclic write (vault target points back into a
@@ -281,10 +249,9 @@ fn secret_ref_guard_rejects_depth_two_chain_at_write() {
 #[test]
 fn secret_ref_guard_rejects_cycle_at_write() {
     let _guard = secret_ref_test_lock().lock().unwrap();
-    let path = temp_db_path("secret_ref_guard_708_cycle");
-    cleanup_related(&path);
+    let path = support::temp_db_file("secret-ref-guard-708-cycle");
 
-    let (rt, _auth) = open_runtime_with_vault(&path, "vault-pass-708-cyc");
+    let (rt, _auth) = open_runtime_with_vault(path.path(), "vault-pass-708-cyc");
     let app = unique_ident("app");
     let secrets = unique_ident("secrets");
 
@@ -314,8 +281,6 @@ fn secret_ref_guard_rejects_cycle_at_write() {
         msg.contains(&format!("{secrets}.loop")),
         "missing target key: {msg}"
     );
-
-    cleanup_related(&path);
 }
 
 /// `SecretRefGuard` — defence-in-depth at read. If a chain somehow exists
@@ -326,10 +291,9 @@ fn secret_ref_guard_rejects_cycle_at_write() {
 #[test]
 fn secret_ref_guard_read_backstop_when_store_contains_chain() {
     let _guard = secret_ref_test_lock().lock().unwrap();
-    let path = temp_db_path("secret_ref_guard_708_read");
-    cleanup_related(&path);
+    let path = support::temp_db_file("secret-ref-guard-708-read");
 
-    let (rt, _auth) = open_runtime_with_vault(&path, "vault-pass-708-r");
+    let (rt, _auth) = open_runtime_with_vault(path.path(), "vault-pass-708-r");
     let app = unique_ident("app");
     let secrets = unique_ident("secrets");
 
@@ -368,8 +332,6 @@ fn secret_ref_guard_read_backstop_when_store_contains_chain() {
         msg.contains(&format!("{secrets}.api_key")),
         "missing target key: {msg}"
     );
-
-    cleanup_related(&path);
 }
 
 /// `SecretRefGuard` — depth-1 references resolve normally and are not
@@ -378,10 +340,9 @@ fn secret_ref_guard_read_backstop_when_store_contains_chain() {
 #[test]
 fn secret_ref_guard_allows_depth_one_reference() {
     let _guard = secret_ref_test_lock().lock().unwrap();
-    let path = temp_db_path("secret_ref_guard_708_ok");
-    cleanup_related(&path);
+    let path = support::temp_db_file("secret-ref-guard-708-ok");
 
-    let (rt, _auth) = open_runtime_with_vault(&path, "vault-pass-708-ok");
+    let (rt, _auth) = open_runtime_with_vault(path.path(), "vault-pass-708-ok");
     let app = unique_ident("app");
     let secrets = unique_ident("secrets");
 
@@ -402,6 +363,4 @@ fn secret_ref_guard_allows_depth_one_reference() {
         resolved.result.records[0].get("value"),
         Some(&Value::text("sk-flat-708".to_string()))
     );
-
-    cleanup_related(&path);
 }

--- a/tests/e2e_config_vault_observation.rs
+++ b/tests/e2e_config_vault_observation.rs
@@ -1,6 +1,5 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::replication::cdc::ChangeOperation;
@@ -8,37 +7,11 @@ use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identit
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
+#[allow(dead_code)]
+mod support;
+
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("in-memory runtime")
-}
-
-fn temp_db_path(name: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
-
-fn cleanup_related(path: &Path) {
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    let Some(stem) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    if let Ok(entries) = std::fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let entry_path = entry.path();
-            let Some(name) = entry_path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if name == stem || name.starts_with(&format!("{stem}-")) {
-                let _ = std::fs::remove_file(&entry_path);
-                let _ = std::fs::remove_dir_all(&entry_path);
-            }
-        }
-    }
 }
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
@@ -208,10 +181,9 @@ fn watch_config_events_include_values_only_when_read_is_allowed() {
 
 #[test]
 fn list_and_watch_vault_are_metadata_only() {
-    let path = temp_db_path("vault_observation");
-    cleanup_related(&path);
+    let path = support::temp_db_file("config-vault-observation");
     let secret = "vault_plaintext_observation_probe";
-    let (rt, _auth) = open_runtime_with_vault(&path, "vault-observation-pass");
+    let (rt, _auth) = open_runtime_with_vault(path.path(), "vault-observation-pass");
 
     rt.execute_query("CREATE VAULT secrets WITH OWN MASTER KEY")
         .expect("create vault");
@@ -251,6 +223,4 @@ fn list_and_watch_vault_are_metadata_only() {
         debug.contains("fingerprint"),
         "vault watch lacks metadata: {debug}"
     );
-
-    cleanup_related(&path);
 }

--- a/tests/e2e_control_events_operational.rs
+++ b/tests/e2e_control_events_operational.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::control_events::CONTROL_EVENTS_COLLECTION;
@@ -9,34 +7,8 @@ use reddb::storage::schema::Value;
 use reddb::storage::EntityData;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn temp_db_path(name: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
-
-fn cleanup_related(path: &Path) {
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    let Some(stem) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    if let Ok(entries) = std::fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let entry_path = entry.path();
-            let Some(name) = entry_path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if name == stem || name.starts_with(&format!("{stem}-")) {
-                let _ = std::fs::remove_file(&entry_path);
-                let _ = std::fs::remove_dir_all(&entry_path);
-            }
-        }
-    }
-}
+#[allow(dead_code)]
+mod support;
 
 fn control_event_rows(rt: &RedDBRuntime) -> Vec<HashMap<String, Value>> {
     rt.db()
@@ -114,8 +86,7 @@ fn ddl_and_rls_control_events_record_allowed_denied_and_error_outcomes() {
 
 #[test]
 fn backup_control_event_records_snapshot_and_wal_metadata() {
-    let path = temp_db_path("control_events_backup_654");
-    cleanup_related(&path);
+    let path = support::temp_db_file("control-events-backup-654");
 
     let rt =
         RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime should open");
@@ -136,6 +107,4 @@ fn backup_control_event_records_snapshot_and_wal_metadata() {
         ledger_body.contains("\"outcome\": Text(\"allowed\")"),
         "{ledger_body}"
     );
-
-    cleanup_related(&path);
 }

--- a/tests/e2e_control_events_operational.rs
+++ b/tests/e2e_control_events_operational.rs
@@ -88,8 +88,8 @@ fn ddl_and_rls_control_events_record_allowed_denied_and_error_outcomes() {
 fn backup_control_event_records_snapshot_and_wal_metadata() {
     let path = support::temp_db_file("control-events-backup-654");
 
-    let rt =
-        RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime should open");
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
+        .expect("runtime should open");
     rt.execute_query("CREATE TABLE docs (id INT)")
         .expect("table should be created before backup");
 

--- a/tests/e2e_ddl_drop_foundation.rs
+++ b/tests/e2e_ddl_drop_foundation.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -7,6 +7,9 @@ use reddb::auth::{AuthConfig, AuthStore};
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
+
+#[allow(dead_code)]
+mod support;
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("in-memory runtime")
@@ -17,41 +20,12 @@ fn ddl_drop_test_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-fn temp_db_path(name: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
-
 fn unique_ident(prefix: &str) -> String {
     let unique = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
     format!("{prefix}_{unique}")
-}
-
-fn cleanup_related(path: &Path) {
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    let Some(stem) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    if let Ok(entries) = std::fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let entry_path = entry.path();
-            let Some(name) = entry_path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if name == stem || name.starts_with(&format!("{stem}-")) {
-                let _ = std::fs::remove_file(&entry_path);
-                let _ = std::fs::remove_dir_all(&entry_path);
-            }
-        }
-    }
 }
 
 fn rt_with_vault(path: &Path) -> RedDBRuntime {
@@ -98,9 +72,8 @@ fn exec_err(rt: &RedDBRuntime, sql: &str) -> String {
 #[test]
 fn typed_drop_removes_non_table_models() {
     let _guard = ddl_drop_test_lock().lock().unwrap();
-    let path = temp_db_path("ddl_drop_typed_models");
-    cleanup_related(&path);
-    let rt = rt_with_vault(&path);
+    let path = support::temp_db_file("ddl-drop-typed-models");
+    let rt = rt_with_vault(path.path());
     for (name, create_sql, drop_sql) in [
         {
             let name = unique_ident("identity");
@@ -157,7 +130,6 @@ fn typed_drop_removes_non_table_models() {
         assert!(rt.db().collection_contract(&name).is_none(), "{name}");
     }
     drop(rt);
-    cleanup_related(&path);
 }
 
 #[test]
@@ -176,9 +148,8 @@ fn drop_collection_dispatches_polymorphically_and_if_exists_is_idempotent() {
 #[test]
 fn create_keyed_models_are_visible_in_typed_show_filters() {
     let _guard = ddl_drop_test_lock().lock().unwrap();
-    let path = temp_db_path("ddl_drop_foundation_vault");
-    cleanup_related(&path);
-    let rt = rt_with_vault(&path);
+    let path = support::temp_db_file("ddl-drop-foundation-vault");
+    let rt = rt_with_vault(path.path());
     let sessions = unique_ident("sessions");
     let app_settings = unique_ident("app_settings");
     let secrets = unique_ident("secrets");
@@ -211,7 +182,6 @@ fn create_keyed_models_are_visible_in_typed_show_filters() {
         );
     }
     drop(rt);
-    cleanup_related(&path);
 }
 
 #[test]

--- a/tests/e2e_fold_dwb_into_wal_crash.rs
+++ b/tests/e2e_fold_dwb_into_wal_crash.rs
@@ -9,36 +9,20 @@
 //! by post-hoc file mutation, which is the same shape as
 //! `e2e_seqn_journal_policy::recovery_handles_present_absent_and_corrupt_binary`.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{set_fold_dwb_into_wal_enabled, RedDBOptions, RedDBRuntime, StorageDeployPreset};
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const PAGE_BYTES: u64 = 4096;
 const ROWS: usize = 25;
 
 // Serialise tests that flip the process-global fold-DWB toggle.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(reddb_file::pager_dwb_path(path));
-    let _ = std::fs::remove_file(reddb_file::pager_header_path(path));
-    let _ = std::fs::remove_file(reddb_file::pager_meta_path(path));
-    let _ = std::fs::remove_file(reddb_file::pager_legacy_wal_path(path));
-    let _ = std::fs::remove_file(reddb_file::unified_wal_path(path));
-    let _ = std::fs::remove_dir_all(reddb_file::support_dir_for(path));
-}
 
 fn operational_options(path: &Path) -> RedDBOptions {
     RedDBOptions::persistent(path)
@@ -48,13 +32,13 @@ fn operational_options(path: &Path) -> RedDBOptions {
 
 /// Populate a fresh DB with `ROWS` rows in its own table and run a
 /// checkpoint so the pages reach the main data file. Returns the
-/// path on disk for the caller to corrupt.
-fn populate(prefix: &str) -> PathBuf {
-    let path = persistent_path(prefix);
-    cleanup(&path);
+/// auto-cleaning guard for the caller to keep alive while corrupting.
+fn populate(prefix: &str) -> support::TempDbFile {
+    let db = support::temp_db_file(prefix);
+    let path = db.path();
 
     let rt =
-        RedDBRuntime::with_options(operational_options(&path)).expect("persistent runtime opens");
+        RedDBRuntime::with_options(operational_options(path)).expect("persistent runtime opens");
     rt.execute_query("CREATE TABLE crash_rows (n INTEGER, label TEXT)")
         .expect("ddl");
     for i in 0..ROWS {
@@ -65,7 +49,7 @@ fn populate(prefix: &str) -> PathBuf {
     }
     rt.checkpoint().expect("flush");
     drop(rt);
-    path
+    db
 }
 
 /// Overwrite the trailing 4 KiB of the data file with deterministic
@@ -104,14 +88,14 @@ fn crash_during_page_write_recovers_with_fold_off() {
     set_fold_dwb_into_wal_enabled(false);
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
 
-    let path = populate("crash_fold_off");
-    corrupt_last_page(&path);
-    let recovered = reopen_and_count(&path);
+    let db = populate("crash_fold_off");
+    let path = db.path();
+    corrupt_last_page(path);
+    let recovered = reopen_and_count(path);
     assert_eq!(
         recovered, ROWS,
         "WAL replay must reconstruct all committed rows when DWB is on",
     );
-    cleanup(&path);
 }
 
 #[test]
@@ -120,13 +104,13 @@ fn crash_during_page_write_recovers_with_fold_on() {
     set_fold_dwb_into_wal_enabled(true);
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
 
-    let path = populate("crash_fold_on");
-    corrupt_last_page(&path);
-    let recovered = reopen_and_count(&path);
+    let db = populate("crash_fold_on");
+    let path = db.path();
+    corrupt_last_page(path);
+    let recovered = reopen_and_count(path);
     assert_eq!(
         recovered, ROWS,
         "WAL replay must reconstruct all committed rows when fold-DWB-into-WAL is on",
     );
-    cleanup(&path);
     set_fold_dwb_into_wal_enabled(false);
 }

--- a/tests/e2e_fold_dwb_into_wal_policy.rs
+++ b/tests/e2e_fold_dwb_into_wal_policy.rs
@@ -11,43 +11,24 @@
 //! Tier auto-enable + checkpoint-cycle FPI emission are deferred (see
 //! issue notes).
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::storage::wal::reader::WalReader;
 use reddb::storage::wal::record::WalRecord;
 use reddb::storage::wal::writer::WalWriter;
 use reddb::{fold_dwb_into_wal_enabled, set_fold_dwb_into_wal_enabled, RedDBOptions, RedDBRuntime};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 // Serialise tests that flip the process-global toggle.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
 
 fn dwb_path(data: &Path) -> PathBuf {
     let mut p = data.to_path_buf().into_os_string();
     p.push("-dwb");
     PathBuf::from(p)
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(dwb_path(path));
-    let mut hdr = path.to_path_buf().into_os_string();
-    hdr.push("-hdr");
-    let _ = std::fs::remove_file(PathBuf::from(hdr));
-    let mut meta = path.to_path_buf().into_os_string();
-    meta.push("-meta");
-    let _ = std::fs::remove_file(PathBuf::from(meta));
-    let mut wal = path.to_path_buf();
-    wal.set_extension("wal");
-    let _ = std::fs::remove_file(&wal);
 }
 
 fn open_persistent(path: &Path) -> RedDBRuntime {
@@ -72,11 +53,11 @@ fn fold_dwb_off_default_preserves_dwb_sidecar() {
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
     assert!(!fold_dwb_into_wal_enabled(), "default policy must be OFF",);
 
-    let path = persistent_path("fold_dwb_off");
-    cleanup(&path);
+    let db = support::temp_db_file("fold_dwb_off");
+    let path = db.path();
 
     {
-        let rt = open_persistent(&path);
+        let rt = open_persistent(path);
         rt.execute_query("CREATE TABLE dwb_off_a (name TEXT)")
             .expect("ddl");
         rt.execute_query("INSERT INTO dwb_off_a (name) VALUES ('a')")
@@ -84,66 +65,59 @@ fn fold_dwb_off_default_preserves_dwb_sidecar() {
         rt.checkpoint().expect("flush");
     }
 
-    let dwb = dwb_path(&path);
+    let dwb = dwb_path(path);
     assert!(
         dwb.exists(),
         "legacy -dwb sidecar must be present when fold is OFF: {dwb:?}",
     );
-
-    cleanup(&path);
 }
 
 #[test]
 fn fold_dwb_on_suppresses_and_removes_sidecar() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
 
-    let path = persistent_path("fold_dwb_on");
-    cleanup(&path);
+    let db = support::temp_db_file("fold_dwb_on");
+    let path = db.path();
 
     // First, create a database with the flag OFF so a -dwb sidecar lands
     // on disk. Then flip ON and reopen: the sidecar must be cleaned up.
     set_fold_dwb_into_wal_enabled(false);
     {
-        let rt = open_persistent(&path);
+        let rt = open_persistent(path);
         rt.execute_query("CREATE TABLE dwb_on_a (name TEXT)")
             .expect("ddl");
         rt.checkpoint().expect("flush");
     }
-    assert!(dwb_path(&path).exists(), "fixture must produce -dwb");
+    assert!(dwb_path(path).exists(), "fixture must produce -dwb");
 
     set_fold_dwb_into_wal_enabled(true);
     {
-        let rt = open_persistent(&path);
+        let rt = open_persistent(path);
         rt.execute_query("INSERT INTO dwb_on_a (name) VALUES ('alpha')")
             .expect("insert");
         rt.checkpoint().expect("flush");
     }
 
     assert!(
-        !dwb_path(&path).exists(),
+        !dwb_path(path).exists(),
         "-dwb sidecar must be removed when fold-DWB-into-WAL is ON",
     );
 
     // Reopen ON and verify data still readable (no DWB needed).
     {
-        let rt = open_persistent(&path);
+        let rt = open_persistent(path);
         let _ = rt
             .execute_query("SELECT name FROM dwb_on_a")
             .expect("select");
     }
 
-    cleanup(&path);
     set_fold_dwb_into_wal_enabled(false);
 }
 
 #[test]
 fn full_page_image_record_roundtrips_through_wal_file() {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let wal = std::env::temp_dir().join(format!("reddb_fpi_roundtrip_{unique}.wal"));
-    let _ = std::fs::remove_file(&wal);
+    let dir = support::temp_data_dir("fpi-roundtrip");
+    let wal = dir.join("roundtrip.wal");
 
     let payload: Vec<u8> = (0..4096).map(|i| (i % 251) as u8).collect();
 
@@ -185,6 +159,4 @@ fn full_page_image_record_roundtrips_through_wal_file() {
     assert_eq!(image.len(), 4096);
     let (_lsn99, image99) = images.get(&99).expect("page 99 image present");
     assert_eq!(image99, &vec![0xCD; 4096]);
-
-    let _ = std::fs::remove_file(&wal);
 }

--- a/tests/e2e_fold_pager_meta_policy.rs
+++ b/tests/e2e_fold_pager_meta_policy.rs
@@ -11,9 +11,7 @@
 #[allow(dead_code)]
 mod support;
 
-use reddb::{
-    fold_pager_meta_enabled, set_fold_pager_meta_enabled, RedDBOptions, RedDBRuntime,
-};
+use reddb::{fold_pager_meta_enabled, set_fold_pager_meta_enabled, RedDBOptions, RedDBRuntime};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 

--- a/tests/e2e_fold_pager_meta_policy.rs
+++ b/tests/e2e_fold_pager_meta_policy.rs
@@ -8,45 +8,22 @@
 //!  - free list overflow works for > N pages (one trunk holds 1014 ids);
 //!  - tests cover massive allocation forcing overflow.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{
-    fold_pager_meta_enabled, set_fold_pager_meta_enabled, PhysicalMetadataFile, RedDBOptions,
-    RedDBRuntime,
+    fold_pager_meta_enabled, set_fold_pager_meta_enabled, RedDBOptions, RedDBRuntime,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // Serialise tests that flip the process-global toggle.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
 
 fn meta_shadow_path(data: &Path) -> PathBuf {
     let mut p = data.to_path_buf().into_os_string();
     p.push("-meta");
     PathBuf::from(p)
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(meta_shadow_path(path));
-    let mut hdr = path.to_path_buf().into_os_string();
-    hdr.push("-hdr");
-    let _ = std::fs::remove_file(PathBuf::from(hdr));
-    let mut dwb = path.to_path_buf().into_os_string();
-    dwb.push("-dwb");
-    let _ = std::fs::remove_file(PathBuf::from(dwb));
-    let mut wal = path.to_path_buf();
-    wal.set_extension("wal");
-    let _ = std::fs::remove_file(&wal);
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_path_for(path));
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_binary_path_for(path));
 }
 
 #[test]
@@ -56,24 +33,22 @@ fn fold_off_default_preserves_meta_shadow() {
     std::env::remove_var("REDDB_FOLD_PAGER_META");
     assert!(!fold_pager_meta_enabled(), "default policy must be OFF");
 
-    let path = persistent_path("fold_off");
-    cleanup(&path);
+    let db = support::temp_db_file("fold_off");
+    let path = db.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE fold_off_a (name TEXT)")
             .expect("ddl");
         rt.checkpoint().expect("flush");
     }
 
-    let shadow = meta_shadow_path(&path);
+    let shadow = meta_shadow_path(path);
     assert!(
         shadow.exists(),
         "legacy <data>-meta shadow must be written when fold is OFF: {shadow:?}",
     );
-
-    cleanup(&path);
 }
 
 #[test]
@@ -81,11 +56,11 @@ fn fold_on_skips_meta_shadow_and_data_round_trips() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
     set_fold_pager_meta_enabled(true);
 
-    let path = persistent_path("fold_on");
-    cleanup(&path);
+    let db = support::temp_db_file("fold_on");
+    let path = db.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE fold_on_a (name TEXT)")
             .expect("ddl");
@@ -94,7 +69,7 @@ fn fold_on_skips_meta_shadow_and_data_round_trips() {
         rt.checkpoint().expect("flush");
     }
 
-    let shadow = meta_shadow_path(&path);
+    let shadow = meta_shadow_path(path);
     assert!(
         !shadow.exists(),
         "<data>-meta shadow must be absent when fold is ON: {shadow:?}",
@@ -102,14 +77,13 @@ fn fold_on_skips_meta_shadow_and_data_round_trips() {
 
     // Reopen: catalog and data must survive without the shadow.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("persistent runtime reopens");
         let _ = rt
             .execute_query("SELECT name FROM fold_on_a")
             .expect("select");
     }
 
-    cleanup(&path);
     set_fold_pager_meta_enabled(false);
 }
 
@@ -121,8 +95,8 @@ fn massive_catalog_forces_meta_overflow_chain() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
     set_fold_pager_meta_enabled(true);
 
-    let path = persistent_path("fold_overflow");
-    cleanup(&path);
+    let db = support::temp_db_file("fold_overflow");
+    let path = db.path();
 
     // Each row in the metadata blob is `name_len:u32 | name | root:u32`. A
     // ~32-char name costs ~40 bytes, so 200 collections clears 4 KiB
@@ -133,7 +107,7 @@ fn massive_catalog_forces_meta_overflow_chain() {
         .collect();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("persistent runtime opens");
         for name in &names {
             rt.execute_query(&format!("CREATE TABLE {name} (id INTEGER)"))
@@ -143,7 +117,7 @@ fn massive_catalog_forces_meta_overflow_chain() {
     }
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("persistent runtime reopens");
         for name in &names {
             // SELECT against the catalog: parse must succeed (no truncation).
@@ -153,7 +127,6 @@ fn massive_catalog_forces_meta_overflow_chain() {
         }
     }
 
-    cleanup(&path);
     set_fold_pager_meta_enabled(false);
 }
 

--- a/tests/e2e_index_replay.rs
+++ b/tests/e2e_index_replay.rs
@@ -6,23 +6,15 @@
 //!   2. equality queries on the indexed column hit the index
 //!      (correctness — they must return the right rows)
 
-use reddb::{RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
+#[allow(dead_code)]
+mod support;
 
-fn unique_data_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("reddb-{prefix}-{pid}-{nanos}"));
-    p
-}
+use reddb::{RedDBOptions, RedDBRuntime};
 
 #[test]
 fn persistent_reopen_restores_indexed_query_results() {
-    let path = unique_data_dir("idx-replay");
+    let dir = support::temp_data_dir("e2e-idx-replay");
+    let path = dir.join("data.rdb");
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).unwrap();
         rt.execute_query("CREATE TABLE users (id INT, age INT, city TEXT)")
@@ -96,6 +88,4 @@ fn persistent_reopen_restores_indexed_query_results() {
         "after restart, indexed equality must use an index path, got plan ops: {}",
         plan_text
     );
-
-    let _ = std::fs::remove_dir_all(&path);
 }

--- a/tests/e2e_issue_480_tier_default_promotion_contract.rs
+++ b/tests/e2e_issue_480_tier_default_promotion_contract.rs
@@ -25,26 +25,19 @@
 //!
 //! Each test maps to one acceptance bullet on the issue.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{
     fold_dwb_into_wal_enabled, fold_pager_meta_enabled, meta_json_sidecar_enabled,
     seqn_journal_enabled, shm_provisioning_enabled, tier_wiring, LogDestination, RedDBOptions,
     RedDBRuntime, StorageLayout,
 };
-use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Tests in this binary poke process-global tier toggles. Serialise so a
 /// parallel runner never observes a half-applied tier state.
 static PROMOTION_GUARD: Mutex<()> = Mutex::new(());
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_issue480_{prefix}_{unique}.rdb"))
-}
 
 fn reset_env() {
     std::env::remove_var("REDDB_META_JSON_SIDECAR");
@@ -55,10 +48,11 @@ fn reset_env() {
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
 }
 
-fn open_at_layout(prefix: &str, layout: StorageLayout) -> RedDBRuntime {
-    let path = persistent_path(prefix);
-    let options = RedDBOptions::persistent(&path).with_layout(layout);
-    RedDBRuntime::with_options(options).expect("runtime opens")
+fn open_at_layout(prefix: &str, layout: StorageLayout) -> (support::TempDbFile, RedDBRuntime) {
+    let db = support::temp_db_file(prefix);
+    let options = RedDBOptions::persistent(db.path()).with_layout(layout);
+    let rt = RedDBRuntime::with_options(options).expect("runtime opens");
+    (db, rt)
 }
 
 fn read_adr_0018() -> String {
@@ -311,8 +305,8 @@ fn promoted_phase_a_log_routing_override_remains_available() {
         },
         ..LayoutOverrides::default()
     };
-    let path = persistent_path("override_phaseA");
-    let options = RedDBOptions::persistent(&path)
+    let db = support::temp_db_file("override_phaseA");
+    let options = RedDBOptions::persistent(db.path())
         .with_layout(StorageLayout::Performance)
         .with_layout_overrides(overrides);
     let _rt = RedDBRuntime::with_options(options).expect("runtime opens");

--- a/tests/e2e_issue_593_materialized_view_persistence.rs
+++ b/tests/e2e_issue_593_materialized_view_persistence.rs
@@ -5,25 +5,13 @@
 //! the view name resolves on `SELECT`, and `DROP MATERIALIZED VIEW`
 //! clears the persisted catalog row.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
-use std::time::{SystemTime, UNIX_EPOCH};
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn persistent_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
@@ -34,11 +22,11 @@ fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
 #[test]
 fn materialized_view_survives_restart() {
     let path = persistent_path("mv_persist_survives");
-    cleanup(&path);
 
     // ── First boot: create table, insert rows, define materialized view.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("first open");
+        let rt =
+            RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("first open");
         exec(&rt, "CREATE TABLE orders (id INT, total INT, status TEXT)");
         exec(
             &rt,
@@ -71,7 +59,7 @@ fn materialized_view_survives_restart() {
     //    the API opens. The view name should resolve on SELECT and
     //    appear in `red.materialized_views`.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("reopen");
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("reopen");
         let names: Vec<String> = rt
             .materialized_view_metadata()
             .into_iter()
@@ -101,17 +89,15 @@ fn materialized_view_survives_restart() {
         let refreshed = exec(&rt, "REFRESH MATERIALIZED VIEW paid_orders");
         assert_eq!(refreshed.statement_type, "refresh_materialized_view");
     }
-
-    cleanup(&path);
 }
 
 #[test]
 fn drop_materialized_view_removes_persisted_descriptor() {
     let path = persistent_path("mv_persist_drop");
-    cleanup(&path);
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("first open");
+        let rt =
+            RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("first open");
         exec(&rt, "CREATE TABLE t (id INT)");
         exec(&rt, "CREATE MATERIALIZED VIEW v AS SELECT * FROM t");
         exec(&rt, "DROP MATERIALIZED VIEW v");
@@ -119,7 +105,7 @@ fn drop_materialized_view_removes_persisted_descriptor() {
     }
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("reopen");
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("reopen");
         let names: Vec<String> = rt
             .materialized_view_metadata()
             .into_iter()
@@ -130,6 +116,4 @@ fn drop_materialized_view_removes_persisted_descriptor() {
             "dropped view must not rehydrate, got {names:?}",
         );
     }
-
-    cleanup(&path);
 }

--- a/tests/e2e_issue_595_materialized_view_atomic_refresh.rs
+++ b/tests/e2e_issue_595_materialized_view_atomic_refresh.rs
@@ -8,27 +8,16 @@
 //! backing-collection count (mirroring the slice-10 invariant on
 //! `queue_pending_gauge` in #527).
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn persistent_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
@@ -189,11 +178,10 @@ fn concurrent_reader_sees_old_or_new_never_partial() {
 #[test]
 fn refresh_survives_clean_restart() {
     let path = persistent_path("mv_atomic_refresh_clean");
-    cleanup(&path);
 
     // First boot: source → MV → REFRESH → 2 rows visible through MV.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("open");
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("open");
         exec(&rt, "CREATE TABLE orders (id INT, status TEXT)");
         exec(
             &rt,
@@ -214,7 +202,7 @@ fn refresh_survives_clean_restart() {
     // Second boot: REFRESH result is durable — backing collection
     // still holds the 2 rows after restart.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("reopen");
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("reopen");
         let r = exec(&rt, "SELECT * FROM paid_orders");
         assert_eq!(
             r.result.records.len(),
@@ -229,8 +217,6 @@ fn refresh_survives_clean_restart() {
             .current_row_count;
         assert_eq!(count, 2, "scraped count survives reopen");
     }
-
-    cleanup(&path);
 }
 
 #[test]

--- a/tests/e2e_issue_596_materialized_view_replica_replay.rs
+++ b/tests/e2e_issue_596_materialized_view_replica_replay.rs
@@ -25,7 +25,9 @@
 //!    (and the replica fetcher) see the boundary explicitly instead
 //!    of having to infer it from a flurry of inserts.
 
-use std::path::PathBuf;
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -40,25 +42,8 @@ use reddb::{RedDBOptions, RedDBRuntime};
 
 const BACKING: &str = "paid_orders_596";
 
-fn temp_path(prefix: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!(
-        "reddb-596-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        nanos
-    ))
-}
-
-fn cleanup(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb", "-uwal"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 /// Build an entity in the same shape as the runtime's REFRESH path
@@ -179,8 +164,6 @@ fn replica_replay_of_refresh_collection_matches_primary_row_for_row() {
 
     drop(primary_rt);
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }
 
 #[test]
@@ -234,8 +217,6 @@ fn replica_replay_of_refresh_collection_is_idempotent() {
 
     drop(primary_rt);
     drop(replica);
-    cleanup(&path);
-    cleanup(&primary_path);
 }
 
 #[test]
@@ -287,5 +268,4 @@ fn primary_refresh_materialized_view_emits_refresh_cdc_event() {
     );
 
     drop(rt);
-    cleanup(&primary_path);
 }

--- a/tests/e2e_issue_753_ddl_policy_aware.rs
+++ b/tests/e2e_issue_753_ddl_policy_aware.rs
@@ -14,22 +14,17 @@
 //!    `schema:write` / `schema:admin` fallbacks gate their respective
 //!    operations.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-issue-753-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>, support::TempDataDir) {
+    let dir = support::temp_data_dir("e2e-issue-753");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -38,7 +33,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (rt, store, dir)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -79,7 +74,7 @@ fn ddl_action_names_are_advertised_in_the_action_catalog() {
 
 #[test]
 fn allowed_create_table_proceeds_with_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     attach(
         &store,
         "alice-create-users",
@@ -97,7 +92,7 @@ fn allowed_create_table_proceeds_with_grant() {
 
 #[test]
 fn denied_create_table_returns_structured_ui_safe_reason() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     attach(
         &store,
         "alice-no-ddl",
@@ -119,7 +114,7 @@ fn denied_create_table_returns_structured_ui_safe_reason() {
 
 #[test]
 fn allowed_alter_proceeds_and_explicit_deny_is_structured() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT)").unwrap();
 
     // Two policies: one that allows alter on accounts, one that denies it.
@@ -155,7 +150,7 @@ fn allowed_alter_proceeds_and_explicit_deny_is_structured() {
 
 #[test]
 fn denied_create_index_returns_structured_reason_on_the_indexed_table() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT, status TEXT)")
         .unwrap();
     attach(
@@ -177,7 +172,7 @@ fn denied_create_index_returns_structured_reason_on_the_indexed_table() {
 #[test]
 fn schema_admin_fallback_gates_create_schema() {
     // No allow → DefaultDeny under PolicyOnly → structured reason.
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     attach(
         &store,
         "alice-select-only",
@@ -194,7 +189,7 @@ fn schema_admin_fallback_gates_create_schema() {
 
 #[test]
 fn schema_admin_grant_allows_create_schema() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     attach(
         &store,
         "alice-schema-admin",

--- a/tests/e2e_issue_755_queue_policy_aware.rs
+++ b/tests/e2e_issue_755_queue_policy_aware.rs
@@ -12,22 +12,17 @@
 //!
 //! Refs #755 — child of PRD #735.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-issue-755-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>, support::TempDataDir) {
+    let dir = support::temp_data_dir("e2e-issue-755");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -35,7 +30,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (rt, store, dir)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -107,7 +102,7 @@ fn catalog_advertises_granular_queue_actions() {
 
 #[test]
 fn enqueue_allowed_with_queue_enqueue_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     attach_alice_policy(
         &store,
@@ -125,7 +120,7 @@ fn enqueue_allowed_with_queue_enqueue_grant() {
 
 #[test]
 fn enqueue_denied_returns_structured_reason() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     // Grant peek but not enqueue: Red UI should see the producer
     // toolbar action rejected with a structured, UI-safe reason.
@@ -147,7 +142,7 @@ fn enqueue_denied_returns_structured_reason() {
 
 #[test]
 fn peek_allowed_with_queue_peek_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     as_user("admin", Role::Admin, || {
         rt.execute_query("QUEUE PUSH jobs 'work'").unwrap();
@@ -171,7 +166,7 @@ fn typed_queue_select_succeeds_with_queue_peek_grant() {
     // carries a `queue:peek` grant on the target queue — pinning that
     // the `queue:peek` action covers the typed-select surface, not
     // just the `QUEUE PEEK` command.
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     as_user("admin", Role::Admin, || {
         rt.execute_query("QUEUE PUSH jobs 'work'").unwrap();
@@ -191,7 +186,7 @@ fn typed_queue_select_succeeds_with_queue_peek_grant() {
 
 #[test]
 fn read_pop_denied_without_queue_read_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     as_user("admin", Role::Admin, || {
         rt.execute_query("QUEUE PUSH jobs 'work'").unwrap();
@@ -213,7 +208,7 @@ fn read_pop_denied_without_queue_read_grant() {
 
 #[test]
 fn ack_and_nack_are_independently_grantable() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     // Seed two messages and read them as admin to acquire delivery
     // handles. The IAM check fires before runtime execution, so we only
@@ -253,7 +248,7 @@ fn ack_and_nack_are_independently_grantable() {
 
 #[test]
 fn purge_requires_dedicated_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     // Grant every consumer/producer verb but NOT purge — a destructive
     // toolbar action must not be reachable through a broad consumer
@@ -289,7 +284,7 @@ fn purge_requires_dedicated_grant() {
 
 #[test]
 fn dlq_move_uses_dedicated_action() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     setup_queue(&rt, "jobs_dlq");
 
@@ -311,7 +306,7 @@ fn dlq_move_uses_dedicated_action() {
 
 #[test]
 fn queue_wildcard_grants_every_operation() {
-    let (rt, store) = runtime_with_auth();
+    let (rt, store, _dir) = runtime_with_auth();
     setup_queue(&rt, "jobs");
     attach_alice_policy(
         &store,

--- a/tests/e2e_issue_756_vector_policy_aware.rs
+++ b/tests/e2e_issue_756_vector_policy_aware.rs
@@ -12,22 +12,17 @@
 //!
 //! Refs #756 — child of PRD #735.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-issue-756-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (support::TempDataDir, RedDBRuntime, Arc<AuthStore>) {
+    let dir = support::temp_data_dir("issue-756");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -35,7 +30,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (dir, rt, store)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -106,7 +101,7 @@ fn catalog_advertises_granular_vector_actions() {
 
 #[test]
 fn search_allowed_with_vector_search_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_vector_collection(&rt, "embeddings");
     // The vector executor checks a `select` projection on the
     // implicit `content` column (the snippet text shown alongside
@@ -129,7 +124,7 @@ fn search_allowed_with_vector_search_grant() {
 
 #[test]
 fn search_denied_returns_structured_reason() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_vector_collection(&rt, "embeddings");
     // Grant an unrelated vector verb so iam_authorization_enabled
     // flips on and the evaluator runs end-to-end.
@@ -151,7 +146,7 @@ fn search_denied_returns_structured_reason() {
 
 #[test]
 fn search_denied_when_grant_is_on_different_collection() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_vector_collection(&rt, "embeddings");
     setup_vector_collection(&rt, "other_vecs");
     // Grant only on `other_vecs` — the IAM gate must scope per
@@ -178,7 +173,7 @@ fn search_similar_text_form_uses_vector_search_action() {
     // `QueryExpr::Vector` shape as `VECTOR SEARCH <c> SIMILAR TO […]`
     // so the IAM envelope must mention the same `vector:search` verb
     // — pin that contract for Red UI.
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_vector_collection(&rt, "embeddings");
     attach_alice_policy(
         &store,
@@ -197,7 +192,7 @@ fn search_similar_text_form_uses_vector_search_action() {
 
 #[test]
 fn vector_wildcard_grants_search() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_vector_collection(&rt, "embeddings");
     attach_alice_policy(
         &store,
@@ -227,7 +222,7 @@ fn search_grant_does_not_unlock_artifact_admin_verbs() {
     // slice).
     use reddb::auth::policies::ResourceRef;
 
-    let (_rt, store) = runtime_with_auth();
+    let (_dir, _rt, store) = runtime_with_auth();
     attach_alice_policy(
         &store,
         "vector-search-only",
@@ -280,7 +275,7 @@ fn vector_admin_verb_is_independently_grantable() {
     // policy evaluator.
     use reddb::auth::policies::ResourceRef;
 
-    let (_rt, store) = runtime_with_auth();
+    let (_dir, _rt, store) = runtime_with_auth();
     attach_alice_policy(
         &store,
         "vector-admin-only",

--- a/tests/e2e_issue_757_graph_policy_aware.rs
+++ b/tests/e2e_issue_757_graph_policy_aware.rs
@@ -11,22 +11,17 @@
 //!
 //! Refs #757 — child of PRD #735.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-issue-757-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (support::TempDataDir, RedDBRuntime, Arc<AuthStore>) {
+    let dir = support::temp_data_dir("issue-757");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -34,7 +29,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Read).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (dir, rt, store)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -108,7 +103,7 @@ fn catalog_advertises_graph_actions() {
 
 #[test]
 fn properties_allowed_with_graph_read_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     attach_alice_policy(
         &store,
@@ -124,7 +119,7 @@ fn properties_allowed_with_graph_read_grant() {
 
 #[test]
 fn properties_denied_returns_structured_reason() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     // Grant traversal but not metadata read — Red UI should see the
     // properties toolbar action rejected with a structured envelope.
@@ -146,7 +141,7 @@ fn properties_denied_returns_structured_reason() {
 
 #[test]
 fn neighborhood_allowed_with_graph_traverse_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     attach_alice_policy(
         &store,
@@ -168,7 +163,7 @@ fn match_pattern_query_uses_graph_traverse() {
     // must gate on `graph:traverse`, not `graph:read`, so the
     // explorer's pattern-walk toolbar action is independently
     // grantable from plain metadata reads.
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     attach_alice_policy(
         &store,
@@ -187,7 +182,7 @@ fn match_pattern_query_uses_graph_traverse() {
 
 #[test]
 fn neighborhood_denied_without_traverse_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     attach_alice_policy(
         &store,
@@ -206,7 +201,7 @@ fn neighborhood_denied_without_traverse_grant() {
 
 #[test]
 fn algorithm_run_requires_dedicated_grant() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     // Grant read + traversal but NOT algorithm — the expensive
     // analytics toolbar must not be reachable through a plain
@@ -239,7 +234,7 @@ fn algorithm_run_requires_dedicated_grant() {
 
 #[test]
 fn graph_wildcard_grants_every_operation() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_graph(&rt);
     attach_alice_policy(
         &store,

--- a/tests/e2e_issue_813_replica_repull_idempotent.rs
+++ b/tests/e2e_issue_813_replica_repull_idempotent.rs
@@ -29,10 +29,11 @@
 //! reconnects) and assert the replica's live row set matches the
 //! primary's and stays flat across repeated re-pulls.
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb::application::{ExecuteQueryInput, QueryUseCases};
 use reddb::replication::cdc::ChangeRecord;
@@ -42,25 +43,8 @@ use reddb::replication::ReplicationConfig;
 use reddb::storage::{EntityKind, RedDB, UnifiedStore};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn temp_path(prefix: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!(
-        "reddb-813-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        nanos
-    ))
-}
-
-fn cleanup(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb", "-uwal", ".logical.wal"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn exec(query: &QueryUseCases<'_, RedDBRuntime>, sql: &str) {
@@ -205,8 +189,6 @@ fn repull_from_lsn_zero_does_not_inflate_table_rows() {
     );
 
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }
 
 /// Reconnect storm: re-pulling from 0 repeatedly must keep the live row
@@ -239,8 +221,6 @@ fn repeated_repull_from_zero_stays_flat() {
     }
 
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }
 
 /// THE 22×-inflation regression. A table row that is UPDATEd installs a
@@ -293,6 +273,4 @@ fn repull_with_updates_converges_to_primary_live_set() {
     );
 
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }

--- a/tests/e2e_issue_815_replica_responsive_under_apply.rs
+++ b/tests/e2e_issue_815_replica_responsive_under_apply.rs
@@ -28,34 +28,19 @@
 //! a timeout. A store-lock wedge would blow the per-call budget; the
 //! decoupled scans keep it fast.
 
-use std::path::PathBuf;
+#[allow(dead_code)]
+mod support;
+
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 
 use reddb::application::{ExecuteQueryInput, QueryUseCases};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn temp_path(prefix: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!(
-        "reddb-815-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        nanos
-    ))
-}
-
-fn cleanup(path: &std::path::Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb", "-uwal", ".logical.wal"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn exec(query: &QueryUseCases<'_, RedDBRuntime>, sql: &str) {
@@ -69,12 +54,8 @@ fn exec(query: &QueryUseCases<'_, RedDBRuntime>, sql: &str) {
 #[test]
 fn catalog_and_readiness_stay_responsive_during_large_reapply() {
     let path = temp_path("responsive");
-    cleanup(&path);
 
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(
-        &path.to_string_lossy().to_string(),
-    ))
-    .expect("open store");
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path())).expect("open store");
 
     // Seed several collections with rows so a catalog/health scan does
     // real work — a no-op snapshot could pass the budget trivially.
@@ -162,5 +143,4 @@ fn catalog_and_readiness_stay_responsive_during_large_reapply() {
     );
 
     drop(rt);
-    cleanup(&path);
 }

--- a/tests/e2e_issue_824_replication_ttl.rs
+++ b/tests/e2e_issue_824_replication_ttl.rs
@@ -5,8 +5,10 @@
 //! absolute expiry has already passed while they are still waiting for
 //! that delete to arrive.
 
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+#[allow(dead_code)]
+mod support;
+
+use std::path::Path;
 
 use reddb::application::NativeUseCases;
 use reddb::replication::cdc::{ChangeOperation, ChangeRecord};
@@ -16,24 +18,8 @@ use reddb::replication::ReplicationConfig;
 use reddb::storage::RedDB;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn temp_path(prefix: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!(
-        "reddb-824-{prefix}-{}-{nanos}.rdb",
-        std::process::id()
-    ))
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    for ext in ["-wal", "-hdr", "-meta", "-dwb", "-uwal", ".logical.wal"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(ext);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn read_spool(path: &Path) -> Vec<ChangeRecord> {
@@ -105,8 +91,6 @@ fn primary_ttl_sweep_replicates_delete_to_replica() {
     );
 
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }
 
 #[test]
@@ -167,8 +151,6 @@ fn lagging_replica_filters_expired_row_before_delete_arrives() {
     );
 
     drop(replica);
-    cleanup(&primary_path);
-    cleanup(&replica_path);
 }
 
 #[test]
@@ -217,5 +199,4 @@ fn replica_hypertable_expiry_sweep_is_read_only_noop() {
     );
 
     drop(replica);
-    cleanup(&path);
 }

--- a/tests/e2e_issue_827_causal_bookmarks.rs
+++ b/tests/e2e_issue_827_causal_bookmarks.rs
@@ -1,5 +1,6 @@
 //! Issue #827 — causal bookmarks and contiguous replica apply waits.
 
+#[allow(dead_code)]
 mod support;
 
 use std::time::Duration;
@@ -10,15 +11,8 @@ use reddb::replication::{CausalBookmark, DEFAULT_REPLICATION_TERM};
 use reddb::storage::RedDB;
 use reddb::{RedDBOptions, RedDBRuntime, ReplicationConfig};
 
-fn temp_path(prefix: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-issue-827-{prefix}-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
+fn temp_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(&format!("issue-827-{prefix}"))
 }
 
 fn record(lsn: u64, payload: &[u8]) -> ChangeRecord {
@@ -76,7 +70,6 @@ fn causal_session_carries_extracts_and_injects_bookmark() {
 #[test]
 fn bookmark_wait_uses_contiguous_applied_lsn_not_gappy_received_frontier() {
     let path = temp_path("gap-wait");
-    let _ = std::fs::remove_file(&path);
     let db = RedDB::open(&path).expect("db");
     let applier = LogicalChangeApplier::new(0);
 
@@ -105,6 +98,4 @@ fn bookmark_wait_uses_contiguous_applied_lsn_not_gappy_received_frontier() {
     applier
         .wait_for_bookmark(&bookmark, Duration::from_secs(1))
         .expect("contiguous apply reaches bookmark");
-
-    let _ = std::fs::remove_file(&path);
 }

--- a/tests/e2e_issue_830_replication_bootstrap.rs
+++ b/tests/e2e_issue_830_replication_bootstrap.rs
@@ -101,17 +101,6 @@ fn bearer_payload(
     request
 }
 
-fn temp_data_path(name: &str) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
-        "reddb-{name}-{}-{}.rdb",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ))
-}
-
 #[tokio::test]
 async fn replication_snapshot_pins_authenticated_replica_slot_at_bootstrap_start() {
     let primary = RedDBRuntime::with_options(
@@ -205,9 +194,7 @@ async fn replication_snapshot_pins_authenticated_replica_slot_at_bootstrap_start
 
 #[tokio::test]
 async fn pull_wal_records_reports_basebackup_catchup_mode_for_invalidated_slot() {
-    let data_path = temp_data_path("issue-830-catchup-mode");
-    let _ = std::fs::remove_file(&data_path);
-    let _ = std::fs::remove_dir_all(data_path.with_extension("primary-replica"));
+    let data_path = support::temp_db_file("issue-830-catchup-mode");
 
     let primary = RedDBRuntime::with_options(
         RedDBOptions::persistent(&data_path)
@@ -294,8 +281,6 @@ async fn pull_wal_records_reports_basebackup_catchup_mode_for_invalidated_slot()
     );
 
     handle.abort();
-    let _ = std::fs::remove_file(&data_path);
-    let _ = std::fs::remove_dir_all(data_path.with_extension("primary-replica"));
 }
 
 #[tokio::test]

--- a/tests/e2e_issue_840_replication_auto_rollback.rs
+++ b/tests/e2e_issue_840_replication_auto_rollback.rs
@@ -21,6 +21,9 @@
 //! the cluster here is a deterministic in-memory model that drives the
 //! recover-to-LSN mechanism exactly as the live wiring will.
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -140,16 +143,10 @@ impl RollbackTransport for DeposedPrimary {
     }
 }
 
-fn make_audit() -> (AuditLogger, PathBuf) {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-840-{}-{}",
-        std::process::id(),
-        reddb::utils::now_unix_nanos()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn make_audit() -> (support::TempDataDir, AuditLogger, PathBuf) {
+    let dir = support::temp_data_dir("840");
     let path = dir.join(".audit.log");
-    (AuditLogger::with_path(path.clone()), path)
+    (dir, AuditLogger::with_path(path.clone()), path)
 }
 
 fn last_audit_line(path: &std::path::Path) -> reddb::json::Value {
@@ -160,7 +157,7 @@ fn last_audit_line(path: &std::path::Path) -> reddb::json::Value {
 
 #[test]
 fn deposed_primary_auto_rolls_back_divergent_tail_and_rejoins() {
-    let (audit, audit_path) = make_audit();
+    let (_dir, audit, audit_path) = make_audit();
     let rollback_dir = audit_path.parent().unwrap().join("rollback");
 
     // The deposed primary's timeline: committed history up to 200 (term 7)
@@ -247,7 +244,7 @@ fn rollback_refuses_to_cross_the_commit_watermark() {
     // committed data. The coordinator must refuse and change nothing —
     // the invariant "nothing at/below the watermark is ever rolled back"
     // is enforced even against a bad election result.
-    let (audit, audit_path) = make_audit();
+    let (_dir, audit, audit_path) = make_audit();
     let rollback_dir = audit_path.parent().unwrap().join("rollback");
     let mut node = DeposedPrimary::new(vec![(150, 7), (200, 7), (250, 7)], rollback_dir, audit);
 
@@ -279,7 +276,7 @@ fn caught_up_ex_primary_rejoins_without_a_rollback() {
     // An ex-primary whose frontier equals the common point has no
     // divergent tail: it rejoins cleanly, with no rollback file and no
     // operator event.
-    let (audit, audit_path) = make_audit();
+    let (_dir, audit, audit_path) = make_audit();
     let rollback_dir = audit_path.parent().unwrap().join("rollback");
     let mut node = DeposedPrimary::new(vec![(180, 7), (200, 7)], rollback_dir, audit);
 

--- a/tests/e2e_logical_wal_crash.rs
+++ b/tests/e2e_logical_wal_crash.rs
@@ -10,21 +10,13 @@
 //!      file-length inspection — a flushed-but-not-synced write may
 //!      still be in the kernel page cache, but `sync_all` forces it).
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::replication::primary::LogicalWalSpool;
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;
-
-fn temp_data_path(tag: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("reddb-logical-wal-{tag}-{pid}-{nanos}"));
-    p
-}
 
 fn spool_file_path(data_path: &std::path::Path) -> PathBuf {
     LogicalWalSpool::path_for(data_path)
@@ -32,7 +24,7 @@ fn spool_file_path(data_path: &std::path::Path) -> PathBuf {
 
 #[test]
 fn truncated_tail_after_append_returns_valid_prefix_only() {
-    let data_path = temp_data_path("truncated-tail");
+    let data_path = support::temp_data_dir("logical-wal-truncated-tail");
     let spool_path = spool_file_path(&data_path);
 
     // Write three records via the public API. After this, every
@@ -81,13 +73,11 @@ fn truncated_tail_after_append_returns_valid_prefix_only() {
     let entries = spool.read_since(0, 100).unwrap();
     assert_eq!(entries.len(), 3);
     assert_eq!(entries[2].0, 4);
-
-    let _ = std::fs::remove_file(&spool_path);
 }
 
 #[test]
 fn checksum_flip_in_middle_record_truncates_at_corrupt_offset() {
-    let data_path = temp_data_path("crc-flip");
+    let data_path = support::temp_data_dir("logical-wal-crc-flip");
     let spool_path = spool_file_path(&data_path);
 
     // Three records, every byte covered by crc32.
@@ -134,26 +124,21 @@ fn checksum_flip_in_middle_record_truncates_at_corrupt_offset() {
     );
     assert_eq!(entries[0].0, 10);
     assert_eq!(spool.current_lsn(), 10);
-
-    let _ = std::fs::remove_file(&spool_path);
 }
 
 #[test]
 fn empty_file_recovers_to_empty_state() {
-    let data_path = temp_data_path("empty");
-    let spool_path = spool_file_path(&data_path);
+    let data_path = support::temp_data_dir("logical-wal-empty");
 
     let spool = LogicalWalSpool::open(&data_path).expect("open empty");
     let entries = spool.read_since(0, 100).expect("read");
     assert!(entries.is_empty());
     assert_eq!(spool.current_lsn(), 0);
-
-    let _ = std::fs::remove_file(&spool_path);
 }
 
 #[test]
 fn first_record_torn_leaves_clean_empty_spool() {
-    let data_path = temp_data_path("first-torn");
+    let data_path = support::temp_data_dir("logical-wal-first-torn");
     let spool_path = spool_file_path(&data_path);
 
     // Single record then chop the crc.
@@ -185,8 +170,6 @@ fn first_record_torn_leaves_clean_empty_spool() {
     let entries = spool.read_since(0, 100).unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].0, 1);
-
-    let _ = std::fs::remove_file(&spool_path);
 }
 
 #[test]
@@ -197,7 +180,7 @@ fn append_is_synced_when_call_returns() {
     // true even for unsynced writes, so the assertion is a regression
     // canary against a future buffered-writer change that would only
     // flush on drop.
-    let data_path = temp_data_path("sync");
+    let data_path = support::temp_data_dir("logical-wal-sync");
     let spool_path = spool_file_path(&data_path);
 
     let spool = LogicalWalSpool::open(&data_path).expect("open");
@@ -208,5 +191,4 @@ fn append_is_synced_when_call_returns() {
         after > before,
         "append must produce visible bytes on disk; before={before} after={after}"
     );
-    let _ = std::fs::remove_file(&spool_path);
 }

--- a/tests/e2e_meta_json_sidecar_policy.rs
+++ b/tests/e2e_meta_json_sidecar_policy.rs
@@ -4,26 +4,17 @@
 //! (which a future tier-wiring slice flips on for `Max`) or the
 //! `REDDB_META_JSON_SIDECAR=1` env escape hatch.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{set_meta_json_sidecar_enabled, PhysicalMetadataFile, RedDBOptions, RedDBRuntime};
-use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // Serialises the two tests because they mutate a process-global toggle.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_path_for(path));
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_binary_path_for(path));
+fn persistent_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 #[test]
@@ -33,10 +24,9 @@ fn standard_tier_default_does_not_write_json_sidecar() {
     std::env::remove_var("REDDB_META_JSON_SIDECAR");
 
     let path = persistent_path("meta_sidecar_off");
-    cleanup(&path);
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE sidecar_off (name TEXT)")
             .expect("ddl");
@@ -65,8 +55,6 @@ fn standard_tier_default_does_not_write_json_sidecar() {
             .any(|c| c.name == "sidecar_off"),
         "catalog should include the new collection",
     );
-
-    cleanup(&path);
 }
 
 #[test]
@@ -75,10 +63,9 @@ fn max_opt_in_writes_json_sidecar() {
     set_meta_json_sidecar_enabled(true);
 
     let path = persistent_path("meta_sidecar_on");
-    cleanup(&path);
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE sidecar_on (name TEXT)")
             .expect("ddl");
@@ -91,6 +78,5 @@ fn max_opt_in_writes_json_sidecar() {
         "JSON sidecar must be written when opt-in is on: {json_path:?}",
     );
 
-    cleanup(&path);
     set_meta_json_sidecar_enabled(false);
 }

--- a/tests/e2e_replica_readonly.rs
+++ b/tests/e2e_replica_readonly.rs
@@ -17,22 +17,13 @@
 //! entity port below, so the shared chokepoints here demonstrate the
 //! gate fires at the right layer.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::{CreateRowInput, DeleteEntityInput, EntityUseCases};
 use reddb::replication::ReplicationConfig;
 use reddb::storage::EntityId;
 use reddb::{RedDBError, RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
-
-fn unique_data_dir(prefix: &str) -> PathBuf {
-    let mut p = std::env::temp_dir();
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    p.push(format!("reddb-{prefix}-{pid}-{nanos}"));
-    p
-}
 
 fn assert_read_only_err<T: std::fmt::Debug>(
     res: Result<T, RedDBError>,
@@ -51,7 +42,7 @@ fn assert_read_only_err<T: std::fmt::Debug>(
 
 #[test]
 fn replica_rejects_sql_ddl_and_dml_on_every_surface() {
-    let primary_path = unique_data_dir("replica-primary");
+    let primary_path = support::temp_data_dir("replica-primary");
 
     // 1. Boot a standalone primary, create a table, insert one row.
     {
@@ -134,7 +125,7 @@ fn replica_rejects_sql_ddl_and_dml_on_every_surface() {
 
 #[test]
 fn explicit_read_only_flag_rejects_writes_on_standalone() {
-    let path = unique_data_dir("readonly-flag");
+    let path = support::temp_data_dir("readonly-flag");
 
     // Seed a table on a writable instance so the read-only re-open has
     // something to read.
@@ -163,7 +154,7 @@ fn explicit_read_only_flag_rejects_writes_on_standalone() {
 
 #[test]
 fn standalone_primary_default_is_writable() {
-    let path = unique_data_dir("primary-writable");
+    let path = support::temp_data_dir("primary-writable");
 
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("primary open");
     rt.execute_query("CREATE TABLE writable (id INT)")
@@ -188,7 +179,7 @@ fn replica_internal_apply_path_remains_privileged() {
     // it succeeds even after the gate has rejected client writes.
     use reddb::storage::{EntityData, EntityKind, RowData, UnifiedEntity};
 
-    let path = unique_data_dir("replica-privileged");
+    let path = support::temp_data_dir("replica-privileged");
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("primary open");
         rt.execute_query("CREATE TABLE shipped (id INT, payload TEXT)")

--- a/tests/e2e_repro_stale_index_post_insert.rs
+++ b/tests/e2e_repro_stale_index_post_insert.rs
@@ -9,6 +9,9 @@
 //!
 //! Expect: all 2N rows considered; bench reports about half are missing.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::{CreateRowInput, CreateRowsBatchInput, RuntimeEntityPort};
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
@@ -215,15 +218,7 @@ fn post_create_index_update_keeps_index_in_sync() {
 /// to corrupt post-CREATE-INDEX entity lookups.
 #[test]
 fn post_create_index_inserts_at_scale_keeps_index_fresh() {
-    let mut p = std::env::temp_dir();
-    p.push(format!(
-        "reddb-scale-repro-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let p = support::temp_data_dir("scale-repro");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&p)).unwrap();
     rt.execute_query("CREATE TABLE users (id INT, age INT, city TEXT)")
         .unwrap();
@@ -308,7 +303,6 @@ fn post_create_index_inserts_at_scale_keeps_index_fresh() {
         );
     }
 
-    let _ = std::fs::remove_dir_all(&p);
 }
 
 /// Mirror of the bench `reddb_wire` `insert_one` path: single-row

--- a/tests/e2e_repro_stale_index_post_insert.rs
+++ b/tests/e2e_repro_stale_index_post_insert.rs
@@ -302,7 +302,6 @@ fn post_create_index_inserts_at_scale_keeps_index_fresh() {
             expected_filtered
         );
     }
-
 }
 
 /// Mirror of the bench `reddb_wire` `insert_one` path: single-row

--- a/tests/e2e_reserved_system_fields.rs
+++ b/tests/e2e_reserved_system_fields.rs
@@ -1,25 +1,16 @@
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::{CreateDocumentInput, EntityUseCases};
 use reddb::json::json;
 use reddb::{PhysicalMetadataFile, RedDBOptions, RedDBRuntime};
-use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
 }
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup_path(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_path_for(path));
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_binary_path_for(path));
+fn persistent_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn assert_reserved_error(message: &str, field: &str, context: &str) {
@@ -86,10 +77,9 @@ fn graph_payloads_reject_reserved_top_level_properties() {
 #[test]
 fn startup_rejects_persisted_table_contract_reserved_columns() {
     let path = persistent_path("reserved_startup");
-    cleanup_path(&path);
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
             .expect("persistent runtime should open");
         rt.execute_query("CREATE TABLE persisted_rows (name TEXT)")
             .expect("table should be created");
@@ -122,11 +112,10 @@ fn startup_rejects_persisted_table_contract_reserved_columns() {
         .save_for_data_path(&path)
         .expect("metadata should be saved");
 
-    let err = match RedDBRuntime::with_options(RedDBOptions::persistent(&path)) {
+    let err = match RedDBRuntime::with_options(RedDBOptions::persistent(path.path())) {
         Ok(_) => panic!("reserved persisted contract should fail startup"),
         Err(err) => err,
     };
 
     assert_reserved_error(&err.to_string(), "collection", "table 'persisted_rows'");
-    cleanup_path(&path);
 }

--- a/tests/e2e_retention_sweeper.rs
+++ b/tests/e2e_retention_sweeper.rs
@@ -4,21 +4,15 @@
 //! reclaims rows expired beyond the retention window, and the three
 //! new observability columns on `red.retention`.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::ExecuteQueryInput;
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 
-fn unique_dir(prefix: &str) -> PathBuf {
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let mut path = std::env::temp_dir();
-    path.push(format!("reddb-{prefix}-{pid}-{nanos}"));
-    std::fs::create_dir_all(&path).unwrap();
-    path
+fn unique_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 /// Sweeper drains expired rows across multiple ticks, never touching
@@ -236,8 +230,6 @@ fn sweeper_after_restart_continues_to_reclaim_via_wal() {
             "WAL replay must reproduce the sweeper's physical deletes"
         );
     }
-
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 /// `CREATE MATERIALIZED VIEW ... WITH RETENTION <duration>` is

--- a/tests/e2e_secret_sql.rs
+++ b/tests/e2e_secret_sql.rs
@@ -1,7 +1,6 @@
 mod support;
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb::auth::vault::Vault;
 use reddb::auth::{AuthConfig, AuthStore};
@@ -9,14 +8,6 @@ use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 use support::PersistentDbPath;
-
-fn temp_db_path(name: &str) -> std::path::PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
 
 fn open_runtime_with_vault(name: &str) -> (PersistentDbPath, RedDBRuntime, Arc<AuthStore>) {
     let path = PersistentDbPath::new(name);
@@ -143,15 +134,15 @@ fn vault_kv_logical_restore_placeholders_use_false() {
 
 #[test]
 fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
-    let source_path = temp_db_path("secret_cli_dump_source");
-    let dest_path = temp_db_path("secret_cli_dump_dest");
-    let dump_path = temp_db_path("secret_cli_dump_jsonl");
-    let _ = std::fs::remove_file(&source_path);
-    let _ = std::fs::remove_file(&dest_path);
-    let _ = std::fs::remove_file(&dump_path);
+    let source_guard = support::temp_db_file("secret-cli-dump-source");
+    let dest_guard = support::temp_db_file("secret-cli-dump-dest");
+    let dump_guard = support::temp_db_file("secret-cli-dump-jsonl");
+    let source_path = source_guard.path();
+    let dest_path = dest_guard.path();
+    let dump_path = dump_guard.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&source_path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(source_path))
             .expect("source runtime should open");
         let _auth = attach_vault(&rt, "cli-pass");
         rt.execute_query("SET CONFIG red.config.demo.enabled = true")
@@ -161,7 +152,7 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         rt.checkpoint().expect("source checkpoint should succeed");
     }
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&source_path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(source_path))
             .expect("source runtime should reopen");
         let auth = attach_vault(&rt, "cli-pass");
         assert_eq!(
@@ -210,7 +201,7 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         String::from_utf8_lossy(&restore.stderr)
     );
 
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&dest_path))
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dest_path))
         .expect("dest runtime should open");
     let auth = attach_vault(&rt, "cli-pass");
     assert_eq!(
@@ -222,9 +213,9 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         .expect("config should restore");
     assert_eq!(config.result.records.len(), 1);
 
-    let _ = std::fs::remove_file(source_path);
-    let _ = std::fs::remove_file(dest_path);
-    let _ = std::fs::remove_file(dump_path);
+    drop(source_guard);
+    drop(dest_guard);
+    drop(dump_guard);
 }
 
 #[test]

--- a/tests/e2e_seqn_journal_policy.rs
+++ b/tests/e2e_seqn_journal_policy.rs
@@ -5,34 +5,21 @@
 //! present, absent, corrupt (passive — load falls through to the next
 //! viable source without panicking).
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{
     seqn_journal_enabled, seqn_journal_retention, set_seqn_journal_enabled,
     set_seqn_journal_retention, PhysicalMetadataFile, RedDBOptions, RedDBRuntime,
 };
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // Process-globals — serialise tests.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
 
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_path_for(path));
-    let _ = std::fs::remove_file(PhysicalMetadataFile::metadata_binary_path_for(path));
-    if let Ok(journals) = PhysicalMetadataFile::journal_paths_for_data_path(path) {
-        for j in journals {
-            let _ = std::fs::remove_file(j);
-        }
-    }
+fn persistent_path(prefix: &str) -> support::TempDbFile {
+    support::temp_db_file(prefix)
 }
 
 fn reset_policy() {
@@ -60,7 +47,6 @@ fn journal_absent_by_default_outside_max_tier() {
     reset_policy();
 
     let path = persistent_path("seqn_off");
-    cleanup(&path);
 
     run_a_few_saves(&path, "seqn_off", 3);
 
@@ -71,8 +57,6 @@ fn journal_absent_by_default_outside_max_tier() {
     );
     let binary = PhysicalMetadataFile::metadata_binary_path_for(&path);
     assert!(binary.exists(), "binary metadata is always written");
-
-    cleanup(&path);
 }
 
 #[test]
@@ -86,7 +70,6 @@ fn journal_written_when_opt_in_with_bounded_retention() {
     assert_eq!(seqn_journal_retention(), 4);
 
     let path = persistent_path("seqn_on");
-    cleanup(&path);
 
     run_a_few_saves(&path, "seqn_on", 10);
 
@@ -101,7 +84,6 @@ fn journal_written_when_opt_in_with_bounded_retention() {
         journals.len(),
     );
 
-    cleanup(&path);
     reset_policy();
 }
 
@@ -113,34 +95,32 @@ fn recovery_handles_present_absent_and_corrupt_binary() {
     set_seqn_journal_retention(4);
 
     // === Case 1: PRESENT — binary intact, journals present, loader uses binary.
-    let path = persistent_path("seqn_present");
-    cleanup(&path);
-    run_a_few_saves(&path, "present", 3);
-    let (_, source) =
-        PhysicalMetadataFile::load_for_data_path_with_source(&path).expect("present binary loads");
-    assert_eq!(source.as_str(), "binary");
-
     // === Case 2: CORRUPT — overwrite the binary with garbage; loader heals from journal.
-    let binary = PhysicalMetadataFile::metadata_binary_path_for(&path);
-    std::fs::write(&binary, b"not-valid-metadata-bytes").expect("corrupt binary");
-    let (_, source) = PhysicalMetadataFile::load_for_data_path_with_source(&path)
-        .expect("corrupt binary heals from journal");
-    assert_eq!(
-        source.as_str(),
-        "binary_journal",
-        "corrupt binary must heal from seq-N journal entry",
-    );
-    cleanup(&path);
+    {
+        let path = persistent_path("seqn_present");
+        run_a_few_saves(&path, "present", 3);
+        let (_, source) = PhysicalMetadataFile::load_for_data_path_with_source(&path)
+            .expect("present binary loads");
+        assert_eq!(source.as_str(), "binary");
+
+        let binary = PhysicalMetadataFile::metadata_binary_path_for(&path);
+        std::fs::write(&binary, b"not-valid-metadata-bytes").expect("corrupt binary");
+        let (_, source) = PhysicalMetadataFile::load_for_data_path_with_source(&path)
+            .expect("corrupt binary heals from journal");
+        assert_eq!(
+            source.as_str(),
+            "binary_journal",
+            "corrupt binary must heal from seq-N journal entry",
+        );
+    }
 
     // === Case 3: ABSENT — no binary, no journal, no JSON sidecar. Loader returns Err.
     let path = persistent_path("seqn_absent");
-    cleanup(&path);
     let result = PhysicalMetadataFile::load_for_data_path_with_source(&path);
     assert!(
         result.is_err(),
         "absent metadata must surface a load error: {result:?}",
     );
 
-    cleanup(&path);
     reset_policy();
 }

--- a/tests/e2e_shm_provisioning.rs
+++ b/tests/e2e_shm_provisioning.rs
@@ -3,30 +3,18 @@
 //! reader coexistence, and crash recovery when the prior owner pid is
 //! dead. Mmap wiring + tier auto-enable are deferred — see ADR-0018.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{
     provision_shm, read_shm_header, set_shm_provisioning_enabled, shm_path_for,
     shm_provisioning_enabled, ShmProvisionState, SHM_FILE_SIZE, SHM_HEADER_SIZE, SHM_MAGIC,
     SHM_VERSION,
 };
-use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // Tests poke a process-global toggle; serialise them.
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
-
-fn unique_data_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(data: &PathBuf) {
-    let _ = std::fs::remove_file(shm_path_for(data));
-    let _ = std::fs::remove_file(data);
-}
 
 fn reset_policy() {
     set_shm_provisioning_enabled(false);
@@ -46,8 +34,7 @@ fn provisioning_disabled_by_default() {
 #[test]
 fn provision_creates_shm_with_canonical_header() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = unique_data_path("shm_create");
-    cleanup(&data);
+    let data = support::temp_db_file("shm-create");
 
     let handle = provision_shm(&data).expect("shm provisions cleanly");
     let shm_path = shm_path_for(&data);
@@ -74,14 +61,12 @@ fn provision_creates_shm_with_canonical_header() {
     assert_eq!(header.reader_count, 0);
 
     drop(handle);
-    cleanup(&data);
 }
 
 #[test]
 fn reopen_by_same_process_attaches_without_bumping_generation() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = unique_data_path("shm_reattach");
-    cleanup(&data);
+    let data = support::temp_db_file("shm-reattach");
 
     let first = provision_shm(&data).expect("first open");
     let gen_after_create = first.generation();
@@ -98,15 +83,12 @@ fn reopen_by_same_process_attaches_without_bumping_generation() {
         gen_after_create,
         "generation must not bump for a same-pid reopen",
     );
-
-    cleanup(&data);
 }
 
 #[test]
 fn multiple_readers_can_attach_concurrently() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = unique_data_path("shm_readers");
-    cleanup(&data);
+    let data = support::temp_db_file("shm-readers");
 
     let mut owner = provision_shm(&data).expect("owner open");
     let count_a = owner.attach_reader().expect("attach reader 1");
@@ -127,15 +109,12 @@ fn multiple_readers_can_attach_concurrently() {
 
     let after_detach = owner.detach_reader().expect("detach reader");
     assert_eq!(after_detach, 2);
-
-    cleanup(&data);
 }
 
 #[test]
 fn crash_of_prior_owner_is_detected_and_state_cleaned() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = unique_data_path("shm_crash");
-    cleanup(&data);
+    let data = support::temp_db_file("shm-crash");
 
     // Bootstrap a valid shm with a fabricated dead-pid owner.
     let mut handle = provision_shm(&data).expect("seed shm");
@@ -185,15 +164,12 @@ fn crash_of_prior_owner_is_detected_and_state_cleaned() {
         "generation must bump on takeover (was {prior_gen}, now {})",
         recovered.header.generation,
     );
-
-    cleanup(&data);
 }
 
 #[test]
 fn corrupt_header_is_healed_in_place() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
-    let data = unique_data_path("shm_corrupt");
-    cleanup(&data);
+    let data = support::temp_db_file("shm-corrupt");
 
     // Plant a file that exists but has no valid magic.
     let shm_path = shm_path_for(&data);
@@ -207,6 +183,4 @@ fn corrupt_header_is_healed_in_place() {
         .expect("re-read")
         .expect("header present after heal");
     assert_eq!(header.version, SHM_VERSION);
-
-    cleanup(&data);
 }

--- a/tests/e2e_statement_execution_contract.rs
+++ b/tests/e2e_statement_execution_contract.rs
@@ -2,6 +2,9 @@
 //! routing. These tests intentionally drive `execute_query` and the
 //! application use case surface instead of private frame modules.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::ExecuteQueryInput;
 use reddb::auth::Role;
 use reddb::runtime::mvcc::{
@@ -10,24 +13,17 @@ use reddb::runtime::mvcc::{
 };
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime")
 }
 
-fn persistent_runtime(path: &PathBuf) -> RedDBRuntime {
+fn persistent_runtime(path: &support::TempDbFile) -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::persistent(path)).expect("persistent runtime")
 }
 
-fn temp_db_path(label: &str) -> PathBuf {
-    let mut path = std::env::temp_dir();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    path.push(format!("reddb-{label}-{}-{nanos}.rdb", std::process::id()));
-    path
+fn temp_db_path(label: &str) -> support::TempDbFile {
+    support::temp_db_file(label)
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {
@@ -98,13 +94,6 @@ fn selected_text(rt: &RedDBRuntime, sql: &str) -> String {
         Some(Value::Text(text)) => text.to_string(),
         other => panic!("expected text scalar, got {other:?} in record {record:?}"),
     }
-}
-
-fn cleanup_persistent_path(path: &PathBuf) {
-    let _ = std::fs::remove_file(path);
-    let l2 = path.with_extension("result-cache.l2");
-    let _ = std::fs::remove_file(&l2);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&l2));
 }
 
 fn seed_target_scan_fixture(rt: &RedDBRuntime) {
@@ -253,7 +242,6 @@ fn blob_result_cache_rehydrates_after_restart_with_tenant_and_auth_isolation() {
 
     clear_current_tenant();
     clear_current_auth_identity();
-    cleanup_persistent_path(&path);
 }
 
 #[test]
@@ -291,8 +279,6 @@ fn blob_result_cache_write_after_restart_invalidates_unrehydrated_l2_entries() {
             "the stale pre-restart result should have been invalidated before rehydrate"
         );
     }
-
-    cleanup_persistent_path(&path);
 }
 
 #[test]

--- a/tests/e2e_system_config_vault.rs
+++ b/tests/e2e_system_config_vault.rs
@@ -10,12 +10,15 @@ use reddb::{RedDBOptions, RedDBRuntime};
 
 fn runtime(name: &str) -> (support::TempDbFile, RedDBRuntime) {
     let path = support::temp_db_file(name);
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
         .expect("runtime should open");
     (path, rt)
 }
 
-fn runtime_with_vault(name: &str, passphrase: &str) -> (support::TempDbFile, RedDBRuntime, Arc<AuthStore>) {
+fn runtime_with_vault(
+    name: &str,
+    passphrase: &str,
+) -> (support::TempDbFile, RedDBRuntime, Arc<AuthStore>) {
     let (path, rt) = runtime(name);
     let pager = Arc::clone(
         rt.db()

--- a/tests/e2e_system_config_vault.rs
+++ b/tests/e2e_system_config_vault.rs
@@ -1,3 +1,6 @@
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
@@ -5,17 +8,15 @@ use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identit
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime(name: &str) -> RedDBRuntime {
-    let unique = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let path = std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"));
-    RedDBRuntime::with_options(RedDBOptions::persistent(path)).expect("runtime should open")
+fn runtime(name: &str) -> (support::TempDbFile, RedDBRuntime) {
+    let path = support::temp_db_file(name);
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        .expect("runtime should open");
+    (path, rt)
 }
 
-fn runtime_with_vault(name: &str, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
-    let rt = runtime(name);
+fn runtime_with_vault(name: &str, passphrase: &str) -> (support::TempDbFile, RedDBRuntime, Arc<AuthStore>) {
+    let (path, rt) = runtime(name);
     let pager = Arc::clone(
         rt.db()
             .store()
@@ -28,7 +29,7 @@ fn runtime_with_vault(name: &str, passphrase: &str) -> (RedDBRuntime, Arc<AuthSt
     );
     auth.ensure_vault_secret_key();
     rt.set_auth_store(Arc::clone(&auth));
-    (rt, auth)
+    (path, rt, auth)
 }
 
 fn text(row: &reddb::storage::query::unified::UnifiedRecord, name: &str) -> String {
@@ -83,7 +84,7 @@ fn attach_user_policy(auth: &AuthStore, user: &str, id: &str, statements: &str) 
 
 #[test]
 fn bootstrap_creates_protected_system_config_and_vault_collections() {
-    let rt = runtime("system_config_vault_bootstrap");
+    let (_path, rt) = runtime("system_config_vault_bootstrap");
 
     let rows = rt
         .execute_query(
@@ -105,7 +106,7 @@ fn bootstrap_creates_protected_system_config_and_vault_collections() {
 
 #[test]
 fn system_config_and_vault_reject_public_create_drop_and_truncate() {
-    let rt = runtime("system_config_vault_protection");
+    let (_path, rt) = runtime("system_config_vault_protection");
 
     for sql in [
         "CREATE CONFIG red.config",
@@ -123,7 +124,7 @@ fn system_config_and_vault_reject_public_create_drop_and_truncate() {
 
 #[test]
 fn system_config_reads_and_writes_require_normalized_system_capabilities() {
-    let rt = runtime("system_config_capabilities");
+    let (_path, rt) = runtime("system_config_capabilities");
     let auth = Arc::new(AuthStore::new(AuthConfig::default()));
     auth.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&auth));
@@ -184,7 +185,7 @@ fn system_config_reads_and_writes_require_normalized_system_capabilities() {
 
 #[test]
 fn system_vault_reads_and_writes_require_normalized_system_capabilities() {
-    let (rt, auth) = runtime_with_vault("system_vault_capabilities", "system-vault-pass");
+    let (_path, rt, auth) = runtime_with_vault("system_vault_capabilities", "system-vault-pass");
     auth.create_user("alice", "p", Role::Write).unwrap();
 
     rt.execute_query("VAULT PUT red.vault.api_key = 'first'")

--- a/tests/e2e_tier_wiring.rs
+++ b/tests/e2e_tier_wiring.rs
@@ -15,27 +15,20 @@
 //! | `fold_dwb_into_wal`        |   off   |    off   |     off     |  on  |
 //! | audit/slow log destination | stderr  |  stderr  |    file     | file |
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{
     fold_dwb_into_wal_enabled, fold_pager_meta_enabled, meta_json_sidecar_enabled,
     seqn_journal_enabled, seqn_journal_retention, shm_provisioning_enabled, tier_wiring,
     LayoutOverrides, LogDestination, RedDBOptions, RedDBRuntime, StorageLayout,
     DEFAULT_METADATA_JOURNAL_RETENTION, OPT_IN_METADATA_JOURNAL_RETENTION,
 };
-use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 /// All tests in this binary mutate process-global tier toggles. Serialise
 /// them so a parallel runner doesn't observe a half-applied tier state.
 static TIER_GUARD: Mutex<()> = Mutex::new(());
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_tier_{prefix}_{unique}.rdb"))
-}
 
 fn reset_env() {
     std::env::remove_var("REDDB_META_JSON_SIDECAR");
@@ -46,11 +39,11 @@ fn reset_env() {
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
 }
 
-fn open_at_layout(prefix: &str, layout: StorageLayout) -> (RedDBRuntime, PathBuf) {
-    let path = persistent_path(prefix);
-    let options = RedDBOptions::persistent(&path).with_layout(layout);
+fn open_at_layout(prefix: &str, layout: StorageLayout) -> (RedDBRuntime, support::TempDbFile) {
+    let guard = support::temp_db_file(prefix);
+    let options = RedDBOptions::persistent(guard.path()).with_layout(layout);
     let rt = RedDBRuntime::with_options(options).expect("runtime opens");
-    (rt, path)
+    (rt, guard)
 }
 
 #[test]
@@ -142,7 +135,7 @@ fn layout_overrides_win_over_tier_default() {
     use reddb::LogRoutingOverrides;
     let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
     reset_env();
-    let path = persistent_path("overrides");
+    let guard = support::temp_db_file("overrides");
     let override_dest = LogDestination::Syslog;
     let overrides = LayoutOverrides {
         logs: LogRoutingOverrides {
@@ -151,7 +144,7 @@ fn layout_overrides_win_over_tier_default() {
         },
         ..LayoutOverrides::default()
     };
-    let options = RedDBOptions::persistent(&path)
+    let options = RedDBOptions::persistent(guard.path())
         .with_layout(StorageLayout::Performance)
         .with_layout_overrides(overrides);
     let _rt = RedDBRuntime::with_options(options).expect("runtime opens");

--- a/tests/e2e_timeseries_session_descriptor.rs
+++ b/tests/e2e_timeseries_session_descriptor.rs
@@ -3,20 +3,14 @@
 //! and surfaces it through the catalog descriptor (and `red.collections`)
 //! across an engine restart.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::ExecuteQueryInput;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-use std::path::PathBuf;
 
-fn unique_dir(prefix: &str) -> PathBuf {
-    let pid = std::process::id();
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let mut path = std::env::temp_dir();
-    path.push(format!("reddb-{prefix}-{pid}-{nanos}"));
-    std::fs::create_dir_all(&path).unwrap();
-    path
+fn unique_dir(prefix: &str) -> support::TempDataDir {
+    support::temp_data_dir(prefix)
 }
 
 #[test]
@@ -91,8 +85,6 @@ fn session_clause_persists_across_restart() {
             other => panic!("expected integer, got {other:?}"),
         }
     }
-
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 #[test]

--- a/tests/e2e_txcommitbatch_explicit_tx.rs
+++ b/tests/e2e_txcommitbatch_explicit_tx.rs
@@ -1,5 +1,8 @@
 //! Atomic TxCommitBatch WAL recovery for explicit table transactions.
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::{Path, PathBuf};
 
 use reddb::api::DurabilityMode;
@@ -8,48 +11,16 @@ use reddb::storage::schema::Value;
 use reddb::storage::wal::{WalReader, WalRecord};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-struct DbPath {
-    path: PathBuf,
+fn db_open(db: &support::TempDbFile) -> RedDBRuntime {
+    RedDBRuntime::with_options(
+        RedDBOptions::persistent(db.path())
+            .with_durability_mode(DurabilityMode::WalDurableGrouped),
+    )
+    .expect("persistent runtime")
 }
 
-impl DbPath {
-    fn new(label: &str) -> Self {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "reddb_txcommitbatch_explicit_{label}_{}_{}.rdb",
-            std::process::id(),
-            nanos
-        ));
-        let db = Self { path };
-        db.cleanup();
-        db
-    }
-
-    fn open(&self) -> RedDBRuntime {
-        RedDBRuntime::with_options(
-            RedDBOptions::persistent(&self.path)
-                .with_durability_mode(DurabilityMode::WalDurableGrouped),
-        )
-        .expect("persistent runtime")
-    }
-
-    fn wal_path(&self) -> PathBuf {
-        self.path.with_extension("rdb-uwal")
-    }
-
-    fn cleanup(&self) {
-        let _ = std::fs::remove_file(&self.path);
-        let _ = std::fs::remove_file(self.wal_path());
-    }
-}
-
-impl Drop for DbPath {
-    fn drop(&mut self) {
-        self.cleanup();
-    }
+fn db_wal_path(db: &support::TempDbFile) -> PathBuf {
+    db.path().with_extension("rdb-uwal")
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {
@@ -110,10 +81,10 @@ fn wal_records(path: &Path) -> Vec<WalRecord> {
 
 #[test]
 fn committed_explicit_transaction_recovers_all_mutations_idempotently() {
-    let db = DbPath::new("recover");
+    let db = support::temp_db_file("txcommitbatch-explicit-recover");
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44101);
         exec(&rt, "CREATE TABLE txb_explicit (id INT, label TEXT)");
         exec(
@@ -135,7 +106,7 @@ fn committed_explicit_transaction_recovers_all_mutations_idempotently() {
     }
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44102);
         assert_eq!(
             label_for_id(&rt, "txb_explicit", 1).as_deref(),
@@ -146,7 +117,7 @@ fn committed_explicit_transaction_recovers_all_mutations_idempotently() {
     }
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44103);
         assert_eq!(
             label_for_id(&rt, "txb_explicit", 1).as_deref(),
@@ -160,11 +131,11 @@ fn committed_explicit_transaction_recovers_all_mutations_idempotently() {
 
 #[test]
 fn torn_explicit_transaction_commit_batch_recovers_no_partial_state() {
-    let db = DbPath::new("torn");
-    let stable_db_image = db.path.with_extension("stable-copy");
+    let db = support::temp_db_file("txcommitbatch-explicit-torn");
+    let stable_db_image = db.path().with_extension("stable-copy");
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44111);
         exec(&rt, "CREATE TABLE txb_explicit_torn (id INT, label TEXT)");
         exec(
@@ -172,7 +143,7 @@ fn torn_explicit_transaction_commit_batch_recovers_no_partial_state() {
             "INSERT INTO txb_explicit_torn (id, label) VALUES (1, 'base'), (2, 'delete-me')",
         );
         rt.checkpoint().expect("checkpoint stable prefix");
-        std::fs::copy(&db.path, &stable_db_image).expect("copy stable db image");
+        std::fs::copy(db.path(), &stable_db_image).expect("copy stable db image");
         exec(&rt, "BEGIN");
         exec(
             &rt,
@@ -187,12 +158,12 @@ fn torn_explicit_transaction_commit_batch_recovers_no_partial_state() {
         clear_current_connection_id();
     }
 
-    std::fs::copy(&stable_db_image, &db.path).expect("restore stable db image");
+    std::fs::copy(&stable_db_image, db.path()).expect("restore stable db image");
     let _ = std::fs::remove_file(&stable_db_image);
-    truncate_wal_tail(&db.wal_path(), 1);
+    truncate_wal_tail(&db_wal_path(&db), 1);
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44112);
         assert_eq!(
             label_for_id(&rt, "txb_explicit_torn", 1).as_deref(),
@@ -212,10 +183,10 @@ fn torn_explicit_transaction_commit_batch_recovers_no_partial_state() {
 
 #[test]
 fn explicit_transaction_writes_one_tx_commit_batch_for_staged_table_mutations() {
-    let db = DbPath::new("shape");
+    let db = support::temp_db_file("txcommitbatch-explicit-shape");
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44121);
         exec(&rt, "CREATE TABLE txb_explicit_shape (id INT, label TEXT)");
         exec(
@@ -236,7 +207,7 @@ fn explicit_transaction_writes_one_tx_commit_batch_for_staged_table_mutations() 
         clear_current_connection_id();
     }
 
-    let records = wal_records(&db.wal_path());
+    let records = wal_records(&db_wal_path(&db));
     let transaction_batches = records
         .iter()
         .filter(|record| matches!(record, WalRecord::TxCommitBatch { actions, .. } if actions.len() >= 3))

--- a/tests/e2e_txcommitbatch_explicit_tx.rs
+++ b/tests/e2e_txcommitbatch_explicit_tx.rs
@@ -13,8 +13,7 @@ use reddb::{RedDBOptions, RedDBRuntime};
 
 fn db_open(db: &support::TempDbFile) -> RedDBRuntime {
     RedDBRuntime::with_options(
-        RedDBOptions::persistent(db.path())
-            .with_durability_mode(DurabilityMode::WalDurableGrouped),
+        RedDBOptions::persistent(db.path()).with_durability_mode(DurabilityMode::WalDurableGrouped),
     )
     .expect("persistent runtime")
 }

--- a/tests/e2e_txcommitbatch_wal.rs
+++ b/tests/e2e_txcommitbatch_wal.rs
@@ -1,5 +1,8 @@
 //! Atomic TxCommitBatch WAL recovery for autocommit table mutations.
 
+#[allow(dead_code)]
+mod support;
+
 use std::path::{Path, PathBuf};
 
 use reddb::api::DurabilityMode;
@@ -8,55 +11,18 @@ use reddb::storage::schema::Value;
 use reddb::storage::wal::{WalReader, WalRecord};
 use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
-struct DbPath {
-    path: PathBuf,
+fn db_open(db: &support::TempDbFile) -> RedDBRuntime {
+    RedDBRuntime::with_options(
+        RedDBOptions::persistent(db.path())
+            .with_durability_mode(DurabilityMode::WalDurableGrouped)
+            .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+            .expect("primary-replica operational profile"),
+    )
+    .expect("persistent runtime")
 }
 
-impl DbPath {
-    fn new(label: &str) -> Self {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let path = std::env::temp_dir().join(format!(
-            "reddb_txcommitbatch_{label}_{}_{}.rdb",
-            std::process::id(),
-            nanos
-        ));
-        let db = Self { path };
-        db.cleanup();
-        db
-    }
-
-    fn open(&self) -> RedDBRuntime {
-        RedDBRuntime::with_options(
-            RedDBOptions::persistent(&self.path)
-                .with_durability_mode(DurabilityMode::WalDurableGrouped)
-                .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
-                .expect("primary-replica operational profile"),
-        )
-        .expect("persistent runtime")
-    }
-
-    fn wal_path(&self) -> PathBuf {
-        reddb_file::unified_wal_path(&self.path)
-    }
-
-    fn cleanup(&self) {
-        let _ = std::fs::remove_file(&self.path);
-        let _ = std::fs::remove_file(self.wal_path());
-        let _ = std::fs::remove_file(reddb_file::pager_dwb_path(&self.path));
-        let _ = std::fs::remove_file(reddb_file::pager_header_path(&self.path));
-        let _ = std::fs::remove_file(reddb_file::pager_meta_path(&self.path));
-        let _ = std::fs::remove_file(reddb_file::pager_legacy_wal_path(&self.path));
-        let _ = std::fs::remove_dir_all(reddb_file::support_dir_for(&self.path));
-    }
-}
-
-impl Drop for DbPath {
-    fn drop(&mut self) {
-        self.cleanup();
-    }
+fn db_wal_path(db: &support::TempDbFile) -> PathBuf {
+    reddb_file::unified_wal_path(db.path())
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {
@@ -124,10 +90,10 @@ fn truncate_wal_tail(path: &Path, bytes: u64) {
 
 #[test]
 fn autocommit_insert_update_delete_recover_from_commit_batches() {
-    let db = DbPath::new("recover");
+    let db = support::temp_db_file("txcommitbatch-wal-recover");
 
     let (keep, deleted) = {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44001);
         exec(&rt, "CREATE TABLE txb_recover (id INT, label TEXT)");
         exec(
@@ -149,7 +115,7 @@ fn autocommit_insert_update_delete_recover_from_commit_batches() {
     };
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44002);
         assert_eq!(
             label_for(&rt, "txb_recover", keep).as_deref(),
@@ -176,7 +142,7 @@ fn autocommit_insert_update_delete_recover_from_commit_batches() {
     }
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44003);
         assert_eq!(
             label_for(&rt, "txb_recover", keep).as_deref(),
@@ -189,11 +155,11 @@ fn autocommit_insert_update_delete_recover_from_commit_batches() {
 
 #[test]
 fn truncated_commit_batch_is_absent_after_recovery() {
-    let db = DbPath::new("truncated");
-    let stable_db_image = db.path.with_extension("stable-copy");
+    let db = support::temp_db_file("txcommitbatch-wal-truncated");
+    let stable_db_image = db.path().with_extension("stable-copy");
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44011);
         exec(&rt, "CREATE TABLE txb_truncated (id INT, label TEXT)");
         exec(
@@ -201,7 +167,7 @@ fn truncated_commit_batch_is_absent_after_recovery() {
             "INSERT INTO txb_truncated (id, label) VALUES (1, 'base')",
         );
         rt.checkpoint().expect("checkpoint stable prefix");
-        std::fs::copy(&db.path, &stable_db_image).expect("copy stable db image");
+        std::fs::copy(db.path(), &stable_db_image).expect("copy stable db image");
         exec(
             &rt,
             "INSERT INTO txb_truncated (id, label) VALUES (2, 'torn')",
@@ -209,12 +175,12 @@ fn truncated_commit_batch_is_absent_after_recovery() {
         clear_current_connection_id();
     }
 
-    std::fs::copy(&stable_db_image, &db.path).expect("restore stable db image");
+    std::fs::copy(&stable_db_image, db.path()).expect("restore stable db image");
     let _ = std::fs::remove_file(&stable_db_image);
-    truncate_wal_tail(&db.wal_path(), 1);
+    truncate_wal_tail(&db_wal_path(&db), 1);
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44012);
         let base = red_entity_id(&rt, "txb_truncated", 1);
         assert_eq!(
@@ -231,10 +197,10 @@ fn truncated_commit_batch_is_absent_after_recovery() {
 
 #[test]
 fn autocommit_table_mutations_write_tx_commit_batch_records() {
-    let db = DbPath::new("record-shape");
+    let db = support::temp_db_file("txcommitbatch-wal-record-shape");
 
     {
-        let rt = db.open();
+        let rt = db_open(&db);
         set_current_connection_id(44021);
         exec(&rt, "CREATE TABLE txb_shape (id INT, label TEXT)");
         exec(
@@ -254,7 +220,7 @@ fn autocommit_table_mutations_write_tx_commit_batch_records() {
         clear_current_connection_id();
     }
 
-    let reader = WalReader::open(db.wal_path()).expect("open wal");
+    let reader = WalReader::open(db_wal_path(&db)).expect("open wal");
     let records: Vec<WalRecord> = reader
         .iter()
         .map(|entry| entry.expect("valid wal record").1)

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -1,3 +1,6 @@
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role};
@@ -77,13 +80,6 @@ fn read_event_payload(rt: &RedDBRuntime, queue: &str) -> serde_json::Value {
     }
 }
 
-fn unique_db_path(prefix: &str) -> std::path::PathBuf {
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb-{prefix}-{}-{nanos}.rdb", std::process::id()))
-}
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
     set_current_auth_identity(name.to_string(), role);
@@ -342,9 +338,7 @@ fn explicit_updates_recheck_changed_indexed_fields() {
 
 #[test]
 fn explicit_multimodel_compound_updates_survive_reopen_as_post_images() {
-    let path = unique_db_path("update-conformance-recovery");
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(path.with_extension("rdb-uwal"));
+    let path = support::temp_db_file("update-conformance-recovery");
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
             .expect("persistent runtime");
@@ -385,6 +379,4 @@ fn explicit_multimodel_compound_updates_survive_reopen_as_post_images() {
     assert_eq!(int_field(only_record(&kv), "value"), 17);
     let node = exec(&rt, "SELECT score FROM recovery_graph WHERE label = 'node'");
     assert_eq!(int_field(only_record(&node), "score"), 12);
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(path.with_extension("rdb-uwal"));
 }

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -80,7 +80,6 @@ fn read_event_payload(rt: &RedDBRuntime, queue: &str) -> serde_json::Value {
     }
 }
 
-
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
     set_current_auth_identity(name.to_string(), role);
     let out = f();

--- a/tests/e2e_vault_sealed_storage.rs
+++ b/tests/e2e_vault_sealed_storage.rs
@@ -1,6 +1,8 @@
-use std::path::{Path, PathBuf};
+#[allow(dead_code)]
+mod support;
+
+use std::path::Path;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
 use reddb::runtime::control_events::CONTROL_EVENTS_COLLECTION;
@@ -8,35 +10,6 @@ use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identit
 use reddb::storage::schema::Value;
 use reddb::storage::EntityData;
 use reddb::{RedDBOptions, RedDBRuntime};
-
-fn temp_db_path(name: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{name}_{unique}.rdb"))
-}
-
-fn cleanup_related(path: &Path) {
-    let Some(parent) = path.parent() else {
-        return;
-    };
-    let Some(stem) = path.file_name().and_then(|name| name.to_str()) else {
-        return;
-    };
-    if let Ok(entries) = std::fs::read_dir(parent) {
-        for entry in entries.flatten() {
-            let entry_path = entry.path();
-            let Some(name) = entry_path.file_name().and_then(|name| name.to_str()) else {
-                continue;
-            };
-            if name == stem || name.starts_with(&format!("{stem}-")) {
-                let _ = std::fs::remove_file(&entry_path);
-                let _ = std::fs::remove_dir_all(&entry_path);
-            }
-        }
-    }
-}
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
     let rt =
@@ -152,12 +125,12 @@ fn named_text(row: &std::collections::HashMap<String, Value>, name: &str) -> Str
 
 #[test]
 fn vault_put_seals_payload_before_persistence() {
-    let path = temp_db_path("vault_sealed_storage");
-    cleanup_related(&path);
+    let guard = support::temp_db_file("vault-sealed-storage");
+    let path = guard.path();
 
     let secret = "vault_plaintext_probe_324";
     {
-        let (rt, auth) = open_runtime_with_vault(&path, "vault-pass");
+        let (rt, auth) = open_runtime_with_vault(path, "vault-pass");
         rt.execute_query("CREATE VAULT secrets WITH OWN MASTER KEY")
             .expect("create vault");
         assert!(
@@ -213,7 +186,7 @@ fn vault_put_seals_payload_before_persistence() {
             .expect("checkpoint should flush sealed payload");
     }
 
-    let persisted = read_related_bytes(&path);
+    let persisted = read_related_bytes(path);
     assert!(
         !persisted
             .windows(secret.len())
@@ -222,7 +195,7 @@ fn vault_put_seals_payload_before_persistence() {
     );
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
             .expect("runtime should reopen without key provider");
         let get = rt
             .execute_query("VAULT GET secrets.api_key")
@@ -236,16 +209,16 @@ fn vault_put_seals_payload_before_persistence() {
         assert!(matches!(record.get("fingerprint"), Some(Value::Text(_))));
     }
 
-    cleanup_related(&path);
+    drop(guard);
 }
 
 #[test]
 fn vault_metadata_and_unseal_control_events_minimize_evidence() {
-    let path = temp_db_path("vault_control_events_unseal_653");
-    cleanup_related(&path);
+    let guard = support::temp_db_file("vault-control-events-unseal-653");
+    let path = guard.path();
 
     let secret = "tok_live_653_probe BEGIN_PRIVATE_KEY_653 BEGIN_CERTIFICATE_653";
-    let (rt, auth) = open_runtime_with_vault(&path, "vault-pass-653");
+    let (rt, auth) = open_runtime_with_vault(path, "vault-pass-653");
     auth.create_user("alice", "p", Role::Write).unwrap();
     rt.execute_query("CREATE VAULT secrets WITH OWN MASTER KEY")
         .expect("create vault");
@@ -352,17 +325,17 @@ fn vault_metadata_and_unseal_control_events_minimize_evidence() {
         );
     }
 
-    cleanup_related(&path);
+    drop(guard);
 }
 
 #[test]
 fn vault_rotation_and_purge_control_events_minimize_evidence() {
-    let path = temp_db_path("vault_control_events_lifecycle_653");
-    cleanup_related(&path);
+    let guard = support::temp_db_file("vault-control-events-lifecycle-653");
+    let path = guard.path();
 
     let secret_v1 = "rotate_tok_live_653 BEGIN_PRIVATE_KEY_ROTATE_653";
     let secret_v2 = "purge_certificate_probe_653 BEGIN_CERTIFICATE_PURGE_653";
-    let (rt, auth) = open_runtime_with_vault(&path, "vault-pass-lifecycle-653");
+    let (rt, auth) = open_runtime_with_vault(path, "vault-pass-lifecycle-653");
     auth.create_user("alice", "p", Role::Write).unwrap();
 
     rt.execute_query("CREATE VAULT secrets WITH OWN MASTER KEY")
@@ -431,20 +404,20 @@ fn vault_rotation_and_purge_control_events_minimize_evidence() {
         );
     }
 
-    cleanup_related(&path);
+    drop(guard);
 }
 
 #[test]
 fn vault_get_is_metadata_only_and_unseal_is_capability_gated_and_audited() {
-    let path = temp_db_path("vault_unseal_audit");
-    cleanup_related(&path);
+    let guard = support::temp_db_file("vault-unseal-audit");
+    let path = guard.path();
 
     let secret = "vault_plaintext_probe_330";
     let ciphertext_hex;
     let rt;
     let auth;
     {
-        let opened = open_runtime_with_vault(&path, "vault-pass-330");
+        let opened = open_runtime_with_vault(path, "vault-pass-330");
         rt = opened.0;
         auth = opened.1;
     }
@@ -545,17 +518,17 @@ fn vault_get_is_metadata_only_and_unseal_is_capability_gated_and_audited() {
         "audit must not include ciphertext: {audit_body}"
     );
 
-    cleanup_related(&path);
+    drop(guard);
 }
 
 #[test]
 fn vault_lifecycle_versions_history_purge_and_historical_unseal_are_audited() {
-    let path = temp_db_path("vault_lifecycle_325");
-    cleanup_related(&path);
+    let guard = support::temp_db_file("vault-lifecycle-325");
+    let path = guard.path();
 
     let secret_v1 = "vault_plaintext_probe_325_v1";
     let secret_v2 = "vault_plaintext_probe_325_v2";
-    let (rt, auth) = open_runtime_with_vault(&path, "vault-pass-325");
+    let (rt, auth) = open_runtime_with_vault(path, "vault-pass-325");
     auth.create_user("alice", "p", Role::Write).unwrap();
 
     rt.execute_query("CREATE VAULT secrets WITH OWN MASTER KEY")
@@ -684,20 +657,19 @@ fn vault_lifecycle_versions_history_purge_and_historical_unseal_are_audited() {
     assert!(!audit_body.contains(secret_v1));
     assert!(!audit_body.contains(secret_v2));
 
-    cleanup_related(&path);
+    drop(guard);
 }
 
 #[test]
 fn create_vault_requires_unsealed_key_provider() {
-    let path = temp_db_path("vault_create_requires_key");
-    cleanup_related(&path);
-    let rt =
-        RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime should open");
+    let guard = support::temp_db_file("vault-create-requires-key");
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(guard.path()))
+        .expect("runtime should open");
 
     let err = rt
         .execute_query("CREATE VAULT secrets")
         .expect_err("CREATE VAULT must not simulate key material");
     assert!(err.to_string().contains("enabled, unsealed vault"));
 
-    cleanup_related(&path);
+    drop(guard);
 }

--- a/tests/fold_dwb_into_wal_bench.rs
+++ b/tests/fold_dwb_into_wal_bench.rs
@@ -18,34 +18,17 @@
 //! relative ratio is still printed deterministically for the iter 2
 //! acceptance note.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::{set_fold_dwb_into_wal_enabled, RedDBOptions, RedDBRuntime};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Mutex;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 
 static POLICY_GUARD: Mutex<()> = Mutex::new(());
 
 const TX_COUNT: usize = 200;
-
-fn persistent_path(prefix: &str) -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"))
-}
-
-fn cleanup(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    for suffix in ["-dwb", "-hdr", "-meta"] {
-        let mut p = path.to_path_buf().into_os_string();
-        p.push(suffix);
-        let _ = std::fs::remove_file(PathBuf::from(p));
-    }
-    let mut wal = path.to_path_buf();
-    wal.set_extension("wal");
-    let _ = std::fs::remove_file(&wal);
-}
 
 fn run_workload(path: &Path) -> std::time::Duration {
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
@@ -86,17 +69,15 @@ fn fold_dwb_into_wal_oltp_overhead_under_20pct() {
 
     // Baseline: DWB OFF (legacy sidecar fsync path).
     set_fold_dwb_into_wal_enabled(false);
-    let off_path = persistent_path("bench_off");
-    cleanup(&off_path);
-    let off = run_workload(&off_path);
-    cleanup(&off_path);
+    let off_db = support::temp_db_file("bench_off");
+    let off = run_workload(off_db.path());
+    drop(off_db);
 
     // Treatment: DWB folded into WAL.
     set_fold_dwb_into_wal_enabled(true);
-    let on_path = persistent_path("bench_on");
-    cleanup(&on_path);
-    let on = run_workload(&on_path);
-    cleanup(&on_path);
+    let on_db = support::temp_db_file("bench_on");
+    let on = run_workload(on_db.path());
+    drop(on_db);
 
     set_fold_dwb_into_wal_enabled(false);
 

--- a/tests/http_batch_insert.rs
+++ b/tests/http_batch_insert.rs
@@ -7,6 +7,9 @@
 //!   re-executing,
 //! * oversize batches reject with 413 before any storage write.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
@@ -15,25 +18,16 @@ use std::time::Duration;
 use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn isolated_runtime(tag: &str) -> RedDBRuntime {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-batch-http-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn isolated_runtime(tag: &str) -> (support::TempDataDir, RedDBRuntime) {
+    let dir = support::temp_data_dir(&format!("batch-http-{tag}"));
     let opts = RedDBOptions::in_memory().with_data_path(dir.join("data.rdb"));
-    RedDBRuntime::with_options(opts).expect("runtime")
+    let rt = RedDBRuntime::with_options(opts).expect("runtime");
+    (dir, rt)
 }
 
-fn spawn_server(tag: &str) -> String {
+fn spawn_server(tag: &str) -> (support::TempDataDir, String) {
     std::env::remove_var("RED_ADMIN_TOKEN");
-    let rt = isolated_runtime(tag);
+    let (dir, rt) = isolated_runtime(tag);
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap();
@@ -48,7 +42,7 @@ fn spawn_server(tag: &str) -> String {
     let ddl = r#"{"query": "CREATE TABLE events (id INTEGER, name TEXT)"}"#;
     let (status, body) = http_post(&addr, "/query", ddl, None);
     assert_eq!(status, 200, "ddl failed: {body}");
-    addr
+    (dir, addr)
 }
 
 fn http_post(addr: &str, path: &str, body: &str, idempotency_key: Option<&str>) -> (u16, String) {
@@ -101,7 +95,7 @@ fn http_get(addr: &str, path: &str) -> (u16, String) {
 
 #[test]
 fn batch_happy_path_commits_every_row() {
-    let addr = spawn_server("happy");
+    let (_dir, addr) = spawn_server("happy");
     let body = r#"[
         {"fields": {"id": 1, "name": "alpha"}},
         {"fields": {"id": 2, "name": "beta"}},
@@ -120,7 +114,7 @@ fn batch_happy_path_commits_every_row() {
 
 #[test]
 fn batch_idempotency_key_replay_does_not_re_execute() {
-    let addr = spawn_server("idem");
+    let (_dir, addr) = spawn_server("idem");
     let body1 = r#"[{"fields": {"id": 10, "name": "only-once"}}]"#;
     let (s1, r1) = http_post(&addr, "/collections/events/batch", body1, Some("k-abc"));
     assert_eq!(s1, 200, "{r1}");
@@ -142,7 +136,7 @@ fn batch_idempotency_key_replay_does_not_re_execute() {
 
 #[test]
 fn batch_row_failure_rolls_back_whole_batch() {
-    let addr = spawn_server("rollback");
+    let (_dir, addr) = spawn_server("rollback");
     // Row index 1 is shaped wrong on purpose — the batch must reject
     // with a typed error and leave storage empty.
     let body = r#"[

--- a/tests/http_tls_limiter.rs
+++ b/tests/http_tls_limiter.rs
@@ -11,6 +11,9 @@
 //!     exceeding `handler_timeout` yields a 503 emitted over the TLS
 //!     stream; the permit drops; a follow-up TLS request succeeds.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
@@ -22,19 +25,6 @@ use reddb::server::tls::{build_server_config, HttpTlsConfig};
 use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 use rustls::pki_types::{CertificateDer, ServerName};
-
-fn tmpdir(label: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-http-tls-limiter-test-{label}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
-}
 
 fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
     use rcgen::{CertificateParams, KeyPair};
@@ -57,8 +47,8 @@ fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
     (cert_path, key_path, cert_der)
 }
 
-fn build_tls_config(label: &str) -> (Arc<rustls::ServerConfig>, Vec<u8>) {
-    let dir = tmpdir(label);
+fn build_tls_config(label: &str) -> (support::TempDataDir, Arc<rustls::ServerConfig>, Vec<u8>) {
+    let dir = support::temp_data_dir(&format!("http-tls-limiter-{label}"));
     let (cert_path, key_path, der) = write_self_signed(&dir);
     let cfg = HttpTlsConfig {
         cert_path,
@@ -66,7 +56,7 @@ fn build_tls_config(label: &str) -> (Arc<rustls::ServerConfig>, Vec<u8>) {
         client_ca_path: None,
     };
     let server_config = build_server_config(&cfg).expect("server config builds");
-    (server_config, der)
+    (dir, server_config, der)
 }
 
 fn client_config_trusting(cert_der: &[u8]) -> Arc<rustls::ClientConfig> {
@@ -146,7 +136,7 @@ fn tls_get_health(addr: &str, client_cfg: Arc<rustls::ClientConfig>) -> String {
 #[test]
 fn tls_rejection_when_clear_text_saturates_then_recovers() {
     let cap = 2;
-    let (tls_cfg, cert_der) = build_tls_config("cross");
+    let (_dir, tls_cfg, cert_der) = build_tls_config("cross");
 
     // Boot a single RedDBServer with one shared limiter, then bind two
     // listeners on it: clear-text and TLS.
@@ -231,7 +221,7 @@ fn tls_handler_deadline_emits_503_then_recovers() {
     let inject_ms: u64 = 500;
     let slack = Duration::from_millis(2_000);
 
-    let (tls_cfg, cert_der) = build_tls_config("deadline");
+    let (_dir, tls_cfg, cert_der) = build_tls_config("deadline");
     let opts = RedDBOptions::in_memory();
     let runtime = RedDBRuntime::with_options(opts).expect("runtime");
     let server = RedDBServer::new(runtime).with_handler_timeout(handler_timeout);
@@ -298,7 +288,7 @@ fn tls_handler_deadline_emits_503_then_recovers() {
 #[test]
 fn mixed_http_https_saturation_rejects_both_transports_then_recovers() {
     let cap = 2;
-    let (tls_cfg, cert_der) = build_tls_config("mixed");
+    let (_dir, tls_cfg, cert_der) = build_tls_config("mixed");
 
     let opts = RedDBOptions::in_memory();
     let runtime = RedDBRuntime::with_options(opts).expect("runtime");

--- a/tests/http_tls_smoke.rs
+++ b/tests/http_tls_smoke.rs
@@ -7,6 +7,9 @@
 //!   * A rustls client completes the handshake and reads `/health`.
 //!   * Authorization: Bearer survives the TLS wrap and reaches handlers.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::path::PathBuf;
@@ -18,19 +21,6 @@ use reddb::server::tls::{build_server_config, HttpTlsConfig};
 use reddb::server::RedDBServer;
 use reddb::RedDBRuntime;
 use rustls::pki_types::{CertificateDer, ServerName};
-
-fn tmpdir(label: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-http-tls-test-{label}-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir
-}
 
 /// Generate a fresh self-signed cert + key pair using rcgen.
 fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
@@ -54,8 +44,8 @@ fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
     (cert_path, key_path, cert_der)
 }
 
-fn spawn_https_server(rt: RedDBRuntime, cert_der: Vec<u8>) -> (String, Vec<u8>) {
-    let dir = tmpdir("server");
+fn spawn_https_server(rt: RedDBRuntime, cert_der: Vec<u8>) -> (support::TempDataDir, String, Vec<u8>) {
+    let dir = support::temp_data_dir("http-tls-smoke-server");
     let (cert_path, key_path, der) = write_self_signed(&dir);
     let _ = cert_der; // shadow path: caller passes empty; we use generated
     let cfg = HttpTlsConfig {
@@ -76,7 +66,7 @@ fn spawn_https_server(rt: RedDBRuntime, cert_der: Vec<u8>) -> (String, Vec<u8>) 
 
     // Give the listener a moment.
     thread::sleep(Duration::from_millis(100));
-    (format!("{}", addr), der)
+    (dir, format!("{}", addr), der)
 }
 
 fn rustls_client_get(
@@ -120,7 +110,7 @@ fn rustls_client_get(
 #[test]
 fn https_handshake_and_health_probe() {
     let rt = RedDBRuntime::in_memory().expect("runtime");
-    let (addr, server_cert_der) = spawn_https_server(rt, vec![]);
+    let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     // /health/live is the universal "process is running" probe — never
     // gated by readiness or auth. Confirms the TLS handshake + HTTP
@@ -137,7 +127,7 @@ fn https_handshake_and_health_probe() {
 #[test]
 fn https_admin_token_over_tls() {
     let rt = RedDBRuntime::in_memory().expect("runtime");
-    let (addr, server_cert_der) = spawn_https_server(rt, vec![]);
+    let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     // Inject an admin token; expect non-bearer hits to 401, correct
     // bearer to 200 on /admin/status (always-routed admin endpoint).
@@ -165,7 +155,7 @@ fn https_admin_token_over_tls() {
 #[test]
 fn https_alpn_advertises_http11() {
     let rt = RedDBRuntime::in_memory().expect("runtime");
-    let (addr, server_cert_der) = spawn_https_server(rt, vec![]);
+    let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     let _ = rustls::crypto::ring::default_provider().install_default();
     let mut roots = rustls::RootCertStore::empty();
@@ -203,12 +193,12 @@ fn https_refuses_with_unknown_root() {
     // Client trusts a different cert: handshake must fail. Confirms we
     // are NOT serving plaintext on the TLS port.
     let rt = RedDBRuntime::in_memory().expect("runtime");
-    let (addr, _server_cert_der) = spawn_https_server(rt, vec![]);
+    let (_dir, addr, _server_cert_der) = spawn_https_server(rt, vec![]);
 
     let _ = rustls::crypto::ring::default_provider().install_default();
     // Use an unrelated freshly-generated cert as the client's only trust anchor.
-    let dir = tmpdir("rogue");
-    let (_cp, _kp, rogue_der) = write_self_signed(&dir);
+    let rogue_dir = support::temp_data_dir("http-tls-smoke-rogue");
+    let (_cp, _kp, rogue_der) = write_self_signed(&rogue_dir);
 
     let mut roots = rustls::RootCertStore::empty();
     roots.add(CertificateDer::from(rogue_der)).unwrap();

--- a/tests/http_tls_smoke.rs
+++ b/tests/http_tls_smoke.rs
@@ -44,7 +44,10 @@ fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
     (cert_path, key_path, cert_der)
 }
 
-fn spawn_https_server(rt: RedDBRuntime, cert_der: Vec<u8>) -> (support::TempDataDir, String, Vec<u8>) {
+fn spawn_https_server(
+    rt: RedDBRuntime,
+    cert_der: Vec<u8>,
+) -> (support::TempDataDir, String, Vec<u8>) {
     let dir = support::temp_data_dir("http-tls-smoke-server");
     let (cert_path, key_path, der) = write_self_signed(&dir);
     let _ = cert_der; // shadow path: caller passes empty; we use generated

--- a/tests/iam_policy_ai_provider_gate.rs
+++ b/tests/iam_policy_ai_provider_gate.rs
@@ -18,6 +18,9 @@
 //! * No `ai.credential.resolve` audit event fires when the planner
 //!   denied the query.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
@@ -26,16 +29,8 @@ use reddb::runtime::mvcc::{
 };
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-ai-provider-gate-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (support::TempDataDir, RedDBRuntime, Arc<AuthStore>) {
+    let dir = support::temp_data_dir("ai-provider-gate");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -45,7 +40,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("alice", "p", Role::Admin).unwrap();
     store.create_user("bob", "p", Role::Admin).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (dir, rt, store)
 }
 
 fn attach_user_policy(store: &AuthStore, user: &str, policy_json: &str) {
@@ -80,7 +75,7 @@ fn gate_error_msg(principal: &str, token: &str) -> String {
 
 #[test]
 fn ask_using_denied_provider_fails_at_planner() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     attach_user_policy(
         &store,
         "alice",
@@ -104,7 +99,7 @@ fn ask_using_denied_provider_fails_at_planner() {
 
 #[test]
 fn ask_using_allowed_provider_passes_the_gate() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     attach_user_policy(
         &store,
         "alice",
@@ -131,7 +126,7 @@ fn ask_using_allowed_provider_passes_the_gate() {
 
 #[test]
 fn ask_back_compat_no_policy_attached_passes_the_gate() {
-    let (rt, _store) = runtime_with_auth();
+    let (_dir, rt, _store) = runtime_with_auth();
     // bob has no `ai:provider:*` policy attached — default-allow.
     let err = err_text(as_user("bob", Role::Admin, || {
         rt.execute_query("ASK 'hello' USING openai")
@@ -144,7 +139,7 @@ fn ask_back_compat_no_policy_attached_passes_the_gate() {
 
 #[test]
 fn ask_gate_records_planner_audit_event_on_deny() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     attach_user_policy(
         &store,
         "alice",
@@ -183,7 +178,7 @@ fn ask_gate_records_planner_audit_event_on_deny() {
 
 #[test]
 fn insert_auto_embed_using_denied_provider_fails_at_planner() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE notes (id INT, body TEXT)")
         .unwrap();
     attach_user_policy(
@@ -213,7 +208,7 @@ fn insert_auto_embed_using_denied_provider_fails_at_planner() {
 
 #[test]
 fn insert_auto_embed_using_allowed_provider_passes_the_gate() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE notes (id INT, body TEXT)")
         .unwrap();
     attach_user_policy(
@@ -245,7 +240,7 @@ fn insert_auto_embed_using_allowed_provider_passes_the_gate() {
 
 #[test]
 fn search_similar_using_denied_provider_fails_at_planner() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE notes (id INT, body TEXT)")
         .unwrap();
     attach_user_policy(
@@ -273,7 +268,7 @@ fn search_similar_using_denied_provider_fails_at_planner() {
 
 #[test]
 fn wildcard_ai_provider_deny_blocks_all_providers() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     attach_user_policy(
         &store,
         "alice",

--- a/tests/iam_policy_http.rs
+++ b/tests/iam_policy_http.rs
@@ -5,6 +5,9 @@
 //! simulator) over plain HTTP. The admin token gate is left unset so
 //! the assertions exercise pure routing + handler behaviour.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -15,25 +18,16 @@ use reddb::auth::{AuthConfig, AuthStore};
 use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn isolated_runtime(tag: &str) -> RedDBRuntime {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-iam-http-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn isolated_runtime(tag: &str) -> (support::TempDataDir, RedDBRuntime) {
+    let dir = support::temp_data_dir(&format!("iam-http-{tag}"));
     let opts = RedDBOptions::in_memory().with_data_path(dir.join("data.rdb"));
-    RedDBRuntime::with_options(opts).expect("runtime")
+    let rt = RedDBRuntime::with_options(opts).expect("runtime");
+    (dir, rt)
 }
 
-fn spawn_server() -> String {
+fn spawn_server() -> (support::TempDataDir, String) {
     std::env::remove_var("RED_ADMIN_TOKEN");
-    let rt = isolated_runtime("base");
+    let (dir, rt) = isolated_runtime("base");
     let store = Arc::new(AuthStore::new(AuthConfig {
         enabled: false,
         ..AuthConfig::default()
@@ -48,7 +42,7 @@ fn spawn_server() -> String {
         let _ = server.serve_on(listener);
     });
     thread::sleep(Duration::from_millis(80));
-    addr.to_string()
+    (dir, addr.to_string())
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<&str>) -> (u16, String) {
@@ -82,7 +76,7 @@ fn http_request(addr: &str, method: &str, path: &str, body: Option<&str>) -> (u1
 
 #[test]
 fn list_policy_actions_returns_catalog() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let (status, body) = http_request(&addr, "GET", "/admin/policies/actions", None);
     assert_eq!(status, 200, "body={body}");
     // Every catalog entry surfaces with its six columns.
@@ -112,7 +106,7 @@ fn list_policy_actions_returns_catalog() {
 
 #[test]
 fn lint_policy_returns_diagnostics() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     // Clean policy — empty diagnostics array.
     let clean = r#"{"id":"p1","version":1,"statements":[
         {"effect":"allow","actions":["select"],"resources":["table:public.orders"]}
@@ -157,21 +151,21 @@ fn lint_policy_returns_diagnostics() {
 
 #[test]
 fn lint_policy_rejects_non_post() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let (status, _) = http_request(&addr, "GET", "/admin/policies/lint", None);
     assert_eq!(status, 405);
 }
 
 #[test]
 fn list_policy_actions_rejects_non_get() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let (status, _) = http_request(&addr, "POST", "/admin/policies/actions", Some("{}"));
     assert_eq!(status, 405);
 }
 
 #[test]
 fn put_get_delete_policy_roundtrip() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let body = r#"{"id":"p1","version":1,"statements":[{"effect":"allow","actions":["select"],"resources":["table:public.orders"]}]}"#;
 
     // PUT (create)
@@ -199,7 +193,7 @@ fn put_get_delete_policy_roundtrip() {
 
 #[test]
 fn attach_then_detach_user() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let body = r#"{"id":"p1","version":1,"statements":[{"effect":"allow","actions":["select"],"resources":["table:public.orders"]}]}"#;
 
     let (s1, _) = http_request(&addr, "PUT", "/admin/policies/p1", Some(body));
@@ -223,7 +217,7 @@ fn attach_then_detach_user() {
 
 #[test]
 fn group_membership_makes_group_policy_effective() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let body = r#"{"id":"p1","version":1,"statements":[{"effect":"allow","actions":["select"],"resources":["table:public.orders"]}]}"#;
 
     let (s1, _) = http_request(&addr, "PUT", "/admin/policies/p1", Some(body));
@@ -259,7 +253,7 @@ fn group_membership_makes_group_policy_effective() {
 
 #[test]
 fn simulate_returns_decision_envelope() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let body = r#"{"id":"p1","version":1,"statements":[{"effect":"allow","actions":["select"],"resources":["table:public.orders"],"condition":{"source_ip":["10.0.0.5"]}}]}"#;
 
     let _ = http_request(&addr, "PUT", "/admin/policies/p1", Some(body));
@@ -283,7 +277,7 @@ fn simulate_returns_decision_envelope() {
 
 #[test]
 fn simulate_default_deny_when_no_attachments() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let sim_body =
         r#"{"principal":"bob","action":"select","resource":{"kind":"table","name":"public.x"}}"#;
     let (status, body_text) =
@@ -301,7 +295,7 @@ fn migrate_policy_mode_dry_run_returns_delta() {
     // legacy_rbac access to writes; under `policy_only` they would
     // lose everything. DRY RUN must return that delta in the body
     // without mutating the live enforcement mode.
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     // Pre-seed a table so the catalog snapshot has a concrete
     // resource to probe.
     let (status, _) = http_request(
@@ -336,7 +330,7 @@ fn migrate_policy_mode_dry_run_returns_delta() {
 
 #[test]
 fn migrate_policy_mode_refuses_with_delta() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let (status, _) = http_request(
         &addr,
         "POST",
@@ -357,7 +351,7 @@ fn migrate_policy_mode_refuses_with_delta() {
 
 #[test]
 fn migrate_policy_mode_rejects_non_policy_only_target() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let body = r#"{"target":"legacy_rbac","dry_run":true}"#;
     let (status, body_text) =
         http_request(&addr, "POST", "/admin/policies/migrate-mode", Some(body));
@@ -366,7 +360,7 @@ fn migrate_policy_mode_rejects_non_policy_only_target() {
 
 #[test]
 fn migrate_policy_mode_rejects_non_post() {
-    let addr = spawn_server();
+    let (_dir, addr) = spawn_server();
     let (status, _) = http_request(&addr, "GET", "/admin/policies/migrate-mode", None);
     assert_eq!(status, 405);
 }

--- a/tests/iam_policy_http_collections.rs
+++ b/tests/iam_policy_http_collections.rs
@@ -15,6 +15,9 @@
 //!  - When IAM is inactive (no policies installed), the gate is a
 //!    no-op and existing clients keep their current behavior.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -28,30 +31,22 @@ use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 struct Harness {
+    _dir: support::TempDataDir,
     addr: String,
     token: String,
     store: Arc<AuthStore>,
 }
 
-fn isolated_runtime(tag: &str) -> RedDBRuntime {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-iam-coll-http-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn isolated_runtime(tag: &str) -> (support::TempDataDir, RedDBRuntime) {
+    let dir = support::temp_data_dir(&format!("iam-coll-http-{tag}"));
     let opts = RedDBOptions::in_memory().with_data_path(dir.join("data.rdb"));
-    RedDBRuntime::with_options(opts).expect("runtime")
+    let rt = RedDBRuntime::with_options(opts).expect("runtime");
+    (dir, rt)
 }
 
 fn spawn(tag: &str) -> Harness {
     std::env::remove_var("RED_ADMIN_TOKEN");
-    let rt = isolated_runtime(tag);
+    let (dir, rt) = isolated_runtime(tag);
     let store = Arc::new(AuthStore::new(AuthConfig {
         enabled: true,
         require_auth: true,
@@ -68,6 +63,7 @@ fn spawn(tag: &str) -> Harness {
     });
     thread::sleep(Duration::from_millis(80));
     Harness {
+        _dir: dir,
         addr: addr.to_string(),
         token: key.key,
         store,

--- a/tests/iam_policy_http_ops.rs
+++ b/tests/iam_policy_http_ops.rs
@@ -18,6 +18,9 @@
 //! * When IAM is inactive (no policies installed), the gate is a
 //!   no-op and dashboards keep their current behavior.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -32,25 +35,17 @@ use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 struct Harness {
+    _dir: support::TempDataDir,
     addr: String,
     token: String,
     store: Arc<AuthStore>,
 }
 
-fn isolated_runtime(tag: &str) -> RedDBRuntime {
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "reddb-iam-ops-http-{}-{}-{}",
-        tag,
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn isolated_runtime(tag: &str) -> (support::TempDataDir, RedDBRuntime) {
+    let dir = support::temp_data_dir(&format!("iam-ops-http-{tag}"));
     let opts = RedDBOptions::in_memory().with_data_path(dir.join("data.rdb"));
-    RedDBRuntime::with_options(opts).expect("runtime")
+    let rt = RedDBRuntime::with_options(opts).expect("runtime");
+    (dir, rt)
 }
 
 fn spawn(tag: &str) -> Harness {
@@ -58,7 +53,7 @@ fn spawn(tag: &str) -> Harness {
     // make sure it's unset for these tests — we exercise the
     // application-auth path that Red UI uses.
     std::env::remove_var("RED_ADMIN_TOKEN");
-    let rt = isolated_runtime(tag);
+    let (dir, rt) = isolated_runtime(tag);
     let store = Arc::new(AuthStore::new(AuthConfig {
         enabled: true,
         require_auth: true,
@@ -75,6 +70,7 @@ fn spawn(tag: &str) -> Harness {
     });
     thread::sleep(Duration::from_millis(80));
     Harness {
+        _dir: dir,
         addr: addr.to_string(),
         token: key.key,
         store,

--- a/tests/iam_policy_migrate_mode.rs
+++ b/tests/iam_policy_migrate_mode.rs
@@ -3,6 +3,9 @@
 //! shape, the DRY RUN no-op, the refusal path, and the actual mode
 //! flip when the delta is empty.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 
 use reddb::auth::enforcement_mode::PolicyEnforcementMode;
@@ -10,16 +13,8 @@ use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-iam-migrate-mode-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
+fn runtime_with_auth() -> (support::TempDataDir, RedDBRuntime, Arc<AuthStore>) {
+    let dir = support::temp_data_dir("iam-migrate-mode");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -29,7 +24,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (dir, rt, store)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -46,7 +41,7 @@ fn seed_orders(rt: &RedDBRuntime) {
 
 #[test]
 fn dry_run_returns_delta_without_changing_mode() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_orders(&rt);
     let result = as_user("admin", Role::Admin, || {
         rt.execute_query("MIGRATE POLICY MODE TO 'policy_only' DRY RUN")
@@ -75,7 +70,7 @@ fn dry_run_returns_delta_without_changing_mode() {
 
 #[test]
 fn non_dry_run_refuses_with_delta() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_orders(&rt);
     let result = as_user("admin", Role::Admin, || {
         rt.execute_query("MIGRATE POLICY MODE TO 'policy_only'")
@@ -92,7 +87,7 @@ fn non_dry_run_refuses_with_delta() {
 
 #[test]
 fn non_dry_run_succeeds_when_delta_empty() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     // Attach an allow-all policy to alice so her delta is empty.
     let policy = reddb::auth::policies::Policy::from_json_str(
         r#"{"id":"p-alice-all","version":1,
@@ -134,7 +129,7 @@ fn non_dry_run_succeeds_when_delta_empty() {
 
 #[test]
 fn invalid_target_is_rejected() {
-    let (rt, _store) = runtime_with_auth();
+    let (_dir, rt, _store) = runtime_with_auth();
     let err = as_user("admin", Role::Admin, || {
         rt.execute_query("MIGRATE POLICY MODE TO 'banana' DRY RUN")
     })
@@ -151,7 +146,7 @@ fn legacy_rbac_as_target_is_rejected() {
     // Only `policy_only` is a valid destination — migrating back to
     // legacy_rbac is supported via direct config writes, not this
     // command.
-    let (rt, _store) = runtime_with_auth();
+    let (_dir, rt, _store) = runtime_with_auth();
     let err = as_user("admin", Role::Admin, || {
         rt.execute_query("MIGRATE POLICY MODE TO 'legacy_rbac' DRY RUN")
     })

--- a/tests/iam_policy_runtime.rs
+++ b/tests/iam_policy_runtime.rs
@@ -4,6 +4,9 @@
 //! executor actually consults IAM policies instead of only the legacy
 //! GRANT table.
 
+#[allow(dead_code)]
+mod support;
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,16 +17,8 @@ use reddb::runtime::mvcc::{
 };
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
-    let now_nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb-iam-policy-runtime-{}-{now_nanos}",
-        std::process::id()
-    ));
-    std::fs::create_dir_all(&dir).expect("tempdir");
+fn runtime_with_auth() -> (support::TempDataDir, RedDBRuntime, Arc<AuthStore>) {
+    let dir = support::temp_data_dir("iam-policy-runtime");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dir.join("data.rdb")))
         .expect("runtime");
     let store = Arc::new(AuthStore::new(AuthConfig::default()));
@@ -37,7 +32,7 @@ fn runtime_with_auth() -> (RedDBRuntime, Arc<AuthStore>) {
     store.create_user("admin", "p", Role::Admin).unwrap();
     store.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&store));
-    (rt, store)
+    (dir, rt, store)
 }
 
 fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
@@ -147,7 +142,7 @@ fn admin_explicit_deny_matches_between_simulator_and_sql_path() {
     // be denied by an explicit Deny. The policy simulator and the runtime
     // SQL projection gate must report the same decision for the
     // allow-all-plus-deny shape.
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_users_table(&rt);
     attach_policy(
         &store,
@@ -203,7 +198,7 @@ fn admin_explicit_deny_matches_between_simulator_and_sql_path() {
 
 #[test]
 fn select_column_policy_allows_safe_projection() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_users_table(&rt);
     attach_alice_policy(
         &store,
@@ -224,7 +219,7 @@ fn select_column_policy_allows_safe_projection() {
 
 #[test]
 fn subscription_create_requires_select_on_source() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     attach_alice_policy(
         &store,
         "events-target-only",
@@ -247,7 +242,7 @@ fn subscription_create_requires_select_on_source() {
 
 #[test]
 fn subscription_alter_requires_write_on_target_queue() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE users (id INT, email TEXT)")
         .unwrap();
     attach_alice_policy(
@@ -272,7 +267,7 @@ fn subscription_alter_requires_write_on_target_queue() {
 
 #[test]
 fn subscription_redact_covers_column_policy_without_warning() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE users (id INT, email TEXT)")
         .unwrap();
     attach_alice_policy(
@@ -299,7 +294,7 @@ fn subscription_redact_covers_column_policy_without_warning() {
 
 #[test]
 fn subscription_redact_gap_warns_but_allows_ddl() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE users (id INT, email TEXT, name TEXT)")
         .unwrap();
     attach_alice_policy(
@@ -335,7 +330,7 @@ fn subscription_redact_gap_warns_but_allows_ddl() {
 
 #[test]
 fn select_column_policy_denies_explicit_column() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_users_table(&rt);
     attach_alice_policy(
         &store,
@@ -354,7 +349,7 @@ fn select_column_policy_denies_explicit_column() {
 
 #[test]
 fn select_column_policy_requires_table_allow_even_with_column_allow() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_users_table(&rt);
     attach_alice_policy(
         &store,
@@ -372,7 +367,7 @@ fn select_column_policy_requires_table_allow_even_with_column_allow() {
 
 #[test]
 fn select_column_policy_denies_wildcard_when_any_declared_column_denied() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     setup_users_table(&rt);
     attach_alice_policy(
         &store,
@@ -391,7 +386,7 @@ fn select_column_policy_denies_wildcard_when_any_declared_column_denied() {
 
 #[test]
 fn select_column_policy_resolves_aliases_across_table_joins() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE users (id INT, name TEXT, email TEXT)")
         .unwrap();
     rt.execute_query("CREATE TABLE orders (id INT, user_id INT, total INT)")
@@ -427,7 +422,7 @@ fn select_column_policy_resolves_aliases_across_table_joins() {
 
 #[test]
 fn runtime_uses_attached_iam_policy_for_dml() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
     rt.execute_query("INSERT INTO orders (id) VALUES (1)")
         .unwrap();
@@ -462,7 +457,7 @@ fn runtime_uses_attached_iam_policy_for_dml() {
 
 #[test]
 fn update_set_column_policy_allows_allowed_target() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT, status TEXT, secret TEXT)")
         .unwrap();
     rt.execute_query("INSERT INTO accounts (id, status, secret) VALUES (1, 'old', 's1')")
@@ -494,7 +489,7 @@ fn update_set_column_policy_allows_allowed_target() {
 
 #[test]
 fn update_set_column_policy_blocks_denied_target_column() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT, status TEXT, secret TEXT)")
         .unwrap();
     rt.execute_query("INSERT INTO accounts (id, status, secret) VALUES (1, 'old', 's1')")
@@ -530,7 +525,7 @@ fn update_set_column_policy_blocks_denied_target_column() {
 
 #[test]
 fn update_set_column_policy_blocks_multi_column_update_when_one_target_is_denied() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT, status TEXT, secret TEXT)")
         .unwrap();
     rt.execute_query("INSERT INTO accounts (id, status, secret) VALUES (1, 'old', 's1')")
@@ -567,7 +562,7 @@ fn update_set_column_policy_blocks_multi_column_update_when_one_target_is_denied
 
 #[test]
 fn update_set_column_allow_does_not_bypass_missing_table_allow() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT, status TEXT)")
         .unwrap();
     rt.execute_query("INSERT INTO accounts (id, status) VALUES (1, 'old')")
@@ -602,7 +597,7 @@ fn update_set_column_allow_does_not_bypass_missing_table_allow() {
 
 #[test]
 fn update_set_column_policy_uses_tenant_context() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE accounts (id INT, status TEXT, secret TEXT)")
         .unwrap();
     rt.execute_query("INSERT INTO accounts (id, status, secret) VALUES (1, 'old', 's1')")
@@ -646,7 +641,7 @@ fn update_set_column_policy_uses_tenant_context() {
 
 #[test]
 fn vector_search_blocks_denied_content_projection() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query(
         "INSERT INTO embeddings VECTOR (dense, content) VALUES ([1.0, 0.0], 'secret')",
     )
@@ -681,7 +676,7 @@ fn vector_search_blocks_denied_content_projection() {
 
 #[test]
 fn graph_match_blocks_denied_node_property_projection() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query(
         "INSERT INTO social NODE (label, name, secret) VALUES ('User', 'alice', 'pii')",
     )
@@ -711,7 +706,7 @@ fn graph_match_blocks_denied_node_property_projection() {
 
 #[test]
 fn timeseries_select_blocks_denied_tags_projection() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TIMESERIES metrics RETENTION 7 d")
         .unwrap();
     rt.execute_query(
@@ -744,7 +739,7 @@ fn timeseries_select_blocks_denied_tags_projection() {
 
 #[test]
 fn kv_invalidate_tags_requires_iam_action() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("KV PUT sessions.blob = 'payload' TAGS [user:42]")
         .unwrap();
 
@@ -788,7 +783,7 @@ fn kv_invalidate_tags_requires_iam_action() {
 
 #[test]
 fn destructive_ddl_requires_drop_or_truncate_policy_before_mutation() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE ddl_drop_guard (id INT)")
         .unwrap();
     rt.execute_query("INSERT INTO ddl_drop_guard (id) VALUES (1)")
@@ -881,7 +876,7 @@ fn destructive_ddl_requires_drop_or_truncate_policy_before_mutation() {
 
 #[test]
 fn group_policy_applies_through_alter_user_membership() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
     rt.execute_query("INSERT INTO orders (id) VALUES (1)")
         .unwrap();
@@ -953,7 +948,7 @@ fn group_policy_applies_through_alter_user_membership() {
 
 #[test]
 fn grant_to_public_compiles_to_implicit_public_policy() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
     rt.execute_query("INSERT INTO orders (id) VALUES (1)")
         .unwrap();
@@ -985,7 +980,7 @@ fn grant_to_public_compiles_to_implicit_public_policy() {
 
 #[test]
 fn revoke_removes_synthetic_grant_policy() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
     rt.execute_query("INSERT INTO orders (id) VALUES (1)")
         .unwrap();
@@ -1040,7 +1035,7 @@ fn revoke_removes_synthetic_grant_policy() {
 
 #[test]
 fn insert_column_policy_allows_named_columns_with_table_allow() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT, note TEXT)")
         .unwrap();
 
@@ -1067,7 +1062,7 @@ fn insert_column_policy_allows_named_columns_with_table_allow() {
 
 #[test]
 fn insert_column_policy_denies_explicit_denied_column() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT, public TEXT, secret TEXT)")
         .unwrap();
 
@@ -1096,7 +1091,7 @@ fn insert_column_policy_denies_explicit_denied_column() {
 
 #[test]
 fn insert_column_policy_ignores_omitted_denied_columns() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT, public TEXT, secret TEXT)")
         .unwrap();
 
@@ -1124,7 +1119,7 @@ fn insert_column_policy_ignores_omitted_denied_columns() {
 
 #[test]
 fn insert_column_policy_denies_tenant_auto_fill_target() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE events (id INT, tenant_id TEXT) TENANT BY (tenant_id)")
         .unwrap();
 
@@ -1156,7 +1151,7 @@ fn insert_column_policy_denies_tenant_auto_fill_target() {
 
 #[test]
 fn insert_column_policy_applies_to_multi_row_insert() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT, note TEXT)")
         .unwrap();
 
@@ -1181,7 +1176,7 @@ fn insert_column_policy_applies_to_multi_row_insert() {
 
 #[test]
 fn insert_column_allow_does_not_bypass_missing_table_allow() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
 
     attach_policy(
@@ -1208,7 +1203,7 @@ fn insert_column_allow_does_not_bypass_missing_table_allow() {
 
 #[test]
 fn document_json_path_projection_allows_non_denied_path() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_document(&rt);
     attach_alice_policy(
         &store,
@@ -1227,7 +1222,7 @@ fn document_json_path_projection_allows_non_denied_path() {
 
 #[test]
 fn document_json_path_projection_denies_explicit_path() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_document(&rt);
     attach_alice_policy(
         &store,
@@ -1246,7 +1241,7 @@ fn document_json_path_projection_denies_explicit_path() {
 
 #[test]
 fn document_json_column_projection_denies_base_document_column() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_document(&rt);
     attach_alice_policy(
         &store,
@@ -1265,7 +1260,7 @@ fn document_json_column_projection_denies_base_document_column() {
 
 #[test]
 fn document_json_wildcard_projection_checks_column_wildcard_policy() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_document(&rt);
     attach_alice_policy(
         &store,
@@ -1287,7 +1282,7 @@ fn document_json_wildcard_projection_checks_column_wildcard_policy() {
 
 #[test]
 fn document_json_table_allow_does_not_bypass_document_path_deny() {
-    let (rt, store) = runtime_with_auth();
+    let (_dir, rt, store) = runtime_with_auth();
     seed_document(&rt);
     attach_alice_policy(
         &store,

--- a/tests/integration_ai_local_models_cache.rs
+++ b/tests/integration_ai_local_models_cache.rs
@@ -156,7 +156,9 @@ fn pull_with_missing_fixture_dir_returns_400() {
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
 
-    let bogus = std::env::temp_dir().join(format!("does_not_exist_{}", std::process::id()));
+    // A path that is guaranteed not to exist: the temp dir is created and then
+    // immediately removed when the guard drops, so the joined child is absent.
+    let bogus = support::temp_data_dir("ai-bogus").join("does_not_exist");
     let body_json = format!(r#"{{"fixture_dir":"{}"}}"#, bogus.display());
     let (status, body) = send(&addr, "POST", "/ai/models/minilm-l6-v2/pull", &body_json);
     assert_eq!(status, 400, "{body}");

--- a/tests/integration_ai_local_models_cache.rs
+++ b/tests/integration_ai_local_models_cache.rs
@@ -4,11 +4,14 @@
 //! #678 registry. Artifact acquisition is fixture-based — these
 //! tests never reach out to HuggingFace.
 
+#[allow(dead_code)]
+mod support;
+
 use std::fs;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::path::Path;
+use std::time::Duration;
 
 use reddb::server::RedDBServer;
 use reddb::RedDBRuntime;
@@ -61,22 +64,11 @@ const MINIMAL_VALID: &str = r#"{
     "dimensions":384
 }"#;
 
-fn unique_temp_dir(label: &str) -> PathBuf {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let p = std::env::temp_dir().join(format!(
-        "reddb_cache_it_{label}_{}_{}",
-        std::process::id(),
-        nanos
-    ));
-    let _ = fs::remove_dir_all(&p);
-    fs::create_dir_all(&p).unwrap();
-    p
+fn unique_temp_dir(label: &str) -> support::TempDataDir {
+    support::temp_data_dir(&format!("ai-cache-{label}"))
 }
 
-fn make_fixture(label: &str) -> PathBuf {
+fn make_fixture(label: &str) -> support::TempDataDir {
     let dir = unique_temp_dir(label);
     fs::write(dir.join("config.json"), b"{\"model_type\":\"bert\"}").unwrap();
     fs::write(dir.join("model.safetensors"), b"fake-weights-bytes").unwrap();

--- a/tests/integration_entity_query.rs
+++ b/tests/integration_entity_query.rs
@@ -4,6 +4,9 @@
 //! with filtering/ordering/pagination, universal queries, EXPLAIN, scan, similarity search,
 //! text search, and cross-model entity scenarios.
 
+#[allow(dead_code)]
+mod support;
+
 use reddb::application::{
     CreateDocumentInput, CreateEdgeInput, CreateKvInput, CreateNodeInput, CreateRowInput,
     CreateVectorInput, DeleteEntityInput, ExecuteQueryInput, ExplainQueryInput, PatchEntityInput,
@@ -2309,15 +2312,9 @@ fn test_fast_entity_id_lookup_persistent() {
     // Regression: WHERE _entity_id = N on a persistent collection
     // used to return 0 rows because the fast path hit the B-tree
     // index with a stale snapshot.
-    let tmp = std::env::temp_dir().join(format!(
-        "reddb_fast_id_{}.rdb",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let _tmp_dir = support::temp_data_dir("entity-fast-id");
+    let tmp = _tmp_dir.join("data.rdb");
     let path_str = tmp.to_string_lossy().to_string();
-    let _ = std::fs::remove_file(&tmp);
 
     let rt = reddb::RedDBRuntime::with_options(reddb::api::RedDBOptions::persistent(&path_str))
         .expect("open persistent runtime");
@@ -2354,8 +2351,6 @@ fn test_fast_entity_id_lookup_persistent() {
         1,
         "fast path `red_entity_id = {eid}` must return the inserted row"
     );
-
-    let _ = std::fs::remove_file(&tmp);
 }
 
 #[test]
@@ -2835,15 +2830,9 @@ fn finding_1_select_after_bulk_insert_persistent_reopen() {
     // writes and the read. This catches the case where data lives
     // in a process-local in-memory segment manager that is never
     // rehydrated from the persisted B-tree on open.
-    let tmp = std::env::temp_dir().join(format!(
-        "reddb_f1_reopen_{}.rdb",
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-    ));
+    let _tmp_dir = support::temp_data_dir("entity-f1-reopen");
+    let tmp = _tmp_dir.join("data.rdb");
     let path_str = tmp.to_string_lossy().to_string();
-    let _ = std::fs::remove_file(&tmp);
 
     const N: usize = 25;
     {
@@ -2895,11 +2884,6 @@ fn finding_1_select_after_bulk_insert_persistent_reopen() {
     );
 
     drop(rt2);
-    let _ = std::fs::remove_dir_all(&tmp);
-    let _ = std::fs::remove_file(&tmp);
-    let _ = std::fs::remove_file(format!("{path_str}-dwb"));
-    let _ = std::fs::remove_file(format!("{path_str}-hdr"));
-    let _ = std::fs::remove_file(format!("{path_str}-meta"));
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -39,6 +39,14 @@ impl AsRef<Path> for TempDataDir {
     }
 }
 
+// Lets `&TempDataDir` satisfy `Into<PathBuf>` (via the std blanket
+// `From<&T> for PathBuf where T: AsRef<OsStr>`) and `Command::arg`.
+impl AsRef<std::ffi::OsStr> for TempDataDir {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.inner.path().as_os_str()
+    }
+}
+
 /// An auto-cleaning `.rdb` file path guard inside a private temp directory.
 /// Derefs to `&Path`.  The parent directory (and the path itself if created)
 /// are removed on drop.
@@ -63,6 +71,15 @@ impl Deref for TempDbFile {
 impl AsRef<Path> for TempDbFile {
     fn as_ref(&self) -> &Path {
         &self.path
+    }
+}
+
+// Lets `&TempDbFile` satisfy `Into<PathBuf>` (via the std blanket
+// `From<&T> for PathBuf where T: AsRef<OsStr>`) and `Command::arg`, so
+// `RedDBOptions::persistent(&db_file)` and CLI subprocess args work.
+impl AsRef<std::ffi::OsStr> for TempDbFile {
+    fn as_ref(&self) -> &std::ffi::OsStr {
+        self.path.as_os_str()
     }
 }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,9 +1,89 @@
 use std::collections::BTreeMap;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use tempfile::TempDir;
+
+// ---------------------------------------------------------------------------
+// Auto-cleaning temp helpers
+// ---------------------------------------------------------------------------
+
+/// An auto-cleaning temporary directory guard.  Derefs to `&Path`.  Removed on
+/// drop, including on panic.  The directory already exists when returned.
+pub struct TempDataDir {
+    inner: TempDir,
+}
+
+impl TempDataDir {
+    pub fn path(&self) -> &Path {
+        self.inner.path()
+    }
+
+    pub fn join<P: AsRef<Path>>(&self, child: P) -> PathBuf {
+        self.inner.path().join(child)
+    }
+}
+
+impl Deref for TempDataDir {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        self.inner.path()
+    }
+}
+
+impl AsRef<Path> for TempDataDir {
+    fn as_ref(&self) -> &Path {
+        self.inner.path()
+    }
+}
+
+/// An auto-cleaning `.rdb` file path guard inside a private temp directory.
+/// Derefs to `&Path`.  The parent directory (and the path itself if created)
+/// are removed on drop.
+pub struct TempDbFile {
+    _dir: TempDir,
+    path: PathBuf,
+}
+
+impl TempDbFile {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Deref for TempDbFile {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl AsRef<Path> for TempDbFile {
+    fn as_ref(&self) -> &Path {
+        &self.path
+    }
+}
+
+/// Return an auto-cleaning temporary directory.  The directory already exists.
+pub fn temp_data_dir(tag: &str) -> TempDataDir {
+    let inner = tempfile::Builder::new()
+        .prefix(&format!("reddb-{tag}-"))
+        .tempdir()
+        .unwrap_or_else(|err| panic!("failed to create temp dir for tag '{tag}': {err}"));
+    TempDataDir { inner }
+}
+
+/// Return an auto-cleaning `.rdb` file path inside a private temp directory.
+pub fn temp_db_file(tag: &str) -> TempDbFile {
+    let dir = tempfile::Builder::new()
+        .prefix(&format!("reddb-{tag}-"))
+        .tempdir()
+        .unwrap_or_else(|err| panic!("failed to create temp dir for tag '{tag}': {err}"));
+    let path = dir.path().join("data.rdb");
+    TempDbFile { _dir: dir, path }
+}
 
 pub mod mock_ai_provider;
 pub mod prometheus;
@@ -74,21 +154,25 @@ pub fn temp_db() -> (TempDir, PathBuf) {
     TestDb::new().into_parts()
 }
 
+/// A persistent `.rdb` path inside a private auto-cleaning temp directory.
+///
+/// The directory (and every engine artifact written beside `data.rdb`:
+/// `data.rdb.red/`, `-uwal`, lease, manifest, …) is removed when the guard
+/// drops, including on panic — so a failing test can never leak temp residue.
 #[derive(Debug)]
 pub struct PersistentDbPath {
+    _dir: TempDir,
     base: PathBuf,
 }
 
 impl PersistentDbPath {
     pub fn new(prefix: &str) -> Self {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let base = std::env::temp_dir().join(format!("reddb_{prefix}_{unique}.rdb"));
-        let path = Self { base };
-        path.cleanup();
-        path
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("reddb-{prefix}-"))
+            .tempdir()
+            .unwrap_or_else(|err| panic!("failed to create temp dir for '{prefix}': {err}"));
+        let base = dir.path().join("data.rdb");
+        Self { _dir: dir, base }
     }
 
     pub fn open_runtime(&self) -> RedDBRuntime {
@@ -99,35 +183,6 @@ impl PersistentDbPath {
 
     fn path_string(&self) -> String {
         self.base.to_string_lossy().to_string()
-    }
-
-    fn cleanup(&self) {
-        if let Some(parent) = self.base.parent() {
-            let stem = self
-                .base
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or_default()
-                .to_string();
-            if let Ok(entries) = std::fs::read_dir(parent) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-                        continue;
-                    };
-                    if name == stem || name.starts_with(&format!("{stem}-")) {
-                        let _ = std::fs::remove_file(&path);
-                        let _ = std::fs::remove_dir_all(&path);
-                    }
-                }
-            }
-        }
-    }
-}
-
-impl Drop for PersistentDbPath {
-    fn drop(&mut self) {
-        self.cleanup();
     }
 }
 

--- a/tests/vault_capacity.rs
+++ b/tests/vault_capacity.rs
@@ -14,6 +14,9 @@
 //!   * AES-GCM tag accidentally being split across pages without
 //!     reassembly (would surface as a Decryption error).
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::HashMap;
 use std::time::Instant;
 
@@ -23,18 +26,10 @@ use reddb::storage::engine::pager::{Pager, PagerConfig};
 
 /// Shared scratch dir per test invocation. Bytes don't survive
 /// across runs but the directory is unique per (pid, counter).
-fn scratch_path(label: &str) -> std::path::PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb_vault_capacity_{}_{}_{}",
-        label,
-        std::process::id(),
-        id
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("vault.rdb")
+fn scratch_path(label: &str) -> (support::TempDataDir, std::path::PathBuf) {
+    let dir = support::temp_data_dir(&format!("vault-capacity-{label}"));
+    let path = dir.join("vault.rdb");
+    (dir, path)
 }
 
 fn now_ms() -> u128 {
@@ -125,7 +120,7 @@ fn assert_states_eq(a: &VaultState, b: &VaultState) {
 
 #[test]
 fn vault_round_trip_5000_users() {
-    let db_path = scratch_path("5k");
+    let (_dir, db_path) = scratch_path("5k");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
 
     let state = synth_state(5_000);
@@ -173,7 +168,7 @@ fn vault_round_trip_5000_users() {
 /// the freelist (page_count must not blow up unboundedly).
 #[test]
 fn vault_grows_and_shrinks_monotonically() {
-    let db_path = scratch_path("growshrink");
+    let (_dir, db_path) = scratch_path("growshrink");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
     let vault = Vault::open(&pager, Some("vault-grow-shrink")).unwrap();
 
@@ -223,7 +218,7 @@ fn vault_grows_and_shrinks_monotonically() {
 /// edge case the spec explicitly calls out.
 #[test]
 fn vault_single_user_fits_in_header_page() {
-    let db_path = scratch_path("single");
+    let (_dir, db_path) = scratch_path("single");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
     let vault = Vault::open(&pager, Some("vault-single-user")).unwrap();
 

--- a/tests/vault_chain_recovery.rs
+++ b/tests/vault_chain_recovery.rs
@@ -17,6 +17,9 @@
 //!   * Legacy v1 vaults that pre-date the chain refuse to load and
 //!     surface operator guidance.
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::HashMap;
 
 use reddb::auth::vault::{Vault, VaultError, VaultState};
@@ -24,18 +27,10 @@ use reddb::auth::{ApiKey, Role, User, UserId};
 use reddb::storage::engine::page::{Page, PageType, HEADER_SIZE};
 use reddb::storage::engine::pager::{Pager, PagerConfig};
 
-fn scratch_path(label: &str) -> std::path::PathBuf {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let dir = std::env::temp_dir().join(format!(
-        "reddb_vault_chain_{}_{}_{}",
-        label,
-        std::process::id(),
-        id
-    ));
-    std::fs::create_dir_all(&dir).unwrap();
-    dir.join("vault.rdb")
+fn scratch_path(label: &str) -> (support::TempDataDir, std::path::PathBuf) {
+    let dir = support::temp_data_dir(&format!("vault-chain-{label}"));
+    let path = dir.join("vault.rdb");
+    (dir, path)
 }
 
 fn now_ms() -> u128 {
@@ -121,7 +116,7 @@ fn read_first_data_pointer(pager: &Pager) -> u32 {
 
 #[test]
 fn header_pointer_to_missing_page_returns_clear_error() {
-    let db_path = scratch_path("missing-data");
+    let (_dir, db_path) = scratch_path("missing-data");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
     let vault = Vault::open(&pager, Some("recovery-pass")).unwrap();
 
@@ -151,7 +146,7 @@ fn header_pointer_to_missing_page_returns_clear_error() {
 
 #[test]
 fn data_page_magic_corruption_returns_clear_error() {
-    let db_path = scratch_path("bad-magic");
+    let (_dir, db_path) = scratch_path("bad-magic");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
     let vault = Vault::open(&pager, Some("recovery-pass")).unwrap();
 
@@ -188,7 +183,7 @@ fn premature_terminator_with_outstanding_payload_fails() {
     // chain_count says >0 but first_data_page_id is 0. Make sure the
     // walker doesn't dereference page id 0 (which is the DB header
     // page) and instead produces a clean error.
-    let db_path = scratch_path("premature-end");
+    let (_dir, db_path) = scratch_path("premature-end");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
     let vault = Vault::open(&pager, Some("recovery-pass")).unwrap();
 
@@ -216,7 +211,7 @@ fn premature_terminator_with_outstanding_payload_fails() {
 fn legacy_v1_vault_refuses_to_load() {
     // Hand-craft a vault page with version byte = 1. We don't need
     // valid ciphertext — the version check fires first.
-    let db_path = scratch_path("legacy-v1");
+    let (_dir, db_path) = scratch_path("legacy-v1");
     let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
 
     // Reserve slots so id 2 is a real on-disk page.

--- a/tests/wal_crash_harness.rs
+++ b/tests/wal_crash_harness.rs
@@ -33,7 +33,7 @@ use reddb::storage::{
 fn tmp_path(name: &str) -> (support::TempDataDir, PathBuf) {
     let base = support::temp_data_dir("wal-crash");
     let path = base.join(format!(
-        "reddb_wal_crash_{}_{}_{}.rdb",
+        "wal_crash_{}_{}_{}.rdb",
         name,
         std::process::id(),
         std::time::SystemTime::now()

--- a/tests/wal_crash_harness.rs
+++ b/tests/wal_crash_harness.rs
@@ -17,6 +17,9 @@
 //! WAL writer implementation; every assertion here must still hold.
 //! If one fails, Phase 2 has lost data on recovery.
 
+#[allow(dead_code)]
+mod support;
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -27,21 +30,8 @@ use reddb::storage::{
     EntityData, EntityId, EntityKind, RowData, UnifiedEntity, UnifiedStore, UnifiedStoreConfig,
 };
 
-struct FileGuard {
-    path: PathBuf,
-}
-
-impl Drop for FileGuard {
-    fn drop(&mut self) {
-        // Best-effort — integration runs in parallel tmp dirs.
-        let _ = std::fs::remove_file(&self.path);
-        let wal = self.path.with_extension("rdb-uwal");
-        let _ = std::fs::remove_file(wal);
-    }
-}
-
-fn tmp_path(name: &str) -> (FileGuard, PathBuf) {
-    let base = std::env::temp_dir();
+fn tmp_path(name: &str) -> (support::TempDataDir, PathBuf) {
+    let base = support::temp_data_dir("wal-crash");
     let path = base.join(format!(
         "reddb_wal_crash_{}_{}_{}.rdb",
         name,
@@ -51,11 +41,7 @@ fn tmp_path(name: &str) -> (FileGuard, PathBuf) {
             .unwrap()
             .as_nanos(),
     ));
-    let guard = FileGuard { path: path.clone() };
-    // Best-effort cleanup of stale files from a prior run.
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(path.with_extension("rdb-uwal"));
-    (guard, path)
+    (base, path)
 }
 
 fn row_entity(id: u64, name: &str) -> UnifiedEntity {


### PR DESCRIPTION
Automated AFK landing for #971. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783625736&installation_id=129708444&pr_number=1057&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1057&signature=ed919afc974c33448cc4ca1297af410cecf1c03b73b79689ddc64341819328be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->