### PR TITLE
merge: #1128 S3: Parser — simple CASE form (CASE expr WHEN val THEN result)

### DIFF
--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -863,16 +863,46 @@ impl<'a> Parser<'a> {
         ))
     }
 
-    /// Parse `CASE WHEN cond THEN val [WHEN …] [ELSE val] END`.
+    /// Parse both CASE forms:
+    /// - searched: `CASE WHEN cond THEN val [WHEN …] [ELSE val] END`
+    /// - simple:   `CASE expr WHEN val THEN val [WHEN …] [ELSE val] END`
+    ///
+    /// The simple form is desugared into the searched form: each
+    /// `WHEN <value>` becomes the equality condition `<selector> = <value>`,
+    /// which preserves SQL's three-valued comparison semantics (a NULL
+    /// selector never matches a WHEN value) without growing the `Expr::Case`
+    /// AST or the executor.
+    ///
     /// Assumes the caller has already peeked `CASE`.
     fn parse_case_expr(&mut self, start: crate::lexer::Position) -> Result<Expr, ParseError> {
         self.advance()?; // consume CASE
+                         // Simple CASE: a selector expression precedes the first WHEN.
+        let selector = if matches!(self.peek(), Token::Ident(id) if id.eq_ignore_ascii_case("WHEN"))
+        {
+            None
+        } else {
+            Some(self.parse_expr_prec(0)?)
+        };
         let mut branches: Vec<(Expr, Expr)> = Vec::new();
         loop {
             if !self.consume_ident_ci("WHEN")? {
                 break;
             }
-            let cond = self.parse_expr_prec(0)?;
+            let when_val = self.parse_expr_prec(0)?;
+            // Searched form keeps the WHEN expression as the condition;
+            // simple form rewrites it to `selector = when_val`.
+            let cond = match &selector {
+                None => when_val,
+                Some(sel) => {
+                    let span = Span::new(sel.span().start, when_val.span().end);
+                    Expr::BinaryOp {
+                        op: BinOp::Eq,
+                        lhs: Box::new(sel.clone()),
+                        rhs: Box::new(when_val),
+                        span,
+                    }
+                }
+            };
             if !self.consume_ident_ci("THEN")? {
                 return Err(ParseError::new(
                     "expected THEN after CASE WHEN condition".to_string(),
@@ -1367,6 +1397,27 @@ mod tests {
         };
         assert_eq!(branches.len(), 2);
         assert!(else_.is_some());
+    }
+
+    #[test]
+    fn simple_case_desugars_to_equality() {
+        let e = parse("CASE id WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'many' END");
+        let Expr::Case {
+            branches, else_, ..
+        } = e
+        else {
+            panic!("expected Case");
+        };
+        assert_eq!(branches.len(), 2);
+        assert!(else_.is_some());
+        // Each WHEN value is rewritten to `selector = value`.
+        for (cond, _) in &branches {
+            let Expr::BinaryOp { op, lhs, .. } = cond else {
+                panic!("expected desugared equality condition");
+            };
+            assert_eq!(*op, BinOp::Eq);
+            assert!(matches!(**lhs, Expr::Column { .. }));
+        }
     }
 
     #[test]

--- a/crates/reddb-rql/tests/corpus/select_case_searched.slt
+++ b/crates/reddb-rql/tests/corpus/select_case_searched.slt
@@ -30,10 +30,6 @@ NULL
 top
 
 # Simple CASE compares the selector against each WHEN value.
-# DIVERGENCE: RedDB's parser only accepts the searched `CASE WHEN <cond>` form;
-# the simple `CASE <expr> WHEN <value>` form errors ("CASE must have at least
-# one WHEN branch"). Tracked under PRD #1098; SQLite-oracle value kept.
-skipif reddb-server
 query T rowsort
 SELECT CASE id WHEN 1 THEN 'one' WHEN 2 THEN 'two' ELSE 'many' END FROM scored
 ----


### PR DESCRIPTION
Automated AFK landing for #1128. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783883909&installation_id=129708444&pr_number=1134&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1134&signature=e24674423e2bebcd6189371e7bdb667bbade98299123490602374b16f40d2ea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for simple CASE expressions in SQL queries (e.g., `CASE column WHEN value1 THEN ... WHEN value2 THEN ...`).

* **Tests**
  * Enabled previously skipped test cases for simple CASE expression syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->