### PR TITLE
merge: #1127 S2: Parser — NOT IN / NOT LIKE infix forms

### DIFF
--- a/crates/reddb-rql/src/parser/filter.rs
+++ b/crates/reddb-rql/src/parser/filter.rs
@@ -131,6 +131,17 @@ impl<'a> Parser<'a> {
             });
         }
 
+        // Infix `NOT IN` / `NOT LIKE`. A prefix `NOT` is consumed earlier at
+        // `parse_not_expr`, so reaching this point with `NOT` means the user
+        // wrote the infix negated form `lhs NOT IN (...)` / `lhs NOT LIKE '…'`.
+        // Only `IN` and `LIKE` follow an infix NOT here; anything else stays an
+        // error so we don't silently swallow malformed input.
+        let negated = matches!(self.peek(), Token::Not)
+            && matches!(self.peek_next()?, Token::In | Token::Like);
+        if negated {
+            self.advance()?;
+        }
+
         if self.consume(&Token::Between)? {
             if let Some(field) = lhs_field.clone() {
                 let low = self.parse_value_or_field()?;
@@ -207,46 +218,52 @@ impl<'a> Parser<'a> {
                 if self.check(&Token::Select) {
                     let query = self.parse_select_query()?;
                     self.expect(Token::RParen)?;
-                    return Ok(Filter::CompareExpr {
-                        lhs: Expr::InList {
-                            target: Box::new(lhs),
-                            values: vec![Expr::Subquery {
-                                query: crate::ast::ExprSubquery {
-                                    query: Box::new(query),
-                                },
+                    return Ok(negate_if(
+                        negated,
+                        Filter::CompareExpr {
+                            lhs: Expr::InList {
+                                target: Box::new(lhs),
+                                values: vec![Expr::Subquery {
+                                    query: crate::ast::ExprSubquery {
+                                        query: Box::new(query),
+                                    },
+                                    span: Span::synthetic(),
+                                }],
+                                negated: false,
                                 span: Span::synthetic(),
-                            }],
-                            negated: false,
-                            span: Span::synthetic(),
+                            },
+                            op: CompareOp::Eq,
+                            rhs: Expr::Literal {
+                                value: Value::Boolean(true),
+                                span: Span::synthetic(),
+                            },
                         },
-                        op: CompareOp::Eq,
-                        rhs: Expr::Literal {
-                            value: Value::Boolean(true),
-                            span: Span::synthetic(),
-                        },
-                    });
+                    ));
                 }
                 let values = self.parse_value_list()?;
                 self.expect(Token::RParen)?;
-                return Ok(Filter::In { field, values });
+                return Ok(negate_if(negated, Filter::In { field, values }));
             }
 
             self.expect(Token::LParen)?;
             let values = self.parse_filter_expr_list()?;
             self.expect(Token::RParen)?;
-            return Ok(Filter::CompareExpr {
-                lhs: Expr::InList {
-                    target: Box::new(lhs),
-                    values,
-                    negated: false,
-                    span: Span::synthetic(),
+            return Ok(negate_if(
+                negated,
+                Filter::CompareExpr {
+                    lhs: Expr::InList {
+                        target: Box::new(lhs),
+                        values,
+                        negated: false,
+                        span: Span::synthetic(),
+                    },
+                    op: CompareOp::Eq,
+                    rhs: Expr::Literal {
+                        value: Value::Boolean(true),
+                        span: Span::synthetic(),
+                    },
                 },
-                op: CompareOp::Eq,
-                rhs: Expr::Literal {
-                    value: Value::Boolean(true),
-                    span: Span::synthetic(),
-                },
-            });
+            ));
         }
 
         // LIKE
@@ -258,7 +275,7 @@ impl<'a> Parser<'a> {
                 ));
             };
             let pattern = self.parse_string()?;
-            return Ok(Filter::Like { field, pattern });
+            return Ok(negate_if(negated, Filter::Like { field, pattern }));
         }
 
         // STARTS WITH
@@ -547,6 +564,17 @@ impl<'a> Parser<'a> {
 pub(super) enum ValueOrField {
     Value(Value),
     Field(FieldRef),
+}
+
+/// Wrap `filter` in `Filter::Not` when `negated` is set. Used by the infix
+/// `NOT IN` / `NOT LIKE` forms, which reuse the positive predicate construction
+/// and negate the whole result.
+fn negate_if(negated: bool, filter: Filter) -> Filter {
+    if negated {
+        Filter::Not(Box::new(filter))
+    } else {
+        filter
+    }
 }
 
 fn expr_as_field_ref(expr: &Expr) -> Option<FieldRef> {

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -955,6 +955,38 @@ fn test_parse_where_like() {
 }
 
 #[test]
+fn test_parse_where_not_like() {
+    let query = parse("SELECT * FROM hosts WHERE hostname NOT LIKE 'a%'").unwrap();
+    if let QueryExpr::Table(tq) = query {
+        match tq.filter {
+            Some(Filter::Not(inner)) => match *inner {
+                Filter::Like { .. } => {}
+                other => panic!("Expected NOT(LIKE), got NOT({other:?})"),
+            },
+            other => panic!("Expected NOT(LIKE) filter, got {other:?}"),
+        }
+    } else {
+        panic!("Expected TableQuery");
+    }
+}
+
+#[test]
+fn test_parse_where_not_in() {
+    let query = parse("SELECT * FROM t1 WHERE a NOT IN (1, 3)").unwrap();
+    if let QueryExpr::Table(tq) = query {
+        match tq.filter {
+            Some(Filter::Not(inner)) => match *inner {
+                Filter::In { .. } => {}
+                other => panic!("Expected NOT(IN), got NOT({other:?})"),
+            },
+            other => panic!("Expected NOT(IN) filter, got {other:?}"),
+        }
+    } else {
+        panic!("Expected TableQuery");
+    }
+}
+
+#[test]
 fn test_parse_simple_match() {
     let query = parse("MATCH (h:Host) RETURN h").unwrap();
     if let QueryExpr::Graph(gq) = query {

--- a/crates/reddb-rql/tests/corpus/select_like.slt
+++ b/crates/reddb-rql/tests/corpus/select_like.slt
@@ -40,11 +40,6 @@ SELECT id FROM fruit WHERE name LIKE '_a%'
 3
 
 # Negated pattern: every name that does not start with `a`.
-# DIVERGENCE: RedDB's parser does not accept the infix `NOT LIKE` membership
-# form (it errors on the NOT after the column), the same seam as `NOT IN`.
-# Prefix `NOT <predicate>` and bare `LIKE` both parse. Tracked under PRD #1098;
-# SQLite-oracle value kept.
-skipif reddb-server
 query I rowsort
 SELECT id FROM fruit WHERE name NOT LIKE 'a%'
 ----

--- a/crates/reddb-rql/tests/corpus/select_predicates.slt
+++ b/crates/reddb-rql/tests/corpus/select_predicates.slt
@@ -61,10 +61,6 @@ SELECT a FROM t1 WHERE a IN (1, 3)
 3
 
 # NOT IN over a literal list.
-# DIVERGENCE: RedDB's parser does not accept the `NOT IN` membership form
-# (it errors on the NOT before IN), though prefix `NOT <predicate>` and bare
-# `IN (...)` both parse. Tracked under PRD #1098; SQLite-oracle value kept.
-skipif reddb-server
 query I rowsort
 SELECT a FROM t1 WHERE a NOT IN (1, 3)
 ----


### PR DESCRIPTION
Automated AFK landing for #1127. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882524&installation_id=129708444&pr_number=1133&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1133&signature=a6124b2ac019a74154ee16e8fc20e679950a76a88b164872f4e1d934e13254d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WHERE clauses now support `NOT IN (...)` and `NOT LIKE '...'` syntax for negated membership and pattern matching queries.

* **Tests**
  * Added comprehensive test coverage for negated filter operations and re-enabled previously skipped conformance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->