### PR TITLE
fix(release): resolve three v1.10.1 release blockers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,6 +248,7 @@ jobs:
         run: |
           docker run --rm -v "${PWD}:/volume" -w /volume messense/rust-musl-cross:aarch64-musl \
             bash -lc '
+              set -euo pipefail
               rm -f rust-toolchain.toml
               curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v28.3/protoc-28.3-linux-x86_64.zip -o /tmp/protoc.zip
               unzip -o /tmp/protoc.zip -d /usr/local >/dev/null
@@ -531,6 +532,7 @@ jobs:
           publish_one reddb-io-wire
           publish_one reddb-io-grpc-proto
           publish_one reddb-io-client-connector
+          publish_one reddb-io-file
           publish_one reddb-io-server
           publish_one reddb-io-client
           publish_one reddb-io

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,22 @@
 # ============================================================================
 # RedDB - Multi-stage Docker build
 # ============================================================================
-# Stage 1: Build release binaries with protobuf support
-# Stage 2: distroless runtime with non-root user
+# Stage 1: Build release binaries with protobuf support (musl static)
+# Stage 2: distroless static runtime with non-root user
 # ============================================================================
 
 FROM rust:1.95-slim-bookworm AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG REDDB_CARGO_FEATURES=""
-ENV CARGO_PROFILE_RELEASE_STRIP=symbols
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y --no-install-recommends protobuf-compiler musl-tools \
+    && rm -rf /var/lib/apt/lists/* \
+    && rustup target add x86_64-unknown-linux-musl
+
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
+    CC_x86_64_unknown_linux_musl=musl-gcc
 
 WORKDIR /app
 
@@ -28,19 +31,19 @@ COPY docs/spec/ docs/spec/
 RUN mkdir -p src/bin \
     && echo 'fn main() {}' > src/bin/red.rs \
     && echo '' > src/lib.rs \
-    && cargo build --release --locked --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} 2>/dev/null || true \
+    && cargo build --profile release-static --locked --target x86_64-unknown-linux-musl --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} 2>/dev/null || true \
     && rm -rf src
 
 # Copy full source and build for real
 COPY src/ src/
 
-RUN cargo build --release --locked --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} \
+RUN cargo build --profile release-static --locked --target x86_64-unknown-linux-musl --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} \
     && mkdir -p /image/data /image/etc/reddb \
     && touch /image/data/.keep /image/etc/reddb/.keep
 
-FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
 
-COPY --from=builder --chown=nonroot:nonroot /app/target/release/red /usr/local/bin/red
+COPY --from=builder --chown=nonroot:nonroot /app/target/x86_64-unknown-linux-musl/release-static/red /usr/local/bin/red
 COPY --from=builder --chown=nonroot:nonroot /image/data /data
 COPY --from=builder --chown=nonroot:nonroot /image/etc/reddb /etc/reddb
 


### PR DESCRIPTION
## Summary

Three root causes blocking the v1.10.1 Release workflow, fixed together:

### 1. `reddb-io-file` missing from crates.io publish list
`reddb-io-server` depends on `reddb-io-file` (`version = "1.0"`) but the crate was never listed in the `publish-cargo` step. First publish at `1.0.0` will satisfy the constraint.

### 2. aarch64-musl: silent build failure
`bash -lc '...'` had no `set -euo pipefail`. When `cargo build --bin red` failed (E0308 `statfs.f_type` — same root cause as armv7, fixed by PR #1066), the shell continued to the next command (`--bin red_client`), which succeeded. Docker exited 0, the step showed "success", but `target/.../release/red` was never produced → Package assets failed. Added `set -euo pipefail` as the first line.

### 3. Docker image size gate (52.98 MB > 50 MB)
Base `gcr.io/distroless/cc-debian12` (~35 MB) + dynamic binary (~18 MB) = ~53 MB. Fix: build with `x86_64-unknown-linux-musl` + `release-static` profile and switch runtime to `gcr.io/distroless/static-debian12` (~2 MB). All TLS uses `ring` + `rustls` (pure-Rust, known to work on x86_64-musl). Expected final size ≈ 18 MB.

## Test plan
- [ ] `publish-cargo` step publishes `reddb-io-file` before `reddb-io-server`
- [ ] CI for this PR compiles without E0308 errors on all targets (armv7 + aarch64-musl fixed by #1066)
- [ ] Artifact size gate passes (`docker image inspect .Size < 50 MB`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783658077&installation_id=129708444&pr_number=1068&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1068&signature=f1308ae4237b2cd3a57c147339cd4f06fe7578730fbd60ac97f62e36de4563a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binary build process to generate statically-linked Linux binaries with protobuf support.
  * Updated container image to use a slimmer, security-focused base image.
  * Added additional crate to the crate registry publishing sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->