### PR TITLE
test(file): repoint stale turboquant snapshot authority fence at live consumer

### DIFF
--- a/crates/reddb-file/tests/layout_authority/runtime.rs
+++ b/crates/reddb-file/tests/layout_authority/runtime.rs
@@ -344,7 +344,10 @@ fn server_does_not_redeclare_zone_map_file_format() {
 #[test]
 fn server_does_not_redeclare_turboquant_snapshot_format() {
     let root = repo_root();
-    let text = read(root.join("crates/reddb-server/src/storage/engine/turboquant/snapshot.rs"));
+    // The server's `turboquant/snapshot.rs` re-export alias was deleted (commit
+    // 8a2e6fc6); `runtime/vector_turbo_kind.rs` is now the sole consumer and
+    // imports the snapshot codec directly from reddb-file.
+    let text = read(root.join("crates/reddb-server/src/runtime/vector_turbo_kind.rs"));
 
     for forbidden in [
         ".TVSNAP",
@@ -363,8 +366,10 @@ fn server_does_not_redeclare_turboquant_snapshot_format() {
     }
 
     assert!(
-        text.contains("reddb_file::{"),
-        "server turboquant snapshot module should only reexport reddb-file contracts"
+        text.contains("reddb_file::{")
+            && text.contains("read_turboquant_snapshot")
+            && text.contains("write_turboquant_snapshot"),
+        "server turboquant consumer should import the snapshot codec from reddb-file"
     );
 }
 


### PR DESCRIPTION
## Problem

`layout_authority::server_does_not_redeclare_turboquant_snapshot_format` was **red on main** (51 passed / 1 failed). It reads `crates/reddb-server/src/storage/engine/turboquant/snapshot.rs` — a 5-line re-export alias that was **deleted** in `8a2e6fc6` ("drop dead file-authority scaffolding"). With the file gone the read returns empty, so the forbidden-pattern checks vacuously pass but the final `text.contains("reddb_file::{")` assertion fails.

## Fix

Repoint the fence at the **live consumer** `crates/reddb-server/src/runtime/vector_turbo_kind.rs`, which now imports `read_turboquant_snapshot` / `write_turboquant_snapshot` / `TurboQuantSnapshotError` directly from `reddb-file` (lines 27-30). This preserves the guard's intent — server must not redeclare the format, and must route through reddb-file — against the current code, matching the sibling tests' pattern (e.g. `server_uses_reddb_file_for_logical_wal_spool_paths`).

The turboquant snapshot format itself lives in `crates/reddb-file/src/turboquant_snapshot.rs` (verified). Pure test-only change; no production code touched.

## Validation

- `cargo test -p reddb-io-file --test layout_authority` → **52 passed** (was 51 + 1 fail)
- `cargo fmt -p reddb-io-file --check` ✓

Finishes the file/wire authority-boundary cleanup tail (collateral of the turboquant alias removal in 8a2e6fc6; related to PRD #1050's ADR 0046 enforcement).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783813349&installation_id=129708444&pr_number=1097&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1097&signature=b34c0d10d6e5f8aa14fb3049752a594d5bbe47edcf540f057d5ca510bd114ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update refines internal test validation for snapshot codec organization with no impact to functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->