### PR TITLE
fix(js-client,js): parse userinfo and query in reds:// / grpc(s):// URLs

### DIFF
--- a/.changeset/reds-userinfo-parse.md
+++ b/.changeset/reds-userinfo-parse.md
@@ -1,0 +1,6 @@
+---
+'@reddb-io/client': patch
+'@reddb-io/sdk': patch
+---
+
+Fix `reds://` and `grpc(s)://` connection strings dropping userinfo and query params: `reds://user:pass@host:5050` parsed host as `user` and port as `NaN`, so credentials never reached the server and the HTTPS auto-login leg never fired. The legacy branch now decodes userinfo, host, port and `token`/`apiKey`/`loginUrl` with standard URL rules; bare-host shapes keep their previous behaviour.

--- a/crates/reddb-server/src/cluster/join.rs
+++ b/crates/reddb-server/src/cluster/join.rs
@@ -1,0 +1,363 @@
+//! Authenticated cluster join through seed members (issue #988, ADR 0030).
+//!
+//! Join is the explicit admission flow a candidate runs to *become* an
+//! authorized cluster member. The glossary fixes the steps: *"a candidate
+//! member authenticates against seed members, verifies cluster identity,
+//! downloads global control-plane state, and only then becomes an authorized
+//! cluster member."* Until that completes, a node is just a reachable network
+//! peer — not a member, and not something autodetect will adopt.
+//!
+//! ## The handshake, structurally
+//!
+//! A seed member holds a [`SeedAuthority`]: the cluster's [`ClusterId`], an
+//! operator-provisioned **allowlist** of which identities may join (and as what
+//! kind), and the current [`MembershipCatalog`]. A candidate sends a
+//! [`JoinRequest`] carrying the cluster id it *believes* it is joining, its
+//! authenticated [`NodeIdentity`], and the kind it intends to be. The seed:
+//!
+//! 1. **Verifies cluster identity.** A request that names a different cluster
+//!    is [`JoinRejection::WrongCluster`] — authenticating correctly to the
+//!    wrong cluster is still a rejection.
+//! 2. **Authorizes the peer.** An identity absent from the allowlist is an
+//!    unknown/unauthorized peer: [`JoinRejection::UnauthorizedPeer`]. This is
+//!    what stops "anyone who can open a connection" from joining.
+//! 3. **Checks the declared kind.** A peer allow-listed as a witness that asks
+//!    to join as a data member (or vice versa) is
+//!    [`JoinRejection::KindMismatch`].
+//! 4. **Admits and snapshots.** The candidate is added to the catalog as a
+//!    [joined-empty member](super::membership::ClusterMember::joined_empty) —
+//!    no user ranges — and the seed returns a [`ControlPlaneSnapshot`] of the
+//!    now-current membership for the candidate to adopt.
+//!
+//! Authentication itself is mTLS: the [`NodeIdentity`] in a request is the
+//! validated X.509 subject of the peer certificate. [`JoinRequest::authenticated`]
+//! is the only constructor, so a request cannot exist without a proven
+//! identity — there is no "anonymous join" shape to defend against.
+
+use super::identity::NodeIdentity;
+use super::membership::{
+    AdmissionOutcome, ClusterId, ClusterMember, MemberKind, MembershipCatalog,
+};
+use std::collections::BTreeMap;
+
+/// A candidate's request to join a cluster through a seed member.
+///
+/// The only way to build one is [`JoinRequest::authenticated`], whose
+/// `identity` is the validated certificate subject of the peer — so a request
+/// always carries a proven identity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JoinRequest {
+    /// The cluster the candidate believes it is joining. Checked against the
+    /// seed's own cluster id.
+    pub target_cluster: ClusterId,
+    /// The candidate's authenticated cluster member identity.
+    pub identity: NodeIdentity,
+    /// The kind the candidate intends to join as.
+    pub kind: MemberKind,
+}
+
+impl JoinRequest {
+    /// Build a join request from an already-authenticated peer identity (the
+    /// validated mTLS certificate subject).
+    pub fn authenticated(
+        target_cluster: ClusterId,
+        identity: NodeIdentity,
+        kind: MemberKind,
+    ) -> Self {
+        Self {
+            target_cluster,
+            identity,
+            kind,
+        }
+    }
+}
+
+/// Why a join was refused. Each variant maps to one of the seed's checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JoinRejection {
+    /// The request named a different cluster than this seed serves.
+    WrongCluster {
+        expected: ClusterId,
+        presented: ClusterId,
+    },
+    /// The authenticated peer is not on the operator allowlist — an unknown or
+    /// unauthorized peer.
+    UnauthorizedPeer(NodeIdentity),
+    /// The peer is allow-listed but asked to join as the wrong kind.
+    KindMismatch {
+        identity: NodeIdentity,
+        allowed: MemberKind,
+        requested: MemberKind,
+    },
+}
+
+impl std::fmt::Display for JoinRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongCluster {
+                expected,
+                presented,
+            } => write!(
+                f,
+                "join targets cluster {presented}, but this seed serves {expected}"
+            ),
+            Self::UnauthorizedPeer(id) => {
+                write!(f, "peer {id} is not an authorized cluster member")
+            }
+            Self::KindMismatch {
+                identity,
+                allowed,
+                requested,
+            } => write!(
+                f,
+                "peer {identity} is allowed as {allowed:?} but requested {requested:?}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for JoinRejection {}
+
+/// The global control-plane state a freshly admitted member downloads — the
+/// authorized membership it should adopt as its starting view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlaneSnapshot {
+    pub cluster_id: ClusterId,
+    pub members: Vec<ClusterMember>,
+}
+
+/// A successful admission: the outcome (newly admitted vs. already a member)
+/// and the control-plane snapshot the candidate adopts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JoinGrant {
+    pub outcome: AdmissionOutcome,
+    pub snapshot: ControlPlaneSnapshot,
+}
+
+/// A seed member's authority to admit join candidates.
+///
+/// It owns the cluster's [`ClusterId`], the operator-provisioned allowlist of
+/// who may join, and the live [`MembershipCatalog`]. [`evaluate_join`] runs the
+/// full handshake and, on success, mutates the catalog to include the new
+/// member.
+///
+/// [`evaluate_join`]: SeedAuthority::evaluate_join
+#[derive(Debug, Clone)]
+pub struct SeedAuthority {
+    allowlist: BTreeMap<NodeIdentity, MemberKind>,
+    catalog: MembershipCatalog,
+}
+
+impl SeedAuthority {
+    /// Build a seed authority over `catalog` with the given operator
+    /// `allowlist` of identities permitted to join (and the kind each is
+    /// permitted to join as). Existing members are implicitly allow-listed.
+    pub fn new(
+        catalog: MembershipCatalog,
+        allowlist: impl IntoIterator<Item = (NodeIdentity, MemberKind)>,
+    ) -> Self {
+        let mut allow: BTreeMap<NodeIdentity, MemberKind> = allowlist.into_iter().collect();
+        // Anyone already in the catalog is, by definition, authorized.
+        for member in catalog.members() {
+            allow
+                .entry(member.identity().clone())
+                .or_insert(member.kind());
+        }
+        Self {
+            allowlist: allow,
+            catalog,
+        }
+    }
+
+    pub fn cluster_id(&self) -> &ClusterId {
+        self.catalog.cluster_id()
+    }
+
+    pub fn catalog(&self) -> &MembershipCatalog {
+        &self.catalog
+    }
+
+    /// Run the join handshake for `request`. On success the candidate is now an
+    /// authorized member of the catalog and the returned [`JoinGrant`] carries
+    /// the control-plane snapshot to adopt; on failure the catalog is
+    /// unchanged and the [`JoinRejection`] says which check failed.
+    pub fn evaluate_join(&mut self, request: JoinRequest) -> Result<JoinGrant, JoinRejection> {
+        // 1. Verify cluster identity.
+        if &request.target_cluster != self.catalog.cluster_id() {
+            return Err(JoinRejection::WrongCluster {
+                expected: self.catalog.cluster_id().clone(),
+                presented: request.target_cluster,
+            });
+        }
+
+        // 2. Authorize the authenticated peer against the allowlist.
+        let allowed_kind = match self.allowlist.get(&request.identity) {
+            Some(kind) => *kind,
+            None => return Err(JoinRejection::UnauthorizedPeer(request.identity)),
+        };
+
+        // 3. The declared kind must match what the peer is allow-listed as.
+        if allowed_kind != request.kind {
+            return Err(JoinRejection::KindMismatch {
+                identity: request.identity,
+                allowed: allowed_kind,
+                requested: request.kind,
+            });
+        }
+
+        // 4. Admit as a joined-empty member and snapshot the control plane.
+        let member = ClusterMember::joined_empty(request.identity, request.kind);
+        let outcome = self.catalog.admit(member);
+        Ok(JoinGrant {
+            outcome,
+            snapshot: self.snapshot(),
+        })
+    }
+
+    fn snapshot(&self) -> ControlPlaneSnapshot {
+        ControlPlaneSnapshot {
+            cluster_id: self.catalog.cluster_id().clone(),
+            members: self.catalog.members().cloned().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(cn: &str) -> NodeIdentity {
+        NodeIdentity::from_certificate_subject(cn).unwrap()
+    }
+
+    fn cid() -> ClusterId {
+        ClusterId::new("cluster-prod").unwrap()
+    }
+
+    /// A two-data-member founding cluster with `node-c` pre-authorized to join.
+    fn seed_with_pending_node_c() -> SeedAuthority {
+        let catalog = MembershipCatalog::new(
+            cid(),
+            [
+                ClusterMember::joined_empty(ident("CN=node-a"), MemberKind::Data),
+                ClusterMember::joined_empty(ident("CN=node-b"), MemberKind::Data),
+            ],
+        );
+        SeedAuthority::new(catalog, [(ident("CN=node-c"), MemberKind::Data)])
+    }
+
+    #[test]
+    fn successful_join_admits_authorized_data_member() {
+        let mut seed = seed_with_pending_node_c();
+        let req = JoinRequest::authenticated(cid(), ident("CN=node-c"), MemberKind::Data);
+
+        let grant = seed
+            .evaluate_join(req)
+            .expect("authorized join should succeed");
+        assert_eq!(grant.outcome, AdmissionOutcome::Admitted);
+
+        // The candidate is now an authorized member, and the snapshot reflects
+        // the full three-data-member cluster it should adopt.
+        assert!(seed.catalog().is_authorized(&ident("CN=node-c")));
+        assert_eq!(grant.snapshot.cluster_id, cid());
+        assert_eq!(grant.snapshot.members.len(), 3);
+        assert!(seed.catalog().assess_baseline().meets_baseline());
+    }
+
+    #[test]
+    fn joined_data_member_starts_with_no_user_ranges() {
+        let mut seed = seed_with_pending_node_c();
+        let req = JoinRequest::authenticated(cid(), ident("CN=node-c"), MemberKind::Data);
+        seed.evaluate_join(req).unwrap();
+
+        let joined = seed.catalog().member(&ident("CN=node-c")).unwrap();
+        assert!(!joined.holds_user_ranges());
+        assert_eq!(joined.owned_range_count(), 0);
+    }
+
+    #[test]
+    fn unauthorized_peer_is_rejected() {
+        let mut seed = seed_with_pending_node_c();
+        // `node-x` authenticated fine (it has a NodeIdentity) but is not on the
+        // allowlist — an unknown/unauthorized peer.
+        let req = JoinRequest::authenticated(cid(), ident("CN=node-x"), MemberKind::Data);
+
+        let err = seed
+            .evaluate_join(req)
+            .expect_err("unknown peer must be rejected");
+        assert_eq!(err, JoinRejection::UnauthorizedPeer(ident("CN=node-x")));
+        // The catalog is unchanged and the peer is not autodetect-eligible.
+        assert!(!seed.catalog().is_autodetect_eligible(&ident("CN=node-x")));
+        assert_eq!(seed.catalog().len(), 2);
+    }
+
+    #[test]
+    fn wrong_cluster_join_is_rejected() {
+        let mut seed = seed_with_pending_node_c();
+        let other = ClusterId::new("cluster-staging").unwrap();
+        // `node-c` is authorized, but it targets the wrong cluster.
+        let req = JoinRequest::authenticated(other.clone(), ident("CN=node-c"), MemberKind::Data);
+
+        let err = seed
+            .evaluate_join(req)
+            .expect_err("wrong-cluster join must be rejected");
+        assert_eq!(
+            err,
+            JoinRejection::WrongCluster {
+                expected: cid(),
+                presented: other,
+            }
+        );
+        assert!(!seed.catalog().is_authorized(&ident("CN=node-c")));
+    }
+
+    #[test]
+    fn kind_mismatch_is_rejected() {
+        let mut seed = seed_with_pending_node_c();
+        // `node-c` is allow-listed as Data but asks to join as a Witness.
+        let req = JoinRequest::authenticated(cid(), ident("CN=node-c"), MemberKind::Witness);
+
+        let err = seed
+            .evaluate_join(req)
+            .expect_err("kind mismatch must be rejected");
+        assert_eq!(
+            err,
+            JoinRejection::KindMismatch {
+                identity: ident("CN=node-c"),
+                allowed: MemberKind::Data,
+                requested: MemberKind::Witness,
+            }
+        );
+    }
+
+    #[test]
+    fn rejoin_is_idempotent() {
+        let mut seed = seed_with_pending_node_c();
+        let req = || JoinRequest::authenticated(cid(), ident("CN=node-c"), MemberKind::Data);
+
+        let first = seed.evaluate_join(req()).unwrap();
+        assert_eq!(first.outcome, AdmissionOutcome::Admitted);
+
+        let second = seed.evaluate_join(req()).unwrap();
+        assert_eq!(second.outcome, AdmissionOutcome::AlreadyMember);
+        assert_eq!(seed.catalog().len(), 3);
+    }
+
+    #[test]
+    fn autodetect_adopts_only_members_after_join() {
+        let mut seed = seed_with_pending_node_c();
+        // Before join: node-c is not an autodetect candidate.
+        assert!(!seed.catalog().is_autodetect_eligible(&ident("CN=node-c")));
+
+        seed.evaluate_join(JoinRequest::authenticated(
+            cid(),
+            ident("CN=node-c"),
+            MemberKind::Data,
+        ))
+        .unwrap();
+
+        // After join: it is, and a never-joined peer still is not.
+        assert!(seed.catalog().is_autodetect_eligible(&ident("CN=node-c")));
+        assert!(!seed.catalog().is_autodetect_eligible(&ident("CN=stranger")));
+    }
+}

--- a/crates/reddb-server/src/cluster/membership.rs
+++ b/crates/reddb-server/src/cluster/membership.rs
@@ -1,0 +1,424 @@
+//! Cluster member identity, the authorized-member catalog, and the resilient
+//! three-data-member baseline (issue #988, PRD #987, ADR 0030).
+//!
+//! This is the first vertical slice of multi-writer cluster membership. It
+//! defines *who is a cluster member* as control-plane state that is distinct
+//! from *which ranges a member owns or replicates* (the per-range roles in
+//! [`clustering`](../../../.red/context/clustering.md) and ADR 0045). A node
+//! has exactly one stable [cluster member identity]; range ownership is a
+//! separate, per-range role assigned later by the rebalancer.
+//!
+//! ## What lives here
+//!
+//! * [`ClusterId`] — the cluster's own stable identity. A candidate must
+//!   present the right cluster id to join; a peer that targets a different
+//!   cluster is rejected ([`super::join`]).
+//! * [`MemberKind`] — whether a member holds user data ([`MemberKind::Data`])
+//!   or is a vote-only witness ([`MemberKind::Witness`]). The resilient
+//!   multi-writer baseline counts **data** members; witnesses are not the
+//!   recommended baseline (glossary: *Voting member*).
+//! * [`ClusterMember`] — one authorized member: its [`NodeIdentity`], its
+//!   kind, and how many user ranges it currently holds. A freshly joined data
+//!   member holds **zero** ranges — joining never moves user ranges.
+//! * [`MembershipCatalog`] — the authorized-member set for one cluster. This
+//!   is the *only* set autodetect of health and topology is allowed to range
+//!   over: an arbitrary network peer that has not joined is not a member and
+//!   is not an autodetect candidate.
+//!
+//! The join handshake itself — authenticate against a seed, verify cluster
+//! identity, reject unknown/unauthorized peers, then admit and hand back the
+//! control-plane snapshot — lives in [`super::join`].
+//!
+//! Everything here is a pure data model with no I/O, so the whole membership
+//! and join story is exercised deterministically.
+
+use std::collections::BTreeMap;
+
+use super::identity::NodeIdentity;
+
+/// The resilient baseline for a multi-writer cluster, in **data** members.
+///
+/// The glossary fixes this: *"A resilient multi-writer cluster starts with
+/// three data members; witness members are not the recommended baseline for
+/// multi-writer clustering."* Three data members give a quorum of two that
+/// survives the loss of any single member without a witness.
+pub const RESILIENT_DATA_MEMBER_BASELINE: usize = 3;
+
+/// The cluster's own stable identity.
+///
+/// Every authorized member agrees on this value, and a join candidate must
+/// present it to be admitted (see [`super::join`]). It is what makes a
+/// "wrong-cluster" join detectable: a peer that authenticates fine but targets
+/// a *different* cluster is rejected, not merged in.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClusterId(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterIdError;
+
+impl std::fmt::Display for ClusterIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "cluster id is empty")
+    }
+}
+
+impl std::error::Error for ClusterIdError {}
+
+impl ClusterId {
+    /// Build a cluster id from an operator-provisioned value. The value must
+    /// be non-empty; a blank cluster id would let any peer "match" by
+    /// presenting nothing.
+    pub fn new(value: impl AsRef<str>) -> Result<Self, ClusterIdError> {
+        let value = value.as_ref().trim();
+        if value.is_empty() {
+            return Err(ClusterIdError);
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ClusterId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Whether a member holds user data or is a vote-only witness.
+///
+/// This mirrors the election-side `MemberKind` (a witness votes but never owns
+/// a range), but it is the *cluster-membership* view: it decides whether a
+/// member counts toward the resilient **data-member** baseline. A witness is a
+/// member, but it is not a data member, so it does not move the cluster toward
+/// [`RESILIENT_DATA_MEMBER_BASELINE`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberKind {
+    /// Holds user data; can be a range owner for some ranges and a range
+    /// replica for others.
+    Data,
+    /// Control-plane only; stores no user data and is never a range owner.
+    Witness,
+}
+
+impl MemberKind {
+    /// Does this member kind store user data (and therefore count toward the
+    /// resilient multi-writer baseline)?
+    pub fn holds_data(self) -> bool {
+        matches!(self, MemberKind::Data)
+    }
+}
+
+/// One authorized cluster member.
+///
+/// The [`NodeIdentity`] is the member's stable cluster identity — the same
+/// validated X.509 subject it authenticates and votes under. `owned_range_count`
+/// is the *per-range* role count, kept deliberately separate: a member's
+/// cluster identity does not change when ranges move on or off it, and a
+/// freshly joined data member starts at zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterMember {
+    identity: NodeIdentity,
+    kind: MemberKind,
+    owned_range_count: usize,
+}
+
+impl ClusterMember {
+    /// A member as it exists immediately after a successful join: authorized,
+    /// of the granted kind, and holding **no** user ranges. Ranges are only
+    /// assigned later by rebalancing or ownership transitions.
+    pub fn joined_empty(identity: NodeIdentity, kind: MemberKind) -> Self {
+        Self {
+            identity,
+            kind,
+            owned_range_count: 0,
+        }
+    }
+
+    pub fn identity(&self) -> &NodeIdentity {
+        &self.identity
+    }
+
+    pub fn kind(&self) -> MemberKind {
+        self.kind
+    }
+
+    /// How many user ranges this member currently owns. Distinct from cluster
+    /// membership: a member with zero ranges is still a full member.
+    pub fn owned_range_count(&self) -> usize {
+        self.owned_range_count
+    }
+
+    /// Does this member currently hold any user ranges? A just-joined member
+    /// answers `false` until the rebalancer assigns ownership.
+    pub fn holds_user_ranges(&self) -> bool {
+        self.owned_range_count > 0
+    }
+
+    /// Record that the rebalancer/ownership transitions have assigned this many
+    /// user ranges to the member. This is the *only* path that gives a member
+    /// ranges — join never does.
+    pub fn assign_ranges(&mut self, count: usize) {
+        self.owned_range_count = count;
+    }
+}
+
+/// How a candidate compared against the authorized-member set on join.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmissionOutcome {
+    /// The candidate was not previously a member and was admitted now.
+    Admitted,
+    /// The candidate was already an authorized member; the catalog is
+    /// unchanged (join is idempotent on reconnect).
+    AlreadyMember,
+}
+
+/// The authorized-member set for one cluster — the control-plane membership
+/// catalog.
+///
+/// Membership is explicit: a node appears here only after a successful join
+/// ([`super::join`]). Autodetect of health and topology ranges over
+/// [`autodetect_candidates`](Self::autodetect_candidates) — i.e. *these
+/// members only* — never over arbitrary peers that happen to be reachable on
+/// the network.
+#[derive(Debug, Clone)]
+pub struct MembershipCatalog {
+    cluster_id: ClusterId,
+    members: BTreeMap<NodeIdentity, ClusterMember>,
+}
+
+impl MembershipCatalog {
+    /// A catalog for `cluster_id` seeded with `founders`. The founding data
+    /// members are the bootstrap set that later candidates authenticate
+    /// against; each starts empty.
+    pub fn new(cluster_id: ClusterId, founders: impl IntoIterator<Item = ClusterMember>) -> Self {
+        let members = founders
+            .into_iter()
+            .map(|m| (m.identity().clone(), m))
+            .collect();
+        Self {
+            cluster_id,
+            members,
+        }
+    }
+
+    pub fn cluster_id(&self) -> &ClusterId {
+        &self.cluster_id
+    }
+
+    /// Is `identity` an authorized member of this cluster? This is the gate
+    /// every control-plane path consults — only an authorized member's health
+    /// and topology are autodetected, and only a member may vote or own ranges.
+    pub fn is_authorized(&self, identity: &NodeIdentity) -> bool {
+        self.members.contains_key(identity)
+    }
+
+    pub fn member(&self, identity: &NodeIdentity) -> Option<&ClusterMember> {
+        self.members.get(identity)
+    }
+
+    pub fn member_mut(&mut self, identity: &NodeIdentity) -> Option<&mut ClusterMember> {
+        self.members.get_mut(identity)
+    }
+
+    /// Admit `member` as authorized. Idempotent: re-admitting an existing
+    /// member leaves the catalog (and the member's range count) untouched, so
+    /// a reconnecting member never has its ranges reset to zero.
+    pub fn admit(&mut self, member: ClusterMember) -> AdmissionOutcome {
+        if self.members.contains_key(member.identity()) {
+            return AdmissionOutcome::AlreadyMember;
+        }
+        self.members.insert(member.identity().clone(), member);
+        AdmissionOutcome::Admitted
+    }
+
+    /// Every authorized member, in stable identity order.
+    pub fn members(&self) -> impl Iterator<Item = &ClusterMember> {
+        self.members.values()
+    }
+
+    /// The members autodetect of health/topology is allowed to range over —
+    /// exactly the authorized members. An arbitrary network peer that has not
+    /// joined is absent here, so autodetect can never silently adopt it.
+    pub fn autodetect_candidates(&self) -> impl Iterator<Item = &ClusterMember> {
+        self.members()
+    }
+
+    /// Whether autodetect may consider `identity`. True only for authorized
+    /// members — the rule that "autodetect applies only to authorized members
+    /// after join, not arbitrary network peers".
+    pub fn is_autodetect_eligible(&self, identity: &NodeIdentity) -> bool {
+        self.is_authorized(identity)
+    }
+
+    pub fn len(&self) -> usize {
+        self.members.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// How many **data** members the cluster currently has (witnesses
+    /// excluded). This is the number the resilient baseline is measured in.
+    pub fn data_member_count(&self) -> usize {
+        self.members().filter(|m| m.kind().holds_data()).count()
+    }
+
+    /// Assess the cluster against the resilient multi-writer baseline of
+    /// [`RESILIENT_DATA_MEMBER_BASELINE`] data members.
+    pub fn assess_baseline(&self) -> BaselineAssessment {
+        BaselineAssessment::evaluate(self.data_member_count())
+    }
+}
+
+/// How the cluster's data-member count compares to the resilient baseline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BaselineAssessment {
+    /// The configured resilient baseline ([`RESILIENT_DATA_MEMBER_BASELINE`]).
+    pub recommended_data_members: usize,
+    /// The cluster's current data-member count.
+    pub data_members: usize,
+}
+
+impl BaselineAssessment {
+    fn evaluate(data_members: usize) -> Self {
+        Self {
+            recommended_data_members: RESILIENT_DATA_MEMBER_BASELINE,
+            data_members,
+        }
+    }
+
+    /// Does the cluster meet (or exceed) the resilient multi-writer baseline?
+    pub fn meets_baseline(&self) -> bool {
+        self.data_members >= self.recommended_data_members
+    }
+
+    /// How many more data members are needed to reach the baseline (zero once
+    /// met).
+    pub fn shortfall(&self) -> usize {
+        self.recommended_data_members
+            .saturating_sub(self.data_members)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(cn: &str) -> NodeIdentity {
+        NodeIdentity::from_certificate_subject(cn).unwrap()
+    }
+
+    fn data_member(cn: &str) -> ClusterMember {
+        ClusterMember::joined_empty(ident(cn), MemberKind::Data)
+    }
+
+    #[test]
+    fn cluster_id_rejects_empty() {
+        assert!(ClusterId::new("   ").is_err());
+        assert_eq!(ClusterId::new(" cluster-x ").unwrap().as_str(), "cluster-x");
+    }
+
+    #[test]
+    fn member_identity_is_distinct_from_range_ownership() {
+        // A member's cluster identity is stable; assigning/removing ranges is a
+        // separate per-range role and does not change membership.
+        let mut m = data_member("CN=node-a");
+        assert!(!m.holds_user_ranges());
+        assert_eq!(m.owned_range_count(), 0);
+
+        m.assign_ranges(4);
+        assert!(m.holds_user_ranges());
+        assert_eq!(m.identity(), &ident("CN=node-a")); // identity unchanged
+    }
+
+    #[test]
+    fn data_member_count_excludes_witnesses() {
+        let cid = ClusterId::new("cluster-x").unwrap();
+        let catalog = MembershipCatalog::new(
+            cid,
+            [
+                data_member("CN=node-a"),
+                data_member("CN=node-b"),
+                ClusterMember::joined_empty(ident("CN=witness"), MemberKind::Witness),
+            ],
+        );
+        assert_eq!(catalog.len(), 3);
+        assert_eq!(catalog.data_member_count(), 2);
+    }
+
+    #[test]
+    fn three_data_members_meet_resilient_baseline() {
+        let cid = ClusterId::new("cluster-x").unwrap();
+        let catalog = MembershipCatalog::new(
+            cid,
+            [
+                data_member("CN=node-a"),
+                data_member("CN=node-b"),
+                data_member("CN=node-c"),
+            ],
+        );
+        let baseline = catalog.assess_baseline();
+        assert_eq!(baseline.recommended_data_members, 3);
+        assert!(baseline.meets_baseline());
+        assert_eq!(baseline.shortfall(), 0);
+    }
+
+    #[test]
+    fn two_data_plus_witness_does_not_meet_baseline() {
+        // A witness is not the recommended baseline: 2 data + 1 witness is
+        // below the three-data-member baseline.
+        let cid = ClusterId::new("cluster-x").unwrap();
+        let catalog = MembershipCatalog::new(
+            cid,
+            [
+                data_member("CN=node-a"),
+                data_member("CN=node-b"),
+                ClusterMember::joined_empty(ident("CN=witness"), MemberKind::Witness),
+            ],
+        );
+        let baseline = catalog.assess_baseline();
+        assert!(!baseline.meets_baseline());
+        assert_eq!(baseline.shortfall(), 1);
+    }
+
+    #[test]
+    fn admit_is_idempotent_and_preserves_ranges() {
+        let cid = ClusterId::new("cluster-x").unwrap();
+        let mut catalog = MembershipCatalog::new(cid, [data_member("CN=node-a")]);
+        catalog
+            .member_mut(&ident("CN=node-a"))
+            .unwrap()
+            .assign_ranges(3);
+
+        // Re-admitting must not reset an existing member's range count.
+        let outcome = catalog.admit(data_member("CN=node-a"));
+        assert_eq!(outcome, AdmissionOutcome::AlreadyMember);
+        assert_eq!(
+            catalog
+                .member(&ident("CN=node-a"))
+                .unwrap()
+                .owned_range_count(),
+            3
+        );
+
+        let outcome = catalog.admit(data_member("CN=node-b"));
+        assert_eq!(outcome, AdmissionOutcome::Admitted);
+        assert_eq!(catalog.len(), 2);
+    }
+
+    #[test]
+    fn autodetect_is_limited_to_authorized_members() {
+        let cid = ClusterId::new("cluster-x").unwrap();
+        let catalog = MembershipCatalog::new(cid, [data_member("CN=node-a")]);
+
+        // An authorized member is an autodetect candidate.
+        assert!(catalog.is_autodetect_eligible(&ident("CN=node-a")));
+        // An arbitrary reachable network peer that never joined is not.
+        assert!(!catalog.is_autodetect_eligible(&ident("CN=random-peer")));
+        assert_eq!(catalog.autodetect_candidates().count(), 1);
+    }
+}

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -1,7 +1,14 @@
-//! Shared cluster identity model.
+//! Shared cluster identity and membership model.
 
 pub mod identity;
+pub mod join;
+pub mod membership;
 
 pub use identity::{
     ClusterVoterIdentity, NodeIdentity, NodeIdentityError, ReplicationPeerIdentity,
+};
+pub use join::{ControlPlaneSnapshot, JoinGrant, JoinRejection, JoinRequest, SeedAuthority};
+pub use membership::{
+    AdmissionOutcome, BaselineAssessment, ClusterId, ClusterIdError, ClusterMember, MemberKind,
+    MembershipCatalog, RESILIENT_DATA_MEMBER_BASELINE,
 };

--- a/drivers/js-client/src/core/url.js
+++ b/drivers/js-client/src/core/url.js
@@ -189,17 +189,31 @@ export function parseLegacyUrl(uri) {
     || uri.startsWith('reds://')
   ) {
     const scheme = uri.split('://', 1)[0]
-    const stripped = uri.slice(`${scheme}://`.length)
-    const [hostPort] = stripped.split(/[/?]/, 1)
-    const [host, portStr] = hostPort.split(':')
-    if (!host) {
+    let parsed
+    try {
+      // Borrow the URL parser via an `https://` authority (same trick as
+      // parseRedWssUrl) so userinfo / host / port / query all decode with
+      // the standard rules — a naive `hostPort.split(':')` breaks on
+      // `reds://user:pass@host:5050` (host becomes `user`, port NaN).
+      parsed = new URL('https://' + uri.slice(`${scheme}://`.length))
+    } catch (err) {
+      throw new RedDBError('UNPARSEABLE_URI', `failed to parse '${uri}': ${err.message}`)
+    }
+    if (!parsed.hostname) {
       throw new TypeError(`invalid ${scheme}:// URI: missing host in '${uri}'`)
     }
-    const legacyKind = scheme === 'reds' ? 'reds' : scheme === 'grpcs' ? 'grpcs' : scheme === 'grpc' ? 'grpc' : 'red'
+    const legacyKind = scheme === 'reds' ? 'reds' : scheme === 'grpcs' ? 'grpcs' : 'grpc'
+    const params = parsed.searchParams
     return {
       kind: legacyKind,
-      host,
-      port: portStr ? Number(portStr) : defaultPortFor(legacyKind),
+      host: parsed.hostname,
+      port: parsed.port ? Number(parsed.port) : defaultPortFor(legacyKind),
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+      token: params.get('token') ?? undefined,
+      apiKey: params.get('apiKey') ?? params.get('api_key') ?? undefined,
+      loginUrl: params.get('loginUrl') ?? params.get('login_url') ?? undefined,
+      params,
       originalUri: uri,
     }
   }

--- a/drivers/js-client/test/url.test.mjs
+++ b/drivers/js-client/test/url.test.mjs
@@ -1,0 +1,67 @@
+/**
+ * Connection-string parser tests. Guards the legacy `reds://`/`grpc(s)://`
+ * branch against the userinfo regression: `reds://user:pass@host:5050` must
+ * parse host/port/credentials (a naive `split(':')` made host become `user`
+ * and port NaN, so the RedDB Cloud conn string never reached the server).
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseUri } from '../src/core/url.js'
+
+test('reds:// with userinfo parses host, port and credentials', () => {
+  const p = parseUri('reds://admin:s3cr%40t@db1.org1.db.reddb.io:5050')
+  assert.equal(p.kind, 'reds')
+  assert.equal(p.host, 'db1.org1.db.reddb.io')
+  assert.equal(p.port, 5050)
+  assert.equal(p.username, 'admin')
+  assert.equal(p.password, 's3cr@t')
+})
+
+test('reds:// without userinfo keeps legacy behaviour (default port)', () => {
+  const p = parseUri('reds://db1.org1.db.reddb.io')
+  assert.equal(p.kind, 'reds')
+  assert.equal(p.host, 'db1.org1.db.reddb.io')
+  assert.equal(p.port, 5050)
+  assert.equal(p.username, undefined)
+  assert.equal(p.password, undefined)
+})
+
+test('reds:// carries token and loginUrl query params', () => {
+  const p = parseUri('reds://host:5050?token=sk-abc&loginUrl=https%3A%2F%2Fapi.example%2Flogin')
+  assert.equal(p.token, 'sk-abc')
+  assert.equal(p.loginUrl, 'https://api.example/login')
+})
+
+test('grpc:// and grpcs:// keep legacy host/port behaviour', () => {
+  const g = parseUri('grpc://localhost:5555')
+  assert.equal(g.kind, 'grpc')
+  assert.equal(g.host, 'localhost')
+  assert.equal(g.port, 5555)
+
+  const gs = parseUri('grpcs://remote.example')
+  assert.equal(gs.kind, 'grpcs')
+  assert.equal(gs.host, 'remote.example')
+})
+
+test('grpcs:// with userinfo parses credentials too', () => {
+  const p = parseUri('grpcs://user:pw@remote.example:5555')
+  assert.equal(p.host, 'remote.example')
+  assert.equal(p.port, 5555)
+  assert.equal(p.username, 'user')
+  assert.equal(p.password, 'pw')
+})
+
+test('reds:// with empty host throws', () => {
+  assert.throws(() => parseUri('reds://'))
+})
+
+test('red:// canonical with userinfo still parses (regression lock)', () => {
+  const p = parseUri('red://admin:pw@host:5050')
+  assert.equal(p.kind, 'red')
+  assert.equal(p.host, 'host')
+  assert.equal(p.port, 5050)
+  assert.equal(p.username, 'admin')
+  assert.equal(p.password, 'pw')
+})

--- a/drivers/js/package.json
+++ b/drivers/js/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "postinstall": "node postinstall.js",
-    "test": "node --test test/ask.test.mjs test/cache.test.mjs test/db-helpers.test.mjs test/embedded-only.test.mjs test/helpers.test.mjs test/insert-ids.test.mjs test/kv.test.mjs test/params.test.mjs test/postinstall.test.mjs test/queue.test.mjs test/redwire.params.test.mjs test/transaction.test.mjs && node test/smoke.test.mjs && node test/conformance.test.mjs && node test/readme-examples.test.mjs"
+    "test": "node --test test/ask.test.mjs test/cache.test.mjs test/db-helpers.test.mjs test/embedded-only.test.mjs test/helpers.test.mjs test/insert-ids.test.mjs test/kv.test.mjs test/params.test.mjs test/postinstall.test.mjs test/queue.test.mjs test/redwire.params.test.mjs test/transaction.test.mjs test/url.test.mjs && node test/smoke.test.mjs && node test/conformance.test.mjs && node test/readme-examples.test.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/drivers/js/src/url.js
+++ b/drivers/js/src/url.js
@@ -153,17 +153,31 @@ export function parseLegacyUrl(uri) {
     || uri.startsWith('reds://')
   ) {
     const scheme = uri.split('://', 1)[0]
-    const stripped = uri.slice(`${scheme}://`.length)
-    const [hostPort] = stripped.split(/[/?]/, 1)
-    const [host, portStr] = hostPort.split(':')
-    if (!host) {
+    let parsed
+    try {
+      // Borrow the URL parser via an `https://` authority so userinfo /
+      // host / port / query all decode with the standard rules — a naive
+      // `hostPort.split(':')` breaks on `reds://user:pass@host:5050`
+      // (host becomes `user`, port NaN).
+      parsed = new URL('https://' + uri.slice(`${scheme}://`.length))
+    } catch (err) {
+      throw new RedDBError('UNPARSEABLE_URI', `failed to parse '${uri}': ${err.message}`)
+    }
+    if (!parsed.hostname) {
       throw new TypeError(`invalid ${scheme}:// URI: missing host in '${uri}'`)
     }
-    const legacyKind = scheme === 'reds' ? 'reds' : scheme === 'grpcs' ? 'grpcs' : scheme === 'grpc' ? 'grpc' : 'red'
+    const legacyKind = scheme === 'reds' ? 'reds' : scheme === 'grpcs' ? 'grpcs' : 'grpc'
+    const params = parsed.searchParams
     return {
       kind: legacyKind,
-      host,
-      port: portStr ? Number(portStr) : defaultPortFor(legacyKind),
+      host: parsed.hostname,
+      port: parsed.port ? Number(parsed.port) : defaultPortFor(legacyKind),
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+      token: params.get('token') ?? undefined,
+      apiKey: params.get('apiKey') ?? params.get('api_key') ?? undefined,
+      loginUrl: params.get('loginUrl') ?? params.get('login_url') ?? undefined,
+      params,
       originalUri: uri,
     }
   }

--- a/drivers/js/test/url.test.mjs
+++ b/drivers/js/test/url.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Connection-string parser tests. Guards the legacy `reds://`/`grpc(s)://`
+ * branch against the userinfo regression: `reds://user:pass@host:5050` must
+ * parse host/port/credentials (a naive `split(':')` made host become `user`
+ * and port NaN, so the RedDB Cloud conn string never reached the server).
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseUri } from '../src/url.js'
+
+test('reds:// with userinfo parses host, port and credentials', () => {
+  const p = parseUri('reds://admin:s3cr%40t@db1.org1.db.reddb.io:5050')
+  assert.equal(p.kind, 'reds')
+  assert.equal(p.host, 'db1.org1.db.reddb.io')
+  assert.equal(p.port, 5050)
+  assert.equal(p.username, 'admin')
+  assert.equal(p.password, 's3cr@t')
+})
+
+test('reds:// without userinfo keeps legacy behaviour (default port)', () => {
+  const p = parseUri('reds://db1.org1.db.reddb.io')
+  assert.equal(p.kind, 'reds')
+  assert.equal(p.host, 'db1.org1.db.reddb.io')
+  assert.equal(p.port, 5050)
+  assert.equal(p.username, undefined)
+  assert.equal(p.password, undefined)
+})
+
+test('reds:// carries token and loginUrl query params', () => {
+  const p = parseUri('reds://host:5050?token=sk-abc&loginUrl=https%3A%2F%2Fapi.example%2Flogin')
+  assert.equal(p.token, 'sk-abc')
+  assert.equal(p.loginUrl, 'https://api.example/login')
+})
+
+test('grpc:// and grpcs:// keep legacy host/port behaviour', () => {
+  const g = parseUri('grpc://localhost:5555')
+  assert.equal(g.kind, 'grpc')
+  assert.equal(g.host, 'localhost')
+  assert.equal(g.port, 5555)
+
+  const gs = parseUri('grpcs://remote.example')
+  assert.equal(gs.kind, 'grpcs')
+  assert.equal(gs.host, 'remote.example')
+})
+
+test('reds:// with empty host throws', () => {
+  assert.throws(() => parseUri('reds://'))
+})


### PR DESCRIPTION
## What
`parseLegacyUrl` split the authority with a naive `hostPort.split(':')`, so `reds://user:pass@host:5050` parsed **host as `user`** and **port as `NaN`**, dropping credentials and query params entirely — the canonical RedDB Cloud connection string never reached the server, and the HTTPS auto-login leg never fired.

## Fix
Route the `reds://` and `grpc(s)://` branches through the URL parser via a borrowed `https://` authority (the same trick `parseRedWssUrl` uses), so userinfo / host / port / `token`/`apiKey`/`loginUrl` query params all decode with standard rules. Bare-host and `host:port` shapes keep their legacy behaviour (default ports included).

Applied identically to `@reddb-io/client` (`src/core/url.js`) and `@reddb-io/sdk` (`src/url.js`).

## Tests
- New `test/url.test.mjs` in both drivers (7 + 5 cases: userinfo, defaults, query params, grpc(s) back-compat, empty-host throw, `red://` regression lock).
- js-client full suite: **172 pass / 0 fail**; sdk unit subset green.

## Context
Found while wiring TLS for the cloud wire path (`reds://<dbId>.<orgId>.db.reddb.io:5050`) — the conn string handed to customers by rio-lair mis-parses without this.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783641780&installation_id=129708444&pr_number=1065&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1065&signature=906bd86483b1fc2f97f77a67c285795d99f2ece7d85ace3cc064cdd3e5bac0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster membership management and authenticated node join flow with admission validation.

* **Bug Fixes**
  * Fixed connection string parsing for `reds://` and `grpc(s)://` schemes to correctly extract and preserve embedded credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->