### PR TITLE
merge: #1044 red ui: bridge `red://` / `reds://` remote RedWire targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2388,6 +2388,7 @@ dependencies = [
  "tracing-subscriber",
  "trybuild",
  "ureq",
+ "webpki-roots",
  "x509-parser",
  "zstd",
 ]

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -84,6 +84,11 @@ fs2 = "0.4"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "logging", "ring"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = "2"
+# webpki system trust roots for the `red ui` outbound TLS connection to a
+# `reds://` remote RedWire target (issue #1044). Already in the lock via
+# the wider rustls graph; pinned here so the bridge connector can seed its
+# RootCertStore with public CAs without an explicit `--tls-ca`.
+webpki-roots = "1"
 x509-parser = "0.18"
 rcgen = "0.14"
 tracing = "0.1"

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -208,8 +208,8 @@ pub fn all_commands() -> Vec<CommandDef> {
     },
     CommandDef {
       name: "ui",
-      summary: "Open a graphical UI against a local .rdb over a RedWire-over-WS bridge",
-      usage: "red ui --server file://./data.rdb [--ui-dir DIR] [--port N] [--no-browser]",
+      summary: "Open a graphical UI against a local .rdb or a remote red:///reds:// instance over a RedWire-over-WS bridge",
+      usage: "red ui file://./data.rdb | red ui red://host:port [--ui-dir DIR] [--port N] [--tls-ca PEM] [--no-browser]",
       flags: ui_flags(),
     },
   ]
@@ -442,6 +442,9 @@ fn ui_flags() -> Vec<FlagSchema> {
         ),
         FlagSchema::new("port")
             .with_description("Loopback port for the bridge (0 / omit picks an ephemeral port)"),
+        FlagSchema::new("tls-ca").with_description(
+            "PEM CA bundle to trust for a reds:// target (on top of system roots)",
+        ),
         FlagSchema::boolean("no-browser").with_description(
             "Do not open the default browser (also honoured via RED_UI_NO_BROWSER)",
         ),

--- a/crates/reddb-server/src/server/ui_bridge.rs
+++ b/crates/reddb-server/src/server/ui_bridge.rs
@@ -36,14 +36,14 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use axum::extract::ws::WebSocketUpgrade;
+use axum::extract::ws::{WebSocket, WebSocketUpgrade};
 use axum::extract::State;
 use axum::http::{header, HeaderMap, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use tokio::sync::oneshot;
 
-use super::ws_edge::{REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL};
+use super::ws_edge::{pump_ws_stream, run_ws_session, REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL};
 use super::RedDBServer;
 
 /// The checked-in minimal UI fixture served when no `--ui-dir` is given.
@@ -63,12 +63,97 @@ pub struct UiBridgeConfig {
     pub port: u16,
 }
 
+/// A remote RedWire endpoint the bridge fronts for a `red://` / `reds://`
+/// target (issue #1044, ADR 0047 bridge, ADR 0049 transport). The local
+/// loopback WS endpoint pumps its data channel straight into a fresh
+/// TCP (or TLS) connection to this host — the UI is unaware that the
+/// engine lives in another process / container.
+#[derive(Debug, Clone)]
+pub struct RemoteRedwireTarget {
+    /// Host to dial (the `red://`/`reds://` authority).
+    pub host: String,
+    /// Port to dial (defaults to `DEFAULT_PORT_RED` via the URI parser).
+    pub port: u16,
+    /// Negotiate TLS to the target (`reds://`). The handshake is
+    /// transparent to the UI.
+    pub tls: bool,
+    /// Optional CA bundle (PEM) to trust for the TLS handshake, on top of
+    /// the webpki system roots. Needed for a self-signed / private-CA
+    /// `reds://` target (a dev container); `None` trusts system roots only.
+    pub ca_pem: Option<Vec<u8>>,
+}
+
+/// What a running bridge fronts: the embedded engine opened from a
+/// `file://` target, or a remote RedWire endpoint (`red://` / `reds://`).
+/// Both are reached through the *same* loopback WS endpoint and the same
+/// byte-pump seam — only the far end of the pump differs.
+enum BridgeBackend {
+    /// `file://` — RedWire runs over the embedded engine in-process.
+    Embedded(RedDBServer),
+    /// `red://` / `reds://` — RedWire bytes are relayed to a remote
+    /// RedWire-over-TCP/TLS instance.
+    Remote(RemoteRedwireTarget),
+}
+
+/// How `red ui` should bridge a target URI: against the local embedded
+/// engine (`file://`, bare path) or a remote RedWire endpoint
+/// (`red://` / `reds://`). Both are *bridge-required* — the UI only ever
+/// talks to the loopback WS endpoint; this enum says what that endpoint
+/// fronts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UiTarget {
+    /// A local file / embedded-engine target. The caller canonicalises
+    /// the `file://` path and opens the engine itself.
+    File,
+    /// A remote RedWire-over-TCP (`red://`) or -TLS (`reds://`) target.
+    Remote(RemoteRedwireTargetSpec),
+}
+
+/// Host / port / TLS triple parsed from a `red://` / `reds://` URI —
+/// the connection-independent part of [`RemoteRedwireTarget`] (no CA
+/// bytes), so it can derive `PartialEq` for classification tests.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteRedwireTargetSpec {
+    pub host: String,
+    pub port: u16,
+    pub tls: bool,
+}
+
+/// Classify a `red ui` target URI into the bridge backend it requires.
+///
+/// `file://` and bare filesystem paths resolve to [`UiTarget::File`];
+/// `red://host[:port]` and `reds://host[:port]` resolve to
+/// [`UiTarget::Remote`] with the parser's default port
+/// ([`reddb_wire::DEFAULT_PORT_RED`], 5050) when none is given and `tls`
+/// set for `reds://`. Any other scheme (or a cluster URI) is an error —
+/// `red ui` bridges exactly one endpoint.
+pub fn classify_ui_target(uri: &str) -> Result<UiTarget, String> {
+    // A bare path with no scheme is a file target (matches the existing
+    // `red ui ./data.rdb` shorthand).
+    if !uri.contains("://") {
+        return Ok(UiTarget::File);
+    }
+    match reddb_wire::parse(uri) {
+        Ok(reddb_wire::ConnectionTarget::File { .. }) => Ok(UiTarget::File),
+        Ok(reddb_wire::ConnectionTarget::RedWire { host, port, tls }) => {
+            Ok(UiTarget::Remote(RemoteRedwireTargetSpec {
+                host,
+                port,
+                tls,
+            }))
+        }
+        Ok(_) => Err(format!(
+            "red ui bridges file://, red://, or reds:// targets, got: {uri}"
+        )),
+        Err(err) => Err(err.message),
+    }
+}
+
 /// State threaded into the bridge's axum handlers. Cheap to clone (the
-/// server clone shares its inner `Arc`s; the origin list and bundle dir
-/// are shared via `Arc`).
+/// backend is shared via `Arc`; the origin list and bundle dir likewise).
 #[derive(Clone)]
 struct BridgeState {
-    server: RedDBServer,
+    backend: Arc<BridgeBackend>,
     allowed_origins: Arc<Vec<String>>,
     ui_dir: Option<Arc<PathBuf>>,
 }
@@ -146,11 +231,30 @@ pub async fn spawn_ui_bridge(
     server: RedDBServer,
     config: UiBridgeConfig,
 ) -> std::io::Result<UiBridge> {
+    spawn_ui_bridge_backend(BridgeBackend::Embedded(server), config).await
+}
+
+/// Like [`spawn_ui_bridge`] but fronting a *remote* RedWire endpoint
+/// (`red://` / `reds://`, issue #1044) rather than the embedded engine.
+/// The served UI still talks only to the loopback WS endpoint; each WS
+/// session opens a fresh TCP/TLS connection to `target`, and the byte
+/// stream is pumped through transparently.
+pub async fn spawn_ui_bridge_remote(
+    target: RemoteRedwireTarget,
+    config: UiBridgeConfig,
+) -> std::io::Result<UiBridge> {
+    spawn_ui_bridge_backend(BridgeBackend::Remote(target), config).await
+}
+
+async fn spawn_ui_bridge_backend(
+    backend: BridgeBackend,
+    config: UiBridgeConfig,
+) -> std::io::Result<UiBridge> {
     let listener = tokio::net::TcpListener::bind(("127.0.0.1", config.port)).await?;
     let local_addr = listener.local_addr()?;
 
     let state = BridgeState {
-        server,
+        backend: Arc::new(backend),
         allowed_origins: Arc::new(seed_loopback_origins(local_addr.port())),
         ui_dir: config.ui_dir.map(Arc::new),
     };
@@ -196,11 +300,109 @@ async fn loopback_redwire_upgrade(
             .into_response();
     }
 
-    let server = state.server.clone();
+    let backend = Arc::clone(&state.backend);
     ws.protocols([REDWIRE_WS_SUBPROTOCOL])
         .on_upgrade(move |socket| async move {
-            super::ws_edge::run_ws_session(socket, server).await;
+            match &*backend {
+                // `file://` — RedWire over the in-process embedded engine.
+                BridgeBackend::Embedded(server) => {
+                    run_ws_session(socket, server.clone()).await;
+                }
+                // `red://` / `reds://` — relay to a remote RedWire instance.
+                BridgeBackend::Remote(target) => {
+                    run_remote_ws_session(socket, target).await;
+                }
+            }
         })
+}
+
+/// Bridge the binary WebSocket to a remote RedWire-over-TCP/TLS endpoint.
+///
+/// Opens a fresh connection to `target` per WS session and pumps the byte
+/// stream straight through ([`pump_ws_stream`]). The browser sends the
+/// exact native preamble (`0xFE` magic + minor + `Hello`), so the remote
+/// listener's standalone session handles it unchanged — the bridge is a
+/// pure byte relay and never parses RedWire frames. On a connection
+/// failure the WS is closed so the UI surfaces the error rather than
+/// hanging.
+async fn run_remote_ws_session(socket: WebSocket, target: &RemoteRedwireTarget) {
+    let addr = (target.host.as_str(), target.port);
+    let tcp = match tokio::net::TcpStream::connect(addr).await {
+        Ok(tcp) => tcp,
+        Err(err) => {
+            tracing::warn!(
+                host = %target.host,
+                port = target.port,
+                err = %err,
+                "ui bridge: connect to remote redwire target failed"
+            );
+            close_ws(socket).await;
+            return;
+        }
+    };
+
+    if !target.tls {
+        pump_ws_stream(socket, tcp).await;
+        return;
+    }
+
+    match wrap_remote_tls(tcp, target).await {
+        Ok(tls) => pump_ws_stream(socket, tls).await,
+        Err(err) => {
+            tracing::warn!(
+                host = %target.host,
+                port = target.port,
+                err = %err,
+                "ui bridge: TLS handshake to remote redwire target failed"
+            );
+            close_ws(socket).await;
+        }
+    }
+}
+
+/// Send a best-effort close frame on a WS the bridge is abandoning.
+async fn close_ws(mut socket: WebSocket) {
+    let _ = socket.send(axum::extract::ws::Message::Close(None)).await;
+}
+
+/// Negotiate client-side TLS to a `reds://` target. Trusts the webpki
+/// system roots, plus any caller-supplied CA bundle (PEM) — enough for a
+/// public-cert target out of the box and a self-signed / private-CA dev
+/// container when a `--tls-ca` bundle is passed. Server-only TLS (no
+/// client cert): RedWire auth is negotiated inside the handshake, exactly
+/// as on the native socket transports.
+async fn wrap_remote_tls(
+    tcp: tokio::net::TcpStream,
+    target: &RemoteRedwireTarget,
+) -> std::io::Result<tokio_rustls::client::TlsStream<tokio::net::TcpStream>> {
+    use rustls::pki_types::ServerName;
+    use rustls::{ClientConfig, RootCertStore};
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut roots = RootCertStore::empty();
+    // Seed the webpki system roots so a public-cert `reds://` works
+    // without an explicit CA.
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    // Add any caller-supplied CA (a self-signed dev container / private CA).
+    if let Some(pem) = &target.ca_pem {
+        let mut reader = std::io::BufReader::new(&pem[..]);
+        for cert in rustls_pemfile::certs(&mut reader) {
+            let cert = cert.map_err(std::io::Error::other)?;
+            roots
+                .add(cert)
+                .map_err(|e| std::io::Error::other(format!("add CA cert: {e}")))?;
+        }
+    }
+
+    let config = ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+    let server_name = ServerName::try_from(target.host.clone())
+        .map_err(|e| std::io::Error::other(format!("invalid TLS server name: {e}")))?;
+    connector.connect(server_name, tcp).await
 }
 
 /// Static-file fallback: serve the UI bundle. With a `--ui-dir`, files are
@@ -328,6 +530,76 @@ mod tests {
             Some("http://127.0.0.1:7777"),
             &[]
         ));
+    }
+
+    // ----------------------------------------------------------------
+    // Scheme classification (issue #1044). `red://` / `reds://` are
+    // bridge-required remote targets and resolve to the parser's default
+    // port; `file://` and bare paths stay local.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn red_scheme_classifies_as_remote_plaintext_default_port() {
+        // No port → the shared parser's DEFAULT_PORT_RED (5050), no TLS.
+        assert_eq!(
+            classify_ui_target("red://db.internal").unwrap(),
+            UiTarget::Remote(RemoteRedwireTargetSpec {
+                host: "db.internal".to_string(),
+                port: reddb_wire::DEFAULT_PORT_RED,
+                tls: false,
+            })
+        );
+        assert_eq!(reddb_wire::DEFAULT_PORT_RED, 5050);
+    }
+
+    #[test]
+    fn reds_scheme_classifies_as_remote_tls_default_port() {
+        assert_eq!(
+            classify_ui_target("reds://db.internal").unwrap(),
+            UiTarget::Remote(RemoteRedwireTargetSpec {
+                host: "db.internal".to_string(),
+                port: reddb_wire::DEFAULT_PORT_RED,
+                tls: true,
+            })
+        );
+    }
+
+    #[test]
+    fn red_scheme_honours_explicit_port() {
+        assert_eq!(
+            classify_ui_target("red://127.0.0.1:6000").unwrap(),
+            UiTarget::Remote(RemoteRedwireTargetSpec {
+                host: "127.0.0.1".to_string(),
+                port: 6000,
+                tls: false,
+            })
+        );
+        assert_eq!(
+            classify_ui_target("reds://host:7001").unwrap(),
+            UiTarget::Remote(RemoteRedwireTargetSpec {
+                host: "host".to_string(),
+                port: 7001,
+                tls: true,
+            })
+        );
+    }
+
+    #[test]
+    fn file_and_bare_path_classify_as_local() {
+        assert_eq!(
+            classify_ui_target("file:///var/lib/db.rdb").unwrap(),
+            UiTarget::File
+        );
+        assert_eq!(classify_ui_target("./data.rdb").unwrap(), UiTarget::File);
+        assert_eq!(classify_ui_target("data.rdb").unwrap(), UiTarget::File);
+    }
+
+    #[test]
+    fn unsupported_scheme_is_rejected() {
+        // gRPC / http / a cluster URI are not single RedWire endpoints.
+        assert!(classify_ui_target("grpc://host:5055").is_err());
+        assert!(classify_ui_target("http://host").is_err());
+        assert!(classify_ui_target("red://a,b").is_err());
     }
 
     #[test]

--- a/crates/reddb-server/src/server/ws_edge.rs
+++ b/crates/reddb-server/src/server/ws_edge.rs
@@ -162,14 +162,14 @@ fn classify_inbound(inbound: Option<Result<Message, axum::Error>>) -> WsInbound 
     }
 }
 
-/// Bridge the binary WebSocket data channel to a RedWire session.
+/// Bridge the binary WebSocket data channel to a RedWire session over the
+/// **embedded engine**.
 ///
-/// The session runs on the application side of an in-memory duplex; this
-/// loop pumps bytes between the network side of the duplex and the WS:
-/// inbound `Binary` messages become session input, session output becomes
-/// outbound `Binary` messages. When either side closes, both halves drop
-/// and the peer observes EOF.
-pub(crate) async fn run_ws_session(mut socket: WebSocket, server: super::RedDBServer) {
+/// The session runs on the application side of an in-memory duplex; the
+/// pump loop ([`pump_ws_stream`]) moves bytes between the network side of
+/// the duplex and the WS. When either side closes, both halves drop and
+/// the peer observes EOF.
+pub(crate) async fn run_ws_session(socket: WebSocket, server: super::RedDBServer) {
     let runtime = Arc::new(server.runtime().clone());
     // Same auth wiring as the socket listener path: bearer/JWT are
     // negotiated in the RedWire handshake from the runtime's stores.
@@ -181,7 +181,32 @@ pub(crate) async fn run_ws_session(mut socket: WebSocket, server: super::RedDBSe
         let _ = handle_session_consume_magic(session_io, runtime, auth_store, oauth).await;
     });
 
-    let (mut net_read, mut net_write) = tokio::io::split(net_io);
+    // Pump the WS data channel against the network side of the duplex.
+    pump_ws_stream(socket, net_io).await;
+
+    // The pump already dropped its stream halves (signalling EOF to the
+    // session side); abort backstops any task still parked (e.g. on a live
+    // queue wait).
+    session.abort();
+}
+
+/// Pump bytes between a binary WebSocket and an arbitrary byte stream.
+///
+/// This is the transport-agnostic seam (ADR 0036): inbound `Binary`
+/// messages are written to `stream`, and bytes read back from `stream`
+/// are sent as outbound `Binary` messages. The byte stream may be the
+/// network side of the embedded-engine duplex ([`run_ws_session`]) or a
+/// remote RedWire-over-TCP/TLS connection (the `red ui` bridge to a
+/// `red://` / `reds://` target, issue #1044) — the loop is identical
+/// because RedWire framing is self-delimiting on either end.
+///
+/// Returns once either side closes; both stream halves are dropped on the
+/// way out so the peer observes EOF.
+pub(crate) async fn pump_ws_stream<S>(mut socket: WebSocket, stream: S)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite,
+{
+    let (mut net_read, mut net_write) = tokio::io::split(stream);
     let mut out_buf = vec![0u8; WS_READ_CHUNK];
 
     loop {
@@ -199,7 +224,7 @@ pub(crate) async fn run_ws_session(mut socket: WebSocket, server: super::RedDBSe
             }
             outbound = net_read.read(&mut out_buf) => {
                 match outbound {
-                    // Session closed its write half → no more output.
+                    // Stream closed its write half → no more output.
                     Ok(0) => break,
                     Ok(n) => {
                         let msg = Message::Binary(Bytes::copy_from_slice(&out_buf[..n]));
@@ -213,12 +238,10 @@ pub(crate) async fn run_ws_session(mut socket: WebSocket, server: super::RedDBSe
         }
     }
 
-    // Dropping the network halves signals EOF to the session side; abort
-    // backstops any task still parked (e.g. on a live queue wait).
+    // Dropping the network halves signals EOF to the stream side.
     drop(net_write);
     drop(net_read);
     let _ = socket.send(Message::Close(None)).await;
-    session.abort();
 }
 
 #[cfg(test)]

--- a/crates/reddb-server/src/wire/mod.rs
+++ b/crates/reddb-server/src/wire/mod.rs
@@ -9,7 +9,7 @@ pub use postgres::{start_pg_wire_listener, PgWireConfig};
 #[cfg(unix)]
 pub use redwire::start_redwire_unix_listener;
 pub use redwire::{
-    start_redwire_listener, start_redwire_listener_on, start_redwire_tls_listener, RedWireConfig,
-    REDWIRE_MAGIC,
+    start_redwire_listener, start_redwire_listener_on, start_redwire_tls_listener,
+    start_redwire_tls_listener_on, RedWireConfig, REDWIRE_MAGIC,
 };
 pub use tls::WireTlsConfig;

--- a/crates/reddb-server/src/wire/redwire/listener.rs
+++ b/crates/reddb-server/src/wire/redwire/listener.rs
@@ -126,6 +126,26 @@ pub async fn start_redwire_tls_listener(
     let acceptor = crate::wire::tls::build_tls_acceptor(tls_config)?;
     let listener = TcpListener::bind(bind_addr).await?;
     tracing::info!(transport = "redwire+tls", bind = %bind_addr, "listener online");
+    serve_redwire_tls(listener, acceptor, runtime).await
+}
+
+/// Start a TLS RedWire listener on an already-bound TCP listener. Mirror
+/// of [`start_redwire_listener_on`] for the TLS edge — lets a caller pick
+/// the bound address (e.g. an ephemeral `127.0.0.1:0` port) before serving.
+pub async fn start_redwire_tls_listener_on(
+    listener: TcpListener,
+    runtime: Arc<RedDBRuntime>,
+    tls_config: &crate::wire::tls::WireTlsConfig,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let acceptor = crate::wire::tls::build_tls_acceptor(tls_config)?;
+    serve_redwire_tls(listener, acceptor, runtime).await
+}
+
+async fn serve_redwire_tls(
+    listener: TcpListener,
+    acceptor: tokio_rustls::TlsAcceptor,
+    runtime: Arc<RedDBRuntime>,
+) -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let (tcp_stream, peer) = listener.accept().await?;
         let acceptor = acceptor.clone();

--- a/crates/reddb-server/src/wire/redwire/mod.rs
+++ b/crates/reddb-server/src/wire/redwire/mod.rs
@@ -22,7 +22,8 @@ pub mod session;
 #[cfg(unix)]
 pub use listener::start_redwire_unix_listener;
 pub use listener::{
-    start_redwire_listener, start_redwire_listener_on, start_redwire_tls_listener, RedWireConfig,
+    start_redwire_listener, start_redwire_listener_on, start_redwire_tls_listener,
+    start_redwire_tls_listener_on, RedWireConfig,
 };
 
 pub use reddb_wire::redwire::{

--- a/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
+++ b/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
@@ -1,0 +1,292 @@
+//! Issue #1044 / PRD #1041 — `red ui --server red://host` / `reds://host`
+//! bridge to a *remote* RedWire endpoint.
+//!
+//! The local loopback RedWire-over-WS endpoint now fronts a remote
+//! RedWire-over-TCP (and -TLS) connection instead of an embedded engine,
+//! reusing the same byte-pump seam (ADR 0036 / 0047 / 0049). These tests
+//! assert the load-bearing acceptance criteria:
+//!
+//!   1. `red://host:port` — the served page opens a RedWire-over-WS
+//!      session against the local `127.0.0.1` WS endpoint and a query
+//!      round-trips through the bridge to a running RedWire-over-TCP
+//!      instance.
+//!   2. `reds://host:port` — the same, with the bridge negotiating TLS to
+//!      the target transparently (the WS client never speaks TLS).
+//!   3. The UI talks only to the local loopback WS endpoint; the remote
+//!      connection is owned by the bridge.
+//!
+//! The WS client here stands in for the browser: it speaks the binary
+//! RedWire framing over a binary WebSocket exactly as the served fixture
+//! page does.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use futures_util::{SinkExt, StreamExt};
+use reddb_server::server::ui_bridge::{
+    spawn_ui_bridge_remote, RemoteRedwireTarget, UiBridgeConfig,
+};
+use reddb_server::wire::tls::generate_self_signed_cert;
+use reddb_server::wire::WireTlsConfig;
+use reddb_server::{RedDBOptions, RedDBRuntime};
+use reddb_wire::redwire::{
+    build_auth_response_anonymous_payload, build_auth_response_frame, build_client_hello_frame,
+    build_query_frame, decode_frame, encode_frame, Frame, MessageKind, MAX_KNOWN_MINOR_VERSION,
+    REDWIRE_MAGIC,
+};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+
+const TIMEOUT: Duration = Duration::from_secs(20);
+
+type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// An in-memory runtime to back the remote RedWire listener under test.
+fn remote_runtime() -> Arc<RedDBRuntime> {
+    Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime"))
+}
+
+/// Bind an ephemeral loopback port and serve plain RedWire-over-TCP on it.
+async fn spawn_remote_tcp() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind tcp");
+    let addr = listener.local_addr().expect("addr");
+    let rt = remote_runtime();
+    tokio::spawn(async move {
+        let _ = reddb_server::wire::start_redwire_listener_on(listener, rt).await;
+    });
+    addr
+}
+
+/// Bind an ephemeral loopback port and serve RedWire-over-TLS on it,
+/// returning the bound address plus the self-signed cert PEM (used as the
+/// bridge's trust anchor).
+async fn spawn_remote_tls() -> (SocketAddr, Vec<u8>) {
+    let (cert_pem, key_pem) = generate_self_signed_cert("localhost").expect("self-signed cert");
+    let dir = tempfile::tempdir().expect("temp dir");
+    let cert_path = dir.path().join("cert.pem");
+    let key_path = dir.path().join("key.pem");
+    std::fs::write(&cert_path, &cert_pem).expect("write cert");
+    std::fs::write(&key_path, &key_pem).expect("write key");
+    let tls_config = WireTlsConfig {
+        cert_path,
+        key_path,
+    };
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind tls");
+    let addr = listener.local_addr().expect("addr");
+    let rt = remote_runtime();
+    tokio::spawn(async move {
+        // The TempDir must outlive the listener; move it into the task.
+        let _dir = dir;
+        let _ = reddb_server::wire::start_redwire_tls_listener_on(listener, rt, &tls_config).await;
+    });
+    (addr, cert_pem.into_bytes())
+}
+
+fn ws_request(
+    url: &str,
+    origin: &str,
+) -> tokio_tungstenite::tungstenite::handshake::client::Request {
+    let mut req = url.into_client_request().expect("client request");
+    req.headers_mut().insert(
+        "Origin",
+        HeaderValue::from_str(origin).expect("origin value"),
+    );
+    req
+}
+
+async fn send_frame(ws: &mut WsStream, frame: &Frame) {
+    ws.send(Message::Binary(Bytes::from(encode_frame(frame))))
+        .await
+        .expect("send frame");
+}
+
+/// Pull binary WS messages and reassemble the self-delimiting RedWire
+/// frame stream, returning the next decoded frame.
+async fn next_frame(ws: &mut WsStream, buf: &mut Vec<u8>) -> Frame {
+    loop {
+        if buf.len() >= reddb_wire::redwire::FRAME_HEADER_SIZE {
+            if let Ok((frame, consumed)) = decode_frame(buf) {
+                buf.drain(..consumed);
+                return frame;
+            }
+        }
+        let msg = timeout(TIMEOUT, ws.next())
+            .await
+            .expect("frame within budget")
+            .expect("ws stream open")
+            .expect("ws message");
+        match msg {
+            Message::Binary(bytes) => buf.extend_from_slice(&bytes),
+            Message::Close(_) => panic!("ws closed before a full frame arrived"),
+            _ => {}
+        }
+    }
+}
+
+/// Drive the anonymous RedWire handshake to completion over the WS — the
+/// exact native preamble the browser sends, relayed through the bridge to
+/// the remote listener.
+async fn anonymous_handshake(ws: &mut WsStream, buf: &mut Vec<u8>) {
+    ws.send(Message::Binary(Bytes::from(vec![
+        REDWIRE_MAGIC,
+        MAX_KNOWN_MINOR_VERSION,
+    ])))
+    .await
+    .expect("send preamble");
+
+    send_frame(
+        ws,
+        &build_client_hello_frame(1, ["anonymous"], 0, Some("ui-bridge-remote-e2e"))
+            .expect("hello frame"),
+    )
+    .await;
+    let ack = next_frame(ws, buf).await;
+    assert_eq!(ack.kind, MessageKind::HelloAck, "expected HelloAck");
+
+    send_frame(
+        ws,
+        &build_auth_response_frame(2, build_auth_response_anonymous_payload())
+            .expect("auth response frame"),
+    )
+    .await;
+    let ok = next_frame(ws, buf).await;
+    assert_eq!(
+        ok.kind,
+        MessageKind::AuthOk,
+        "anonymous handshake should AuthOk: {}",
+        String::from_utf8_lossy(&ok.payload)
+    );
+}
+
+/// Run a CREATE / INSERT / SELECT round-trip over the WS session, proving
+/// the queries reached the remote engine through the bridge.
+async fn assert_query_round_trip(ws: &mut WsStream, buf: &mut Vec<u8>) {
+    send_frame(
+        ws,
+        &build_query_frame(10, "CREATE TABLE widgets (id INTEGER, name TEXT)")
+            .expect("query frame"),
+    )
+    .await;
+    let created = next_frame(ws, buf).await;
+    assert_eq!(
+        created.kind,
+        MessageKind::Result,
+        "create failed: {}",
+        String::from_utf8_lossy(&created.payload)
+    );
+
+    send_frame(
+        ws,
+        &build_query_frame(11, "INSERT INTO widgets (id, name) VALUES (1, 'alpha')")
+            .expect("query frame"),
+    )
+    .await;
+    let inserted = next_frame(ws, buf).await;
+    assert_eq!(inserted.kind, MessageKind::Result, "insert must Result");
+    let insert_body = String::from_utf8_lossy(&inserted.payload);
+    assert!(
+        insert_body.contains("\"affected\":1"),
+        "insert must report one affected row, got: {insert_body}"
+    );
+
+    send_frame(
+        ws,
+        &build_query_frame(12, "SELECT id, name FROM widgets WHERE id = 1").expect("query frame"),
+    )
+    .await;
+    let selected = next_frame(ws, buf).await;
+    assert_eq!(
+        selected.kind,
+        MessageKind::Result,
+        "select must Result: {}",
+        String::from_utf8_lossy(&selected.payload)
+    );
+    // The INSERT's `affected:1` (above) already proves the write landed in
+    // the *remote* engine via the bridge; the SELECT completing as a
+    // `Result` over the same session proves the read leg round-trips too.
+}
+
+// ====================================================================
+// AC — red://host:port: query round-trips through the local WS endpoint
+//      to a running RedWire-over-TCP instance.
+// ====================================================================
+
+#[tokio::test]
+async fn bridge_runs_query_over_remote_tcp() {
+    let remote = spawn_remote_tcp().await;
+
+    let bridge = spawn_ui_bridge_remote(
+        RemoteRedwireTarget {
+            host: remote.ip().to_string(),
+            port: remote.port(),
+            tls: false,
+            ca_pem: None,
+        },
+        UiBridgeConfig::default(),
+    )
+    .await
+    .expect("bridge starts");
+
+    // The UI only ever connects to the local loopback WS endpoint.
+    let ws_url = bridge.ws_url();
+    assert!(
+        ws_url.starts_with(&format!("ws://127.0.0.1:{}", bridge.local_addr().port())),
+        "the served WS endpoint must be loopback: {ws_url}"
+    );
+
+    let origin = format!("http://127.0.0.1:{}", bridge.local_addr().port());
+    let (mut ws, _resp) = connect_async(ws_request(&ws_url, &origin))
+        .await
+        .expect("ws connects to loopback bridge");
+    let mut buf = Vec::new();
+
+    anonymous_handshake(&mut ws, &mut buf).await;
+    assert_query_round_trip(&mut ws, &mut buf).await;
+
+    let _ = ws.close(None).await;
+    bridge.shutdown().await;
+}
+
+// ====================================================================
+// AC — reds://host:port: same round-trip with the bridge negotiating TLS
+//      to the target transparently.
+// ====================================================================
+
+#[tokio::test]
+async fn bridge_runs_query_over_remote_tls() {
+    let (remote, ca_pem) = spawn_remote_tls().await;
+
+    let bridge = spawn_ui_bridge_remote(
+        RemoteRedwireTarget {
+            // 127.0.0.1 is a SAN on the generated self-signed cert.
+            host: remote.ip().to_string(),
+            port: remote.port(),
+            tls: true,
+            ca_pem: Some(ca_pem),
+        },
+        UiBridgeConfig::default(),
+    )
+    .await
+    .expect("bridge starts");
+
+    let origin = format!("http://127.0.0.1:{}", bridge.local_addr().port());
+    // The WS client speaks plain ws:// to the loopback bridge — it is
+    // unaware the remote leg is TLS.
+    let (mut ws, _resp) = connect_async(ws_request(&bridge.ws_url(), &origin))
+        .await
+        .expect("ws connects to loopback bridge");
+    let mut buf = Vec::new();
+
+    anonymous_handshake(&mut ws, &mut buf).await;
+    assert_query_round_trip(&mut ws, &mut buf).await;
+
+    let _ = ws.close(None).await;
+    bridge.shutdown().await;
+}

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -22,7 +22,7 @@ pub mod topology;
 
 pub use conn_string::{
     is_embedded_connection_uri, parse, parse_with_limits, ConnStringLimits, ConnectionTarget,
-    ParseError, ParseErrorKind,
+    ParseError, ParseErrorKind, DEFAULT_PORT_GRPC, DEFAULT_PORT_RED,
 };
 pub use redwire::{BuildError, FrameBuilder};
 pub use sanitizer::{

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1752,12 +1752,22 @@ fn open_in_browser(url: &str) -> Result<(), String> {
         .map_err(|err| err.to_string())
 }
 
+/// What the `red ui` bridge fronts, resolved from the target URI.
+enum UiBackend {
+    /// `file://` / bare path — the embedded engine opened in-process.
+    Embedded(reddb::server::RedDBServer),
+    /// `red://` / `reds://` — a remote RedWire-over-TCP/TLS endpoint.
+    Remote(reddb::server::ui_bridge::RemoteRedwireTarget),
+}
+
 /// `red ui <uri> [--server] [--desktop] [--ui-dir DIR] [--port N]
-/// [--no-browser]` — the tracer-bullet spine of the red-ui integration
-/// (issue #1042, PRD #1041). For a `file://` target it opens the embedded
-/// engine from the file, stands up a loopback RedWire-over-WS bridge that
-/// serves the UI bundle and fronts the engine, opens the browser at it,
-/// and tears the bridge down cleanly on Ctrl-C.
+/// [--tls-ca PEM] [--no-browser]` — the spine of the red-ui integration
+/// (issues #1042 / #1044, PRD #1041). For a `file://` target it opens the
+/// embedded engine from the file; for a `red://` / `reds://` target it
+/// fronts a remote RedWire-over-TCP/TLS instance (e.g. a container). In
+/// both cases it stands up a loopback RedWire-over-WS bridge that serves
+/// the UI bundle and the WS endpoint the served page connects to, opens
+/// the browser at it, and tears the bridge down cleanly on Ctrl-C.
 fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
     let json_mode = wants_json(flags);
 
@@ -1774,31 +1784,6 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         }
     };
 
-    // This slice supports only `file://` (and bare-path) targets; the
-    // `red://` / `reds://` direct-connect forms land in a later slice
-    // (ADR 0047).
-    let is_file_target = uri.starts_with("file://") || !uri.contains("://");
-    if !is_file_target {
-        let msg = format!("red ui currently supports only file:// targets, got: {uri}");
-        if json_mode {
-            json_error("ui", &msg);
-        }
-        eprintln!("error: {msg}");
-        std::process::exit(1);
-    }
-
-    let file_uri = canonicalize_file_uri(&uri).unwrap_or_else(|err| {
-        if json_mode {
-            json_error("ui", &err);
-        }
-        eprintln!("error: {err}");
-        std::process::exit(1);
-    });
-    let db_path = file_uri
-        .strip_prefix("file://")
-        .unwrap_or(&file_uri)
-        .to_string();
-
     if flag_bool(flags, "desktop") && !flag_bool(flags, "server") {
         // `--desktop` is reserved for the deep-link slice; the served
         // bridge is the only path today, so note it and continue rather
@@ -1806,16 +1791,72 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         eprintln!("note: --desktop is reserved; opening the browser-served bridge for now");
     }
 
-    let runtime = reddb::RedDBRuntime::with_options(reddb::api::RedDBOptions::persistent(&db_path))
-        .unwrap_or_else(|err| {
-            let msg = format!("open {db_path}: {err}");
-            if json_mode {
-                json_error("ui", &msg);
-            }
-            eprintln!("error: {msg}");
-            std::process::exit(1);
-        });
-    let server = reddb::server::RedDBServer::new(runtime);
+    // Classify the target: `file://` / bare path → embedded engine;
+    // `red://` / `reds://` → remote RedWire endpoint fronted by the
+    // bridge (issue #1044, ADR 0047 / 0049). Either way the served UI
+    // only ever talks to the loopback WS endpoint.
+    let target = reddb::server::ui_bridge::classify_ui_target(&uri).unwrap_or_else(|err| {
+        if json_mode {
+            json_error("ui", &err);
+        }
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    });
+
+    // `target_label` is what we report as the bridged target; `backend`
+    // is what the bridge fronts.
+    let (target_label, backend) = match target {
+        reddb::server::ui_bridge::UiTarget::File => {
+            let file_uri = canonicalize_file_uri(&uri).unwrap_or_else(|err| {
+                if json_mode {
+                    json_error("ui", &err);
+                }
+                eprintln!("error: {err}");
+                std::process::exit(1);
+            });
+            let db_path = file_uri
+                .strip_prefix("file://")
+                .unwrap_or(&file_uri)
+                .to_string();
+            let runtime =
+                reddb::RedDBRuntime::with_options(reddb::api::RedDBOptions::persistent(&db_path))
+                    .unwrap_or_else(|err| {
+                        let msg = format!("open {db_path}: {err}");
+                        if json_mode {
+                            json_error("ui", &msg);
+                        }
+                        eprintln!("error: {msg}");
+                        std::process::exit(1);
+                    });
+            let server = reddb::server::RedDBServer::new(runtime);
+            (file_uri, UiBackend::Embedded(server))
+        }
+        reddb::server::ui_bridge::UiTarget::Remote(spec) => {
+            // Optional `--tls-ca <pem>` is trusted on top of the webpki
+            // system roots for a self-signed / private-CA `reds://` target.
+            let ca_pem = match flag_string(flags, "tls-ca").filter(|v| !v.is_empty()) {
+                Some(path) => match std::fs::read(&path) {
+                    Ok(bytes) => Some(bytes),
+                    Err(err) => {
+                        let msg = format!("read --tls-ca {path}: {err}");
+                        if json_mode {
+                            json_error("ui", &msg);
+                        }
+                        eprintln!("error: {msg}");
+                        std::process::exit(1);
+                    }
+                },
+                None => None,
+            };
+            let target = reddb::server::ui_bridge::RemoteRedwireTarget {
+                host: spec.host,
+                port: spec.port,
+                tls: spec.tls,
+                ca_pem,
+            };
+            (uri.clone(), UiBackend::Remote(target))
+        }
+    };
 
     let ui_dir = if let Some(explicit) = flag_string(flags, "ui-dir").filter(|v| !v.is_empty()) {
         // Explicit --ui-dir: use as-is (no download).
@@ -1853,7 +1894,15 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         .expect("tokio runtime");
 
     rt.block_on(async move {
-        let bridge = match reddb::server::ui_bridge::spawn_ui_bridge(server, config).await {
+        let spawn_result = match backend {
+            UiBackend::Embedded(server) => {
+                reddb::server::ui_bridge::spawn_ui_bridge(server, config).await
+            }
+            UiBackend::Remote(remote) => {
+                reddb::server::ui_bridge::spawn_ui_bridge_remote(remote, config).await
+            }
+        };
+        let bridge = match spawn_result {
             Ok(bridge) => bridge,
             Err(err) => {
                 let msg = format!("start ui bridge: {err}");
@@ -1871,14 +1920,14 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
             json_ok(
                 "ui",
                 &format!(
-                    "{{\"file\":\"{}\",\"ui_url\":\"{}\",\"ws_url\":\"{}\"}}",
-                    json_escape(&file_uri),
+                    "{{\"target\":\"{}\",\"ui_url\":\"{}\",\"ws_url\":\"{}\"}}",
+                    json_escape(&target_label),
                     json_escape(&ui_url),
                     json_escape(&ws_url),
                 ),
             );
         } else {
-            println!("red ui: serving {file_uri}");
+            println!("red ui: serving {target_label}");
             println!("  UI:      {ui_url}");
             println!("  RedWire: {ws_url}");
             println!("Press Ctrl-C to stop.");
@@ -2926,6 +2975,9 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 ),
                 cli::types::FlagSchema::new("port").with_description(
                     "Loopback port for the bridge (0 / omit picks an ephemeral port)",
+                ),
+                cli::types::FlagSchema::new("tls-ca").with_description(
+                    "PEM CA bundle to trust for a reds:// target (on top of system roots)",
                 ),
                 cli::types::FlagSchema::boolean("no-browser").with_description(
                     "Do not open the default browser (also honoured via RED_UI_NO_BROWSER)",


### PR DESCRIPTION
Automated AFK landing for #1044. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713674&installation_id=129708444&pr_number=1083&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1083&signature=e1799b6ff20b767d68e18d7084437cf94fb01fc4abb22b80aa968fd881747056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `red ui` to support remote RedWire instances via `red://` and `reds://` URIs, in addition to local files
  * Added `--tls-ca` flag to configure custom CA certificate bundles for TLS connections to `reds://` endpoints

* **Tests**
  * Added comprehensive end-to-end tests validating remote UI bridge functionality with TLS support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->