### PR TITLE
merge: #1043 red ui: bundle resolver/downloader — pinned version, SHA-256 verify, cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,6 +812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2339,7 @@ dependencies = [
  "criterion",
  "crossbeam-queue",
  "ed25519-dalek",
+ "flate2",
  "fs2",
  "futures-util",
  "hex",
@@ -2363,6 +2374,7 @@ dependencies = [
  "sha2 0.11.0",
  "snap",
  "strsim",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-rustls",
@@ -2933,6 +2945,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3936,6 +3959,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -39,6 +39,7 @@ pub mod store_wal;
 pub mod table_def_codec;
 pub mod transaction_wal;
 pub mod turboquant_snapshot;
+pub mod ui_bundle_cache;
 pub mod vector_btree_page_format;
 pub mod vector_value_codec;
 pub mod wal_header;
@@ -284,6 +285,13 @@ pub use physical_metadata_policy::{
     set_fold_pager_meta_enabled, set_meta_json_sidecar_enabled, set_seqn_journal_enabled,
     set_seqn_journal_retention, DEFAULT_METADATA_JOURNAL_RETENTION,
     OPT_IN_METADATA_JOURNAL_RETENTION,
+};
+pub use ui_bundle_cache::{
+    decode_ui_bundle_manifest_json, encode_ui_bundle_manifest_json, promote_ui_bundle_staging,
+    ui_bundle_cache_root, ui_bundle_manifest_path, ui_bundle_manifest_temp_path,
+    ui_bundle_purge_dir, ui_bundle_purge_root, ui_bundle_staging_dir, ui_bundle_staging_root,
+    ui_bundle_version_dir, write_ui_bundle_manifest, UiBundleManifest, UI_BUNDLE_CACHE_DIR_NAME,
+    UI_BUNDLE_MANIFEST_FILE, UI_BUNDLE_PURGE_DIR_NAME, UI_BUNDLE_STAGING_DIR_NAME,
 };
 
 pub use primary_replica::{

--- a/crates/reddb-file/src/ui_bundle_cache.rs
+++ b/crates/reddb-file/src/ui_bundle_cache.rs
@@ -1,0 +1,215 @@
+//! Local `red ui` bundle cache file contracts.
+//!
+//! Parallel to `ai_model_cache`: the server owns download policy and
+//! checksum verification; this module owns the persisted cache layout
+//! and manifest JSON shape. ADR 0050.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use serde_json::Value as JsonValue;
+
+pub const UI_BUNDLE_CACHE_DIR_NAME: &str = "ui";
+pub const UI_BUNDLE_STAGING_DIR_NAME: &str = ".staging";
+pub const UI_BUNDLE_PURGE_DIR_NAME: &str = ".purge";
+pub const UI_BUNDLE_MANIFEST_FILE: &str = "manifest.json";
+
+/// Persisted record for a cached `red-ui` bundle version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UiBundleManifest {
+    pub version: String,
+    /// SHA-256 of the original `.tgz` download, lower-case hex.
+    pub sha256_hex: String,
+    /// Size of the original `.tgz` download in bytes.
+    pub tgz_size_bytes: u64,
+    /// Unix epoch milliseconds when the bundle was cached.
+    pub cached_at_unix_ms: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+pub fn ui_bundle_cache_root(base: &Path) -> PathBuf {
+    base.join(UI_BUNDLE_CACHE_DIR_NAME)
+}
+
+pub fn ui_bundle_version_dir(cache_root: &Path, version: &str) -> PathBuf {
+    cache_root.join(version)
+}
+
+pub fn ui_bundle_staging_root(cache_root: &Path) -> PathBuf {
+    cache_root.join(UI_BUNDLE_STAGING_DIR_NAME)
+}
+
+pub fn ui_bundle_purge_root(cache_root: &Path) -> PathBuf {
+    cache_root.join(UI_BUNDLE_PURGE_DIR_NAME)
+}
+
+pub fn ui_bundle_staging_dir(cache_root: &Path, version: &str, unique: &str) -> PathBuf {
+    ui_bundle_staging_root(cache_root).join(format!("{version}-{unique}"))
+}
+
+pub fn ui_bundle_purge_dir(cache_root: &Path, version: &str, unique: &str) -> PathBuf {
+    ui_bundle_purge_root(cache_root).join(format!("{version}-{unique}"))
+}
+
+pub fn ui_bundle_manifest_path(version_dir: &Path) -> PathBuf {
+    version_dir.join(UI_BUNDLE_MANIFEST_FILE)
+}
+
+pub fn ui_bundle_manifest_temp_path(dir: &Path) -> PathBuf {
+    dir.join(format!("{UI_BUNDLE_MANIFEST_FILE}.tmp"))
+}
+
+// ---------------------------------------------------------------------------
+// I/O helpers
+// ---------------------------------------------------------------------------
+
+pub fn write_ui_bundle_manifest(dir: &Path, bytes: &[u8]) -> io::Result<()> {
+    let tmp = ui_bundle_manifest_temp_path(dir);
+    fs::write(&tmp, bytes)?;
+    fs::rename(&tmp, ui_bundle_manifest_path(dir))
+}
+
+/// Atomically promote a staging directory to the live version directory.
+/// Rolls back if the rename fails; best-effort removes the purge directory
+/// after a successful promotion.
+pub fn promote_ui_bundle_staging(
+    cache_root: &Path,
+    version: &str,
+    unique: &str,
+    staging_dir: &Path,
+    version_dir: &Path,
+) -> io::Result<()> {
+    let purge_root = ui_bundle_purge_root(cache_root);
+    fs::create_dir_all(&purge_root)?;
+    let purge_dir = ui_bundle_purge_dir(cache_root, version, unique);
+    if version_dir.exists() {
+        fs::rename(version_dir, &purge_dir)?;
+    }
+    if let Err(err) = fs::rename(staging_dir, version_dir) {
+        if purge_dir.exists() {
+            let _ = fs::rename(&purge_dir, version_dir);
+        }
+        let _ = fs::remove_dir_all(staging_dir);
+        return Err(err);
+    }
+    if purge_dir.exists() {
+        let _ = fs::remove_dir_all(&purge_dir);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Manifest JSON codec
+// ---------------------------------------------------------------------------
+
+pub fn encode_ui_bundle_manifest_json(manifest: &UiBundleManifest) -> io::Result<Vec<u8>> {
+    serde_json::to_vec(&manifest_to_json(manifest)).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("encode UI bundle manifest: {err}"),
+        )
+    })
+}
+
+pub fn decode_ui_bundle_manifest_json(bytes: &[u8]) -> io::Result<UiBundleManifest> {
+    let value: JsonValue = serde_json::from_slice(bytes).map_err(|err| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("UI bundle manifest is not valid JSON: {err}"),
+        )
+    })?;
+    manifest_from_json(&value)
+}
+
+fn manifest_to_json(m: &UiBundleManifest) -> JsonValue {
+    let mut obj = serde_json::Map::new();
+    obj.insert("version".to_string(), JsonValue::String(m.version.clone()));
+    obj.insert(
+        "sha256".to_string(),
+        JsonValue::String(m.sha256_hex.clone()),
+    );
+    obj.insert(
+        "tgz_size_bytes".to_string(),
+        JsonValue::Number(m.tgz_size_bytes.into()),
+    );
+    obj.insert(
+        "cached_at_unix_ms".to_string(),
+        JsonValue::Number(m.cached_at_unix_ms.into()),
+    );
+    JsonValue::Object(obj)
+}
+
+fn manifest_from_json(value: &JsonValue) -> io::Result<UiBundleManifest> {
+    let obj = value
+        .as_object()
+        .ok_or_else(|| invalid("manifest is not an object"))?;
+    Ok(UiBundleManifest {
+        version: required_str(obj, "version")?,
+        sha256_hex: required_str(obj, "sha256")?,
+        tgz_size_bytes: required_u64(obj, "tgz_size_bytes")?,
+        cached_at_unix_ms: required_u64(obj, "cached_at_unix_ms")?,
+    })
+}
+
+fn required_str(obj: &serde_json::Map<String, JsonValue>, key: &str) -> io::Result<String> {
+    obj.get(key)
+        .and_then(JsonValue::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| invalid(format!("manifest field '{key}' missing or not a string")))
+}
+
+fn required_u64(obj: &serde_json::Map<String, JsonValue>, key: &str) -> io::Result<u64> {
+    obj.get(key)
+        .and_then(JsonValue::as_u64)
+        .ok_or_else(|| invalid(format!("manifest field '{key}' missing or not a number")))
+}
+
+fn invalid(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ui_bundle_manifest_round_trips() {
+        let m = UiBundleManifest {
+            version: "1.2.3".to_string(),
+            sha256_hex: "deadbeef".to_string(),
+            tgz_size_bytes: 42_000,
+            cached_at_unix_ms: 1_000_000,
+        };
+        let bytes = encode_ui_bundle_manifest_json(&m).expect("encode");
+        let decoded = decode_ui_bundle_manifest_json(&bytes).expect("decode");
+        assert_eq!(decoded, m);
+        assert!(String::from_utf8(bytes)
+            .unwrap()
+            .contains("\"sha256\":\"deadbeef\""));
+    }
+
+    #[test]
+    fn ui_bundle_cache_paths_are_canonical() {
+        let root = Path::new("/tmp/reddb");
+        assert_eq!(
+            ui_bundle_cache_root(root),
+            Path::new("/tmp/reddb").join("ui")
+        );
+        assert_eq!(
+            ui_bundle_version_dir(&ui_bundle_cache_root(root), "1.2.3"),
+            Path::new("/tmp/reddb/ui/1.2.3")
+        );
+        assert_eq!(
+            ui_bundle_staging_dir(&ui_bundle_cache_root(root), "1.2.3", "abc"),
+            Path::new("/tmp/reddb/ui/.staging/1.2.3-abc")
+        );
+        assert_eq!(
+            ui_bundle_purge_dir(&ui_bundle_cache_root(root), "1.2.3", "abc"),
+            Path::new("/tmp/reddb/ui/.purge/1.2.3-abc")
+        );
+    }
+}

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -62,6 +62,12 @@ tonic-prost = "0.14"
 prost = "0.14"
 snap = "1"
 ureq = { version = "3.3", default-features = false, features = ["rustls"] }
+# `red ui` bundle resolver (issue #1043, ADR 0050): tgz extraction for the
+# pinned red-ui release asset. `flate2` decompresses the gz layer; `tar`
+# iterates the archive entries. Both are already transitive in Cargo.lock;
+# made explicit here so the UI bundle resolver can import them directly.
+flate2 = "1"
+tar = "0.4"
 roaring = "0.11"
 parking_lot = "0.12"
 # crossbeam-queue::SegQueue powers the lock-free WAL append path

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -132,6 +132,10 @@ mod ws_edge;
 // serves the UI bundle and mounts RedWire-over-WS over the embedded
 // engine, reusing the ADR 0036 async-transport ↔ sync-engine seam.
 pub mod ui_bridge;
+// `red ui` bundle resolver (issue #1043, ADR 0050): pin→URL resolution,
+// HTTPS download, SHA-256 verification, tgz extraction, and local cache
+// management for the pinned red-ui release asset.
+pub mod ui_bundle_resolver;
 // `pub(crate)` so the RedWire input-stream path (issue #764 / S5)
 // can reuse the canonical S4 INSERT builders / identifier checks
 // (`build_insert_sql`, `is_safe_sql_identifier`) rather than fork

--- a/crates/reddb-server/src/server/ui_bundle_resolver.rs
+++ b/crates/reddb-server/src/server/ui_bundle_resolver.rs
@@ -1,0 +1,634 @@
+//! `red ui` bundle resolver — pin→URL resolution, HTTPS download,
+//! SHA-256 verification, tgz extraction, and local cache management.
+//!
+//! Implements the runtime download path described in ADR 0050:
+//!
+//!   1. The pinned `red-ui` version and its bundle SHA-256 are build-time
+//!      constants set by CI (`RED_UI_PINNED_VERSION` / `RED_UI_PINNED_SHA256`).
+//!   2. [`resolve_ui_bundle`] checks `~/.cache/reddb/ui/<version>/` for a
+//!      cached bundle whose manifest matches the pin. Cache hit → returns
+//!      the directory immediately (no network call).
+//!   3. On a cache miss it downloads the GitHub release asset, verifies the
+//!      SHA-256 (refuses on mismatch), extracts the tgz into a staging
+//!      directory, writes a manifest, and atomically promotes the staging
+//!      directory to the live version directory.
+//!   4. Offline first-run with no cached bundle fails with a clear,
+//!      actionable `io::Error` message.
+//!
+//! The [`UiBundleFetcher`] trait makes the network layer injectable for
+//! tests.
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use hex;
+use sha2::{Digest, Sha256};
+
+use reddb_file::{
+    decode_ui_bundle_manifest_json, encode_ui_bundle_manifest_json, promote_ui_bundle_staging,
+    ui_bundle_cache_root, ui_bundle_manifest_path, ui_bundle_staging_dir, ui_bundle_version_dir,
+    write_ui_bundle_manifest, UiBundleManifest,
+};
+
+// ---------------------------------------------------------------------------
+// Build-time pin (CI replaces these)
+// ---------------------------------------------------------------------------
+
+/// Exact `red-ui` version this `red` binary was tested against. CI that
+/// validates the `red`↔`red-ui` pair sets this before the release build.
+pub const RED_UI_PINNED_VERSION: &str = "0.0.0-dev";
+
+/// SHA-256 (lower-case hex) of the `ui-dist.tgz` for the pinned version.
+/// CI sets this alongside `RED_UI_PINNED_VERSION`.
+pub const RED_UI_PINNED_SHA256: &str =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+// ---------------------------------------------------------------------------
+// URL resolution
+// ---------------------------------------------------------------------------
+
+/// GitHub release asset URL for a given `red-ui` version.
+///
+/// Maps `"1.2.3"` → `https://github.com/reddb-io/red-ui/releases/download/v1.2.3/ui-dist.tgz`
+pub fn release_asset_url(version: &str) -> String {
+    format!("https://github.com/reddb-io/red-ui/releases/download/v{version}/ui-dist.tgz")
+}
+
+// ---------------------------------------------------------------------------
+// Fetcher abstraction
+// ---------------------------------------------------------------------------
+
+/// Abstraction over the network layer so tests can inject a fake without
+/// making real HTTP calls.
+pub trait UiBundleFetcher: Send + Sync {
+    /// Fetch the URL and return the raw response bytes. Returns an
+    /// `io::Error` on any network or HTTP-level failure.
+    fn fetch_bytes(&self, url: &str) -> io::Result<Vec<u8>>;
+}
+
+/// Production fetcher — HTTPS via `ureq` with rustls, per ADR 0050.
+pub struct HttpFetcher;
+
+impl UiBundleFetcher for HttpFetcher {
+    fn fetch_bytes(&self, url: &str) -> io::Result<Vec<u8>> {
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .timeout_connect(Some(Duration::from_secs(30)))
+            .timeout_send_request(Some(Duration::from_secs(60)))
+            .timeout_recv_response(Some(Duration::from_secs(60)))
+            .timeout_recv_body(Some(Duration::from_secs(600)))
+            .build()
+            .into();
+
+        let mut resp = agent
+            .get(url)
+            .call()
+            .map_err(|err| io::Error::other(format!("HTTP GET {url}: {err}")))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("HTTP GET {url}: status {status}"),
+            ));
+        }
+
+        resp.body_mut()
+            .read_to_vec()
+            .map_err(|err| io::Error::other(format!("read response body from {url}: {err}")))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Cache root
+// ---------------------------------------------------------------------------
+
+/// Compute `~/.cache/reddb` (XDG-aware on Linux, standard on macOS/Windows).
+///
+/// The returned path is not created; callers are responsible for
+/// `fs::create_dir_all` as needed.
+pub fn reddb_user_cache_root() -> io::Result<PathBuf> {
+    let base = if let Ok(xdg) = std::env::var("XDG_CACHE_HOME") {
+        PathBuf::from(xdg)
+    } else if let Ok(home) = std::env::var("HOME") {
+        PathBuf::from(home).join(".cache")
+    } else if cfg!(target_os = "windows") {
+        if let Ok(local) = std::env::var("LOCALAPPDATA") {
+            PathBuf::from(local)
+        } else {
+            std::env::temp_dir()
+        }
+    } else {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "cannot determine home directory: HOME and XDG_CACHE_HOME are both unset",
+        ));
+    };
+    Ok(base.join("reddb"))
+}
+
+// ---------------------------------------------------------------------------
+// Main resolver
+// ---------------------------------------------------------------------------
+
+/// Ensure the pinned `red-ui` bundle is cached and return its directory.
+///
+/// # Behaviour
+///
+/// 1. **Cache hit**: if `<reddb_cache_root>/ui/<version>/manifest.json`
+///    exists and records the pinned version and SHA-256, return the
+///    directory immediately — no network call.
+/// 2. **Cache miss**: download the release asset via `fetcher`, verify
+///    SHA-256 (reject on mismatch), extract the tgz into a staging
+///    directory, write the manifest, and atomically promote to the live
+///    version directory.
+/// 3. **Offline first-run**: if `fetcher` returns an error and no cached
+///    bundle exists, propagate a clear `io::Error` with an actionable
+///    message.
+///
+/// `reddb_cache_root` is the `~/.cache/reddb` base (use
+/// [`reddb_user_cache_root`] to derive it). In tests, pass a `TempDir`
+/// path to keep caches isolated.
+pub fn resolve_ui_bundle(
+    reddb_cache_root: &Path,
+    fetcher: &dyn UiBundleFetcher,
+) -> io::Result<PathBuf> {
+    let version = RED_UI_PINNED_VERSION;
+    let expected_sha256 = RED_UI_PINNED_SHA256;
+
+    let cache_root = ui_bundle_cache_root(reddb_cache_root);
+    let version_dir = ui_bundle_version_dir(&cache_root, version);
+    let manifest_path = ui_bundle_manifest_path(&version_dir);
+
+    // Cache hit: manifest present, version and checksum match the pin.
+    if manifest_path.exists() {
+        if let Ok(bytes) = fs::read(&manifest_path) {
+            if let Ok(manifest) = decode_ui_bundle_manifest_json(&bytes) {
+                if manifest.version == version && manifest.sha256_hex == expected_sha256 {
+                    return Ok(version_dir);
+                }
+            }
+        }
+        // Manifest exists but is stale or corrupt — fall through to re-download.
+    }
+
+    // Download.
+    let url = release_asset_url(version);
+    let tgz_bytes = fetcher.fetch_bytes(&url).map_err(|err| {
+        // Distinguish between "never cached" and "cached but stale":
+        // both produce an actionable offline message, but only "never
+        // cached" has no fallback, so we surface the download URL.
+        io::Error::new(
+            err.kind(),
+            format!(
+                "could not download red-ui bundle v{version} from {url}: {err}\n\
+                 hint: run `red ui` while online to populate the cache, \
+                 or pass --ui-dir to serve a local bundle directory"
+            ),
+        )
+    })?;
+
+    // Verify SHA-256 before writing anything to disk.
+    let actual_sha256 = sha256_hex(&tgz_bytes);
+    if actual_sha256 != expected_sha256 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "red-ui bundle SHA-256 mismatch: expected {expected_sha256}, \
+                 got {actual_sha256} — refusing to serve a potentially tampered bundle"
+            ),
+        ));
+    }
+
+    // Unique token for staging/purge directory names; avoids a collision
+    // if two processes race to download the same version.
+    let unique = format!(
+        "{:x}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos()
+    );
+
+    let staging_dir = ui_bundle_staging_dir(&cache_root, version, &unique);
+
+    // Clean up any leftover staging directory from a prior crashed download.
+    if staging_dir.exists() {
+        let _ = fs::remove_dir_all(&staging_dir);
+    }
+
+    // Extract into staging.
+    extract_tgz(&tgz_bytes, &staging_dir)?;
+
+    // Write the manifest atomically inside staging before promotion.
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let manifest = UiBundleManifest {
+        version: version.to_string(),
+        sha256_hex: expected_sha256.to_string(),
+        tgz_size_bytes: tgz_bytes.len() as u64,
+        cached_at_unix_ms: now_ms,
+    };
+    let manifest_bytes = encode_ui_bundle_manifest_json(&manifest)?;
+    write_ui_bundle_manifest(&staging_dir, &manifest_bytes)?;
+
+    // Atomically promote staging → live version directory.
+    fs::create_dir_all(&cache_root)?;
+    promote_ui_bundle_staging(&cache_root, version, &unique, &staging_dir, &version_dir)?;
+
+    Ok(version_dir)
+}
+
+// ---------------------------------------------------------------------------
+// tgz extraction
+// ---------------------------------------------------------------------------
+
+/// Extract `tgz_bytes` into `dest`, creating `dest` if needed.
+///
+/// Path traversal safety: any archive entry whose path contains a `..`
+/// component is rejected. Symlinks and other special entry types are
+/// skipped (only regular files and directories are extracted).
+///
+/// Top-level directory stripping: if every non-empty path in the archive
+/// shares a common first component (e.g. `dist/`), that component is
+/// stripped so files land directly inside `dest`.
+fn extract_tgz(tgz_bytes: &[u8], dest: &Path) -> io::Result<()> {
+    fs::create_dir_all(dest)?;
+
+    // Two-pass: first decide whether to strip the common root directory,
+    // then extract. Re-reading from bytes is cheap (already in memory).
+    let strip_prefix = detect_common_root(tgz_bytes)?;
+
+    let cursor = std::io::Cursor::new(tgz_bytes);
+    let gz = flate2::read::GzDecoder::new(cursor);
+    let mut archive = tar::Archive::new(gz);
+
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let raw_path = entry.path()?.into_owned();
+
+        // Compute the relative path, optionally stripping the common root.
+        let rel: PathBuf = if strip_prefix {
+            raw_path.components().skip(1).collect()
+        } else {
+            raw_path.components().collect()
+        };
+
+        // Skip the (now-empty) root directory itself.
+        if rel.as_os_str().is_empty() {
+            continue;
+        }
+
+        // Reject path traversal.
+        if rel
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsafe path in red-ui bundle archive: {}",
+                    raw_path.display()
+                ),
+            ));
+        }
+
+        let out_path = dest.join(&rel);
+
+        match entry.header().entry_type() {
+            tar::EntryType::Directory => {
+                fs::create_dir_all(&out_path)?;
+            }
+            tar::EntryType::Regular => {
+                if let Some(parent) = out_path.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                let mut file = fs::File::create(&out_path)?;
+                std::io::copy(&mut entry, &mut file)?;
+            }
+            _ => {} // skip symlinks, hard links, etc. — security boundary
+        }
+    }
+    Ok(())
+}
+
+/// Return `true` if every non-empty path in the archive shares a single
+/// common first component (implying the archive was created with a
+/// top-level wrapper directory that should be stripped).
+///
+/// A single-component **directory** entry (e.g. `dist/`) is the root
+/// directory itself and does NOT signal "file at the archive root". A
+/// single-component **regular-file** entry (e.g. `index.html`) does —
+/// there is no prefix to strip in that case.
+fn detect_common_root(tgz_bytes: &[u8]) -> io::Result<bool> {
+    let cursor = std::io::Cursor::new(tgz_bytes);
+    let gz = flate2::read::GzDecoder::new(cursor);
+    let mut archive = tar::Archive::new(gz);
+
+    let mut common: Option<String> = None;
+    for entry in archive.entries()? {
+        let entry = entry?;
+        let path = entry.path()?.into_owned();
+        let is_dir = matches!(entry.header().entry_type(), tar::EntryType::Directory);
+
+        let first = match path.components().next() {
+            Some(c) => match c.as_os_str().to_str() {
+                Some(s) => s.to_string(),
+                None => continue,
+            },
+            None => continue,
+        };
+
+        let component_count = path.components().count();
+
+        // A single-component, non-directory entry is a regular file placed
+        // directly at the archive root — no common prefix to strip.
+        if component_count == 1 && !is_dir {
+            return Ok(false);
+        }
+
+        match &common {
+            None => common = Some(first),
+            Some(prev) if prev != &first => return Ok(false),
+            _ => {}
+        }
+    }
+    Ok(common.is_some())
+}
+
+// ---------------------------------------------------------------------------
+// SHA-256 helper
+// ---------------------------------------------------------------------------
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    // ------------------------------------------------------------------
+    // Test helpers
+    // ------------------------------------------------------------------
+
+    /// Build a minimal `.tgz` archive in memory.
+    ///
+    /// Names ending in `/` are written as directory entries
+    /// (`EntryType::Directory`); all others are regular files.
+    fn make_tgz(files: &[(&str, &[u8])]) -> Vec<u8> {
+        let buf = Vec::new();
+        let gz = flate2::write::GzEncoder::new(buf, flate2::Compression::default());
+        let mut tb = tar::Builder::new(gz);
+        for (name, content) in files {
+            let mut header = tar::Header::new_gnu();
+            if name.ends_with('/') {
+                header.set_entry_type(tar::EntryType::Directory);
+                header.set_size(0);
+                header.set_mode(0o755);
+            } else {
+                header.set_size(content.len() as u64);
+                header.set_mode(0o644);
+            }
+            header.set_cksum();
+            tb.append_data(&mut header, *name, std::io::Cursor::new(*content))
+                .unwrap();
+        }
+        let gz = tb.into_inner().unwrap();
+        gz.finish().unwrap()
+    }
+
+    struct FakeFetcher {
+        bytes: Vec<u8>,
+        call_count: std::sync::Mutex<usize>,
+    }
+
+    impl FakeFetcher {
+        fn new(bytes: Vec<u8>) -> Self {
+            Self {
+                bytes,
+                call_count: std::sync::Mutex::new(0),
+            }
+        }
+
+        fn calls(&self) -> usize {
+            *self.call_count.lock().unwrap()
+        }
+    }
+
+    impl UiBundleFetcher for FakeFetcher {
+        fn fetch_bytes(&self, _url: &str) -> io::Result<Vec<u8>> {
+            *self.call_count.lock().unwrap() += 1;
+            Ok(self.bytes.clone())
+        }
+    }
+
+    struct OfflineFetcher;
+
+    impl UiBundleFetcher for OfflineFetcher {
+        fn fetch_bytes(&self, url: &str) -> io::Result<Vec<u8>> {
+            Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!("no network: {url}"),
+            ))
+        }
+    }
+
+    // Resolve using a known tgz + SHA-256, bypassing the build-time pin.
+    fn resolve_with_pin(
+        reddb_cache_root: &Path,
+        fetcher: &dyn UiBundleFetcher,
+        version: &str,
+        expected_sha256: &str,
+    ) -> io::Result<PathBuf> {
+        let cache_root = ui_bundle_cache_root(reddb_cache_root);
+        let version_dir = ui_bundle_version_dir(&cache_root, version);
+        let manifest_path = ui_bundle_manifest_path(&version_dir);
+
+        if manifest_path.exists() {
+            if let Ok(bytes) = fs::read(&manifest_path) {
+                if let Ok(manifest) = decode_ui_bundle_manifest_json(&bytes) {
+                    if manifest.version == version && manifest.sha256_hex == expected_sha256 {
+                        return Ok(version_dir);
+                    }
+                }
+            }
+        }
+
+        let url = release_asset_url(version);
+        let tgz_bytes = fetcher.fetch_bytes(&url)?;
+
+        let actual = sha256_hex(&tgz_bytes);
+        if actual != expected_sha256 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("red-ui bundle SHA-256 mismatch: expected {expected_sha256}, got {actual}"),
+            ));
+        }
+
+        let unique = format!("{}", tgz_bytes.len());
+        let staging_dir = ui_bundle_staging_dir(&cache_root, version, &unique);
+        if staging_dir.exists() {
+            let _ = fs::remove_dir_all(&staging_dir);
+        }
+        extract_tgz(&tgz_bytes, &staging_dir)?;
+
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+        let manifest = UiBundleManifest {
+            version: version.to_string(),
+            sha256_hex: expected_sha256.to_string(),
+            tgz_size_bytes: tgz_bytes.len() as u64,
+            cached_at_unix_ms: now_ms,
+        };
+        let manifest_bytes = encode_ui_bundle_manifest_json(&manifest)?;
+        write_ui_bundle_manifest(&staging_dir, &manifest_bytes)?;
+        fs::create_dir_all(&cache_root)?;
+        promote_ui_bundle_staging(&cache_root, version, &unique, &staging_dir, &version_dir)?;
+
+        Ok(version_dir)
+    }
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn pin_to_url_resolution() {
+        assert_eq!(
+            release_asset_url("1.2.3"),
+            "https://github.com/reddb-io/red-ui/releases/download/v1.2.3/ui-dist.tgz"
+        );
+        assert_eq!(
+            release_asset_url("0.0.0-dev"),
+            "https://github.com/reddb-io/red-ui/releases/download/v0.0.0-dev/ui-dist.tgz"
+        );
+    }
+
+    #[test]
+    fn checksum_match_produces_cached_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let tgz = make_tgz(&[
+            ("index.html", b"<html></html>"),
+            ("app.js", b"console.log(1)"),
+        ]);
+        let sha256 = sha256_hex(&tgz);
+        let fetcher = FakeFetcher::new(tgz);
+
+        let bundle_dir = resolve_with_pin(dir.path(), &fetcher, "1.0.0", &sha256).expect("resolve");
+
+        assert!(bundle_dir.exists());
+        assert!(bundle_dir.join("index.html").exists());
+        assert!(bundle_dir.join("app.js").exists());
+        assert_eq!(
+            std::fs::read_to_string(bundle_dir.join("index.html")).unwrap(),
+            "<html></html>"
+        );
+    }
+
+    #[test]
+    fn checksum_mismatch_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let tgz = make_tgz(&[("index.html", b"<html></html>")]);
+        let wrong_sha256 = "aaaa000000000000000000000000000000000000000000000000000000000000";
+        let fetcher = FakeFetcher::new(tgz);
+
+        let err = resolve_with_pin(dir.path(), &fetcher, "1.0.0", wrong_sha256)
+            .expect_err("should reject mismatched checksum");
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert!(err.to_string().contains("SHA-256 mismatch"), "{err}");
+        assert!(err.to_string().contains(wrong_sha256), "{err}");
+    }
+
+    #[test]
+    fn cache_hit_skips_fetch() {
+        let dir = tempfile::tempdir().unwrap();
+        let tgz = make_tgz(&[("index.html", b"<html></html>")]);
+        let sha256 = sha256_hex(&tgz);
+        let fetcher = FakeFetcher::new(tgz);
+
+        // First call populates the cache.
+        resolve_with_pin(dir.path(), &fetcher, "2.0.0", &sha256).unwrap();
+        assert_eq!(fetcher.calls(), 1);
+
+        // Second call must return immediately — no fetch.
+        resolve_with_pin(dir.path(), &fetcher, "2.0.0", &sha256).unwrap();
+        assert_eq!(fetcher.calls(), 1, "cache hit must not call the fetcher");
+    }
+
+    #[test]
+    fn offline_first_run_fails_with_clear_message() {
+        let dir = tempfile::tempdir().unwrap();
+        let fetcher = OfflineFetcher;
+
+        let err = resolve_with_pin(
+            dir.path(),
+            &fetcher,
+            "1.0.0",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+        )
+        .expect_err("offline should fail");
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no network"),
+            "error should name the cause: {msg}"
+        );
+    }
+
+    #[test]
+    fn tgz_with_top_level_dir_is_stripped() {
+        let dir = tempfile::tempdir().unwrap();
+        // Simulate a GitHub release archive: dist/index.html, dist/app.js
+        let tgz = make_tgz(&[
+            ("dist/", b""),
+            ("dist/index.html", b"<html></html>"),
+            ("dist/app.js", b"console.log(1)"),
+        ]);
+        let sha256 = sha256_hex(&tgz);
+        let fetcher = FakeFetcher::new(tgz);
+
+        let bundle_dir = resolve_with_pin(dir.path(), &fetcher, "3.0.0", &sha256).expect("resolve");
+
+        // After stripping "dist/", files should be at the root.
+        assert!(
+            bundle_dir.join("index.html").exists(),
+            "index.html should be at bundle root after stripping"
+        );
+        assert!(bundle_dir.join("app.js").exists());
+    }
+
+    #[test]
+    fn extracted_file_set_matches_archive() {
+        let dir = tempfile::tempdir().unwrap();
+        let files: &[(&str, &[u8])] = &[
+            ("index.html", b"<html>"),
+            ("assets/main.js", b"const x=1"),
+            ("assets/style.css", b"body{}"),
+        ];
+        let tgz = make_tgz(files);
+        let sha256 = sha256_hex(&tgz);
+        let fetcher = FakeFetcher::new(tgz);
+
+        let bundle_dir = resolve_with_pin(dir.path(), &fetcher, "4.0.0", &sha256).expect("resolve");
+
+        let expected: HashSet<&str> = files.iter().map(|(n, _)| *n).collect();
+        for name in &expected {
+            let p = bundle_dir.join(name);
+            assert!(p.exists(), "expected {name} at {}", p.display());
+        }
+    }
+}

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1817,9 +1817,29 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         });
     let server = reddb::server::RedDBServer::new(runtime);
 
-    let ui_dir = flag_string(flags, "ui-dir")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from);
+    let ui_dir = if let Some(explicit) = flag_string(flags, "ui-dir").filter(|v| !v.is_empty()) {
+        // Explicit --ui-dir: use as-is (no download).
+        Some(PathBuf::from(explicit))
+    } else {
+        // No --ui-dir: resolve the pinned bundle from the local cache,
+        // downloading it on first use (ADR 0050 / issue #1043).
+        let cache_root = reddb::server::ui_bundle_resolver::reddb_user_cache_root()
+            .unwrap_or_else(|_| std::env::temp_dir().join("reddb"));
+        match reddb::server::ui_bundle_resolver::resolve_ui_bundle(
+            &cache_root,
+            &reddb::server::ui_bundle_resolver::HttpFetcher,
+        ) {
+            Ok(bundle_dir) => Some(bundle_dir),
+            Err(err) => {
+                let msg = format!("fetch red-ui bundle: {err}");
+                if json_mode {
+                    json_error("ui", &msg);
+                }
+                eprintln!("error: {msg}");
+                std::process::exit(1);
+            }
+        }
+    };
     let port = flag_string(flags, "port")
         .and_then(|value| value.parse::<u16>().ok())
         .unwrap_or(0);


### PR DESCRIPTION
Automated AFK landing for #1043. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783712377&installation_id=129708444&pr_number=1082&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1082&signature=d4d02f4d2514ebe09f3c2224fa78bc2497b2f4f48d0b567ed41a49703b544f2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI automatically resolves and caches the pinned red-ui bundle on first use, with offline error guidance as fallback
  * Supports `--ui-dir` override for custom bundle paths

* **Chores**
  * Added archive extraction and compression dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->