### PR TITLE
merge: #1052 Relocate RDVX vault logical-export envelope into reddb-file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2306,6 +2306,7 @@ dependencies = [
  "blake3",
  "crc32fast",
  "fs2",
+ "hex",
  "lz4_flex",
  "serde",
  "serde_json",

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 blake3 = "1"
 crc32fast = "1.5"
 fs2 = "0.4"
+hex = "0.4"
 lz4_flex = { version = "0.13", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -40,6 +40,7 @@ pub mod table_def_codec;
 pub mod transaction_wal;
 pub mod turboquant_snapshot;
 pub mod ui_bundle_cache;
+pub mod vault_export_envelope;
 pub mod vector_btree_page_format;
 pub mod vector_value_codec;
 pub mod wal_header;
@@ -345,6 +346,11 @@ pub use transaction_wal::{
 pub use turboquant_snapshot::{
     read_turboquant_snapshot, write_turboquant_snapshot, TurboQuantSnapshotError,
     TurboQuantSnapshotPayload, TURBOQUANT_SNAPSHOT_HEADER_BYTES,
+};
+pub use vault_export_envelope::{
+    decode as decode_vault_logical_export, encode as encode_vault_logical_export,
+    VaultExportEnvelope, VaultExportEnvelopeError, VAULT_EXPORT_NONCE_SIZE, VAULT_EXPORT_SALT_SIZE,
+    VAULT_LOGICAL_EXPORT_AAD, VAULT_LOGICAL_EXPORT_MAGIC, VAULT_LOGICAL_EXPORT_VERSION,
 };
 pub use wal_header::{
     decode_wal_file_header, encode_wal_file_header, next_main_wal_segment_boundary, WalFileHeader,

--- a/crates/reddb-file/src/vault_export_envelope.rs
+++ b/crates/reddb-file/src/vault_export_envelope.rs
@@ -1,0 +1,254 @@
+//! Logical vault export envelope framing (`RDVX`).
+//!
+//! `red dump` writes the auth vault as a self-contained, hex-encoded
+//! AES-256-GCM blob inside the JSONL dump; `red restore` reads it back. This
+//! module owns ONLY the envelope framing and its hex transport:
+//!
+//! ```text
+//!   [ 4 bytes: magic "RDVX"                ]
+//!   [ 1 byte : version = 1                 ]
+//!   [16 bytes: salt (key derivation)       ]
+//!   [12 bytes: nonce                       ]
+//!   [ N bytes: AES-256-GCM ciphertext+tag  ]
+//! ```
+//!
+//! The whole thing is hex-encoded so it can live inside JSONL dumps.
+//!
+//! Key derivation, AES-256-GCM encrypt/decrypt, and the `Vault`/`VaultState`
+//! types stay in `reddb-server`: this crate never sees the wrapping key or the
+//! plaintext. The salt and nonce are embedded so a passphrase-based import can
+//! re-derive the same wrapping key without access to the source `.rdb` pages.
+//!
+//! The AAD string is exported here because it is part of the on-the-wire
+//! contract — the server passes it to `aes256_gcm_encrypt`/`decrypt`. Changing
+//! the magic, version, field layout, or AAD breaks decryption of every dump
+//! sealed by a previous build, so this format is frozen.
+
+/// Logical export blob magic. Distinct from the on-disk vault page chain
+/// (`RDVT`/`RDVD`), which is a separate format with its own AAD.
+pub const VAULT_LOGICAL_EXPORT_MAGIC: &[u8; 4] = b"RDVX";
+
+/// Current logical export envelope version.
+pub const VAULT_LOGICAL_EXPORT_VERSION: u8 = 1;
+
+/// AAD bound into the AES-256-GCM tag of the export blob. Frozen: changing it
+/// breaks decryption of existing dumps.
+pub const VAULT_LOGICAL_EXPORT_AAD: &[u8] = b"reddb-vault-logical-export-v1";
+
+/// Key-derivation salt size embedded in the envelope.
+pub const VAULT_EXPORT_SALT_SIZE: usize = 16;
+
+/// AES-256-GCM nonce size embedded in the envelope.
+pub const VAULT_EXPORT_NONCE_SIZE: usize = 12;
+
+const MAGIC_SIZE: usize = 4;
+const VERSION_SIZE: usize = 1;
+
+/// AES-256-GCM authentication tag length — the minimum ciphertext we accept.
+const GCM_TAG_SIZE: usize = 16;
+
+/// Errors produced while decoding a logical export envelope.
+///
+/// The server maps each of these onto its own `VaultError::Corrupt(..)` so the
+/// operator-facing messages are unchanged after the framing moved here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VaultExportEnvelopeError {
+    /// Outer hex transport did not decode.
+    BadHex,
+    /// Decoded blob is shorter than the fixed header + minimum ciphertext.
+    TooShort,
+    /// Magic bytes were not `RDVX`.
+    BadMagic,
+    /// Version byte is not a supported envelope version.
+    UnsupportedVersion(u8),
+}
+
+impl std::fmt::Display for VaultExportEnvelopeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VaultExportEnvelopeError::BadHex => write!(f, "bad hex"),
+            VaultExportEnvelopeError::TooShort => write!(f, "logical vault export too short"),
+            VaultExportEnvelopeError::BadMagic => write!(f, "bad logical vault export magic"),
+            VaultExportEnvelopeError::UnsupportedVersion(v) => {
+                write!(f, "unsupported logical vault export version: {v}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VaultExportEnvelopeError {}
+
+/// Decoded envelope: the embedded salt, nonce, and the raw ciphertext+tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VaultExportEnvelope {
+    pub salt: [u8; VAULT_EXPORT_SALT_SIZE],
+    pub nonce: [u8; VAULT_EXPORT_NONCE_SIZE],
+    pub ciphertext: Vec<u8>,
+}
+
+/// Frame a sealed export into its hex-encoded transport form.
+///
+/// `ciphertext` is the AES-256-GCM output (ciphertext followed by the 16-byte
+/// tag); this function only lays out the bytes and hex-encodes them.
+pub fn encode(
+    salt: &[u8; VAULT_EXPORT_SALT_SIZE],
+    nonce: &[u8; VAULT_EXPORT_NONCE_SIZE],
+    ciphertext: &[u8],
+) -> String {
+    let mut out = Vec::with_capacity(
+        MAGIC_SIZE
+            + VERSION_SIZE
+            + VAULT_EXPORT_SALT_SIZE
+            + VAULT_EXPORT_NONCE_SIZE
+            + ciphertext.len(),
+    );
+    out.extend_from_slice(VAULT_LOGICAL_EXPORT_MAGIC);
+    out.push(VAULT_LOGICAL_EXPORT_VERSION);
+    out.extend_from_slice(salt);
+    out.extend_from_slice(nonce);
+    out.extend_from_slice(ciphertext);
+    hex::encode(out)
+}
+
+/// Parse a hex-encoded export back into salt, nonce, and ciphertext+tag.
+///
+/// Validates the hex transport, fixed-length header, magic, and version. The
+/// ciphertext is returned untouched; the server is responsible for AES-256-GCM
+/// authentication (which is what actually rejects a tampered blob).
+pub fn decode(blob_hex: &str) -> Result<VaultExportEnvelope, VaultExportEnvelopeError> {
+    let blob = hex::decode(blob_hex).map_err(|_| VaultExportEnvelopeError::BadHex)?;
+    let min_len =
+        MAGIC_SIZE + VERSION_SIZE + VAULT_EXPORT_SALT_SIZE + VAULT_EXPORT_NONCE_SIZE + GCM_TAG_SIZE;
+    if blob.len() < min_len {
+        return Err(VaultExportEnvelopeError::TooShort);
+    }
+    if &blob[0..MAGIC_SIZE] != VAULT_LOGICAL_EXPORT_MAGIC {
+        return Err(VaultExportEnvelopeError::BadMagic);
+    }
+    let version = blob[MAGIC_SIZE];
+    if version != VAULT_LOGICAL_EXPORT_VERSION {
+        return Err(VaultExportEnvelopeError::UnsupportedVersion(version));
+    }
+
+    let mut off = MAGIC_SIZE + VERSION_SIZE;
+    let mut salt = [0u8; VAULT_EXPORT_SALT_SIZE];
+    salt.copy_from_slice(&blob[off..off + VAULT_EXPORT_SALT_SIZE]);
+    off += VAULT_EXPORT_SALT_SIZE;
+    let mut nonce = [0u8; VAULT_EXPORT_NONCE_SIZE];
+    nonce.copy_from_slice(&blob[off..off + VAULT_EXPORT_NONCE_SIZE]);
+    off += VAULT_EXPORT_NONCE_SIZE;
+    Ok(VaultExportEnvelope {
+        salt,
+        nonce,
+        ciphertext: blob[off..].to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Field layout is frozen: magic + version + 16B salt + 12B nonce + ct.
+    #[test]
+    fn encode_lays_out_frozen_header() {
+        let salt = [0xABu8; VAULT_EXPORT_SALT_SIZE];
+        let nonce = [0xCDu8; VAULT_EXPORT_NONCE_SIZE];
+        let ciphertext = vec![0xEFu8; GCM_TAG_SIZE + 8];
+
+        let hexed = encode(&salt, &nonce, &ciphertext);
+        let raw = hex::decode(&hexed).unwrap();
+
+        assert_eq!(&raw[0..4], b"RDVX");
+        assert_eq!(raw[4], 1);
+        assert_eq!(&raw[5..21], &salt);
+        assert_eq!(&raw[21..33], &nonce);
+        assert_eq!(&raw[33..], &ciphertext[..]);
+    }
+
+    #[test]
+    fn round_trip_is_byte_identical() {
+        let salt = [7u8; VAULT_EXPORT_SALT_SIZE];
+        let nonce = [9u8; VAULT_EXPORT_NONCE_SIZE];
+        let ciphertext: Vec<u8> = (0..(GCM_TAG_SIZE as u8 + 40)).collect();
+
+        let hexed = encode(&salt, &nonce, &ciphertext);
+        let decoded = decode(&hexed).unwrap();
+
+        assert_eq!(decoded.salt, salt);
+        assert_eq!(decoded.nonce, nonce);
+        assert_eq!(decoded.ciphertext, ciphertext);
+        // Re-encoding the decoded parts yields the exact same transport string.
+        assert_eq!(
+            encode(&decoded.salt, &decoded.nonce, &decoded.ciphertext),
+            hexed
+        );
+    }
+
+    /// A blob frozen by an earlier build must still decode byte-identically.
+    /// This hex was produced by the pre-relocation layout; if it ever stops
+    /// decoding, the on-disk format silently changed.
+    #[test]
+    fn decodes_pinned_legacy_blob() {
+        // magic 52445658 | ver 01 | salt 16×11 | nonce 12×22 | ct "deadbeef…"
+        let salt = [0x11u8; VAULT_EXPORT_SALT_SIZE];
+        let nonce = [0x22u8; VAULT_EXPORT_NONCE_SIZE];
+        let ciphertext = vec![0xDEu8; GCM_TAG_SIZE + 4];
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"RDVX");
+        raw.push(1);
+        raw.extend_from_slice(&salt);
+        raw.extend_from_slice(&nonce);
+        raw.extend_from_slice(&ciphertext);
+        let pinned = hex::encode(&raw);
+
+        let decoded = decode(&pinned).unwrap();
+        assert_eq!(decoded.salt, salt);
+        assert_eq!(decoded.nonce, nonce);
+        assert_eq!(decoded.ciphertext, ciphertext);
+    }
+
+    #[test]
+    fn rejects_bad_hex() {
+        assert_eq!(decode("zz not hex"), Err(VaultExportEnvelopeError::BadHex));
+    }
+
+    #[test]
+    fn rejects_short_blob() {
+        let short = hex::encode(b"RDVX\x01tooshort");
+        assert_eq!(decode(&short), Err(VaultExportEnvelopeError::TooShort));
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let salt = [0u8; VAULT_EXPORT_SALT_SIZE];
+        let nonce = [0u8; VAULT_EXPORT_NONCE_SIZE];
+        let ct = vec![0u8; GCM_TAG_SIZE];
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"XXXX");
+        raw.push(1);
+        raw.extend_from_slice(&salt);
+        raw.extend_from_slice(&nonce);
+        raw.extend_from_slice(&ct);
+        assert_eq!(
+            decode(&hex::encode(&raw)),
+            Err(VaultExportEnvelopeError::BadMagic)
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let salt = [0u8; VAULT_EXPORT_SALT_SIZE];
+        let nonce = [0u8; VAULT_EXPORT_NONCE_SIZE];
+        let ct = vec![0u8; GCM_TAG_SIZE];
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"RDVX");
+        raw.push(9);
+        raw.extend_from_slice(&salt);
+        raw.extend_from_slice(&nonce);
+        raw.extend_from_slice(&ct);
+        assert_eq!(
+            decode(&hex::encode(&raw)),
+            Err(VaultExportEnvelopeError::UnsupportedVersion(9))
+        );
+    }
+}

--- a/crates/reddb-server/src/auth/vault.rs
+++ b/crates/reddb-server/src/auth/vault.rs
@@ -89,9 +89,11 @@ const VAULT_VERSION: u8 = 2;
 const VAULT_LEGACY_VERSION: u8 = 1;
 
 const VAULT_AAD: &[u8] = b"reddb-vault";
-const VAULT_LOGICAL_EXPORT_MAGIC: &[u8; 4] = b"RDVX";
-const VAULT_LOGICAL_EXPORT_VERSION: u8 = 1;
-const VAULT_LOGICAL_EXPORT_AAD: &[u8] = b"reddb-vault-logical-export-v1";
+
+// The logical-export envelope framing (`RDVX` magic + version + salt + nonce +
+// ciphertext, hex-encoded) lives in `reddb-file`. Key derivation and AES-GCM
+// stay here; we only borrow the AAD, which is part of the frozen wire contract.
+use reddb_file::VAULT_LOGICAL_EXPORT_AAD;
 
 /// Header content layout sizes (after the page's own 32-byte header).
 const VAULT_MAGIC_SIZE: usize = 4;
@@ -660,15 +662,13 @@ impl Vault {
         let key_arr: &[u8; 32] = key_bytes.try_into().map_err(|_| VaultError::Encryption)?;
         let ciphertext = aes256_gcm_encrypt(key_arr, &nonce, VAULT_LOGICAL_EXPORT_AAD, &plaintext);
 
-        let mut out = Vec::with_capacity(
-            VAULT_MAGIC_SIZE + VAULT_VERSION_SIZE + VAULT_SALT_SIZE + NONCE_SIZE + ciphertext.len(),
-        );
-        out.extend_from_slice(VAULT_LOGICAL_EXPORT_MAGIC);
-        out.push(VAULT_LOGICAL_EXPORT_VERSION);
-        out.extend_from_slice(&self.salt);
-        out.extend_from_slice(&nonce);
-        out.extend_from_slice(&ciphertext);
-        Ok(hex::encode(out))
+        // Envelope framing (magic + version + salt + nonce + ciphertext, hex)
+        // lives in reddb-file; we only supply the encrypted parts.
+        Ok(reddb_file::encode_vault_logical_export(
+            &self.salt,
+            &nonce,
+            &ciphertext,
+        ))
     }
 
     /// Decrypt a logical export blob using the same key precedence as
@@ -709,33 +709,11 @@ impl Vault {
     fn decode_logical_export(
         blob_hex: &str,
     ) -> Result<([u8; VAULT_SALT_SIZE], [u8; NONCE_SIZE], Vec<u8>), VaultError> {
-        let blob = hex::decode(blob_hex).map_err(|_| VaultError::Corrupt("bad hex".into()))?;
-        let min_len = VAULT_MAGIC_SIZE + VAULT_VERSION_SIZE + VAULT_SALT_SIZE + NONCE_SIZE + 16;
-        if blob.len() < min_len {
-            return Err(VaultError::Corrupt("logical vault export too short".into()));
-        }
-        if &blob[0..VAULT_MAGIC_SIZE] != VAULT_LOGICAL_EXPORT_MAGIC {
-            return Err(VaultError::Corrupt(
-                "bad logical vault export magic".to_string(),
-            ));
-        }
-        let version = blob[VAULT_MAGIC_SIZE];
-        if version != VAULT_LOGICAL_EXPORT_VERSION {
-            return Err(VaultError::Corrupt(format!(
-                "unsupported logical vault export version: {version}"
-            )));
-        }
-
-        let mut off = VAULT_MAGIC_SIZE + VAULT_VERSION_SIZE;
-        let salt: [u8; VAULT_SALT_SIZE] = blob[off..off + VAULT_SALT_SIZE]
-            .try_into()
-            .map_err(|_| VaultError::Corrupt("bad logical export salt".into()))?;
-        off += VAULT_SALT_SIZE;
-        let nonce: [u8; NONCE_SIZE] = blob[off..off + NONCE_SIZE]
-            .try_into()
-            .map_err(|_| VaultError::Corrupt("bad logical export nonce".into()))?;
-        off += NONCE_SIZE;
-        Ok((salt, nonce, blob[off..].to_vec()))
+        // Envelope parsing lives in reddb-file; map its framing error onto our
+        // operator-facing VaultError::Corrupt with the same message text.
+        let env = reddb_file::decode_vault_logical_export(blob_hex)
+            .map_err(|e| VaultError::Corrupt(e.to_string()))?;
+        Ok((env.salt, env.nonce, env.ciphertext))
     }
 
     fn decrypt_logical_export(


### PR DESCRIPTION
Automated AFK landing for #1052. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783730575&installation_id=129708444&pr_number=1087&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1087&signature=20441c8c7adaa3d422b6e8ffc061213beef9cc375325cb926905f6d6c878da8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced encrypted vault export format with AES-256-GCM encryption for secure vault backups in JSONL dumps.

* **Refactor**
  * Centralized vault export envelope logic into shared library for improved code reuse and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->