### PR TITLE
merge: #1129 S4: Executor — SUM returns INTEGER when inputs are integers

### DIFF
--- a/crates/reddb-rql/tests/corpus/select_aggregate_numeric.slt
+++ b/crates/reddb-rql/tests/corpus/select_aggregate_numeric.slt
@@ -15,10 +15,6 @@ statement ok
 INSERT INTO nums (g, v) VALUES ('a', 10), ('a', 20), ('a', 30), ('b', 5), ('b', 15)
 
 # SUM over an integer column. SQLite yields the integer 80.
-# DIVERGENCE: RedDB surfaces SUM as a REAL, so the cell renders "80.000" where
-# SQLite renders the bare integer "80". Tracked under PRD #1098; expected block
-# holds the SQLite oracle value.
-skipif reddb-server
 query I nosort
 SELECT SUM(v) FROM nums
 ----
@@ -30,9 +26,7 @@ SELECT AVG(v) FROM nums
 ----
 16.000
 
-# Per-group SUM. Same REAL-vs-INTEGER seam as the table-wide SUM above:
-# RedDB renders "60.000" / "20.000" where SQLite renders "60" / "20".
-skipif reddb-server
+# Per-group SUM.
 query TI rowsort
 SELECT g, SUM(v) FROM nums GROUP BY g
 ----

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -1185,7 +1185,7 @@ fn aggregate_projection_result_slotted(
             if state.sum_agg_counts[idx] == 0 {
                 Value::Null
             } else {
-                Value::Float(state.sums[idx])
+                sum_f64_to_value(state.sums[idx])
             }
         }
         "AVG" => {
@@ -1863,6 +1863,14 @@ fn value_to_f64(val: &Value) -> Option<f64> {
         Value::Float(f) => Some(*f),
         Value::Decimal(d) => Some(*d as f64 / 10_000.0),
         _ => None,
+    }
+}
+
+fn sum_f64_to_value(f: f64) -> Value {
+    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+        Value::Integer(f as i64)
+    } else {
+        Value::Float(f)
     }
 }
 
@@ -3012,7 +3020,7 @@ fn try_execute_parallel_single_col_numeric_aggs(
                     let value = if state.counts.get(*slot).copied().unwrap_or(0) == 0 {
                         Value::Null
                     } else {
-                        Value::Float(state.sums.get(*slot).copied().unwrap_or_default())
+                        sum_f64_to_value(state.sums.get(*slot).copied().unwrap_or_default())
                     };
                     record.set(output_name, value);
                 }

--- a/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
@@ -147,7 +147,7 @@ impl GroupAccumulator {
                 }
                 Slot::Sum { sum, seen_any } => {
                     if seen_any {
-                        Value::Float(sum)
+                        sum_f64_to_value(sum)
                     } else {
                         Value::Null
                     }
@@ -162,6 +162,14 @@ impl GroupAccumulator {
                 Slot::Min { current } | Slot::Max { current } => current.unwrap_or(Value::Null),
             })
             .collect()
+    }
+}
+
+fn sum_f64_to_value(f: f64) -> Value {
+    if f.fract() == 0.0 && f >= i64::MIN as f64 && f <= i64::MAX as f64 {
+        Value::Integer(f as i64)
+    } else {
+        Value::Float(f)
     }
 }
 


### PR DESCRIPTION
Automated AFK landing for #1129. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783884806&installation_id=129708444&pr_number=1135&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1135&signature=053e0b349ad472e737c6154aad503c99ec7cb0acebea5830190c653ad57a7735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric aggregate functions to return integer values when appropriate. SUM operations now return integers for whole number results instead of always returning floating-point values, providing more accurate behavior for integer column summations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->