### PR TITLE
merge: #1105 reddb-io-rql S7: move the analyzer + expression typing into the crate behind the shim

### DIFF
--- a/crates/reddb-rql/src/analyzer.rs
+++ b/crates/reddb-rql/src/analyzer.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
-use super::CreateTableQuery;
-use crate::storage::schema::{DataType, SqlTypeName};
+use crate::ast::CreateTableQuery;
+use reddb_types::types::{DataType, SqlTypeName};
 
 #[derive(Debug, Clone)]
 pub enum AnalysisError {

--- a/crates/reddb-rql/src/expr_typing.rs
+++ b/crates/reddb-rql/src/expr_typing.rs
@@ -28,9 +28,9 @@
 //! emits Expr trees as the canonical projection / filter
 //! representation.
 
-use super::ast::{BinOp, Expr, FieldRef, UnaryOp};
-use crate::storage::schema::cast_catalog::{can_implicit_cast, CastContext};
-use crate::storage::schema::types::{DataType, TypeCategory, Value};
+use crate::ast::{BinOp, Expr, FieldRef, UnaryOp};
+use reddb_types::cast_catalog::{can_implicit_cast, CastContext};
+use reddb_types::types::{DataType, TypeCategory, Value};
 
 /// Errors reported by the expression typer. All variants are
 /// recoverable diagnostics — the analyzer can collect several and
@@ -230,7 +230,7 @@ pub fn type_expr(expr: &Expr, scope: &dyn Scope) -> Result<TypedExpr, TypeError>
             let inner_typed = type_expr(inner, scope)?;
             // Validate the cast against the catalog using Explicit
             // context — user wrote it, so the widest rule applies.
-            if !crate::storage::schema::cast_catalog::can_explicit_cast(inner_typed.ty, *target) {
+            if !reddb_types::cast_catalog::can_explicit_cast(inner_typed.ty, *target) {
                 return Err(TypeError::InvalidCast {
                     src: inner_typed.ty,
                     target: *target,
@@ -462,7 +462,7 @@ fn resolve_function_return_type(name: &str, arg_types: &[DataType]) -> DataType 
         // COALESCE is effectively `anycompatible`: ignore NULL/unknown
         // args, then widen left-to-right using the implicit-cast graph.
         "COALESCE" => resolve_coalesce_return_type(arg_types),
-        _ => crate::storage::schema::function_catalog::resolve(name, arg_types)
+        _ => reddb_types::function_catalog::resolve(name, arg_types)
             .map(|entry| entry.return_type)
             .unwrap_or(DataType::Nullable),
     }

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -39,8 +39,10 @@
     clippy::new_without_default
 )]
 
+pub mod analyzer;
 pub mod ast;
 pub mod conformance;
+pub mod expr_typing;
 pub mod filter_optimizer;
 pub mod lexer;
 pub mod limits;

--- a/crates/reddb-server/src/storage/query/analyzer.rs
+++ b/crates/reddb-server/src/storage/query/analyzer.rs
@@ -1,0 +1,18 @@
+//! DDL analyzer — re-export shim.
+//!
+//! The CREATE TABLE analyzer — the pass that validates declared columns and
+//! resolves each declared `SqlTypeName` into a concrete storage `DataType`
+//! (`analyze_create_table`, `resolve_declared_data_type`, `resolve_sql_type_name`,
+//! and the `Analyzed*` result types) — was re-homed into the `reddb-io-rql`
+//! language front-end crate (#1105, ADR 0053). It consumes the canonical AST
+//! that already lives there (#1113) and produces its typed representation using
+//! `reddb-io-types` for the logical type vocabulary, so the crate graph stays
+//! acyclic — no `reddb-io-rql -> reddb-server` back-edge.
+//!
+//! This shim preserves the historical `crate::storage::query::analyzer::*`
+//! import path — and the `crate::storage::query::{analyze_create_table, …}`
+//! re-exports in the parent module — so every runtime and application
+//! call-site across the workspace keeps resolving unchanged. A byte-faithful
+//! move with zero call-site edits.
+
+pub use reddb_rql::analyzer::*;

--- a/crates/reddb-server/src/storage/query/expr_typing.rs
+++ b/crates/reddb-server/src/storage/query/expr_typing.rs
@@ -1,0 +1,15 @@
+//! Expression typer — re-export shim.
+//!
+//! The Fase 3 expression typer — the pass that walks an `ast::Expr` tree and
+//! assigns a concrete `DataType` to every node (`type_expr`, `TypedExpr`,
+//! `TypedExprKind`, `TypeError`, `Scope`) — was re-homed into the
+//! `reddb-io-rql` language front-end crate (#1105, ADR 0053). It consumes the
+//! canonical AST that already lives there (#1113) and types it through the cast
+//! and function catalogs in `reddb-io-types`, so the crate graph stays acyclic
+//! — no `reddb-io-rql -> reddb-server` back-edge.
+//!
+//! This shim preserves the historical `crate::storage::query::expr_typing::*`
+//! import path so every call-site across the workspace keeps resolving
+//! unchanged. A byte-faithful move with zero call-site edits.
+
+pub use reddb_rql::expr_typing::*;


### PR DESCRIPTION
Automated AFK landing for #1105. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783871101&installation_id=129708444&pr_number=1122&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1122&signature=c206e5bb05676d11e903c3330fb617c4151f7210ef04c5518aea7b377e0bb65c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SQL `CREATE TABLE` validation to detect duplicate column names and unsupported data types with clear error messages.
  * Implemented expression type inference system for improved type safety and validation of SQL expressions.

* **Refactor**
  * Reorganized core SQL analysis modules for better code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->