### PR TITLE
merge: #1101 reddb-io-rql S3: hand-authored conformance goldens for RedDB-only surfaces (vector + graph modes)

### DIFF
--- a/crates/reddb-rql/tests/corpus/README.md
+++ b/crates/reddb-rql/tests/corpus/README.md
@@ -1,0 +1,48 @@
+# RQL standard-SQL conformance corpus
+
+Each `*.slt` file in this directory is a [sqllogictest][slt]-format script. The
+harness (`tests/conformance.rs`) discovers every `.slt` file automatically and
+runs it end-to-end against the current in-server engine
+(`reddb-server`'s `RedDBRuntime::in_memory()`), one fresh runtime per file so
+state never leaks between scripts.
+
+## Truth is the SQLite oracle
+
+The standard-SQL slice is sourced from the **public SQLite sqllogictest
+corpus**. Every expected result block is the value **SQLite** produces — never
+whatever the current engine happens to emit (ADR 0053). Engine output is the
+thing under test, not the source of truth.
+
+## Recording dialect divergences (skip, never drop)
+
+When a standard-SQL case is genuinely correct against the SQLite oracle but the
+RedDB engine diverges (a dialect difference, an unimplemented surface, or a
+rendering seam), the case is **kept and skipped with a reason**, never silently
+dropped. Use sqllogictest's conditional directive keyed on the engine name
+(`reddb-server`) and write the reason in a comment directly above it:
+
+```
+# RedDB renders an integer SUM as a REAL; SQLite renders a bare integer.
+# Divergence tracked under PRD #1098. Keep the oracle value; skip the run.
+skipif reddb-server
+query I nosort
+SELECT SUM(v) FROM nums
+----
+80
+```
+
+`skipif reddb-server` skips that one record for our engine while leaving the
+oracle-correct expectation on the page as documentation. `onlyif reddb-server`
+is the inverse (run only on our engine) and should be avoided here — it would
+let engine output masquerade as truth.
+
+## Cell rendering
+
+The harness renders each engine `Value` into a comparison cell with the rules
+SQLite's reference harness uses (see `src/conformance.rs`): `NULL` → the literal
+`NULL`; text passes printable ASCII through and scrubs the rest to `@`; integers
+print in decimal; reals print with exactly three decimals. The `query <types>`
+header documents the intended column shape; the engine's intrinsic value kind
+drives the actual rendering.
+
+[slt]: https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki

--- a/crates/reddb-rql/tests/corpus/select_aggregate.slt
+++ b/crates/reddb-rql/tests/corpus/select_aggregate.slt
@@ -1,0 +1,54 @@
+# RedDB RQL conformance — standard-SQL aggregate slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (COUNT / MIN / MAX over a single table, plus GROUP BY with a per-group count
+# and a HAVING filter). Truth is the SQLite oracle.
+
+statement ok
+CREATE TABLE sales (region TEXT, amount INTEGER)
+
+statement ok
+INSERT INTO sales (region, amount) VALUES ('NA', 10), ('NA', 20), ('EU', 30), ('EU', 40), ('EU', 5)
+
+# COUNT(*) over the whole table.
+query I nosort
+SELECT COUNT(*) FROM sales
+----
+5
+
+# MIN of an integer column.
+query I nosort
+SELECT MIN(amount) FROM sales
+----
+5
+
+# MAX of an integer column.
+query I nosort
+SELECT MAX(amount) FROM sales
+----
+40
+
+# GROUP BY with a per-group count.
+query TI rowsort
+SELECT region, COUNT(*) FROM sales GROUP BY region
+----
+EU 3
+NA 2
+
+# GROUP BY with a per-group MAX.
+query TI rowsort
+SELECT region, MAX(amount) FROM sales GROUP BY region
+----
+EU 40
+NA 20
+
+# GROUP BY filtered by HAVING on the per-group count.
+# DIVERGENCE: when the projection lists only the group key and no aggregate,
+# RedDB does not collapse to one row per group (it returns every base row and
+# ignores HAVING), where SQLite returns the single grouped row 'EU'. Tracked
+# under PRD #1098; expected block holds the SQLite oracle value.
+skipif reddb-server
+query T rowsort
+SELECT region FROM sales GROUP BY region HAVING COUNT(*) > 2
+----
+EU

--- a/crates/reddb-rql/tests/corpus/select_aggregate_numeric.slt
+++ b/crates/reddb-rql/tests/corpus/select_aggregate_numeric.slt
@@ -1,0 +1,40 @@
+# RedDB RQL conformance — standard-SQL numeric-aggregate slice (SUM / AVG).
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus.
+# Truth is the SQLite oracle. SUM/AVG sit on a known dialect seam: SQLite's
+# reference harness renders an integer SUM as a bare integer and AVG as a fixed
+# 3-decimal real, while RedDB's value model may surface a different intrinsic
+# numeric kind. Where the rendered cell diverges from the SQLite oracle the
+# case is recorded as `skipif reddb-server` with the reason inline, never
+# silently dropped (ADR 0053: truth is the external oracle, never engine output).
+
+statement ok
+CREATE TABLE nums (g TEXT, v INTEGER)
+
+statement ok
+INSERT INTO nums (g, v) VALUES ('a', 10), ('a', 20), ('a', 30), ('b', 5), ('b', 15)
+
+# SUM over an integer column. SQLite yields the integer 80.
+# DIVERGENCE: RedDB surfaces SUM as a REAL, so the cell renders "80.000" where
+# SQLite renders the bare integer "80". Tracked under PRD #1098; expected block
+# holds the SQLite oracle value.
+skipif reddb-server
+query I nosort
+SELECT SUM(v) FROM nums
+----
+80
+
+# AVG over an integer column. SQLite yields the real 16.0, rendered "16.000".
+query R nosort
+SELECT AVG(v) FROM nums
+----
+16.000
+
+# Per-group SUM. Same REAL-vs-INTEGER seam as the table-wide SUM above:
+# RedDB renders "60.000" / "20.000" where SQLite renders "60" / "20".
+skipif reddb-server
+query TI rowsort
+SELECT g, SUM(v) FROM nums GROUP BY g
+----
+a 60
+b 20

--- a/crates/reddb-rql/tests/corpus/select_distinct.slt
+++ b/crates/reddb-rql/tests/corpus/select_distinct.slt
@@ -1,0 +1,45 @@
+# RedDB RQL conformance — standard-SQL SELECT DISTINCT slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (duplicate elimination over single and multiple projected columns). Truth is
+# the SQLite oracle.
+#
+# DIVERGENCE: RedDB's parser does not accept a `DISTINCT` quantifier on the
+# SELECT projection — it rejects `SELECT DISTINCT a FROM t` with a parse error
+# ("Unexpected token after query"). DISTINCT is only recognised inside an
+# aggregate argument. Every projection-level DISTINCT case below is therefore
+# recorded `skipif reddb-server` with the SQLite-oracle expectation kept on the
+# page; tracked under PRD #1098 rather than silently dropped (ADR 0053).
+
+statement ok
+CREATE TABLE t (a INTEGER, b TEXT)
+
+statement ok
+INSERT INTO t (a, b) VALUES (1, 'x'), (1, 'x'), (2, 'x'), (2, 'y'), (3, 'y')
+
+# DISTINCT over a single column collapses duplicate values.
+skipif reddb-server
+query I rowsort
+SELECT DISTINCT a FROM t
+----
+1
+2
+3
+
+# DISTINCT over a single text column.
+skipif reddb-server
+query T rowsort
+SELECT DISTINCT b FROM t
+----
+x
+y
+
+# DISTINCT over a column pair keeps each unique combination.
+skipif reddb-server
+query IT rowsort
+SELECT DISTINCT a, b FROM t
+----
+1 x
+2 x
+2 y
+3 y

--- a/crates/reddb-rql/tests/corpus/select_expressions.slt
+++ b/crates/reddb-rql/tests/corpus/select_expressions.slt
@@ -1,0 +1,66 @@
+# RedDB RQL conformance — standard-SQL scalar-expression slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (integer arithmetic, string concatenation, and the common scalar functions
+# UPPER / LOWER / LENGTH / ABS / CASE). Truth is the SQLite oracle.
+
+statement ok
+CREATE TABLE t (id INTEGER, name TEXT, delta INTEGER)
+
+statement ok
+INSERT INTO t (id, name, delta) VALUES (1, 'alice', -3), (2, 'BOB', 4), (3, 'Carol', -7)
+
+# Integer arithmetic in the projection.
+query I rowsort
+SELECT id * 10 + 1 FROM t
+----
+11
+21
+31
+
+# String concatenation with the || operator.
+query T rowsort
+SELECT name || '!' FROM t
+----
+BOB!
+Carol!
+alice!
+
+# UPPER / LOWER case folding.
+query T rowsort
+SELECT UPPER(name) FROM t
+----
+ALICE
+BOB
+CAROL
+
+query T rowsort
+SELECT LOWER(name) FROM t
+----
+alice
+bob
+carol
+
+# LENGTH counts characters.
+query I rowsort
+SELECT LENGTH(name) FROM t
+----
+3
+5
+5
+
+# ABS of a signed integer.
+query I rowsort
+SELECT ABS(delta) FROM t
+----
+3
+4
+7
+
+# CASE expression mapping a sign to a label.
+query T rowsort
+SELECT CASE WHEN delta < 0 THEN 'neg' ELSE 'pos' END FROM t
+----
+neg
+neg
+pos

--- a/crates/reddb-rql/tests/corpus/select_join.slt
+++ b/crates/reddb-rql/tests/corpus/select_join.slt
@@ -1,0 +1,42 @@
+# RedDB RQL conformance — standard-SQL JOIN slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (INNER and LEFT joins on an equi-key, with the unmatched LEFT side carrying
+# NULLs). Truth is the SQLite oracle.
+
+statement ok
+CREATE TABLE users (id INTEGER, name TEXT)
+
+statement ok
+INSERT INTO users (id, name) VALUES (1, 'Ada'), (2, 'Linus'), (3, 'Grace')
+
+statement ok
+CREATE TABLE orders (id INTEGER, user_id INTEGER, total INTEGER)
+
+statement ok
+INSERT INTO orders (id, user_id, total) VALUES (10, 1, 100), (11, 1, 50), (12, 2, 75)
+
+# INNER JOIN keeps only matched pairs.
+query TI rowsort
+SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id
+----
+Ada 100
+Ada 50
+Linus 75
+
+# LEFT JOIN keeps every left row; the unmatched right side is NULL.
+query TI rowsort
+SELECT u.name, o.total FROM users u LEFT JOIN orders o ON u.id = o.user_id
+----
+Ada 100
+Ada 50
+Grace NULL
+Linus 75
+
+# Ordered INNER JOIN projection.
+query TI nosort
+SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id ORDER BY o.total
+----
+Ada 50
+Linus 75
+Ada 100

--- a/crates/reddb-rql/tests/corpus/select_null.slt
+++ b/crates/reddb-rql/tests/corpus/select_null.slt
@@ -1,0 +1,47 @@
+# RedDB RQL conformance — standard-SQL NULL-handling slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (IS NULL / IS NOT NULL predicates and NULL's three-valued behaviour under
+# comparison). Truth is the SQLite oracle: a NULL is never equal to anything,
+# including another NULL, so an `=` predicate filters NULL rows out.
+
+statement ok
+CREATE TABLE t (id INTEGER, v INTEGER)
+
+statement ok
+INSERT INTO t (id, v) VALUES (1, 10), (2, NULL), (3, 30), (4, NULL)
+
+# IS NULL selects the rows whose value is NULL.
+query I rowsort
+SELECT id FROM t WHERE v IS NULL
+----
+2
+4
+
+# IS NOT NULL selects the complementary rows.
+query I rowsort
+SELECT id FROM t WHERE v IS NOT NULL
+----
+1
+3
+
+# An equality predicate never matches a NULL value (three-valued logic).
+query I rowsort
+SELECT id FROM t WHERE v = 10
+----
+1
+
+# Projecting a NULL value renders as the NULL keyword.
+query II nosort
+SELECT id, v FROM t WHERE id = 2
+----
+2 NULL
+
+# COALESCE substitutes a default for NULL.
+query II rowsort
+SELECT id, COALESCE(v, 0) FROM t
+----
+1 10
+2 0
+3 30
+4 0

--- a/crates/reddb-rql/tests/corpus/select_order_limit.slt
+++ b/crates/reddb-rql/tests/corpus/select_order_limit.slt
@@ -1,0 +1,66 @@
+# RedDB RQL conformance — standard-SQL ORDER BY / LIMIT / OFFSET slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (deterministic ordering with ascending/descending sort keys and row
+# windowing). Truth is the SQLite oracle. These queries use `nosort` because the
+# ORDER BY makes the row order itself part of what is under test.
+
+statement ok
+CREATE TABLE t (id INTEGER, v INTEGER)
+
+statement ok
+INSERT INTO t (id, v) VALUES (1, 30), (2, 10), (3, 20), (4, 40)
+
+# Ascending ORDER BY (ASC is the default).
+query I nosort
+SELECT id FROM t ORDER BY v
+----
+2
+3
+1
+4
+
+# Descending ORDER BY.
+query I nosort
+SELECT id FROM t ORDER BY v DESC
+----
+4
+1
+3
+2
+
+# LIMIT caps the row count after ordering.
+query I nosort
+SELECT id FROM t ORDER BY v LIMIT 2
+----
+2
+3
+
+# LIMIT with OFFSET skips leading rows.
+query I nosort
+SELECT id FROM t ORDER BY v LIMIT 2 OFFSET 1
+----
+3
+1
+
+statement ok
+CREATE TABLE t2 (c TEXT, n INTEGER)
+
+statement ok
+INSERT INTO t2 (c, n) VALUES ('banana', 1), ('cherry', 3), ('apple', 5)
+
+# ORDER BY a numeric key, project the text column.
+query T nosort
+SELECT c FROM t2 ORDER BY n DESC
+----
+apple
+cherry
+banana
+
+# ORDER BY the text column directly (ascending, lexicographic).
+query T nosort
+SELECT c FROM t2 ORDER BY c
+----
+apple
+banana
+cherry

--- a/crates/reddb-rql/tests/corpus/select_predicates.slt
+++ b/crates/reddb-rql/tests/corpus/select_predicates.slt
@@ -1,0 +1,78 @@
+# RedDB RQL conformance — standard-SQL WHERE predicate slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (the canonical comparison / boolean / range / membership predicates over a
+# small integer+text table). Truth is the SQLite oracle: every expected block
+# is the result SQLite produces, not whatever the current engine emits.
+
+statement ok
+CREATE TABLE t1 (a INTEGER, b INTEGER, c TEXT)
+
+statement ok
+INSERT INTO t1 (a, b, c) VALUES (1, 10, 'x'), (2, 20, 'y'), (3, 30, 'z'), (4, 40, 'x')
+
+# Strict greater-than.
+query I rowsort
+SELECT a FROM t1 WHERE b > 20
+----
+3
+4
+
+# Inclusive range via two bounds.
+query I rowsort
+SELECT a FROM t1 WHERE b >= 20 AND b <= 30
+----
+2
+3
+
+# Inequality with the SQL-standard <> operator.
+query I rowsort
+SELECT a FROM t1 WHERE c <> 'x'
+----
+2
+3
+
+# Boolean OR.
+query I rowsort
+SELECT a FROM t1 WHERE a = 1 OR a = 4
+----
+1
+4
+
+# Boolean NOT.
+query I rowsort
+SELECT a FROM t1 WHERE NOT c = 'x'
+----
+2
+3
+
+# BETWEEN is inclusive on both bounds.
+query I rowsort
+SELECT a FROM t1 WHERE b BETWEEN 20 AND 30
+----
+2
+3
+
+# IN over a literal list.
+query I rowsort
+SELECT a FROM t1 WHERE a IN (1, 3)
+----
+1
+3
+
+# NOT IN over a literal list.
+# DIVERGENCE: RedDB's parser does not accept the `NOT IN` membership form
+# (it errors on the NOT before IN), though prefix `NOT <predicate>` and bare
+# `IN (...)` both parse. Tracked under PRD #1098; SQLite-oracle value kept.
+skipif reddb-server
+query I rowsort
+SELECT a FROM t1 WHERE a NOT IN (1, 3)
+----
+2
+4
+
+# Combined AND/OR with explicit grouping.
+query I rowsort
+SELECT a FROM t1 WHERE (a = 1 OR a = 2) AND b < 20
+----
+1

--- a/crates/reddb-rql/tests/reddb_conformance.rs
+++ b/crates/reddb-rql/tests/reddb_conformance.rs
@@ -1,0 +1,185 @@
+//! sqllogictest-format conformance harness for the **RedDB-only query
+//! surfaces** that have no external oracle (ADR 0053, S3).
+//!
+//! Where the standard-SQL slice (`tests/conformance.rs` over `tests/corpus/`)
+//! draws its truth from the public SQLite corpus, the surfaces covered here —
+//! vector search, the native `GRAPH` command family, the four graph DSL modes
+//! (Gremlin / Cypher / SPARQL / Path), natural-language, and vector
+//! extensions — are RedDB inventions. Their expected results are
+//! **hand-authored**: each value in a `query` block is what the surface's
+//! semantics dictate (cosine ranking, neighbourhood reachability, shortest-path
+//! hop counts), never blindly copied from engine output. Engine output is the
+//! thing under test, not the source of truth.
+//!
+//! ## Volatile columns are projected away, not pinned
+//!
+//! The engine decorates every vector/graph result row with engine-internal,
+//! run-varying columns — auto-assigned entity ids (`entity_id`, `node_id`,
+//! `red_entity_id`), wall-clock stamps (`created_at`, `updated_at`), sequence
+//! numbers, and the `red_*` capability metadata. Pinning those would freeze
+//! non-determinism, so this harness projects each result down to a fixed
+//! allowlist of **semantic, deterministic** columns (see [`KEEP`]) in a canonical
+//! order. A golden therefore asserts the *meaning* of a result (which node,
+//! which content, how many hops) and stays silent about engine bookkeeping.
+//!
+//! ## Accepted-but-unprojected surfaces are characterization-only
+//!
+//! The in-server executor parses and accepts the four graph DSL modes,
+//! natural-language, and the `SEARCH SIMILAR … COLLECTION` form, but does not
+//! yet *project* semantic columns for them — they return an empty column set.
+//! Such a query has no hand-authorable result yet, so this harness reports it
+//! as a completed statement and the corpus pins it with `statement ok`. Those
+//! goldens are a **regression layer only** (clearly marked in each file and in
+//! `reddb_corpus/README.md`); they characterize "the surface is accepted by
+//! today's engine", never "this is the correct SPARQL/Gremlin/Cypher result".
+
+use std::path::{Path, PathBuf};
+
+use reddb_rql::{render_cell, CellType};
+use reddb_server::{RedDBError, RedDBRuntime};
+use reddb_types::Value;
+use sqllogictest::{DBOutput, DefaultColumnType, Runner, DB};
+
+/// Semantic, deterministic result columns, in canonical render order. Any
+/// column not listed here (auto ids, timestamps, sequence numbers, `red_*`
+/// capability metadata, raw distance/score floats whose exact value is
+/// engine-defined rather than oracle-defined) is projected away before
+/// comparison. A surface that yields none of these columns is treated as
+/// accepted-but-unprojected and pinned with `statement ok` (characterization).
+const KEEP: &[&str] = &[
+    "label",
+    "name",
+    "content",
+    "depth",
+    "path_found",
+    "hop_count",
+    "total_weight",
+    "nodes_visited",
+    "negative_cycle_detected",
+];
+
+/// One sqllogictest connection to the RedDB engine — a fresh in-memory runtime.
+struct EngineDb {
+    runtime: RedDBRuntime,
+}
+
+impl EngineDb {
+    fn connect() -> Result<Self, RedDBError> {
+        Ok(Self {
+            runtime: RedDBRuntime::in_memory()?,
+        })
+    }
+}
+
+/// The natural sqllogictest cell type for a logical value. Mirrors the
+/// standard-SQL harness so a RedDB value renders identically on both pages.
+fn natural_type(value: &Value) -> CellType {
+    match value {
+        Value::Integer(_)
+        | Value::UnsignedInteger(_)
+        | Value::Boolean(_)
+        | Value::Timestamp(_)
+        | Value::TimestampMs(_)
+        | Value::Duration(_)
+        | Value::Date(_)
+        | Value::Time(_) => CellType::Integer,
+        Value::Float(_) => CellType::Real,
+        _ => CellType::Text,
+    }
+}
+
+impl DB for EngineDb {
+    type Error = RedDBError;
+    type ColumnType = DefaultColumnType;
+
+    fn run(&mut self, sql: &str) -> Result<DBOutput<DefaultColumnType>, RedDBError> {
+        let result = self.runtime.execute_query(sql)?;
+
+        if result.statement_type != "select" {
+            return Ok(DBOutput::StatementComplete(result.affected_rows));
+        }
+
+        // Project to the deterministic semantic allowlist, in canonical order.
+        let present: Vec<&str> = KEEP
+            .iter()
+            .copied()
+            .filter(|k| result.result.columns.iter().any(|c| c == k))
+            .collect();
+
+        // A select that yields none of the semantic columns is an
+        // accepted-but-unprojected RedDB surface (a graph DSL mode,
+        // natural-language, or the `SEARCH SIMILAR … COLLECTION` form). Report
+        // it as a completed statement so the corpus can pin the accepted shape
+        // with `statement ok` — a regression-only characterization, never
+        // conformance truth.
+        if present.is_empty() {
+            return Ok(DBOutput::StatementComplete(
+                result.result.records.len() as u64
+            ));
+        }
+
+        let types = present
+            .iter()
+            .map(|_| DefaultColumnType::Any)
+            .collect::<Vec<_>>();
+
+        let rows = result
+            .result
+            .records
+            .iter()
+            .map(|record| {
+                present
+                    .iter()
+                    .map(|col| match record.get(col) {
+                        Some(value) => render_cell(value, natural_type(value)),
+                        None => render_cell(&Value::Null, CellType::Text),
+                    })
+                    .collect::<Vec<String>>()
+            })
+            .collect::<Vec<_>>();
+
+        Ok(DBOutput::Rows { types, rows })
+    }
+
+    fn engine_name(&self) -> &str {
+        "reddb-server"
+    }
+}
+
+fn corpus_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/reddb_corpus")
+}
+
+fn slt_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(dir)
+        .unwrap_or_else(|e| panic!("read reddb corpus dir {}: {e}", dir.display()))
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("slt"))
+        .collect();
+    files.sort();
+    files
+}
+
+/// Runs the whole RedDB-only golden slice against the server engine. Each
+/// script gets a fresh runtime so state never leaks between files.
+#[test]
+fn reddb_only_conformance_is_green_against_server_engine() {
+    let dir = corpus_dir();
+    let files = slt_files(&dir);
+    assert!(
+        !files.is_empty(),
+        "no .slt goldens found under {}",
+        dir.display()
+    );
+
+    for file in files {
+        let mut runner = Runner::new(|| async { EngineDb::connect() });
+        if let Err(err) = runner.run_file(&file) {
+            panic!(
+                "reddb-only conformance {} failed:\n{}",
+                file.display(),
+                err.display(true)
+            );
+        }
+    }
+}

--- a/crates/reddb-rql/tests/reddb_corpus/README.md
+++ b/crates/reddb-rql/tests/reddb_corpus/README.md
@@ -1,0 +1,60 @@
+# RedDB-only conformance corpus (no external oracle)
+
+Each `*.slt` file here is a [sqllogictest][slt]-format script covering a
+**RedDB-only query surface** — one with no standard-SQL counterpart and no
+external oracle: vector search, the native `GRAPH` command family, the four
+graph DSL modes (Gremlin / Cypher / SPARQL / Path), natural-language, and
+vector extensions. The harness (`tests/reddb_conformance.rs`) discovers every
+`.slt` file here automatically and runs it end-to-end against the in-server
+engine (`reddb-server`'s `RedDBRuntime::in_memory()`), one fresh runtime per
+file so state never leaks between scripts.
+
+This is the S3 companion to the standard-SQL slice in `../corpus/`, whose truth
+is the public SQLite oracle (ADR 0053).
+
+## Truth is hand-authored — engine output is the thing under test
+
+These surfaces are RedDB inventions, so no third-party engine can adjudicate
+them. Every expected value in a `query` block is authored from the **semantics**
+of the surface — cosine ranking, neighbourhood reachability, shortest-path hop
+counts, downstream PageRank flow — and never copied from whatever the engine
+happens to emit. The fixtures are kept deliberately small and tie-free so the
+correct answer is unambiguous (e.g. a vector fixture whose cosine similarities
+are 1.00 / 0.60 / 0.00 gives one strict ranking).
+
+## Volatile columns are projected away, not pinned
+
+The engine decorates each vector/graph result row with engine-internal,
+run-varying columns: auto-assigned entity ids (`entity_id`, `node_id`,
+`red_entity_id`), wall-clock stamps (`created_at`, `updated_at`), sequence
+numbers, `red_*` capability metadata, and raw distance/score floats whose exact
+value is engine-defined rather than oracle-defined. The harness projects every
+result down to a fixed allowlist of **semantic, deterministic** columns
+(`label`, `name`, `content`, `depth`, `path_found`, `hop_count`,
+`total_weight`, `nodes_visited`, `negative_cycle_detected`) in a canonical
+order. A golden therefore asserts the *meaning* of a result and stays silent
+about engine bookkeeping, so it never freezes non-determinism.
+
+## Characterization is clearly marked regression-only
+
+`characterization_unprojected_surfaces.slt` covers surfaces the executor
+currently **accepts but does not project** (the four graph DSL modes,
+natural-language, and the `SEARCH SIMILAR … COLLECTION` form, which return an
+empty semantic column set today). Those have no hand-authorable result yet, so
+they are pinned with `statement ok` — asserting only that today's engine
+accepts the query. Per ADR 0053 this is a **cheap regression layer, never
+promoted to conformance truth**: the file is loudly marked, and each surface is
+upgraded to a real `query` golden the moment the executor begins projecting
+semantic columns for it.
+
+## Files
+
+- `vector_search.slt` — TRUTH: cosine nearest-first ranking, `LIMIT`,
+  `THRESHOLD`, and the `inner_product` metric extension.
+- `graph_commands.slt` — TRUTH: `GRAPH NEIGHBORHOOD` / `TRAVERSE` /
+  `PROPERTIES` / `SHORTEST_PATH` / `CENTRALITY` over a directed chain.
+- `characterization_unprojected_surfaces.slt` — REGRESSION-ONLY: Gremlin,
+  Cypher, SPARQL, Path, natural-language, and the `SEARCH SIMILAR … COLLECTION`
+  form, each pinned with `statement ok`.
+
+[slt]: https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki

--- a/crates/reddb-rql/tests/reddb_corpus/characterization_unprojected_surfaces.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/characterization_unprojected_surfaces.slt
@@ -1,0 +1,64 @@
+# RedDB-only conformance — CHARACTERIZATION ONLY (regression layer, ADR 0053).
+#
+# !!! NOT CONFORMANCE TRUTH !!!
+#
+# The four graph DSL modes (Gremlin / Cypher / SPARQL / Path) and the
+# natural-language and `SEARCH SIMILAR … COLLECTION` surfaces are parsed and
+# ACCEPTED by the in-server engine, but its executor does not yet *project*
+# semantic result columns for them — they currently return an empty column set.
+# There is therefore no hand-authorable result to pin: a `query` golden here
+# would freeze "what the engine emits today" as truth, which ADR 0053
+# explicitly forbids for RedDB-only surfaces.
+#
+# Instead each surface is pinned with `statement ok`, asserting only the durable
+# fact that today's engine ACCEPTS the query without error. This is a cheap
+# regression net (it will fail loudly if a surface starts rejecting input), and
+# is upgraded to a real `query` golden in graph_commands.slt / vector_search.slt
+# semantics the moment the executor begins projecting columns for the mode.
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('alice', 'Alice')
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('bob', 'Bob')
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('carol', 'Carol')
+
+statement ok
+INSERT INTO tales EDGE (label, from, to) VALUES ('KNOWS', 'alice', 'bob')
+
+statement ok
+INSERT INTO tales EDGE (label, from, to) VALUES ('KNOWS', 'bob', 'carol')
+
+# --- Cypher mode: pattern MATCH with a RETURN projection. ---
+statement ok
+MATCH (a)-[r:KNOWS]->(b) RETURN a.name, b.name
+
+# --- Gremlin mode: a vertex traversal. ---
+statement ok
+g.V().hasLabel('alice')
+
+# --- SPARQL mode: a triple-pattern SELECT. ---
+statement ok
+SELECT ?s WHERE { ?s ?p ?o }
+
+# --- Path mode: a standalone path query. ---
+statement ok
+PATH FROM 'alice' TO 'carol' ALGORITHM bfs
+
+# --- Natural-language mode. ---
+statement ok
+find all nodes
+
+# --- Vector extension: the `SEARCH SIMILAR … COLLECTION` surface form, which
+#     today projects only engine-internal id/score columns (both run-varying),
+#     so it has no semantic column to assert as truth. ---
+statement ok
+CREATE VECTOR vc DIM 2 METRIC cosine
+
+statement ok
+INSERT INTO vc VECTOR (embedding, content) VALUES ([1.0, 0.0], 'near')
+
+statement ok
+SEARCH SIMILAR [1.0, 0.0] COLLECTION vc LIMIT 2

--- a/crates/reddb-rql/tests/reddb_corpus/graph_commands.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/graph_commands.slt
@@ -1,0 +1,85 @@
+# RedDB-only conformance — native GRAPH command family (HAND-AUTHORED TRUTH,
+# ADR 0053 S3).
+#
+# Fixture: a directed KNOWS chain alice -> bob -> carol. Node identity is the
+# `label`; `name` is a display property. Every expectation below is derived from
+# graph semantics (reachability, hop distance, downstream PageRank flow), not
+# copied from engine output. The harness projects results to their semantic
+# columns (label/name/depth/path metrics); auto-assigned node ids and timestamps
+# are run-varying and not pinned (see tests/reddb_conformance.rs).
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('alice', 'Alice')
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('bob', 'Bob')
+
+statement ok
+INSERT INTO tales NODE (label, name) VALUES ('carol', 'Carol')
+
+statement ok
+INSERT INTO tales EDGE (label, from, to) VALUES ('KNOWS', 'alice', 'bob')
+
+statement ok
+INSERT INTO tales EDGE (label, from, to) VALUES ('KNOWS', 'bob', 'carol')
+
+# NEIGHBORHOOD depth 1 from alice reaches the source (depth 0) and its direct
+# successor bob (depth 1); carol is two hops away and excluded.
+query TI rowsort
+GRAPH NEIGHBORHOOD 'alice' DEPTH 1
+----
+alice 0
+bob 1
+
+# Depth 2 extends one further hop, picking up carol at depth 2.
+query TI rowsort
+GRAPH NEIGHBORHOOD 'alice' DEPTH 2
+----
+alice 0
+bob 1
+carol 2
+
+# EDGES IN restricts traversal to the named edge label; the whole chain is
+# KNOWS, so depth 1 still yields {alice@0, bob@1}.
+query TI rowsort
+GRAPH NEIGHBORHOOD 'alice' EDGES IN ('KNOWS') DEPTH 1
+----
+alice 0
+bob 1
+
+# TRAVERSE walks the full reachable set from alice with hop depths.
+query TI rowsort
+GRAPH TRAVERSE 'alice'
+----
+alice 0
+bob 1
+carol 2
+
+# PROPERTIES resolves a node by label and returns its stored properties.
+query TT nosort
+GRAPH PROPERTIES 'alice'
+----
+alice Alice
+
+# SHORTEST_PATH alice -> bob is the single KNOWS edge: 1 hop, unit weight,
+# 2 nodes visited, no negative cycle.
+query IIRIT nosort
+GRAPH SHORTEST_PATH 'alice' TO 'bob' ALGORITHM dijkstra
+----
+1 1 1.000 2 NULL
+
+# SHORTEST_PATH alice -> carol traverses both edges: 2 hops, total weight 2,
+# 3 nodes visited.
+query IIRIT nosort
+GRAPH SHORTEST_PATH 'alice' TO 'carol' ALGORITHM dijkstra
+----
+1 2 2.000 3 NULL
+
+# CENTRALITY (PageRank) scores every node. On a directed chain rank flows
+# downstream, so the strict order is carol > bob > alice.
+query T nosort
+GRAPH CENTRALITY ALGORITHM pagerank
+----
+carol
+bob
+alice

--- a/crates/reddb-rql/tests/reddb_corpus/vector_search.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/vector_search.slt
@@ -1,0 +1,58 @@
+# RedDB-only conformance — vector search (HAND-AUTHORED TRUTH, ADR 0053 S3).
+#
+# There is no external oracle for vector similarity, so every expectation here
+# is authored from the *semantics* of the query, not copied from engine output.
+# The fixture is deliberately tie-free so a strict ranking is well-defined:
+# against the unit query [1,0], the cosine similarity of each stored vector is
+#   near = [1.0, 0.0] -> 1.00   (colinear)
+#   mid  = [0.6, 0.8] -> 0.60
+#   far  = [0.0, 1.0] -> 0.00   (orthogonal)
+# so the correct nearest-first order is near, mid, far.
+#
+# The harness projects each result to its semantic `content` column; the
+# engine-internal id/score/timestamp columns are run-varying and intentionally
+# not pinned (see tests/reddb_conformance.rs).
+
+statement ok
+CREATE VECTOR v DIM 2 METRIC cosine
+
+statement ok
+INSERT INTO v VECTOR (embedding, content) VALUES ([1.0, 0.0], 'near')
+
+statement ok
+INSERT INTO v VECTOR (embedding, content) VALUES ([0.6, 0.8], 'mid')
+
+statement ok
+INSERT INTO v VECTOR (embedding, content) VALUES ([0.0, 1.0], 'far')
+
+# Nearest-first by cosine similarity.
+query T nosort
+VECTOR SEARCH v SIMILAR TO [1.0, 0.0] LIMIT 3
+----
+near
+mid
+far
+
+# LIMIT truncates to the top-k nearest, preserving the ranking.
+query T nosort
+VECTOR SEARCH v SIMILAR TO [1.0, 0.0] LIMIT 2
+----
+near
+mid
+
+# THRESHOLD drops everything below the cosine cut-off: 'far' (0.00) is excluded
+# at 0.5, leaving the two vectors with similarity >= 0.5.
+query T nosort
+VECTOR SEARCH v SIMILAR TO [1.0, 0.0] THRESHOLD 0.5 LIMIT 10
+----
+near
+mid
+
+# Vector extension: an explicit inner-product metric. On these unit-scaled
+# vectors the inner product equals the cosine similarity, so the ranking holds.
+query T nosort
+VECTOR SEARCH v SIMILAR TO [1.0, 0.0] METRIC inner_product LIMIT 3
+----
+near
+mid
+far


### PR DESCRIPTION
Automated AFK landing for #1101. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783821662&installation_id=129708444&pr_number=1110&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1110&signature=ef7382e731e720bf8c5acf43334c45c62c0d7a1d316074dcf0685faeb8dce9d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for SQL conformance test framework organization and execution methodology.

* **Tests**
  * Added extensive SQL conformance test suite covering aggregates, joins, NULL handling, ORDER BY, predicates, expressions, and DISTINCT behavior.
  * Added RedDB-specific conformance tests for vector search and graph command operations.
  * Introduced new test harness for validating engine conformance against established standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->