### PR TITLE
merge: #972 CI leak-check: fail if the suite leaves reddb_* residue in temp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,14 @@ jobs:
           CARGO_TARGET_DIR: target/persistent-tests
         run: >-
           cargo test --locked --test integration_persistent_multimodel -- --ignored
+      - name: Check for temp-file residue (leak guard)
+        # Issue #972 — fail the build if any reddb-*/reddb_*/*.rdb/*.wal
+        # temp residue remains in TMPDIR after the full test suite.  All
+        # test-DB helpers in tests/support/mod.rs use TempDir guards that
+        # clean up on drop (including on panic), so a clean suite leaves
+        # nothing behind.  A non-zero count means a test bypassed the
+        # helpers and the leak must be fixed.
+        run: bash scripts/check-temp-residue.sh
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats

--- a/scripts/check-temp-residue.sh
+++ b/scripts/check-temp-residue.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# CI guard: fail if the test suite left reddb-*/reddb_*/*.rdb/*.wal
+# residue in the OS temp directory ($TMPDIR, default /tmp).
+#
+# Run this after `cargo test` to detect tests that created persistent
+# databases without using the auto-cleaning temp helpers in
+# tests/support/mod.rs, turning silent disk leaks into a hard CI failure.
+#
+# Usage (from repo root, after running the test suite):
+#   ./scripts/check-temp-residue.sh
+#
+# Exit codes:
+#   0 - no residue found
+#   1 - residue found (paths listed to stdout)
+
+set -euo pipefail
+
+tmpdir="${TMPDIR:-/tmp}"
+
+# Collect matches at depth 1 (tempfile creates dirs directly in TMPDIR).
+# 2>/dev/null suppresses permission-denied noise from foreign /tmp entries.
+# || true prevents set -e from aborting on find permission errors.
+entries=()
+while IFS= read -r -d '' entry; do
+    entries+=("$entry")
+done < <(find "$tmpdir" -maxdepth 1 \
+    \( -name 'reddb-*' -o -name 'reddb_*' -o -name '*.rdb' -o -name '*.wal' \) \
+    -print0 2>/dev/null || true)
+
+if [[ ${#entries[@]} -eq 0 ]]; then
+    echo "OK — no reddb temp residue in $tmpdir."
+    exit 0
+fi
+
+for entry in "${entries[@]}"; do
+    echo "LEAK: $entry"
+done
+
+count=${#entries[@]}
+printf '\n'
+printf '::error::Test suite left %d temp residue path(s) in %s.\n' "$count" "$tmpdir" >&2
+printf 'Each LEAK line above is a file or directory that was not cleaned up.\n' >&2
+printf 'Fix: use temp_data_dir()/temp_db_file()/PersistentDbPath from tests/support/mod.rs\n' >&2
+printf 'so cleanup happens on drop (including on panic).\n' >&2
+exit 1


### PR DESCRIPTION
Automated AFK landing for #972. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783628962&installation_id=129708444&pr_number=1058&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1058&signature=2f5219ab2a9719bcff6678c1167bf26383eca29f225762038e57477c5e372341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated CI validation that scans for and reports leftover temporary database files and directories following test execution. Builds will fail if any residue is detected, providing detailed diagnostics and clear instructions for developers to use proper temporary resource handling utilities to prevent future accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->