### PR TITLE
merge: #1046 red ui: deep-link dispatch — Tauri-first with browser fallback

### DIFF
--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -433,9 +433,9 @@ fn replica_flags() -> Vec<FlagSchema> {
 fn ui_flags() -> Vec<FlagSchema> {
     vec![
         FlagSchema::boolean("server")
-            .with_description("Force the browser-served bridge path (default for file:// targets)"),
+            .with_description("Force the browser-served bridge path (skip the desktop deep link)"),
         FlagSchema::boolean("desktop").with_description(
-            "Reserved: open the native desktop UI (lands in the deep-link slice)",
+            "Force the desktop app via the redui:// deep link (no browser fallback)",
         ),
         FlagSchema::new("ui-dir").with_description(
             "Directory to serve the UI bundle from (defaults to the built-in fixture)",

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -136,6 +136,11 @@ pub mod ui_bridge;
 // HTTPS download, SHA-256 verification, tgz extraction, and local cache
 // management for the pinned red-ui release asset.
 pub mod ui_bundle_resolver;
+// `red ui <uri>` deep-link dispatch (issue #1046, ADR 0051): prefer the
+// installed desktop app via the `redui://` scheme, fall back to the served
+// browser bridge when no handler is registered. Decision + canonical
+// deep-link string live behind a testable seam.
+pub mod ui_deeplink;
 // `pub(crate)` so the RedWire input-stream path (issue #764 / S5)
 // can reuse the canonical S4 INSERT builders / identifier checks
 // (`build_insert_sql`, `is_safe_sql_identifier`) rather than fork

--- a/crates/reddb-server/src/server/ui_deeplink.rs
+++ b/crates/reddb-server/src/server/ui_deeplink.rs
@@ -1,0 +1,474 @@
+//! Deep-link dispatch for `red ui <uri>` (ADR 0051, issue #1046, PRD #1041).
+//!
+//! The default `red ui <uri>` (no `--server`) prefers the installed desktop
+//! app via the `redui://` URL scheme and falls back to the served browser
+//! bridge ([`super::ui_bridge`]) when no handler is registered. This module
+//! owns the *decision*, the canonicalised deep-link *string*, and the OS
+//! handoff — all behind a [`DeepLinkEnv`] seam so both branches (handoff vs
+//! fallback) and the deep-link URL are unit-testable without touching the OS.
+//!
+//! The dispatched `redui://?connect=<canonical-uri>` URL carries the target
+//! only — never a credential. Auth handoff is a separate slice (ADR 0051: the
+//! token crosses via a local secret channel, never the deep-link URL).
+
+use std::path::{Component, Path, PathBuf};
+
+/// Which dispatch path `red ui` should take, before consulting the OS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchMode {
+    /// Default: prefer the desktop app when its `redui://` handler is
+    /// registered, else fall back to the served browser bridge.
+    Auto,
+    /// `--server`: force the browser-served bridge path.
+    Server,
+    /// `--desktop`: force the desktop download/install path.
+    Desktop,
+}
+
+impl DispatchMode {
+    /// Resolve the mode from the `--server` / `--desktop` flags. `--server`
+    /// wins if both are somehow set — it is the path that always works.
+    pub fn from_flags(server: bool, desktop: bool) -> Self {
+        if server {
+            DispatchMode::Server
+        } else if desktop {
+            DispatchMode::Desktop
+        } else {
+            DispatchMode::Auto
+        }
+    }
+}
+
+/// What the caller (`red ui`) should do once dispatch has run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// Handed off to the desktop app — [`DeepLinkEnv::open_url`] was already
+    /// invoked with `deep_link`. The caller prints the handoff line and exits
+    /// cleanly; it must *not* start the bridge.
+    HandedOff {
+        /// The exact `redui://?connect=…` URL that was opened.
+        deep_link: String,
+    },
+    /// Serve the pinned bundle and open the browser (the [`super::ui_bridge`]
+    /// path). When `upsell` is set, the caller first prints the one-line nudge
+    /// to install the desktop app for a faster native shell.
+    ServeBrowser {
+        /// True only when we fell back from [`DispatchMode::Auto`] because no
+        /// handler was registered — print the install upsell.
+        upsell: bool,
+    },
+    /// `--desktop` was requested but no `redui://` handler is registered, so
+    /// there was nothing to hand off to. The caller prints install guidance.
+    /// (The download/install itself lives in the `red-ui` repo — ADR 0051.)
+    DesktopNotInstalled,
+}
+
+/// The OS-touching seam dispatch runs over: probing whether the `redui://`
+/// handler is registered, and opening a URL with the platform handler. Both
+/// branches of [`dispatch`] are driven through this trait so tests assert the
+/// decision and the emitted deep-link string without any OS state.
+pub trait DeepLinkEnv {
+    /// Whether a handler for the `redui://` URL scheme is registered (i.e.
+    /// the desktop app is installed).
+    fn handler_registered(&self) -> bool;
+    /// Open `url` with the platform default handler (the `xdg-open` /
+    /// `open` / `start` equivalent). Returns the spawn error on failure.
+    fn open_url(&self, url: &str) -> Result<(), String>;
+}
+
+/// Decide-and-dispatch. Pure decision logic over the [`DeepLinkEnv`] seam:
+///
+/// - [`DispatchMode::Server`] → [`DispatchOutcome::ServeBrowser`] (no upsell);
+///   the handler is never probed and no URL is opened.
+/// - [`DispatchMode::Auto`] → if the handler is registered, build the deep
+///   link, open it, and return [`DispatchOutcome::HandedOff`]; otherwise
+///   [`DispatchOutcome::ServeBrowser`] with the upsell.
+/// - [`DispatchMode::Desktop`] → if the handler is registered, hand off the
+///   same way; otherwise [`DispatchOutcome::DesktopNotInstalled`].
+///
+/// `canonical_uri` must already be canonicalised (see
+/// [`canonicalize_target_uri`]); it is embedded verbatim (percent-encoded) in
+/// the deep link and never carries a credential.
+pub fn dispatch(
+    mode: DispatchMode,
+    canonical_uri: &str,
+    env: &dyn DeepLinkEnv,
+) -> Result<DispatchOutcome, String> {
+    match mode {
+        DispatchMode::Server => Ok(DispatchOutcome::ServeBrowser { upsell: false }),
+        DispatchMode::Auto => {
+            if env.handler_registered() {
+                let deep_link = build_deep_link(canonical_uri);
+                env.open_url(&deep_link)?;
+                Ok(DispatchOutcome::HandedOff { deep_link })
+            } else {
+                Ok(DispatchOutcome::ServeBrowser { upsell: true })
+            }
+        }
+        DispatchMode::Desktop => {
+            if env.handler_registered() {
+                let deep_link = build_deep_link(canonical_uri);
+                env.open_url(&deep_link)?;
+                Ok(DispatchOutcome::HandedOff { deep_link })
+            } else {
+                Ok(DispatchOutcome::DesktopNotInstalled)
+            }
+        }
+    }
+}
+
+/// Build the `redui://?connect=<canonical-uri>` deep link (ADR 0051). The
+/// canonical URI is percent-encoded so query-breaking characters (spaces,
+/// `&`, `?`, `#`, …) survive, while the readable URI shape (`file:///…`,
+/// `red://…`) is preserved. The link carries the target only — never a token.
+pub fn build_deep_link(canonical_uri: &str) -> String {
+    format!("redui://?connect={}", percent_encode_connect(canonical_uri))
+}
+
+/// Percent-encode a target URI for the `connect=` query value. Keeps the
+/// characters that are already query-safe and shape-significant for our
+/// supported schemes (`A-Za-z0-9` and `-._~:/`), and encodes everything else —
+/// including `%` itself — as upper-case `%XX`.
+fn percent_encode_connect(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for &byte in value.as_bytes() {
+        let keep =
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b':' | b'/');
+        if keep {
+            out.push(byte as char);
+        } else {
+            out.push('%');
+            out.push(hex_upper(byte >> 4));
+            out.push(hex_upper(byte & 0x0f));
+        }
+    }
+    out
+}
+
+fn hex_upper(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        _ => (b'A' + (nibble - 10)) as char,
+    }
+}
+
+/// Canonicalise a `red ui` target URI for embedding in the deep link.
+///
+/// A `file://` / bare-path target is resolved to an absolute, lexically
+/// normalised `file://` URI — the OS handler runs with a different cwd, so a
+/// relative path would break. Any other supported scheme (`red://`, `reds://`,
+/// `red+ws://`, `red+wss://`) is already location-independent and passes
+/// through unchanged. `cwd` is injected so the file branch is testable without
+/// depending on the process working directory.
+pub fn canonicalize_target_uri(uri: &str, cwd: &Path) -> Result<String, String> {
+    match super::ui_bridge::classify_ui_target(uri)? {
+        super::ui_bridge::UiTarget::File => canonicalize_file_uri(uri, cwd),
+        _ => Ok(uri.to_string()),
+    }
+}
+
+/// Resolve a `file://` / bare-path target to an absolute `file://` URI using
+/// `cwd` as the base for relative paths. Folds `.`/`..` lexically so the
+/// result never depends on the target existing on disk.
+fn canonicalize_file_uri(input: &str, cwd: &Path) -> Result<String, String> {
+    let path_part = input.strip_prefix("file://").unwrap_or(input);
+    if path_part.is_empty() {
+        return Err("file:// URI has no path".to_string());
+    }
+
+    let raw = Path::new(path_part);
+    let absolute = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        cwd.join(raw)
+    };
+
+    let mut normalized = PathBuf::new();
+    for component in absolute.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+
+    let rendered = normalized
+        .to_str()
+        .ok_or_else(|| "resolved path is not valid UTF-8".to_string())?;
+    Ok(format!("file://{rendered}"))
+}
+
+/// The production [`DeepLinkEnv`]: probes the OS for the `redui://` handler and
+/// opens URLs via the platform default handler.
+///
+/// The probe can be overridden with `RED_UI_DEEPLINK_REGISTERED` (truthy =>
+/// registered, `0`/`false`/`no` => not registered) — useful for forcing a
+/// branch in manual testing or on platforms without a cheap probe. When unset,
+/// it falls back to a best-effort per-OS check.
+pub struct OsDeepLinkEnv;
+
+impl DeepLinkEnv for OsDeepLinkEnv {
+    fn handler_registered(&self) -> bool {
+        if let Some(forced) = env_override("RED_UI_DEEPLINK_REGISTERED") {
+            return forced;
+        }
+        os_handler_registered()
+    }
+
+    fn open_url(&self, url: &str) -> Result<(), String> {
+        open_url_with_os_handler(url)
+    }
+}
+
+/// Parse a truthy/falsy override env var. Returns `None` when unset/empty so
+/// the caller falls back to the real probe.
+fn env_override(key: &str) -> Option<bool> {
+    match std::env::var(key) {
+        Ok(value) => {
+            let v = value.trim().to_ascii_lowercase();
+            if v.is_empty() {
+                None
+            } else {
+                Some(!matches!(v.as_str(), "0" | "false" | "no" | "off"))
+            }
+        }
+        Err(_) => None,
+    }
+}
+
+/// Best-effort, per-OS probe for a registered `redui://` scheme handler.
+#[cfg(target_os = "linux")]
+fn os_handler_registered() -> bool {
+    // `xdg-mime query default x-scheme-handler/redui` prints the handler's
+    // .desktop file name (and exits 0) when one is registered, nothing
+    // otherwise.
+    std::process::Command::new("xdg-mime")
+        .args(["query", "default", "x-scheme-handler/redui"])
+        .output()
+        .map(|out| out.status.success() && !out.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "windows")]
+fn os_handler_registered() -> bool {
+    // A registered URL-scheme handler lives under HKCU/HKCR\Software\Classes\redui.
+    let user = std::process::Command::new("reg")
+        .args(["query", "HKCU\\Software\\Classes\\redui", "/ve"])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    user || std::process::Command::new("reg")
+        .args(["query", "HKCR\\redui", "/ve"])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn os_handler_registered() -> bool {
+    // macOS (and others) have no cheap CLI probe for a Launch Services URL
+    // handler; default to "not registered" so first contact still works via
+    // the browser fallback. Force the desktop path with `--desktop` or the
+    // `RED_UI_DEEPLINK_REGISTERED` override.
+    false
+}
+
+/// Open `url` with the platform default handler (`xdg-open` / `open` /
+/// `start`). Best-effort: a spawn failure is returned so the caller can react.
+fn open_url_with_os_handler(url: &str) -> Result<(), String> {
+    let (cmd, args): (&str, Vec<&str>) = if cfg!(target_os = "macos") {
+        ("open", vec![url])
+    } else if cfg!(target_os = "windows") {
+        ("cmd", vec!["/C", "start", "", url])
+    } else {
+        ("xdg-open", vec![url])
+    };
+    std::process::Command::new(cmd)
+        .args(args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .map(|_| ())
+        .map_err(|err| err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// Test seam: a scripted [`DeepLinkEnv`] that records every `open_url`
+    /// call so both branches can be asserted without the OS.
+    struct FakeEnv {
+        registered: bool,
+        opened: RefCell<Vec<String>>,
+    }
+
+    impl FakeEnv {
+        fn new(registered: bool) -> Self {
+            Self {
+                registered,
+                opened: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl DeepLinkEnv for FakeEnv {
+        fn handler_registered(&self) -> bool {
+            self.registered
+        }
+        fn open_url(&self, url: &str) -> Result<(), String> {
+            self.opened.borrow_mut().push(url.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn mode_from_flags_resolves_precedence() {
+        assert_eq!(DispatchMode::from_flags(false, false), DispatchMode::Auto);
+        assert_eq!(DispatchMode::from_flags(true, false), DispatchMode::Server);
+        assert_eq!(DispatchMode::from_flags(false, true), DispatchMode::Desktop);
+        // --server wins over --desktop: the always-works path.
+        assert_eq!(DispatchMode::from_flags(true, true), DispatchMode::Server);
+    }
+
+    #[test]
+    fn build_deep_link_keeps_file_uri_shape() {
+        assert_eq!(
+            build_deep_link("file:///home/user/data.rdb"),
+            "redui://?connect=file:///home/user/data.rdb"
+        );
+    }
+
+    #[test]
+    fn build_deep_link_encodes_query_breaking_chars() {
+        // Spaces, `&`, `?`, `#` would corrupt the query — must be encoded.
+        assert_eq!(
+            build_deep_link("file:///tmp/my db?x&y#z.rdb"),
+            "redui://?connect=file:///tmp/my%20db%3Fx%26y%23z.rdb"
+        );
+    }
+
+    #[test]
+    fn build_deep_link_passes_remote_scheme() {
+        assert_eq!(
+            build_deep_link("reds://db.internal:5050"),
+            "redui://?connect=reds://db.internal:5050"
+        );
+    }
+
+    #[test]
+    fn canonicalize_resolves_relative_file_uri_against_cwd() {
+        let cwd = Path::new("/work/project");
+        assert_eq!(
+            canonicalize_target_uri("file://./data.rdb", cwd).unwrap(),
+            "file:///work/project/data.rdb"
+        );
+        // `..` folds lexically; no filesystem touch.
+        assert_eq!(
+            canonicalize_target_uri("file://../sib/data.rdb", cwd).unwrap(),
+            "file:///work/sib/data.rdb"
+        );
+    }
+
+    #[test]
+    fn canonicalize_keeps_absolute_file_uri() {
+        let cwd = Path::new("/elsewhere");
+        assert_eq!(
+            canonicalize_target_uri("file:///abs/data.rdb", cwd).unwrap(),
+            "file:///abs/data.rdb"
+        );
+    }
+
+    #[test]
+    fn canonicalize_passes_remote_targets_through() {
+        let cwd = Path::new("/work");
+        assert_eq!(
+            canonicalize_target_uri("red://db.internal:6000", cwd).unwrap(),
+            "red://db.internal:6000"
+        );
+        assert_eq!(
+            canonicalize_target_uri("red+wss://edge.example/redwire", cwd).unwrap(),
+            "red+wss://edge.example/redwire"
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // The two dispatch branches over the seam (acceptance criteria).
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn auto_with_handler_hands_off_with_canonical_deep_link() {
+        let env = FakeEnv::new(true);
+        let canonical = canonicalize_target_uri("file://./data.rdb", Path::new("/work")).unwrap();
+        let outcome = dispatch(DispatchMode::Auto, &canonical, &env).unwrap();
+        assert_eq!(
+            outcome,
+            DispatchOutcome::HandedOff {
+                deep_link: "redui://?connect=file:///work/data.rdb".to_string(),
+            }
+        );
+        // The seam's open_url was driven with exactly that deep link.
+        assert_eq!(
+            *env.opened.borrow(),
+            vec!["redui://?connect=file:///work/data.rdb".to_string()]
+        );
+    }
+
+    #[test]
+    fn auto_without_handler_falls_back_with_upsell_and_opens_nothing() {
+        let env = FakeEnv::new(false);
+        let outcome = dispatch(DispatchMode::Auto, "file:///work/data.rdb", &env).unwrap();
+        assert_eq!(outcome, DispatchOutcome::ServeBrowser { upsell: true });
+        assert!(env.opened.borrow().is_empty());
+    }
+
+    #[test]
+    fn server_mode_forces_browser_without_probing_or_opening() {
+        let env = FakeEnv::new(true); // handler present, but --server overrides
+        let outcome = dispatch(DispatchMode::Server, "file:///work/data.rdb", &env).unwrap();
+        assert_eq!(outcome, DispatchOutcome::ServeBrowser { upsell: false });
+        assert!(env.opened.borrow().is_empty());
+    }
+
+    #[test]
+    fn desktop_mode_with_handler_hands_off() {
+        let env = FakeEnv::new(true);
+        let outcome = dispatch(DispatchMode::Desktop, "file:///work/data.rdb", &env).unwrap();
+        assert_eq!(
+            outcome,
+            DispatchOutcome::HandedOff {
+                deep_link: "redui://?connect=file:///work/data.rdb".to_string(),
+            }
+        );
+        assert_eq!(env.opened.borrow().len(), 1);
+    }
+
+    #[test]
+    fn desktop_mode_without_handler_reports_not_installed() {
+        let env = FakeEnv::new(false);
+        let outcome = dispatch(DispatchMode::Desktop, "file:///work/data.rdb", &env).unwrap();
+        assert_eq!(outcome, DispatchOutcome::DesktopNotInstalled);
+        assert!(env.opened.borrow().is_empty());
+    }
+
+    #[test]
+    fn deep_link_never_carries_a_credential() {
+        // Even if a token-looking string is appended to the path, the deep
+        // link only ever contains the connect target — dispatch never adds
+        // auth, and the builder has no token parameter at all.
+        let env = FakeEnv::new(true);
+        let outcome = dispatch(DispatchMode::Auto, "red://db.internal:5050", &env).unwrap();
+        if let DispatchOutcome::HandedOff { deep_link } = outcome {
+            assert!(!deep_link.contains("token"));
+            assert!(!deep_link.contains("password"));
+            assert!(!deep_link.contains("secret"));
+            assert!(!deep_link.contains("auth"));
+            assert_eq!(deep_link, "redui://?connect=red://db.internal:5050");
+        } else {
+            panic!("expected handoff");
+        }
+    }
+}

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1764,12 +1764,21 @@ enum UiBackend {
 
 /// `red ui <uri> [--server] [--desktop] [--ui-dir DIR] [--port N]
 /// [--tls-ca PEM] [--no-browser]` — the spine of the red-ui integration
-/// (issues #1042 / #1044, PRD #1041). For a `file://` target it opens the
-/// embedded engine from the file; for a `red://` / `reds://` target it
-/// fronts a remote RedWire-over-TCP/TLS instance (e.g. a container). In
-/// both cases it stands up a loopback RedWire-over-WS bridge that serves
-/// the UI bundle and the WS endpoint the served page connects to, opens
-/// the browser at it, and tears the bridge down cleanly on Ctrl-C.
+/// (issues #1042 / #1044 / #1046, PRD #1041, ADR 0051).
+///
+/// By default it prefers the installed desktop app: when the `redui://`
+/// handler is registered it hands off via `xdg-open redui://?connect=<uri>`
+/// (the URI canonicalized, carrying the target only — never a credential)
+/// and exits. With no handler registered it falls back to the served browser
+/// path and nudges the user to install the desktop app. `--server` forces the
+/// browser path; `--desktop` forces the desktop deep link.
+///
+/// On the browser path: for a `file://` target it opens the embedded engine
+/// from the file; for a `red://` / `reds://` target it fronts a remote
+/// RedWire-over-TCP/TLS instance (e.g. a container). In both cases it stands
+/// up a loopback RedWire-over-WS bridge that serves the UI bundle and the WS
+/// endpoint the served page connects to, opens the browser at it, and tears
+/// the bridge down cleanly on Ctrl-C.
 fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
     let json_mode = wants_json(flags);
 
@@ -1786,11 +1795,80 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         }
     };
 
-    if flag_bool(flags, "desktop") && !flag_bool(flags, "server") {
-        // `--desktop` is reserved for the deep-link slice; the served
-        // bridge is the only path today, so note it and continue rather
-        // than failing the command.
-        eprintln!("note: --desktop is reserved; opening the browser-served bridge for now");
+    // Deep-link dispatch (issue #1046, ADR 0051): the default `red ui <uri>`
+    // (no `--server`) prefers the installed desktop app via the `redui://`
+    // scheme and only falls back to the served browser bridge when no handler
+    // is registered. `--server` forces the browser path; `--desktop` forces
+    // the desktop path. The decision + canonical deep-link string live behind
+    // a testable seam in `reddb::server::ui_deeplink`.
+    let mode = reddb::server::ui_deeplink::DispatchMode::from_flags(
+        flag_bool(flags, "server"),
+        flag_bool(flags, "desktop"),
+    );
+    if mode != reddb::server::ui_deeplink::DispatchMode::Server {
+        let cwd = std::env::current_dir().unwrap_or_else(|err| {
+            let msg = format!("resolve current directory: {err}");
+            if json_mode {
+                json_error("ui", &msg);
+            }
+            eprintln!("error: {msg}");
+            std::process::exit(1);
+        });
+        let canonical = reddb::server::ui_deeplink::canonicalize_target_uri(&uri, &cwd)
+            .unwrap_or_else(|err| {
+                if json_mode {
+                    json_error("ui", &err);
+                }
+                eprintln!("error: {err}");
+                std::process::exit(1);
+            });
+        let env = reddb::server::ui_deeplink::OsDeepLinkEnv;
+        match reddb::server::ui_deeplink::dispatch(mode, &canonical, &env) {
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::HandedOff { deep_link }) => {
+                if json_mode {
+                    json_ok(
+                        "ui",
+                        &format!(
+                            "{{\"dispatch\":\"desktop\",\"deep_link\":\"{}\",\"target\":\"{}\"}}",
+                            json_escape(&deep_link),
+                            json_escape(&canonical),
+                        ),
+                    );
+                } else {
+                    println!("red ui: handing off to the desktop app");
+                    println!("  {deep_link}");
+                }
+                return;
+            }
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::DesktopNotInstalled) => {
+                let msg = "no redui:// handler registered; the desktop app is not installed. \
+                           Install it from https://reddb.io/download, or run \
+                           `red ui --server <uri>` to use the browser.";
+                if json_mode {
+                    json_error("ui", msg);
+                }
+                eprintln!("error: {msg}");
+                std::process::exit(1);
+            }
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::ServeBrowser { upsell }) => {
+                if upsell && !json_mode {
+                    // Auto fallback: nudge the native shell, then serve.
+                    eprintln!(
+                        "note: desktop app not installed — serving the browser UI. \
+                         Install it from https://reddb.io/download for a faster native shell."
+                    );
+                }
+                // Fall through to the served browser-bridge path below.
+            }
+            Err(err) => {
+                let msg = format!("deep-link dispatch: {err}");
+                if json_mode {
+                    json_error("ui", &msg);
+                }
+                eprintln!("error: {msg}");
+                std::process::exit(1);
+            }
+        }
     }
 
     // Classify the target: `file://` / bare path → embedded engine;
@@ -2976,10 +3054,10 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
         Some("ui") => {
             flags.extend(vec![
                 cli::types::FlagSchema::boolean("server").with_description(
-                    "Force the browser-served bridge path (default for file:// targets)",
+                    "Force the browser-served bridge path (skip the desktop deep link)",
                 ),
                 cli::types::FlagSchema::boolean("desktop").with_description(
-                    "Reserved: open the native desktop UI (lands in the deep-link slice)",
+                    "Force the desktop app via the redui:// deep link (no browser fallback)",
                 ),
                 cli::types::FlagSchema::new("ui-dir").with_description(
                     "Directory to serve the UI bundle from (defaults to the built-in fixture)",

--- a/tests/cli_ui_deeplink.rs
+++ b/tests/cli_ui_deeplink.rs
@@ -1,0 +1,129 @@
+//! Issue #1046 / PRD #1041 (ADR 0051) — `red ui <uri>` deep-link dispatch.
+//!
+//! CLI-level coverage that the deep-link seam is wired through `main()`:
+//! the handler-registered probe is overridden via `RED_UI_DEEPLINK_REGISTERED`
+//! so both branches are deterministic without OS handler state.
+//!
+//!   1. `--desktop` with a registered handler → hands off, emitting the
+//!      canonicalized `redui://?connect=<abs-file-uri>` deep link, carrying
+//!      no credential, and never starting the bridge.
+//!   2. `--desktop` with no handler registered → errors with install
+//!      guidance (no silent browser fallback for the forced desktop path).
+//!
+//! The exhaustive decision matrix (Auto/Server/Desktop × registered) lives in
+//! the `reddb_server::server::ui_deeplink` unit tests, which drive the seam
+//! directly; these tests pin the `main()` wiring end-to-end.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+fn xdg_open_present() -> bool {
+    Command::new("xdg-open")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|_| true)
+        .unwrap_or(false)
+}
+
+#[test]
+fn desktop_with_registered_handler_emits_canonical_deep_link() {
+    if cfg!(not(target_os = "linux")) || !xdg_open_present() {
+        // The handoff path spawns the OS opener; only assert it where a
+        // spawnable `xdg-open` exists so the test stays deterministic.
+        eprintln!("skipping: no spawnable xdg-open on this platform");
+        return;
+    }
+
+    // Relative file:// → must be canonicalized to an absolute path, because
+    // the OS handler runs with a different cwd (ADR 0051).
+    let output = Command::new(red_binary())
+        .args(["ui", "--desktop", "--json", "file://./data.rdb"])
+        .env("RED_UI_DEEPLINK_REGISTERED", "1")
+        .current_dir(std::env::temp_dir())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run red ui --desktop");
+
+    assert!(
+        output.status.success(),
+        "expected clean handoff exit; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"dispatch\":\"desktop\""),
+        "stdout: {stdout}"
+    );
+    // The deep link points at an absolute file:// URI (canonicalized).
+    assert!(
+        stdout.contains("redui://?connect=file:///"),
+        "deep link not canonicalized to an absolute path: {stdout}"
+    );
+    assert!(stdout.contains("/data.rdb"), "stdout: {stdout}");
+    // The deep link carries the target only — never a credential.
+    assert!(
+        !stdout.contains("token"),
+        "deep link leaked a token: {stdout}"
+    );
+    assert!(
+        !stdout.contains("password") && !stdout.contains("secret"),
+        "deep link leaked a credential: {stdout}"
+    );
+}
+
+#[test]
+fn desktop_without_handler_errors_with_install_guidance() {
+    let output = Command::new(red_binary())
+        .args(["ui", "--desktop", "--json", "file://./data.rdb"])
+        .env("RED_UI_DEEPLINK_REGISTERED", "0")
+        .current_dir(std::env::temp_dir())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run red ui --desktop with no handler");
+
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit when the desktop app is not installed"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("redui:// handler") || combined.contains("not installed"),
+        "expected install guidance; got: {combined}"
+    );
+}
+
+#[test]
+fn ui_help_documents_desktop_and_server_dispatch() {
+    let output = Command::new(red_binary())
+        .args(["ui", "--help"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run red ui --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--desktop"),
+        "help missing --desktop: {stdout}"
+    );
+    assert!(
+        stdout.contains("--server"),
+        "help missing --server: {stdout}"
+    );
+    assert!(
+        stdout.contains("deep link") || stdout.contains("redui://"),
+        "help should mention the deep link: {stdout}"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #1046. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783716638&installation_id=129708444&pr_number=1085&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1085&signature=68057b1b54d8803ac160a645a52cb6294da09d177efb97997e0b80bb8ff78387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `red ui` command now prioritizes the installed desktop app via deep-link handler when available, with automatic fallback to browser UI if unavailable.

* **Documentation**
  * Updated help descriptions for `--server` and `--desktop` flags to clarify deep-link dispatch routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->