### PR TITLE
merge: #1130 S5: Executor — GROUP BY key-only collapses rows and honours HAVING

### DIFF
--- a/crates/reddb-rql/tests/corpus/select_aggregate.slt
+++ b/crates/reddb-rql/tests/corpus/select_aggregate.slt
@@ -43,11 +43,6 @@ EU 40
 NA 20
 
 # GROUP BY filtered by HAVING on the per-group count.
-# DIVERGENCE: when the projection lists only the group key and no aggregate,
-# RedDB does not collapse to one row per group (it returns every base row and
-# ignores HAVING), where SQLite returns the single grouped row 'EU'. Tracked
-# under PRD #1098; expected block holds the SQLite oracle value.
-skipif reddb-server
 query T rowsort
 SELECT region FROM sales GROUP BY region HAVING COUNT(*) > 2
 ----

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -146,7 +146,7 @@ fn execute_runtime_table_query_materialized(
     }
 
     // ── AGGREGATE PATH: COUNT, AVG, SUM, MIN, MAX, GROUP BY ──
-    if has_aggregate_projections(&effective_projections) {
+    if has_aggregate_projections(&effective_projections) || !effective_group_by.is_empty() {
         return execute_aggregate_query(db, query);
     }
 


### PR DESCRIPTION
Automated AFK landing for #1130. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783888445&installation_id=129708444&pr_number=1137&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1137&signature=691bc7c919b6e19ccc92b5bb98b34ed49d38d5f81df6444a3ffa14ff1b9f8482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GROUP BY queries with HAVING conditions to execute correctly and return accurate aggregated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->