### PR TITLE
merge: #1100 reddb-io-rql S2: expand standard-SQL conformance coverage from the SQLite corpus

### DIFF
--- a/crates/reddb-rql/tests/corpus/README.md
+++ b/crates/reddb-rql/tests/corpus/README.md
@@ -36,6 +36,49 @@ oracle-correct expectation on the page as documentation. `onlyif reddb-server`
 is the inverse (run only on our engine) and should be avoided here — it would
 let engine output masquerade as truth.
 
+## Coverage map
+
+Each slice is one `.slt` file holding a focused corner of standard SQL:
+
+| File | Surface |
+| --- | --- |
+| `standard_select.slt` | projection, equality filter |
+| `select_predicates.slt` | comparison / boolean / range / membership predicates |
+| `select_expressions.slt` | integer arithmetic, `\|\|`, UPPER/LOWER/LENGTH/ABS, CASE |
+| `select_arithmetic.slt` | `-` `*` operators, precedence, parentheses, unary minus |
+| `select_string_functions.slt` | SUBSTR slicing, TRIM family, function composition |
+| `select_like.slt` | LIKE `%` / `_` wildcards and the negated form |
+| `select_case_searched.slt` | searched CASE, no-ELSE NULL fall-through, simple CASE, COALESCE |
+| `select_null.slt` | IS NULL / IS NOT NULL, three-valued comparison, COALESCE |
+| `select_distinct.slt` | SELECT DISTINCT over single and multiple columns |
+| `select_order_limit.slt` | ORDER BY ASC/DESC, LIMIT, OFFSET |
+| `select_order_multikey.slt` | multi-key ORDER BY with mixed directions |
+| `select_join.slt` | INNER / LEFT join on an equi-key |
+| `select_aggregate.slt` | COUNT/MIN/MAX, GROUP BY, HAVING |
+| `select_aggregate_numeric.slt` | SUM / AVG numeric-aggregate rendering |
+| `select_aggregate_count_variants.slt` | COUNT(\*) vs COUNT(col), COUNT(DISTINCT), MIN/MAX over text |
+
+## Recorded divergences (skip-with-reason, never dropped)
+
+Every case below is oracle-correct against SQLite but the RedDB engine diverges,
+so it is kept on the page with `skipif reddb-server` and a reason inline. All are
+tracked under PRD #1098; none are silently dropped (ADR 0053).
+
+- **`NOT IN` / `NOT LIKE`** (`select_predicates.slt`, `select_like.slt`) — the
+  parser rejects the infix `NOT` before `IN`/`LIKE`, though prefix
+  `NOT <predicate>` and the bare membership forms both parse.
+- **Simple `CASE <expr> WHEN`** (`select_case_searched.slt`) — only the searched
+  `CASE WHEN <cond>` form parses; the selector form errors.
+- **TRIM / LTRIM / RTRIM** (`select_string_functions.slt`) — catalogued but
+  unimplemented in the SELECT path; they resolve to NULL.
+- **SELECT-level DISTINCT** (`select_distinct.slt`) — DISTINCT is only accepted
+  inside an aggregate argument, not as a projection quantifier.
+- **Integer SUM renders as REAL** (`select_aggregate_numeric.slt`) — `SUM`
+  surfaces a REAL, so `80` renders `80.000`.
+- **Group-key-only GROUP BY** (`select_aggregate.slt`) — a projection of only the
+  group key (no aggregate) does not collapse to one row per group and ignores
+  HAVING.
+
 ## Cell rendering
 
 The harness renders each engine `Value` into a comparison cell with the rules

--- a/crates/reddb-rql/tests/corpus/select_aggregate_count_variants.slt
+++ b/crates/reddb-rql/tests/corpus/select_aggregate_count_variants.slt
@@ -1,0 +1,53 @@
+# RedDB RQL conformance — standard-SQL COUNT / MIN / MAX variant slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (COUNT(*) vs COUNT(<column>) and their NULL-skipping difference, COUNT over a
+# DISTINCT argument, and MIN/MAX over a text column). Truth is the SQLite
+# oracle: COUNT(<column>) and MIN/MAX skip NULLs, COUNT(*) counts every row
+# (ADR 0053).
+
+statement ok
+CREATE TABLE t (g TEXT, v INTEGER)
+
+statement ok
+INSERT INTO t (g, v) VALUES ('a', 10), ('a', NULL), ('b', 20), ('b', 30), ('b', NULL)
+
+# COUNT(*) counts every row, NULLs included.
+query I nosort
+SELECT COUNT(*) FROM t
+----
+5
+
+# COUNT(<column>) skips the NULL values.
+query I nosort
+SELECT COUNT(v) FROM t
+----
+3
+
+# COUNT(DISTINCT <column>) counts distinct non-NULL values.
+query I nosort
+SELECT COUNT(DISTINCT v) FROM t
+----
+3
+
+# MIN / MAX skip NULLs.
+query I nosort
+SELECT MIN(v) FROM t
+----
+10
+
+query I nosort
+SELECT MAX(v) FROM t
+----
+30
+
+# MIN / MAX over a text column compare lexicographically.
+query T nosort
+SELECT MIN(g) FROM t
+----
+a
+
+query T nosort
+SELECT MAX(g) FROM t
+----
+b

--- a/crates/reddb-rql/tests/corpus/select_arithmetic.slt
+++ b/crates/reddb-rql/tests/corpus/select_arithmetic.slt
@@ -1,0 +1,58 @@
+# RedDB RQL conformance — standard-SQL integer-arithmetic slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (the binary arithmetic operators -, *, /, % plus unary minus, operator
+# precedence, and explicit parenthesised grouping over a small integer table).
+# Truth is the SQLite oracle: every expected block is the result SQLite
+# produces, not whatever the current engine emits (ADR 0053).
+
+statement ok
+CREATE TABLE nums (a INTEGER, b INTEGER)
+
+statement ok
+INSERT INTO nums (a, b) VALUES (7, 2), (10, 5), (9, 4), (-8, 3)
+
+# Subtraction.
+query I rowsort
+SELECT a - b FROM nums
+----
+-11
+5
+5
+5
+
+# Multiplication.
+query I rowsort
+SELECT a * b FROM nums
+----
+-24
+14
+36
+50
+
+# Addition then multiplication — * binds tighter than +.
+query I rowsort
+SELECT a + b * 2 FROM nums
+----
+-2
+11
+17
+20
+
+# Explicit parentheses override the default precedence.
+query I rowsort
+SELECT (a + b) * 2 FROM nums
+----
+-10
+18
+26
+30
+
+# Unary minus negates the column.
+query I rowsort
+SELECT -a FROM nums
+----
+-10
+-7
+-9
+8

--- a/crates/reddb-rql/tests/corpus/select_case_searched.slt
+++ b/crates/reddb-rql/tests/corpus/select_case_searched.slt
@@ -1,0 +1,52 @@
+# RedDB RQL conformance — standard-SQL CASE / COALESCE slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (a multi-branch searched CASE, the simple `CASE <expr> WHEN` form, a CASE
+# with no ELSE falling through to NULL, and multi-argument COALESCE). Truth is
+# the SQLite oracle (ADR 0053).
+
+statement ok
+CREATE TABLE scored (id INTEGER, score INTEGER)
+
+statement ok
+INSERT INTO scored (id, score) VALUES (1, 95), (2, 82), (3, 67), (4, 50)
+
+# Multi-branch searched CASE: first matching WHEN wins.
+query T rowsort
+SELECT CASE WHEN score >= 90 THEN 'A' WHEN score >= 80 THEN 'B' WHEN score >= 70 THEN 'C' ELSE 'F' END FROM scored
+----
+A
+B
+F
+F
+
+# A searched CASE with no ELSE yields NULL for the non-matching rows.
+query T rowsort
+SELECT CASE WHEN score >= 90 THEN 'top' END FROM scored
+----
+NULL
+NULL
+NULL
+top
+
+# Simple CASE compares the selector against each WHEN value.
+# DIVERGENCE: RedDB's parser only accepts the searched `CASE WHEN <cond>` form;
+# the simple `CASE <expr> WHEN <value>` form errors ("CASE must have at least
+# one WHEN branch"). Tracked under PRD #1098; SQLite-oracle value kept.
+skipif reddb-server
+query T rowsort
+SELECT CASE id WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'many' END FROM scored
+----
+many
+many
+one
+two
+
+# COALESCE returns the first non-NULL argument.
+query I rowsort
+SELECT COALESCE(NULL, NULL, score) FROM scored
+----
+50
+67
+82
+95

--- a/crates/reddb-rql/tests/corpus/select_like.slt
+++ b/crates/reddb-rql/tests/corpus/select_like.slt
@@ -1,0 +1,53 @@
+# RedDB RQL conformance — standard-SQL LIKE pattern slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (the `%` multi-character and `_` single-character wildcards in a LIKE
+# predicate, plus the negated form). Truth is the SQLite oracle (ADR 0053).
+
+statement ok
+CREATE TABLE fruit (id INTEGER, name TEXT)
+
+statement ok
+INSERT INTO fruit (id, name) VALUES (1, 'apple'), (2, 'apricot'), (3, 'banana'), (4, 'cherry'), (5, 'grape')
+
+# Prefix match: `%` matches any trailing run of characters.
+query I rowsort
+SELECT id FROM fruit WHERE name LIKE 'ap%'
+----
+1
+2
+
+# Substring match: a `%` on both sides.
+query I rowsort
+SELECT id FROM fruit WHERE name LIKE '%a%'
+----
+1
+2
+3
+5
+
+# Suffix match.
+query I rowsort
+SELECT id FROM fruit WHERE name LIKE '%e'
+----
+1
+5
+
+# `_` matches exactly one character: second letter is `a`.
+query I rowsort
+SELECT id FROM fruit WHERE name LIKE '_a%'
+----
+3
+
+# Negated pattern: every name that does not start with `a`.
+# DIVERGENCE: RedDB's parser does not accept the infix `NOT LIKE` membership
+# form (it errors on the NOT after the column), the same seam as `NOT IN`.
+# Prefix `NOT <predicate>` and bare `LIKE` both parse. Tracked under PRD #1098;
+# SQLite-oracle value kept.
+skipif reddb-server
+query I rowsort
+SELECT id FROM fruit WHERE name NOT LIKE 'a%'
+----
+3
+4
+5

--- a/crates/reddb-rql/tests/corpus/select_order_multikey.slt
+++ b/crates/reddb-rql/tests/corpus/select_order_multikey.slt
@@ -1,0 +1,39 @@
+# RedDB RQL conformance — standard-SQL multi-key ORDER BY slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (ordering by two sort keys with independent ASC/DESC directions). Truth is
+# the SQLite oracle. These use `nosort` because ORDER BY makes the row order
+# itself the thing under test (ADR 0053).
+
+statement ok
+CREATE TABLE t (a INTEGER, b INTEGER, label TEXT)
+
+statement ok
+INSERT INTO t (a, b, label) VALUES (2, 5, 'p'), (1, 9, 'q'), (2, 3, 'r'), (1, 4, 's')
+
+# Primary ascending, secondary ascending.
+query T nosort
+SELECT label FROM t ORDER BY a ASC, b ASC
+----
+s
+q
+r
+p
+
+# Primary ascending, secondary descending.
+query T nosort
+SELECT label FROM t ORDER BY a ASC, b DESC
+----
+q
+s
+p
+r
+
+# Primary descending, secondary ascending.
+query T nosort
+SELECT label FROM t ORDER BY a DESC, b ASC
+----
+r
+p
+s
+q

--- a/crates/reddb-rql/tests/corpus/select_string_functions.slt
+++ b/crates/reddb-rql/tests/corpus/select_string_functions.slt
@@ -1,0 +1,75 @@
+# RedDB RQL conformance — standard-SQL string-function slice.
+#
+# Shape and statements are sourced from the public SQLite sqllogictest corpus
+# (SUBSTR position/length slicing, TRIM/LTRIM/RTRIM whitespace stripping, and
+# nested function composition). Truth is the SQLite oracle: every expected block
+# is the value SQLite produces (ADR 0053).
+
+statement ok
+CREATE TABLE words (id INTEGER, w TEXT)
+
+statement ok
+INSERT INTO words (id, w) VALUES (1, 'Hello'), (2, 'world'), (3, 'RedDB')
+
+# SUBSTR with an explicit start and length (1-based start).
+query T rowsort
+SELECT SUBSTR(w, 1, 3) FROM words
+----
+Hel
+Red
+wor
+
+# SUBSTR with only a start position runs to the end of the string.
+query T rowsort
+SELECT SUBSTR(w, 2) FROM words
+----
+edDB
+ello
+orld
+
+# LENGTH counts characters.
+query I rowsort
+SELECT LENGTH(w) FROM words
+----
+5
+5
+5
+
+statement ok
+INSERT INTO words (id, w) VALUES (4, '  padded  '), (5, '  left'), (6, 'right  ')
+
+# TRIM strips leading and trailing spaces from a column value.
+# DIVERGENCE: the TRIM family is catalogued but unimplemented in the SELECT
+# evaluation path — TRIM/LTRIM/RTRIM resolve to NULL rather than the trimmed
+# string. Tracked under PRD #1098; SQLite-oracle value kept.
+skipif reddb-server
+query T nosort
+SELECT TRIM(w) FROM words WHERE id = 4
+----
+padded
+
+# LTRIM strips only the leading spaces; the result here has no trailing space.
+# DIVERGENCE: see TRIM above — LTRIM resolves to NULL in the SELECT path.
+# Tracked under PRD #1098; SQLite-oracle value kept.
+skipif reddb-server
+query T nosort
+SELECT LTRIM(w) FROM words WHERE id = 5
+----
+left
+
+# RTRIM strips only the trailing spaces.
+# DIVERGENCE: see TRIM above — RTRIM resolves to NULL in the SELECT path.
+# Tracked under PRD #1098; SQLite-oracle value kept.
+skipif reddb-server
+query T nosort
+SELECT RTRIM(w) FROM words WHERE id = 6
+----
+right
+
+# Function composition: upper-case a substring.
+query T rowsort
+SELECT UPPER(SUBSTR(w, 1, 2)) FROM words WHERE id <= 3
+----
+HE
+RE
+WO


### PR DESCRIPTION
Automated AFK landing for #1100. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783822938&installation_id=129708444&pr_number=1111&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1111&signature=0c1704668616bc0f4f02ce6358231bf74312d38b2d55df063182cf4d571824db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded RQL conformance test coverage for aggregate functions, arithmetic operations, CASE expressions, pattern matching, multi-key sorting, and string functions.

* **Documentation**
  * Enhanced test corpus documentation with coverage mapping and documented engine divergences from standard SQLite behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->