### PR TITLE
merge: #991 Extend WAL/logical records with range identity, term, and ownership epoch

### DIFF
--- a/crates/reddb-server/src/replication/cdc.rs
+++ b/crates/reddb-server/src/replication/cdc.rs
@@ -10,6 +10,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use crate::json::{Map, Value as JsonValue};
 
 pub use reddb_wire::replication::{public_item_kind, ChangeOperation, ChangeRecord};
+// Issue #991 — range-authority fence types travel with the ChangeRecord
+// contract; re-exported separately to keep the pinned contract line above
+// byte-for-byte (see `protocol_authority` reddb-wire test).
+pub use reddb_wire::replication::{RangeAdmitError, RangeAuthority};
 
 /// A single change event.
 #[derive(Debug, Clone)]
@@ -118,6 +122,11 @@ pub fn change_record_from_entity(
         entity_bytes,
         metadata: metadata.map(server_json_to_wire_json),
         refresh_records: None,
+        // Issue #991 — range authority is stamped by callers that route the
+        // change through the ownership catalog via `with_range_authority`;
+        // the base builder leaves it unset so non-range paths are unaffected.
+        range_id: None,
+        ownership_epoch: None,
     }
 }
 
@@ -520,6 +529,8 @@ mod tests {
             entity_bytes: Some(vec![1, 2, 3]),
             metadata: Some(server_json_to_wire_json(crate::json!({"role": "admin"}))),
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         };
 
         let decoded = ChangeRecord::decode(&record.encode()).expect("decode");

--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -7,6 +7,7 @@ use crate::api::{RedDBError, RedDBResult};
 use crate::application::entity::metadata_from_json;
 use crate::replication::cdc::{
     change_record_from_entity, wire_json_to_server_json, ChangeOperation, ChangeRecord,
+    RangeAdmitError, RangeAuthority,
 };
 use crate::storage::{EntityId, EntityKind, RedDB, UnifiedStore};
 
@@ -119,6 +120,7 @@ impl LogicalApplyError {
             Self::Divergence { .. } => ApplyErrorKind::Divergence,
             Self::Apply { .. } => ApplyErrorKind::Apply,
             Self::StaleTermFenced { .. } => ApplyErrorKind::Fenced,
+            Self::RangeFenced { .. } => ApplyErrorKind::Fenced,
         }
     }
 }
@@ -164,6 +166,18 @@ pub enum LogicalApplyError {
         current_term: u64,
         lsn: u64,
     },
+    /// Issue #991 — the record is stamped for a range whose authority
+    /// watermark has moved past it: a write from a deposed range owner
+    /// (stale ownership epoch) or a superseded timeline (stale term) for the
+    /// target range. Rejected at the apply boundary before the LSN state
+    /// machine runs — fail-closed, so a stale owner cannot apply or advance
+    /// the chain/watermark for that range. Shares the `Fenced` metrics lane
+    /// with the global stale-term fence.
+    RangeFenced {
+        range_id: u64,
+        lsn: u64,
+        reason: RangeAdmitError,
+    },
 }
 
 impl std::fmt::Display for LogicalApplyError {
@@ -178,6 +192,26 @@ impl std::fmt::Display for LogicalApplyError {
                 f,
                 "stale-term record fenced at lsn={lsn}: record term {record_term} is behind current term {current_term}"
             ),
+            Self::RangeFenced {
+                range_id,
+                lsn,
+                reason,
+            } => match reason {
+                RangeAdmitError::StaleTerm {
+                    record_term,
+                    accepted_term,
+                } => write!(
+                    f,
+                    "range-stale record fenced at lsn={lsn} for range {range_id}: record term {record_term} is behind accepted term {accepted_term}"
+                ),
+                RangeAdmitError::StaleOwnershipEpoch {
+                    record_epoch,
+                    accepted_epoch,
+                } => write!(
+                    f,
+                    "range-stale record fenced at lsn={lsn} for range {range_id}: ownership epoch {record_epoch} is behind accepted epoch {accepted_epoch}"
+                ),
+            },
             Self::Divergence {
                 expected_term,
                 got_term,
@@ -350,8 +384,41 @@ impl LogicalChangeApplier {
         record: &ChangeRecord,
         mode: ApplyMode,
     ) -> Result<ApplyOutcome, LogicalApplyError> {
+        self.apply_fenced(db, record, mode, None)
+    }
+
+    /// Apply one record, first gating it against the target range's authority
+    /// watermark (issue #991). When `range_fence` is `Some`, a record stamped
+    /// for that range whose term or ownership epoch is behind the watermark is
+    /// rejected before the global term fence and the LSN state machine run —
+    /// fail-closed, so a deposed range owner cannot advance anything. Records
+    /// for a different range, or with no range identity (legacy /
+    /// non-range-replicated), pass the range fence untouched. `apply` is the
+    /// unfenced shorthand for callers that do not yet hold range authority.
+    pub fn apply_fenced(
+        &self,
+        db: &RedDB,
+        record: &ChangeRecord,
+        mode: ApplyMode,
+        range_fence: Option<&RangeAuthority>,
+    ) -> Result<ApplyOutcome, LogicalApplyError> {
         let last = self.last_applied_lsn.load(Ordering::Acquire);
         let last_term = self.last_applied_term.load(Ordering::Acquire);
+
+        // Per-range authority fence (issue #991). Runs before the global
+        // term fence so a stale ownership epoch is rejected even when the
+        // record's term is otherwise current. Only records stamped for the
+        // fence's range are gated; the rest fall through.
+        if let Some(fence) = range_fence {
+            if let Err(reason) = fence.admit(record) {
+                self.metrics.record(ApplyErrorKind::Fenced);
+                return Err(LogicalApplyError::RangeFenced {
+                    range_id: fence.range_id,
+                    lsn: record.lsn,
+                    reason,
+                });
+            }
+        }
 
         // Stale-term fence (issue #835, ADR 0030). A record from a term
         // *behind* the highest term this replica has adopted is a returning
@@ -596,6 +663,13 @@ fn record_payload_hash(record: &ChangeRecord) -> [u8; 32] {
     hasher.update(&[record.operation as u8]);
     hasher.update(record.collection.as_bytes());
     hasher.update(&record.entity_id.to_le_bytes());
+    // Issue #991 — range authority participates in the payload hash so two
+    // records at the same LSN that differ only in range identity or ownership
+    // epoch are flagged divergent rather than silently treated as idempotent.
+    // `u64::MAX` stands in for an absent field (a value real epochs/ids never
+    // reach) so `None` and `Some(MAX)` stay distinguishable.
+    hasher.update(&record.range_id.unwrap_or(u64::MAX).to_le_bytes());
+    hasher.update(&record.ownership_epoch.unwrap_or(u64::MAX).to_le_bytes());
     if let Some(bytes) = &record.entity_bytes {
         hasher.update(bytes);
     }
@@ -678,6 +752,8 @@ mod tests {
             entity_bytes: None,
             metadata: None,
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         }
     }
 
@@ -964,6 +1040,123 @@ mod tests {
             matches!(err, LogicalApplyError::StaleTermFenced { .. }),
             "got {err:?}"
         );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Issue #991 — a record stamped for the target range but carrying an
+    // ownership epoch behind the range's accepted epoch is a write from a
+    // deposed owner. It is fenced at the apply boundary: rejected, counted on
+    // the Fenced lane, and the LSN/term chain does not advance.
+    #[test]
+    fn apply_fenced_rejects_stale_ownership_epoch() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+        let fence = RangeAuthority {
+            range_id: 7,
+            min_term: 1,
+            min_ownership_epoch: 5,
+        };
+
+        let stale = record(1, b"a").with_range_authority(7, 4);
+        let before = applier.metrics().fenced_total.load(Ordering::Relaxed);
+        let err = applier
+            .apply_fenced(&db, &stale, ApplyMode::Replica, Some(&fence))
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LogicalApplyError::RangeFenced {
+                    range_id: 7,
+                    lsn: 1,
+                    reason: RangeAdmitError::StaleOwnershipEpoch {
+                        record_epoch: 4,
+                        accepted_epoch: 5,
+                    },
+                }
+            ),
+            "got {err:?}"
+        );
+        assert_eq!(err.kind(), ApplyErrorKind::Fenced);
+        assert_eq!(
+            applier.metrics().fenced_total.load(Ordering::Relaxed),
+            before + 1
+        );
+        assert_eq!(applier.last_applied_lsn(), 0, "watermark must not advance");
+        assert_eq!(
+            applier.received_frontier_lsn(),
+            0,
+            "a range-fenced record must not advance the received frontier"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Issue #991 — the same fence applies on the recovery/restore path: a
+    // record on a stale term for the target range is rejected there too.
+    #[test]
+    fn apply_fenced_rejects_stale_range_term_on_restore() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+        let fence = RangeAuthority {
+            range_id: 3,
+            min_term: 6,
+            min_ownership_epoch: 1,
+        };
+
+        let stale = record(1, b"a").with_term(4).with_range_authority(3, 9);
+        let err = applier
+            .apply_fenced(&db, &stale, ApplyMode::Restore, Some(&fence))
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                LogicalApplyError::RangeFenced {
+                    range_id: 3,
+                    reason: RangeAdmitError::StaleTerm {
+                        record_term: 4,
+                        accepted_term: 6,
+                    },
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    // Issue #991 — a record current for the range applies through the fence,
+    // and a record for a *different* range is not gated by this fence.
+    #[test]
+    fn apply_fenced_admits_current_and_ignores_other_ranges() {
+        let (db, path) = open_db();
+        let applier = LogicalChangeApplier::new(0);
+        let fence = RangeAuthority {
+            range_id: 7,
+            min_term: 1,
+            min_ownership_epoch: 5,
+        };
+
+        // Current epoch for the fenced range → applies and advances.
+        applier
+            .apply_fenced(
+                &db,
+                &record(1, b"a").with_range_authority(7, 5),
+                ApplyMode::Replica,
+                Some(&fence),
+            )
+            .expect("current record applies");
+        assert_eq!(applier.last_applied_lsn(), 1);
+
+        // A record stamped for a different (stale-looking) range is not this
+        // fence's concern and still applies.
+        applier
+            .apply_fenced(
+                &db,
+                &record(2, b"b").with_range_authority(99, 1),
+                ApplyMode::Replica,
+                Some(&fence),
+            )
+            .expect("other-range record bypasses this fence");
+        assert_eq!(applier.last_applied_lsn(), 2);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/reddb-server/src/replication/primary/tests.rs
+++ b/crates/reddb-server/src/replication/primary/tests.rs
@@ -27,6 +27,8 @@ fn logical_wal_spool_roundtrip_and_prune() {
         entity_bytes: Some(vec![1, 2, 3]),
         metadata: None,
         refresh_records: None,
+        range_id: None,
+        ownership_epoch: None,
     };
     let record2 = ChangeRecord {
         term: 2,
@@ -39,6 +41,8 @@ fn logical_wal_spool_roundtrip_and_prune() {
         entity_bytes: Some(vec![4, 5, 6]),
         metadata: None,
         refresh_records: None,
+        range_id: None,
+        ownership_epoch: None,
     };
 
     spool
@@ -64,6 +68,47 @@ fn logical_wal_spool_roundtrip_and_prune() {
     assert_eq!(retained.len(), 1);
     assert_eq!(retained[0].0, 8);
     assert_eq!(ChangeRecord::decode(&retained[0].1).unwrap().term, 2);
+
+    let _ = fs::remove_file(spool_path);
+}
+
+// Issue #991 — a logical record stamped with range identity and ownership
+// epoch must survive derivation through the logical-WAL spool: the primary
+// appends the encoded ChangeRecord, and a replica/recovery read decodes the
+// range authority unchanged. The binary v3 envelope carries the payload
+// opaquely, so no format bump is needed for the range metadata to flow.
+#[test]
+fn logical_wal_spool_preserves_range_authority() {
+    let data_path = temp_data_path("logical_spool_range");
+    let spool_path = LogicalWalSpool::path_for(&data_path);
+    let spool = LogicalWalSpool::open(&data_path).expect("open spool");
+
+    let record = ChangeRecord {
+        term: 5,
+        lsn: 21,
+        timestamp: 7,
+        operation: ChangeOperation::Insert,
+        collection: "orders".to_string(),
+        entity_id: 99,
+        entity_kind: "row".to_string(),
+        entity_bytes: Some(vec![7, 7, 7]),
+        metadata: None,
+        refresh_records: None,
+        range_id: None,
+        ownership_epoch: None,
+    }
+    .with_range_authority(13, 4);
+
+    spool
+        .append_with_term_and_timestamp(record.term, record.lsn, 7, &record.encode())
+        .expect("append stamped record");
+
+    let entries = spool.read_since(0, usize::MAX).expect("read");
+    assert_eq!(entries.len(), 1);
+    let derived = ChangeRecord::decode(&entries[0].1).expect("decode derived record");
+    assert_eq!(derived.range_id, Some(13));
+    assert_eq!(derived.ownership_epoch, Some(4));
+    assert_eq!(derived.term, 5);
 
     let _ = fs::remove_file(spool_path);
 }

--- a/crates/reddb-server/src/runtime/impl_cdc.rs
+++ b/crates/reddb-server/src/runtime/impl_cdc.rs
@@ -58,6 +58,8 @@ impl RedDBRuntime {
                     .map(|e| UnifiedStore::serialize_entity(e, store.format_version())),
                 metadata: self.latest_metadata_for(collection, entity_id),
                 refresh_records: None,
+                range_id: None,
+                ownership_epoch: None,
             };
             let encoded = record.encode();
             primary.append_logical_record(record.lsn, encoded);
@@ -143,6 +145,8 @@ impl RedDBRuntime {
                     .map(|entity| UnifiedStore::serialize_entity(entity, store.format_version())),
                 metadata: self.latest_metadata_for(collection, entity_id),
                 refresh_records: None,
+                range_id: None,
+                ownership_epoch: None,
             };
             let encoded = record.encode();
             primary.append_logical_record(record.lsn, encoded);
@@ -272,6 +276,8 @@ impl RedDBRuntime {
                     .map(server_json_to_wire_json)
                     .or_else(|| self.latest_metadata_for(collection, entity.id.raw())),
                 refresh_records: None,
+                range_id: None,
+                ownership_epoch: None,
             };
             let encoded = record.encode();
             primary.append_logical_record(record.lsn, encoded);

--- a/crates/reddb-server/src/storage/wal/archiver.rs
+++ b/crates/reddb-server/src/storage/wal/archiver.rs
@@ -606,6 +606,8 @@ mod tests {
             entity_bytes: Some(vec![1, 2, 3]),
             metadata: None,
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         };
 
         let meta =
@@ -642,6 +644,8 @@ mod tests {
             entity_bytes: Some(b"x".to_vec()),
             metadata: None,
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         };
         let meta =
             archive_change_records(&backend, &prefix, &[(record.lsn, record.encode())], None)
@@ -765,6 +769,8 @@ mod tests {
             entity_bytes: Some(format!("payload-{lsn}").into_bytes()),
             metadata: None,
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         };
 
         let r1 = mk(10);

--- a/crates/reddb-wire/src/replication/change_record.rs
+++ b/crates/reddb-wire/src/replication/change_record.rs
@@ -63,6 +63,18 @@ pub struct ChangeRecord {
     pub entity_bytes: Option<Vec<u8>>,
     pub metadata: Option<JsonValue>,
     pub refresh_records: Option<Vec<Vec<u8>>>,
+    /// Issue #991 — stable identity of the range this user-data change
+    /// belongs to (`RangeId`, from the #989 ownership catalog), or `None`
+    /// for records that predate range replication. Carried so replicas and
+    /// recovery can route a change to its range and gate it against that
+    /// range's authority watermark.
+    pub range_id: Option<u64>,
+    /// Issue #991 — the owning range's `OwnershipEpoch` at the moment this
+    /// change was produced. The epoch bumps only when write authority moves
+    /// to a new owner, so a record whose epoch is behind the target range's
+    /// accepted epoch is a write from a deposed owner and is fenced. `None`
+    /// for legacy records and non-range-replicated changes.
+    pub ownership_epoch: Option<u64>,
 }
 
 impl ChangeRecord {
@@ -83,7 +95,18 @@ impl ChangeRecord {
             entity_bytes: None,
             metadata: None,
             refresh_records: Some(records),
+            range_id: None,
+            ownership_epoch: None,
         }
+    }
+
+    /// Stamp this record with the authority metadata of the range that owns
+    /// it (issue #991): the stable range identity and the owner's current
+    /// ownership epoch. The term is set independently via [`Self::with_term`].
+    pub fn with_range_authority(mut self, range_id: u64, ownership_epoch: u64) -> Self {
+        self.range_id = Some(range_id);
+        self.ownership_epoch = Some(ownership_epoch);
+        self
     }
 
     pub fn to_json_value(&self) -> JsonValue {
@@ -122,6 +145,17 @@ impl ChangeRecord {
                 .map(|bytes| JsonValue::String(hex_encode(bytes)))
                 .collect();
             object.insert("refresh_records_hex".to_string(), JsonValue::Array(arr));
+        }
+        // Issue #991 — range authority is omitted entirely when absent so a
+        // non-range-replicated record stays byte-for-byte the legacy shape.
+        if let Some(range_id) = self.range_id {
+            object.insert("range_id".to_string(), JsonValue::Number(range_id.into()));
+        }
+        if let Some(epoch) = self.ownership_epoch {
+            object.insert(
+                "ownership_epoch".to_string(),
+                JsonValue::Number(epoch.into()),
+            );
         }
         JsonValue::Object(object)
     }
@@ -194,7 +228,75 @@ impl ChangeRecord {
                 None | Some(JsonValue::Null) => None,
                 _ => return Err("refresh_records_hex is not an array".to_string()),
             },
+            // Issue #991 — absent on legacy records (decodes to `None`), so
+            // old payloads keep round-tripping unchanged.
+            range_id: value.get("range_id").and_then(JsonValue::as_u64),
+            ownership_epoch: value.get("ownership_epoch").and_then(JsonValue::as_u64),
         })
+    }
+}
+
+/// Issue #991 — the range-authority watermark a replica or recovery target
+/// holds for a single range: the minimum term and ownership epoch it will
+/// accept for that range's user-data changes.
+///
+/// The physical WAL stays the source of truth; this fence operates purely on
+/// the derived metadata each [`ChangeRecord`] carries. A record stamped for
+/// this range whose term or ownership epoch is behind the watermark is a write
+/// from a stale (deposed) owner or a superseded timeline and must be rejected
+/// before it is applied. Records for a *different* range, or records with no
+/// range identity at all (legacy / non-range-replicated), are not this fence's
+/// concern and pass through untouched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RangeAuthority {
+    pub range_id: u64,
+    pub min_term: u64,
+    pub min_ownership_epoch: u64,
+}
+
+/// Why a [`RangeAuthority`] rejected a record (issue #991).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeAdmitError {
+    /// The record's term is behind the term this range has accepted — a
+    /// returning ex-owner streaming on a superseded timeline.
+    StaleTerm {
+        record_term: u64,
+        accepted_term: u64,
+    },
+    /// The record's ownership epoch is behind the range's accepted epoch — a
+    /// write produced by an owner that has since lost write authority.
+    StaleOwnershipEpoch {
+        record_epoch: u64,
+        accepted_epoch: u64,
+    },
+}
+
+impl RangeAuthority {
+    /// Decide whether `record` may be applied to this range. Only records
+    /// explicitly stamped for `self.range_id` are gated; everything else is
+    /// admitted. Term is checked before epoch so a stale timeline is reported
+    /// as such even when its epoch also lags.
+    pub fn admit(&self, record: &ChangeRecord) -> Result<(), RangeAdmitError> {
+        if record.range_id != Some(self.range_id) {
+            return Ok(());
+        }
+        if record.term < self.min_term {
+            return Err(RangeAdmitError::StaleTerm {
+                record_term: record.term,
+                accepted_term: self.min_term,
+            });
+        }
+        // A record stamped for this range but missing an epoch predates epoch
+        // fencing; admit it on term alone rather than fail closed on absence.
+        if let Some(epoch) = record.ownership_epoch {
+            if epoch < self.min_ownership_epoch {
+                return Err(RangeAdmitError::StaleOwnershipEpoch {
+                    record_epoch: epoch,
+                    accepted_epoch: self.min_ownership_epoch,
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -234,6 +336,8 @@ mod tests {
             entity_bytes: Some(vec![1, 2, 3]),
             metadata: Some(serde_json::json!({"role": "admin"})),
             refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
         };
 
         let decoded = ChangeRecord::decode(&record.encode()).expect("decode");
@@ -244,6 +348,122 @@ mod tests {
         assert_eq!(decoded.entity_id, record.entity_id);
         assert_eq!(decoded.entity_bytes, record.entity_bytes);
         assert_eq!(decoded.metadata, record.metadata);
+    }
+
+    #[test]
+    fn range_authority_round_trips_on_the_json_wire() {
+        let record = ChangeRecord {
+            term: 5,
+            lsn: 12,
+            timestamp: 999,
+            operation: ChangeOperation::Insert,
+            collection: "orders".to_string(),
+            entity_id: 8,
+            entity_kind: "row".to_string(),
+            entity_bytes: Some(vec![9, 9]),
+            metadata: None,
+            refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
+        }
+        .with_range_authority(7, 3);
+
+        let decoded = ChangeRecord::decode(&record.encode()).expect("decode");
+
+        assert_eq!(decoded.range_id, Some(7));
+        assert_eq!(decoded.ownership_epoch, Some(3));
+        assert_eq!(decoded.term, 5);
+    }
+
+    #[test]
+    fn legacy_record_without_range_authority_decodes_to_none() {
+        // A payload from before #991 carries neither field; decoding must
+        // leave both absent rather than fabricate a default that would later
+        // collide with a real range fence.
+        let legacy =
+            br#"{"term":2,"lsn":4,"timestamp":1,"operation":"insert","collection":"users","rid":1,"kind":"row"}"#;
+
+        let decoded = ChangeRecord::decode(legacy).expect("decode legacy");
+
+        assert_eq!(decoded.range_id, None);
+        assert_eq!(decoded.ownership_epoch, None);
+    }
+
+    #[test]
+    fn unstamped_record_omits_range_keys_from_the_wire() {
+        let record = ChangeRecord::for_refresh(1, 1, "mv", Vec::new());
+        let text = String::from_utf8(record.encode()).expect("utf8");
+        assert!(!text.contains("range_id"), "got {text}");
+        assert!(!text.contains("ownership_epoch"), "got {text}");
+    }
+
+    fn stamped(term: u64, range_id: u64, epoch: u64) -> ChangeRecord {
+        ChangeRecord {
+            term,
+            lsn: 1,
+            timestamp: 1,
+            operation: ChangeOperation::Insert,
+            collection: "c".to_string(),
+            entity_id: 1,
+            entity_kind: "row".to_string(),
+            entity_bytes: Some(vec![1]),
+            metadata: None,
+            refresh_records: None,
+            range_id: None,
+            ownership_epoch: None,
+        }
+        .with_range_authority(range_id, epoch)
+    }
+
+    #[test]
+    fn range_authority_admits_current_term_and_epoch() {
+        let fence = RangeAuthority {
+            range_id: 7,
+            min_term: 3,
+            min_ownership_epoch: 4,
+        };
+        assert_eq!(fence.admit(&stamped(3, 7, 4)), Ok(()));
+        assert_eq!(fence.admit(&stamped(9, 7, 9)), Ok(()));
+    }
+
+    #[test]
+    fn range_authority_rejects_stale_epoch_and_term() {
+        let fence = RangeAuthority {
+            range_id: 7,
+            min_term: 3,
+            min_ownership_epoch: 4,
+        };
+        assert_eq!(
+            fence.admit(&stamped(3, 7, 2)),
+            Err(RangeAdmitError::StaleOwnershipEpoch {
+                record_epoch: 2,
+                accepted_epoch: 4,
+            })
+        );
+        // Term is checked first, so a doubly-stale record reports the term.
+        assert_eq!(
+            fence.admit(&stamped(1, 7, 1)),
+            Err(RangeAdmitError::StaleTerm {
+                record_term: 1,
+                accepted_term: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn range_authority_ignores_other_ranges_and_unstamped_records() {
+        let fence = RangeAuthority {
+            range_id: 7,
+            min_term: 5,
+            min_ownership_epoch: 5,
+        };
+        // Stale, but for a different range — not this fence's business.
+        assert_eq!(fence.admit(&stamped(1, 99, 1)), Ok(()));
+        // No range identity at all — legacy record passes through.
+        let mut legacy = stamped(1, 7, 1);
+        legacy.range_id = None;
+        legacy.ownership_epoch = None;
+        assert_eq!(fence.admit(&legacy), Ok(()));
     }
 
     #[test]

--- a/crates/reddb-wire/src/replication/mod.rs
+++ b/crates/reddb-wire/src/replication/mod.rs
@@ -23,7 +23,8 @@ pub use bookmark::{BookmarkDecodeError, CausalBookmark};
 pub use catchup::{CatchupMode, CatchupModeReply};
 pub use change_record::{
     change_record_json_value_to_string, parse_change_record_json_value, public_item_kind,
-    ChangeOperation, ChangeRecord, ChangeRecordJsonValue, DEFAULT_REPLICATION_TERM,
+    ChangeOperation, ChangeRecord, ChangeRecordJsonValue, RangeAdmitError, RangeAuthority,
+    DEFAULT_REPLICATION_TERM,
 };
 pub use timeline::{
     FailoverPromotionReply, FailoverPromotionRequest, RejoinPlanNotice, RejoinRewindConfirmation,


### PR DESCRIPTION
Automated AFK landing for #991. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783660013&installation_id=129708444&pr_number=1069&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1069&signature=05906f0e5cbc6b8efc846b61d8fd46cdd5031fe8118df107d103692c4667a915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added range authority support to logical replication, enabling range fencing to prevent stale replication across ranges. Records now carry optional range metadata with term and ownership epoch validation.

* **Tests**
  * Expanded test coverage for range authority round-trips, legacy record compatibility, and range admission validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->