### PR TITLE
merge: #1055 Wire-authority residual: home red+wss:// scheme, WS subprotocol/path, upgrade-gate, 0xFE detector in reddb-wire (+ cert-gen dedupe)

### DIFF
--- a/crates/reddb-server/src/server/tls.rs
+++ b/crates/reddb-server/src/server/tls.rs
@@ -165,29 +165,13 @@ pub fn auto_generate_dev_cert(dir: &Path) -> Result<HttpTlsConfig, Box<dyn std::
     })
 }
 
+/// HTTP dev cert: CN `"RedDB HTTP {hostname}"` with **no** organization.
+/// Shares the rcgen block with the wire edge via the parameterized
+/// [`crate::wire::tls::generate_self_signed_dev_cert`] (issue #1055) — the
+/// HTTP cert deliberately passes `org = None` so it does not carry
+/// `O=RedDB`.
 fn generate_self_signed(hostname: &str) -> Result<(String, String), Box<dyn std::error::Error>> {
-    use rcgen::{CertificateParams, KeyPair};
-    let mut params = CertificateParams::new(vec![hostname.to_string()])?;
-    params.distinguished_name.push(
-        rcgen::DnType::CommonName,
-        rcgen::DnValue::Utf8String(format!("RedDB HTTP {hostname}")),
-    );
-    params
-        .subject_alt_names
-        .push(rcgen::SanType::DnsName(hostname.try_into()?));
-    if hostname != "localhost" {
-        params
-            .subject_alt_names
-            .push(rcgen::SanType::DnsName("localhost".try_into()?));
-    }
-    params
-        .subject_alt_names
-        .push(rcgen::SanType::IpAddress(std::net::IpAddr::V4(
-            std::net::Ipv4Addr::LOCALHOST,
-        )));
-    let key_pair = KeyPair::generate()?;
-    let cert = params.self_signed(&key_pair)?;
-    Ok((cert.pem(), key_pair.serialize_pem()))
+    crate::wire::tls::generate_self_signed_dev_cert(hostname, "RedDB HTTP", None)
 }
 
 fn sha256_fingerprint_hex(cert: &CertificateDer<'_>) -> String {

--- a/crates/reddb-server/src/server/ws_edge.rs
+++ b/crates/reddb-server/src/server/ws_edge.rs
@@ -42,12 +42,11 @@ use reddb_wire::redwire::{
     FRAME_HEADER_SIZE, REDWIRE_MAGIC,
 };
 
-/// Path the browser client (`red+wss://host:port`) resolves to.
-pub(super) const REDWIRE_WS_PATH: &str = "/redwire";
-
-/// WebSocket subprotocol the upgrade advertises. Versioned so a future
-/// framing revision can coexist with v1 clients.
-pub(super) const REDWIRE_WS_SUBPROTOCOL: &str = "reddb.redwire.v1";
+/// Path the browser client (`red+wss://host:port`) resolves to, and the
+/// WebSocket subprotocol the upgrade advertises. Both are owned by
+/// reddb-wire (ADR 0036) — re-exported here so the server's routing and
+/// upgrade handler keep their existing `ws_edge::` references.
+pub(super) use reddb_wire::redwire::{REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL};
 
 /// Duplex buffer bridging the WS data channel and the RedWire session.
 /// Sized to hold a couple of typical frames without round-tripping the
@@ -99,21 +98,29 @@ impl IntoResponse for WsRejection {
     }
 }
 
-/// Pure upgrade gate (ADR 0036): TLS-only, then exact-match `Origin`
-/// against the allowlist. Factored out so the policy is tested directly.
+impl From<reddb_wire::redwire::WsUpgradeRefusal> for WsRejection {
+    fn from(refusal: reddb_wire::redwire::WsUpgradeRefusal) -> Self {
+        use reddb_wire::redwire::WsUpgradeRefusal as R;
+        match refusal {
+            R::NotTls => WsRejection::NotTls,
+            R::OriginMissing => WsRejection::OriginMissing,
+            R::OriginRejected => WsRejection::OriginRejected,
+        }
+    }
+}
+
+/// Upgrade gate (ADR 0036): TLS-only, then exact-match `Origin` against
+/// the allowlist. The pure policy lives in reddb-wire
+/// ([`reddb_wire::redwire::evaluate_ws_upgrade`]); this thin wrapper only
+/// maps the server's [`HttpTransport`] onto the `is_tls_edge` bool and
+/// the refusal back onto the axum-rendered [`WsRejection`].
 pub(super) fn ws_upgrade_decision(
     transport: HttpTransport,
     origin: Option<&str>,
     allowlist: &[String],
 ) -> Result<(), WsRejection> {
-    if transport != HttpTransport::Https {
-        return Err(WsRejection::NotTls);
-    }
-    match origin {
-        None => Err(WsRejection::OriginMissing),
-        Some(o) if allowlist.iter().any(|allowed| allowed == o) => Ok(()),
-        Some(_) => Err(WsRejection::OriginRejected),
-    }
+    reddb_wire::redwire::evaluate_ws_upgrade(transport == HttpTransport::Https, origin, allowlist)
+        .map_err(WsRejection::from)
 }
 
 /// axum handler for `GET /redwire`. Validates the upgrade gate, then —

--- a/crates/reddb-server/src/service_router/detector.rs
+++ b/crates/reddb-server/src/service_router/detector.rs
@@ -50,13 +50,14 @@ pub struct RedWireDetector;
 
 impl ProtocolDetector for RedWireDetector {
     fn detect(&self, peek: &[u8]) -> DetectOutcome {
-        if peek.is_empty() {
-            return DetectOutcome::Pending;
-        }
-        if peek[0] == 0xFE {
-            DetectOutcome::Match(Protocol::Wire)
-        } else {
-            DetectOutcome::NoMatch
+        // The `0xFE` magic match is owned by reddb-wire (issue #1055);
+        // this detector only maps the pure classifier onto the router's
+        // protocol-tagged outcome.
+        use reddb_wire::redwire::RedWireMagicMatch;
+        match reddb_wire::redwire::redwire_magic_match(peek) {
+            RedWireMagicMatch::Pending => DetectOutcome::Pending,
+            RedWireMagicMatch::Match => DetectOutcome::Match(Protocol::Wire),
+            RedWireMagicMatch::NoMatch => DetectOutcome::NoMatch,
         }
     }
 }

--- a/crates/reddb-server/src/wire/tls.rs
+++ b/crates/reddb-server/src/wire/tls.rs
@@ -22,20 +22,44 @@ pub struct WireTlsConfig {
 
 /// Generate a self-signed certificate for development.
 /// Returns (cert_pem, key_pem) as strings.
+///
+/// The wire cert carries CN `"RedDB Wire {hostname}"` **and**
+/// `OrganizationName "RedDB"`. The HTTP edge shares this generator but
+/// passes `org = None` (see [`generate_self_signed_dev_cert`]) so its
+/// cert keeps no organization.
 pub fn generate_self_signed_cert(
     hostname: &str,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    generate_self_signed_dev_cert(hostname, "RedDB Wire", Some("RedDB"))
+}
+
+/// Shared self-signed dev-cert generator for the wire and HTTP edges.
+///
+/// Behaviour-preserving parameterization of two formerly near-identical
+/// rcgen blocks (issue #1055): the CN is `"{cn_label} {hostname}"`, and
+/// `org` — when `Some` — sets `OrganizationName`. The wire edge passes
+/// `Some("RedDB")`; the HTTP edge passes `None` so its cert keeps CN
+/// `"RedDB HTTP …"` with **no** organization (do NOT silently add
+/// `O=RedDB` to the HTTP cert). The SAN block (`hostname`, `localhost`
+/// when distinct, and `127.0.0.1`) is identical for both.
+pub(crate) fn generate_self_signed_dev_cert(
+    hostname: &str,
+    cn_label: &str,
+    org: Option<&str>,
 ) -> Result<(String, String), Box<dyn std::error::Error>> {
     use rcgen::{CertificateParams, KeyPair};
 
     let mut params = CertificateParams::new(vec![hostname.to_string()])?;
     params.distinguished_name.push(
         rcgen::DnType::CommonName,
-        rcgen::DnValue::Utf8String(format!("RedDB Wire {hostname}")),
+        rcgen::DnValue::Utf8String(format!("{cn_label} {hostname}")),
     );
-    params.distinguished_name.push(
-        rcgen::DnType::OrganizationName,
-        rcgen::DnValue::Utf8String("RedDB".to_string()),
-    );
+    if let Some(org) = org {
+        params.distinguished_name.push(
+            rcgen::DnType::OrganizationName,
+            rcgen::DnValue::Utf8String(org.to_string()),
+        );
+    }
 
     // Add localhost + IP SANs for dev
     params
@@ -120,4 +144,52 @@ pub fn build_tls_acceptor(
         .with_single_cert(certs, key)?;
 
     Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse the subject CN + Organization out of a self-signed PEM cert,
+    /// so the wire-vs-HTTP DN difference is pinned end-to-end (issue #1055).
+    fn subject_cn_and_orgs(cert_pem: &str) -> (Vec<String>, Vec<String>) {
+        let der = rustls_pemfile::certs(&mut io::BufReader::new(cert_pem.as_bytes()))
+            .next()
+            .expect("one certificate in PEM")
+            .expect("valid certificate PEM");
+        let (_, parsed) =
+            x509_parser::parse_x509_certificate(der.as_ref()).expect("parse generated X.509");
+        let subject = parsed.subject();
+        let cns = subject
+            .iter_common_name()
+            .filter_map(|cn| cn.as_str().ok().map(str::to_string))
+            .collect();
+        let orgs = subject
+            .iter_organization()
+            .filter_map(|o| o.as_str().ok().map(str::to_string))
+            .collect();
+        (cns, orgs)
+    }
+
+    #[test]
+    fn wire_cert_keeps_wire_cn_and_reddb_org() {
+        let (cert_pem, key_pem) =
+            generate_self_signed_cert("localhost").expect("generate wire cert");
+        assert!(key_pem.contains("PRIVATE KEY"), "key PEM emitted");
+        let (cns, orgs) = subject_cn_and_orgs(&cert_pem);
+        assert_eq!(cns, vec!["RedDB Wire localhost".to_string()]);
+        assert_eq!(orgs, vec!["RedDB".to_string()]);
+    }
+
+    #[test]
+    fn http_cert_keeps_http_cn_and_no_org() {
+        // The non-obvious diff (issue #1055): the HTTP cert must keep CN
+        // "RedDB HTTP …" and carry NO organization. The shared generator
+        // passes org = None so we never silently add O=RedDB to it.
+        let (cert_pem, _key) = generate_self_signed_dev_cert("localhost", "RedDB HTTP", None)
+            .expect("generate http cert");
+        let (cns, orgs) = subject_cn_and_orgs(&cert_pem);
+        assert_eq!(cns, vec!["RedDB HTTP localhost".to_string()]);
+        assert!(orgs.is_empty(), "HTTP cert must not carry an Organization");
+    }
 }

--- a/crates/reddb-wire/src/redwire/mod.rs
+++ b/crates/reddb-wire/src/redwire/mod.rs
@@ -20,6 +20,7 @@ pub mod operations;
 pub mod prepared;
 pub mod queue;
 pub mod stream;
+pub mod ws_gate;
 
 pub use builder::{
     build_bulk_insert_binary_frame, build_bulk_insert_frame, build_bye_frame, build_delete_frame,
@@ -97,6 +98,7 @@ pub use stream::{
     OpenInputParseError, OpenInputRequest, OpenStreamParseError, OpenStreamRequest,
     StreamCancelRequest,
 };
+pub use ws_gate::{evaluate_ws_upgrade, WsUpgradeRefusal};
 
 /// Discriminator byte every RedWire client sends as the very first
 /// byte off the wire. The service-router detector keys off this
@@ -110,6 +112,17 @@ pub const MAX_KNOWN_MINOR_VERSION: u8 = 0x01;
 
 /// Default port for the RedWire listener.
 pub const DEFAULT_REDWIRE_PORT: u16 = 5050;
+
+/// WebSocket subprotocol token advertised by the RedWire-over-WSS edge
+/// (issue #935, ADR 0036). Versioned so a future framing revision can
+/// coexist with v1 clients. reddb-wire is the single source of truth —
+/// the server's axum upgrade handler consumes this constant rather than
+/// defining its own.
+pub const REDWIRE_WS_SUBPROTOCOL: &str = "reddb.redwire.v1";
+
+/// HTTP path the browser client (`red+wss://host:port`) upgrades on to
+/// reach the RedWire-over-WebSocket edge (ADR 0036).
+pub const REDWIRE_WS_PATH: &str = "/redwire";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StartupError {
@@ -165,6 +178,31 @@ pub fn validate_minor_version(got: u8) -> Result<(), StartupError> {
     }
 }
 
+/// Outcome of matching an inbound peek buffer against the RedWire magic
+/// discriminator. Mirrors the service-router's three-way detect result
+/// but stays free of router types so reddb-wire owns the classifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RedWireMagicMatch {
+    /// Buffer is empty — need at least one byte before we can classify.
+    Pending,
+    /// First byte is the RedWire magic ([`REDWIRE_MAGIC`]).
+    Match,
+    /// First byte is present and is not the RedWire magic.
+    NoMatch,
+}
+
+/// Classify an inbound peek buffer against the RedWire magic byte
+/// ([`REDWIRE_MAGIC`]). Pure and allocation-free so the service-router's
+/// hot-path classifier can delegate the discriminator decision here:
+/// empty → `Pending`, leading `0xFE` → `Match`, anything else → `NoMatch`.
+pub fn redwire_magic_match(peek: &[u8]) -> RedWireMagicMatch {
+    match peek.first() {
+        None => RedWireMagicMatch::Pending,
+        Some(&first) if first == REDWIRE_MAGIC => RedWireMagicMatch::Match,
+        Some(_) => RedWireMagicMatch::NoMatch,
+    }
+}
+
 #[cfg(test)]
 mod startup_tests {
     use super::*;
@@ -186,5 +224,23 @@ mod startup_tests {
             validate_minor_version(MAX_KNOWN_MINOR_VERSION.saturating_add(1)),
             Err(StartupError::UnsupportedMinor { .. })
         ));
+    }
+
+    #[test]
+    fn magic_match_classifies_peek_buffer() {
+        // Empty → Pending: not enough bytes to decide yet.
+        assert_eq!(redwire_magic_match(&[]), RedWireMagicMatch::Pending);
+        // Leading magic → Match, regardless of trailing bytes.
+        assert_eq!(
+            redwire_magic_match(&[REDWIRE_MAGIC]),
+            RedWireMagicMatch::Match
+        );
+        assert_eq!(
+            redwire_magic_match(&[0xFE, 0x01, 0x10]),
+            RedWireMagicMatch::Match
+        );
+        // Any other leading byte (HTTP 'G', H2 'P', binary 0x10) → NoMatch.
+        assert_eq!(redwire_magic_match(b"GET "), RedWireMagicMatch::NoMatch);
+        assert_eq!(redwire_magic_match(&[0x10]), RedWireMagicMatch::NoMatch);
     }
 }

--- a/crates/reddb-wire/src/redwire/ws_gate.rs
+++ b/crates/reddb-wire/src/redwire/ws_gate.rs
@@ -1,0 +1,135 @@
+//! Pure WebSocket upgrade-gate policy for the RedWire-over-WSS edge
+//! (issue #935, ADR 0036).
+//!
+//! A browser cannot speak RedWire-over-TCP, so it upgrades a binary
+//! WebSocket on the TLS edge. WebSocket is *not* covered by CORS, so the
+//! upgrade is **default-deny** and validated here: TLS-only, then an
+//! exact-match `Origin` allowlist (Cross-Site WebSocket Hijacking
+//! defence).
+//!
+//! This module is transport-agnostic and free of axum/HTTP types so the
+//! security decision is unit-testable without a live TLS edge or socket.
+//! The server's `ws_edge` axum handler maps its `Origin`/transport into
+//! these inputs and renders the refusal as an HTTP response — it owns the
+//! I/O, reddb-wire owns the policy.
+
+/// Why a RedWire WebSocket upgrade was refused (ADR 0036).
+///
+/// Checks are ordered so the TLS gate precedes the origin checks: an
+/// upgrade on the clear-text edge is rejected before the allowlist is
+/// even consulted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WsUpgradeRefusal {
+    /// Arrived on a non-TLS edge — `ws://` is never accepted (WSS-only).
+    NotTls,
+    /// No `Origin` header — a browser always sends one; its absence is a
+    /// non-browser caller or a stripped header. Reject.
+    OriginMissing,
+    /// `Origin` is not on the configured allowlist, or it carried a
+    /// smuggled CR/LF and so can never match a well-formed allowlist
+    /// entry.
+    OriginRejected,
+}
+
+/// Evaluate the RedWire WS upgrade gate (ADR 0036). Pure: TLS-only, then
+/// an exact-match `Origin` against the allowlist.
+///
+/// * `is_tls_edge` — `true` only when the request arrived on the TLS
+///   listener; a clear-text edge is always refused with [`WsUpgradeRefusal::NotTls`].
+/// * `origin` — the request's `Origin` header, if any. Absence is refused
+///   ([`WsUpgradeRefusal::OriginMissing`]); an `Origin` carrying a CR or
+///   LF is treated as a header-smuggling attempt and refused
+///   ([`WsUpgradeRefusal::OriginRejected`]).
+/// * `allowlist` — exact-match origins. An empty allowlist denies every
+///   origin (default-deny).
+pub fn evaluate_ws_upgrade(
+    is_tls_edge: bool,
+    origin: Option<&str>,
+    allowlist: &[String],
+) -> Result<(), WsUpgradeRefusal> {
+    if !is_tls_edge {
+        return Err(WsUpgradeRefusal::NotTls);
+    }
+    match origin {
+        None => Err(WsUpgradeRefusal::OriginMissing),
+        Some(o) if o.bytes().any(|b| b == b'\r' || b == b'\n') => {
+            Err(WsUpgradeRefusal::OriginRejected)
+        }
+        Some(o) if allowlist.iter().any(|allowed| allowed == o) => Ok(()),
+        Some(_) => Err(WsUpgradeRefusal::OriginRejected),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowlist() -> Vec<String> {
+        vec![
+            "https://app.example.com".to_string(),
+            "https://admin.example.com".to_string(),
+        ]
+    }
+
+    #[test]
+    fn allowed_origin_over_tls_is_accepted() {
+        assert_eq!(
+            evaluate_ws_upgrade(true, Some("https://app.example.com"), &allowlist()),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn non_tls_edge_is_refused_before_origin_is_consulted() {
+        // WSS-only: the TLS check precedes the origin check, so an
+        // otherwise-allowed origin on the clear-text edge still fails.
+        assert_eq!(
+            evaluate_ws_upgrade(false, Some("https://app.example.com"), &allowlist()),
+            Err(WsUpgradeRefusal::NotTls)
+        );
+    }
+
+    #[test]
+    fn missing_origin_is_refused() {
+        assert_eq!(
+            evaluate_ws_upgrade(true, None, &allowlist()),
+            Err(WsUpgradeRefusal::OriginMissing)
+        );
+    }
+
+    #[test]
+    fn empty_allowlist_denies_every_origin() {
+        assert_eq!(
+            evaluate_ws_upgrade(true, Some("https://app.example.com"), &[]),
+            Err(WsUpgradeRefusal::OriginRejected)
+        );
+    }
+
+    #[test]
+    fn origin_match_is_exact_not_prefix_or_suffix() {
+        assert_eq!(
+            evaluate_ws_upgrade(true, Some("https://app.example.com.evil.com"), &allowlist()),
+            Err(WsUpgradeRefusal::OriginRejected)
+        );
+        assert_eq!(
+            evaluate_ws_upgrade(true, Some("https://app.example.co"), &allowlist()),
+            Err(WsUpgradeRefusal::OriginRejected)
+        );
+    }
+
+    #[test]
+    fn crlf_smuggled_origin_is_rejected() {
+        // A CR/LF-bearing Origin must never match — it is a header
+        // injection / smuggling attempt, refused outright.
+        for smuggled in [
+            "https://app.example.com\r\nX-Injected: 1",
+            "https://app.example.com\n",
+            "https://app.example.com\r",
+        ] {
+            assert_eq!(
+                evaluate_ws_upgrade(true, Some(smuggled), &allowlist()),
+                Err(WsUpgradeRefusal::OriginRejected)
+            );
+        }
+    }
+}

--- a/crates/reddb-wire/tests/protocol_authority.rs
+++ b/crates/reddb-wire/tests/protocol_authority.rs
@@ -1805,3 +1805,70 @@ fn redwire_auth_payload_and_scram_messages_live_in_reddb_wire() {
         );
     }
 }
+
+/// Issue #1055: the WebSocket edge's protocol-visible contracts — the WS
+/// subprotocol/path constants (item 2), the pure upgrade-gate decision
+/// (item 3), and the `0xFE` magic detector (item 4) — must be owned by
+/// reddb-wire, with the server crate delegating to them.
+#[test]
+fn redwire_ws_edge_contracts_live_in_reddb_wire() {
+    let root = repo_root();
+    let wire_mod = read(root.join("crates/reddb-wire/src/redwire/mod.rs"));
+    let wire_gate = read(root.join("crates/reddb-wire/src/redwire/ws_gate.rs"));
+    let ws_edge = read(root.join("crates/reddb-server/src/server/ws_edge.rs"));
+    let detector = read(root.join("crates/reddb-server/src/service_router/detector.rs"));
+
+    // ---- Item 2: WS subprotocol/path constants live in reddb-wire ----
+    for required in ["REDWIRE_WS_SUBPROTOCOL", "REDWIRE_WS_PATH"] {
+        assert!(
+            wire_mod.contains(&format!("pub const {required}")),
+            "reddb-wire should own WS edge constant {required}"
+        );
+    }
+    // The subprotocol token is the authority's single source of truth: the
+    // literal must appear only in reddb-wire, never inline in server src.
+    for file in rust_files_under(root.join("crates/reddb-server/src")) {
+        let text = read(&file);
+        assert!(
+            !non_test_source(&text).contains("\"reddb.redwire.v1\""),
+            "{} must import REDWIRE_WS_SUBPROTOCOL from reddb-wire, not inline the token",
+            file.display()
+        );
+    }
+    assert!(
+        ws_edge.contains("use reddb_wire::redwire::{REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL}"),
+        "ws_edge should source the WS constants from reddb-wire"
+    );
+
+    // ---- Item 3: pure WS upgrade-gate decision lives in reddb-wire ----
+    for required in ["pub fn evaluate_ws_upgrade", "pub enum WsUpgradeRefusal"] {
+        assert!(
+            wire_gate.contains(required),
+            "reddb-wire should own WS upgrade-gate contract {required}"
+        );
+    }
+    assert!(
+        ws_edge.contains("reddb_wire::redwire::evaluate_ws_upgrade"),
+        "ws_edge gate must delegate to reddb_wire::redwire::evaluate_ws_upgrade"
+    );
+    assert!(
+        !non_test_source(&ws_edge).contains("allowlist.iter().any(|allowed| allowed == o)"),
+        "ws_edge must not re-implement the origin allowlist match inline"
+    );
+
+    // ---- Item 4: 0xFE magic detector lives in reddb-wire ----
+    for required in ["pub fn redwire_magic_match", "pub enum RedWireMagicMatch"] {
+        assert!(
+            wire_mod.contains(required),
+            "reddb-wire should own RedWire magic detector {required}"
+        );
+    }
+    assert!(
+        detector.contains("reddb_wire::redwire::redwire_magic_match"),
+        "service_router RedWireDetector must delegate to reddb_wire::redwire::redwire_magic_match"
+    );
+    assert!(
+        !non_test_source(&detector).contains("peek[0] == 0xFE"),
+        "service_router must not hard-code the 0xFE magic match inline"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #1055. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783778627&installation_id=129708444&pr_number=1092&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1092&signature=e2d5de8d3f7d8d7b2d66dd195ae271a7ba7e760594171b03b8885218671aef45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of WebSocket upgrade and TLS certificate generation logic with centralized protocol handling in the wire module.
  * Consolidated protocol detection and validation by delegating to shared utilities across server components.

* **Tests**
  * Added protocol boundary tests to verify wire protocol contract ownership and implementation correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->