### PR TITLE
merge: #1126 S1: Parser — SELECT DISTINCT projection support

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -953,6 +953,12 @@ pub struct TableQuery {
     /// without the other resolved at execution time is the typed
     /// `MissingSessionKey` error.
     pub sessionize: Option<SessionizeClause>,
+    /// `SELECT DISTINCT` projection quantifier. When `true` the executor
+    /// deduplicates the projected output row-set (over the projected
+    /// columns) before ORDER BY / LIMIT. `DISTINCT` inside an aggregate
+    /// argument (`COUNT(DISTINCT x)`) is unrelated and lives on the
+    /// aggregate call, not here.
+    pub distinct: bool,
 }
 
 /// `SESSIONIZE BY <actor_col> GAP <duration> [ORDER BY <ts_col>]`.
@@ -1063,6 +1069,7 @@ impl TableQuery {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         }
     }
 
@@ -1096,6 +1103,7 @@ impl TableQuery {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         }
     }
 }

--- a/crates/reddb-rql/src/parser/join.rs
+++ b/crates/reddb-rql/src/parser/join.rs
@@ -71,6 +71,7 @@ impl<'a> Parser<'a> {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             }
         };
 
@@ -239,6 +240,7 @@ impl<'a> Parser<'a> {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         };
 
         let mut expr = QueryExpr::Join(JoinQuery {

--- a/crates/reddb-rql/src/parser/property_tests.rs
+++ b/crates/reddb-rql/src/parser/property_tests.rs
@@ -84,6 +84,7 @@ fn arb_table_query_no_filter() -> impl Strategy<Value = QueryExpr> {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             })
         })
 }
@@ -125,6 +126,7 @@ fn arb_table_query_with_filter() -> impl Strategy<Value = QueryExpr> {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             })
         })
 }

--- a/crates/reddb-rql/src/parser/table.rs
+++ b/crates/reddb-rql/src/parser/table.rs
@@ -325,6 +325,12 @@ impl<'a> Parser<'a> {
     fn parse_select_query_inner(&mut self) -> Result<QueryExpr, ParseError> {
         self.expect(Token::Select)?;
 
+        // `SELECT DISTINCT <projection>` — the projection-level quantifier
+        // (issue #1126). Detected immediately after SELECT, before the
+        // projection list, so it never collides with the aggregate-argument
+        // form `COUNT(DISTINCT x)`, which is parsed inside the call args.
+        let distinct = self.consume(&Token::Distinct)?;
+
         // Parse column list
         let (select_items, columns) = self.parse_select_items_and_projections()?;
 
@@ -465,6 +471,7 @@ impl<'a> Parser<'a> {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct,
         };
 
         if self.is_join_keyword() {

--- a/crates/reddb-rql/src/planner/optimizer.rs
+++ b/crates/reddb-rql/src/planner/optimizer.rs
@@ -546,6 +546,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         })
     }
 
@@ -583,6 +584,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         });
 
         let large = QueryExpr::Table(TableQuery {
@@ -605,6 +607,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         });
 
         let join = QueryExpr::Join(JoinQuery {

--- a/crates/reddb-rql/tests/corpus/select_distinct.slt
+++ b/crates/reddb-rql/tests/corpus/select_distinct.slt
@@ -4,12 +4,10 @@
 # (duplicate elimination over single and multiple projected columns). Truth is
 # the SQLite oracle.
 #
-# DIVERGENCE: RedDB's parser does not accept a `DISTINCT` quantifier on the
-# SELECT projection — it rejects `SELECT DISTINCT a FROM t` with a parse error
-# ("Unexpected token after query"). DISTINCT is only recognised inside an
-# aggregate argument. Every projection-level DISTINCT case below is therefore
-# recorded `skipif reddb-server` with the SQLite-oracle expectation kept on the
-# page; tracked under PRD #1098 rather than silently dropped (ADR 0053).
+# The parser accepts a projection-level `DISTINCT` quantifier
+# (`SELECT DISTINCT a FROM t`) and the executor deduplicates the projected
+# row-set, so these cases run directly against the reddb-server engine
+# (issue #1126, under PRD #1098 / ADR 0053).
 
 statement ok
 CREATE TABLE t (a INTEGER, b TEXT)
@@ -18,7 +16,6 @@ statement ok
 INSERT INTO t (a, b) VALUES (1, 'x'), (1, 'x'), (2, 'x'), (2, 'y'), (3, 'y')
 
 # DISTINCT over a single column collapses duplicate values.
-skipif reddb-server
 query I rowsort
 SELECT DISTINCT a FROM t
 ----
@@ -27,7 +24,6 @@ SELECT DISTINCT a FROM t
 3
 
 # DISTINCT over a single text column.
-skipif reddb-server
 query T rowsort
 SELECT DISTINCT b FROM t
 ----
@@ -35,7 +31,6 @@ x
 y
 
 # DISTINCT over a column pair keeps each unique combination.
-skipif reddb-server
 query IT rowsort
 SELECT DISTINCT a, b FROM t
 ----

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -6540,6 +6540,7 @@ impl RedDBRuntime {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             };
             self.check_table_column_projection_authz(&query, frame)?;
         }

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -223,12 +223,47 @@ fn execute_runtime_table_query_materialized(
     }
     let columns = projected_columns(&records, &effective_projections);
 
+    // `SELECT DISTINCT` — collapse duplicate projected rows (issue
+    // #1126). Runs after projection (so dedup keys off the projected
+    // columns) and before the caller's ORDER BY / LIMIT semantics would
+    // slice the set. First occurrence wins, so any upstream ordering the
+    // scan already applied survives.
+    if query.distinct {
+        dedup_distinct_records(&mut records, &columns);
+    }
+
     Ok(UnifiedResult {
         columns,
         records,
         stats: Default::default(),
         pre_serialized_json: None,
     })
+}
+
+/// Collapse duplicate rows for a `SELECT DISTINCT` projection (issue
+/// #1126). Two rows are duplicates when every projected column holds an
+/// equal value; the first occurrence is kept. Like the UNION DISTINCT
+/// set operator (`storage::query::executors::set_ops`), dedup is keyed on
+/// a row hash — `Value` is not `Hash`/`Eq`, so each cell is folded in via
+/// its deterministic `Debug` rendering, which distinguishes both kind and
+/// payload (`Integer(1)` vs `Float(1.0)` vs `String("1")`).
+fn dedup_distinct_records(records: &mut Vec<UnifiedRecord>, columns: &[String]) {
+    use std::collections::hash_map::DefaultHasher;
+    use std::collections::HashSet;
+    use std::hash::{Hash, Hasher};
+
+    let mut seen: HashSet<u64> = HashSet::with_capacity(records.len());
+    records.retain(|record| {
+        let mut hasher = DefaultHasher::new();
+        for col in columns {
+            col.hash(&mut hasher);
+            match record.get(col) {
+                Some(value) => format!("{value:?}").hash(&mut hasher),
+                None => 0u8.hash(&mut hasher),
+            }
+        }
+        seen.insert(hasher.finish())
+    });
 }
 
 fn resolve_table_row_by_logical_id(

--- a/crates/reddb-server/src/storage/query/planner/cache.rs
+++ b/crates/reddb-server/src/storage/query/planner/cache.rs
@@ -339,6 +339,7 @@ mod tests {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             }),
             QueryExpr::Table(TableQuery {
                 table: "test".to_string(),
@@ -360,6 +361,7 @@ mod tests {
                 expand: None,
                 as_of: None,
                 sessionize: None,
+                distinct: false,
             }),
             PlanCost::default(),
         )

--- a/crates/reddb-server/src/storage/query/planner/cost.rs
+++ b/crates/reddb-server/src/storage/query/planner/cost.rs
@@ -1055,6 +1055,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         }
     }
 
@@ -1209,6 +1210,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         });
 
         let cost = estimator.estimate(&query);
@@ -1280,6 +1282,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         };
 
         let card = estimator.estimate_table_cardinality(&query);

--- a/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
@@ -1001,6 +1001,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         })
     }
 

--- a/crates/reddb-server/src/storage/query/planner/shape.rs
+++ b/crates/reddb-server/src/storage/query/planner/shape.rs
@@ -163,6 +163,7 @@ fn parameterize_table_query(query: &TableQuery, next_index: &mut usize) -> Optio
         expand: query.expand.clone(),
         as_of: query.as_of.clone(),
         sessionize: query.sessionize.clone(),
+        distinct: query.distinct,
     })
 }
 
@@ -1204,6 +1205,7 @@ fn bind_table_query(query: &TableQuery, binds: &[Value]) -> Option<TableQuery> {
         expand: query.expand.clone(),
         as_of: query.as_of.clone(),
         sessionize: query.sessionize.clone(),
+        distinct: query.distinct,
     })
 }
 
@@ -1367,6 +1369,7 @@ mod tests {
             expand: None,
             as_of: None,
             sessionize: None,
+            distinct: false,
         });
 
         let prepared = parameterize_query_expr(&query).unwrap();


### PR DESCRIPTION
Automated AFK landing for #1126. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783881443&installation_id=129708444&pr_number=1132&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1132&signature=f7c09fe02a068d67005a4f0f45ad1b1755ec897e8f6a1d4d482039a513595d6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **SELECT DISTINCT support**: Queries can now specify `SELECT DISTINCT` to eliminate duplicate rows from results. The parser recognizes the `DISTINCT` keyword at the projection level, and the query executor automatically deduplicates rows based on all projected columns before applying any sorting or limiting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->