### PR TITLE
merge: #996 Decide Cluster Supervisor control-plane consensus approach

### DIFF
--- a/.red/adr/0052-cluster-supervisor-control-plane-consensus.md
+++ b/.red/adr/0052-cluster-supervisor-control-plane-consensus.md
@@ -1,0 +1,138 @@
+# ADR 0052 — Cluster Supervisor Control-Plane Consensus
+
+Status: accepted
+Date: 2026-06-10
+
+Resolves issue #996 (parent #987). Extends [ADR 0030](0030-replication-consistency-and-failover-model.md)
+(replication consistency and failover model) and [ADR 0037](0037-shard-range-ownership-catalog.md)
+(shard/range ownership catalog).
+
+The Cluster Supervisor is RedDB's native control-plane module: it manages
+membership, health, failover, and shard/range ownership while staying
+decoupled from the data-plane write path (see the
+[clustering glossary](../context/clustering.md)). ADR 0030 fixed *who decides
+the leader* and *what a write acknowledgement guarantees*. ADR 0037 fixed that
+ownership is versioned catalog state mutated through fenced transitions. What
+neither pinned down — and what this ADR decides — is the **concrete
+control-plane consensus approach**: how Supervisor membership, leader election,
+durable vote/log state, and ownership-catalog transitions are agreed and
+persisted, so follow-up implementation slices can proceed without re-opening the
+protocol choice or selecting a consensus library.
+
+## Decision
+
+**A Raft-equivalent consensus layer governs the control plane only.** Supervisor
+membership, leader election, durable vote/log state, and global ownership
+catalog transitions are agreed through a single replicated control-plane log
+with Raft-equivalent safety: a term-based election with a strict-majority quorum,
+a durable per-node last-vote so no node double-votes across a restart, and an
+append-only log whose entries are committed once replicated to a quorum. This is
+the layer the existing election core
+([`replication::election`](../../crates/reddb-server/src/replication/election.rs),
+issue #834) and witness profile (issue #836) already begin; this ADR names the
+log half of the same protocol and fixes its boundaries.
+
+**User-data writes stay outside the control-plane consensus log.** The
+control-plane log carries *only* control-plane entries — membership changes and
+ownership-catalog transitions. User-data writes are never recorded in it and are
+never gated by reaching a control-plane commit index. User data continues to
+flow through the data plane (WAL → logical replication stream → replicas, ADR
+0030/0044) under per-range ownership and commit policy. The control plane decides
+*who may write a range and where it lives*; it does not carry *what* is written.
+This is the central line ADR 0030 drew ("we take the term/epoch and vote-safety
+ideas without running data payloads through a Raft log") made concrete: the two
+logs are physically separate and a user write touches exactly one of them.
+
+**Durable vote/log state is a hard requirement for Supervisor leader election.**
+Every voting member persists, on disk and fsync-ordered *before* the grant is
+acknowledged: (1) the current term, (2) `voted_for` for that term (the existing
+[`LastVoteStore`](../../crates/reddb-server/src/replication/election.rs)), and
+(3) the control-plane log entries it has accepted plus the highest committed
+index. A member that crashes and restarts mid-term must recover this state and
+must not double-vote or lose a committed control-plane entry. Election safety
+(at most one leader per term) and log safety (a committed entry is never lost)
+both depend on this durability and are not optional for an HA deployment.
+
+**The elected Supervisor leader is the normal writer for ownership-catalog
+transitions.** A shard/range ownership transition (move, split, merge, promote;
+ADR 0037) is, in the normal path, proposed and appended to the control-plane log
+by the current Supervisor leader and applied once committed. The leader is the
+single normal writer of catalog state; followers learn transitions by applying
+the committed log. This keeps ADR 0037's "ownership changes are transitions, not
+arbitrary row edits" intact and gives those transitions the same fenced,
+versioned, audited machinery. Forced/administrative recovery transitions remain
+the documented exception (ADR 0037), proceeding without ordinary quorum under a
+special capability with an epoch bump that fences any stale owner.
+
+**The concrete consensus engine sits behind a small internal abstraction.**
+Follow-up slices target a narrow seam —
+[`replication::control_plane::ControlPlaneConsensus`](../../crates/reddb-server/src/replication/control_plane.rs)
+— rather than a specific library or hand-rolled protocol. The seam exposes the
+role/term/leader, the committed index, and a leader-only `propose` over a closed
+`ControlPlaneEntry` set (membership changes and ownership transitions only). The
+entry type is closed by construction so there is *no* user-data variant to
+misuse, and the encoding of each entry's payload is owned by the slice that
+implements it. Whether the engine is an embedded Raft crate, the in-house
+election core extended with a replicated log, or another quorum protocol is an
+implementation detail behind this seam; swapping it must not change the boundary.
+
+## Considered Options
+
+- **Raft-equivalent control plane, user data outside it (chosen).** Gives RedDB
+  built-in automatic failover and a single auditable order for membership and
+  ownership decisions, with the strong safety properties Raft provides, while
+  keeping the data path free of consensus latency. Honours ADR 0030's
+  decoupling and ADR 0037's transition model.
+- **Fully embedded Raft owning the leader *and* the data writes (Mongo/Neo4j
+  shape).** Rejected: routing user payloads through a consensus log couples write
+  throughput and latency to control-plane quorum and re-entangles the write path
+  that ADR 0030 deliberately separated. We adopt Raft's vote/log safety for the
+  control plane without paying its cost on every user write.
+- **Fully external orchestration only (Patroni/Sentinel).** Rejected as the sole
+  model: it leaves RedDB the lone reference system without native failover and
+  pushes ownership-catalog authority outside the database. RedDB may still
+  *consume* operator-declared desired state, but it keeps native autodetect and
+  failover.
+- **No consensus — gossip/heartbeat ownership with last-writer-wins.** Rejected:
+  without a quorum-committed order, concurrent Supervisors can record divergent
+  ownership and two writers can believe they own the same range. The whole point
+  of the ownership catalog (ADR 0037) is a single fenced order.
+- **Commit a library now (e.g. pin `openraft`).** Deferred, not rejected: the
+  seam means a slice can adopt a library later without re-deciding the boundary.
+  Choosing one now would over-commit before the log-storage and snapshot slices
+  define their needs.
+
+## Safety properties required before implementation
+
+1. **Single leader per term.** A control-plane term has at most one leader.
+   Enforced structurally: a win needs a strict majority of voting members, any
+   two majorities intersect, and the shared voter grants at most one vote per
+   term from durable state.
+2. **Committed-entry durability.** A control-plane entry committed (replicated to
+   a quorum) is never lost or reordered across any failover or restart. The
+   ownership state a committed transition establishes survives leader change.
+3. **No double-vote across restart.** A voter that restarts mid-term honours its
+   persisted `(term, voted_for)` and refuses a conflicting grant from disk.
+4. **Data/control isolation.** No user-data write is recorded in, ordered by, or
+   gated on the control-plane log; no control-plane entry carries user-data
+   payloads. The closed `ControlPlaneEntry` set enforces the second half at the
+   type level.
+5. **Fenced ownership transitions.** Ownership transitions written by the leader
+   carry term + ownership epoch so a stale former leader/owner cannot apply a
+   divergent transition (ADR 0037 fencing, ADR 0032 term framing).
+
+## Consequences
+
+- The election core (issue #834) and witness profile (issue #836) are the
+  election half of this layer; a follow-up slice adds the **replicated
+  control-plane log** (append/commit + durable log store) behind the same seam.
+- The control-plane log needs durable per-node storage distinct from the data
+  WAL, plus a snapshot/compaction story for membership + ownership state — a
+  named follow-up, not part of this decision.
+- Ownership-catalog writes (ADR 0037) route through the leader's `propose` path
+  in the normal case; administrative `FORCE` transitions keep their documented
+  out-of-band recovery path.
+- Implementation slices after #996 depend on the
+  [`ControlPlaneConsensus`](../../crates/reddb-server/src/replication/control_plane.rs)
+  seam and the boundaries above, and do not re-open the protocol or library
+  choice.

--- a/crates/reddb-server/src/replication/control_plane.rs
+++ b/crates/reddb-server/src/replication/control_plane.rs
@@ -1,0 +1,349 @@
+//! Control-plane consensus seam (issue #996, parent #987, ADR 0052).
+//!
+//! The Cluster Supervisor coordinates membership, leader election, and
+//! shard/range ownership through a **Raft-equivalent control-plane consensus
+//! layer** — and *only* the control plane. [ADR 0052] fixes the boundary; this
+//! module is the small internal abstraction that boundary lives behind, so the
+//! follow-up implementation slices (the replicated log, its durable store, its
+//! snapshot/compaction) target a named seam instead of picking a consensus
+//! library or inventing protocol semantics.
+//!
+//! ## What goes through this layer — and what never does
+//!
+//! The control-plane log carries exactly two kinds of entry:
+//!
+//! * a **membership change** — admission, removal, or role change of a cluster
+//!   member; and
+//! * an **ownership-catalog transition** — a fenced, versioned move / split /
+//!   merge / promote of a shard/range (ADR 0037).
+//!
+//! [`ControlPlaneEntry`] is *closed* over exactly these two: there is, by
+//! construction, **no user-data variant**. User-data writes are never recorded
+//! in, ordered by, or gated on the control-plane log — they flow through the
+//! data plane (WAL → logical stream → replicas, ADR 0030/0044) under per-range
+//! ownership and commit policy. The control plane decides *who may write a
+//! range and where it lives*; it does not carry *what* is written. The two logs
+//! are physically separate and a user write touches exactly one of them. This
+//! is the central line ADR 0030 drew ("the term/epoch and vote-safety ideas
+//! without running data payloads through a Raft log") made concrete and
+//! type-enforced.
+//!
+//! ## Relationship to the election core
+//!
+//! The election half of this protocol already exists: term-based, quorum-gated
+//! election with a durable last-vote in [`super::election`] (issue #834), and
+//! the vote-only [`super::witness`] profile (issue #836). This seam names the
+//! *log* half — append + commit of control-plane entries — and ties it to the
+//! same role/term so the whole forms one Raft-equivalent layer. The concrete
+//! engine behind [`ControlPlaneConsensus`] (an embedded Raft crate, the
+//! election core extended with a replicated log, or another quorum protocol) is
+//! an implementation detail; swapping it must not change the boundary above.
+//!
+//! ## Durable state requirement
+//!
+//! An implementation must persist, fsync-ordered, before acknowledging a vote
+//! grant or reporting an entry committed: the current term, `voted_for` for
+//! that term (the existing [`super::election::LastVoteStore`]), and the accepted
+//! control-plane log entries plus the highest committed index. Election safety
+//! (one leader per term) and log safety (a committed entry is never lost) both
+//! depend on it (ADR 0052, safety properties 1–3).
+//!
+//! [ADR 0052]: ../../../../.red/adr/0052-cluster-supervisor-control-plane-consensus.md
+
+/// Stable identity of a cluster member, matching the election membership id
+/// ([`super::election::Member::id`]) and the replica/ack id namespace.
+pub type MemberId = String;
+
+/// Position of an entry in the control-plane log. Monotonic per term-history;
+/// an entry is durable once its index is at or below the committed index of a
+/// quorum.
+pub type ControlPlaneLogIndex = u64;
+
+/// This node's role in the control-plane consensus layer.
+///
+/// Mirrors the Raft-equivalent roles. A node that holds data may take any role;
+/// a [witness](super::witness) participates as a [`Follower`](Self::Follower) or
+/// [`Candidate`](Self::Candidate) but never leads a data range — its leadership
+/// is over control-plane state only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlPlaneRole {
+    /// Currently leading the control-plane log; the normal writer of ownership
+    /// catalog transitions (ADR 0037, ADR 0052).
+    Leader,
+    /// Following the current leader; applies committed entries, votes per the
+    /// durable last-vote rule.
+    Follower,
+    /// Standing in an election for a new term; not yet a leader.
+    Candidate,
+}
+
+/// The kind of a [`ControlPlaneEntry`], without its payload.
+///
+/// Exhaustive over everything the control-plane log may carry. The deliberate
+/// absence of a user-data kind is the type-level half of ADR 0052's
+/// data/control isolation property.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControlPlaneEntryKind {
+    /// Admission, removal, or role change of a cluster member.
+    MembershipChange,
+    /// A fenced, versioned shard/range ownership catalog transition (ADR 0037).
+    OwnershipTransition,
+}
+
+/// Opaque, already-encoded body of a control-plane entry.
+///
+/// The seam stays agnostic to *how* a membership change or an ownership
+/// transition is encoded: the slice that implements that entry owns its wire
+/// shape. The seam only guarantees the body is one of the two control-plane
+/// kinds — never user data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ControlPlanePayload(pub Vec<u8>);
+
+impl ControlPlanePayload {
+    /// Borrow the encoded bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+/// A single entry in the control-plane log.
+///
+/// Closed over exactly the two control-plane concerns (see
+/// [`ControlPlaneEntryKind`]). There is no constructor for a user-data entry,
+/// so the data/control boundary cannot be crossed by appending to this log.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ControlPlaneEntry {
+    /// Admission, removal, or role change of a cluster member.
+    MembershipChange(ControlPlanePayload),
+    /// A fenced, versioned shard/range ownership catalog transition (ADR 0037),
+    /// normally proposed by the Supervisor leader.
+    OwnershipTransition(ControlPlanePayload),
+}
+
+impl ControlPlaneEntry {
+    /// The kind of this entry, without its payload.
+    #[must_use]
+    pub fn kind(&self) -> ControlPlaneEntryKind {
+        match self {
+            Self::MembershipChange(_) => ControlPlaneEntryKind::MembershipChange,
+            Self::OwnershipTransition(_) => ControlPlaneEntryKind::OwnershipTransition,
+        }
+    }
+
+    /// Borrow the entry's opaque payload.
+    #[must_use]
+    pub fn payload(&self) -> &ControlPlanePayload {
+        match self {
+            Self::MembershipChange(p) | Self::OwnershipTransition(p) => p,
+        }
+    }
+}
+
+/// Why a [`ControlPlaneConsensus::propose`] was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProposeRefusal {
+    /// This node is not the current leader. Only the leader is the normal writer
+    /// of control-plane entries (ADR 0052); the caller should route to
+    /// [`ControlPlaneConsensus::leader`] or retry after the next election.
+    NotLeader {
+        /// The leader this node currently believes in, if any.
+        leader: Option<MemberId>,
+    },
+    /// The node lost the control-plane quorum and cannot commit new entries
+    /// until quorum/lease authority is restored (owner self-fence, ADR 0037).
+    NoQuorum,
+}
+
+/// The Cluster Supervisor's control-plane consensus seam.
+///
+/// A follow-up slice implements this over a concrete Raft-equivalent engine.
+/// Callers — the rebalancer, the join/drain flows, the ownership-transition
+/// machinery — depend on this trait and the ADR 0052 boundaries, never on the
+/// engine. The contract is intentionally narrow: read the current
+/// role/term/leader and committed index, and (leader-only) propose a
+/// control-plane entry.
+///
+/// Implementations must uphold ADR 0052's safety properties: one leader per
+/// term, committed entries never lost, no double-vote across restart, and the
+/// data/control isolation that [`ControlPlaneEntry`] already enforces at the
+/// type level.
+pub trait ControlPlaneConsensus {
+    /// This node's current control-plane role.
+    fn role(&self) -> ControlPlaneRole;
+
+    /// The current control-plane term.
+    fn term(&self) -> u64;
+
+    /// The member this node currently believes is leader, if any.
+    fn leader(&self) -> Option<MemberId>;
+
+    /// Highest control-plane log index known committed (durable to a quorum).
+    fn committed_index(&self) -> ControlPlaneLogIndex;
+
+    /// Whether this node is the current leader — the normal writer of
+    /// ownership-catalog transitions (ADR 0052).
+    fn is_leader(&self) -> bool {
+        self.role() == ControlPlaneRole::Leader
+    }
+
+    /// Append a control-plane entry to the replicated log.
+    ///
+    /// Leader-only. Returns the index the entry will occupy once committed by a
+    /// quorum, or a [`ProposeRefusal`] if this node is not the leader or has
+    /// lost quorum. The returned index is *assigned*, not yet committed; callers
+    /// that need durability wait for [`committed_index`](Self::committed_index)
+    /// to reach it.
+    fn propose(&mut self, entry: ControlPlaneEntry)
+        -> Result<ControlPlaneLogIndex, ProposeRefusal>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload() -> ControlPlanePayload {
+        ControlPlanePayload(vec![1, 2, 3])
+    }
+
+    #[test]
+    fn entry_kind_maps_each_variant() {
+        assert_eq!(
+            ControlPlaneEntry::MembershipChange(payload()).kind(),
+            ControlPlaneEntryKind::MembershipChange,
+        );
+        assert_eq!(
+            ControlPlaneEntry::OwnershipTransition(payload()).kind(),
+            ControlPlaneEntryKind::OwnershipTransition,
+        );
+    }
+
+    #[test]
+    fn entry_payload_is_accessible_for_both_kinds() {
+        let m = ControlPlaneEntry::MembershipChange(payload());
+        let o = ControlPlaneEntry::OwnershipTransition(payload());
+        assert_eq!(m.payload().as_bytes(), &[1, 2, 3]);
+        assert_eq!(o.payload().as_bytes(), &[1, 2, 3]);
+    }
+
+    /// The control-plane entry set is closed over exactly the two control-plane
+    /// concerns — there is no user-data variant to match. This exhaustive match
+    /// fails to compile if a non-control-plane variant is ever added, which is
+    /// the type-level enforcement of ADR 0052's data/control isolation.
+    #[test]
+    fn entry_set_is_closed_over_control_plane_only() {
+        let kinds = [
+            ControlPlaneEntryKind::MembershipChange,
+            ControlPlaneEntryKind::OwnershipTransition,
+        ];
+        for kind in kinds {
+            match kind {
+                ControlPlaneEntryKind::MembershipChange
+                | ControlPlaneEntryKind::OwnershipTransition => {}
+            }
+        }
+    }
+
+    /// A minimal seam implementation, proving the trait expresses leader-only
+    /// `propose` and the role/term/leader/committed reads a slice will rely on.
+    struct FakeConsensus {
+        role: ControlPlaneRole,
+        term: u64,
+        leader: Option<MemberId>,
+        committed: ControlPlaneLogIndex,
+        next_index: ControlPlaneLogIndex,
+        has_quorum: bool,
+    }
+
+    impl ControlPlaneConsensus for FakeConsensus {
+        fn role(&self) -> ControlPlaneRole {
+            self.role
+        }
+        fn term(&self) -> u64 {
+            self.term
+        }
+        fn leader(&self) -> Option<MemberId> {
+            self.leader.clone()
+        }
+        fn committed_index(&self) -> ControlPlaneLogIndex {
+            self.committed
+        }
+        fn propose(
+            &mut self,
+            _entry: ControlPlaneEntry,
+        ) -> Result<ControlPlaneLogIndex, ProposeRefusal> {
+            if self.role != ControlPlaneRole::Leader {
+                return Err(ProposeRefusal::NotLeader {
+                    leader: self.leader.clone(),
+                });
+            }
+            if !self.has_quorum {
+                return Err(ProposeRefusal::NoQuorum);
+            }
+            let idx = self.next_index;
+            self.next_index += 1;
+            Ok(idx)
+        }
+    }
+
+    #[test]
+    fn follower_propose_is_refused_with_leader_hint() {
+        let mut node = FakeConsensus {
+            role: ControlPlaneRole::Follower,
+            term: 7,
+            leader: Some("n1".to_string()),
+            committed: 42,
+            next_index: 43,
+            has_quorum: true,
+        };
+        assert!(!node.is_leader());
+        assert_eq!(node.term(), 7);
+        assert_eq!(node.committed_index(), 42);
+        let refusal = node
+            .propose(ControlPlaneEntry::OwnershipTransition(payload()))
+            .unwrap_err();
+        assert_eq!(
+            refusal,
+            ProposeRefusal::NotLeader {
+                leader: Some("n1".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn leader_propose_assigns_increasing_indexes() {
+        let mut node = FakeConsensus {
+            role: ControlPlaneRole::Leader,
+            term: 9,
+            leader: Some("self".to_string()),
+            committed: 10,
+            next_index: 11,
+            has_quorum: true,
+        };
+        assert!(node.is_leader());
+        let a = node
+            .propose(ControlPlaneEntry::OwnershipTransition(payload()))
+            .unwrap();
+        let b = node
+            .propose(ControlPlaneEntry::MembershipChange(payload()))
+            .unwrap();
+        assert_eq!(a, 11);
+        assert_eq!(b, 12);
+    }
+
+    #[test]
+    fn leader_without_quorum_self_fences() {
+        let mut node = FakeConsensus {
+            role: ControlPlaneRole::Leader,
+            term: 9,
+            leader: Some("self".to_string()),
+            committed: 10,
+            next_index: 11,
+            has_quorum: false,
+        };
+        let refusal = node
+            .propose(ControlPlaneEntry::MembershipChange(payload()))
+            .unwrap_err();
+        assert_eq!(refusal, ProposeRefusal::NoQuorum);
+    }
+}

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -25,6 +25,7 @@ pub mod cascade;
 pub mod cdc;
 pub mod commit_policy;
 pub mod commit_waiter;
+pub mod control_plane;
 pub mod election;
 pub mod failover;
 pub mod fence;
@@ -47,6 +48,10 @@ pub use cascade::{
 };
 pub use commit_policy::CommitPolicy;
 pub use commit_waiter::{AwaitOutcome, CommitWaiter};
+pub use control_plane::{
+    ControlPlaneConsensus, ControlPlaneEntry, ControlPlaneEntryKind, ControlPlaneLogIndex,
+    ControlPlanePayload, ControlPlaneRole, MemberId, ProposeRefusal,
+};
 pub use election::{
     quorum_threshold, randomized_election_timeout, ElectionCoordinator, ElectionOutcome,
     ElectionRequest, ElectionTransport, FileLastVoteStore, LastVote, LastVoteError, LastVoteStore,


### PR DESCRIPTION
Automated AFK landing for #996. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783656614&installation_id=129708444&pr_number=1067&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1067&signature=ba9490e9f34f294d5dcf33e951cfcb11e5ded72e48362655f1dcdf203ed448df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented cluster supervisor consensus strategy for multi-node deployments.

* **New Features**
  * Implemented cluster control-plane consensus mechanism enabling distributed coordination, leader election, and membership management across cluster nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->