### PR TITLE
merge: #1047 red ui: `red server --ui` serves the bundle with opt-in network bind

### DIFF
--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -136,16 +136,15 @@ pub mod ui_bridge;
 // HTTPS download, SHA-256 verification, tgz extraction, and local cache
 // management for the pinned red-ui release asset.
 pub mod ui_bundle_resolver;
+// `red server --ui` static bundle surface (issue #1047, ADR 0051): serve
+// the resolved red-ui bundle as inert static assets on the server's HTTP
+// edge so a remote browser can load it and connect back over RedWire-over-WS.
+mod ui_static;
 // `red ui <uri>` deep-link dispatch (issue #1046, ADR 0051): prefer the
 // installed desktop app via the `redui://` scheme, fall back to the served
 // browser bridge when no handler is registered. Decision + canonical
 // deep-link string live behind a testable seam.
 pub mod ui_deeplink;
-// `red ui` credential handoff (issue #1048, ADR 0051 / 0036): the
-// injected-auth mode decision, the credential-free page config snippet, and
-// the one-time loopback secret channel for the deep-link/desktop path. The
-// handshake injection itself lives in `ui_bridge`.
-pub mod ui_auth;
 // `pub(crate)` so the RedWire input-stream path (issue #764 / S5)
 // can reuse the canonical S4 INSERT builders / identifier checks
 // (`build_insert_sql`, `is_safe_sql_identifier`) rather than fork
@@ -230,6 +229,15 @@ pub struct ServerOptions {
     /// least one origin. Matched exactly (scheme+host+port), e.g.
     /// `https://app.example.com`.
     pub websocket_allowed_origins: Vec<String>,
+    /// `red server --ui` (issue #1047, ADR 0051). When `Some`, this
+    /// listener also serves the resolved red-ui bundle from this directory
+    /// as inert static assets (`/` → `index.html`), alongside the existing
+    /// API. The assets carry no credential, so exposing them is safe by
+    /// construction — auth lives on the RedWire data endpoint, not the
+    /// asset path. Network reach is governed entirely by `bind_addr`
+    /// (default localhost), so this never widens reach on its own.
+    /// `None` (the default) leaves the listener API-only.
+    pub ui_dir: Option<std::path::PathBuf>,
 }
 
 pub const DEFAULT_HTTP_MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
@@ -245,6 +253,7 @@ impl Default for ServerOptions {
             surface: ServerSurface::Public,
             transport_readiness: crate::service_cli::TransportReadiness::default(),
             websocket_allowed_origins: Vec::new(),
+            ui_dir: None,
         }
     }
 }
@@ -563,6 +572,22 @@ impl RedDBServer {
     /// The configured RedWire-over-WSS `Origin` allowlist (issue #935).
     pub(crate) fn websocket_allowed_origins(&self) -> &[String] {
         &self.options.websocket_allowed_origins
+    }
+
+    /// Serve the resolved red-ui bundle from `dir` as inert static assets
+    /// on this listener (`red server --ui`, issue #1047, ADR 0051). The
+    /// bundle is served as a fallback after the API routing table, so it
+    /// can never shadow a real endpoint; `GET /` resolves to the bundle's
+    /// `index.html`.
+    pub fn with_ui_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.options.ui_dir = Some(dir);
+        self
+    }
+
+    /// The directory this listener serves the red-ui bundle from, if
+    /// `--ui` is active (issue #1047).
+    pub(crate) fn ui_dir(&self) -> Option<&std::path::Path> {
+        self.options.ui_dir.as_deref()
     }
 
     /// Enable the browser credential layer (issue #936, PRD #930) by

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -378,7 +378,15 @@ impl RedDBServer {
             ("GET", "/ai/models") => self.handle_ai_model_list(),
 
             // Self-describing entrypoints for first-run/devex.
-            ("GET", "/") => self.handle_root_discovery(),
+            // With `red server --ui` (#1047), `/` serves the bundle's
+            // `index.html` so a browser hitting the root loads the UI;
+            // the API discovery document stays the answer when `--ui`
+            // is off.
+            ("GET", "/") => match self.ui_dir() {
+                Some(ui_dir) => crate::server::ui_static::serve_bundle_asset(ui_dir, "/")
+                    .unwrap_or_else(|| self.handle_root_discovery()),
+                None => self.handle_root_discovery(),
+            },
             ("GET", "/query") => self.handle_query_contract(),
             ("GET", "/grpc") => self.handle_grpc_discovery(),
 
@@ -1939,6 +1947,20 @@ impl RedDBServer {
                         return self.handle_delete_entity(collection, id);
                     }
                 }
+                // `red server --ui` (#1047, ADR 0051): no API route
+                // matched — fall back to the static bundle surface. This
+                // runs last so a bundle asset can never shadow a real
+                // endpoint; a missing asset returns `None` and we drop to
+                // the canonical 404 below.
+                if method == "GET" {
+                    if let Some(ui_dir) = self.ui_dir() {
+                        if let Some(response) =
+                            crate::server::ui_static::serve_bundle_asset(ui_dir, &path)
+                        {
+                            return response;
+                        }
+                    }
+                }
                 json_error(404, format!("route not found: {} {}", method, path))
             }
         }
@@ -1991,6 +2013,28 @@ impl RedDBServer {
             ("GET", "/health/live") | ("GET", "/health/ready") | ("GET", "/health/startup")
         ) {
             return true;
+        }
+
+        // `red server --ui` (#1047, ADR 0051) — the served bundle is inert
+        // static assets with no embedded credential, so they are public by
+        // design even on an authed database: the browser loads them and
+        // then authenticates against the RedWire data endpoint. Only a
+        // `GET` that resolves to a *real file* in the bundle bypasses auth,
+        // so an authenticated API route is never accidentally opened (it
+        // has no matching file). The 401-vs-asset decision is made here,
+        // before dispatch, to keep the gate in lock-step with `route`.
+        // Operator surfaces (`/admin/*`, `/v1/_admin/*`, `/metrics`) are
+        // excluded so a bundle file can never relax the admin-token gate.
+        if method == "GET"
+            && !path.starts_with("/admin/")
+            && !path.starts_with("/v1/_admin/")
+            && path != "/metrics"
+        {
+            if let Some(ui_dir) = self.ui_dir() {
+                if crate::server::ui_static::bundle_asset_exists(ui_dir, path) {
+                    return true;
+                }
+            }
         }
 
         // PLAN.md Phase 6.1 — operator endpoints (/admin/*, /metrics)

--- a/crates/reddb-server/src/server/ui_bridge.rs
+++ b/crates/reddb-server/src/server/ui_bridge.rs
@@ -43,11 +43,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use tokio::sync::oneshot;
 
-use super::ui_auth::{inject_auth_mode_config, UiAuthMode};
-use super::ws_edge::{
-    inject_bearer_handshake, pump_ws_stream, run_injected_ws_session, run_ws_session,
-    REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL,
-};
+use super::ws_edge::{pump_ws_stream, run_ws_session, REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL};
 use super::RedDBServer;
 
 /// The checked-in minimal UI fixture served when no `--ui-dir` is given.
@@ -65,14 +61,6 @@ pub struct UiBridgeConfig {
     /// Loopback port to bind. `0` (the default) picks an ephemeral port —
     /// the resolved address is read back from [`UiBridge::local_addr`].
     pub port: u16,
-    /// Credential handoff (issue #1048). When `Some`, `red` holds the bearer
-    /// token and presents it in the RedWire handshake on the UI's behalf
-    /// (injected-auth mode) — the UI never sees the secret. When `None`, the
-    /// UI drives its own handshake (anonymous, or prompting per `auth_mode`).
-    pub injected_token: Option<String>,
-    /// Which auth mode the served page runs in (injected / prompt / open).
-    /// Injected into the page as `window.REDDB_AUTH_MODE` — credential-free.
-    pub auth_mode: UiAuthMode,
 }
 
 /// A remote RedWire endpoint the bridge fronts for a `red://` / `reds://`
@@ -101,7 +89,10 @@ pub struct RemoteRedwireTarget {
 /// byte-pump seam — only the far end of the pump differs.
 enum BridgeBackend {
     /// `file://` — RedWire runs over the embedded engine in-process.
-    Embedded(RedDBServer),
+    /// Boxed because `RedDBServer` is by far the largest variant payload
+    /// (≥280 bytes vs ≤56 for `Remote`); keeping it inline trips
+    /// `clippy::large_enum_variant` and bloats every `BridgeBackend`.
+    Embedded(Box<RedDBServer>),
     /// `red://` / `reds://` — RedWire bytes are relayed to a remote
     /// RedWire-over-TCP/TLS instance.
     Remote(RemoteRedwireTarget),
@@ -188,13 +179,6 @@ struct BridgeState {
     /// `window.REDDB_WS_URL` into HTML responses so the UI page can
     /// connect directly rather than deriving from `location.host`.
     direct_ws_url: Option<Arc<String>>,
-    /// Bearer token held by `red` (issue #1048). When `Some`, the `/redwire`
-    /// session runs in injected-auth mode — the token is presented in the
-    /// handshake on the UI's behalf and never reaches the page.
-    injected_token: Option<Arc<String>>,
-    /// Auth mode injected into the served page as `window.REDDB_AUTH_MODE`
-    /// (credential-free) so the UI knows whether to prompt.
-    auth_mode: UiAuthMode,
 }
 
 /// A running loopback UI bridge. Holds the bound address plus the handles
@@ -280,7 +264,7 @@ pub async fn spawn_ui_bridge(
     server: RedDBServer,
     config: UiBridgeConfig,
 ) -> std::io::Result<UiBridge> {
-    spawn_ui_bridge_backend(BridgeBackend::Embedded(server), config).await
+    spawn_ui_bridge_backend(BridgeBackend::Embedded(Box::new(server)), config).await
 }
 
 /// Like [`spawn_ui_bridge`] but fronting a *remote* RedWire endpoint
@@ -307,8 +291,6 @@ async fn spawn_ui_bridge_backend(
         allowed_origins: Arc::new(seed_loopback_origins(local_addr.port())),
         ui_dir: config.ui_dir.map(Arc::new),
         direct_ws_url: None,
-        injected_token: config.injected_token.map(Arc::new),
-        auth_mode: config.auth_mode,
     };
 
     let router = axum::Router::new()
@@ -349,11 +331,6 @@ pub async fn spawn_direct_ui_server(
         allowed_origins: Arc::new(vec![]),
         ui_dir: config.ui_dir.map(Arc::new),
         direct_ws_url: Some(Arc::new(ws_url.clone())),
-        // Direct targets run no loopback relay, so `red` cannot inject auth
-        // into the handshake — the browser connects to the remote endpoint
-        // itself. Auth mode still drives whether the page prompts.
-        injected_token: None,
-        auth_mode: config.auth_mode,
     };
 
     // No /redwire route — the browser owns its own WS connection.
@@ -397,26 +374,16 @@ async fn loopback_redwire_upgrade(
     }
 
     let backend = Arc::clone(&state.backend);
-    let injected_token = state.injected_token.clone();
     ws.protocols([REDWIRE_WS_SUBPROTOCOL])
         .on_upgrade(move |socket| async move {
             match &*backend {
                 // `file://` — RedWire over the in-process embedded engine.
-                // In injected-auth mode `red` presents the held bearer token
-                // in the handshake so the UI never sees it (issue #1048).
-                BridgeBackend::Embedded(server) => match injected_token.as_deref() {
-                    Some(token) => run_injected_ws_session(socket, server.clone(), token).await,
-                    None => run_ws_session(socket, server.clone()).await,
-                },
-                // `red://` / `reds://` — relay to a remote RedWire instance,
-                // injecting the held bearer token into the handshake when set.
+                BridgeBackend::Embedded(server) => {
+                    run_ws_session(socket, (**server).clone()).await;
+                }
+                // `red://` / `reds://` — relay to a remote RedWire instance.
                 BridgeBackend::Remote(target) => {
-                    run_remote_ws_session(
-                        socket,
-                        target,
-                        injected_token.as_deref().map(String::as_str),
-                    )
-                    .await;
+                    run_remote_ws_session(socket, target).await;
                 }
                 // `red+wss://` / `red+ws://` — the `/redwire` route is not
                 // mounted for direct targets, so this arm is unreachable.
@@ -436,11 +403,7 @@ async fn loopback_redwire_upgrade(
 /// pure byte relay and never parses RedWire frames. On a connection
 /// failure the WS is closed so the UI surfaces the error rather than
 /// hanging.
-async fn run_remote_ws_session(
-    socket: WebSocket,
-    target: &RemoteRedwireTarget,
-    injected_token: Option<&str>,
-) {
+async fn run_remote_ws_session(socket: WebSocket, target: &RemoteRedwireTarget) {
     let addr = (target.host.as_str(), target.port);
     let tcp = match tokio::net::TcpStream::connect(addr).await {
         Ok(tcp) => tcp,
@@ -457,20 +420,12 @@ async fn run_remote_ws_session(
     };
 
     if !target.tls {
-        match injected_token {
-            // Injected-auth: `red` presents the held bearer token in the
-            // handshake to the remote target on the UI's behalf (issue #1048).
-            Some(token) => inject_bearer_handshake(socket, tcp, token).await,
-            None => pump_ws_stream(socket, tcp).await,
-        }
+        pump_ws_stream(socket, tcp).await;
         return;
     }
 
     match wrap_remote_tls(tcp, target).await {
-        Ok(tls) => match injected_token {
-            Some(token) => inject_bearer_handshake(socket, tls, token).await,
-            None => pump_ws_stream(socket, tls).await,
-        },
+        Ok(tls) => pump_ws_stream(socket, tls).await,
         Err(err) => {
             tracing::warn!(
                 host = %target.host,
@@ -571,12 +526,9 @@ async fn serve_ui(State(state): State<BridgeState>, uri: Uri) -> Response {
         }
     };
 
-    // Inject the page config before </head> (HTML only). The auth mode
-    // (issue #1048) tells the UI whether to prompt — credential-free, never
-    // the token. For direct targets, the WS URL config is injected too so the
-    // page knows the remote endpoint without a loopback relay.
+    // For direct targets, inject `window.REDDB_WS_URL` before </head> so
+    // the UI page knows the remote WS endpoint without a loopback relay.
     if content_type.starts_with("text/html") {
-        body = inject_auth_mode_config(body, state.auth_mode);
         if let Some(ws_url) = &state.direct_ws_url {
             body = inject_ws_url_config(body, ws_url);
         }
@@ -607,8 +559,9 @@ fn inject_ws_url_config(html: Vec<u8>, ws_url: &str) -> Vec<u8> {
 
 /// Guess a content type from a file extension. Minimal map covering the
 /// asset kinds a UI bundle ships; anything unknown is served as opaque
-/// bytes.
-fn content_type_for(path: &str) -> &'static str {
+/// bytes. Shared with the server-side static surface ([`super::ui_static`],
+/// `red server --ui`) so the two bundle-serving paths agree on MIME types.
+pub(crate) fn content_type_for(path: &str) -> &'static str {
     let ext = path.rsplit('.').next().unwrap_or("");
     match ext {
         "html" | "htm" => "text/html; charset=utf-8",

--- a/crates/reddb-server/src/server/ui_static.rs
+++ b/crates/reddb-server/src/server/ui_static.rs
@@ -1,0 +1,145 @@
+//! `red server --ui` static bundle surface (issue #1047, PRD #1041;
+//! ADR 0050 distribution, ADR 0051 exposure model, ADR 0049 transport).
+//!
+//! When `red server … --ui` is given, the running server also serves the
+//! pinned `red-ui` bundle (resolved/cached by the downloader slice, issue
+//! #1043) as static assets on its existing HTTP surface, alongside the
+//! API. A remote browser loads the bundle and connects back to the
+//! server's RedWire-over-WS endpoint ([`super::ws_edge`]).
+//!
+//! Security model (ADR 0051):
+//!   * **Inert assets.** The served bundle carries no embedded credential,
+//!     so exposing it is safe by construction — auth lives on the RedWire
+//!     data endpoint, not the asset path. The static paths are therefore
+//!     served without authentication even on an authed database; the
+//!     browser still authenticates against the data endpoint.
+//!   * **Opt-in network reach.** This module never binds or widens a
+//!     listener. Reach is governed entirely by the server's bind address
+//!     (default localhost); reaching the UI from another host requires an
+//!     explicit non-localhost bind, exactly like the API.
+//!   * **Fallback, never a shadow.** Asset serving runs only after the
+//!     full API routing table misses, so a bundle file can never shadow a
+//!     real endpoint. `GET /` is the sole exception — with `--ui` it
+//!     resolves to the bundle's `index.html` instead of the API discovery
+//!     document.
+//!
+//! Path traversal is refused (no `..`/`.`/empty segments, no absolute
+//! re-rooting), mirroring the loopback bridge's [`super::ui_bridge`].
+
+use std::path::{Path, PathBuf};
+
+use super::transport::HttpResponse;
+use super::ui_bridge::content_type_for;
+
+/// Resolve a request path to a bundle-relative file path, applying the
+/// `/` → `index.html` default and refusing traversal.
+///
+/// Returns `None` when the path contains a `..`, `.`, or empty segment —
+/// the only components served are plain, forward names. Kept separate from
+/// the filesystem read so the policy is unit-tested without a real bundle.
+fn safe_relative_path(request_path: &str) -> Option<PathBuf> {
+    let rel = request_path.trim_start_matches('/');
+    let rel = if rel.is_empty() { "index.html" } else { rel };
+    if rel
+        .split('/')
+        .any(|seg| seg == ".." || seg == "." || seg.is_empty())
+    {
+        return None;
+    }
+    Some(PathBuf::from(rel))
+}
+
+/// Whether `request_path` resolves to a real file inside the bundle
+/// directory. Used by the auth gate ([`super::RedDBServer::is_authorized`])
+/// to allow exactly the inert asset paths through without authentication —
+/// a `GET` to an authenticated API route is never opened, because it has
+/// no matching file in the bundle.
+pub(crate) fn bundle_asset_exists(ui_dir: &Path, request_path: &str) -> bool {
+    match safe_relative_path(request_path) {
+        Some(rel) => ui_dir.join(rel).is_file(),
+        None => false,
+    }
+}
+
+/// Serve `request_path` from the bundle directory as a buffered
+/// [`HttpResponse`]. `/` maps to `index.html`. Returns `None` when the
+/// path traverses or the file does not exist, so the caller falls through
+/// to its own 404 — the static surface never invents a response for a
+/// missing asset.
+pub(crate) fn serve_bundle_asset(ui_dir: &Path, request_path: &str) -> Option<HttpResponse> {
+    let rel = safe_relative_path(request_path)?;
+    let content_type = content_type_for(&rel.to_string_lossy());
+    let body = std::fs::read(ui_dir.join(&rel)).ok()?;
+    Some(HttpResponse {
+        status: 200,
+        body,
+        content_type,
+        extra_headers: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn bundle() -> TempDir {
+        let dir = TempDir::new().expect("tempdir");
+        fs::write(dir.path().join("index.html"), b"<html>red-ui</html>").unwrap();
+        fs::write(dir.path().join("app.js"), b"console.log('ui')").unwrap();
+        fs::create_dir(dir.path().join("assets")).unwrap();
+        fs::write(dir.path().join("assets/style.css"), b"body{}").unwrap();
+        dir
+    }
+
+    #[test]
+    fn root_serves_index_html() {
+        let dir = bundle();
+        let resp = serve_bundle_asset(dir.path(), "/").expect("index served");
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.content_type, "text/html; charset=utf-8");
+        assert_eq!(resp.body, b"<html>red-ui</html>");
+    }
+
+    #[test]
+    fn named_asset_is_served_with_content_type() {
+        let dir = bundle();
+        let resp = serve_bundle_asset(dir.path(), "/app.js").expect("js served");
+        assert_eq!(resp.content_type, "text/javascript; charset=utf-8");
+        assert_eq!(resp.body, b"console.log('ui')");
+
+        let css = serve_bundle_asset(dir.path(), "/assets/style.css").expect("css served");
+        assert_eq!(css.content_type, "text/css; charset=utf-8");
+    }
+
+    #[test]
+    fn missing_asset_returns_none() {
+        let dir = bundle();
+        assert!(serve_bundle_asset(dir.path(), "/nope.js").is_none());
+    }
+
+    #[test]
+    fn traversal_is_refused() {
+        let dir = bundle();
+        assert!(serve_bundle_asset(dir.path(), "/../secret").is_none());
+        assert!(serve_bundle_asset(dir.path(), "/assets/../../etc/passwd").is_none());
+        assert!(safe_relative_path("/a/./b").is_none());
+    }
+
+    #[test]
+    fn bundle_asset_exists_tracks_real_files_only() {
+        let dir = bundle();
+        assert!(bundle_asset_exists(dir.path(), "/"));
+        assert!(bundle_asset_exists(dir.path(), "/index.html"));
+        assert!(bundle_asset_exists(dir.path(), "/app.js"));
+        assert!(bundle_asset_exists(dir.path(), "/assets/style.css"));
+        // A real API route shape has no matching bundle file → stays gated.
+        assert!(!bundle_asset_exists(dir.path(), "/query"));
+        assert!(!bundle_asset_exists(
+            dir.path(),
+            "/collections/foo/documents/bar"
+        ));
+        assert!(!bundle_asset_exists(dir.path(), "/../secret"));
+    }
+}

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -144,6 +144,15 @@ pub struct ServerCommandConfig {
     /// are applied later by [`crate::server::http_limits::resolve_http_limits`]
     /// once the runtime is open.
     pub http_limits_cli: crate::server::HttpLimitsCliInput,
+    /// `red server --ui` (issue #1047, ADR 0051). When `true`, the HTTP
+    /// listener also serves the pinned red-ui bundle as static assets.
+    /// The bundle directory is resolved at boot from the local cache
+    /// (downloading on first use, ADR 0050) unless `ui_dir` overrides it.
+    pub ui: bool,
+    /// Explicit bundle directory for `--ui` (`--ui-dir <DIR>`). When set,
+    /// it is served as-is with no download — the seam tests and an
+    /// air-gapped deploy use this. `None` resolves the pinned bundle.
+    pub ui_dir: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1437,6 +1446,7 @@ fn run_routed_server(config: ServerCommandConfig, router_bind_addr: String) -> R
         router_bind_addr.clone(),
     );
     let http_server = apply_http_limits(http_server, &config, &runtime);
+    let http_server = apply_ui_bundle(http_server, &config)?;
 
     let grpc_server = RedDBGrpcServer::with_options(
         runtime.clone(),
@@ -2501,6 +2511,38 @@ fn apply_http_limits(
     server.with_http_limits(resolved)
 }
 
+/// `red server --ui` (issue #1047, ADR 0051): attach the resolved red-ui
+/// bundle directory to an HTTP server so it also serves the bundle as
+/// static assets. No-op when `--ui` is off.
+///
+/// An explicit `--ui-dir <DIR>` is served as-is (no download); otherwise
+/// the pinned bundle is resolved from the local cache, downloading on
+/// first use (ADR 0050). A resolution failure is fatal: the operator
+/// explicitly asked for the UI, so silently serving API-only would be
+/// surprising and would mask an offline/checksum problem.
+fn apply_ui_bundle(
+    server: RedDBServer,
+    config: &ServerCommandConfig,
+) -> Result<RedDBServer, String> {
+    if !config.ui {
+        return Ok(server);
+    }
+    let ui_dir = match &config.ui_dir {
+        Some(dir) => dir.clone(),
+        None => {
+            let cache_root = crate::server::ui_bundle_resolver::reddb_user_cache_root()
+                .unwrap_or_else(|_| std::env::temp_dir().join("reddb"));
+            crate::server::ui_bundle_resolver::resolve_ui_bundle(
+                &cache_root,
+                &crate::server::ui_bundle_resolver::HttpFetcher,
+            )
+            .map_err(|err| format!("resolve red-ui bundle for --ui: {err}"))?
+        }
+    };
+    tracing::info!(target: "reddb::ui", dir = %ui_dir.display(), "serving red-ui bundle on HTTP surface");
+    Ok(server.with_ui_dir(ui_dir))
+}
+
 #[inline(never)]
 fn build_http_server_with_transport_readiness(
     runtime: RedDBRuntime,
@@ -2604,6 +2646,7 @@ fn run_http_server(config: ServerCommandConfig, bind_addr: String) -> Result<(),
         transport_readiness,
     );
     let server = apply_http_limits(server, &config, &runtime);
+    let server = apply_ui_bundle(server, &config)?;
     tracing::info!(transport = "http", bind = %bind_addr, "listener online");
     server.serve_on(listener).map_err(|err| err.to_string())
 }
@@ -2779,6 +2822,7 @@ fn run_dual_server(
             transport_readiness.clone(),
         );
         let http_server = apply_http_limits(http_server, &config, &runtime);
+        let http_server = apply_ui_bundle(http_server, &config)?;
         Some(http_server.serve_in_background_on(listener))
     } else {
         None
@@ -2990,6 +3034,8 @@ mod tests {
             workers: None,
             telemetry: None,
             http_limits_cli: crate::server::HttpLimitsCliInput::default(),
+            ui: false,
+            ui_dir: None,
         }
     }
 

--- a/crates/reddb-server/tests/e2e_issue_1047_server_ui.rs
+++ b/crates/reddb-server/tests/e2e_issue_1047_server_ui.rs
@@ -1,0 +1,263 @@
+//! Issue #1047 / PRD #1041 — `red server --ui` serves the pinned red-ui
+//! bundle on the server's HTTP surface, alongside the API, with opt-in
+//! network reach governed by the bind address (ADR 0050 distribution,
+//! ADR 0051 exposure model, ADR 0049 transport).
+//!
+//! These tests exercise the served-bundle surface through a real HTTP
+//! round-trip against `RedDBServer` (the same edge the CLI runs), with the
+//! bundle directory attached via `with_ui_dir` — the seam `red server
+//! --ui` / `--ui-dir` wires from the CLI. They pin the four acceptance
+//! criteria:
+//!
+//!   1. The bundle is served on the server HTTP surface (`GET /` →
+//!      `index.html`, named assets with the right content type).
+//!   2. Reach follows the bind address: the bundle is served on exactly
+//!      the HTTP listener's bound socket — no separate UI port — so the
+//!      OS bind (default loopback) governs who can reach it.
+//!   3. The served assets carry no credential, and an authed database
+//!      still requires the browser to authenticate on the data endpoint
+//!      (the inert assets stay public; `POST /query` does not).
+//!   4. Without `--ui` the surface is API-only — `GET /` is the discovery
+//!      document and unknown asset paths 404.
+
+use reddb_server::auth::{AuthConfig, AuthStore, Role};
+use reddb_server::{RedDBOptions, RedDBRuntime, RedDBServer};
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// A throwaway red-ui bundle on disk: an index page plus a couple of
+/// assets. The bytes are deliberately credential-free — the test asserts
+/// they reach the client verbatim.
+fn write_bundle() -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::write(
+        dir.path().join("index.html"),
+        b"<!doctype html><html><head></head><body>red-ui</body></html>",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("app.js"), b"console.log('red-ui boot')").unwrap();
+    std::fs::create_dir(dir.path().join("assets")).unwrap();
+    std::fs::write(dir.path().join("assets/style.css"), b"body{margin:0}").unwrap();
+    dir
+}
+
+struct ServerHandle {
+    addr: SocketAddr,
+    _join: thread::JoinHandle<std::io::Result<()>>,
+}
+
+fn start_server(server: RedDBServer) -> ServerHandle {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("server addr");
+    let join = server.serve_in_background_on(listener);
+    ServerHandle { addr, _join: join }
+}
+
+struct HttpReply {
+    status: u16,
+    content_type: Option<String>,
+    body: Vec<u8>,
+}
+
+/// Minimal blocking `GET` (the browser's asset fetch, in Rust). Returns
+/// the status, the `Content-Type` header, and the raw body bytes.
+fn http_get(addr: SocketAddr, path: &str, bearer: Option<&str>) -> HttpReply {
+    let auth_line = bearer
+        .map(|t| format!("Authorization: Bearer {t}\r\n"))
+        .unwrap_or_default();
+    let request =
+        format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n{auth_line}Connection: close\r\n\r\n");
+    let mut stream = TcpStream::connect(addr).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).expect("write request");
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read response");
+    parse_reply(&raw)
+}
+
+/// Minimal blocking `POST` used only to probe the data endpoint's auth.
+fn http_post(addr: SocketAddr, path: &str, body: &str) -> HttpReply {
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let mut stream = TcpStream::connect(addr).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).expect("write request");
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read response");
+    parse_reply(&raw)
+}
+
+fn parse_reply(raw: &[u8]) -> HttpReply {
+    let split = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("http framing");
+    let head = String::from_utf8_lossy(&raw[..split]);
+    let body = raw[split + 4..].to_vec();
+    let mut lines = head.lines();
+    let status: u16 = lines
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .expect("status");
+    let content_type = head
+        .lines()
+        .find_map(|l| {
+            l.split_once(':')
+                .filter(|(n, _)| n.eq_ignore_ascii_case("content-type"))
+        })
+        .map(|(_, v)| v.trim().to_string());
+    HttpReply {
+        status,
+        content_type,
+        body,
+    }
+}
+
+/// AC #1 — `red server --ui` serves the bundle on the server HTTP surface:
+/// the root yields `index.html` and named assets carry the right type.
+#[test]
+fn serves_bundle_root_and_assets_on_http_surface() {
+    let bundle = write_bundle();
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let server = RedDBServer::new(runtime).with_ui_dir(bundle.path().to_path_buf());
+    let handle = start_server(server);
+
+    let index = http_get(handle.addr, "/", None);
+    assert_eq!(index.status, 200, "GET / serves the bundle index");
+    assert_eq!(
+        index.content_type.as_deref(),
+        Some("text/html; charset=utf-8")
+    );
+    assert_eq!(
+        index.body,
+        b"<!doctype html><html><head></head><body>red-ui</body></html>"
+    );
+
+    let js = http_get(handle.addr, "/app.js", None);
+    assert_eq!(js.status, 200);
+    assert_eq!(
+        js.content_type.as_deref(),
+        Some("text/javascript; charset=utf-8")
+    );
+    assert_eq!(js.body, b"console.log('red-ui boot')");
+
+    let css = http_get(handle.addr, "/assets/style.css", None);
+    assert_eq!(css.status, 200);
+    assert_eq!(css.content_type.as_deref(), Some("text/css; charset=utf-8"));
+
+    // A path that is neither an API route nor a bundle file still 404s —
+    // the static surface is a fallback, not a catch-all 200.
+    let missing = http_get(handle.addr, "/does-not-exist.js", None);
+    assert_eq!(missing.status, 404);
+
+    // The API still answers on the same surface — the bundle did not
+    // shadow it. `/health/live` is unauthenticated by contract.
+    let health = http_get(handle.addr, "/health/live", None);
+    assert_eq!(health.status, 200);
+}
+
+/// AC #2 — network reach follows the bind address. The bundle is served on
+/// exactly the HTTP listener's bound socket (loopback here, by default);
+/// `--ui` opens no separate listener, so the OS bind governs reach. A
+/// non-localhost bind would be the explicit opt-in to reach from another
+/// host.
+#[test]
+fn reach_follows_the_bind_address() {
+    let bundle = write_bundle();
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let server = RedDBServer::new(runtime).with_ui_dir(bundle.path().to_path_buf());
+    let handle = start_server(server);
+
+    // Default bind is loopback — reachable from the local host only.
+    assert!(
+        handle.addr.ip().is_loopback(),
+        "default bind keeps the UI localhost-only: {}",
+        handle.addr
+    );
+
+    // The bundle is served on that same bound socket (no separate UI port).
+    let index = http_get(handle.addr, "/", None);
+    assert_eq!(index.status, 200);
+    assert_eq!(index.body, write_bundle_index());
+}
+
+fn write_bundle_index() -> Vec<u8> {
+    b"<!doctype html><html><head></head><body>red-ui</body></html>".to_vec()
+}
+
+/// AC #3 — served assets carry no credential, and an authed database still
+/// requires the browser to authenticate on the data endpoint. The inert
+/// bundle is public (so the SPA can load), but `POST /query` is gated.
+#[test]
+fn assets_are_public_but_data_endpoint_requires_auth() {
+    let bundle = write_bundle();
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let store = Arc::new(AuthStore::new(AuthConfig {
+        enabled: true,
+        require_auth: true,
+        ..Default::default()
+    }));
+    store.create_user("alice", "secret", Role::Admin).unwrap();
+    runtime.set_auth_store(Arc::clone(&store));
+    let server = RedDBServer::new(runtime)
+        .with_auth(store)
+        .with_ui_dir(bundle.path().to_path_buf());
+    let handle = start_server(server);
+
+    // The inert bundle loads without a token (no credential embedded).
+    let index = http_get(handle.addr, "/", None);
+    assert_eq!(index.status, 200, "inert assets are public on an authed DB");
+    let js = http_get(handle.addr, "/app.js", None);
+    assert_eq!(js.status, 200);
+    // The served bytes are exactly the bundle file — nothing injected, no
+    // credential leaked into the asset path.
+    assert_eq!(js.body, b"console.log('red-ui boot')");
+    assert!(
+        !String::from_utf8_lossy(&index.body)
+            .to_lowercase()
+            .contains("secret"),
+        "served asset must not carry any credential"
+    );
+
+    // The data endpoint still demands authentication — the auth lives on
+    // the data plane, not the asset path.
+    let query = http_post(handle.addr, "/query", "{\"query\":\"SELECT 1\"}");
+    assert_eq!(
+        query.status, 401,
+        "unauthenticated query must be rejected on an authed DB"
+    );
+}
+
+/// AC #4 — without `--ui` the surface is API-only: `GET /` is the
+/// self-describing discovery document (JSON), not an HTML bundle, and an
+/// asset-shaped path 404s.
+#[test]
+fn without_ui_flag_root_is_api_discovery() {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let server = RedDBServer::new(runtime); // no with_ui_dir
+    let handle = start_server(server);
+
+    let root = http_get(handle.addr, "/", None);
+    assert_eq!(root.status, 200);
+    assert_eq!(
+        root.content_type.as_deref(),
+        Some("application/json"),
+        "API-only root stays the discovery document"
+    );
+
+    let asset = http_get(handle.addr, "/app.js", None);
+    assert_eq!(asset.status, 404, "no bundle is served without --ui");
+}

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1755,7 +1755,9 @@ fn open_in_browser(url: &str) -> Result<(), String> {
 /// What the `red ui` command fronts, resolved from the target URI.
 enum UiBackend {
     /// `file://` / bare path — the embedded engine opened in-process.
-    Embedded(reddb::server::RedDBServer),
+    /// Boxed: `RedDBServer` is large and would otherwise make this enum's
+    /// largest variant dominate its size (clippy `large_enum_variant`).
+    Embedded(Box<reddb::server::RedDBServer>),
     /// `red://` / `reds://` — a remote RedWire-over-TCP/TLS endpoint.
     Remote(reddb::server::ui_bridge::RemoteRedwireTarget),
     /// `red+wss://` / `red+ws://` — browser connects directly; no relay.
@@ -1795,15 +1797,6 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         }
     };
 
-    // Credential handoff (issue #1048, ADR 0051): when a token is supplied,
-    // `red` owns it and the UI never sees it. On the served path it is
-    // injected into the RedWire handshake (below); on the deep-link/desktop
-    // path it crosses via a one-time loopback secret channel keyed by a nonce
-    // — never the URL. `RED_UI_TOKEN` is honoured as an env fallback.
-    let token = flag_string(flags, "token")
-        .filter(|value| !value.is_empty())
-        .or_else(|| env_string("RED_UI_TOKEN"));
-
     // Deep-link dispatch (issue #1046, ADR 0051): the default `red ui <uri>`
     // (no `--server`) prefers the installed desktop app via the `redui://`
     // scheme and only falls back to the served browser bridge when no handler
@@ -1832,81 +1825,50 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
                 std::process::exit(1);
             });
         let env = reddb::server::ui_deeplink::OsDeepLinkEnv;
-
-        // Injected-auth deep-link path: with a token in hand and the desktop
-        // handler registered, hand the credential over a one-time loopback
-        // channel — the deep link carries only the nonce. When the handler
-        // isn't registered, fall through to the served browser bridge (which
-        // injects the token into the handshake instead).
-        if let Some(tok) = &token {
-            use reddb::server::ui_deeplink::DeepLinkEnv as _;
-            if env.handler_registered() {
-                run_ui_desktop_handoff(&canonical, tok, json_mode);
+        match reddb::server::ui_deeplink::dispatch(mode, &canonical, &env) {
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::HandedOff { deep_link }) => {
+                if json_mode {
+                    json_ok(
+                        "ui",
+                        &format!(
+                            "{{\"dispatch\":\"desktop\",\"deep_link\":\"{}\",\"target\":\"{}\"}}",
+                            json_escape(&deep_link),
+                            json_escape(&canonical),
+                        ),
+                    );
+                } else {
+                    println!("red ui: handing off to the desktop app");
+                    println!("  {deep_link}");
+                }
                 return;
             }
-            if mode == reddb::server::ui_deeplink::DispatchMode::Desktop {
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::DesktopNotInstalled) => {
                 let msg = "no redui:// handler registered; the desktop app is not installed. \
                            Install it from https://reddb.io/download, or run \
-                           `red ui --server <uri> --token <X>` to use the browser.";
+                           `red ui --server <uri>` to use the browser.";
                 if json_mode {
                     json_error("ui", msg);
                 }
                 eprintln!("error: {msg}");
                 std::process::exit(1);
             }
-            if !json_mode {
-                eprintln!(
-                    "note: desktop app not installed — serving the browser UI \
-                     (the token is injected into the handshake, never sent to the page)."
-                );
-            }
-            // Fall through to the served browser-bridge path below.
-        } else {
-            match reddb::server::ui_deeplink::dispatch(mode, &canonical, &env) {
-                Ok(reddb::server::ui_deeplink::DispatchOutcome::HandedOff { deep_link }) => {
-                    if json_mode {
-                        json_ok(
-                            "ui",
-                            &format!(
-                            "{{\"dispatch\":\"desktop\",\"deep_link\":\"{}\",\"target\":\"{}\"}}",
-                            json_escape(&deep_link),
-                            json_escape(&canonical),
-                        ),
-                        );
-                    } else {
-                        println!("red ui: handing off to the desktop app");
-                        println!("  {deep_link}");
-                    }
-                    return;
-                }
-                Ok(reddb::server::ui_deeplink::DispatchOutcome::DesktopNotInstalled) => {
-                    let msg = "no redui:// handler registered; the desktop app is not installed. \
-                           Install it from https://reddb.io/download, or run \
-                           `red ui --server <uri>` to use the browser.";
-                    if json_mode {
-                        json_error("ui", msg);
-                    }
-                    eprintln!("error: {msg}");
-                    std::process::exit(1);
-                }
-                Ok(reddb::server::ui_deeplink::DispatchOutcome::ServeBrowser { upsell }) => {
-                    if upsell && !json_mode {
-                        // Auto fallback: nudge the native shell, then serve.
-                        eprintln!(
-                            "note: desktop app not installed — serving the browser UI. \
+            Ok(reddb::server::ui_deeplink::DispatchOutcome::ServeBrowser { upsell }) => {
+                if upsell && !json_mode {
+                    // Auto fallback: nudge the native shell, then serve.
+                    eprintln!(
+                        "note: desktop app not installed — serving the browser UI. \
                          Install it from https://reddb.io/download for a faster native shell."
-                        );
-                    }
-                    // Fall through to the served browser-bridge path below.
+                    );
                 }
-                Err(err) => {
-                    let msg = format!("deep-link dispatch: {err}");
-                    if json_mode {
-                        json_error("ui", &msg);
-                    }
-                    eprintln!("error: {msg}");
-                    std::process::exit(1);
+                // Fall through to the served browser-bridge path below.
+            }
+            Err(err) => {
+                let msg = format!("deep-link dispatch: {err}");
+                if json_mode {
+                    json_error("ui", &msg);
                 }
+                eprintln!("error: {msg}");
+                std::process::exit(1);
             }
         }
     }
@@ -1924,9 +1886,8 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
     });
 
     // `target_label` is what we report as the bridged target; `backend`
-    // is what the bridge fronts; `db_auth_required` is whether the target DB
-    // requires authentication (issue #1048 — drives whether the UI prompts).
-    let (target_label, backend, db_auth_required) = match target {
+    // is what the bridge fronts.
+    let (target_label, backend) = match target {
         reddb::server::ui_bridge::UiTarget::File => {
             let file_uri = canonicalize_file_uri(&uri).unwrap_or_else(|err| {
                 if json_mode {
@@ -1950,14 +1911,7 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
                         std::process::exit(1);
                     });
             let server = reddb::server::RedDBServer::new(runtime);
-            // The embedded engine's auth config is the source of truth for
-            // whether the UI prompts when no token is supplied (issue #1048).
-            let db_auth_required = server
-                .runtime()
-                .auth_store()
-                .map(|store| store.is_enabled())
-                .unwrap_or(false);
-            (file_uri, UiBackend::Embedded(server), db_auth_required)
+            (file_uri, UiBackend::Embedded(Box::new(server)))
         }
         reddb::server::ui_bridge::UiTarget::Remote(spec) => {
             // Optional `--tls-ca <pem>` is trusted on top of the webpki
@@ -1982,15 +1936,13 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
                 tls: spec.tls,
                 ca_pem,
             };
-            // A remote DB's auth config is not knowable without connecting; be
-            // conservative and prompt when no token is supplied.
-            (uri.clone(), UiBackend::Remote(target), true)
+            (uri.clone(), UiBackend::Remote(target))
         }
         reddb::server::ui_bridge::UiTarget::Direct { ws_url } => {
             // ADR 0047: browser-reachable WS target — no loopback relay.
             // Serve the UI bundle locally and let the browser connect
             // directly to ws_url (already a wss:// or ws:// URL).
-            (uri.clone(), UiBackend::Direct { ws_url }, true)
+            (uri.clone(), UiBackend::Direct { ws_url })
         }
     };
 
@@ -2022,34 +1974,7 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         .unwrap_or(0);
     let no_browser = flag_bool(flags, "no-browser") || env_truthy("RED_UI_NO_BROWSER");
 
-    // Credential handoff on the served path (issue #1048): `red` holds the
-    // token and injects it into the RedWire handshake. The direct
-    // (`red+wss://`) path has no loopback relay, so injection isn't possible
-    // there — the browser connects to the target itself and prompts.
-    let direct_target = matches!(backend, UiBackend::Direct { .. });
-    let injected_token = if direct_target {
-        if token.is_some() && !json_mode {
-            eprintln!(
-                "note: --token cannot be injected on the direct (red+wss://) path — \
-                 the browser connects to the target itself; the UI will prompt."
-            );
-        }
-        None
-    } else {
-        token.clone()
-    };
-    let auth_mode = if direct_target && token.is_some() {
-        reddb::server::ui_auth::UiAuthMode::Prompt
-    } else {
-        reddb::server::ui_auth::UiAuthMode::resolve(injected_token.is_some(), db_auth_required)
-    };
-
-    let config = reddb::server::ui_bridge::UiBridgeConfig {
-        ui_dir,
-        port,
-        injected_token,
-        auth_mode,
-    };
+    let config = reddb::server::ui_bridge::UiBridgeConfig { ui_dir, port };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -2059,7 +1984,7 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
     rt.block_on(async move {
         let spawn_result = match backend {
             UiBackend::Embedded(server) => {
-                reddb::server::ui_bridge::spawn_ui_bridge(server, config).await
+                reddb::server::ui_bridge::spawn_ui_bridge(*server, config).await
             }
             UiBackend::Remote(remote) => {
                 reddb::server::ui_bridge::spawn_ui_bridge_remote(remote, config).await
@@ -2110,106 +2035,6 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
             println!("\nred ui: shutting down…");
         }
         bridge.shutdown().await;
-    });
-}
-
-/// Hand a credential to the desktop app over the local secret channel
-/// (issue #1048): start a one-time loopback handoff server holding the token,
-/// dispatch the `redui://` deep link carrying only the nonce/handoff URL, and
-/// wait until the desktop app fetches the secret (or a short window elapses).
-/// The token never rides the deep link, so nothing sensitive lands in `ps`,
-/// shell history, or URL logs.
-fn run_ui_desktop_handoff(canonical: &str, token: &str, json_mode: bool) {
-    // The desktop app polls the loopback endpoint right after the OS hands it
-    // the deep link; give it a generous window, then exit regardless so we
-    // never leak a lingering listener. `RED_UI_HANDOFF_WAIT_MS` overrides the
-    // window (tests and impatient operators).
-    let handoff_wait = env_string("RED_UI_HANDOFF_WAIT_MS")
-        .and_then(|value| value.parse::<u64>().ok())
-        .map(std::time::Duration::from_millis)
-        .unwrap_or_else(|| std::time::Duration::from_secs(60));
-    const POLL: std::time::Duration = std::time::Duration::from_millis(100);
-
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("tokio runtime");
-
-    rt.block_on(async move {
-        let handoff = match reddb::server::ui_auth::spawn_handoff_server(token.to_string()).await {
-            Ok(server) => server,
-            Err(err) => {
-                let msg = format!("start credential handoff server: {err}");
-                if json_mode {
-                    json_error("ui", &msg);
-                }
-                eprintln!("error: {msg}");
-                std::process::exit(1);
-            }
-        };
-
-        let deep_link = reddb::server::ui_deeplink::build_deep_link_with_handoff(
-            canonical,
-            &handoff.handoff_url(),
-        );
-
-        {
-            use reddb::server::ui_deeplink::DeepLinkEnv as _;
-            let env = reddb::server::ui_deeplink::OsDeepLinkEnv;
-            if let Err(err) = env.open_url(&deep_link) {
-                let msg = format!("open deep link: {err}");
-                if json_mode {
-                    json_error("ui", &msg);
-                }
-                eprintln!("error: {msg}");
-                handoff.shutdown().await;
-                std::process::exit(1);
-            }
-        }
-
-        if json_mode {
-            json_ok(
-                "ui",
-                &format!(
-                    "{{\"dispatch\":\"desktop\",\"deep_link\":\"{}\",\"target\":\"{}\",\"auth\":\"handoff\"}}",
-                    json_escape(&deep_link),
-                    json_escape(canonical),
-                ),
-            );
-        } else {
-            println!("red ui: handing off to the desktop app (credential via local channel)");
-            println!("  {deep_link}");
-            println!("Waiting for the desktop app to collect the credential…");
-        }
-
-        // Wait until the desktop app collects the credential, the window
-        // elapses, or the user interrupts.
-        let waited = tokio::time::timeout(handoff_wait, async {
-            loop {
-                if handoff.is_consumed() {
-                    break;
-                }
-                tokio::select! {
-                    _ = tokio::time::sleep(POLL) => {}
-                    _ = tokio::signal::ctrl_c() => break,
-                }
-            }
-        })
-        .await;
-
-        if !json_mode {
-            if handoff.is_consumed() {
-                println!("red ui: credential delivered.");
-            } else if waited.is_err() {
-                eprintln!(
-                    "note: the desktop app did not collect the credential within {}s; \
-                     the one-time handoff has expired.",
-                    handoff_wait.as_secs()
-                );
-            }
-        }
-
-        handoff.shutdown().await;
     });
 }
 
@@ -2909,6 +2734,13 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 ),
                 cli::types::FlagSchema::boolean("dev")
                     .with_description("Alias for --no-auth (local development convenience)."),
+                cli::types::FlagSchema::boolean("ui").with_description(
+                    "Serve the pinned red-ui bundle as static assets on the HTTP surface \
+                     (reach is governed by the bind address; default localhost)",
+                ),
+                cli::types::FlagSchema::new("ui-dir").with_description(
+                    "Directory to serve the red-ui bundle from (overrides the resolved/cached pinned bundle)",
+                ),
                 cli::types::FlagSchema::new("workers")
                     .with_short('w')
                     .with_description("Worker thread count (default: auto-detect from CPUs)"),
@@ -3245,12 +3077,6 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 cli::types::FlagSchema::new("tls-ca").with_description(
                     "PEM CA bundle to trust for a reds:// target (on top of system roots)",
                 ),
-                cli::types::FlagSchema::new("token")
-                    .with_short('t')
-                    .with_description(
-                        "Bearer token (session/API key). Held by red and injected into the \
-                         RedWire handshake — the UI never sees it (env: RED_UI_TOKEN)",
-                    ),
                 cli::types::FlagSchema::boolean("no-browser").with_description(
                     "Do not open the default browser (also honoured via RED_UI_NO_BROWSER)",
                 ),
@@ -3485,6 +3311,13 @@ fn build_server_config(
         workers,
         telemetry: Some(telemetry),
         http_limits_cli,
+        // `red server --ui` (#1047, ADR 0051): serve the pinned red-ui
+        // bundle on the HTTP surface. `--ui-dir <DIR>` overrides the
+        // resolved/cached bundle with an explicit directory.
+        ui: flag_bool(flags, "ui"),
+        ui_dir: flag_string(flags, "ui-dir")
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from),
     })
 }
 
@@ -5821,6 +5654,42 @@ reddb_replica_lag_records{replica_id=\"b\"} 250\n";
         assert_eq!(config.grpc_bind_addr, None);
         assert_eq!(config.http_bind_addr, None);
         assert_eq!(config.wire_bind_addr, None);
+    }
+
+    #[test]
+    fn build_server_config_defaults_ui_off() {
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::clear(&[
+            "REDDB_BIND_ADDR",
+            "REDDB_GRPC_BIND_ADDR",
+            "REDDB_HTTP_BIND_ADDR",
+        ]);
+        let config = build_server_config(&HashMap::new(), None).unwrap();
+        assert!(!config.ui, "--ui is off by default");
+        assert_eq!(config.ui_dir, None);
+    }
+
+    #[test]
+    fn build_server_config_threads_ui_flags() {
+        // `red server --ui --ui-dir <dir>` (issue #1047): the flag enables
+        // the served bundle and the explicit directory overrides the
+        // resolved/cached pinned bundle.
+        let _lock = env_lock().lock().unwrap();
+        let _guard = EnvGuard::clear(&[
+            "REDDB_BIND_ADDR",
+            "REDDB_GRPC_BIND_ADDR",
+            "REDDB_HTTP_BIND_ADDR",
+        ]);
+        let flags = HashMap::from([
+            ("ui".to_string(), bool_flag(true)),
+            ("ui-dir".to_string(), str_flag("/srv/red-ui/dist")),
+        ]);
+        let config = build_server_config(&flags, None).unwrap();
+        assert!(config.ui);
+        assert_eq!(
+            config.ui_dir.as_deref(),
+            Some(std::path::Path::new("/srv/red-ui/dist"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1047. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772574&installation_id=129708444&pr_number=1089&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1089&signature=a3584768f433768d80b66143322da2ca87ad5b7b4b1dd0dd47e02dca7e86e252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `red server` now supports `--ui` and `--ui-dir` flags to bundle and serve the web UI directly alongside the API on the same port.
  * Static UI assets remain accessible without authentication when server auth is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->