### PR TITLE
fix(server): widen statfs.f_type for 32-bit targets (armv7 release build)

### DIFF
--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -46,7 +46,10 @@ fn linux_fstatfs_type(file: &File) -> Option<i64> {
         return None;
     }
     let stat = unsafe { stat.assume_init() };
-    Some(stat.f_type)
+    // `statfs.f_type` is i32 on 32-bit glibc targets (armv7) and i64 on
+    // 64-bit ones — widen explicitly so both compile.
+    #[allow(clippy::unnecessary_cast)]
+    Some(stat.f_type as i64)
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Release run 27251197303 failed on Build linux-armv7 with E0308: `statfs.f_type` is `i32` on 32-bit glibc targets but `i64` on 64-bit ones, and `linux_fstatfs_type` returns `Option<i64>`. Explicit `as i64` compiles on both; no-op on 64-bit.

Part of unblocking the v1.10.1 release train (npm publishes were skipped). Remaining failures are separate: crates publish ordering (`reddb-io-file` never published to crates.io), linux-aarch64-static producing no `red` binary, and the image size gate (52.98MB > limit).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783656256&installation_id=129708444&pr_number=1066&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1066&signature=dacf92c5fd79b1441a8b78a826d311dd92c322c19daa99e687a0f7634a4522a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filesystem-type detection behavior on Linux systems to ensure correct handling across different `glibc` target architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->