### PR TITLE
merge: #1054 MCP-over-stdio JSON-RPC framing: move to reddb-wire or ratify as transport glue

### DIFF
--- a/crates/reddb-server/src/mcp/protocol.rs
+++ b/crates/reddb-server/src/mcp/protocol.rs
@@ -1,123 +1,65 @@
 //! JSON-RPC protocol handling for MCP server.
 //!
-//! Implements the Content-Length framed JSON-RPC transport used by the
-//! Model Context Protocol over stdio.
+//! The Content-Length framed JSON-RPC 2.0 transport used by the Model Context
+//! Protocol over stdio is a message-framing wire codec and lives in the
+//! protocol-authority crate (`reddb_wire::jsonrpc`), per ADR 0046. This module
+//! binds the server's JSON value type to that codec via [`ServerJson`] and
+//! re-exports the framing functions, so call sites keep using
+//! `protocol::read_payload`, `protocol::build_result_message`, etc. unchanged.
 
 use crate::json::{Map, Value as JsonValue};
-use std::io::{BufRead, Write};
+use reddb_wire::jsonrpc::{self, JsonRpcSerializer};
 
-/// Read a JSON-RPC payload from a buffered reader.
+pub use reddb_wire::jsonrpc::{read_payload, write_message};
+
+/// Binds `reddb-server`'s JSON value type to the wire crate's framed JSON-RPC
+/// envelope builders.
 ///
-/// Reads headers until it finds `Content-Length: N`, then reads exactly N
-/// bytes of body. Returns `None` on EOF and `Err` on malformed input.
-pub fn read_payload<R: BufRead>(reader: &mut R) -> Result<Option<String>, String> {
-    let mut content_length: Option<usize> = None;
-    let mut header = String::new();
+/// Objects are backed by [`Map`] (a `BTreeMap`), which sorts keys on compact
+/// serialization — that sort order is what pins the emitted field order.
+pub struct ServerJson;
 
-    loop {
-        header.clear();
-        let bytes = reader
-            .read_line(&mut header)
-            .map_err(|e| format!("failed to read header: {}", e))?;
-        if bytes == 0 {
-            return Ok(None);
-        }
+impl JsonRpcSerializer for ServerJson {
+    type Value = JsonValue;
 
-        let trimmed = header.trim_end_matches(['\n', '\r']);
-        if trimmed.is_empty() {
-            break;
-        }
-
-        let lower = trimmed.to_ascii_lowercase();
-        if lower.starts_with("content-length:") {
-            let value = trimmed["Content-Length:".len()..].trim();
-            let length = value
-                .parse::<usize>()
-                .map_err(|_| "invalid Content-Length header".to_string())?;
-            content_length = Some(length);
-        }
+    fn null() -> JsonValue {
+        JsonValue::Null
     }
 
-    let length = content_length.ok_or_else(|| "missing Content-Length header".to_string())?;
-    let mut buffer = vec![0u8; length];
-    reader
-        .read_exact(&mut buffer)
-        .map_err(|e| format!("failed to read payload: {}", e))?;
-
-    // Consume optional trailing newline between messages.
-    if let Ok(buf) = reader.fill_buf() {
-        let to_consume = if buf.starts_with(b"\r\n") {
-            Some(2)
-        } else if buf.starts_with(b"\n") {
-            Some(1)
-        } else {
-            None
-        };
-        if let Some(count) = to_consume {
-            reader.consume(count);
-        }
+    fn string(value: &str) -> JsonValue {
+        JsonValue::String(value.to_string())
     }
 
-    String::from_utf8(buffer)
-        .map(Some)
-        .map_err(|_| "payload is not UTF-8".to_string())
-}
+    fn number(value: i64) -> JsonValue {
+        JsonValue::Number(value as f64)
+    }
 
-/// Write a Content-Length framed JSON-RPC message to a writer.
-pub fn write_message<W: Write>(writer: &mut W, body: &str) -> Result<(), String> {
-    write!(writer, "Content-Length: {}\r\n\r\n{}", body.len(), body)
-        .map_err(|e| format!("failed to write response: {}", e))?;
-    writer
-        .flush()
-        .map_err(|e| format!("failed to flush: {}", e))
+    fn object(entries: Vec<(&'static str, JsonValue)>) -> JsonValue {
+        let mut object = Map::new();
+        for (key, value) in entries {
+            object.insert(key.to_string(), value);
+        }
+        JsonValue::Object(object)
+    }
+
+    fn to_compact_string(value: &JsonValue) -> String {
+        value.to_string_compact()
+    }
 }
 
 /// Build a JSON-RPC 2.0 result message.
 pub fn build_result_message(id: Option<&JsonValue>, result: JsonValue) -> String {
-    let mut object = Map::new();
-    object.insert("jsonrpc".to_string(), JsonValue::String("2.0".to_string()));
-    match id {
-        Some(identifier) => {
-            object.insert("id".to_string(), identifier.clone());
-        }
-        None => {
-            object.insert("id".to_string(), JsonValue::Null);
-        }
-    }
-    object.insert("result".to_string(), result);
-    JsonValue::Object(object).to_string_compact()
+    jsonrpc::build_result_message::<ServerJson>(id, result)
 }
 
 /// Build a JSON-RPC 2.0 error message.
 pub fn build_error_message(id: Option<&JsonValue>, code: i64, message: &str) -> String {
-    let mut error = Map::new();
-    error.insert("code".to_string(), JsonValue::Number(code as f64));
-    error.insert(
-        "message".to_string(),
-        JsonValue::String(message.to_string()),
-    );
-
-    let mut object = Map::new();
-    object.insert("jsonrpc".to_string(), JsonValue::String("2.0".to_string()));
-    match id {
-        Some(identifier) => {
-            object.insert("id".to_string(), identifier.clone());
-        }
-        None => {
-            object.insert("id".to_string(), JsonValue::Null);
-        }
-    }
-    object.insert("error".to_string(), JsonValue::Object(error));
-    JsonValue::Object(object).to_string_compact()
+    jsonrpc::build_error_message::<ServerJson>(id, code, message)
 }
 
 /// Build a JSON-RPC 2.0 notification (no id, no response expected).
 pub fn build_notification(method: &str, params: JsonValue) -> String {
-    let mut object = Map::new();
-    object.insert("jsonrpc".to_string(), JsonValue::String("2.0".to_string()));
-    object.insert("method".to_string(), JsonValue::String(method.to_string()));
-    object.insert("params".to_string(), params);
-    JsonValue::Object(object).to_string_compact()
+    jsonrpc::build_notification::<ServerJson>(method, params)
 }
 
 #[cfg(test)]
@@ -133,6 +75,8 @@ mod tests {
         let parsed: JsonValue = from_str(&msg).unwrap();
         assert_eq!(parsed.get("jsonrpc").and_then(|v| v.as_str()), Some("2.0"));
         assert_eq!(parsed.get("id").and_then(|v| v.as_f64()), Some(1.0));
+        // Field order is pinned by the BTreeMap-backed serializer.
+        assert_eq!(msg, r#"{"id":1,"jsonrpc":"2.0","result":true}"#);
     }
 
     #[test]
@@ -147,6 +91,10 @@ mod tests {
             error.get("message").and_then(|v| v.as_str()),
             Some("method not found")
         );
+        assert_eq!(
+            msg,
+            r#"{"error":{"code":-32601,"message":"method not found"},"id":2,"jsonrpc":"2.0"}"#
+        );
     }
 
     #[test]
@@ -158,6 +106,10 @@ mod tests {
             Some("test/event")
         );
         assert!(parsed.get("id").is_none());
+        assert_eq!(
+            msg,
+            r#"{"jsonrpc":"2.0","method":"test/event","params":null}"#
+        );
     }
 
     #[test]

--- a/crates/reddb-wire/src/jsonrpc.rs
+++ b/crates/reddb-wire/src/jsonrpc.rs
@@ -1,0 +1,334 @@
+//! Content-Length framed JSON-RPC 2.0 codec.
+//!
+//! This is the message framing used by JSON-RPC over stdio transports such as
+//! the Model Context Protocol (MCP): each message is prefixed with a
+//! `Content-Length: N\r\n\r\n` header followed by exactly `N` bytes of UTF-8
+//! JSON body.
+//!
+//! The framing codec ([`read_payload`], [`write_message`]) is serializer
+//! agnostic — it operates on raw strings. The JSON-RPC 2.0 envelope builders
+//! ([`build_result_message`], [`build_error_message`], [`build_notification`])
+//! are parameterized over a [`JsonRpcSerializer`] so this crate does not depend
+//! on any concrete JSON value type; the caller binds its own serializer.
+
+use std::io::{BufRead, Write};
+
+/// Read a JSON-RPC payload from a buffered reader.
+///
+/// Reads headers until it finds `Content-Length: N`, then reads exactly N
+/// bytes of body. Returns `None` on EOF and `Err` on malformed input.
+///
+/// Behavioral contract (must be preserved by any caller relying on it):
+/// the `Content-Length` header match is case-insensitive, the body is read
+/// with `read_exact` for exactly N bytes, and a single optional trailing
+/// `\r\n` (or bare `\n`) between messages is consumed.
+pub fn read_payload<R: BufRead>(reader: &mut R) -> Result<Option<String>, String> {
+    let mut content_length: Option<usize> = None;
+    let mut header = String::new();
+
+    loop {
+        header.clear();
+        let bytes = reader
+            .read_line(&mut header)
+            .map_err(|e| format!("failed to read header: {}", e))?;
+        if bytes == 0 {
+            return Ok(None);
+        }
+
+        let trimmed = header.trim_end_matches(['\n', '\r']);
+        if trimmed.is_empty() {
+            break;
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("content-length:") {
+            let value = trimmed["Content-Length:".len()..].trim();
+            let length = value
+                .parse::<usize>()
+                .map_err(|_| "invalid Content-Length header".to_string())?;
+            content_length = Some(length);
+        }
+    }
+
+    let length = content_length.ok_or_else(|| "missing Content-Length header".to_string())?;
+    let mut buffer = vec![0u8; length];
+    reader
+        .read_exact(&mut buffer)
+        .map_err(|e| format!("failed to read payload: {}", e))?;
+
+    // Consume optional trailing newline between messages.
+    if let Ok(buf) = reader.fill_buf() {
+        let to_consume = if buf.starts_with(b"\r\n") {
+            Some(2)
+        } else if buf.starts_with(b"\n") {
+            Some(1)
+        } else {
+            None
+        };
+        if let Some(count) = to_consume {
+            reader.consume(count);
+        }
+    }
+
+    String::from_utf8(buffer)
+        .map(Some)
+        .map_err(|_| "payload is not UTF-8".to_string())
+}
+
+/// Write a Content-Length framed JSON-RPC message to a writer.
+pub fn write_message<W: Write>(writer: &mut W, body: &str) -> Result<(), String> {
+    write!(writer, "Content-Length: {}\r\n\r\n{}", body.len(), body)
+        .map_err(|e| format!("failed to write response: {}", e))?;
+    writer
+        .flush()
+        .map_err(|e| format!("failed to flush: {}", e))
+}
+
+/// Abstraction over a JSON serializer so the JSON-RPC envelope builders do not
+/// depend on a concrete JSON value type.
+///
+/// The caller binds this to its own JSON value type. The envelope builders only
+/// require constructing nulls, strings, integer numbers, and objects, plus
+/// compact serialization. Object key ordering in the emitted bytes is entirely
+/// determined by the implementor's [`object`](JsonRpcSerializer::object) and
+/// [`to_compact_string`](JsonRpcSerializer::to_compact_string).
+pub trait JsonRpcSerializer {
+    /// The JSON value type produced by this serializer.
+    type Value: Clone;
+
+    /// A JSON `null`.
+    fn null() -> Self::Value;
+
+    /// A JSON string.
+    fn string(value: &str) -> Self::Value;
+
+    /// A JSON number from a signed integer.
+    fn number(value: i64) -> Self::Value;
+
+    /// A JSON object built from the given key/value entries, in order.
+    fn object(entries: Vec<(&'static str, Self::Value)>) -> Self::Value;
+
+    /// Serialize a value to a compact (whitespace-free) JSON string.
+    fn to_compact_string(value: &Self::Value) -> String;
+}
+
+/// Build a JSON-RPC 2.0 result message.
+///
+/// A `None` id is encoded as JSON `null`, matching the original transport.
+pub fn build_result_message<S: JsonRpcSerializer>(
+    id: Option<&S::Value>,
+    result: S::Value,
+) -> String {
+    let id_value = match id {
+        Some(identifier) => identifier.clone(),
+        None => S::null(),
+    };
+    let object = S::object(vec![
+        ("jsonrpc", S::string("2.0")),
+        ("id", id_value),
+        ("result", result),
+    ]);
+    S::to_compact_string(&object)
+}
+
+/// Build a JSON-RPC 2.0 error message.
+///
+/// A `None` id is encoded as JSON `null`, matching the original transport.
+pub fn build_error_message<S: JsonRpcSerializer>(
+    id: Option<&S::Value>,
+    code: i64,
+    message: &str,
+) -> String {
+    let error = S::object(vec![
+        ("code", S::number(code)),
+        ("message", S::string(message)),
+    ]);
+    let id_value = match id {
+        Some(identifier) => identifier.clone(),
+        None => S::null(),
+    };
+    let object = S::object(vec![
+        ("jsonrpc", S::string("2.0")),
+        ("id", id_value),
+        ("error", error),
+    ]);
+    S::to_compact_string(&object)
+}
+
+/// Build a JSON-RPC 2.0 notification (no id, no response expected).
+pub fn build_notification<S: JsonRpcSerializer>(method: &str, params: S::Value) -> String {
+    let object = S::object(vec![
+        ("jsonrpc", S::string("2.0")),
+        ("method", S::string(method)),
+        ("params", params),
+    ]);
+    S::to_compact_string(&object)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// Minimal self-contained JSON value + serializer for the framing tests.
+    ///
+    /// `Object` is backed by a `BTreeMap`, so it sorts keys on serialization —
+    /// mirroring `reddb-server`'s production serializer, which is what pins the
+    /// emitted field order.
+    #[derive(Clone)]
+    enum TestJson {
+        Null,
+        Number(i64),
+        Str(String),
+        Object(BTreeMap<String, TestJson>),
+    }
+
+    struct TestSerializer;
+
+    impl JsonRpcSerializer for TestSerializer {
+        type Value = TestJson;
+
+        fn null() -> TestJson {
+            TestJson::Null
+        }
+        fn string(value: &str) -> TestJson {
+            TestJson::Str(value.to_string())
+        }
+        fn number(value: i64) -> TestJson {
+            TestJson::Number(value)
+        }
+        fn object(entries: Vec<(&'static str, TestJson)>) -> TestJson {
+            let mut map = BTreeMap::new();
+            for (key, value) in entries {
+                map.insert(key.to_string(), value);
+            }
+            TestJson::Object(map)
+        }
+        fn to_compact_string(value: &TestJson) -> String {
+            let mut out = String::new();
+            write(value, &mut out);
+            out
+        }
+    }
+
+    fn write(value: &TestJson, out: &mut String) {
+        match value {
+            TestJson::Null => out.push_str("null"),
+            TestJson::Number(n) => out.push_str(&n.to_string()),
+            TestJson::Str(s) => {
+                out.push('"');
+                out.push_str(s);
+                out.push('"');
+            }
+            TestJson::Object(map) => {
+                out.push('{');
+                for (idx, (key, value)) in map.iter().enumerate() {
+                    if idx > 0 {
+                        out.push(',');
+                    }
+                    out.push('"');
+                    out.push_str(key);
+                    out.push('"');
+                    out.push(':');
+                    write(value, out);
+                }
+                out.push('}');
+            }
+        }
+    }
+
+    #[test]
+    fn test_read_payload_basic() {
+        let body = r#"{"id":1}"#;
+        let msg = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+        let mut reader = std::io::BufReader::new(msg.as_bytes());
+        let payload = read_payload(&mut reader).unwrap();
+        assert_eq!(payload, Some(body.to_string()));
+    }
+
+    #[test]
+    fn test_read_payload_eof() {
+        let input = b"";
+        let mut reader = std::io::BufReader::new(&input[..]);
+        let payload = read_payload(&mut reader).unwrap();
+        assert!(payload.is_none());
+    }
+
+    #[test]
+    fn test_read_payload_case_insensitive_header() {
+        let body = r#"{"ok":true}"#;
+        let msg = format!("content-LENGTH: {}\r\n\r\n{}", body.len(), body);
+        let mut reader = std::io::BufReader::new(msg.as_bytes());
+        let payload = read_payload(&mut reader).unwrap();
+        assert_eq!(payload, Some(body.to_string()));
+    }
+
+    #[test]
+    fn test_read_payload_consumes_trailing_newline_and_reads_next() {
+        // Two back-to-back messages separated by a bare "\n": the trailing
+        // newline after the first body must be consumed so the second frame
+        // parses cleanly.
+        let first = r#"{"n":1}"#;
+        let second = r#"{"n":2}"#;
+        let msg = format!(
+            "Content-Length: {}\r\n\r\n{}\nContent-Length: {}\r\n\r\n{}",
+            first.len(),
+            first,
+            second.len(),
+            second
+        );
+        let mut reader = std::io::BufReader::new(msg.as_bytes());
+        assert_eq!(read_payload(&mut reader).unwrap(), Some(first.to_string()));
+        assert_eq!(read_payload(&mut reader).unwrap(), Some(second.to_string()));
+    }
+
+    #[test]
+    fn test_write_message_framing_roundtrip() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":true}"#;
+        let mut buffer = Vec::new();
+        write_message(&mut buffer, body).unwrap();
+        let written = String::from_utf8(buffer).unwrap();
+        assert_eq!(
+            written,
+            format!("Content-Length: {}\r\n\r\n{}", body.len(), body)
+        );
+
+        // Frame survives a read_payload round-trip.
+        let mut reader = std::io::BufReader::new(written.as_bytes());
+        assert_eq!(read_payload(&mut reader).unwrap(), Some(body.to_string()));
+    }
+
+    #[test]
+    fn test_build_result_message_field_order() {
+        let id = TestJson::Number(1);
+        let msg =
+            build_result_message::<TestSerializer>(Some(&id), TestJson::Str("ok".to_string()));
+        // BTreeMap sorts keys: id, jsonrpc, result.
+        assert_eq!(msg, r#"{"id":1,"jsonrpc":"2.0","result":"ok"}"#);
+    }
+
+    #[test]
+    fn test_build_result_message_null_id() {
+        let msg = build_result_message::<TestSerializer>(None, TestJson::Null);
+        assert_eq!(msg, r#"{"id":null,"jsonrpc":"2.0","result":null}"#);
+    }
+
+    #[test]
+    fn test_build_error_message_field_order() {
+        let id = TestJson::Number(2);
+        let msg = build_error_message::<TestSerializer>(Some(&id), -32601, "method not found");
+        assert_eq!(
+            msg,
+            r#"{"error":{"code":-32601,"message":"method not found"},"id":2,"jsonrpc":"2.0"}"#
+        );
+    }
+
+    #[test]
+    fn test_build_notification_field_order() {
+        let msg = build_notification::<TestSerializer>("test/event", TestJson::Null);
+        assert_eq!(
+            msg,
+            r#"{"jsonrpc":"2.0","method":"test/event","params":null}"#
+        );
+    }
+}

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod auth;
 pub mod conn_string;
+pub mod jsonrpc;
 pub mod legacy;
 pub mod query_with_params;
 pub mod redwire;


### PR DESCRIPTION
Automated AFK landing for #1054. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783776859&installation_id=129708444&pr_number=1091&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1091&signature=8713b36d6df5a882800b898098f73a6a671d94a647834a697defe06cab459900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added JSON-RPC 2.0 codec with Content-Length framing for reliable message transmission
  * Implemented deterministic JSON serialization ensuring consistent message formatting across requests

* **Refactor**
  * Consolidated server protocol handling with shared wire layer for unified JSON-RPC message building

<!-- end of auto-generated comment: release notes by coderabbit.ai -->