### PR TITLE
merge: #1064 reddb-io-types S4: authority fence test + llvm-cov coverage reporting

### DIFF
--- a/.github/workflows/types-coverage.yml
+++ b/.github/workflows/types-coverage.yml
@@ -1,0 +1,129 @@
+name: Types Coverage
+
+# Report-only llvm-cov signal for the reddb-io-types keystone crate
+# (ADR 0052, PRD #1060). Aspirational target is ~95%+, but this workflow
+# NEVER blocks merge — it only surfaces the number in the job summary and,
+# on PRs, as an advisory comment. A hard merge gate is explicitly out of
+# scope per the PRD's Human Decisions.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/reddb-types/**'
+      - '.github/workflows/types-coverage.yml'
+  pull_request:
+    paths:
+      - 'crates/reddb-types/**'
+      - '.github/workflows/types-coverage.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: types-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  types-coverage:
+    name: Types Coverage Report
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 20
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@1.91.0
+        with:
+          components: llvm-tools-preview
+
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-rust-1.91.0-llvm-cov
+          cache-on-failure: "true"
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage (reddb-io-types)
+        run: |
+          # Collect profdata once, then render it twice (text table + JSON
+          # totals) without re-running the tests. reddb-io-types depends on no
+          # other workspace crate, so this is a fast, self-contained measure.
+          cargo llvm-cov --no-report -p reddb-io-types
+          cargo llvm-cov report --summary-only | tee coverage-summary.txt
+          cargo llvm-cov report --json --summary-only > coverage-summary.json
+
+      - name: Build report
+        id: report
+        run: |
+          # Pull the headline line-coverage percentage straight from the JSON
+          # totals — robust against column-layout changes in the text table.
+          total_line=$(python3 -c "import json; print(f\"{json.load(open('coverage-summary.json'))['data'][0]['totals']['lines']['percent']:.2f}%\")" 2>/dev/null || echo "n/a")
+
+          {
+            echo "## Types Coverage Report"
+            echo ""
+            echo "Crate: \`reddb-io-types\` — line coverage: **${total_line}** (target ~95%, advisory)"
+            echo ""
+            echo '```'
+            cat coverage-summary.txt
+            echo '```'
+            echo ""
+            echo "> ℹ️ Report-only — this never blocks merge (ADR 0052 / PRD #1060)."
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-types --summary-only\`"
+          } > coverage-report.md
+
+          # Mirror to the job summary so the signal is visible without a PR.
+          cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+
+          # Expose the rendered body for the PR-comment step.
+          {
+            echo "body<<TYPES_COV_EOF"
+            echo "<!-- types-coverage-comment -->"
+            cat coverage-report.md
+            echo "TYPES_COV_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Post or update PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- types-coverage-comment -->';
+            const body = `${{ steps.report.outputs.body }}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/crates/reddb-types/tests/type_authority.rs
+++ b/crates/reddb-types/tests/type_authority.rs
@@ -1,0 +1,208 @@
+//! Authority fence for the logical type system (ADR 0052, PRD #1060).
+//!
+//! `reddb-io-types` is the neutral keystone crate that owns the logical type
+//! vocabulary — `Value`, `DataType`, `SqlTypeName`, `TypeModifier`,
+//! `TypeCategory`, `ValueError`, `Row` — and the coercion entry points
+//! (`coerce`, `find_cast`, the spine resolvers). The server tree may only
+//! *re-export* those items through its `storage::schema` shim; it must never
+//! *declare* them again.
+//!
+//! This mirrors the layout-authority prior art in `reddb-file`'s test suite
+//! (`tests/layout_authority/boundary.rs`): a mechanical fence that fails the
+//! instant a forbidden redeclaration reappears in the server source tree.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("crates/reddb-types has workspace root two levels up")
+        .to_path_buf()
+}
+
+fn read(path: impl AsRef<Path>) -> String {
+    fs::read_to_string(path.as_ref())
+        .unwrap_or_else(|err| panic!("read {}: {err}", path.as_ref().display()))
+}
+
+/// Drop the `#[cfg(test)]` tail so a test module's local fixtures never trip
+/// the fence. Matches the `reddb-file` prior art's helper of the same name.
+fn non_test_source(text: &str) -> &str {
+    text.split("#[cfg(test)]").next().unwrap_or(text)
+}
+
+fn rust_files_under(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries =
+            fs::read_dir(&path).unwrap_or_else(|err| panic!("read_dir {}: {err}", path.display()));
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// True when `text` *declares* a type named `name` (as opposed to re-exporting
+/// it via `pub use`). Trailing-delimiter forms give a cheap word boundary so a
+/// longer identifier like `DataTypeRegistry` does not match `DataType`.
+fn declares_type(text: &str, name: &str) -> bool {
+    ["enum", "struct"].iter().any(|kind| {
+        [" ", "{", "<", "("]
+            .iter()
+            .any(|suffix| text.contains(&format!("{kind} {name}{suffix}")))
+    })
+}
+
+/// True when `text` declares a free function (or method) named `name`.
+/// Re-exports use `pub use`, never `fn name(`, so this only fires on a real
+/// redeclaration of a coercion entry point.
+fn declares_fn(text: &str, name: &str) -> bool {
+    text.contains(&format!("fn {name}("))
+}
+
+/// The types crate is the sole declaration site for the logical vocabulary.
+/// Anchors the positive side of the boundary so the fence below has meaning.
+#[test]
+fn types_crate_owns_the_logical_type_system() {
+    let root = repo_root();
+    let types_rs = read(root.join("crates/reddb-types/src/types.rs"));
+    for name in [
+        "Value",
+        "DataType",
+        "TypeModifier",
+        "TypeCategory",
+        "ValueError",
+    ] {
+        assert!(
+            declares_type(&types_rs, name),
+            "reddb-types/src/types.rs must declare the `{name}` enum"
+        );
+    }
+    for name in ["SqlTypeName", "Row"] {
+        assert!(
+            declares_type(&types_rs, name),
+            "reddb-types/src/types.rs must declare the `{name}` struct"
+        );
+    }
+
+    let coerce_rs = read(root.join("crates/reddb-types/src/coerce.rs"));
+    assert!(
+        declares_fn(&coerce_rs, "coerce"),
+        "reddb-types/src/coerce.rs must declare the `coerce` entry point"
+    );
+    let cast_rs = read(root.join("crates/reddb-types/src/cast_catalog.rs"));
+    assert!(
+        declares_fn(&cast_rs, "find_cast"),
+        "reddb-types/src/cast_catalog.rs must declare the `find_cast` entry point"
+    );
+    let spine_rs = read(root.join("crates/reddb-types/src/coercion_spine.rs"));
+    assert!(
+        declares_fn(&spine_rs, "resolve_function"),
+        "reddb-types/src/coercion_spine.rs must declare the `resolve_function` entry point"
+    );
+}
+
+/// The fence: the server source tree must never redeclare a logical
+/// type-system item. Reintroduce any declaration below and this test fails.
+#[test]
+fn server_must_not_redeclare_the_logical_type_system() {
+    let root = repo_root();
+    let server_src = root.join("crates/reddb-server/src");
+
+    // Distinctive type-system names — they have zero legitimate collisions in
+    // the server, so the fence applies tree-wide.
+    const TYPE_NAMES: &[&str] = &[
+        "DataType",
+        "SqlTypeName",
+        "TypeModifier",
+        "TypeCategory",
+        "ValueError",
+    ];
+    // Coercion entry points re-homed into reddb-types (ADR 0052).
+    const COERCION_FNS: &[&str] = &[
+        "coerce",
+        "coerce_via_catalog",
+        "find_cast",
+        "can_implicit_cast",
+        "can_explicit_cast",
+        "can_assignment_cast",
+        "resolve_function",
+        "resolve_binop",
+        "resolve_cast",
+    ];
+
+    for path in rust_files_under(&server_src) {
+        let raw = read(&path);
+        let text = non_test_source(&raw);
+        let rel = path.strip_prefix(&root).unwrap_or(path.as_path());
+
+        for name in TYPE_NAMES {
+            assert!(
+                !declares_type(text, name),
+                "{} declares `{name}`; re-export `reddb_types::{name}` instead of redeclaring it",
+                rel.display()
+            );
+        }
+        for name in COERCION_FNS {
+            assert!(
+                !declares_fn(text, name),
+                "{} declares coercion entry point `{name}`; call `reddb_types::{name}` instead",
+                rel.display()
+            );
+        }
+    }
+
+    // `Value` and `Row` are generic names the server legitimately reuses for
+    // unrelated domains — the JSON value (`serde_json.rs`) and the graph
+    // binding value (`storage/query/engine/binding.rs`). The *logical* SQL
+    // `Value`/`Row` historically lived in `storage::schema`, which is now a
+    // pure re-export shim. Fence those two names there: the only way to
+    // reintroduce the logical type into the server is to redeclare it in the
+    // schema module, and this catches exactly that.
+    let schema = server_src.join("storage/schema");
+    for path in rust_files_under(&schema) {
+        let raw = read(&path);
+        let text = non_test_source(&raw);
+        let rel = path.strip_prefix(&root).unwrap_or(path.as_path());
+        for name in ["Value", "Row"] {
+            assert!(
+                !declares_type(text, name),
+                "{} declares `{name}`; the logical type lives in reddb_types — re-export it",
+                rel.display()
+            );
+        }
+    }
+}
+
+/// The `storage::schema` shims must stay pure re-exports of the keystone crate.
+/// Guards the boundary from the positive side: if a shim is ever replaced by a
+/// real declaration, its `pub use reddb_types::` line disappears and this fails.
+#[test]
+fn schema_shims_reexport_from_types_crate() {
+    let root = repo_root();
+    let schema = root.join("crates/reddb-server/src/storage/schema");
+    for shim in [
+        "types.rs",
+        "coerce.rs",
+        "cast_catalog.rs",
+        "coercion_spine.rs",
+        "function_catalog.rs",
+        "operator_catalog.rs",
+        "value_codec.rs",
+    ] {
+        let text = read(schema.join(shim));
+        assert!(
+            text.contains("pub use reddb_types::"),
+            "storage/schema/{shim} must re-export from reddb_types, not declare types locally"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1064. Final slice of PRD #1060.

- `crates/reddb-types/tests/type_authority.rs` — authority fence (3 tests, all green): types crate owns the logical type system, server must not redeclare it, schema shims re-export from the types crate.
- `.github/workflows/types-coverage.yml` — report-only llvm-cov coverage for reddb-io-types.

Recovered after worker wWEJ3 died post-commit (pre-DONE). Validated by operator: `cargo check -p reddb-io-types` ✓, `cargo fmt --check` ✓, `cargo test -p reddb-io-types --test type_authority` → 3 passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783810577&installation_id=129708444&pr_number=1096&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1096&signature=8606cc8cf4be11020983b73556d164bab3a9a35afde26d87d34aa0271d1ce237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->