### PR TITLE
test(rql): keep coverage graph pure

### DIFF
--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -61,12 +61,11 @@ jobs:
         run: |
           # Measure the language front-end through its embedded library unit
           # tests only (`--lib`): that exercises the lexer/parser/AST/analyzer/
-          # typer/optimizer code without pulling in the heavy `reddb-server`
-          # dev-dependency that the conformance harness reaches for. The crate's
-          # sole non-dev workspace edge is `reddb-io-types`, which we exclude
-          # below so the totals reflect reddb-io-rql alone. Collect profdata
-          # once, then render it twice (text table + JSON totals) without
-          # re-running the tests.
+          # typer/optimizer code. The server-backed sqllogictest harness lives
+          # in the umbrella crate, so the measured crate graph stays
+          # `reddb-io-rql -> reddb-io-types`. Exclude `reddb-io-types` below so
+          # the totals reflect reddb-io-rql alone. Collect profdata once, then
+          # render it twice (text table + JSON totals) without re-running tests.
           cargo llvm-cov --no-report -p reddb-io-rql --lib
           cargo llvm-cov report --summary-only \
             --ignore-filename-regex 'crates/reddb-types/' \

--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: dtolnay/rust-toolchain@1.95.0
         with:
           components: llvm-tools-preview
 
@@ -51,13 +51,15 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-rust-1.91.0-llvm-cov
+          shared-key: ubuntu-rust-1.95.0-llvm-cov
           cache-on-failure: "true"
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
 
       - name: Run coverage (reddb-io-rql)
+        env:
+          RUSTC_WRAPPER: ""
         run: |
           # Measure the language front-end through its embedded library unit
           # tests only (`--lib`): that exercises the lexer/parser/AST/analyzer/
@@ -108,10 +110,12 @@ jobs:
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          RQL_COVERAGE_BODY: ${{ steps.report.outputs.body }}
         with:
           script: |
             const marker = '<!-- rql-coverage-comment -->';
-            const body = `${{ steps.report.outputs.body }}`;
+            const body = process.env.RQL_COVERAGE_BODY;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: llvm-tools-preview
 

--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -66,22 +66,116 @@ jobs:
           # typer/optimizer code. The server-backed sqllogictest harness lives
           # in the umbrella crate, so the measured crate graph stays
           # `reddb-io-rql -> reddb-io-types`. Exclude `reddb-io-types` below so
-          # the totals reflect reddb-io-rql alone. Collect profdata once, then
-          # render it twice (text table + JSON totals) without re-running tests.
-          cargo llvm-cov --no-report -p reddb-io-rql --lib
-          cargo llvm-cov report --summary-only \
+          # the totals reflect reddb-io-rql alone. Generate the summary JSON in
+          # the same cargo-llvm-cov invocation that runs tests so CI cannot lose
+          # profile data between a separate collection and report phase.
+          cargo llvm-cov -p reddb-io-rql --lib --json --summary-only \
             --ignore-filename-regex 'crates/reddb-types/' \
-            | tee coverage-summary.txt
-          cargo llvm-cov report --json --summary-only \
-            --ignore-filename-regex 'crates/reddb-types/' \
-            > coverage-summary.json
+            --output-path coverage-summary.json
 
       - name: Build report
         id: report
         run: |
-          # Pull the headline line-coverage percentage straight from the JSON
-          # totals — robust against column-layout changes in the text table.
-          total_line=$(python3 -c "import json; print(f\"{json.load(open('coverage-summary.json'))['data'][0]['totals']['lines']['percent']:.2f}%\")" 2>/dev/null || echo "n/a")
+          # Pull the headline and table straight from the JSON totals. This is
+          # robust against column-layout changes in cargo-llvm-cov text output.
+          python3 <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path("coverage-summary.json").read_text())["data"][0]
+
+          def pct(metric):
+              count = metric["count"]
+              if count == 0:
+                  return "-"
+              return f"{metric['percent']:.2f}%"
+
+          def missed(metric):
+              return metric["count"] - metric["covered"]
+
+          def display_name(filename):
+              marker = "/crates/reddb-rql/src/"
+              if marker in filename:
+                  return filename.split(marker, 1)[1]
+              return Path(filename).name
+
+          rows = []
+          for item in data["files"]:
+              summary = item["summary"]
+              rows.append(
+                  (
+                      display_name(item["filename"]),
+                      summary["regions"]["count"],
+                      missed(summary["regions"]),
+                      pct(summary["regions"]),
+                      summary["functions"]["count"],
+                      missed(summary["functions"]),
+                      pct(summary["functions"]),
+                      summary["lines"]["count"],
+                      missed(summary["lines"]),
+                      pct(summary["lines"]),
+                      summary["branches"]["count"],
+                      summary["branches"].get("notcovered", missed(summary["branches"])),
+                      pct(summary["branches"]),
+                  )
+              )
+
+          totals = data["totals"]
+          rows.append(
+              (
+                  "TOTAL",
+                  totals["regions"]["count"],
+                  missed(totals["regions"]),
+                  pct(totals["regions"]),
+                  totals["functions"]["count"],
+                  missed(totals["functions"]),
+                  pct(totals["functions"]),
+                  totals["lines"]["count"],
+                  missed(totals["lines"]),
+                  pct(totals["lines"]),
+                  totals["branches"]["count"],
+                  totals["branches"].get("notcovered", missed(totals["branches"])),
+                  pct(totals["branches"]),
+              )
+          )
+
+          header = (
+              "Filename",
+              "Regions",
+              "Missed Regions",
+              "Cover",
+              "Functions",
+              "Missed Functions",
+              "Executed",
+              "Lines",
+              "Missed Lines",
+              "Cover",
+              "Branches",
+              "Missed Branches",
+              "Cover",
+          )
+          widths = [len(name) for name in header]
+          for row in rows:
+              for idx, value in enumerate(row):
+                  widths[idx] = max(widths[idx], len(str(value)))
+
+          def format_row(row):
+              cells = []
+              for idx, value in enumerate(row):
+                  value = str(value)
+                  if idx == 0:
+                      cells.append(value.ljust(widths[idx]))
+                  else:
+                      cells.append(value.rjust(widths[idx]))
+              return "  ".join(cells)
+
+          lines = [format_row(header), "-" * len(format_row(header))]
+          lines.extend(format_row(row) for row in rows)
+          Path("coverage-summary.txt").write_text("\n".join(lines) + "\n")
+          Path("coverage-line-percent.txt").write_text(pct(totals["lines"]) + "\n")
+          PY
+
+          total_line=$(cat coverage-line-percent.txt)
 
           {
             echo "## RQL Coverage Report"
@@ -93,7 +187,7 @@ jobs:
             echo '```'
             echo ""
             echo "> ℹ️ Report-only — this never blocks merge (ADR 0053 / PRD #1098)."
-            echo "> Run locally: \`cargo llvm-cov -p reddb-io-rql --lib --summary-only\`"
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-rql --lib --summary-only --ignore-filename-regex 'crates/reddb-types/'\`"
           } > coverage-report.md
 
           # Mirror to the job summary so the signal is visible without a PR.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,11 +2437,14 @@ dependencies = [
  "reddb-io-client",
  "reddb-io-file",
  "reddb-io-grpc-proto",
+ "reddb-io-rql",
  "reddb-io-server",
+ "reddb-io-types",
  "reddb-io-wire",
  "rustls",
  "serde_json",
  "snap",
+ "sqllogictest",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2526,10 +2529,8 @@ name = "reddb-io-rql"
 version = "1.0.0"
 dependencies = [
  "proptest",
- "reddb-io-server",
  "reddb-io-types",
  "serde_json",
- "sqllogictest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,12 @@ redwire = ["reddb-client/redwire"]
 # the tests need.
 reddb-client = { package = "reddb-io-client", version = "1.0", path = "crates/reddb-client", features = ["embedded", "redwire"] }
 reddb-file = { package = "reddb-io-file", version = "1.0", path = "crates/reddb-file" }
+# Workspace-level RQL conformance drivers execute the corpus owned by
+# `crates/reddb-rql` against the current in-server engine. Keeping these deps
+# here preserves the pure `reddb-io-rql -> reddb-io-types` crate graph.
+reddb-rql = { package = "reddb-io-rql", version = "1.0", path = "crates/reddb-rql" }
+reddb-types = { package = "reddb-io-types", version = "1.0", path = "crates/reddb-types" }
+sqllogictest = "0.29"
 # Used by `tests/compile_fail.rs` to assert that misuse of
 # `LeaseStore::new` (passing a non-CAS backend) fails to compile.
 trybuild = "1"

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -21,14 +21,7 @@ path = "src/lib.rs"
 [dependencies]
 reddb-types = { package = "reddb-io-types", version = "1.0", path = "../reddb-types" }
 
-# The conformance harness runs the corpus end-to-end against the *current
-# in-server engine* (ADR 0053: executors stay in reddb-server during the
-# extraction). It reaches the engine only from the integration-test target, so
-# `reddb-server` and the `sqllogictest` harness are dev-only — the published
-# crate graph keeps `reddb-io-rql -> reddb-io-types` as its sole edge.
 [dev-dependencies]
-reddb-server = { package = "reddb-io-server", version = "1.10", path = "../reddb-server" }
-sqllogictest = "0.29"
 # Parser property round-trip tests (issue #87) moved in with the parser family
 # (#1103); the AST→SQL renderer moved with them, so the round-trip stays a
 # single in-crate type instance (no `reddb-server` round-trip).

--- a/crates/reddb-rql/src/analyzer.rs
+++ b/crates/reddb-rql/src/analyzer.rs
@@ -81,3 +81,112 @@ pub fn resolve_sql_type_name(sql_type: &SqlTypeName) -> Result<DataType, Analysi
     DataType::from_sql_type_name(sql_type)
         .ok_or_else(|| AnalysisError::UnsupportedType(sql_type.base_name()))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{CreateColumnDef, CreateTableQuery};
+    use reddb_types::catalog::CollectionModel;
+
+    fn column(name: &str, declared: &str) -> CreateColumnDef {
+        CreateColumnDef {
+            name: name.to_string(),
+            data_type: declared.to_string(),
+            sql_type: SqlTypeName::parse_declared(declared),
+            not_null: false,
+            default: None,
+            compress: None,
+            unique: false,
+            primary_key: false,
+            enum_variants: Vec::new(),
+            array_element: None,
+            decimal_precision: None,
+        }
+    }
+
+    fn create_table(columns: Vec<CreateColumnDef>) -> CreateTableQuery {
+        CreateTableQuery {
+            collection_model: CollectionModel::Table,
+            name: "orders".to_string(),
+            columns,
+            if_not_exists: true,
+            default_ttl_ms: Some(60_000),
+            metrics_rollup_policies: Vec::new(),
+            context_index_fields: vec!["description".to_string()],
+            context_index_enabled: true,
+            timestamps: true,
+            partition_by: None,
+            tenant_by: None,
+            append_only: false,
+            subscriptions: Vec::new(),
+            analytics_config: Vec::new(),
+            vault_own_master_key: false,
+        }
+    }
+
+    #[test]
+    fn analyze_create_table_resolves_columns_and_preserves_options() {
+        let mut id = column("id", "INTEGER");
+        id.primary_key = true;
+        id.not_null = true;
+
+        let mut description = column("description", "VARCHAR");
+        description.default = Some("'new'".to_string());
+        description.unique = true;
+
+        let query = create_table(vec![id, description]);
+        let analyzed = analyze_create_table(&query).unwrap();
+
+        assert_eq!(analyzed.name, "orders");
+        assert!(analyzed.if_not_exists);
+        assert_eq!(analyzed.default_ttl_ms, Some(60_000));
+        assert_eq!(analyzed.context_index_fields, ["description"]);
+        assert!(analyzed.timestamps);
+        assert_eq!(analyzed.columns.len(), 2);
+        assert_eq!(analyzed.columns[0].name, "id");
+        assert_eq!(analyzed.columns[0].storage_type, DataType::Integer);
+        assert!(analyzed.columns[0].not_null);
+        assert!(analyzed.columns[0].primary_key);
+        assert_eq!(analyzed.columns[1].declared_type.base_name(), "VARCHAR");
+        assert_eq!(analyzed.columns[1].storage_type, DataType::Text);
+        assert_eq!(analyzed.columns[1].default.as_deref(), Some("'new'"));
+        assert!(analyzed.columns[1].unique);
+    }
+
+    #[test]
+    fn duplicate_columns_are_case_insensitive() {
+        let query = create_table(vec![column("Id", "INT"), column("id", "INT")]);
+        let err = analyze_create_table(&query).unwrap_err();
+
+        assert!(matches!(err, AnalysisError::DuplicateColumn(ref name) if name == "id"));
+        assert_eq!(err.to_string(), "duplicate column name: id");
+    }
+
+    #[test]
+    fn unsupported_type_is_reported_with_normalized_name() {
+        let query = create_table(vec![column("mystery", "not_a_real_type")]);
+        let err = analyze_create_table(&query).unwrap_err();
+
+        assert!(
+            matches!(err, AnalysisError::UnsupportedType(ref name) if name == "NOT_A_REAL_TYPE")
+        );
+        assert_eq!(err.to_string(), "unsupported SQL type: NOT_A_REAL_TYPE");
+    }
+
+    #[test]
+    fn resolve_declared_data_type_accepts_sql_aliases() {
+        assert_eq!(
+            resolve_declared_data_type("varchar").unwrap(),
+            DataType::Text
+        );
+        assert_eq!(
+            resolve_declared_data_type("numeric(10)").unwrap(),
+            DataType::Decimal
+        );
+        assert_eq!(
+            resolve_declared_data_type("timestamptz").unwrap(),
+            DataType::TimestampMs
+        );
+        assert!(resolve_declared_data_type("definitely_not_sql").is_err());
+    }
+}

--- a/crates/reddb-rql/src/builders.rs
+++ b/crates/reddb-rql/src/builders.rs
@@ -624,3 +624,208 @@ impl Default for CteQueryBuilder {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn eq_filter(column: &str, value: Value) -> Filter {
+        Filter::compare(FieldRef::column("", column), CompareOp::Eq, value)
+    }
+
+    fn join_condition() -> JoinCondition {
+        JoinCondition::new(
+            FieldRef::column("left", "id"),
+            FieldRef::column("right", "id"),
+        )
+    }
+
+    #[test]
+    fn table_builder_covers_selection_filters_order_limit_and_offset() {
+        let query = TableQueryBuilder::new("hosts")
+            .alias("h")
+            .select("ip")
+            .filter(eq_filter("os", Value::text("linux")))
+            .filter(eq_filter("active", Value::Boolean(true)))
+            .order_by(OrderByClause::desc(FieldRef::column("h", "last_seen")))
+            .limit(10)
+            .offset(5)
+            .build();
+
+        let QueryExpr::Table(table) = query else {
+            panic!("expected table query");
+        };
+        assert_eq!(table.table, "hosts");
+        assert_eq!(table.alias.as_deref(), Some("h"));
+        assert_eq!(table.select_items.len(), 1);
+        assert_eq!(table.columns.len(), 1);
+        assert!(matches!(table.filter, Some(Filter::And(_, _))));
+        assert!(matches!(
+            table.where_expr,
+            Some(Expr::BinaryOp { op: BinOp::And, .. })
+        ));
+        assert_eq!(table.order_by.len(), 1);
+        assert_eq!(table.limit, Some(10));
+        assert_eq!(table.offset, Some(5));
+
+        let QueryExpr::Table(table) = TableQueryBuilder::new("hosts").select_all().build() else {
+            panic!("expected table query");
+        };
+        assert_eq!(table.select_items, vec![SelectItem::Wildcard]);
+        assert!(table.columns.is_empty());
+    }
+
+    #[test]
+    fn graph_builder_combines_filters_alias_limit_and_returns() {
+        let query = GraphQueryBuilder::new()
+            .node(NodePattern::new("h").of_label("Host"))
+            .edge(EdgePattern::new("h", "s").of_label("HAS_SERVICE"))
+            .filter(eq_filter("critical", Value::Boolean(true)))
+            .filter(eq_filter("active", Value::Boolean(true)))
+            .alias("g")
+            .limit(3)
+            .return_field(FieldRef::node_prop("h", "ip"))
+            .build();
+
+        let QueryExpr::Graph(graph) = query else {
+            panic!("expected graph query");
+        };
+        assert_eq!(graph.alias.as_deref(), Some("g"));
+        assert_eq!(graph.pattern.nodes.len(), 1);
+        assert_eq!(graph.pattern.edges.len(), 1);
+        assert!(matches!(graph.filter, Some(Filter::And(_, _))));
+        assert_eq!(graph.limit, Some(3));
+        assert_eq!(graph.return_.len(), 1);
+    }
+
+    #[test]
+    fn join_builder_aliases_supported_right_sources_and_builds_options() {
+        let condition = join_condition();
+        let cases = vec![
+            TableQueryBuilder::new("hosts").join_table("services", condition.clone()),
+            TableQueryBuilder::new("hosts").join_graph(GraphPattern::new(), condition.clone()),
+            TableQueryBuilder::new("hosts").join_path(
+                PathQuery::new(NodeSelector::by_id("a"), NodeSelector::by_id("b")),
+                condition.clone(),
+            ),
+            TableQueryBuilder::new("hosts").join_vector(
+                VectorQuery::new("embeddings", VectorSource::text("ssh")),
+                condition.clone(),
+            ),
+            TableQueryBuilder::new("hosts").join_hybrid(
+                HybridQuery::new(
+                    QueryExpr::Table(TableQuery::new("hosts")),
+                    VectorQuery::new("embeddings", VectorSource::text("ssh")),
+                ),
+                condition.clone(),
+            ),
+        ];
+
+        for builder in cases {
+            let query = builder
+                .right_alias("rhs")
+                .join_type(JoinType::FullOuter)
+                .filter(eq_filter("ok", Value::Boolean(true)))
+                .order_by(OrderByClause::asc(FieldRef::column("", "id")))
+                .limit(4)
+                .offset(2)
+                .return_field(FieldRef::column("hosts", "id"))
+                .select("name")
+                .build();
+
+            let QueryExpr::Join(join) = query else {
+                panic!("expected join query");
+            };
+            assert_eq!(join.join_type, JoinType::FullOuter);
+            assert!(join.filter.is_some());
+            assert_eq!(join.order_by.len(), 1);
+            assert_eq!(join.limit, Some(4));
+            assert_eq!(join.offset, Some(2));
+            assert_eq!(join.return_.len(), 2);
+            assert_eq!(join.return_items.len(), 2);
+            match *join.right {
+                QueryExpr::Table(table) => assert_eq!(table.alias.as_deref(), Some("rhs")),
+                QueryExpr::Graph(graph) => assert_eq!(graph.alias.as_deref(), Some("rhs")),
+                QueryExpr::Path(path) => assert_eq!(path.alias.as_deref(), Some("rhs")),
+                QueryExpr::Vector(vector) => assert_eq!(vector.alias.as_deref(), Some("rhs")),
+                QueryExpr::Hybrid(hybrid) => assert_eq!(hybrid.alias.as_deref(), Some("rhs")),
+                other => panic!("unexpected right source: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn join_builder_right_alias_ignores_non_source_variants() {
+        let builder = JoinQueryBuilder {
+            left: QueryExpr::Table(TableQuery::new("left")),
+            right: QueryExpr::SetTenant(Some("acme".to_string())),
+            on: join_condition(),
+            join_type: JoinType::Inner,
+            filter: None,
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+            return_items: Vec::new(),
+            return_: Vec::new(),
+        };
+        let query = builder.right_alias("ignored").build();
+        let QueryExpr::Join(join) = query else {
+            panic!("expected join query");
+        };
+        assert!(matches!(*join.right, QueryExpr::SetTenant(Some(ref tenant)) if tenant == "acme"));
+    }
+
+    #[test]
+    fn path_builder_sets_alias_via_filter_and_length() {
+        let query = PathQueryBuilder::new(NodeSelector::by_id("a"), NodeSelector::by_id("b"))
+            .via_label("CONNECTS_TO")
+            .max_length(7)
+            .filter(eq_filter("kind", Value::text("vpn")))
+            .alias("p")
+            .build();
+
+        let QueryExpr::Path(path) = query else {
+            panic!("expected path query");
+        };
+        assert_eq!(path.alias.as_deref(), Some("p"));
+        assert_eq!(path.via, vec!["CONNECTS_TO"]);
+        assert_eq!(path.max_length, 7);
+        assert!(path.filter.is_some());
+    }
+
+    #[test]
+    fn cte_helpers_track_recursive_state_and_lookup() {
+        let base = QueryExpr::Table(TableQuery::new("hosts"));
+        let cte = CteDefinition::new("active", base.clone())
+            .with_columns(vec!["id".to_string(), "ip".to_string()]);
+        assert_eq!(cte.name, "active");
+        assert_eq!(cte.columns, vec!["id", "ip"]);
+        assert!(!cte.recursive);
+
+        let recursive = CteDefinition::recursive("walk", base.clone());
+        assert!(recursive.recursive);
+
+        let clause = WithClause::new().add(cte).add(recursive);
+        assert!(!clause.is_empty());
+        assert!(clause.has_recursive);
+        assert!(clause.get("active").is_some());
+        assert!(clause.get("missing").is_none());
+
+        let simple = QueryWithCte::simple(base.clone());
+        assert!(simple.with_clause.is_none());
+        assert!(matches!(simple.query, QueryExpr::Table(_)));
+
+        let with_ctes = QueryWithCte::with_ctes(clause.clone(), base.clone());
+        assert!(with_ctes.with_clause.is_some());
+
+        let built = CteQueryBuilder::new()
+            .cte("one", base.clone())
+            .recursive_cte("two", base.clone())
+            .cte_with_columns("three", vec!["id".to_string()], base.clone())
+            .build(base);
+        let clause = built.with_clause.expect("with clause");
+        assert_eq!(clause.ctes.len(), 3);
+        assert!(clause.has_recursive);
+        assert_eq!(clause.get("three").expect("cte").columns, vec!["id"]);
+    }
+}

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -3206,6 +3206,264 @@ pub enum ConfigCommand {
     },
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Expr, Span};
+
+    fn table_expr(name: &str) -> QueryExpr {
+        QueryExpr::Table(TableQuery::new(name))
+    }
+
+    #[test]
+    fn policy_target_kind_identifiers_cover_all_variants() {
+        assert_eq!(PolicyTargetKind::Table.as_ident(), "table");
+        assert_eq!(PolicyTargetKind::Nodes.as_ident(), "nodes");
+        assert_eq!(PolicyTargetKind::Edges.as_ident(), "edges");
+        assert_eq!(PolicyTargetKind::Vectors.as_ident(), "vectors");
+        assert_eq!(PolicyTargetKind::Messages.as_ident(), "messages");
+        assert_eq!(PolicyTargetKind::Points.as_ident(), "points");
+        assert_eq!(PolicyTargetKind::Documents.as_ident(), "documents");
+    }
+
+    #[test]
+    fn index_method_display_names_are_sql_keywords() {
+        assert_eq!(IndexMethod::BTree.to_string(), "BTREE");
+        assert_eq!(IndexMethod::Hash.to_string(), "HASH");
+        assert_eq!(IndexMethod::Bitmap.to_string(), "BITMAP");
+        assert_eq!(IndexMethod::RTree.to_string(), "RTREE");
+    }
+
+    #[test]
+    fn table_query_defaults_and_subquery_source() {
+        let query = TableQuery::new("hosts");
+        assert_eq!(query.table, "hosts");
+        assert!(query.source.is_none());
+        assert!(query.alias.is_none());
+        assert!(query.select_items.is_empty());
+        assert!(!query.distinct);
+
+        let subquery = table_expr("inner");
+        let wrapped = TableQuery::from_subquery(subquery, Some("h".to_string()));
+        assert_eq!(wrapped.table, "__subq_h");
+        assert_eq!(wrapped.alias.as_deref(), Some("h"));
+        assert!(matches!(wrapped.source, Some(TableSource::Subquery(_))));
+
+        let anonymous = TableQuery::from_subquery(table_expr("inner"), None);
+        assert_eq!(anonymous.table, "__subq_anon");
+        assert!(anonymous.alias.is_none());
+    }
+
+    #[test]
+    fn graph_pattern_query_and_components_builders_set_fields() {
+        let node = NodePattern::new("h").of_label("Host").with_property(
+            "os",
+            CompareOp::Eq,
+            Value::text("linux"),
+        );
+        assert_eq!(node.alias, "h");
+        assert_eq!(node.node_label.as_deref(), Some("Host"));
+        assert_eq!(node.properties.len(), 1);
+
+        let edge = EdgePattern::new("h", "s")
+            .alias("r")
+            .of_label("HAS_SERVICE")
+            .direction(EdgeDirection::Incoming)
+            .hops(2, 4);
+        assert_eq!(edge.alias.as_deref(), Some("r"));
+        assert_eq!(edge.edge_label.as_deref(), Some("HAS_SERVICE"));
+        assert_eq!(edge.direction, EdgeDirection::Incoming);
+        assert_eq!((edge.min_hops, edge.max_hops), (2, 4));
+
+        let pattern = GraphPattern::new().node(node).edge(edge);
+        assert_eq!(pattern.nodes.len(), 1);
+        assert_eq!(pattern.edges.len(), 1);
+
+        let graph = GraphQuery::new(pattern).alias("g");
+        assert_eq!(graph.alias.as_deref(), Some("g"));
+        assert!(graph.filter.is_none());
+        assert!(graph.return_.is_empty());
+    }
+
+    #[test]
+    fn join_condition_and_join_query_defaults() {
+        let left = FieldRef::column("hosts", "id");
+        let right = FieldRef::node_id("h");
+        let condition = JoinCondition::new(left.clone(), right.clone());
+        assert_eq!(condition.left_field, left);
+        assert_eq!(condition.right_field, right);
+
+        let join = JoinQuery::new(
+            table_expr("hosts"),
+            table_expr("services"),
+            condition.clone(),
+        )
+        .join_type(JoinType::LeftOuter);
+        assert!(matches!(*join.left, QueryExpr::Table(_)));
+        assert!(matches!(*join.right, QueryExpr::Table(_)));
+        assert_eq!(join.join_type, JoinType::LeftOuter);
+        assert_eq!(join.on.left_field, condition.left_field);
+        assert!(join.return_items.is_empty());
+    }
+
+    #[test]
+    fn field_ref_projection_filter_and_order_builders() {
+        let column = FieldRef::column("hosts", "ip");
+        let node_prop = FieldRef::node_prop("h", "os");
+        let edge_prop = FieldRef::edge_prop("r", "weight");
+        assert!(matches!(column, FieldRef::TableColumn { .. }));
+        assert!(matches!(node_prop, FieldRef::NodeProperty { .. }));
+        assert!(matches!(edge_prop, FieldRef::EdgeProperty { .. }));
+
+        assert!(matches!(
+            Projection::from_field(column.clone()),
+            Projection::Field(_, None)
+        ));
+        assert!(matches!(
+            Projection::column("ip"),
+            Projection::Column(ref name) if name == "ip"
+        ));
+        assert!(matches!(
+            Projection::with_alias("ip", "addr"),
+            Projection::Alias(ref column, ref alias) if column == "ip" && alias == "addr"
+        ));
+
+        let eq = Filter::compare(column.clone(), CompareOp::Eq, Value::text("127.0.0.1"));
+        let gt = Filter::compare(node_prop, CompareOp::Gt, Value::Integer(7));
+        let combined = eq.clone().and(gt.clone()).or(eq.clone().not());
+        assert!(matches!(combined, Filter::Or(_, _)));
+        assert!(matches!(gt.optimize(), Filter::Compare { .. }));
+
+        assert_eq!(CompareOp::Eq.to_string(), "=");
+        assert_eq!(CompareOp::Ne.to_string(), "<>");
+        assert_eq!(CompareOp::Lt.to_string(), "<");
+        assert_eq!(CompareOp::Le.to_string(), "<=");
+        assert_eq!(CompareOp::Gt.to_string(), ">");
+        assert_eq!(CompareOp::Ge.to_string(), ">=");
+
+        let asc = OrderByClause::asc(column.clone());
+        assert!(asc.ascending);
+        assert!(!asc.nulls_first);
+        assert!(asc.expr.is_none());
+
+        let desc = OrderByClause::desc(column).with_expr(Expr::lit(Value::Integer(1)));
+        assert!(!desc.ascending);
+        assert!(desc.nulls_first);
+        assert!(desc.expr.is_some());
+    }
+
+    #[test]
+    fn path_and_node_selector_builders_set_expected_defaults() {
+        let from = NodeSelector::by_id("a");
+        let to = NodeSelector::by_row("hosts", 42);
+        let path = PathQuery::new(from, to).alias("p").via_label("CONNECTS_TO");
+        assert_eq!(path.alias.as_deref(), Some("p"));
+        assert_eq!(path.via, vec!["CONNECTS_TO"]);
+        assert_eq!(path.max_length, 10);
+        assert!(path.filter.is_none());
+
+        assert!(matches!(NodeSelector::by_id("n1"), NodeSelector::ById(id) if id == "n1"));
+        assert!(matches!(
+            NodeSelector::by_label("Host"),
+            NodeSelector::ByType { node_label, filter: None } if node_label == "Host"
+        ));
+        assert!(matches!(
+            NodeSelector::by_row("hosts", 7),
+            NodeSelector::ByRow { table, row_id } if table == "hosts" && row_id == 7
+        ));
+    }
+
+    #[test]
+    fn vector_and_hybrid_builders_set_options() {
+        let literal = VectorSource::literal(vec![0.1, 0.2]);
+        assert!(matches!(literal, VectorSource::Literal(ref values) if values == &[0.1, 0.2]));
+        assert!(matches!(VectorSource::text("ssh"), VectorSource::Text(ref text) if text == "ssh"));
+        assert!(matches!(
+            VectorSource::reference("embeddings", 9),
+            VectorSource::Reference { collection, vector_id }
+                if collection == "embeddings" && vector_id == 9
+        ));
+
+        let vector = VectorQuery::new("embeddings", VectorSource::text("ssh"))
+            .limit(3)
+            .with_filter(MetadataFilter::eq("source", "nmap"))
+            .with_vectors()
+            .min_similarity(0.8)
+            .alias("sim");
+        assert_eq!(vector.collection, "embeddings");
+        assert_eq!(vector.k, 3);
+        assert!(vector.filter.is_some());
+        assert!(vector.include_vectors);
+        assert!(vector.include_metadata);
+        assert_eq!(vector.threshold, Some(0.8));
+        assert_eq!(vector.alias.as_deref(), Some("sim"));
+
+        let hybrid = HybridQuery::new(table_expr("hosts"), vector)
+            .with_fusion(FusionStrategy::RRF { k: 60 })
+            .limit(5)
+            .alias("hy");
+        assert!(matches!(*hybrid.structured, QueryExpr::Table(_)));
+        assert_eq!(hybrid.limit, Some(5));
+        assert_eq!(hybrid.alias.as_deref(), Some("hy"));
+        assert!(matches!(hybrid.fusion, FusionStrategy::RRF { k: 60 }));
+    }
+
+    #[test]
+    fn window_spec_structs_are_constructible() {
+        let order = WindowOrderItem {
+            expr: Expr::lit(Value::Integer(1)),
+            ascending: false,
+            nulls_first: true,
+        };
+        let frame = WindowFrame {
+            unit: WindowFrameUnit::Rows,
+            start: WindowFrameBound::UnboundedPreceding,
+            end: Some(WindowFrameBound::CurrentRow),
+        };
+        let spec = WindowSpec {
+            partition_by: vec![Expr::lit(Value::text("tenant"))],
+            order_by: vec![order],
+            frame: Some(frame),
+        };
+        assert_eq!(spec.partition_by.len(), 1);
+        assert_eq!(spec.order_by.len(), 1);
+        assert!(matches!(
+            spec.frame,
+            Some(WindowFrame {
+                unit: WindowFrameUnit::Rows,
+                ..
+            })
+        ));
+
+        let default = WindowSpec::default();
+        assert!(default.partition_by.is_empty());
+        assert!(default.order_by.is_empty());
+        assert!(default.frame.is_none());
+
+        let _ = Span::synthetic();
+    }
+
+    #[test]
+    fn config_value_type_aliases_and_display_names() {
+        for (input, expected, as_str) in [
+            ("bool", ConfigValueType::Bool, "bool"),
+            ("boolean", ConfigValueType::Bool, "bool"),
+            ("int", ConfigValueType::Int, "int"),
+            ("integer", ConfigValueType::Int, "int"),
+            ("str", ConfigValueType::String, "string"),
+            ("text", ConfigValueType::String, "string"),
+            ("url", ConfigValueType::Url, "url"),
+            ("json_object", ConfigValueType::Object, "object"),
+            ("list", ConfigValueType::Array, "array"),
+        ] {
+            let parsed = ConfigValueType::parse(input).expect("known type");
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.as_str(), as_str);
+        }
+        assert_eq!(ConfigValueType::parse("bogus"), None);
+    }
+}
+
 // ============================================================================
 // Builders (Fluent API)
 // ============================================================================

--- a/crates/reddb-rql/src/expr_typing.rs
+++ b/crates/reddb-rql/src/expr_typing.rs
@@ -577,3 +577,348 @@ fn binop_result_type(op: BinOp, lhs: DataType, rhs: DataType) -> Result<DataType
 fn _ctx_explicit() -> CastContext {
     CastContext::Explicit
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::Span;
+    use crate::lexer::Position;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::sync::Arc;
+
+    fn span() -> Span {
+        Span {
+            start: Position::default(),
+            end: Position::default(),
+        }
+    }
+
+    fn lit(value: Value) -> Expr {
+        Expr::Literal {
+            value,
+            span: span(),
+        }
+    }
+
+    fn col(table: &str, column: &str) -> Expr {
+        Expr::Column {
+            field: FieldRef::column(table, column),
+            span: span(),
+        }
+    }
+
+    fn bin(op: BinOp, lhs: Expr, rhs: Expr) -> Expr {
+        Expr::BinaryOp {
+            op,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+            span: span(),
+        }
+    }
+
+    fn unary(op: UnaryOp, operand: Expr) -> Expr {
+        Expr::UnaryOp {
+            op,
+            operand: Box::new(operand),
+            span: span(),
+        }
+    }
+
+    fn scope(table: &str, column: &str) -> Option<DataType> {
+        match (table, column) {
+            ("", "age") => Some(DataType::Integer),
+            ("", "active") => Some(DataType::Boolean),
+            ("users", "name") => Some(DataType::Text),
+            ("n", "score") => Some(DataType::Float),
+            _ => None,
+        }
+    }
+
+    fn no_scope(_: &str, _: &str) -> Option<DataType> {
+        None
+    }
+
+    #[test]
+    fn literal_values_map_to_declared_types() {
+        let values = vec![
+            (Value::Null, DataType::Nullable),
+            (Value::Boolean(true), DataType::Boolean),
+            (Value::Integer(1), DataType::Integer),
+            (Value::UnsignedInteger(1), DataType::UnsignedInteger),
+            (Value::Float(1.0), DataType::Float),
+            (Value::BigInt(1), DataType::BigInt),
+            (Value::Decimal(100), DataType::Decimal),
+            (Value::Text(Arc::from("x")), DataType::Text),
+            (Value::Blob(vec![1, 2]), DataType::Blob),
+            (Value::Timestamp(1), DataType::Timestamp),
+            (Value::TimestampMs(1), DataType::TimestampMs),
+            (Value::Duration(1), DataType::Duration),
+            (Value::Date(1), DataType::Date),
+            (Value::Time(1), DataType::Time),
+            (
+                Value::IpAddr(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                DataType::IpAddr,
+            ),
+            (Value::Ipv4(0x7f00_0001), DataType::Ipv4),
+            (Value::Ipv6([0; 16]), DataType::Ipv6),
+            (Value::Subnet(0, 24), DataType::Subnet),
+            (Value::Cidr(0, 24), DataType::Cidr),
+            (Value::MacAddr([1, 2, 3, 4, 5, 6]), DataType::MacAddr),
+            (Value::Port(5432), DataType::Port),
+            (Value::Latitude(1), DataType::Latitude),
+            (Value::Longitude(1), DataType::Longitude),
+            (Value::GeoPoint(1, 2), DataType::GeoPoint),
+            (Value::Country2(*b"BR"), DataType::Country2),
+            (Value::Country3(*b"BRA"), DataType::Country3),
+            (Value::Lang2(*b"pt"), DataType::Lang2),
+            (Value::Lang5(*b"pt-BR"), DataType::Lang5),
+            (Value::Currency(*b"BRL"), DataType::Currency),
+            (Value::AssetCode("BTC".to_string()), DataType::AssetCode),
+            (
+                Value::Money {
+                    asset_code: "BRL".to_string(),
+                    minor_units: 123,
+                    scale: 2,
+                },
+                DataType::Money,
+            ),
+            (Value::Color([1, 2, 3]), DataType::Color),
+            (Value::ColorAlpha([1, 2, 3, 4]), DataType::ColorAlpha),
+            (Value::Email("a@example.com".to_string()), DataType::Email),
+            (Value::Url("https://example.com".to_string()), DataType::Url),
+            (Value::Phone(5511999999999), DataType::Phone),
+            (Value::Semver(1_002_003), DataType::Semver),
+            (Value::Uuid([1; 16]), DataType::Uuid),
+            (Value::Vector(vec![1.0, 2.0]), DataType::Vector),
+            (Value::Array(vec![Value::Integer(1)]), DataType::Array),
+            (Value::Json(br#"{"x":1}"#.to_vec()), DataType::Json),
+            (Value::EnumValue(1), DataType::Enum),
+            (Value::NodeRef("n1".to_string()), DataType::NodeRef),
+            (Value::EdgeRef("e1".to_string()), DataType::EdgeRef),
+            (Value::VectorRef("vecs".to_string(), 1), DataType::VectorRef),
+            (Value::RowRef("rows".to_string(), 1), DataType::RowRef),
+            (
+                Value::KeyRef("kv".to_string(), "k".to_string()),
+                DataType::KeyRef,
+            ),
+            (Value::DocRef("docs".to_string(), 1), DataType::DocRef),
+            (Value::TableRef("users".to_string()), DataType::TableRef),
+            (Value::PageRef(7), DataType::PageRef),
+            (Value::Secret(vec![1, 2, 3]), DataType::Secret),
+            (Value::Password("argon2".to_string()), DataType::Password),
+        ];
+
+        for (value, expected) in values {
+            let typed = type_expr(&lit(value), &no_scope).unwrap();
+            assert_eq!(typed.ty, expected);
+            assert!(matches!(typed.kind, TypedExprKind::Literal(_)));
+        }
+    }
+
+    #[test]
+    fn column_lookup_preserves_field_ref_and_reports_unknowns() {
+        let typed = type_expr(&col("users", "name"), &scope).unwrap();
+        assert_eq!(typed.ty, DataType::Text);
+        assert!(matches!(
+            typed.kind,
+            TypedExprKind::Column(FieldRef::TableColumn { table, column })
+                if table == "users" && column == "name"
+        ));
+
+        let err = type_expr(&col("", "missing"), &scope).unwrap_err();
+        assert!(matches!(
+            err,
+            TypeError::UnknownColumn { ref table, ref column }
+                if table.is_empty() && column == "missing"
+        ));
+        assert_eq!(err.to_string(), "unknown column `missing`");
+    }
+
+    #[test]
+    fn arithmetic_logical_and_unary_ops_return_expected_types() {
+        let add = bin(BinOp::Add, lit(Value::Integer(1)), lit(Value::Float(2.0)));
+        assert_eq!(type_expr(&add, &scope).unwrap().ty, DataType::Float);
+
+        let and = bin(BinOp::And, col("", "active"), lit(Value::Boolean(false)));
+        assert_eq!(type_expr(&and, &scope).unwrap().ty, DataType::Boolean);
+
+        let neg = unary(UnaryOp::Neg, col("", "age"));
+        assert_eq!(type_expr(&neg, &scope).unwrap().ty, DataType::Integer);
+
+        let not = unary(UnaryOp::Not, col("", "active"));
+        assert_eq!(type_expr(&not, &scope).unwrap().ty, DataType::Boolean);
+    }
+
+    #[test]
+    fn operator_mismatches_are_reported() {
+        let bad_and = bin(
+            BinOp::And,
+            lit(Value::Boolean(true)),
+            lit(Value::Integer(1)),
+        );
+        assert!(matches!(
+            type_expr(&bad_and, &scope).unwrap_err(),
+            TypeError::OperatorMismatch {
+                op: BinOp::And,
+                lhs: DataType::Boolean,
+                rhs: DataType::Integer,
+            }
+        ));
+
+        let bad_neg = unary(UnaryOp::Neg, lit(Value::Text(Arc::from("x"))));
+        assert!(matches!(
+            type_expr(&bad_neg, &scope).unwrap_err(),
+            TypeError::UnaryMismatch {
+                op: UnaryOp::Neg,
+                operand: DataType::Text,
+            }
+        ));
+    }
+
+    #[test]
+    fn casts_functions_and_parameters_have_stable_types() {
+        let cast = Expr::Cast {
+            inner: Box::new(lit(Value::Integer(1))),
+            target: DataType::Text,
+            span: span(),
+        };
+        assert_eq!(type_expr(&cast, &scope).unwrap().ty, DataType::Text);
+
+        let concat = Expr::FunctionCall {
+            name: "concat".to_string(),
+            args: vec![lit(Value::Text(Arc::from("a"))), lit(Value::Integer(1))],
+            span: span(),
+        };
+        assert_eq!(type_expr(&concat, &scope).unwrap().ty, DataType::Text);
+
+        let money_minor = Expr::FunctionCall {
+            name: "money_minor".to_string(),
+            args: vec![lit(Value::Money {
+                asset_code: "BRL".to_string(),
+                minor_units: 10,
+                scale: 2,
+            })],
+            span: span(),
+        };
+        assert_eq!(
+            type_expr(&money_minor, &scope).unwrap().ty,
+            DataType::BigInt
+        );
+
+        let coalesce = Expr::FunctionCall {
+            name: "coalesce".to_string(),
+            args: vec![
+                lit(Value::Null),
+                lit(Value::Integer(1)),
+                lit(Value::Float(2.0)),
+            ],
+            span: span(),
+        };
+        assert_eq!(type_expr(&coalesce, &scope).unwrap().ty, DataType::Integer);
+
+        let unknown = Expr::FunctionCall {
+            name: "not_a_function".to_string(),
+            args: Vec::new(),
+            span: span(),
+        };
+        assert_eq!(type_expr(&unknown, &scope).unwrap().ty, DataType::Nullable);
+
+        let parameter = Expr::Parameter {
+            index: 1,
+            span: span(),
+        };
+        assert_eq!(
+            type_expr(&parameter, &scope).unwrap().ty,
+            DataType::Nullable
+        );
+    }
+
+    #[test]
+    fn invalid_casts_case_branches_and_lists_are_errors() {
+        let bad_cast = Expr::Cast {
+            inner: Box::new(lit(Value::Blob(vec![1]))),
+            target: DataType::Money,
+            span: span(),
+        };
+        assert!(matches!(
+            type_expr(&bad_cast, &scope).unwrap_err(),
+            TypeError::InvalidCast {
+                src: DataType::Blob,
+                target: DataType::Money,
+            }
+        ));
+
+        let case = Expr::Case {
+            branches: vec![(
+                lit(Value::Boolean(true)),
+                lit(Value::Text(Arc::from("text"))),
+            )],
+            else_: Some(Box::new(lit(Value::Integer(1)))),
+            span: span(),
+        };
+        assert!(matches!(
+            type_expr(&case, &scope).unwrap_err(),
+            TypeError::CaseBranchMismatch {
+                first: DataType::Text,
+                other: DataType::Integer,
+            }
+        ));
+
+        let in_list = Expr::InList {
+            target: Box::new(lit(Value::Integer(1))),
+            values: vec![lit(Value::Text(Arc::from("x")))],
+            negated: false,
+            span: span(),
+        };
+        assert!(matches!(
+            type_expr(&in_list, &scope).unwrap_err(),
+            TypeError::InListMismatch {
+                target: DataType::Integer,
+                element: DataType::Text,
+            }
+        ));
+    }
+
+    #[test]
+    fn predicates_return_boolean_when_bounds_and_values_are_compatible() {
+        let is_null = Expr::IsNull {
+            operand: Box::new(col("", "age")),
+            negated: true,
+            span: span(),
+        };
+        assert_eq!(type_expr(&is_null, &scope).unwrap().ty, DataType::Boolean);
+
+        let in_list = Expr::InList {
+            target: Box::new(col("", "age")),
+            values: vec![lit(Value::Integer(1)), lit(Value::Integer(2))],
+            negated: false,
+            span: span(),
+        };
+        assert_eq!(type_expr(&in_list, &scope).unwrap().ty, DataType::Boolean);
+
+        let between = Expr::Between {
+            target: Box::new(col("", "age")),
+            low: Box::new(lit(Value::Integer(1))),
+            high: Box::new(lit(Value::Integer(9))),
+            negated: false,
+            span: span(),
+        };
+        assert_eq!(type_expr(&between, &scope).unwrap().ty, DataType::Boolean);
+
+        let bad_between = Expr::Between {
+            target: Box::new(col("", "age")),
+            low: Box::new(lit(Value::Text(Arc::from("low")))),
+            high: Box::new(lit(Value::Integer(9))),
+            negated: false,
+            span: span(),
+        };
+        assert!(matches!(
+            type_expr(&bad_between, &scope).unwrap_err(),
+            TypeError::OperatorMismatch {
+                op: BinOp::Ge,
+                lhs: DataType::Integer,
+                rhs: DataType::Text,
+            }
+        ));
+    }
+}

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -1,21 +1,17 @@
 //! `reddb-io-rql` — the RedDB Query Language (RQL) front-end + conformance
 //! authority (ADR 0053).
 //!
-//! This crate is being stood up in phases. The eventual home of the RQL
-//! language front-end (lexer → parser → AST → mode translators → analyzer →
-//! typing → optimizer) is here, but in this **S1 tracer-bullet slice** the
-//! language front-end still lives in `reddb-server`. What ships first is the
-//! half of ADR 0053 that is portable today: ownership of the
-//! **correctness specification of execution** — an sqllogictest-format
-//! conformance suite whose truth comes from the public SQLite corpus, run
-//! end-to-end against the current in-server engine.
+//! This crate owns the RQL language front-end: lexer, parser, AST, mode
+//! translators, analyzer, typing, storage-agnostic optimizer, and the
+//! sqllogictest-format conformance corpus whose truth comes from the public
+//! SQLite corpus plus RedDB-authored extensions.
 //!
 //! The crate sits near the bottom of the workspace graph: it depends only on
-//! [`reddb_types`] (the neutral keystone, ADR 0052) and on nothing else of the
-//! workspace. The conformance harness reaches the engine from the
-//! integration-test target alone (a dev-dependency on `reddb-io-server`), so
-//! the published crate graph keeps its single edge `reddb-io-rql ->
-//! reddb-io-types`.
+//! [`reddb_types`] (the neutral keystone, ADR 0052) and on nothing else in the
+//! workspace. Server-backed conformance drivers live in the umbrella package's
+//! integration tests and execute this crate's corpus against the current
+//! in-server engine, so pure `reddb-io-rql` coverage never pulls
+//! `reddb-server` or gRPC into the crate graph.
 //!
 //! The one piece of conformance machinery that is genuinely storage-agnostic —
 //! and therefore lives in the library rather than the test harness — is the

--- a/crates/reddb-rql/src/modes/gremlin.rs
+++ b/crates/reddb-rql/src/modes/gremlin.rs
@@ -1055,4 +1055,160 @@ mod tests {
         let expr = t.to_query_expr();
         assert!(matches!(expr, QueryExpr::Graph(_)));
     }
+
+    #[test]
+    fn test_parse_edge_vertex_terminal_and_path_steps() {
+        let t = GremlinParser::parse(
+            "g.E('edge-1').outV().inV().bothV().otherV().toList().toSet().next().fold()",
+        )
+        .unwrap();
+        assert!(matches!(&t.steps[0], GremlinStep::E(Some(id)) if id == "edge-1"));
+        assert!(matches!(t.steps[1], GremlinStep::OutV));
+        assert!(matches!(t.steps[2], GremlinStep::InV));
+        assert!(matches!(t.steps[3], GremlinStep::BothV));
+        assert!(matches!(t.steps[4], GremlinStep::OtherV));
+        assert!(matches!(t.steps[5], GremlinStep::ToList));
+        assert!(matches!(t.steps[6], GremlinStep::ToSet));
+        assert!(matches!(t.steps[7], GremlinStep::Next));
+        assert!(matches!(t.steps[8], GremlinStep::Fold));
+
+        let t = GremlinParser::parse(
+            "g.V().outE('created').inE('owned').bothE('related').path().simplePath().cyclicPath()",
+        )
+        .unwrap();
+        assert!(matches!(&t.steps[1], GremlinStep::OutE(Some(label)) if label == "created"));
+        assert!(matches!(&t.steps[2], GremlinStep::InE(Some(label)) if label == "owned"));
+        assert!(matches!(&t.steps[3], GremlinStep::BothE(Some(label)) if label == "related"));
+        assert!(matches!(t.steps[4], GremlinStep::Path));
+        assert!(matches!(t.steps[5], GremlinStep::SimplePath));
+        assert!(matches!(t.steps[6], GremlinStep::CyclicPath));
+    }
+
+    #[test]
+    fn test_parse_filter_values_and_map_steps() {
+        let t = GremlinParser::parse(
+            "g.V().has('active', true).has('score', 1.5).has('count', 2).has('name').hasNot('deleted').hasId('node-1').dedup().skip(1).range(2, 5)",
+        )
+        .unwrap();
+        assert!(matches!(
+            &t.steps[1],
+            GremlinStep::Has(key, Some(GremlinValue::Boolean(true))) if key == "active"
+        ));
+        assert!(matches!(
+            &t.steps[2],
+            GremlinStep::Has(key, Some(GremlinValue::Float(value)))
+                if key == "score" && *value == 1.5
+        ));
+        assert!(matches!(
+            &t.steps[3],
+            GremlinStep::Has(key, Some(GremlinValue::Integer(value)))
+                if key == "count" && *value == 2
+        ));
+        assert!(matches!(&t.steps[4], GremlinStep::Has(key, None) if key == "name"));
+        assert!(matches!(&t.steps[5], GremlinStep::HasNot(key) if key == "deleted"));
+        assert!(matches!(&t.steps[6], GremlinStep::HasId(id) if id == "node-1"));
+        assert!(matches!(t.steps[7], GremlinStep::Dedup));
+        assert!(matches!(t.steps[8], GremlinStep::Skip(1)));
+        assert!(matches!(t.steps[9], GremlinStep::Range(2, 5)));
+
+        let t = GremlinParser::parse(
+            "g.V().valueMap('name', 'age').id().label().properties('ip').sum().min().max().mean().select('a', 'b').project('x', 'y')",
+        )
+        .unwrap();
+        assert!(
+            matches!(&t.steps[1], GremlinStep::ValueMap(keys) if keys == &vec!["name".to_string(), "age".to_string()])
+        );
+        assert!(matches!(t.steps[2], GremlinStep::Id));
+        assert!(matches!(t.steps[3], GremlinStep::Label));
+        assert!(
+            matches!(&t.steps[4], GremlinStep::Properties(keys) if keys == &vec!["ip".to_string()])
+        );
+        assert!(matches!(t.steps[5], GremlinStep::Sum));
+        assert!(matches!(t.steps[6], GremlinStep::Min));
+        assert!(matches!(t.steps[7], GremlinStep::Max));
+        assert!(matches!(t.steps[8], GremlinStep::Mean));
+        assert!(matches!(&t.steps[9], GremlinStep::Select(labels) if labels.len() == 2));
+        assert!(matches!(&t.steps[10], GremlinStep::Project(keys) if keys.len() == 2));
+    }
+
+    #[test]
+    fn test_parse_branch_side_effect_and_error_paths() {
+        let t = GremlinParser::parse(
+            "g.V().repeat(__.out('knows')).until(has('name', 'bob')).emit().as('a').aggregate('seen').store('stash').group().groupCount()",
+        )
+        .unwrap();
+        assert!(matches!(&t.steps[1], GremlinStep::Repeat(inner) if inner.steps.len() == 1));
+        assert!(matches!(&t.steps[2], GremlinStep::Until(inner) if inner.steps.len() == 1));
+        assert!(matches!(t.steps[3], GremlinStep::Emit));
+        assert!(matches!(&t.steps[4], GremlinStep::As(label) if label == "a"));
+        assert!(matches!(&t.steps[5], GremlinStep::Aggregate(label) if label == "seen"));
+        assert!(matches!(&t.steps[6], GremlinStep::Store(label) if label == "stash"));
+        assert!(matches!(t.steps[7], GremlinStep::Group));
+        assert!(matches!(t.steps[8], GremlinStep::GroupCount));
+
+        let err = GremlinParser::parse("x.V()").expect_err("invalid traversal source");
+        assert!(err.to_string().contains("Expected 'g.' or '__'"));
+        let err = GremlinParser::parse("g.V().unknown()").expect_err("unknown step");
+        assert!(err.to_string().contains("Unknown step"));
+    }
+
+    #[test]
+    fn test_to_query_expr_covers_filters_aliases_edges_and_projections() {
+        let traversal = GremlinTraversal {
+            source: TraversalSource::Graph,
+            steps: vec![
+                GremlinStep::V(Some("host:1".to_string())),
+                GremlinStep::HasLabel("vuln".to_string()),
+                GremlinStep::Has(
+                    "name".to_string(),
+                    Some(GremlinValue::String("alice".to_string())),
+                ),
+                GremlinStep::Has("seen".to_string(), Some(GremlinValue::Boolean(true))),
+                GremlinStep::Has("count".to_string(), Some(GremlinValue::Integer(2))),
+                GremlinStep::Has("score".to_string(), Some(GremlinValue::Float(9.5))),
+                GremlinStep::Has(
+                    "predicate".to_string(),
+                    Some(GremlinValue::Predicate(GremlinPredicate::Eq(Box::new(
+                        GremlinValue::String("ignored".to_string()),
+                    )))),
+                ),
+                GremlinStep::Out(Some("connects".to_string())),
+                GremlinStep::In(Some("hasService".to_string())),
+                GremlinStep::Both(Some("relatedTo".to_string())),
+                GremlinStep::Values(vec!["name".to_string(), "status".to_string()]),
+                GremlinStep::Count,
+                GremlinStep::As("renamed".to_string()),
+            ],
+        };
+
+        let QueryExpr::Graph(graph) = traversal.to_query_expr() else {
+            panic!("Gremlin should lower to GraphQuery");
+        };
+        assert_eq!(
+            graph.pattern.nodes[0].node_label.as_deref(),
+            Some("vulnerability")
+        );
+        assert_eq!(graph.pattern.edges.len(), 3);
+        assert!(graph
+            .pattern
+            .edges
+            .iter()
+            .any(|edge| edge.edge_label.as_deref() == Some("connects_to")
+                && edge.direction == EdgeDirection::Outgoing));
+        assert!(graph
+            .pattern
+            .edges
+            .iter()
+            .any(|edge| edge.edge_label.as_deref() == Some("has_service")
+                && edge.direction == EdgeDirection::Incoming));
+        assert!(graph
+            .pattern
+            .edges
+            .iter()
+            .any(|edge| edge.edge_label.as_deref() == Some("related_to")
+                && edge.direction == EdgeDirection::Both));
+        assert!(graph.filter.is_some());
+        assert_eq!(graph.return_.len(), 3);
+        assert_eq!(graph.pattern.nodes.last().unwrap().alias, "renamed");
+    }
 }

--- a/crates/reddb-rql/src/modes/mod.rs
+++ b/crates/reddb-rql/src/modes/mod.rs
@@ -169,4 +169,65 @@ mod tests {
             QueryMode::Natural
         );
     }
+
+    #[test]
+    fn parse_multi_routes_supported_modes_to_query_exprs() {
+        assert!(matches!(
+            parse_multi("SELECT * FROM hosts").expect("sql"),
+            QueryExpr::Table(_)
+        ));
+        assert!(matches!(
+            parse_multi("g.V().hasLabel('Host').limit(2)").expect("gremlin"),
+            QueryExpr::Graph(_)
+        ));
+        assert!(matches!(
+            parse_multi("SELECT ?s WHERE { ?s :name 'alice' }").expect("sparql"),
+            QueryExpr::Graph(_)
+        ));
+        assert!(matches!(
+            parse_multi("find all hosts with ssh").expect("natural"),
+            QueryExpr::Graph(_)
+        ));
+    }
+
+    #[test]
+    fn parse_multi_surfaces_parse_and_unknown_errors() {
+        let err = parse_multi("SELECT * FROM").expect_err("bad SQL should fail");
+        assert!(matches!(err, MultiParseError::Parse(_)));
+        assert!(err.to_string().starts_with("Parse error:"));
+
+        let err = parse_multi("").expect_err("empty should be unknown");
+        assert!(matches!(err, MultiParseError::UnknownMode(ref q) if q.is_empty()));
+        assert_eq!(err.to_string(), "Unknown query mode for: ");
+    }
+
+    #[test]
+    fn multi_parse_error_display_covers_all_variants() {
+        let cases = [
+            (
+                MultiParseError::Parse("bad".to_string()),
+                "Parse error: bad",
+            ),
+            (
+                MultiParseError::Gremlin("bad".to_string()),
+                "Gremlin error: bad",
+            ),
+            (
+                MultiParseError::Sparql("bad".to_string()),
+                "SPARQL error: bad",
+            ),
+            (
+                MultiParseError::Natural("bad".to_string()),
+                "Natural language error: bad",
+            ),
+            (
+                MultiParseError::UnknownMode("???".to_string()),
+                "Unknown query mode for: ???",
+            ),
+        ];
+
+        for (err, expected) in cases {
+            assert_eq!(err.to_string(), expected);
+        }
+    }
 }

--- a/crates/reddb-rql/src/modes/natural.rs
+++ b/crates/reddb-rql/src/modes/natural.rs
@@ -720,6 +720,21 @@ impl NaturalQuery {
 mod tests {
     use super::*;
 
+    fn graph(expr: QueryExpr) -> GraphQuery {
+        match expr {
+            QueryExpr::Graph(graph) => graph,
+            other => panic!("expected graph query, got {other:?}"),
+        }
+    }
+
+    fn entity(entity_type: EntityType, alias: &str) -> ExtractedEntity {
+        ExtractedEntity {
+            entity_type,
+            value: None,
+            alias: alias.to_string(),
+        }
+    }
+
     #[test]
     fn test_parse_find_hosts() {
         let q = NaturalParser::parse("find all hosts with ssh open").unwrap();
@@ -803,5 +818,312 @@ mod tests {
     fn test_detect_relationship() {
         let q = NaturalParser::parse("credentials that can access host 10.0.0.1").unwrap();
         assert_eq!(q.relationship, Some(RelationshipType::AuthAccess));
+    }
+
+    #[test]
+    fn test_parse_rejects_empty_after_normalization() {
+        let err = NaturalParser::parse(" ?! ").unwrap_err();
+        assert_eq!(err.message, "Empty query");
+    }
+
+    #[test]
+    fn test_parse_intent_variants() {
+        let cases = [
+            ("search hosts", QueryIntent::Find),
+            ("display users", QueryIntent::Show),
+            ("count users", QueryIntent::Count),
+            ("how are hosts", QueryIntent::Find),
+            ("route between hosts", QueryIntent::Path),
+            ("does user admin access host 10.0.0.1", QueryIntent::Check),
+            ("which services are public", QueryIntent::Find),
+            ("unexpected words", QueryIntent::Find),
+        ];
+
+        for (input, expected) in cases {
+            let q = NaturalParser::parse(input).unwrap();
+            assert_eq!(q.intent, expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn test_parse_entities_from_values_and_identifiers() {
+        let user = NaturalParser::parse("show user the admin").unwrap();
+        assert!(user
+            .entities
+            .iter()
+            .any(|e| e.entity_type == EntityType::User && e.value == Some("admin".to_string())));
+
+        let host = NaturalParser::parse("find 192.168.1.10").unwrap();
+        assert!(host.entities.iter().any(|e| {
+            e.entity_type == EntityType::Host && e.value == Some("192.168.1.10".to_string())
+        }));
+
+        let cve = NaturalParser::parse("show cve:2024-1234").unwrap();
+        assert!(cve.entities.iter().any(|e| {
+            e.entity_type == EntityType::Vulnerability
+                && e.value == Some("CVE-2024-1234".to_string())
+        }));
+    }
+
+    #[test]
+    fn test_parse_filter_variants() {
+        let high = NaturalParser::parse("find high vulnerabilities").unwrap();
+        assert!(high
+            .filters
+            .iter()
+            .any(|f| f.property == "severity" && f.op == CompareOp::Ge && f.value == "7.0"));
+
+        let medium = NaturalParser::parse("find medium vulnerabilities").unwrap();
+        assert!(medium
+            .filters
+            .iter()
+            .any(|f| f.property == "severity" && f.op == CompareOp::Ge && f.value == "4.0"));
+
+        let public_rdp = NaturalParser::parse("find public rdp services").unwrap();
+        assert!(public_rdp
+            .filters
+            .iter()
+            .any(|f| f.property == "service" && f.value == "rdp"));
+        assert!(public_rdp
+            .filters
+            .iter()
+            .any(|f| f.property == "status" && f.value == "open"));
+
+        let zero_port = NaturalParser::parse("find hosts with port 0").unwrap();
+        assert!(!zero_port.filters.iter().any(|f| f.property == "port"));
+    }
+
+    #[test]
+    fn test_parse_limit_variants() {
+        let cases = [
+            ("top 3 hosts", Some(3)),
+            ("first 4 hosts", Some(4)),
+            ("limit 5 hosts", Some(5)),
+            ("show 6 hosts", Some(6)),
+            ("show hosts", None),
+            ("top hosts", None),
+        ];
+
+        for (input, expected) in cases {
+            let q = NaturalParser::parse(input).unwrap();
+            assert_eq!(q.limit, expected, "{input}");
+        }
+    }
+
+    #[test]
+    fn test_parse_explicit_relationship_phrases() {
+        let cases = [
+            (
+                "find hosts running on technology linux",
+                RelationshipType::RunsOn,
+            ),
+            (
+                "find services using certificate tls",
+                RelationshipType::Uses,
+            ),
+            (
+                "show host 10.0.0.1 exposes port 443",
+                RelationshipType::Exposes,
+            ),
+            (
+                "find hosts affected by cve-2024-1234",
+                RelationshipType::Affects,
+            ),
+            (
+                "check users authenticate to host 10.0.0.1",
+                RelationshipType::AuthAccess,
+            ),
+        ];
+
+        for (input, expected) in cases {
+            let q = NaturalParser::parse(input).unwrap();
+            assert_eq!(q.relationship, Some(expected), "{input}");
+        }
+    }
+
+    #[test]
+    fn test_parse_inferred_relationships_from_entity_pairs() {
+        let cases = [
+            ("find hosts services", RelationshipType::HasService),
+            ("find hosts port 443", RelationshipType::HasPort),
+            ("find hosts vulnerabilities", RelationshipType::HasVuln),
+            ("find users credentials", RelationshipType::HasCredential),
+            (
+                "find credentials for 10.0.0.1",
+                RelationshipType::AuthAccess,
+            ),
+            ("find cves for 10.0.0.1", RelationshipType::Affects),
+        ];
+
+        for (input, expected) in cases {
+            let q = NaturalParser::parse(input).unwrap();
+            assert_eq!(q.relationship, Some(expected), "{input}");
+        }
+
+        let unrelated = NaturalParser::parse("find domains certificates").unwrap();
+        assert_eq!(unrelated.relationship, None);
+    }
+
+    #[test]
+    fn test_unknown_text_falls_back_to_find_without_entities() {
+        let q = NaturalParser::parse("unmapped gibberish").unwrap();
+        assert_eq!(q.intent, QueryIntent::Find);
+        assert_eq!(q.primary_entity, None);
+        assert_eq!(q.secondary_entity, None);
+        assert!(q.entities.is_empty());
+        assert!(q.filters.is_empty());
+        assert_eq!(q.relationship, None);
+
+        let graph = graph(q.to_query_expr());
+        assert!(graph.pattern.nodes.is_empty());
+        assert!(graph.pattern.edges.is_empty());
+        assert_eq!(graph.limit, None);
+    }
+
+    #[test]
+    fn test_to_query_expr_builds_count_projection_limit_and_nested_filters() {
+        let q = NaturalParser::parse("count top 2 hosts with ssh open").unwrap();
+        let graph = graph(q.to_query_expr());
+
+        assert_eq!(graph.limit, Some(2));
+        assert!(matches!(graph.filter, Some(Filter::And(_, _))));
+        match graph.return_.as_slice() {
+            [Projection::Field(FieldRef::NodeId { alias }, Some(name))] => {
+                assert_eq!(alias, "e0");
+                assert_eq!(name, "count");
+            }
+            other => panic!("unexpected projection: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_to_query_expr_maps_all_relationship_edge_labels() {
+        let cases = [
+            (RelationshipType::HasService, "has_service"),
+            (RelationshipType::HasPort, "has_endpoint"),
+            (RelationshipType::HasVuln, "affected_by"),
+            (RelationshipType::HasCredential, "auth_access"),
+            (RelationshipType::HasUser, "has_user"),
+            (RelationshipType::ConnectsTo, "connects_to"),
+            (RelationshipType::Affects, "affected_by"),
+            (RelationshipType::AuthAccess, "auth_access"),
+            (RelationshipType::Uses, "uses_tech"),
+            (RelationshipType::RunsOn, "contains"),
+            (RelationshipType::Exposes, "has_endpoint"),
+        ];
+
+        for (relationship, expected_label) in cases {
+            let debug_name = format!("{relationship:?}");
+            let q = NaturalQuery {
+                intent: QueryIntent::Find,
+                primary_entity: Some(EntityType::Host),
+                secondary_entity: Some(EntityType::Service),
+                entities: vec![
+                    entity(EntityType::Host, "source"),
+                    entity(EntityType::Service, "target"),
+                ],
+                filters: Vec::new(),
+                relationship: Some(relationship),
+                limit: None,
+            };
+            let graph = graph(q.to_query_expr());
+
+            assert_eq!(graph.pattern.edges.len(), 1, "{debug_name}");
+            let edge = &graph.pattern.edges[0];
+            assert_eq!(edge.from, "source", "{debug_name}");
+            assert_eq!(edge.to, "target", "{debug_name}");
+            assert_eq!(
+                edge.edge_label.as_deref(),
+                Some(expected_label),
+                "{debug_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_to_query_expr_skips_edge_without_two_nodes() {
+        let q = NaturalQuery {
+            intent: QueryIntent::Find,
+            primary_entity: Some(EntityType::Host),
+            secondary_entity: None,
+            entities: vec![entity(EntityType::Host, "source")],
+            filters: Vec::new(),
+            relationship: Some(RelationshipType::ConnectsTo),
+            limit: None,
+        };
+
+        let graph = graph(q.to_query_expr());
+        assert_eq!(graph.pattern.nodes.len(), 1);
+        assert!(graph.pattern.edges.is_empty());
+    }
+
+    #[test]
+    fn test_to_query_expr_maps_entity_labels_and_id_properties() {
+        let cases = [
+            (EntityType::Host, Some("host")),
+            (EntityType::Service, Some("service")),
+            (EntityType::Port, None),
+            (EntityType::User, Some("user")),
+            (EntityType::Credential, Some("credential")),
+            (EntityType::Vulnerability, Some("vulnerability")),
+            (EntityType::Technology, Some("technology")),
+            (EntityType::Domain, Some("domain")),
+            (EntityType::Certificate, Some("certificate")),
+            (EntityType::Network, None),
+        ];
+        let entities: Vec<_> = cases
+            .iter()
+            .enumerate()
+            .map(|(i, (entity_type, _))| ExtractedEntity {
+                entity_type: entity_type.clone(),
+                value: Some(format!("value{i}")),
+                alias: format!("e{i}"),
+            })
+            .collect();
+        let q = NaturalQuery {
+            intent: QueryIntent::Find,
+            primary_entity: Some(EntityType::Host),
+            secondary_entity: None,
+            entities,
+            filters: Vec::new(),
+            relationship: None,
+            limit: None,
+        };
+        let graph = graph(q.to_query_expr());
+
+        for (node, (_, expected_label)) in graph.pattern.nodes.iter().zip(cases.iter()) {
+            assert_eq!(node.node_label.as_deref(), *expected_label);
+            assert_eq!(node.properties.len(), 1);
+            assert_eq!(node.properties[0].name, "id");
+        }
+    }
+
+    #[test]
+    fn test_to_query_expr_creates_default_node_from_primary_entity() {
+        let cases = [
+            (EntityType::Host, Some("host")),
+            (EntityType::Service, Some("service")),
+            (EntityType::User, Some("user")),
+            (EntityType::Credential, Some("credential")),
+            (EntityType::Vulnerability, Some("vulnerability")),
+            (EntityType::Network, None),
+        ];
+
+        for (entity_type, expected_label) in cases {
+            let q = NaturalQuery {
+                intent: QueryIntent::Find,
+                primary_entity: Some(entity_type),
+                secondary_entity: None,
+                entities: Vec::new(),
+                filters: Vec::new(),
+                relationship: None,
+                limit: None,
+            };
+            let graph = graph(q.to_query_expr());
+
+            assert_eq!(graph.pattern.nodes.len(), 1);
+            assert_eq!(graph.pattern.nodes[0].alias, "n0");
+            assert_eq!(graph.pattern.nodes[0].node_label.as_deref(), expected_label);
+        }
     }
 }

--- a/crates/reddb-rql/src/modes/sparql.rs
+++ b/crates/reddb-rql/src/modes/sparql.rs
@@ -995,4 +995,178 @@ mod tests {
         let expr = q.to_query_expr();
         assert!(matches!(expr, QueryExpr::Graph(_)));
     }
+
+    #[test]
+    fn test_parse_optional_order_offset_and_filter_functions() {
+        let q = SparqlParser::parse(
+            r#"
+            PREFIX ex: <http://example.org/>
+            SELECT DISTINCT ?host ?name WHERE {
+                # comments are whitespace
+                ?host a ex:Host .
+                OPTIONAL {
+                    ?host :hasName "web"^^<http://www.w3.org/2001/XMLSchema#string> .
+                }
+                FILTER (REGEX(?name, "web", "i"))
+                FILTER (BOUND(?name))
+                FILTER (!BOUND(?missing))
+                FILTER (isIRI(?host))
+                FILTER (isURI(?host))
+                FILTER (isLiteral(?name))
+                FILTER (CONTAINS(?name, "w"))
+                FILTER (STRSTARTS(?name, "w"))
+                FILTER (STRENDS(?name, "b"))
+            }
+            FILTER (?score >= 0.5)
+            ORDER BY DESC(?score) ASC(?host) ?name
+            LIMIT 5
+            OFFSET 2
+            "#,
+        )
+        .unwrap();
+
+        assert!(q.distinct);
+        assert_eq!(
+            q.prefixes.get("ex").map(String::as_str),
+            Some("http://example.org/")
+        );
+        assert_eq!(q.where_patterns.len(), 1);
+        assert_eq!(q.optionals.len(), 1);
+        assert_eq!(q.filters.len(), 10);
+        assert_eq!(
+            q.order_by,
+            vec![
+                ("score".to_string(), false),
+                ("host".to_string(), true),
+                ("name".to_string(), true),
+            ]
+        );
+        assert_eq!(q.limit, Some(5));
+        assert_eq!(q.offset, Some(2));
+
+        assert!(matches!(
+            &q.optionals[0][0].object,
+            SparqlTerm::TypedLiteral(value, datatype)
+                if value == "web"
+                    && datatype == "http://www.w3.org/2001/XMLSchema#string"
+        ));
+    }
+
+    #[test]
+    fn test_to_query_expr_normalizes_edges_literals_and_star_projection() {
+        let q = SparqlParser::parse(
+            "SELECT * WHERE { ?host :hasService ?svc . ?host <http://example.org/connectsTo> ?peer . ?host :hasName 'web' . } LIMIT 3",
+        )
+        .unwrap();
+        let QueryExpr::Graph(graph) = q.to_query_expr() else {
+            panic!("SPARQL should lower to GraphQuery");
+        };
+
+        assert_eq!(graph.limit, Some(3));
+        assert_eq!(graph.pattern.edges.len(), 2);
+        assert!(graph
+            .pattern
+            .edges
+            .iter()
+            .any(|edge| edge.edge_label.as_deref() == Some("has_service")));
+        assert!(graph
+            .pattern
+            .edges
+            .iter()
+            .any(|edge| edge.edge_label.as_deref() == Some("connects_to")));
+        assert_eq!(graph.return_.len(), graph.pattern.nodes.len());
+        assert!(graph.filter.is_some());
+    }
+
+    #[test]
+    fn test_convert_sparql_filter_variants() {
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Compare(
+                "age".to_string(),
+                CompareOp::Ge,
+                SparqlTerm::Number(18.5),
+            )),
+            Some(Filter::Compare {
+                op: CompareOp::Ge,
+                value: Value::Float(18.5),
+                ..
+            })
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Compare(
+                "active".to_string(),
+                CompareOp::Eq,
+                SparqlTerm::Boolean(true),
+            )),
+            Some(Filter::Compare {
+                value: Value::Boolean(true),
+                ..
+            })
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Compare(
+                "name".to_string(),
+                CompareOp::Eq,
+                SparqlTerm::Literal("alice".to_string()),
+            )),
+            Some(Filter::Compare {
+                value: Value::Text(text),
+                ..
+            }) if text.as_ref() == "alice"
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Bound("name".to_string())),
+            Some(Filter::IsNotNull(_))
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::NotBound("name".to_string())),
+            Some(Filter::IsNull(_))
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Contains("name".to_string(), "lic".to_string())),
+            Some(Filter::Like { pattern, .. }) if pattern == "%lic%"
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::StrStarts("name".to_string(), "a".to_string())),
+            Some(Filter::StartsWith { prefix, .. }) if prefix == "a"
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::StrEnds("name".to_string(), "e".to_string())),
+            Some(Filter::EndsWith { suffix, .. }) if suffix == "e"
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::And(
+                Box::new(SparqlFilter::Bound("a".to_string())),
+                Box::new(SparqlFilter::Bound("b".to_string())),
+            )),
+            Some(Filter::And(_, _))
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Or(
+                Box::new(SparqlFilter::Bound("a".to_string())),
+                Box::new(SparqlFilter::Bound("b".to_string())),
+            )),
+            Some(Filter::Or(_, _))
+        ));
+        assert!(matches!(
+            convert_sparql_filter(&SparqlFilter::Not(Box::new(SparqlFilter::Bound(
+                "a".to_string(),
+            )))),
+            Some(Filter::Not(_))
+        ));
+        assert!(convert_sparql_filter(&SparqlFilter::Regex(
+            "name".to_string(),
+            "a.*".to_string(),
+            None,
+        ))
+        .is_none());
+        assert!(convert_sparql_filter(&SparqlFilter::IsIri("s".to_string())).is_none());
+        assert!(convert_sparql_filter(&SparqlFilter::IsLiteral("s".to_string())).is_none());
+        assert!(convert_sparql_filter(&SparqlFilter::Compare(
+            "iri".to_string(),
+            CompareOp::Eq,
+            SparqlTerm::Iri("http://example.org/id".to_string()),
+        ))
+        .is_none());
+    }
 }

--- a/crates/reddb-rql/src/parser/auth_ddl.rs
+++ b/crates/reddb-rql/src/parser/auth_ddl.rs
@@ -728,3 +728,258 @@ impl<'a> Parser<'a> {
         Ok(true)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parser(input: &str) -> Parser<'_> {
+        Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"))
+    }
+
+    #[test]
+    fn parse_grant_statement_covers_columns_default_table_and_principals() {
+        let grant = parser(
+            "GRANT SELECT, UPDATE (id, email) ON public.users TO PUBLIC, GROUP analysts, tenant.alice WITH GRANT OPTION",
+        )
+        .parse_grant_statement()
+        .expect("grant");
+
+        assert_eq!(grant.actions, vec!["SELECT", "UPDATE"]);
+        assert_eq!(
+            grant.columns.as_deref(),
+            Some(&["id".to_string(), "email".to_string()][..])
+        );
+        assert_eq!(grant.object_kind, GrantObjectKind::Table);
+        assert_eq!(grant.objects.len(), 1);
+        assert_eq!(grant.objects[0].schema.as_deref(), Some("public"));
+        assert_eq!(grant.objects[0].name, "users");
+        assert!(matches!(grant.principals[0], GrantPrincipalRef::Public));
+        assert!(matches!(
+            &grant.principals[1],
+            GrantPrincipalRef::Group(group) if group == "analysts"
+        ));
+        assert!(matches!(
+            &grant.principals[2],
+            GrantPrincipalRef::User { tenant: Some(t), name } if t == "tenant" && name == "alice"
+        ));
+        assert!(grant.with_grant_option);
+        assert!(!grant.all);
+    }
+
+    #[test]
+    fn parse_revoke_statement_covers_grant_option_for_all_and_function_objects() {
+        let revoke = parser(
+            "REVOKE GRANT OPTION FOR ALL PRIVILEGES (id) ON FUNCTION public.recalc FROM GROUP analysts",
+        )
+        .parse_revoke_statement()
+        .expect("revoke");
+
+        assert!(revoke.grant_option_for);
+        assert!(revoke.all);
+        assert_eq!(revoke.actions, vec!["ALL"]);
+        assert_eq!(revoke.columns.as_deref(), Some(&["id".to_string()][..]));
+        assert_eq!(revoke.object_kind, GrantObjectKind::Function);
+        assert_eq!(revoke.objects[0].schema.as_deref(), Some("public"));
+        assert_eq!(revoke.objects[0].name, "recalc");
+        assert!(matches!(
+            &revoke.principals[0],
+            GrantPrincipalRef::Group(group) if group == "analysts"
+        ));
+
+        let revoke = parser("REVOKE USAGE ON SCHEMA analytics FROM bob")
+            .parse_revoke_statement()
+            .expect("revoke without grant option");
+        assert!(!revoke.grant_option_for);
+        assert_eq!(revoke.object_kind, GrantObjectKind::Schema);
+        assert_eq!(revoke.objects[0].name, "analytics");
+    }
+
+    #[test]
+    fn parse_grant_and_revoke_option_errors_are_specific() {
+        let err = parser("GRANT SELECT ON TABLE users TO alice WITH OPTION")
+            .parse_grant_statement()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: GRANT"), "{err}");
+
+        let err = parser("GRANT SELECT ON TABLE users TO alice WITH GRANT")
+            .parse_grant_statement()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: OPTION"), "{err}");
+
+        let err = parser("REVOKE GRANT SELECT ON TABLE users FROM alice")
+            .parse_revoke_statement()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: OPTION"), "{err}");
+
+        let err = parser("REVOKE GRANT OPTION SELECT ON TABLE users FROM alice")
+            .parse_revoke_statement()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: FOR"), "{err}");
+    }
+
+    #[test]
+    fn parse_alter_user_statement_covers_attribute_variants_and_errors() {
+        let mut p = parser(
+            "ALTER USER tenant.bob VALID UNTIL '2030-01-01' CONNECTION LIMIT 10 ENABLE \
+             SET search_path TO 'public,analytics' ADD GROUP analysts DROP GROUP temp PASSWORD 'pw'",
+        );
+        p.expect(Token::Alter).expect("ALTER");
+        let stmt = p.parse_alter_user_statement().expect("alter user");
+
+        assert_eq!(stmt.tenant.as_deref(), Some("tenant"));
+        assert_eq!(stmt.username, "bob");
+        assert!(matches!(
+            &stmt.attributes[0],
+            AlterUserAttribute::ValidUntil(value) if value == "2030-01-01"
+        ));
+        assert!(matches!(
+            stmt.attributes[1],
+            AlterUserAttribute::ConnectionLimit(10)
+        ));
+        assert!(matches!(stmt.attributes[2], AlterUserAttribute::Enable));
+        assert!(matches!(
+            &stmt.attributes[3],
+            AlterUserAttribute::SetSearchPath(value) if value == "public,analytics"
+        ));
+        assert!(matches!(
+            &stmt.attributes[4],
+            AlterUserAttribute::AddGroup(group) if group == "analysts"
+        ));
+        assert!(matches!(
+            &stmt.attributes[5],
+            AlterUserAttribute::DropGroup(group) if group == "temp"
+        ));
+        assert!(matches!(
+            &stmt.attributes[6],
+            AlterUserAttribute::Password(password) if password == "pw"
+        ));
+
+        let mut p = parser("ALTER USER alice");
+        p.expect(Token::Alter).expect("ALTER");
+        let err = p.parse_alter_user_statement().unwrap_err();
+        assert!(err.to_string().contains("expected:"), "{err}");
+
+        let mut p = parser("ALTER USER alice ADD ROLE analysts");
+        p.expect(Token::Alter).expect("ALTER");
+        let err = p.parse_alter_user_statement().unwrap_err();
+        assert!(err.to_string().contains("expected: GROUP"), "{err}");
+    }
+
+    #[test]
+    fn parse_iam_policy_helpers_cover_policy_sources_and_principals() {
+        assert!(matches!(
+            parser("'readonly' AS '{\"Statement\":[]}'")
+                .parse_create_iam_policy_after_keywords()
+                .expect("create iam policy"),
+            QueryExpr::CreateIamPolicy { ref id, ref json }
+                if id == "readonly" && json == "{\"Statement\":[]}"
+        ));
+        assert!(matches!(
+            parser("'readonly'")
+                .parse_drop_iam_policy_after_keywords()
+                .expect("drop iam policy"),
+            QueryExpr::DropIamPolicy { ref id } if id == "readonly"
+        ));
+        assert!(matches!(
+            parser("LINT POLICY JSON '{\"Statement\":[]}'")
+                .parse_lint_policy()
+                .expect("lint json"),
+            QueryExpr::LintPolicy {
+                source: LintPolicySource::Json(ref json),
+            } if json == "{\"Statement\":[]}"
+        ));
+        assert!(matches!(
+            parser("LINT POLICY 'readonly'")
+                .parse_lint_policy()
+                .expect("lint id"),
+            QueryExpr::LintPolicy {
+                source: LintPolicySource::Id(ref id),
+            } if id == "readonly"
+        ));
+        assert!(matches!(
+            parser("MIGRATE POLICY MODE TO 'policy_only' DRY RUN")
+                .parse_migrate_policy_mode()
+                .expect("migrate policy mode"),
+            QueryExpr::MigratePolicyMode { ref target, dry_run }
+                if target == "policy_only" && dry_run
+        ));
+
+        assert!(matches!(
+            parser("ATTACH POLICY 'readonly' TO USER tenant.alice")
+                .parse_attach_policy()
+                .expect("attach policy"),
+            QueryExpr::AttachPolicy {
+                ref policy_id,
+                principal: PolicyPrincipalRef::User(ref user),
+            } if policy_id == "readonly"
+                && user.tenant.as_deref() == Some("tenant")
+                && user.username == "alice"
+        ));
+        assert!(matches!(
+            parser("DETACH POLICY 'readonly' FROM GROUP analysts")
+                .parse_detach_policy()
+                .expect("detach policy"),
+            QueryExpr::DetachPolicy {
+                ref policy_id,
+                principal: PolicyPrincipalRef::Group(ref group),
+            } if policy_id == "readonly" && group == "analysts"
+        ));
+    }
+
+    #[test]
+    fn parse_show_and_simulate_helpers_cover_resources_and_action_errors() {
+        let mut p = parser("SHOW POLICIES FOR USER tenant.alice");
+        p.advance().expect("SHOW");
+        assert!(matches!(
+            p.parse_show_iam_after_show()
+                .expect("show policies")
+                .expect("iam show"),
+            QueryExpr::ShowPolicies {
+                filter: Some(PolicyPrincipalRef::User(ref user)),
+            } if user.tenant.as_deref() == Some("tenant") && user.username == "alice"
+        ));
+
+        let mut p = parser("SHOW EFFECTIVE PERMISSIONS FOR alice ON TABLE:public.orders");
+        p.advance().expect("SHOW");
+        assert!(matches!(
+            p.parse_show_iam_after_show()
+                .expect("show effective")
+                .expect("iam show"),
+            QueryExpr::ShowEffectivePermissions {
+                ref user,
+                resource: Some(ref resource),
+            } if user.tenant.is_none()
+                && user.username == "alice"
+                && resource.kind == "table"
+                && resource.name == "public.orders"
+        ));
+
+        assert!(matches!(
+            parser("SIMULATE alice ACTION DELETE ON 'table:public.orders'")
+                .parse_simulate_policy()
+                .expect("simulate"),
+            QueryExpr::SimulatePolicy {
+                ref user,
+                ref action,
+                ref resource,
+            } if user.username == "alice"
+                && action == "delete"
+                && resource.kind == "table"
+                && resource.name == "public.orders"
+        ));
+
+        let err = parser("SIMULATE alice ACTION 42 ON table:public.orders")
+            .parse_simulate_policy()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("expected: action keyword"),
+            "{err}"
+        );
+
+        let err = parser("SIMULATE alice ACTION SELECT ON 'missing-colon'")
+            .parse_simulate_policy()
+            .unwrap_err();
+        assert!(err.to_string().contains("kind:name"), "{err}");
+    }
+}

--- a/crates/reddb-rql/src/parser/config.rs
+++ b/crates/reddb-rql/src/parser/config.rs
@@ -327,3 +327,101 @@ impl<'a> Parser<'a> {
         Ok(Some(value_type))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reddb_types::types::Value;
+
+    fn expr(input: &str) -> Result<QueryExpr, ParseError> {
+        let mut parser = Parser::new(input)?;
+        parser.parse_config_command()
+    }
+
+    #[test]
+    fn config_command_covers_dotted_collections_and_schema_type_forms() {
+        let QueryExpr::ConfigCommand(ConfigCommand::Put {
+            collection,
+            key,
+            value,
+            value_type,
+            tags,
+        }) = expr("PUT CONFIG App.Prod Feature = 'on' SCHEMA string TAGS [scope:prod]").unwrap()
+        else {
+            panic!("expected config put");
+        };
+        assert_eq!(collection, "app.prod");
+        assert_eq!(key, "feature");
+        assert_eq!(value, Value::text("on"));
+        assert_eq!(value_type, Some(ConfigValueType::String));
+        assert_eq!(tags, vec!["scope:prod".to_string()]);
+
+        let QueryExpr::ConfigCommand(ConfigCommand::Rotate {
+            collection,
+            key,
+            value_type,
+            ..
+        }) = expr("ROTATE CONFIG app feature = true WITH TYPE bool").unwrap()
+        else {
+            panic!("expected config rotate");
+        };
+        assert_eq!(collection, "app");
+        assert_eq!(key, "feature");
+        assert_eq!(value_type, Some(ConfigValueType::Bool));
+    }
+
+    #[test]
+    fn config_list_watch_and_invalid_operations_cover_optional_branches() {
+        assert!(matches!(
+            expr("LIST CONFIG App.Prod LIMIT -1 OFFSET -2").unwrap(),
+            QueryExpr::ConfigCommand(ConfigCommand::List {
+                collection,
+                prefix: None,
+                limit: Some(0),
+                offset: 0,
+            }) if collection == "app.prod"
+        ));
+        assert!(matches!(
+            expr("WATCH CONFIG App.Prod feature FROM LSN 9").unwrap(),
+            QueryExpr::ConfigCommand(ConfigCommand::Watch {
+                collection,
+                key,
+                prefix: false,
+                from_lsn: Some(9),
+            }) if collection == "app.prod" && key == "feature"
+        ));
+        assert!(matches!(
+            expr("ADD CONFIG app").unwrap(),
+            QueryExpr::ConfigCommand(ConfigCommand::InvalidVolatileOperation {
+                operation,
+                collection,
+                key: None,
+            }) if operation == "ADD" && collection == "app"
+        ));
+        assert!(matches!(
+            expr("DECR CONFIG app counter").unwrap(),
+            QueryExpr::ConfigCommand(ConfigCommand::InvalidVolatileOperation {
+                operation,
+                collection,
+                key: Some(key),
+            }) if operation == "DECR" && collection == "app" && key == "counter"
+        ));
+    }
+
+    #[test]
+    fn config_errors_are_reported_before_construction() {
+        for sql in [
+            "UPSERT CONFIG app key = 'v'",
+            "PUT app key = 'v'",
+            "PUT CONFIG app = 'v'",
+            "GET CONFIG app",
+            "WATCH CONFIG app",
+            "WATCH CONFIG app feature FROM 9",
+            "PUT CONFIG app feature = 'v' WITH",
+            "PUT CONFIG app feature = 'v' WITH TYPE nope",
+        ] {
+            assert!(expr(sql).is_err(), "{sql}");
+        }
+        assert!(crate::sql::parse_frontend("LIST CONFIG app key").is_err());
+    }
+}

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -1427,3 +1427,251 @@ fn hex_nibble(c: u8) -> Result<u8, String> {
         _ => Err(format!("non-hex char: {:?}", c as char)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reddb_types::catalog::{AnalyticsOutput, CollectionModel, SubscriptionOperation};
+
+    fn parser(input: &str) -> Parser<'_> {
+        Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"))
+    }
+
+    #[test]
+    fn parse_create_table_body_parenthesized_options_and_trailing_clauses() {
+        let QueryExpr::CreateTable(table) = parser(
+            "IF NOT EXISTS events (id INT, tenant_meta TEXT) \
+             WITH (tenant_by = 'tenant_id', append_only = true, timestamps = false) \
+             PARTITION BY HASH (id) TENANT BY (tenant_meta.tenant)",
+        )
+        .parse_create_table_body()
+        .expect("create table body") else {
+            panic!("Expected CreateTableQuery");
+        };
+
+        assert_eq!(table.name, "events");
+        assert!(table.if_not_exists);
+        assert!(table.append_only);
+        assert!(!table.timestamps);
+        assert_eq!(table.tenant_by.as_deref(), Some("tenant_id"));
+        assert_eq!(
+            table
+                .partition_by
+                .as_ref()
+                .map(|spec| (spec.kind, spec.column.as_str())),
+            Some((PartitionKind::Hash, "id"))
+        );
+
+        let err = parser("bad (id INT) WITH (tenant_by = 42)")
+            .parse_create_table_body()
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("WITH tenant_by expects a text literal"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_keyed_bodies_cover_vault_analytics_and_dotted_drop_names() {
+        let QueryExpr::CreateTable(vault) =
+            parser("IF NOT EXISTS tenant.secrets WITH OWN MASTER KEY")
+                .parse_create_keyed_body(CollectionModel::Vault)
+                .expect("create vault")
+        else {
+            panic!("Expected CreateTableQuery");
+        };
+        assert_eq!(vault.collection_model, CollectionModel::Vault);
+        assert_eq!(vault.name, "tenant.secrets");
+        assert!(vault.if_not_exists);
+        assert!(vault.vault_own_master_key);
+
+        let QueryExpr::CreateTable(graph) = parser(
+            "g WITH ANALYTICS (centrality (using = pagerank, max_iterations = 12, tolerance = 0.001))",
+        )
+        .parse_create_keyed_body(CollectionModel::Graph)
+        .expect("create graph")
+        else {
+            panic!("Expected CreateTableQuery");
+        };
+        assert_eq!(graph.analytics_config.len(), 1);
+        let view = &graph.analytics_config[0];
+        assert_eq!(view.output, AnalyticsOutput::Centrality);
+        assert_eq!(view.algorithm.as_deref(), Some("pagerank"));
+        assert_eq!(view.max_iterations, Some(12));
+        assert_eq!(view.tolerance, Some(0.001));
+
+        let err = parser("g WITH OTHER")
+            .parse_create_keyed_body(CollectionModel::Graph)
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: ANALYTICS"), "{err}");
+
+        assert!(parser("CREATE KV cache WITH ANALYTICS (components)")
+            .parse()
+            .unwrap_err()
+            .to_string()
+            .contains("Unexpected token after query"));
+
+        let QueryExpr::DropKv(drop) = parser("IF EXISTS tenant.cache.*")
+            .parse_drop_keyed_body(CollectionModel::Kv)
+            .expect("drop kv")
+        else {
+            panic!("Expected DropKvQuery");
+        };
+        assert_eq!(drop.name, "tenant.cache.*");
+        assert!(drop.if_exists);
+        assert_eq!(drop.model, CollectionModel::Kv);
+    }
+
+    #[test]
+    fn parse_collection_signed_by_list_and_errors() {
+        let pk_a = "aa".repeat(32);
+        let pk_b = "BB".repeat(32);
+        let QueryExpr::CreateCollection(collection) =
+            parser(&format!("signed KIND graph SIGNED_BY ('{pk_a}', '{pk_b}')"))
+                .parse_create_collection_body()
+                .expect("create collection")
+        else {
+            panic!("Expected CreateCollectionQuery");
+        };
+        assert_eq!(collection.allowed_signers, vec![[0xaau8; 32], [0xBBu8; 32]]);
+
+        let err = parser("signed KIND graph SIGNED_BY (42)")
+            .parse_create_collection_body()
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("string literal (ed25519 pubkey hex)"),
+            "{err}"
+        );
+
+        let err = parser("signed KIND graph SIGNED_BY ('deadbeef')")
+            .parse_create_collection_body()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected 64 hex chars"), "{err}");
+    }
+
+    #[test]
+    fn parse_alter_operations_cover_subscriptions_partitions_tenancy_and_signers() {
+        let pk = "11".repeat(32);
+        let QueryExpr::AlterTable(alter) = parser(&format!(
+            "ALTER COLLECTION audit \
+             ADD SUBSCRIPTION pii TO audit_events REDACT (payload.ssn, *.secret) WHERE level = 'warn', \
+             DROP SUBSCRIPTION pii, \
+             ADD SIGNER '{pk}', \
+             REVOKE SIGNER '{pk}', \
+             ATTACH PARTITION audit_2026 FOR VALUES FROM (2026) TO (2027), \
+             DETACH PARTITION audit_2026, \
+             ENABLE EVENTS (INSERT, UPDATE) TO table_events ON ALL TENANTS, \
+             DISABLE EVENTS, \
+             ENABLE TENANCY ON (metadata.tenant), \
+             DISABLE TENANCY, \
+             SET APPEND_ONLY = true, \
+             SET VERSIONED = false, \
+             SET RETENTION 2 h, \
+             UNSET RETENTION"
+        ))
+        .parse_alter_table_query()
+        .expect("alter collection")
+        else {
+            panic!("Expected AlterTableQuery");
+        };
+
+        assert_eq!(alter.name, "audit");
+        assert_eq!(alter.operations.len(), 14);
+        match &alter.operations[0] {
+            AlterOperation::AddSubscription { name, descriptor } => {
+                assert_eq!(name, "pii");
+                assert_eq!(descriptor.target_queue, "audit_events");
+                assert_eq!(descriptor.redact_fields, vec!["payload.ssn", "*.secret"]);
+                assert_eq!(descriptor.where_filter.as_deref(), Some("LEVEL = 'warn'"));
+            }
+            other => panic!("expected AddSubscription, got {other:?}"),
+        }
+        assert!(matches!(
+            &alter.operations[1],
+            AlterOperation::DropSubscription { name } if name == "pii"
+        ));
+        assert!(matches!(
+            &alter.operations[2],
+            AlterOperation::AddSigner { pubkey } if *pubkey == [0x11; 32]
+        ));
+        assert!(matches!(
+            &alter.operations[3],
+            AlterOperation::RevokeSigner { pubkey } if *pubkey == [0x11; 32]
+        ));
+        assert!(matches!(
+            &alter.operations[4],
+            AlterOperation::AttachPartition { child, bound }
+                if child == "audit_2026" && bound == "FROM ( 2026 ) TO ( 2027 )"
+        ));
+        assert!(matches!(
+            &alter.operations[5],
+            AlterOperation::DetachPartition { child } if child == "audit_2026"
+        ));
+        match &alter.operations[6] {
+            AlterOperation::EnableEvents(descriptor) => {
+                assert_eq!(
+                    descriptor.ops_filter,
+                    vec![SubscriptionOperation::Insert, SubscriptionOperation::Update]
+                );
+                assert_eq!(descriptor.target_queue, "table_events");
+                assert!(descriptor.all_tenants);
+            }
+            other => panic!("expected EnableEvents, got {other:?}"),
+        }
+        assert!(matches!(
+            &alter.operations[7],
+            AlterOperation::DisableEvents
+        ));
+        assert!(matches!(
+            &alter.operations[8],
+            AlterOperation::EnableTenancy { column } if column == "METADATA.tenant"
+        ));
+        assert!(matches!(
+            &alter.operations[9],
+            AlterOperation::DisableTenancy
+        ));
+        assert!(matches!(
+            &alter.operations[10],
+            AlterOperation::SetAppendOnly(true)
+        ));
+        assert!(matches!(
+            &alter.operations[11],
+            AlterOperation::SetVersioned(false)
+        ));
+        assert!(matches!(
+            &alter.operations[12],
+            AlterOperation::SetRetention { duration_ms } if *duration_ms == 7_200_000
+        ));
+        assert!(matches!(
+            &alter.operations[13],
+            AlterOperation::UnsetRetention
+        ));
+    }
+
+    #[test]
+    fn parse_alter_graph_analytics_keyword_errors() {
+        let err = parser("ALTER GRAPH g ADD centrality")
+            .parse_alter_graph_query()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: ANALYTICS"), "{err}");
+
+        let err = parser("ALTER GRAPH g DROP centrality")
+            .parse_alter_graph_query()
+            .unwrap_err();
+        assert!(err.to_string().contains("expected: ANALYTICS"), "{err}");
+    }
+
+    #[test]
+    fn decode_hex_32_reports_length_and_character_errors() {
+        assert_eq!(decode_hex_32(&"0f".repeat(32)).unwrap(), [0x0f; 32]);
+        assert_eq!(
+            decode_hex_32("deadbeef").unwrap_err(),
+            "expected 64 hex chars, got 8"
+        );
+        assert!(decode_hex_32(&"gg".repeat(32))
+            .unwrap_err()
+            .contains("non-hex char"));
+    }
+}

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -1023,3 +1023,350 @@ fn secret_ref_value(store: &str, collection: &str, key: &str) -> Value {
         reddb_types::json::to_vec(&reddb_types::json::Value::Object(map)).unwrap_or_default(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{InsertEntityType, ReturningItem, UpdateTarget};
+
+    fn make_parser(input: &str) -> Parser<'_> {
+        Parser::new(input).expect("lexer")
+    }
+
+    fn insert(input: &str) -> InsertQuery {
+        let mut parser = make_parser(input);
+        let QueryExpr::Insert(query) = parser.parse_insert_query().expect("insert") else {
+            panic!("expected insert query");
+        };
+        query
+    }
+
+    fn update(input: &str) -> UpdateQuery {
+        let mut parser = make_parser(input);
+        let QueryExpr::Update(query) = parser.parse_update_query().expect("update") else {
+            panic!("expected update query");
+        };
+        query
+    }
+
+    fn delete(input: &str) -> DeleteQuery {
+        let mut parser = make_parser(input);
+        let QueryExpr::Delete(query) = parser.parse_delete_query().expect("delete") else {
+            panic!("expected delete query");
+        };
+        query
+    }
+
+    fn ask(input: &str) -> AskQuery {
+        let mut parser = make_parser(input);
+        let QueryExpr::Ask(query) = parser.parse_ask_query().expect("ask") else {
+            panic!("expected ask query");
+        };
+        query
+    }
+
+    #[test]
+    fn insert_entity_types_with_options_returning_and_suppress_events() {
+        let cases = [
+            (
+                "INSERT INTO items NODE (id) VALUES (1)",
+                InsertEntityType::Node,
+            ),
+            (
+                "INSERT INTO items EDGE (id) VALUES (1)",
+                InsertEntityType::Edge,
+            ),
+            (
+                "INSERT INTO items VECTOR (id) VALUES (1)",
+                InsertEntityType::Vector,
+            ),
+            (
+                "INSERT INTO items DOCUMENT (id) VALUES (1)",
+                InsertEntityType::Document,
+            ),
+            ("INSERT INTO items KV (id) VALUES (1)", InsertEntityType::Kv),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(insert(input).entity_type, expected, "{input}");
+        }
+
+        let query = insert(
+            "INSERT INTO docs (id, body) VALUES (1, 'red'), (2, ?) \
+             WITH TTL 2 h WITH EXPIRES AT 999 \
+             WITH METADATA (source = 'test', score = 3) \
+             WITH AUTO EMBED (body, title) USING openai MODEL 'text-embedding-3-small' \
+             RETURNING * SUPPRESS EVENTS",
+        );
+        assert_eq!(query.table, "docs");
+        assert_eq!(query.entity_type, InsertEntityType::Row);
+        assert_eq!(query.columns, vec!["id", "body"]);
+        assert_eq!(query.values.len(), 2);
+        assert_eq!(query.value_exprs.len(), 2);
+        assert_eq!(query.ttl_ms, Some(7_200_000));
+        assert_eq!(query.expires_at_ms, Some(999));
+        assert_eq!(query.with_metadata.len(), 2);
+        assert_eq!(
+            query.returning.as_deref(),
+            Some([ReturningItem::All].as_slice())
+        );
+        let auto_embed = query.auto_embed.expect("auto embed");
+        assert_eq!(auto_embed.fields, vec!["body", "title"]);
+        assert_eq!(auto_embed.provider, "openai");
+        assert_eq!(auto_embed.model.as_deref(), Some("text-embedding-3-small"));
+        assert!(query.suppress_events);
+    }
+
+    #[test]
+    fn insert_rejects_metric_and_bad_with_clause() {
+        let mut parser = make_parser("INSERT INTO METRIC cpu.usage (value) VALUES (1)");
+        let err = parser
+            .parse_insert_query()
+            .expect_err("metric insert should fail");
+        assert!(err.to_string().contains("INSERT INTO METRIC"));
+
+        let mut parser = make_parser("INSERT INTO docs (id) VALUES (1) WITH TTL 1 fortnight");
+        let err = parser
+            .parse_insert_query()
+            .expect_err("bad ttl unit should fail");
+        assert!(err.to_string().contains("unsupported TTL unit"));
+
+        let mut parser = make_parser("INSERT INTO docs (id) VALUES (1) WITH UNKNOWN");
+        let err = parser
+            .parse_insert_query()
+            .expect_err("bad WITH should fail");
+        assert!(err.to_string().contains("expected"));
+    }
+
+    #[test]
+    fn update_targets_compound_assignments_order_limit_returning() {
+        let cases = [
+            ("UPDATE docs KV SET count = 1", UpdateTarget::Kv),
+            ("UPDATE docs ROWS SET count = 1", UpdateTarget::Rows),
+            (
+                "UPDATE docs DOCUMENTS SET count = 1",
+                UpdateTarget::Documents,
+            ),
+            ("UPDATE docs NODES SET count = 1", UpdateTarget::Nodes),
+            ("UPDATE docs EDGES SET count = 1", UpdateTarget::Edges),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(update(input).target, expected, "{input}");
+        }
+
+        let query = update(
+            "UPDATE docs DOCUMENTS SET count += 2, title = UPPER(title) \
+             WHERE id = 1 WITH TTL 30 s WITH METADATA (source = 'update') \
+             ORDER BY updated_at DESC LIMIT 5 RETURNING weight, title SUPPRESS EVENTS",
+        );
+        assert_eq!(query.table, "docs");
+        assert_eq!(query.target, UpdateTarget::Documents);
+        assert_eq!(query.assignment_exprs.len(), 2);
+        assert_eq!(query.compound_assignment_ops, vec![Some(BinOp::Add), None]);
+        assert_eq!(query.assignments.len(), 0);
+        assert!(query.filter.is_some());
+        assert!(query.where_expr.is_some());
+        assert_eq!(query.ttl_ms, Some(30_000));
+        assert_eq!(query.with_metadata.len(), 1);
+        assert_eq!(query.limit, Some(5));
+        assert_eq!(query.order_by.len(), 2);
+        assert!(matches!(
+            &query.order_by[1].field,
+            FieldRef::TableColumn { column, .. } if column == "rid"
+        ));
+        assert_eq!(
+            query.returning.as_deref(),
+            Some(
+                [
+                    ReturningItem::Column("weight".to_string()),
+                    ReturningItem::Column("title".to_string())
+                ]
+                .as_slice()
+            )
+        );
+        assert!(query.suppress_events);
+    }
+
+    #[test]
+    fn update_rejects_invalid_assignment_and_order_by_forms() {
+        let mut parser = make_parser("UPDATE docs SET count ^= 1");
+        let err = parser
+            .parse_update_query()
+            .expect_err("unknown compound assignment should fail");
+        assert!(err.to_string().contains("expected"));
+
+        let mut parser = make_parser("UPDATE docs SET count = 1 ORDER BY updated_at");
+        let err = parser
+            .parse_update_query()
+            .expect_err("ORDER BY without LIMIT should fail");
+        assert!(err.to_string().contains("requires LIMIT"));
+
+        let mut parser = make_parser("UPDATE docs SET count = 1 ORDER BY updated_at + 1 LIMIT 1");
+        let err = parser
+            .parse_update_query()
+            .expect_err("ORDER BY expression should fail");
+        assert!(err.to_string().contains("top-level fields"));
+    }
+
+    #[test]
+    fn delete_returning_and_suppress_events() {
+        let query = delete("DELETE FROM docs WHERE id = 1 RETURNING id, title SUPPRESS EVENTS");
+        assert_eq!(query.table, "docs");
+        assert!(query.filter.is_some());
+        assert!(query.where_expr.is_some());
+        assert_eq!(
+            query.returning.as_deref(),
+            Some(
+                [
+                    ReturningItem::Column("id".to_string()),
+                    ReturningItem::Column("title".to_string())
+                ]
+                .as_slice()
+            )
+        );
+        assert!(query.suppress_events);
+
+        let query = delete("DELETE FROM docs RETURNING *");
+        assert_eq!(
+            query.returning.as_deref(),
+            Some([ReturningItem::All].as_slice())
+        );
+    }
+
+    #[test]
+    fn returning_rejects_expression_forms() {
+        for input in [
+            "DELETE FROM docs RETURNING 1",
+            "DELETE FROM docs RETURNING UPPER(title)",
+            "DELETE FROM docs RETURNING title || body",
+        ] {
+            let mut parser = make_parser(input);
+            let err = parser
+                .parse_delete_query()
+                .expect_err("RETURNING expression should fail");
+            assert!(err.to_string().contains("RETURNING expressions"));
+        }
+    }
+
+    #[test]
+    fn ask_parses_all_optional_clauses_and_cache_modes() {
+        let query = ask(
+            "ASK 'what changed?' USING 'openai' MODEL 'gpt' DEPTH 3 LIMIT 4 \
+             MIN_SCORE 0.7 COLLECTION docs TEMPERATURE 0.2 SEED 42 STRICT OFF \
+             STREAM CACHE TTL '10m'",
+        );
+        assert_eq!(query.question, "what changed?");
+        assert_eq!(query.provider.as_deref(), Some("openai"));
+        assert_eq!(query.model.as_deref(), Some("gpt"));
+        assert_eq!(query.depth, Some(3));
+        assert_eq!(query.limit, Some(4));
+        assert_eq!(query.min_score, Some(0.7));
+        assert_eq!(query.collection.as_deref(), Some("docs"));
+        assert_eq!(query.temperature, Some(0.2));
+        assert_eq!(query.seed, Some(42));
+        assert!(!query.strict);
+        assert!(query.stream);
+        assert_eq!(query.cache, AskCacheClause::CacheTtl("10m".to_string()));
+
+        let query = ask("ASK ? NOCACHE");
+        assert_eq!(query.question, "");
+        assert_eq!(query.question_param, Some(0));
+        assert_eq!(query.cache, AskCacheClause::NoCache);
+    }
+
+    #[test]
+    fn explain_ask_and_ask_error_paths() {
+        let mut parser = make_parser("EXPLAIN ASK $2 STRICT ON");
+        let QueryExpr::Ask(query) = parser.parse_explain_ask_query().expect("explain ask") else {
+            panic!("expected ask query");
+        };
+        assert!(query.explain);
+        assert_eq!(query.question_param, Some(1));
+        assert!(query.strict);
+
+        let mut parser = make_parser("EXPLAIN SELECT 1");
+        let err = parser
+            .parse_explain_ask_query()
+            .expect_err("missing ASK should fail");
+        assert!(err.to_string().contains("expected"));
+
+        let mut parser = make_parser("ASK 'q' STRICT MAYBE");
+        let err = parser
+            .parse_ask_query()
+            .expect_err("bad strict should fail");
+        assert!(err.to_string().contains("Expected ON or OFF"));
+
+        let mut parser = make_parser("ASK 'q' CACHE TTL '10m' NOCACHE");
+        let err = parser
+            .parse_ask_query()
+            .expect_err("duplicate cache should fail");
+        assert!(err.to_string().contains("cache clause"));
+
+        let mut parser = make_parser("ASK 'q' CACHE FOREVER '10m'");
+        let err = parser
+            .parse_ask_query()
+            .expect_err("bad cache ttl keyword should fail");
+        assert!(err.to_string().contains("Expected TTL"));
+    }
+
+    #[test]
+    fn literal_value_special_constructors_arrays_and_objects() {
+        let mut parser = make_parser("PASSWORD('pw')");
+        assert!(matches!(
+            parser.parse_literal_value().expect("password"),
+            Value::Password(secret) if secret == "@@plain@@pw"
+        ));
+
+        let mut parser = make_parser("SECRET('pw')");
+        assert!(matches!(
+            parser.parse_literal_value().expect("secret"),
+            Value::Secret(bytes) if bytes == b"@@plain@@pw"
+        ));
+
+        let mut parser = make_parser("SECRET_REF(vault, red.vault.api_key)");
+        let value = parser.parse_literal_value().expect("secret ref");
+        assert!(matches!(value, Value::Json(_)));
+
+        let mut parser = make_parser("[1, 2.5]");
+        assert!(matches!(
+            parser.parse_literal_value().expect("vector"),
+            Value::Vector(values) if values == vec![1.0, 2.5]
+        ));
+
+        let mut parser = make_parser("['a', 2]");
+        assert!(matches!(
+            parser.parse_literal_value().expect("json array"),
+            Value::Json(_)
+        ));
+
+        let mut parser = make_parser("{level = 'info', count: 2}");
+        assert!(matches!(
+            parser.parse_literal_value().expect("json object"),
+            Value::Json(_)
+        ));
+    }
+
+    #[test]
+    fn literal_value_rejects_invalid_secret_ref_and_scalar_start() {
+        let mut parser = make_parser("SECRET_REF(config, red.vault.api_key)");
+        let err = parser
+            .parse_literal_value()
+            .expect_err("non-vault secret ref should fail");
+        assert!(err.to_string().contains("expected"));
+
+        let mut parser = make_parser("ORDER");
+        let err = parser
+            .parse_literal_value()
+            .expect_err("non literal should fail");
+        assert!(err.to_string().contains("expected"));
+    }
+
+    #[test]
+    fn json_depth_check_rejects_deep_literals() {
+        let mut deep = reddb_types::utils::json::JsonValue::Array(vec![]);
+        for _ in 0..JSON_LITERAL_MAX_DEPTH {
+            deep = reddb_types::utils::json::JsonValue::Array(vec![deep]);
+        }
+        let err = json_literal_depth_check(&deep).expect_err("depth should fail");
+        assert!(err.contains("JSON_LITERAL_MAX_DEPTH"));
+    }
+}

--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -1671,6 +1671,231 @@ mod tests {
     }
 
     #[test]
+    fn unary_plus_is_noop() {
+        let e = parse("+42");
+        assert!(matches!(
+            e,
+            Expr::Literal {
+                value: Value::Integer(42),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn parenthesised_select_becomes_subquery_expr() {
+        let e = parse("(SELECT 1)");
+        assert!(matches!(e, Expr::Subquery { .. }));
+    }
+
+    #[test]
+    fn bare_zero_arg_current_functions_parse_as_calls() {
+        for (input, expected) in [
+            ("CURRENT_TIMESTAMP", "CURRENT_TIMESTAMP"),
+            ("CURRENT_DATE", "CURRENT_DATE"),
+            ("CURRENT_TIME", "CURRENT_TIME"),
+        ] {
+            let e = parse(input);
+            let Expr::FunctionCall { name, args, .. } = e else {
+                panic!("expected FunctionCall for {input}");
+            };
+            assert_eq!(name, expected);
+            assert!(args.is_empty());
+        }
+    }
+
+    #[test]
+    fn keyword_function_names_parse_as_calls() {
+        for (input, expected_len) in [
+            ("COUNT(*)", 1),
+            ("SUM(amount)", 1),
+            ("LEFT(name, 2)", 2),
+            ("RIGHT(name, 2)", 2),
+            ("CONTAINS(body, 'red')", 2),
+            ("KV(cfg, path)", 2),
+        ] {
+            let e = parse(input);
+            let Expr::FunctionCall { args, .. } = e else {
+                panic!("expected FunctionCall for {input}");
+            };
+            assert_eq!(args.len(), expected_len, "{input}");
+        }
+    }
+
+    #[test]
+    fn count_distinct_lowers_to_count_distinct_function() {
+        let e = parse("COUNT(DISTINCT user_id)");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected FunctionCall");
+        };
+        assert_eq!(name, "COUNT_DISTINCT");
+        assert_eq!(args.len(), 1);
+    }
+
+    #[test]
+    fn dollar_secret_and_config_refs_become_function_calls() {
+        for (input, expected_name, expected_key) in [
+            ("$secret.api_key", "__SECRET_REF", "red.vault/api_key"),
+            ("$red.secret.api_key", "__SECRET_REF", "red.vault/api_key"),
+            ("$config.ai.provider", "CONFIG", "red.config/ai.provider"),
+            (
+                "$red.config.ai.provider",
+                "CONFIG",
+                "red.config/ai.provider",
+            ),
+        ] {
+            let e = parse(input);
+            let Expr::FunctionCall { name, args, .. } = e else {
+                panic!("expected FunctionCall for {input}");
+            };
+            assert_eq!(name, expected_name);
+            assert!(matches!(
+                &args[..],
+                [Expr::Literal { value: Value::Text(key), .. }] if key.as_ref() == expected_key
+            ));
+        }
+    }
+
+    #[test]
+    fn dollar_ref_rejects_unknown_namespace() {
+        let mut parser = Parser::new("$tenant.id").expect("lexer");
+        let err = parser
+            .parse_expr()
+            .expect_err("unknown namespace should fail");
+        assert!(err.to_string().contains("unknown $ reference"));
+    }
+
+    #[test]
+    fn config_and_kv_bare_path_args_lowercase_to_text() {
+        let e = parse("CONFIG(Red.AI.Default.Provider, 'openai')");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected FunctionCall");
+        };
+        assert_eq!(name, "CONFIG");
+        assert_eq!(args.len(), 2);
+        assert!(matches!(
+            &args[0],
+            Expr::Literal { value: Value::Text(path), .. }
+                if path.as_ref() == "red.ai.default.provider"
+        ));
+        assert!(matches!(
+            &args[1],
+            Expr::Literal { value: Value::Text(provider), .. } if provider.as_ref() == "openai"
+        ));
+
+        let e = parse("KV(cfg, default.role, LOWER(name))");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected FunctionCall");
+        };
+        assert_eq!(name, "KV");
+        assert!(matches!(
+            &args[0],
+            Expr::Literal { value: Value::Text(path), .. } if path.as_ref() == "cfg"
+        ));
+        assert!(matches!(
+            &args[1],
+            Expr::Literal { value: Value::Text(path), .. } if path.as_ref() == "default.role"
+        ));
+        assert!(matches!(&args[2], Expr::FunctionCall { name, .. } if name == "LOWER"));
+    }
+
+    #[test]
+    fn cast_rejects_unknown_type_name() {
+        let mut parser = Parser::new("CAST(age AS BOGUS_TYPE)").expect("lexer");
+        let err = parser
+            .parse_expr()
+            .expect_err("unknown cast target should fail");
+        assert!(err.to_string().contains("unknown type name"));
+    }
+
+    #[test]
+    fn trim_position_and_substring_sql_forms_lower_to_function_args() {
+        let e = parse("TRIM(LEADING 'x' FROM name)");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected trim function");
+        };
+        assert_eq!(name, "LTRIM");
+        assert_eq!(args.len(), 2);
+
+        let e = parse("TRIM(TRAILING FROM name)");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected trim function");
+        };
+        assert_eq!(name, "RTRIM");
+        assert_eq!(args.len(), 1);
+
+        let e = parse("POSITION('x' IN name)");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected position function");
+        };
+        assert_eq!(name, "POSITION");
+        assert_eq!(args.len(), 2);
+
+        let e = parse("POSITION('x', name)");
+        let Expr::FunctionCall { args, .. } = e else {
+            panic!("expected position function");
+        };
+        assert_eq!(args.len(), 2);
+
+        let e = parse("SUBSTRING(name FROM 2 FOR 3)");
+        let Expr::FunctionCall { name, args, .. } = e else {
+            panic!("expected substring function");
+        };
+        assert_eq!(name, "SUBSTRING");
+        assert_eq!(args.len(), 3);
+
+        let e = parse("SUBSTRING(name FOR 3)");
+        let Expr::FunctionCall { args, .. } = e else {
+            panic!("expected substring function");
+        };
+        assert_eq!(args.len(), 3);
+        assert!(matches!(
+            args[1],
+            Expr::Literal {
+                value: Value::Integer(1),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn postfix_in_accepts_subquery_and_empty_list() {
+        let e = parse("id IN (SELECT user_id FROM users)");
+        let Expr::InList { values, .. } = e else {
+            panic!("expected InList");
+        };
+        assert!(matches!(&values[..], [Expr::Subquery { .. }]));
+
+        let e = parse("id IN ()");
+        let Expr::InList { values, .. } = e else {
+            panic!("expected InList");
+        };
+        assert!(values.is_empty());
+    }
+
+    #[test]
+    fn postfix_not_requires_between_or_in() {
+        let mut parser = Parser::new("status NOT NULL").expect("lexer");
+        let err = parser.parse_expr().expect_err("postfix NOT should fail");
+        assert!(err.to_string().contains("BETWEEN or IN"));
+    }
+
+    #[test]
+    fn case_reports_missing_then_end_and_empty_branch() {
+        for input in [
+            "CASE END",
+            "CASE WHEN a = 1 'one' END",
+            "CASE WHEN a = 1 THEN 'one'",
+        ] {
+            let mut parser = Parser::new(input).expect("lexer");
+            assert!(
+                parser.parse_expr().is_err(),
+                "expected CASE parse failure for {input}"
+            );
+        }
+    }
+
+    #[test]
     fn span_tracks_token_range() {
         // A literal's span must cover the exact tokens consumed.
         let mut parser = Parser::new("123 + 456").expect("lexer");
@@ -1828,5 +2053,55 @@ mod tests {
         assert_eq!(args.len(), 1);
         assert_eq!(window.partition_by.len(), 1);
         assert!(window.order_by.is_empty());
+    }
+
+    #[test]
+    fn window_order_nulls_first_and_last() {
+        let e = parse("SUM(x) OVER (ORDER BY score ASC NULLS FIRST, ts DESC NULLS LAST)");
+        let Expr::WindowFunctionCall { window, .. } = e else {
+            panic!("expected WindowFunctionCall");
+        };
+        assert_eq!(window.order_by.len(), 2);
+        assert!(window.order_by[0].ascending);
+        assert!(window.order_by[0].nulls_first);
+        assert!(!window.order_by[1].ascending);
+        assert!(!window.order_by[1].nulls_first);
+    }
+
+    #[test]
+    fn window_single_bound_frames() {
+        let e = parse("SUM(x) OVER (ORDER BY ts ROWS 3 PRECEDING)");
+        let Expr::WindowFunctionCall { window, .. } = e else {
+            panic!("expected WindowFunctionCall");
+        };
+        let frame = window.frame.expect("frame");
+        assert!(matches!(
+            frame.start,
+            crate::ast::WindowFrameBound::Preceding(_)
+        ));
+        assert!(frame.end.is_none());
+
+        let e = parse("SUM(x) OVER (ORDER BY ts RANGE 1 FOLLOWING)");
+        let Expr::WindowFunctionCall { window, .. } = e else {
+            panic!("expected WindowFunctionCall");
+        };
+        let frame = window.frame.expect("frame");
+        assert!(matches!(
+            frame.start,
+            crate::ast::WindowFrameBound::Following(_)
+        ));
+        assert!(frame.end.is_none());
+    }
+
+    #[test]
+    fn window_reports_nulls_and_frame_bound_errors() {
+        for input in [
+            "SUM(x) OVER (ORDER BY score NULLS MIDDLE)",
+            "SUM(x) OVER (ORDER BY score ROWS UNBOUNDED)",
+            "SUM(x) OVER (ORDER BY score ROWS 3)",
+        ] {
+            let err = try_parse(input).expect_err("window syntax should fail");
+            assert!(!err.to_string().is_empty(), "{input}");
+        }
     }
 }

--- a/crates/reddb-rql/src/parser/filter.rs
+++ b/crates/reddb-rql/src/parser/filter.rs
@@ -610,3 +610,360 @@ fn expr_is_booleanish(expr: &Expr) -> bool {
         _ => false,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> Filter {
+        let mut parser =
+            Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"));
+        let filter = parser
+            .parse_filter()
+            .unwrap_or_else(|err| panic!("failed to parse filter {input:?}: {err:?}"));
+        assert_eq!(
+            parser.peek(),
+            &Token::Eof,
+            "filter did not consume all input: {input:?}"
+        );
+        filter
+    }
+
+    fn parse_err(input: &str) -> ParseError {
+        let mut parser =
+            Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"));
+        parser.parse_filter().unwrap_err()
+    }
+
+    fn assert_table_column(field: &FieldRef, table: &str, column: &str) {
+        let FieldRef::TableColumn {
+            table: actual_table,
+            column: actual_column,
+        } = field
+        else {
+            panic!("expected table column, got {field:?}");
+        };
+        assert_eq!(actual_table, table);
+        assert_eq!(actual_column, column);
+    }
+
+    fn assert_compare_integer(filter: &Filter, column: &str, op: CompareOp, expected: i64) {
+        let Filter::Compare {
+            field,
+            op: actual_op,
+            value,
+        } = filter
+        else {
+            panic!("expected integer Compare filter, got {filter:?}");
+        };
+        assert_table_column(field, "", column);
+        assert_eq!(*actual_op, op);
+        assert_eq!(value, &Value::Integer(expected));
+    }
+
+    fn assert_true_literal(expr: &Expr) {
+        assert!(
+            matches!(
+                expr,
+                Expr::Literal {
+                    value: Value::Boolean(true),
+                    ..
+                }
+            ),
+            "expected literal true, got {expr:?}"
+        );
+    }
+
+    fn assert_text_value(value: &Value, expected: &str) {
+        let Value::Text(actual) = value else {
+            panic!("expected text value {expected:?}, got {value:?}");
+        };
+        assert_eq!(actual.as_ref(), expected);
+    }
+
+    #[test]
+    fn parse_or_expression_chains_left_associatively() {
+        let filter = parse("a = 1 OR b = 2 OR c = 3");
+        let Filter::Or(left, right) = filter else {
+            panic!("expected OR filter");
+        };
+
+        assert!(matches!(*left, Filter::Or(_, _)));
+        assert_compare_integer(right.as_ref(), "c", CompareOp::Eq, 3);
+    }
+
+    #[test]
+    fn parse_all_compare_operators_on_literal_rhs() {
+        for (input, expected_op) in [
+            ("a = 1", CompareOp::Eq),
+            ("a <> 1", CompareOp::Ne),
+            ("a < 1", CompareOp::Lt),
+            ("a <= 1", CompareOp::Le),
+            ("a > 1", CompareOp::Gt),
+            ("a >= 1", CompareOp::Ge),
+        ] {
+            assert_compare_integer(&parse(input), "a", expected_op, 1);
+        }
+    }
+
+    #[test]
+    fn parse_compare_rhs_field_value_and_expression_paths() {
+        let filter = parse("temp = max_temp");
+        let Filter::CompareFields { left, op, right } = filter else {
+            panic!("expected CompareFields");
+        };
+        assert_table_column(&left, "", "temp");
+        assert_eq!(op, CompareOp::Eq);
+        assert_table_column(&right, "", "max_temp");
+
+        let filter = parse("temp = max_temp + 1");
+        let Filter::CompareExpr { rhs, .. } = filter else {
+            panic!("expected CompareExpr for arithmetic rhs");
+        };
+        assert!(matches!(rhs, Expr::BinaryOp { op: BinOp::Add, .. }));
+
+        let filter = parse("created_at >= CURRENT_TIMESTAMP");
+        let Filter::CompareExpr { rhs, .. } = filter else {
+            panic!("expected CompareExpr for bare zero-arg function rhs");
+        };
+        assert!(matches!(
+            rhs,
+            Expr::FunctionCall { ref name, ref args, .. }
+                if name == "CURRENT_TIMESTAMP" && args.is_empty()
+        ));
+
+        let filter = parse("LOWER(name) = 'ada'");
+        let Filter::CompareExpr { lhs, rhs, .. } = filter else {
+            panic!("expected CompareExpr for expression lhs");
+        };
+        assert!(matches!(lhs, Expr::FunctionCall { ref name, .. } if name == "LOWER"));
+        assert!(matches!(
+            rhs,
+            Expr::Literal {
+                value: Value::Text(ref text),
+                ..
+            } if text.as_ref() == "ada"
+        ));
+    }
+
+    #[test]
+    fn parse_in_value_expression_and_subquery_lists() {
+        let filter = parse("status IN ('open', 'closed')");
+        let Filter::In { field, values } = filter else {
+            panic!("expected value-list IN filter");
+        };
+        assert_table_column(&field, "", "status");
+        assert_eq!(values.len(), 2);
+        assert_text_value(&values[0], "open");
+        assert_text_value(&values[1], "closed");
+
+        let filter = parse("LOWER(name) IN ('ada', UPPER(alias), 1 + 2)");
+        let Filter::CompareExpr { lhs, op, rhs } = filter else {
+            panic!("expected expression-list IN as CompareExpr");
+        };
+        assert_eq!(op, CompareOp::Eq);
+        assert_true_literal(&rhs);
+        let Expr::InList { target, values, .. } = lhs else {
+            panic!("expected InList lhs");
+        };
+        assert!(matches!(*target, Expr::FunctionCall { ref name, .. } if name == "LOWER"));
+        assert_eq!(values.len(), 3);
+        assert!(matches!(values[0], Expr::Literal { .. }));
+        assert!(matches!(values[1], Expr::FunctionCall { ref name, .. } if name == "UPPER"));
+        assert!(matches!(values[2], Expr::BinaryOp { op: BinOp::Add, .. }));
+
+        let filter = parse("LOWER(name) IN ()");
+        let Filter::CompareExpr { lhs, .. } = filter else {
+            panic!("expected empty expression-list IN as CompareExpr");
+        };
+        let Expr::InList { values, .. } = lhs else {
+            panic!("expected InList lhs");
+        };
+        assert!(values.is_empty());
+
+        let filter = parse("id IN (SELECT user_id FROM users)");
+        let Filter::CompareExpr { lhs, rhs, .. } = filter else {
+            panic!("expected subquery IN as CompareExpr");
+        };
+        assert_true_literal(&rhs);
+        let Expr::InList { values, .. } = lhs else {
+            panic!("expected InList lhs");
+        };
+        assert!(matches!(&values[..], [Expr::Subquery { .. }]));
+    }
+
+    #[test]
+    fn parse_between_literal_mixed_and_expression_variants() {
+        let filter = parse("temp BETWEEN 10 AND 20");
+        let Filter::Between { field, low, high } = filter else {
+            panic!("expected literal BETWEEN");
+        };
+        assert_table_column(&field, "", "temp");
+        assert_eq!(low, Value::Integer(10));
+        assert_eq!(high, Value::Integer(20));
+
+        let filter = parse("temp BETWEEN 0 AND max_temp");
+        let Filter::And(left, right) = filter else {
+            panic!("expected mixed value/field BETWEEN to lower to AND");
+        };
+        assert_compare_integer(left.as_ref(), "temp", CompareOp::Ge, 0);
+        let Filter::CompareFields { left, op, right } = right.as_ref() else {
+            panic!("expected upper field bound CompareFields");
+        };
+        assert_table_column(left, "", "temp");
+        assert_eq!(*op, CompareOp::Le);
+        assert_table_column(right, "", "max_temp");
+
+        let filter = parse("temp BETWEEN min_temp AND 100");
+        let Filter::And(left, right) = filter else {
+            panic!("expected mixed field/value BETWEEN to lower to AND");
+        };
+        let Filter::CompareFields {
+            left: lower_left,
+            op,
+            right: lower_right,
+        } = left.as_ref()
+        else {
+            panic!("expected lower field bound CompareFields");
+        };
+        assert_table_column(lower_left, "", "temp");
+        assert_eq!(*op, CompareOp::Ge);
+        assert_table_column(lower_right, "", "min_temp");
+        assert_compare_integer(right.as_ref(), "temp", CompareOp::Le, 100);
+
+        let filter = parse("LOWER(name) BETWEEN 'a' AND 'm'");
+        let Filter::CompareExpr { lhs, op, rhs } = filter else {
+            panic!("expected expression BETWEEN to become CompareExpr");
+        };
+        assert_eq!(op, CompareOp::Eq);
+        assert_true_literal(&rhs);
+        let Expr::Between {
+            target,
+            low,
+            high,
+            negated,
+            ..
+        } = lhs
+        else {
+            panic!("expected Expr::Between lhs");
+        };
+        assert!(!negated);
+        assert!(matches!(*target, Expr::FunctionCall { ref name, .. } if name == "LOWER"));
+        assert!(matches!(
+            *low,
+            Expr::Literal {
+                value: Value::Text(ref text),
+                ..
+            } if text.as_ref() == "a"
+        ));
+        assert!(matches!(
+            *high,
+            Expr::Literal {
+                value: Value::Text(ref text),
+                ..
+            } if text.as_ref() == "m"
+        ));
+    }
+
+    #[test]
+    fn parse_string_predicates_and_infix_not() {
+        let filter = parse("name LIKE 'A%'");
+        let Filter::Like { field, pattern } = filter else {
+            panic!("expected LIKE filter");
+        };
+        assert_table_column(&field, "", "name");
+        assert_eq!(pattern, "A%");
+
+        let filter = parse("name NOT LIKE 'A%'");
+        let Filter::Not(inner) = filter else {
+            panic!("expected NOT LIKE filter");
+        };
+        assert!(matches!(*inner, Filter::Like { .. }));
+
+        let filter = parse("name STARTS WITH 'A'");
+        let Filter::StartsWith { field, prefix } = filter else {
+            panic!("expected STARTS WITH filter");
+        };
+        assert_table_column(&field, "", "name");
+        assert_eq!(prefix, "A");
+
+        let filter = parse("name ENDS WITH 'z'");
+        let Filter::EndsWith { field, suffix } = filter else {
+            panic!("expected ENDS WITH filter");
+        };
+        assert_table_column(&field, "", "name");
+        assert_eq!(suffix, "z");
+
+        let filter = parse("name CONTAINS 'mid'");
+        let Filter::Contains { field, substring } = filter else {
+            panic!("expected CONTAINS filter");
+        };
+        assert_table_column(&field, "", "name");
+        assert_eq!(substring, "mid");
+    }
+
+    #[test]
+    fn string_predicates_reject_expression_lhs() {
+        for (input, message) in [
+            (
+                "LOWER(name) LIKE 'a%'",
+                "LIKE requires a column reference on the left-hand side",
+            ),
+            (
+                "LOWER(name) STARTS WITH 'a'",
+                "STARTS WITH requires a column reference on the left-hand side",
+            ),
+            (
+                "LOWER(name) ENDS WITH 'z'",
+                "ENDS WITH requires a column reference on the left-hand side",
+            ),
+            (
+                "LOWER(name) CONTAINS 'm'",
+                "CONTAINS requires a column reference on the left-hand side",
+            ),
+        ] {
+            let err = parse_err(input);
+            assert!(
+                err.to_string().contains(message),
+                "unexpected error for {input:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn booleanish_lhs_becomes_compare_expr_against_true() {
+        let filter = parse("TRUE");
+        let Filter::CompareExpr { lhs, op, rhs } = filter else {
+            panic!("expected boolean literal to become CompareExpr");
+        };
+        assert_eq!(op, CompareOp::Eq);
+        assert_true_literal(&lhs);
+        assert_true_literal(&rhs);
+    }
+
+    #[test]
+    fn compare_operator_error_reports_expected_ops() {
+        let err = parse_err("age AND active = true");
+        let message = err.to_string();
+        assert!(message.contains("="), "{message}");
+        assert!(message.contains("<="), "{message}");
+        assert!(message.contains(">="), "{message}");
+    }
+
+    #[test]
+    fn field_ref_segments_accept_keywords_and_reject_empty_segments() {
+        let mut parser = Parser::new("table.ORDER.by").expect("lexer init");
+        let field = parser.parse_field_ref().expect("parse field ref");
+        assert_table_column(&field, "table", "order.by");
+        assert_eq!(parser.peek(), &Token::Eof);
+
+        for input in ["table.", "*"] {
+            let mut parser = Parser::new(input).expect("lexer init");
+            let err = parser.parse_field_ref().unwrap_err();
+            assert!(
+                err.to_string().contains("identifier or field name"),
+                "unexpected error for {input:?}: {err}"
+            );
+        }
+    }
+}

--- a/crates/reddb-rql/src/parser/index_ddl.rs
+++ b/crates/reddb-rql/src/parser/index_ddl.rs
@@ -115,3 +115,97 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parser(input: &str) -> Parser<'_> {
+        Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"))
+    }
+
+    fn parse_create_index(input: &str) -> CreateIndexQuery {
+        let mut parser = parser(input);
+        parser.expect(Token::Create).expect("CREATE");
+        let QueryExpr::CreateIndex(query) = parser
+            .parse_create_index_query()
+            .unwrap_or_else(|err| panic!("failed to parse {input:?}: {err:?}"))
+        else {
+            panic!("Expected CreateIndexQuery");
+        };
+        query
+    }
+
+    fn parse_drop_index(input: &str) -> DropIndexQuery {
+        let mut parser = parser(input);
+        parser.expect(Token::Drop).expect("DROP");
+        let QueryExpr::DropIndex(query) = parser
+            .parse_drop_index_query()
+            .unwrap_or_else(|err| panic!("failed to parse {input:?}: {err:?}"))
+        else {
+            panic!("Expected DropIndexQuery");
+        };
+        query
+    }
+
+    #[test]
+    fn parse_create_index_defaults_and_options() {
+        let query = parse_create_index("CREATE INDEX IF NOT EXISTS idx ON users (email, type)");
+        assert_eq!(query.name, "idx");
+        assert_eq!(query.table, "users");
+        assert_eq!(query.columns, vec!["email", "type"]);
+        assert_eq!(query.method, IndexMethod::BTree);
+        assert!(query.if_not_exists);
+        assert!(!query.unique);
+
+        let query = parse_create_index("CREATE UNIQUE INDEX idx_orders ON orders (id) USING HASH");
+        assert!(query.unique);
+        assert_eq!(query.method, IndexMethod::Hash);
+    }
+
+    #[test]
+    fn parse_index_method_accepts_all_ident_variants() {
+        for (method, expected) in [
+            ("BTREE", IndexMethod::BTree),
+            ("BITMAP", IndexMethod::Bitmap),
+            ("RTREE", IndexMethod::RTree),
+            ("hash", IndexMethod::Hash),
+        ] {
+            let query = parse_create_index(&format!(
+                "CREATE INDEX idx_{method} ON users (email) USING {method}"
+            ));
+            assert_eq!(query.method, expected);
+        }
+    }
+
+    #[test]
+    fn parse_drop_index_body_covers_if_exists() {
+        let query = parse_drop_index("DROP INDEX IF EXISTS idx_email ON users");
+        assert_eq!(query.name, "idx_email");
+        assert_eq!(query.table, "users");
+        assert!(query.if_exists);
+
+        let query = parse_drop_index("DROP INDEX idx_email ON users");
+        assert!(!query.if_exists);
+    }
+
+    #[test]
+    fn parse_index_method_reports_unknown_ident_and_non_ident_errors() {
+        let mut p = parser("CREATE INDEX idx ON users (email) USING GIN");
+        p.expect(Token::Create).expect("CREATE");
+        let err = p.parse_create_index_query().unwrap_err();
+        assert!(
+            err.to_string().contains("unknown index method 'GIN'"),
+            "{err}"
+        );
+
+        let mut p = parser("CREATE INDEX idx ON users (email) USING 42");
+        p.expect(Token::Create).expect("CREATE");
+        let err = p.parse_create_index_query().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("expected: HASH, BTREE, BITMAP, RTREE"),
+            "{err}"
+        );
+    }
+}

--- a/crates/reddb-rql/src/parser/index_ddl.rs
+++ b/crates/reddb-rql/src/parser/index_ddl.rs
@@ -133,6 +133,10 @@ mod tests {
         else {
             panic!("Expected CreateIndexQuery");
         };
+        assert!(
+            matches!(parser.peek(), Token::Eof),
+            "CREATE INDEX parse did not consume all input: {input:?}"
+        );
         query
     }
 
@@ -145,6 +149,10 @@ mod tests {
         else {
             panic!("Expected DropIndexQuery");
         };
+        assert!(
+            matches!(parser.peek(), Token::Eof),
+            "DROP INDEX parse did not consume all input: {input:?}"
+        );
         query
     }
 

--- a/crates/reddb-rql/src/parser/kv.rs
+++ b/crates/reddb-rql/src/parser/kv.rs
@@ -701,3 +701,241 @@ impl<'a> Parser<'a> {
         Ok(mult)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reddb_types::types::Value;
+
+    fn parser(input: &str) -> Parser<'_> {
+        Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"))
+    }
+
+    #[test]
+    fn kv_key_helper_handles_multisegment_and_vault_aliases() {
+        let mut p = parser("settings.feature.flag");
+        let (collection, key) = p.parse_kv_key(CollectionModel::Kv).unwrap();
+        assert_eq!(collection, "settings");
+        assert_eq!(key, "feature.flag");
+
+        let mut p = parser("red.vault.prod.api_key");
+        let (collection, key) = p.parse_kv_key(CollectionModel::Vault).unwrap();
+        assert_eq!(collection, "red.vault");
+        assert_eq!(key, "prod.api_key");
+
+        let mut p = parser("red.secret.prod.api_key");
+        let (collection, key) = p.parse_kv_key(CollectionModel::Vault).unwrap();
+        assert_eq!(collection, "red.vault");
+        assert_eq!(key, "prod.api_key");
+
+        let mut p = parser("secret.prod.api_key");
+        let (collection, key) = p.parse_kv_key(CollectionModel::Vault).unwrap();
+        assert_eq!(collection, "red.vault");
+        assert_eq!(key, "prod.api_key");
+
+        let mut p = parser("settings.feature:flag");
+        let err = p
+            .parse_kv_key(CollectionModel::Kv)
+            .expect_err("unquoted colon in nested key should fail");
+        assert!(err.to_string().contains("settings.'feature:flag'"));
+    }
+
+    #[test]
+    fn keyed_list_watch_tags_and_duration_helpers_cover_edges() {
+        let mut p = parser("items PREFIX tenant LIMIT -2 OFFSET -3");
+        let QueryExpr::KvCommand(KvCommand::List {
+            model,
+            collection,
+            prefix,
+            limit,
+            offset,
+        }) = p.parse_keyed_list(CollectionModel::Kv).unwrap()
+        else {
+            panic!("expected kv list");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "items");
+        assert_eq!(prefix.as_deref(), Some("tenant"));
+        assert_eq!(limit, Some(0));
+        assert_eq!(offset, 0);
+
+        let mut p = parser("secrets.env PREFIX api FROM LSN 12");
+        let QueryExpr::KvCommand(KvCommand::Watch {
+            model,
+            collection,
+            key,
+            prefix,
+            from_lsn,
+        }) = p.parse_kv_watch(CollectionModel::Vault).unwrap()
+        else {
+            panic!("expected vault watch");
+        };
+        assert_eq!(model, CollectionModel::Vault);
+        assert_eq!(collection, "secrets.env");
+        assert_eq!(key, "api");
+        assert!(prefix);
+        assert_eq!(from_lsn, Some(12));
+
+        let mut p = parser("[org:7, region.us-east-1, 1.5]");
+        assert_eq!(
+            p.parse_kv_tag_list().unwrap(),
+            vec![
+                "org:7".to_string(),
+                "region.us-east-1".to_string(),
+                "1.5".to_string()
+            ]
+        );
+
+        for (unit, expected) in [
+            ("ms", 1.0),
+            ("secs", 1_000.0),
+            ("mins", 60_000.0),
+            ("hrs", 3_600_000.0),
+            ("days", 86_400_000.0),
+            ("fortnight", 1_000.0),
+            ("", 1_000.0),
+        ] {
+            let mut p = parser(unit);
+            assert_eq!(p.parse_kv_duration_unit().unwrap(), expected, "{unit}");
+        }
+    }
+
+    #[test]
+    fn kv_command_error_paths_are_structured() {
+        for sql in [
+            "KV PUT a = 1 IF EXISTS",
+            "KV PUT a = 1 IF NOT",
+            "INVALIDATE [tag] FROM c",
+            "INVALIDATE TAGS [tag] c",
+            "KV CAS key SET 1",
+            "KV CAS key EXPECT NULL VALUE 1",
+            "KV WATCH key FROM 7",
+        ] {
+            assert!(parser(sql).parse_frontend_statement().is_err(), "{sql}");
+        }
+        assert!(crate::sql::parse_frontend("VAULT UNSEAL secret.key FROM 7").is_err());
+    }
+
+    #[test]
+    fn kv_cas_and_vault_lifecycle_cover_remaining_shapes() {
+        let QueryExpr::KvCommand(KvCommand::Cas {
+            model,
+            collection,
+            key,
+            expected,
+            new_value,
+            ttl_ms,
+        }) = parser("KV CAS settings.feature EXPECT NULL SET 'on' EXPIRE 2 min")
+            .parse_frontend_statement()
+            .unwrap()
+            .into_query_expr()
+        else {
+            panic!("expected kv cas");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "settings");
+        assert_eq!(key, "feature");
+        assert_eq!(expected, None);
+        assert_eq!(new_value, Value::text("on"));
+        assert_eq!(ttl_ms, Some(120_000));
+
+        assert!(matches!(
+            parser("DELETE VAULT secrets.api_key")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Delete {
+                model: CollectionModel::Vault,
+                collection,
+                key,
+            }) if collection == "secrets" && key == "api_key"
+        ));
+        assert!(matches!(
+            parser("VAULT PURGE secrets.api_key")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Purge { collection, key })
+                if collection == "secrets" && key == "api_key"
+        ));
+        assert!(matches!(
+            parser("VAULT ROTATE secrets.api_key = 'v2' TAGS [scope:prod]")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Rotate {
+                collection,
+                key,
+                tags,
+                ..
+            }) if collection == "secrets"
+                && key == "api_key"
+                && tags == vec!["scope:prod".to_string()]
+        ));
+    }
+
+    #[test]
+    fn vault_body_and_kv_error_variants_cover_remaining_dispatch() {
+        assert!(parser("NOPE GET key").parse_vault_command().is_err());
+
+        for sql in [
+            "KV UNSEAL secret.key",
+            "KV ROTATE secret.key = 'v2'",
+            "KV HISTORY secret.key",
+            "KV PURGE secret.key",
+        ] {
+            assert!(parser(sql).parse_frontend_statement().is_err(), "{sql}");
+        }
+
+        assert!(matches!(
+            parser("VAULT UNSEAL secret.api_key VERSION 2")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Unseal {
+                collection,
+                key,
+                version: Some(2),
+            }) if collection == "red.vault" && key == "api_key"
+        ));
+        assert!(matches!(
+            parser("VAULT HISTORY secret.api_key")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::History { collection, key })
+                if collection == "red.vault" && key == "api_key"
+        ));
+        assert!(matches!(
+            parser("PURGE VAULT secret.api_key")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Purge { collection, key })
+                if collection == "red.vault" && key == "api_key"
+        ));
+
+        let mut p = parser("settings:feature");
+        assert!(p.parse_kv_key(CollectionModel::Kv).is_err());
+
+        assert!(matches!(
+            parser("WATCH user.*")
+                .parse_frontend_statement()
+                .unwrap()
+                .into_query_expr(),
+            QueryExpr::KvCommand(KvCommand::Watch {
+                model: CollectionModel::Kv,
+                collection,
+                key,
+                prefix: true,
+                from_lsn: None,
+            }) if collection == KV_DEFAULT_COLLECTION && key == "user"
+        ));
+
+        let mut p = parser("[, scope:prod]");
+        assert_eq!(
+            p.parse_kv_tag_list().unwrap(),
+            vec!["scope:prod".to_string()]
+        );
+    }
+}

--- a/crates/reddb-rql/src/parser/search_commands.rs
+++ b/crates/reddb-rql/src/parser/search_commands.rs
@@ -582,3 +582,258 @@ impl<'a> Parser<'a> {
         Ok(items)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(input: &str) -> QueryExpr {
+        crate::parser::parse(input).unwrap().query
+    }
+
+    fn assert_parse_err(input: &str) {
+        assert!(crate::parser::parse(input).is_err(), "{input}");
+    }
+
+    #[test]
+    fn parses_search_similar_text_vector_and_limit_parameters() {
+        let query = parse_query(
+            "SEARCH SIMILAR TEXT 'semantic query' COLLECTION docs LIMIT 7 MIN_SCORE 0.42 USING openai",
+        );
+        let QueryExpr::SearchCommand(SearchCommand::Similar {
+            vector,
+            text,
+            provider,
+            collection,
+            limit,
+            min_score,
+            vector_param,
+            limit_param,
+            min_score_param,
+            text_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Similar");
+        };
+        assert!(vector.is_empty());
+        assert_eq!(text, Some("semantic query".to_string()));
+        assert_eq!(provider, Some("openai".to_string()));
+        assert_eq!(collection, "docs");
+        assert_eq!(limit, 7);
+        assert!((min_score - 0.42).abs() < 0.01);
+        assert_eq!(vector_param, None);
+        assert_eq!(limit_param, None);
+        assert_eq!(min_score_param, None);
+        assert_eq!(text_param, None);
+
+        let query = parse_query("SEARCH SIMILAR TEXT $1 COLLECTION docs LIMIT $2 MIN_SCORE $3");
+        let QueryExpr::SearchCommand(SearchCommand::Similar {
+            vector,
+            text,
+            limit,
+            min_score,
+            vector_param,
+            limit_param,
+            min_score_param,
+            text_param,
+            ..
+        }) = query
+        else {
+            panic!("Expected parameterized SearchCommand::Similar");
+        };
+        assert!(vector.is_empty());
+        assert_eq!(text, None);
+        assert_eq!(limit, 0);
+        assert!((min_score).abs() < 0.01);
+        assert_eq!(vector_param, None);
+        assert_eq!(limit_param, Some(1));
+        assert_eq!(min_score_param, Some(2));
+        assert_eq!(text_param, Some(0));
+
+        let query = parse_query("SEARCH SIMILAR $1 COLLECTION embeddings");
+        let QueryExpr::SearchCommand(SearchCommand::Similar {
+            vector,
+            vector_param,
+            limit,
+            min_score,
+            ..
+        }) = query
+        else {
+            panic!("Expected vector parameter SearchCommand::Similar");
+        };
+        assert!(vector.is_empty());
+        assert_eq!(vector_param, Some(0));
+        assert_eq!(limit, 10);
+        assert!((min_score).abs() < 0.01);
+    }
+
+    #[test]
+    fn parses_search_text_in_collection_with_question_limit() {
+        let query = parse_query("SEARCH TEXT 'needle' IN docs LIMIT ? FUZZY");
+        let QueryExpr::SearchCommand(SearchCommand::Text {
+            query,
+            collection,
+            limit,
+            fuzzy,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Text");
+        };
+        assert_eq!(query, "needle");
+        assert_eq!(collection, Some("docs".to_string()));
+        assert_eq!(limit, 0);
+        assert!(fuzzy);
+        assert_eq!(limit_param, Some(0));
+    }
+
+    #[test]
+    fn parses_search_hybrid_vector_keyword_k_equals_and_keyword_collection() {
+        let query = parse_query("SEARCH HYBRID VECTOR [1, 2] TEXT 'needle' IN TEXT K = $1");
+        let QueryExpr::SearchCommand(SearchCommand::Hybrid {
+            vector,
+            query,
+            collection,
+            limit,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Hybrid");
+        };
+        assert_eq!(vector, Some(vec![1.0, 2.0]));
+        assert_eq!(query, Some("needle".to_string()));
+        assert_eq!(collection, "text");
+        assert_eq!(limit, 0);
+        assert_eq!(limit_param, Some(0));
+    }
+
+    #[test]
+    fn parses_multimodal_and_index_parameterized_limits() {
+        let query = parse_query("SEARCH MULTIMODAL 'image query' COLLECTION assets LIMIT $1");
+        let QueryExpr::SearchCommand(SearchCommand::Multimodal {
+            query,
+            collection,
+            limit,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Multimodal");
+        };
+        assert_eq!(query, "image query");
+        assert_eq!(collection, Some("assets".to_string()));
+        assert_eq!(limit, 0);
+        assert_eq!(limit_param, Some(0));
+
+        let query = parse_query(
+            "SEARCH INDEX email VALUE 'a@example.test' COLLECTION users LIMIT $1 EXACT",
+        );
+        let QueryExpr::SearchCommand(SearchCommand::Index {
+            index,
+            value,
+            collection,
+            limit,
+            exact,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Index");
+        };
+        assert_eq!(index, "email");
+        assert_eq!(value, "a@example.test");
+        assert_eq!(collection, Some("users".to_string()));
+        assert_eq!(limit, 0);
+        assert!(exact);
+        assert_eq!(limit_param, Some(0));
+    }
+
+    #[test]
+    fn parses_search_context_depth_before_parameterized_limit() {
+        let query =
+            parse_query("SEARCH CONTEXT 'who' FIELD subject COLLECTION docs DEPTH 3 LIMIT $1");
+        let QueryExpr::SearchCommand(SearchCommand::Context {
+            query,
+            field,
+            collection,
+            limit,
+            depth,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::Context");
+        };
+        assert_eq!(query, "who");
+        assert_eq!(field, Some("subject".to_string()));
+        assert_eq!(collection, Some("docs".to_string()));
+        assert_eq!(limit, 0);
+        assert_eq!(depth, 3);
+        assert_eq!(limit_param, Some(0));
+    }
+
+    #[test]
+    fn parses_search_spatial_bbox_and_nearest_parameters() {
+        let query =
+            parse_query("SEARCH SPATIAL BBOX -10 -20 10 20 COLLECTION sites COLUMN geog LIMIT $1");
+        let QueryExpr::SearchCommand(SearchCommand::SpatialBbox {
+            min_lat,
+            min_lon,
+            max_lat,
+            max_lon,
+            collection,
+            column,
+            limit,
+            limit_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::SpatialBbox");
+        };
+        assert!((min_lat + 10.0).abs() < 0.001);
+        assert!((min_lon + 20.0).abs() < 0.001);
+        assert!((max_lat - 10.0).abs() < 0.001);
+        assert!((max_lon - 20.0).abs() < 0.001);
+        assert_eq!(collection, "sites");
+        assert_eq!(column, "geog");
+        assert_eq!(limit, 0);
+        assert_eq!(limit_param, Some(0));
+
+        let query =
+            parse_query("SEARCH SPATIAL NEAREST 48.85 2.35 K ?2 COLLECTION sites COLUMN geog");
+        let QueryExpr::SearchCommand(SearchCommand::SpatialNearest {
+            lat,
+            lon,
+            k,
+            collection,
+            column,
+            k_param,
+        }) = query
+        else {
+            panic!("Expected SearchCommand::SpatialNearest");
+        };
+        assert!((lat - 48.85).abs() < 0.001);
+        assert!((lon - 2.35).abs() < 0.001);
+        assert_eq!(k, 0);
+        assert_eq!(collection, "sites");
+        assert_eq!(column, "geog");
+        assert_eq!(k_param, Some(1));
+    }
+
+    #[test]
+    fn rejects_invalid_search_command_forms() {
+        for input in [
+            "SEARCH AUDIO 'needle'",
+            "SEARCH HYBRID TEXT 'needle'",
+            "SEARCH SPATIAL WITHIN 0 0 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL RADIUS 91 0 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL RADIUS 45 181 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL RADIUS 45 90 0 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL BBOX -91 0 1 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL BBOX 0 -181 1 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL BBOX 0 0 91 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL BBOX 0 0 1 181 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL NEAREST 91 0 K 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL NEAREST 0 181 K 1 COLLECTION sites COLUMN geog",
+            "SEARCH SPATIAL NEAREST 0 0 K 0 COLLECTION sites COLUMN geog",
+        ] {
+            assert_parse_err(input);
+        }
+    }
+}

--- a/crates/reddb-rql/src/parser/timeseries.rs
+++ b/crates/reddb-rql/src/parser/timeseries.rs
@@ -532,3 +532,136 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reddb_types::catalog::CollectionModel;
+
+    fn parse_query(input: &str) -> Result<QueryExpr, ParseError> {
+        crate::parser::parse(input).map(|query| query.query)
+    }
+
+    #[test]
+    fn create_timeseries_accepts_clause_order_defaults_and_columnar() {
+        let query = parse_query(
+            "CREATE TIMESERIES IF NOT EXISTS readings COLUMNAR DOWNSAMPLE 1h:raw \
+             RETENTION 2 h CHUNKSIZE 64",
+        )
+        .unwrap();
+
+        let QueryExpr::CreateTimeSeries(timeseries) = query else {
+            panic!("expected create timeseries");
+        };
+        assert_eq!(timeseries.name, "readings");
+        assert!(timeseries.if_not_exists);
+        assert!(timeseries.columnar);
+        assert_eq!(timeseries.retention_ms, Some(2 * 3_600_000));
+        assert_eq!(timeseries.chunk_size, Some(64));
+        assert_eq!(timeseries.downsample_policies, vec!["1h:raw:avg"]);
+        assert_eq!(timeseries.session_key, None);
+        assert_eq!(timeseries.session_gap_ms, None);
+        assert!(timeseries.hypertable.is_none());
+    }
+
+    #[test]
+    fn create_metrics_sets_collection_defaults_and_optional_clauses() {
+        let query = parse_query(
+            "CREATE METRICS IF NOT EXISTS telemetry RETENTION 30 m \
+             DOWNSAMPLE 5m:raw:max TENANT BY (ctx.tenant)",
+        )
+        .unwrap();
+
+        let QueryExpr::CreateTable(metrics) = query else {
+            panic!("expected metrics collection");
+        };
+        assert_eq!(metrics.collection_model, CollectionModel::Metrics);
+        assert_eq!(metrics.name, "telemetry");
+        assert!(metrics.if_not_exists);
+        assert_eq!(metrics.default_ttl_ms, Some(30 * 60_000));
+        assert_eq!(metrics.metrics_rollup_policies, vec!["5m:raw:max"]);
+        assert_eq!(metrics.tenant_by.as_deref(), Some("ctx.tenant"));
+        assert!(metrics.append_only);
+        assert!(metrics.columns.is_empty());
+    }
+
+    #[test]
+    fn create_metric_alter_metric_and_slo_parse_descriptor_forms() {
+        let query = parse_query(
+            "CREATE METRIC Svc.Latency.P99 TYPE gauge ROLE sli SOURCE rollups \
+             QUERY 'SELECT p99 FROM rollups' WINDOW 5 min TIME_FIELD observed_at",
+        )
+        .unwrap();
+        let QueryExpr::CreateMetric(metric) = query else {
+            panic!("expected create metric");
+        };
+        assert_eq!(metric.path, "svc.latency.p99");
+        assert_eq!(metric.kind, "gauge");
+        assert_eq!(metric.role, "sli");
+        assert_eq!(metric.source.as_deref(), Some("rollups"));
+        assert_eq!(metric.query.as_deref(), Some("SELECT p99 FROM rollups"));
+        assert_eq!(metric.window_ms, Some(5 * 60_000));
+        assert_eq!(metric.time_field.as_deref(), Some("observed_at"));
+
+        let query = parse_query("ALTER METRIC Svc.Latency.P99 SET PATH svc.latency.p95").unwrap();
+        let QueryExpr::AlterMetric(alter) = query else {
+            panic!("expected alter metric");
+        };
+        assert_eq!(alter.path, "svc.latency.p99");
+        assert_eq!(alter.set_role, None);
+        assert_eq!(alter.attempted_kind, None);
+        assert_eq!(alter.attempted_path.as_deref(), Some("svc.latency.p95"));
+
+        let query =
+            parse_query("CREATE SLO Api.Availability ON Svc.Latency.P99 TARGET 0.999 WINDOW 28 d")
+                .unwrap();
+        let QueryExpr::CreateSlo(slo) = query else {
+            panic!("expected create slo");
+        };
+        assert_eq!(slo.path, "api.availability");
+        assert_eq!(slo.metric_path, "svc.latency.p99");
+        assert!((slo.target - 0.999).abs() < f64::EPSILON);
+        assert_eq!(slo.window_ms, 28 * 86_400_000);
+    }
+
+    #[test]
+    fn create_hypertable_and_drop_timeseries_parse_variants() {
+        let query = parse_query(
+            "CREATE HYPERTABLE IF NOT EXISTS events TIME_COLUMN ts COLUMNAR \
+             CHUNK_INTERVAL '30m' TTL '10s' RETENTION 1 h",
+        )
+        .unwrap();
+        let QueryExpr::CreateTimeSeries(timeseries) = query else {
+            panic!("expected hypertable as timeseries");
+        };
+        let hypertable = timeseries.hypertable.expect("hypertable ddl");
+        assert_eq!(timeseries.name, "events");
+        assert!(timeseries.if_not_exists);
+        assert!(timeseries.columnar);
+        assert_eq!(timeseries.retention_ms, Some(3_600_000));
+        assert_eq!(hypertable.time_column, "ts");
+        assert_eq!(hypertable.chunk_interval_ns, 30 * 60 * 1_000_000_000);
+        assert_eq!(hypertable.default_ttl_ns, Some(10 * 1_000_000_000));
+
+        let query = parse_query("DROP TIMESERIES IF EXISTS tenant.metrics.*").unwrap();
+        assert!(matches!(
+            query,
+            QueryExpr::DropTimeSeries(drop) if drop.name == "tenant.metrics.*" && drop.if_exists
+        ));
+    }
+
+    #[test]
+    fn timeseries_metric_and_slo_errors_are_reported() {
+        for sql in [
+            "CREATE TIMESERIES events WITH RETENTION 1 d",
+            "CREATE METRICS telemetry TENANT (ctx.tenant)",
+            "CREATE METRIC svc.latency TYPE gauge",
+            "CREATE METRIC svc.latency TYPE gauge ROLE sli QUERY 42",
+            "ALTER METRIC svc.latency ROLE sli",
+            "CREATE SLO api.availability ON svc.latency WINDOW 1 h",
+            "CREATE HYPERTABLE events TIME_COLUMN ts CHUNK_INTERVAL 'not-duration'",
+        ] {
+            assert!(parse_query(sql).is_err(), "{sql} should not parse");
+        }
+    }
+}

--- a/crates/reddb-rql/src/parser/tree.rs
+++ b/crates/reddb-rql/src/parser/tree.rs
@@ -309,3 +309,148 @@ fn tree_json_value_to_storage_value(value: &JsonValue) -> Result<Value, ParseErr
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(input: &str) -> Result<QueryExpr, ParseError> {
+        crate::parser::parse(input).map(|query| query.query)
+    }
+
+    fn entry_value<'a>(entries: &'a [(String, Value)], key: &str) -> &'a Value {
+        entries
+            .iter()
+            .find_map(|(entry_key, value)| (entry_key == key).then_some(value))
+            .unwrap_or_else(|| panic!("missing entry {key}"))
+    }
+
+    #[test]
+    fn create_tree_accepts_root_options_and_maxchildren_alias() {
+        let query = parse_query(
+            "CREATE TREE IF NOT EXISTS org IN forest ROOT LABEL 'Company' TYPE root \
+             METADATA {active: true, rank: 3, nested: {tier: 'gold'}} MAXCHILDREN 2",
+        )
+        .unwrap();
+
+        let QueryExpr::CreateTree(tree) = query else {
+            panic!("expected create tree");
+        };
+        assert_eq!(tree.collection, "forest");
+        assert_eq!(tree.name, "org");
+        assert!(tree.if_not_exists);
+        assert_eq!(tree.default_max_children, 2);
+        assert_eq!(tree.root.label, "Company");
+        assert_eq!(tree.root.node_type.as_deref(), Some("root"));
+        assert_eq!(tree.root.max_children, None);
+        assert_eq!(
+            entry_value(&tree.root.metadata, "active"),
+            &Value::Boolean(true)
+        );
+        assert_eq!(entry_value(&tree.root.metadata, "rank"), &Value::Integer(3));
+        assert!(matches!(
+            entry_value(&tree.root.metadata, "nested"),
+            Value::Json(_)
+        ));
+    }
+
+    #[test]
+    fn tree_insert_defaults_to_last_and_accepts_string_entity_ids() {
+        let query = parse_query(
+            "TREE INSERT INTO forest.org PARENT 'e42' LABEL child \
+             PROPERTIES {name: 'Platform'} MAX_CHILDREN 4",
+        )
+        .unwrap();
+
+        let QueryExpr::TreeCommand(TreeCommand::Insert {
+            collection,
+            tree_name,
+            parent_id,
+            node,
+            position,
+        }) = query
+        else {
+            panic!("expected tree insert");
+        };
+        assert_eq!(collection, "forest");
+        assert_eq!(tree_name, "org");
+        assert_eq!(parent_id, 42);
+        assert_eq!(node.label, "child");
+        assert_eq!(node.max_children, Some(4));
+        assert!(matches!(
+            entry_value(&node.properties, "name"),
+            Value::Text(value) if value.as_ref() == "Platform"
+        ));
+        assert_eq!(position, TreePosition::Last);
+    }
+
+    #[test]
+    fn tree_commands_cover_move_delete_validate_rebalance_and_drop() {
+        let query = parse_query("TREE MOVE forest.org NODE 'e9' TO PARENT 1 POSITION 3").unwrap();
+        let QueryExpr::TreeCommand(TreeCommand::Move {
+            collection,
+            tree_name,
+            node_id,
+            parent_id,
+            position,
+        }) = query
+        else {
+            panic!("expected tree move");
+        };
+        assert_eq!(collection, "forest");
+        assert_eq!(tree_name, "org");
+        assert_eq!(node_id, 9);
+        assert_eq!(parent_id, 1);
+        assert_eq!(position, TreePosition::Index(3));
+
+        let query = parse_query("TREE DELETE forest.org NODE 5").unwrap();
+        assert!(matches!(
+            query,
+            QueryExpr::TreeCommand(TreeCommand::Delete {
+                collection,
+                tree_name,
+                node_id,
+            }) if collection == "forest" && tree_name == "org" && node_id == 5
+        ));
+
+        let query = parse_query("TREE VALIDATE forest.org").unwrap();
+        assert!(matches!(
+            query,
+            QueryExpr::TreeCommand(TreeCommand::Validate {
+                collection,
+                tree_name,
+            }) if collection == "forest" && tree_name == "org"
+        ));
+
+        let query = parse_query("TREE REBALANCE forest.org").unwrap();
+        assert!(matches!(
+            query,
+            QueryExpr::TreeCommand(TreeCommand::Rebalance {
+                collection,
+                tree_name,
+                dry_run,
+            }) if collection == "forest" && tree_name == "org" && !dry_run
+        ));
+
+        let query = parse_query("DROP TREE IF EXISTS org IN forest").unwrap();
+        assert!(matches!(
+            query,
+            QueryExpr::DropTree(drop) if drop.name == "org"
+                && drop.collection == "forest"
+                && drop.if_exists
+        ));
+    }
+
+    #[test]
+    fn tree_parser_rejects_malformed_commands() {
+        for sql in [
+            "CREATE TREE org IN forest ROOT LABEL root",
+            "TREE INSERT INTO forest.org PARENT 0 LABEL child",
+            "TREE INSERT INTO forest.org PARENT 1 LABEL child POSITION 0",
+            "TREE INSERT INTO forest.org PARENT 1 LABEL child PROPERTIES 'not-object'",
+            "TREE UNKNOWN forest.org",
+        ] {
+            assert!(parse_query(sql).is_err(), "{sql} should not parse");
+        }
+    }
+}

--- a/crates/reddb-rql/src/parser/vector.rs
+++ b/crates/reddb-rql/src/parser/vector.rs
@@ -328,3 +328,185 @@ impl<'a> Parser<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_query(input: &str) -> Result<QueryExpr, ParseError> {
+        crate::parser::parse(input).map(|query| query.query)
+    }
+
+    #[test]
+    fn vector_query_uses_defaults_for_bare_identifier_source() {
+        let query = parse_query("VECTOR SEARCH embeddings SIMILAR TO nearest_neighbor").unwrap();
+
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        assert_eq!(vector.collection, "embeddings");
+        assert_eq!(vector.k, 10);
+        assert!(vector.filter.is_none());
+        assert_eq!(vector.metric, None);
+        assert_eq!(vector.threshold, None);
+        assert!(!vector.include_vectors);
+        assert!(!vector.include_metadata);
+        assert!(matches!(
+            vector.query_vector,
+            VectorSource::Text(text) if text == "nearest_neighbor"
+        ));
+    }
+
+    #[test]
+    fn vector_query_parses_reference_sources_and_k_alias() {
+        let query =
+            parse_query("VECTOR SEARCH embeddings SIMILAR TO docs(42) INCLUDE METADATA K = 7")
+                .unwrap();
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        assert_eq!(vector.k, 7);
+        assert!(vector.include_metadata);
+        assert!(matches!(
+            vector.query_vector,
+            VectorSource::Reference {
+                collection,
+                vector_id,
+            } if collection == "docs" && vector_id == 42
+        ));
+
+        let query =
+            parse_query("VECTOR SEARCH embeddings SIMILAR TO (archive, 99) LIMIT 4").unwrap();
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        assert_eq!(vector.k, 4);
+        assert!(matches!(
+            vector.query_vector,
+            VectorSource::Reference {
+                collection,
+                vector_id,
+            } if collection == "archive" && vector_id == 99
+        ));
+    }
+
+    #[test]
+    fn vector_query_parses_subquery_source() {
+        let query =
+            parse_query("VECTOR SEARCH docs SIMILAR TO (SELECT id FROM seeds) LIMIT 2").unwrap();
+
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        assert_eq!(vector.collection, "docs");
+        assert_eq!(vector.k, 2);
+        match vector.query_vector {
+            VectorSource::Subquery(expr) => match *expr {
+                QueryExpr::Table(table) => assert_eq!(table.table, "seeds"),
+                other => panic!("expected table subquery, got {other:?}"),
+            },
+            other => panic!("expected subquery source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vector_query_parses_filter_sets_metric_threshold_and_includes() {
+        let query = parse_query(
+            "VECTOR SEARCH docs SIMILAR TO [0.1, 0.2] \
+             WHERE (source IN ('nmap', 'nessus') OR severity NOT IN (1, 2)) \
+             AND archived = false METRIC DOT THRESHOLD 0.25 INCLUDE VECTORS LIMIT 3",
+        )
+        .unwrap();
+
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        assert_eq!(vector.k, 3);
+        assert_eq!(vector.metric, Some(DistanceMetric::InnerProduct));
+        assert_eq!(vector.threshold, Some(0.25));
+        assert!(vector.include_vectors);
+        assert!(
+            matches!(vector.query_vector, VectorSource::Literal(values) if values == vec![0.1, 0.2])
+        );
+
+        let Some(MetadataFilter::And(and_parts)) = vector.filter else {
+            panic!("expected AND filter");
+        };
+        assert_eq!(and_parts.len(), 2);
+        match &and_parts[0] {
+            MetadataFilter::Or(or_parts) => {
+                assert_eq!(or_parts.len(), 2);
+                assert!(matches!(
+                    &or_parts[0],
+                    MetadataFilter::In(field, values)
+                        if field == "source"
+                            && values == &vec![
+                                MetadataValue::String("nmap".to_string()),
+                                MetadataValue::String("nessus".to_string())
+                            ]
+                ));
+                assert!(matches!(
+                    &or_parts[1],
+                    MetadataFilter::NotIn(field, values)
+                        if field == "severity"
+                            && values == &vec![MetadataValue::Integer(1), MetadataValue::Integer(2)]
+                ));
+            }
+            other => panic!("expected OR filter, got {other:?}"),
+        }
+        assert!(matches!(
+            &and_parts[1],
+            MetadataFilter::Eq(field, MetadataValue::Bool(false)) if field == "archived"
+        ));
+    }
+
+    #[test]
+    fn metadata_filter_parses_comparisons_and_contains() {
+        let query = parse_query(
+            "VECTOR SEARCH docs SIMILAR TO [0.3] \
+             WHERE score < 0.7 OR rank >= 10 AND title CONTAINS 'redis'",
+        )
+        .unwrap();
+
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        let Some(MetadataFilter::Or(or_parts)) = vector.filter else {
+            panic!("expected OR filter");
+        };
+        assert_eq!(or_parts.len(), 2);
+        assert!(matches!(
+            &or_parts[0],
+            MetadataFilter::Lt(field, MetadataValue::Float(value))
+                if field == "score" && (*value - 0.7).abs() < f64::EPSILON
+        ));
+        match &or_parts[1] {
+            MetadataFilter::And(and_parts) => {
+                assert_eq!(and_parts.len(), 2);
+                assert!(matches!(
+                    &and_parts[0],
+                    MetadataFilter::Gte(field, MetadataValue::Integer(10)) if field == "rank"
+                ));
+                assert!(matches!(
+                    &and_parts[1],
+                    MetadataFilter::Contains(field, value)
+                        if field == "title" && value == "redis"
+                ));
+            }
+            other => panic!("expected AND filter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vector_parser_reports_malformed_queries() {
+        for sql in [
+            "VECTOR SEARCH docs SIMILAR TO []",
+            "VECTOR SEARCH docs SIMILAR TO [0.1] INCLUDE SCORES",
+            "VECTOR SEARCH docs SIMILAR TO [0.1] METRIC MANHATTAN",
+            "VECTOR SEARCH docs SIMILAR TO [0.1] WHERE source",
+            "VECTOR SEARCH docs SIMILAR TO (docs)",
+        ] {
+            assert!(parse_query(sql).is_err(), "{sql} should not parse");
+        }
+    }
+}

--- a/crates/reddb-rql/src/planner/optimizer.rs
+++ b/crates/reddb-rql/src/planner/optimizer.rs
@@ -522,8 +522,10 @@ fn swap_condition(condition: crate::ast::JoinCondition) -> crate::ast::JoinCondi
 mod tests {
     use super::*;
     use crate::ast::{
-        DistanceMetric, FieldRef, FusionStrategy, JoinCondition, Projection, TableQuery,
+        CompareOp, DistanceMetric, FieldRef, Filter, FusionStrategy, JoinCondition, Projection,
+        TableQuery,
     };
+    use reddb_types::Value;
 
     fn make_table_query(name: &str) -> QueryExpr {
         QueryExpr::Table(TableQuery {
@@ -635,11 +637,128 @@ mod tests {
         let (optimized, passes) = optimizer.optimize(join);
 
         // Should have applied JoinReordering
+        assert!(passes.iter().any(|pass| pass == "JoinReordering"));
         if let QueryExpr::Join(jq) = optimized {
             // Small table should now be on left (build side)
-            if let QueryExpr::Table(left) = *jq.left {
+            if let QueryExpr::Table(left) = jq.left.as_ref() {
                 assert_eq!(left.table, "small");
             }
+            assert!(matches!(
+                &jq.on.left_field,
+                FieldRef::TableColumn { table, column } if table == "small" && column == "id"
+            ));
         }
+    }
+
+    #[test]
+    fn optimize_with_hints_can_disable_join_reordering() {
+        let optimizer = QueryOptimizer::new();
+
+        let large = make_table_query("large");
+        let mut small_table = TableQuery::new("small");
+        small_table.limit = Some(1);
+        let small = QueryExpr::Table(small_table);
+
+        let join = QueryExpr::Join(JoinQuery {
+            left: Box::new(large),
+            right: Box::new(small),
+            join_type: JoinType::Inner,
+            on: JoinCondition {
+                left_field: FieldRef::TableColumn {
+                    table: "large".to_string(),
+                    column: "id".to_string(),
+                },
+                right_field: FieldRef::TableColumn {
+                    table: "small".to_string(),
+                    column: "id".to_string(),
+                },
+            },
+            filter: None,
+            order_by: Vec::new(),
+            limit: None,
+            offset: None,
+            return_items: Vec::new(),
+            return_: Vec::new(),
+        });
+        let hints = OptimizationHints {
+            disabled_passes: vec!["JoinReordering".to_string()],
+            ..OptimizationHints::default()
+        };
+
+        let optimized = optimizer.optimize_with_hints(join, &hints);
+        let QueryExpr::Join(join) = optimized else {
+            panic!("expected join query");
+        };
+        let QueryExpr::Table(left) = join.left.as_ref() else {
+            panic!("expected table on left side");
+        };
+
+        assert_eq!(left.table, "large");
+        assert!(matches!(
+            &join.on.left_field,
+            FieldRef::TableColumn { table, column } if table == "large" && column == "id"
+        ));
+    }
+
+    #[test]
+    fn optimizer_sets_index_hint_on_table_filters() {
+        let optimizer = QueryOptimizer::new();
+        let mut table = TableQuery::new("hosts");
+        table.filter = Some(Filter::Compare {
+            field: FieldRef::column("", "host_id"),
+            op: CompareOp::Eq,
+            value: Value::Integer(7),
+        });
+
+        let (optimized, passes) = optimizer.optimize(QueryExpr::Table(table));
+        let QueryExpr::Table(table) = optimized else {
+            panic!("expected table query");
+        };
+        let hint = table
+            .expand
+            .and_then(|expand| expand.index_hint)
+            .expect("expected optimizer index hint");
+
+        assert!(passes.iter().any(|pass| pass == "IndexSelection"));
+        assert_eq!(hint.method, IndexHintMethod::Hash);
+        assert_eq!(hint.column, "host_id");
+    }
+
+    #[test]
+    fn index_selection_analyzes_supported_filter_shapes() {
+        let range = IndexSelectionPass::analyze_filter(&Filter::Between {
+            field: FieldRef::node_prop("n", "score"),
+            low: Value::Integer(1),
+            high: Value::Integer(9),
+        })
+        .expect("expected range hint");
+        assert_eq!(range.method, IndexHintMethod::BTree);
+        assert_eq!(range.column, "score");
+
+        let bitmap = IndexSelectionPass::analyze_filter(&Filter::In {
+            field: FieldRef::edge_prop("e", "kind"),
+            values: vec![Value::text("http"), Value::text("ssh")],
+        })
+        .expect("expected bitmap hint");
+        assert_eq!(bitmap.method, IndexHintMethod::Bitmap);
+        assert_eq!(bitmap.column, "kind");
+
+        assert!(IndexSelectionPass::analyze_filter(&Filter::In {
+            field: FieldRef::column("", "status"),
+            values: (0..11).map(Value::Integer).collect(),
+        })
+        .is_none());
+
+        let fallback_right = IndexSelectionPass::analyze_filter(&Filter::And(
+            Box::new(Filter::IsNull(FieldRef::column("", "deleted_at"))),
+            Box::new(Filter::Compare {
+                field: FieldRef::node_id("n"),
+                op: CompareOp::Eq,
+                value: Value::Integer(1),
+            }),
+        ))
+        .expect("expected right-side AND hint");
+        assert_eq!(fallback_right.method, IndexHintMethod::Hash);
+        assert_eq!(fallback_right.column, "n.id");
     }
 }

--- a/crates/reddb-rql/src/planner/pathkeys.rs
+++ b/crates/reddb-rql/src/planner/pathkeys.rs
@@ -232,3 +232,98 @@ pub fn plan_sort(input_order: &PathKeys, required_order: &PathKeys) -> SortStrat
     }
     SortStrategy::Incremental { prefix_len: prefix }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str) -> FieldRef {
+        FieldRef::column("", name)
+    }
+
+    #[test]
+    fn constructors_apply_sql_default_null_placement() {
+        let asc = PathKey::asc(col("created_at"));
+        assert_eq!(asc.direction, PathKeyDirection::Ascending);
+        assert_eq!(asc.nulls, PathKeyNulls::Last);
+
+        let desc = PathKey::desc(col("score"));
+        assert_eq!(desc.direction, PathKeyDirection::Descending);
+        assert_eq!(desc.nulls, PathKeyNulls::First);
+    }
+
+    #[test]
+    fn prefix_matching_ignores_null_placement_but_not_direction_or_column() {
+        let input = PathKeys {
+            keys: vec![
+                PathKey {
+                    field: col("tenant_id"),
+                    direction: PathKeyDirection::Ascending,
+                    nulls: PathKeyNulls::First,
+                },
+                PathKey::desc(col("created_at")),
+            ],
+        };
+        let required = PathKeys {
+            keys: vec![
+                PathKey::asc(col("tenant_id")),
+                PathKey::desc(col("created_at")),
+                PathKey::asc(col("id")),
+            ],
+        };
+
+        assert_eq!(input.prefix_match(&required), 2);
+
+        let wrong_direction = PathKeys::desc(col("tenant_id"));
+        assert_eq!(input.prefix_match(&wrong_direction), 0);
+
+        let wrong_column = PathKeys::asc(col("account_id"));
+        assert_eq!(input.prefix_match(&wrong_column), 0);
+    }
+
+    #[test]
+    fn satisfies_requires_all_required_keys_in_order() {
+        let input = PathKeys::asc(col("a"))
+            .appended(PathKey::asc(col("b")))
+            .appended(PathKey::desc(col("c")));
+
+        assert!(input.satisfies(&PathKeys::asc(col("a"))));
+        assert!(input.satisfies(&PathKeys::asc(col("a")).appended(PathKey::asc(col("b")))));
+        assert!(!PathKeys::asc(col("a")).satisfies(&input));
+        assert!(!input.satisfies(&PathKeys::asc(col("b"))));
+    }
+
+    #[test]
+    fn appended_truncated_and_empty_report_stable_lengths() {
+        let unordered = PathKeys::unordered();
+        assert!(unordered.is_unordered());
+        assert!(unordered.is_empty());
+        assert_eq!(unordered.len(), 0);
+
+        let keys = unordered
+            .appended(PathKey::asc(col("a")))
+            .appended(PathKey::desc(col("b")));
+        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.truncated(1), PathKeys::asc(col("a")));
+        assert_eq!(keys.truncated(99), keys);
+    }
+
+    #[test]
+    fn plan_sort_distinguishes_none_incremental_and_full() {
+        let input = PathKeys::asc(col("tenant_id")).appended(PathKey::desc(col("created_at")));
+        let exact = input.clone();
+        let extension = exact.clone().appended(PathKey::asc(col("id")));
+        let unrelated = PathKeys::asc(col("status"));
+
+        assert_eq!(
+            plan_sort(&input, &PathKeys::unordered()),
+            SortStrategy::None
+        );
+        assert_eq!(plan_sort(&input, &exact), SortStrategy::None);
+        assert_eq!(
+            plan_sort(&input, &extension),
+            SortStrategy::Incremental { prefix_len: 2 }
+        );
+        assert_eq!(plan_sort(&input, &unrelated), SortStrategy::Full);
+    }
+}

--- a/crates/reddb-rql/src/planner/rewriter.rs
+++ b/crates/reddb-rql/src/planner/rewriter.rs
@@ -691,7 +691,7 @@ fn is_always_false(filter: &AstFilter) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{TableQuery, WindowSpec};
+    use crate::ast::{JoinCondition, TableQuery, WindowSpec};
 
     fn make_field(name: &str) -> FieldRef {
         FieldRef::TableColumn {
@@ -892,6 +892,74 @@ mod tests {
             }) if column == "age"
         ));
         assert!(ctx.stats.filters_simplified >= 1);
+    }
+
+    #[test]
+    fn query_rewriter_recurses_into_join_children_and_tracks_pushdown() {
+        let mut left = TableQuery::new("users");
+        left.columns = vec![
+            Projection::Column("z".to_string()),
+            Projection::Column("a".to_string()),
+        ];
+        left.filter = Some(AstFilter::And(
+            Box::new(AstFilter::Compare {
+                field: make_field("1"),
+                op: CompareOp::Eq,
+                value: Value::Integer(1),
+            }),
+            Box::new(AstFilter::Compare {
+                field: make_field("age"),
+                op: CompareOp::Ge,
+                value: Value::Integer(18),
+            }),
+        ));
+
+        let join = JoinQuery::new(
+            QueryExpr::Table(left),
+            QueryExpr::Table(TableQuery::new("orders")),
+            JoinCondition::new(make_field("id"), make_field("user_id")),
+        );
+
+        let mut ctx = RewriteContext::default();
+        let rewritten =
+            QueryRewriter::default().rewrite_with_context(QueryExpr::Join(join), &mut ctx);
+        let QueryExpr::Join(join) = rewritten else {
+            panic!("expected join query");
+        };
+        let QueryExpr::Table(left) = join.left.as_ref() else {
+            panic!("expected table on left side");
+        };
+
+        assert_eq!(
+            left.columns.iter().map(projection_name).collect::<Vec<_>>(),
+            vec!["a", "z"]
+        );
+        assert!(matches!(
+            &left.filter,
+            Some(AstFilter::Compare {
+                field: FieldRef::TableColumn { ref column, .. },
+                op: CompareOp::Ge,
+                value: Value::Integer(18),
+            }) if column == "age"
+        ));
+        assert!(ctx.stats.predicates_pushed >= 1);
+    }
+
+    #[test]
+    fn query_rewriter_eliminates_always_true_table_filters() {
+        let mut table = TableQuery::new("users");
+        table.filter = Some(AstFilter::Compare {
+            field: make_field("1"),
+            op: CompareOp::Eq,
+            value: Value::Integer(1),
+        });
+
+        let rewritten = QueryRewriter::default().rewrite(QueryExpr::Table(table));
+        let QueryExpr::Table(table) = rewritten else {
+            panic!("expected table query");
+        };
+
+        assert!(table.filter.is_none());
     }
 
     struct CountingRule;

--- a/crates/reddb-rql/src/planner/rewriter.rs
+++ b/crates/reddb-rql/src/planner/rewriter.rs
@@ -691,6 +691,7 @@ fn is_always_false(filter: &AstFilter) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::{TableQuery, WindowSpec};
 
     fn make_field(name: &str) -> FieldRef {
         FieldRef::TableColumn {
@@ -744,5 +745,182 @@ mod tests {
             }
             _ => panic!("Expected Compare filter"),
         }
+    }
+
+    #[test]
+    fn projection_name_uses_visible_output_name_for_all_projection_shapes() {
+        assert_eq!(projection_name(&Projection::All), "*");
+        assert_eq!(
+            projection_name(&Projection::Column("raw".to_string())),
+            "raw"
+        );
+        assert_eq!(
+            projection_name(&Projection::Alias("raw".to_string(), "alias".to_string())),
+            "alias"
+        );
+        assert_eq!(
+            projection_name(&Projection::Function(
+                "LOWER:display".to_string(),
+                Vec::new()
+            )),
+            "display"
+        );
+        assert_eq!(
+            projection_name(&Projection::Expression(
+                Box::new(AstFilter::Compare {
+                    field: make_field("x"),
+                    op: CompareOp::Eq,
+                    value: Value::Integer(1),
+                }),
+                Some("expr_alias".to_string()),
+            )),
+            "expr_alias"
+        );
+        assert_eq!(
+            projection_name(&Projection::Field(
+                FieldRef::node_prop("n", "name"),
+                Some("node_name".to_string()),
+            )),
+            "node_name"
+        );
+        assert_eq!(
+            projection_name(&Projection::Window {
+                name: "ROW_NUMBER".to_string(),
+                args: Vec::new(),
+                window: Box::new(WindowSpec::default()),
+                alias: Some("rn".to_string()),
+            }),
+            "rn"
+        );
+    }
+
+    #[test]
+    fn normalize_rule_sorts_table_columns_by_output_name() {
+        let mut table = TableQuery::new("users");
+        table.columns = vec![
+            Projection::Column("z".to_string()),
+            Projection::Function("LOWER:a_alias".to_string(), Vec::new()),
+            Projection::Alias("name".to_string(), "m".to_string()),
+        ];
+
+        let mut ctx = RewriteContext::default();
+        let normalized = NormalizeRule.apply(QueryExpr::Table(table), &mut ctx);
+        let QueryExpr::Table(table) = normalized else {
+            panic!("expected table query");
+        };
+
+        assert_eq!(ctx.stats.expressions_normalized, 1);
+        assert_eq!(
+            table
+                .columns
+                .iter()
+                .map(projection_name)
+                .collect::<Vec<_>>(),
+            vec!["a_alias", "m", "z"]
+        );
+    }
+
+    #[test]
+    fn simplify_filter_covers_or_true_false_and_not_paths() {
+        let mut ctx = RewriteContext::default();
+        let truth = AstFilter::Compare {
+            field: make_field("1"),
+            op: CompareOp::Eq,
+            value: Value::Integer(1),
+        };
+        let falsehood = AstFilter::Compare {
+            field: make_field("1"),
+            op: CompareOp::Eq,
+            value: Value::Integer(0),
+        };
+        let predicate = AstFilter::Compare {
+            field: make_field("x"),
+            op: CompareOp::Eq,
+            value: Value::Integer(5),
+        };
+
+        assert_eq!(
+            simplify_filter(
+                AstFilter::Or(Box::new(falsehood.clone()), Box::new(predicate.clone())),
+                &mut ctx,
+            ),
+            predicate
+        );
+        assert!(is_always_true(&simplify_filter(
+            AstFilter::Or(Box::new(truth), Box::new(falsehood.clone())),
+            &mut ctx,
+        )));
+        assert!(is_always_false(&simplify_filter(
+            AstFilter::And(
+                Box::new(falsehood),
+                Box::new(AstFilter::IsNotNull(make_field("x")))
+            ),
+            &mut ctx,
+        )));
+        assert!(ctx.stats.filters_simplified >= 3);
+    }
+
+    #[test]
+    fn query_rewriter_runs_rules_until_fixed_point_and_exposes_context() {
+        let mut table = TableQuery::new("users");
+        table.filter = Some(AstFilter::And(
+            Box::new(AstFilter::Compare {
+                field: make_field("1"),
+                op: CompareOp::Eq,
+                value: Value::Integer(1),
+            }),
+            Box::new(AstFilter::Compare {
+                field: make_field("age"),
+                op: CompareOp::Ge,
+                value: Value::Integer(18),
+            }),
+        ));
+
+        let mut ctx = RewriteContext::default();
+        let rewritten =
+            QueryRewriter::default().rewrite_with_context(QueryExpr::Table(table), &mut ctx);
+        let QueryExpr::Table(table) = rewritten else {
+            panic!("expected table query");
+        };
+
+        assert!(matches!(
+            table.filter,
+            Some(AstFilter::Compare {
+                field: FieldRef::TableColumn { column, .. },
+                op: CompareOp::Ge,
+                value: Value::Integer(18),
+            }) if column == "age"
+        ));
+        assert!(ctx.stats.filters_simplified >= 1);
+    }
+
+    struct CountingRule;
+
+    impl RewriteRule for CountingRule {
+        fn name(&self) -> &str {
+            "CountingRule"
+        }
+
+        fn apply(&self, query: QueryExpr, ctx: &mut RewriteContext) -> QueryExpr {
+            ctx.warnings.push(self.name().to_string());
+            query
+        }
+
+        fn is_applicable(&self, query: &QueryExpr) -> bool {
+            matches!(query, QueryExpr::Table(_))
+        }
+    }
+
+    #[test]
+    fn custom_rules_can_be_added_after_defaults() {
+        let mut rewriter = QueryRewriter::new();
+        rewriter.add_rule(Box::new(CountingRule));
+
+        let mut ctx = RewriteContext::default();
+        let rewritten =
+            rewriter.rewrite_with_context(QueryExpr::Table(TableQuery::new("users")), &mut ctx);
+
+        assert!(matches!(rewritten, QueryExpr::Table(_)));
+        assert!(ctx.warnings.iter().any(|warning| warning == "CountingRule"));
     }
 }

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -194,6 +194,998 @@ fn collection_model_filter(model: &str) -> Filter {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reddb_types::catalog::CollectionModel;
+
+    fn frontend(input: &str) -> FrontendStatement {
+        parse_frontend(input)
+            .unwrap_or_else(|err| panic!("failed to parse frontend {input:?}: {err:?}"))
+    }
+
+    fn expr(input: &str) -> QueryExpr {
+        frontend(input).into_query_expr()
+    }
+
+    fn sql_command(input: &str) -> SqlCommand {
+        sql_command_result(input)
+            .unwrap_or_else(|err| panic!("failed to parse SQL command {input:?}: {err:?}"))
+    }
+
+    fn sql_command_result(input: &str) -> Result<SqlCommand, ParseError> {
+        let mut parser = Parser::new(input)?;
+        parser.parse_sql_command()
+    }
+
+    fn assert_text(value: &Value, expected: &str) {
+        match value {
+            Value::Text(text) => assert_eq!(text.as_ref(), expected),
+            other => panic!("expected text {expected:?}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_frontend_routes_core_sql_statements() {
+        let FrontendStatement::Sql(SqlStatement::Query(SqlQuery::Select(query))) =
+            frontend("SELECT * FROM users")
+        else {
+            panic!("SELECT should route to SqlStatement::Query::Select");
+        };
+        assert_eq!(query.table, "users");
+
+        let QueryExpr::Insert(query) = expr("INSERT INTO users (id, name) VALUES (1, 'ada')")
+        else {
+            panic!("INSERT should lower through the SQL frontend");
+        };
+        assert_eq!(query.table, "users");
+        assert_eq!(query.columns, vec!["id", "name"]);
+        assert_eq!(query.values.len(), 1);
+
+        let QueryExpr::Update(query) = expr("UPDATE users SET name = 'ada' WHERE id = 1") else {
+            panic!("UPDATE should lower through the SQL frontend");
+        };
+        assert_eq!(query.table, "users");
+        assert_eq!(query.assignments[0].0, "name");
+
+        let QueryExpr::Delete(query) = expr("DELETE FROM users WHERE id = 1") else {
+            panic!("DELETE should lower through the SQL frontend");
+        };
+        assert_eq!(query.table, "users");
+        assert!(query.filter.is_some());
+
+        let QueryExpr::CreateTable(query) = expr("CREATE TABLE users (id INT, name TEXT)") else {
+            panic!("CREATE TABLE should lower through the SQL frontend");
+        };
+        assert_eq!(query.collection_model, CollectionModel::Table);
+        assert_eq!(query.name, "users");
+        assert_eq!(query.columns[0].name, "id");
+
+        let QueryExpr::DropTable(query) = expr("DROP TABLE IF EXISTS users") else {
+            panic!("DROP TABLE should lower through the SQL frontend");
+        };
+        assert_eq!(query.name, "users");
+        assert!(query.if_exists);
+    }
+
+    #[test]
+    fn parse_frontend_routes_admin_and_catalog_sql() {
+        let QueryExpr::Table(query) = expr("SHOW COLLECTIONS") else {
+            panic!("SHOW COLLECTIONS should become a red.collections table query");
+        };
+        assert_eq!(query.table, "red.collections");
+        assert!(query.filter.is_some());
+
+        let QueryExpr::Table(query) = expr("SHOW TABLES LIMIT 5") else {
+            panic!("SHOW TABLES should become a filtered red.collections table query");
+        };
+        assert_eq!(query.table, "red.collections");
+        assert_eq!(query.limit, Some(5));
+        assert!(query.filter.is_some());
+
+        assert!(matches!(
+            expr("SHOW CONFIG durability.mode"),
+            QueryExpr::ShowConfig { prefix: Some(prefix) } if prefix == "durability.mode"
+        ));
+        assert!(matches!(
+            expr("SHOW CONFIG"),
+            QueryExpr::ShowConfig { prefix: None }
+        ));
+
+        let QueryExpr::SetConfig { key, value } = expr("SET CONFIG durability.mode = 'sync'")
+        else {
+            panic!("SET CONFIG should stay on the SQL admin surface");
+        };
+        assert_eq!(key, "durability.mode");
+        assert_text(&value, "sync");
+
+        let QueryExpr::SetSecret { key, value } = expr("SET SECRET provider.api_key = 'sk_test'")
+        else {
+            panic!("SET SECRET should stay on the SQL admin surface");
+        };
+        assert_eq!(key, "provider.api_key");
+        assert_text(&value, "sk_test");
+
+        assert!(matches!(
+            expr("DELETE SECRET provider.api_key"),
+            QueryExpr::DeleteSecret { key } if key == "provider.api_key"
+        ));
+        assert!(matches!(
+            expr("SHOW SECRETS provider"),
+            QueryExpr::ShowSecrets { prefix: Some(prefix) } if prefix == "provider"
+        ));
+        assert!(matches!(
+            expr("SET TENANT 'acme'"),
+            QueryExpr::SetTenant(Some(tenant)) if tenant == "acme"
+        ));
+        assert!(matches!(expr("RESET TENANT"), QueryExpr::SetTenant(None)));
+        assert!(matches!(expr("SHOW TENANT"), QueryExpr::ShowTenant));
+        assert!(matches!(
+            expr("BEGIN ISOLATION LEVEL SNAPSHOT"),
+            QueryExpr::TransactionControl(TxnControl::Begin)
+        ));
+        assert!(matches!(
+            expr("ROLLBACK TO SAVEPOINT sp1"),
+            QueryExpr::TransactionControl(TxnControl::RollbackToSavepoint(name)) if name == "sp1"
+        ));
+        assert!(matches!(
+            expr("VACUUM FULL users"),
+            QueryExpr::MaintenanceCommand(MaintenanceCommand::Vacuum {
+                target: Some(target),
+                full: true,
+            }) if target == "users"
+        ));
+    }
+
+    #[test]
+    fn parse_frontend_routes_extended_schema_sql() {
+        assert!(matches!(
+            expr("CREATE SCHEMA IF NOT EXISTS app"),
+            QueryExpr::CreateSchema(CreateSchemaQuery {
+                name,
+                if_not_exists: true,
+            }) if name == "app"
+        ));
+        assert!(matches!(
+            expr("DROP SCHEMA IF EXISTS app CASCADE"),
+            QueryExpr::DropSchema(DropSchemaQuery {
+                name,
+                if_exists: true,
+                cascade: true,
+            }) if name == "app"
+        ));
+        assert!(matches!(
+            expr("CREATE SEQUENCE IF NOT EXISTS seq START WITH 10 INCREMENT BY 2"),
+            QueryExpr::CreateSequence(CreateSequenceQuery {
+                name,
+                if_not_exists: true,
+                start: 10,
+                increment: 2,
+            }) if name == "seq"
+        ));
+        assert!(matches!(
+            expr("DROP SEQUENCE IF EXISTS seq"),
+            QueryExpr::DropSequence(DropSequenceQuery {
+                name,
+                if_exists: true,
+            }) if name == "seq"
+        ));
+
+        let QueryExpr::CopyFrom(copy) = expr(
+            "COPY users FROM '/tmp/u.csv' WITH (FORMAT = csv, HEADER = true, DELIMITER = ';')",
+        ) else {
+            panic!("COPY should lower through SQL frontend");
+        };
+        assert_eq!(copy.table, "users");
+        assert_eq!(copy.path, "/tmp/u.csv");
+        assert_eq!(copy.format, CopyFormat::Csv);
+        assert_eq!(copy.delimiter, Some(';'));
+        assert!(copy.has_header);
+
+        let QueryExpr::CreateView(view) = expr(
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS mv WITH RETENTION 1 h \
+             AS SELECT id FROM users REFRESH EVERY 5 s",
+        ) else {
+            panic!("CREATE MATERIALIZED VIEW should lower through SQL frontend");
+        };
+        assert_eq!(view.name, "mv");
+        assert!(view.materialized);
+        assert!(view.if_not_exists);
+        assert_eq!(view.retention_duration_ms, Some(3_600_000));
+        assert_eq!(view.refresh_every_ms, Some(5_000));
+        assert!(matches!(*view.query, QueryExpr::Table(_)));
+
+        assert!(matches!(
+            expr("DROP MATERIALIZED VIEW IF EXISTS mv"),
+            QueryExpr::DropView(DropViewQuery {
+                name,
+                materialized: true,
+                if_exists: true,
+            }) if name == "mv"
+        ));
+        assert!(matches!(
+            expr("REFRESH MATERIALIZED VIEW mv"),
+            QueryExpr::RefreshMaterializedView(RefreshMaterializedViewQuery { name }) if name == "mv"
+        ));
+    }
+
+    #[test]
+    fn parse_frontend_routes_fdw_policy_auth_and_migrations() {
+        let QueryExpr::CreateServer(server) = expr(
+            "CREATE SERVER IF NOT EXISTS csvsrv FOREIGN DATA WRAPPER csv OPTIONS (path '/data')",
+        ) else {
+            panic!("CREATE SERVER should lower through SQL frontend");
+        };
+        assert_eq!(server.name, "csvsrv");
+        assert_eq!(server.wrapper, "csv");
+        assert!(server.if_not_exists);
+        assert_eq!(
+            server.options,
+            vec![("path".to_string(), "/data".to_string())]
+        );
+
+        let QueryExpr::CreateForeignTable(table) = expr(
+            "CREATE FOREIGN TABLE IF NOT EXISTS ext_users \
+             (id INT, name TEXT) SERVER csvsrv OPTIONS (file 'users.csv')",
+        ) else {
+            panic!("CREATE FOREIGN TABLE should lower through SQL frontend");
+        };
+        assert_eq!(table.name, "ext_users");
+        assert_eq!(table.server, "csvsrv");
+        assert!(table.if_not_exists);
+        assert_eq!(table.columns.len(), 2);
+        assert!(!table.columns[0].not_null);
+
+        assert!(matches!(
+            expr("DROP SERVER IF EXISTS csvsrv CASCADE"),
+            QueryExpr::DropServer(DropServerQuery {
+                name,
+                if_exists: true,
+                cascade: true,
+            }) if name == "csvsrv"
+        ));
+        assert!(matches!(
+            expr("DROP FOREIGN TABLE IF EXISTS ext_users"),
+            QueryExpr::DropForeignTable(DropForeignTableQuery {
+                name,
+                if_exists: true,
+            }) if name == "ext_users"
+        ));
+
+        let QueryExpr::CreatePolicy(policy) = expr(
+            "CREATE POLICY readonly ON NODES OF mygraph FOR SELECT TO analytics USING (public = 1)",
+        ) else {
+            panic!("CREATE POLICY should lower through SQL frontend");
+        };
+        assert_eq!(policy.name, "readonly");
+        assert_eq!(policy.table, "mygraph");
+        assert_eq!(policy.action, Some(PolicyAction::Select));
+        assert_eq!(policy.role.as_deref(), Some("analytics"));
+        assert_eq!(policy.target_kind.as_ident(), "nodes");
+
+        assert!(matches!(
+            expr("DROP POLICY IF EXISTS readonly ON mygraph"),
+            QueryExpr::DropPolicy(DropPolicyQuery {
+                name,
+                table,
+                if_exists: true,
+            }) if name == "readonly" && table == "mygraph"
+        ));
+
+        assert!(matches!(
+            expr("GRANT SELECT ON TABLE public.users TO tenant1.alice"),
+            QueryExpr::Grant(grant)
+                if grant.actions == vec!["SELECT"]
+                    && grant.objects[0].schema.as_deref() == Some("public")
+        ));
+        assert!(matches!(
+            expr("REVOKE GRANT OPTION FOR USAGE ON SCHEMA analytics FROM GROUP analysts"),
+            QueryExpr::Revoke(revoke) if revoke.grant_option_for && revoke.all == false
+        ));
+        assert!(matches!(
+            expr("ALTER USER bob ENABLE SET search_path TO 'public'"),
+            QueryExpr::AlterUser(user)
+                if user.username == "bob" && user.attributes.len() == 2
+        ));
+
+        assert!(matches!(
+            expr("CREATE POLICY 'readonly' AS '{\"Statement\":[]}'"),
+            QueryExpr::CreateIamPolicy { id, json }
+                if id == "readonly" && json == "{\"Statement\":[]}"
+        ));
+        assert!(matches!(
+            expr("DROP POLICY 'readonly'"),
+            QueryExpr::DropIamPolicy { id } if id == "readonly"
+        ));
+
+        assert!(matches!(
+            expr("CREATE MIGRATION m2 DEPENDS ON m0 BATCH 10 ROWS AS CREATE TABLE accounts (id INT)"),
+            QueryExpr::CreateMigration(migration)
+                if migration.name == "m2"
+                    && migration.depends_on == vec!["m0".to_string()]
+                    && migration.batch_size == Some(10)
+        ));
+        assert!(matches!(
+            expr("APPLY MIGRATION * FOR TENANT tenant1"),
+            QueryExpr::ApplyMigration(apply)
+                if apply.for_tenant.as_deref() == Some("tenant1")
+        ));
+        assert!(matches!(
+            expr("ROLLBACK MIGRATION m2"),
+            QueryExpr::RollbackMigration(RollbackMigrationQuery { name }) if name == "m2"
+        ));
+        assert!(matches!(
+            expr("EXPLAIN MIGRATION m2"),
+            QueryExpr::ExplainMigration(ExplainMigrationQuery { name }) if name == "m2"
+        ));
+    }
+
+    #[test]
+    fn parse_sql_statement_covers_statement_category_wrapping() {
+        enum Expected {
+            Select,
+            Insert,
+            CreateSchema,
+            SetTenant,
+        }
+
+        let cases = [
+            ("SELECT * FROM users", Expected::Select),
+            ("INSERT INTO users (id) VALUES (1)", Expected::Insert),
+            ("CREATE SCHEMA app", Expected::CreateSchema),
+            ("SET TENANT 'acme'", Expected::SetTenant),
+        ];
+
+        for (input, expected) in cases {
+            let mut parser = Parser::new(input).expect("lexer");
+            let statement = parser
+                .parse_sql_statement()
+                .unwrap_or_else(|err| panic!("failed to parse {input:?}: {err:?}"));
+            let matched = match expected {
+                Expected::Select => matches!(statement, SqlStatement::Query(SqlQuery::Select(_))),
+                Expected::Insert => {
+                    matches!(statement, SqlStatement::Mutation(SqlMutation::Insert(_)))
+                }
+                Expected::CreateSchema => matches!(
+                    statement,
+                    SqlStatement::Schema(SqlSchemaCommand::CreateSchema(_))
+                ),
+                Expected::SetTenant => {
+                    matches!(
+                        statement,
+                        SqlStatement::Admin(SqlAdminCommand::SetTenant(_))
+                    )
+                }
+            };
+            assert!(matched, "{input}");
+        }
+    }
+
+    #[test]
+    fn parse_frontend_routes_non_sql_frontends() {
+        let QueryExpr::KvCommand(KvCommand::Get {
+            model,
+            collection,
+            key,
+        }) = expr("KV GET settings.feature")
+        else {
+            panic!("KV GET should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "settings");
+        assert_eq!(key, "feature");
+
+        let QueryExpr::ConfigCommand(ConfigCommand::Watch {
+            collection,
+            key,
+            prefix,
+            from_lsn,
+        }) = expr("WATCH CONFIG app PREFIX feature FROM LSN 7")
+        else {
+            panic!("WATCH CONFIG should route to FrontendStatement::ConfigCommand");
+        };
+        assert_eq!(collection, "app");
+        assert_eq!(key, "feature");
+        assert!(prefix);
+        assert_eq!(from_lsn, Some(7));
+
+        let QueryExpr::ConfigCommand(ConfigCommand::List {
+            collection,
+            prefix,
+            limit,
+            offset,
+        }) = expr("LIST CONFIG app PREFIX feature LIMIT 3 OFFSET 1")
+        else {
+            panic!("LIST CONFIG should route to FrontendStatement::ConfigCommand");
+        };
+        assert_eq!(collection, "app");
+        assert_eq!(prefix.as_deref(), Some("feature"));
+        assert_eq!(limit, Some(3));
+        assert_eq!(offset, 1);
+
+        let QueryExpr::KvCommand(KvCommand::Watch {
+            model,
+            collection,
+            key,
+            prefix,
+            from_lsn,
+        }) = expr("WATCH sessions.user.* FROM LSN 3")
+        else {
+            panic!("bare WATCH should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "sessions");
+        assert_eq!(key, "user");
+        assert!(prefix);
+        assert_eq!(from_lsn, Some(3));
+
+        let QueryExpr::KvCommand(KvCommand::Watch {
+            model,
+            collection,
+            key,
+            prefix,
+            from_lsn,
+        }) = expr("WATCH VAULT secrets PREFIX api FROM LSN 7")
+        else {
+            panic!("WATCH VAULT should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Vault);
+        assert_eq!(collection, "secrets");
+        assert_eq!(key, "api");
+        assert!(prefix);
+        assert_eq!(from_lsn, Some(7));
+
+        let QueryExpr::KvCommand(KvCommand::List {
+            model,
+            collection,
+            prefix,
+            limit,
+            offset,
+        }) = expr("LIST VAULT secrets PREFIX api LIMIT 10 OFFSET 2")
+        else {
+            panic!("LIST VAULT should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Vault);
+        assert_eq!(collection, "secrets");
+        assert_eq!(prefix.as_deref(), Some("api"));
+        assert_eq!(limit, Some(10));
+        assert_eq!(offset, 2);
+
+        assert!(matches!(
+            expr("INVALIDATE CONFIG app feature_flag"),
+            QueryExpr::ConfigCommand(ConfigCommand::InvalidVolatileOperation {
+                operation,
+                collection,
+                key: Some(key),
+            }) if operation == "INVALIDATE" && collection == "app" && key == "feature_flag"
+        ));
+        assert!(matches!(
+            expr("INVALIDATE TAGS [user:42, org:7] FROM sessions"),
+            QueryExpr::KvCommand(KvCommand::InvalidateTags { collection, tags })
+                if collection == "sessions" && tags == vec!["user:42".to_string(), "org:7".to_string()]
+        ));
+
+        let QueryExpr::EventsBackfill(query) =
+            expr("EVENTS BACKFILL users WHERE status = 'active' TO audit LIMIT 10")
+        else {
+            panic!("EVENTS BACKFILL should route to FrontendStatement::EventsBackfill");
+        };
+        assert_eq!(query.collection, "users");
+        assert_eq!(query.where_filter.as_deref(), Some("status = 'active'"));
+        assert_eq!(query.target_queue, "audit");
+        assert_eq!(query.limit, Some(10));
+
+        let QueryExpr::Table(query) = expr("EVENTS STATUS users LIMIT 2") else {
+            panic!("EVENTS STATUS should route through the SQL select surface");
+        };
+        assert_eq!(query.table, "red.subscriptions");
+        assert_eq!(query.limit, Some(2));
+        assert!(query.filter.is_some());
+
+        assert!(matches!(
+            expr("EVENTS BACKFILL STATUS users"),
+            QueryExpr::EventsBackfillStatus { collection } if collection == "users"
+        ));
+        assert!(parse_frontend("LIST UNKNOWN").is_err());
+        assert!(parse_frontend("EVENTS UNKNOWN").is_err());
+    }
+
+    #[test]
+    fn parse_frontend_routes_ranking_reads() {
+        assert!(matches!(
+            expr("RANK OF 42 IN page_rank"),
+            QueryExpr::RankOf(RankOfQuery { ranking, entity_id })
+                if ranking == "page_rank" && entity_id == 42
+        ));
+        assert!(matches!(
+            expr("APPROX RANK OF 7 IN page_rank"),
+            QueryExpr::ApproxRankOf(RankOfQuery { ranking, entity_id })
+                if ranking == "page_rank" && entity_id == 7
+        ));
+        assert!(matches!(
+            expr("RANK RANGE 1 TO 3 IN page_rank"),
+            QueryExpr::RankRange(RankRangeQuery { ranking, lo, hi })
+                if ranking == "page_rank" && lo == 1 && hi == 3
+        ));
+        assert!(matches!(
+            expr("ZRANK page_rank 0"),
+            QueryExpr::RankOf(RankOfQuery { ranking, entity_id })
+                if ranking == "page_rank" && entity_id == 0
+        ));
+        assert!(matches!(
+            expr("ZRANGE page_rank 0 3 WITHSCORES"),
+            QueryExpr::RankRange(RankRangeQuery { ranking, lo, hi })
+                if ranking == "page_rank" && lo == 1 && hi == 4
+        ));
+        assert!(
+            parse_frontend("RANK RANGE 3 TO 1 IN page_rank").is_err(),
+            "rank range must reject reversed bounds"
+        );
+    }
+
+    #[test]
+    fn parse_frontend_covers_multimodel_command_routing() {
+        assert!(matches!(
+            expr("GRAPH CENTRALITY ALGORITHM pagerank LIMIT 5"),
+            QueryExpr::GraphCommand(GraphCommand::Centrality {
+                algorithm,
+                limit: Some(5),
+                ..
+            }) if algorithm == "pagerank"
+        ));
+        assert!(matches!(
+            expr("SEARCH TEXT 'login failure' COLLECTION incidents LIMIT 20 FUZZY"),
+            QueryExpr::SearchCommand(SearchCommand::Text {
+                query,
+                collection: Some(collection),
+                limit: 20,
+                fuzzy: true,
+                ..
+            }) if query == "login failure" && collection == "incidents"
+        ));
+        assert!(matches!(
+            expr("ASK 'why did login fail?' USING openai LIMIT 3"),
+            QueryExpr::Ask(query)
+                if query.question == "why did login fail?"
+                    && query.provider.as_deref() == Some("openai")
+                    && query.limit == Some(3)
+        ));
+        assert!(matches!(
+            expr("QUEUE LEN tasks"),
+            QueryExpr::QueueCommand(QueueCommand::Len { queue }) if queue == "tasks"
+        ));
+        assert!(matches!(
+            expr("TREE REBALANCE forest.org DRY RUN"),
+            QueryExpr::TreeCommand(TreeCommand::Rebalance {
+                collection,
+                tree_name,
+                dry_run: true,
+            }) if collection == "forest" && tree_name == "org"
+        ));
+        assert!(matches!(
+            expr("HLL COUNT visitors"),
+            QueryExpr::ProbabilisticCommand(ProbabilisticCommand::HllCount { names })
+                if names == vec!["visitors".to_string()]
+        ));
+    }
+
+    #[test]
+    fn sql_command_round_trips_multimodel_schema_variants() {
+        macro_rules! assert_command_round_trip {
+            ($input:expr, $pattern:pat) => {{
+                let command = sql_command($input);
+                assert!(matches!(command, $pattern), "unexpected command for {}", $input);
+
+                let statement = sql_command($input).into_statement();
+                let command = statement.into_command();
+                assert!(
+                    matches!(command, $pattern),
+                    "statement round trip changed command for {}",
+                    $input
+                );
+
+                let expr = sql_command($input).into_query_expr();
+                assert!(
+                    !matches!(expr, QueryExpr::Table(TableQuery { table, .. }) if table.is_empty()),
+                    "lowering produced an empty table placeholder for {}",
+                    $input
+                );
+            }};
+        }
+
+        assert_command_round_trip!(
+            "EXPLAIN ALTER FOR CREATE TABLE users (id INT) FORMAT JSON",
+            SqlCommand::ExplainAlter(_)
+        );
+        assert_command_round_trip!("CREATE TABLE users (id INT)", SqlCommand::CreateTable(_));
+        assert_command_round_trip!("DROP TABLE IF EXISTS users", SqlCommand::DropTable(_));
+        assert_command_round_trip!(
+            "ALTER TABLE users ADD COLUMN status TEXT",
+            SqlCommand::AlterTable(_)
+        );
+        assert_command_round_trip!(
+            "CREATE INDEX idx_email ON users (email) USING HASH",
+            SqlCommand::CreateIndex(_)
+        );
+        assert_command_round_trip!(
+            "DROP INDEX IF EXISTS idx_email ON users",
+            SqlCommand::DropIndex(_)
+        );
+        assert_command_round_trip!("CREATE GRAPH identity", SqlCommand::CreateTable(_));
+        assert_command_round_trip!("CREATE DOCUMENT docs", SqlCommand::CreateTable(_));
+        assert_command_round_trip!(
+            "CREATE VECTOR embeddings DIM 4",
+            SqlCommand::CreateVector(_)
+        );
+        assert_command_round_trip!(
+            "CREATE COLLECTION turbo KIND vector.turbo DIM 3",
+            SqlCommand::CreateCollection(_)
+        );
+        assert_command_round_trip!("CREATE KV settings", SqlCommand::CreateTable(_));
+        assert_command_round_trip!("CREATE CONFIG app", SqlCommand::CreateTable(_));
+        assert_command_round_trip!(
+            "CREATE VAULT secrets WITH OWN MASTER KEY",
+            SqlCommand::CreateTable(_)
+        );
+        assert_command_round_trip!(
+            "CREATE TIMESERIES metrics RETENTION 90 d",
+            SqlCommand::CreateTimeSeries(_)
+        );
+        assert_command_round_trip!(
+            "CREATE METRIC svc.latency TYPE gauge ROLE sli",
+            SqlCommand::CreateMetric(_)
+        );
+        assert_command_round_trip!(
+            "ALTER METRIC svc.latency SET ROLE internal",
+            SqlCommand::AlterMetric(_)
+        );
+        assert_command_round_trip!(
+            "CREATE SLO svc.availability ON svc.latency TARGET 99.9 WINDOW 5 m",
+            SqlCommand::CreateSlo(_)
+        );
+        assert_command_round_trip!(
+            "CREATE QUEUE tasks MAX_SIZE 100",
+            SqlCommand::CreateQueue(_)
+        );
+        assert_command_round_trip!(
+            "ALTER QUEUE tasks SET MODE FANOUT",
+            SqlCommand::AlterQueue(_)
+        );
+        assert_command_round_trip!(
+            "CREATE TREE org IN forest ROOT LABEL root MAX_CHILDREN 4",
+            SqlCommand::CreateTree(_)
+        );
+        assert_command_round_trip!(
+            "CREATE HLL visitors PRECISION 14",
+            SqlCommand::Probabilistic(_)
+        );
+        assert_command_round_trip!(
+            "CREATE SKETCH freqs WIDTH 512 DEPTH 3",
+            SqlCommand::Probabilistic(_)
+        );
+        assert_command_round_trip!(
+            "CREATE FILTER seen CAPACITY 1024",
+            SqlCommand::Probabilistic(_)
+        );
+        assert_command_round_trip!("COPY users FROM '/tmp/u.csv'", SqlCommand::CopyFrom(_));
+        assert_command_round_trip!(
+            "CREATE VIEW active_users AS SELECT * FROM users",
+            SqlCommand::CreateView(_)
+        );
+        assert_command_round_trip!("DROP VIEW active_users", SqlCommand::DropView(_));
+        assert_command_round_trip!(
+            "REFRESH MATERIALIZED VIEW active_users",
+            SqlCommand::RefreshMaterializedView(_)
+        );
+        assert_command_round_trip!(
+            "CREATE SERVER mycsv FOREIGN DATA WRAPPER csv OPTIONS (base_path '/data')",
+            SqlCommand::CreateServer(_)
+        );
+        assert_command_round_trip!(
+            "DROP SERVER IF EXISTS mycsv CASCADE",
+            SqlCommand::DropServer(_)
+        );
+        assert_command_round_trip!(
+            "CREATE FOREIGN TABLE ext_users (id INT, name TEXT) SERVER mycsv OPTIONS (path 'users.csv')",
+            SqlCommand::CreateForeignTable(_)
+        );
+        assert_command_round_trip!(
+            "DROP FOREIGN TABLE IF EXISTS ext_users",
+            SqlCommand::DropForeignTable(_)
+        );
+    }
+
+    #[test]
+    fn sql_command_round_trips_drop_truncate_and_maintenance_variants() {
+        macro_rules! assert_command_round_trip {
+            ($input:expr, $pattern:pat) => {{
+                let command = sql_command($input);
+                assert!(
+                    matches!(command, $pattern),
+                    "unexpected command for {}",
+                    $input
+                );
+                let statement = sql_command($input).into_statement();
+                assert!(
+                    matches!(statement.into_command(), $pattern),
+                    "statement round trip changed command for {}",
+                    $input
+                );
+            }};
+        }
+
+        assert_command_round_trip!("DROP GRAPH IF EXISTS identity", SqlCommand::DropGraph(_));
+        assert_command_round_trip!(
+            "DROP VECTOR IF EXISTS embeddings",
+            SqlCommand::DropVector(_)
+        );
+        assert_command_round_trip!("DROP DOCUMENT IF EXISTS docs", SqlCommand::DropDocument(_));
+        assert_command_round_trip!("DROP KV IF EXISTS settings", SqlCommand::DropKv(_));
+        assert_command_round_trip!("DROP CONFIG IF EXISTS app", SqlCommand::DropKv(_));
+        assert_command_round_trip!("DROP VAULT IF EXISTS secrets", SqlCommand::DropKv(_));
+        assert_command_round_trip!(
+            "DROP COLLECTION IF EXISTS docs",
+            SqlCommand::DropCollection(_)
+        );
+        assert_command_round_trip!(
+            "DROP TIMESERIES IF EXISTS metrics",
+            SqlCommand::DropTimeSeries(_)
+        );
+        assert_command_round_trip!(
+            "DROP HYPERTABLE IF EXISTS metrics",
+            SqlCommand::DropTimeSeries(_)
+        );
+        assert_command_round_trip!("DROP QUEUE IF EXISTS tasks", SqlCommand::DropQueue(_));
+        assert_command_round_trip!("DROP TREE IF EXISTS org IN forest", SqlCommand::DropTree(_));
+        assert_command_round_trip!("DROP HLL IF EXISTS visitors", SqlCommand::Probabilistic(_));
+        assert_command_round_trip!("DROP SKETCH IF EXISTS freqs", SqlCommand::Probabilistic(_));
+        assert_command_round_trip!("DROP FILTER IF EXISTS seen", SqlCommand::Probabilistic(_));
+        assert_command_round_trip!(
+            "TRUNCATE VECTOR IF EXISTS embeddings",
+            SqlCommand::Truncate(_)
+        );
+        assert_command_round_trip!(
+            "COMMIT WORK",
+            SqlCommand::TransactionControl(TxnControl::Commit)
+        );
+        assert_command_round_trip!(
+            "ROLLBACK",
+            SqlCommand::TransactionControl(TxnControl::Rollback)
+        );
+        assert_command_round_trip!(
+            "SAVEPOINT before_batch",
+            SqlCommand::TransactionControl(TxnControl::Savepoint(_))
+        );
+        assert_command_round_trip!(
+            "RELEASE SAVEPOINT before_batch",
+            SqlCommand::TransactionControl(TxnControl::ReleaseSavepoint(_))
+        );
+        assert_command_round_trip!(
+            "ANALYZE users",
+            SqlCommand::Maintenance(MaintenanceCommand::Analyze { .. })
+        );
+        assert_command_round_trip!(
+            "VACUUM",
+            SqlCommand::Maintenance(MaintenanceCommand::Vacuum { .. })
+        );
+    }
+
+    #[test]
+    fn parse_sql_command_covers_show_and_error_branches() {
+        assert!(matches!(
+            sql_command("SHOW CREATE TABLE public.users"),
+            SqlCommand::Select(TableQuery { table, .. }) if table == "red.show_create"
+        ));
+        assert!(matches!(
+            sql_command("SHOW COLLECTIONS INCLUDING INTERNAL LIMIT 2"),
+            SqlCommand::Select(TableQuery { table, limit: Some(2), .. }) if table == "red.collections"
+        ));
+        assert!(matches!(
+            sql_command("SHOW QUEUES INCLUDING INTERNAL"),
+            SqlCommand::Select(TableQuery { table, filter: None, .. }) if table == "red.queues"
+        ));
+        assert!(matches!(
+            sql_command("SHOW INDICES ON users"),
+            SqlCommand::Select(TableQuery { table, filter: Some(_), .. }) if table == "red.show_indexes"
+        ));
+        assert!(matches!(
+            sql_command("SHOW POLICIES ON users WHERE action = 'SELECT'"),
+            SqlCommand::Select(TableQuery { table, filter: Some(_), .. }) if table == "red.policies"
+        ));
+        assert!(matches!(
+            sql_command("SHOW STATS 'users' WHERE rows > 0"),
+            SqlCommand::Select(TableQuery { table, filter: Some(_), .. }) if table == "red.stats"
+        ));
+        assert!(matches!(
+            sql_command("SHOW SAMPLE users"),
+            SqlCommand::Select(TableQuery { table, limit: Some(10), .. }) if table == "users"
+        ));
+        assert!(matches!(
+            sql_command("DESC public.users"),
+            SqlCommand::Select(TableQuery { table, filter: Some(_), .. }) if table == "red.describe"
+        ));
+        assert!(
+            sql_command_result("CREATE VIEW v WITH RETENTION 1 h AS SELECT * FROM users").is_err()
+        );
+        assert!(sql_command_result("CREATE TABLE bad WITH ANALYTICS (centrality)").is_err());
+        assert!(sql_command_result("BEGIN ISOLATION LEVEL SERIALIZABLE").is_err());
+        assert!(sql_command_result("EVENTS BACKFILL STATUS users").is_err());
+    }
+
+    #[test]
+    fn parse_sql_command_covers_remaining_catalog_and_copy_shapes() {
+        for input in [
+            "SHOW VECTORS",
+            "SHOW DOCUMENTS",
+            "SHOW TIMESERIES",
+            "SHOW GRAPHS",
+            "SHOW CONFIGS",
+            "SHOW VAULTS",
+            "SHOW KV",
+            "SHOW SCHEMA public.users",
+        ] {
+            assert!(
+                matches!(sql_command(input), SqlCommand::Select(_)),
+                "{input}"
+            );
+        }
+
+        for input in [
+            "TRUNCATE TABLE users",
+            "TRUNCATE GRAPH identity",
+            "TRUNCATE DOCUMENT docs",
+            "TRUNCATE TIMESERIES metrics",
+            "TRUNCATE METRICS metrics",
+            "TRUNCATE KV settings",
+            "TRUNCATE QUEUE tasks",
+            "TRUNCATE COLLECTION docs",
+        ] {
+            assert!(
+                matches!(sql_command(input), SqlCommand::Truncate(_)),
+                "{input}"
+            );
+        }
+        assert!(sql_command_result("TRUNCATE UNKNOWN users").is_err());
+
+        let SqlCommand::CopyFrom(copy) = sql_command("COPY users FROM '/tmp/u.csv' WITH (HEADER)")
+        else {
+            panic!("expected COPY");
+        };
+        assert!(copy.has_header);
+        assert_eq!(copy.delimiter, None);
+
+        let SqlCommand::CopyFrom(copy) =
+            sql_command("COPY users FROM '/tmp/u.csv' WITH (HEADER = false)")
+        else {
+            panic!("expected COPY");
+        };
+        assert!(!copy.has_header);
+
+        let SqlCommand::CopyFrom(copy) =
+            sql_command("COPY users FROM '/tmp/u.csv' DELIMITER '|' HEADER")
+        else {
+            panic!("expected COPY");
+        };
+        assert_eq!(copy.delimiter, Some('|'));
+        assert!(copy.has_header);
+    }
+
+    #[test]
+    fn parse_sql_command_covers_remaining_ranking_and_event_errors() {
+        assert!(matches!(
+            expr("APPROXIMATE RANK OF 9 IN page_rank"),
+            QueryExpr::ApproxRankOf(RankOfQuery { ranking, entity_id })
+                if ranking == "page_rank" && entity_id == 9
+        ));
+        assert!(parse_frontend("APPROX OF 7 IN page_rank").is_err());
+        assert!(parse_frontend("RANK 1 IN page_rank").is_err());
+        assert!(parse_frontend("RANK RANGE 0 TO 3 IN page_rank").is_err());
+        assert!(parse_frontend("ZRANK page_rank -1").is_err());
+        assert!(parse_frontend("ZRANGE page_rank 3 1").is_err());
+
+        let QueryExpr::Table(query) = expr("EVENTS STATUS 'users' WHERE active = true") else {
+            panic!("EVENTS STATUS should accept a quoted collection");
+        };
+        assert_eq!(query.table, "red.subscriptions");
+        assert!(query.filter.is_some());
+        assert!(query.where_expr.is_some());
+
+        let QueryExpr::EventsBackfill(query) = expr("EVENTS BACKFILL users TO audit") else {
+            panic!("EVENTS BACKFILL should allow omitted filter and limit");
+        };
+        assert_eq!(query.collection, "users");
+        assert_eq!(query.where_filter, None);
+        assert_eq!(query.limit, None);
+
+        assert!(parse_frontend("EVENTS BACKFILL users WHERE TO audit").is_err());
+    }
+
+    #[test]
+    fn parse_sql_command_covers_analytics_non_goal_rejections() {
+        for head in ["ANALYTICS", "EVENT", "COHORT", "FUNNEL", "SLA", "ADAPTER"] {
+            let err = sql_command_result(&format!("CREATE {head} demo"))
+                .expect_err("analytics v0 non-goal should be rejected");
+            assert!(err.to_string().contains(&format!("CREATE {head}")), "{err}");
+        }
+    }
+
+    #[test]
+    fn parse_sql_command_covers_transaction_isolation_edges() {
+        for input in [
+            "BEGIN ISOLATION LEVEL READ UNCOMMITTED",
+            "BEGIN ISOLATION LEVEL READ COMMITTED",
+            "BEGIN ISOLATION LEVEL REPEATABLE READ",
+            "START TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        ] {
+            assert!(
+                matches!(
+                    sql_command(input),
+                    SqlCommand::TransactionControl(TxnControl::Begin)
+                ),
+                "{input}"
+            );
+        }
+
+        assert!(sql_command_result("BEGIN ISOLATION LEVEL READ").is_err());
+        assert!(sql_command_result("BEGIN ISOLATION LEVEL REPEATABLE").is_err());
+        assert!(sql_command_result("BEGIN ISOLATION LEVEL CHAOS").is_err());
+    }
+
+    #[test]
+    fn parse_sql_command_covers_iam_and_hypertable_dispatch_edges() {
+        assert!(matches!(
+            expr("CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1d'"),
+            QueryExpr::CreateTimeSeries(query)
+                if query.name == "metrics" && query.hypertable.is_some()
+        ));
+        assert!(sql_command_result("CREATE OR TABLE bad (id INT)").is_err());
+        assert!(sql_command_result("DROP MATERIALIZED TABLE bad").is_err());
+
+        assert!(matches!(
+            expr("ATTACH POLICY 'readonly' TO USER tenant1.alice"),
+            QueryExpr::AttachPolicy { policy_id, .. } if policy_id == "readonly"
+        ));
+        assert!(matches!(
+            expr("DETACH POLICY 'readonly' FROM GROUP analysts"),
+            QueryExpr::DetachPolicy { policy_id, .. } if policy_id == "readonly"
+        ));
+        assert!(matches!(
+            expr("SHOW POLICIES FOR USER alice"),
+            QueryExpr::ShowPolicies { filter: Some(_) }
+        ));
+        assert!(matches!(
+            expr("SHOW EFFECTIVE PERMISSIONS FOR alice"),
+            QueryExpr::ShowEffectivePermissions { resource: None, .. }
+        ));
+        assert!(matches!(
+            expr("SIMULATE alice ACTION 'iam:PassRole' ON TABLE:public.orders"),
+            QueryExpr::SimulatePolicy { action, .. } if action == "iam:PassRole"
+        ));
+        assert!(matches!(
+            expr("LINT POLICY JSON '{\"Statement\":[]}'"),
+            QueryExpr::LintPolicy { .. }
+        ));
+        assert!(matches!(
+            expr("MIGRATE POLICY MODE TO 'policy_only' DRY RUN"),
+            QueryExpr::MigratePolicyMode {
+                target,
+                dry_run: true,
+            } if target == "policy_only"
+        ));
+        assert!(parse_frontend("MIGRATE OTHER").is_err());
+    }
+
+    #[test]
+    fn parse_frontend_rejects_trailing_tokens() {
+        let err = parse_frontend("SET TENANT 'acme' junk")
+            .expect_err("parse_frontend should reject trailing tokens");
+        assert!(
+            err.to_string().contains("Unexpected token after query"),
+            "{err}"
+        );
+    }
+}
+
 fn add_table_filter(query: &mut TableQuery, filter: Filter) {
     let combined = match query.filter.take() {
         Some(existing) => existing.and(filter),
@@ -858,6 +1850,9 @@ impl<'a> Parser<'a> {
             Token::Ident(name) if name.eq_ignore_ascii_case("SHOW") => {
                 self.parse_sql_statement().map(FrontendStatement::Sql)
             }
+            Token::Ident(name) if name.eq_ignore_ascii_case("RESET") => {
+                self.parse_sql_statement().map(FrontendStatement::Sql)
+            }
             Token::Ident(name)
                 if name.eq_ignore_ascii_case("RANK")
                     || name.eq_ignore_ascii_case("APPROX")
@@ -1253,7 +2248,7 @@ impl<'a> Parser<'a> {
                     "SELECT", "MATCH", "PATH", "FROM", "VECTOR", "HYBRID", "INSERT", "UPDATE",
                     "DELETE", "TRUNCATE", "CREATE", "DROP", "ALTER", "GRAPH", "SEARCH", "ASK",
                     "QUEUE", "EVENTS", "KV", "HLL", "TREE", "SKETCH", "FILTER", "SET", "SHOW",
-                    "DESCRIBE", "DESC", "RANK", "ZRANK", "ZRANGE",
+                    "RESET", "DESCRIBE", "DESC", "RANK", "ZRANK", "ZRANGE",
                 ],
                 other,
                 self.position(),

--- a/crates/reddb-rql/src/sql_lowering.rs
+++ b/crates/reddb-rql/src/sql_lowering.rs
@@ -1105,3 +1105,486 @@ fn literal_expr_value(expr: &Expr) -> Option<Value> {
 fn all_literal_values(values: &[Expr]) -> Option<Vec<Value>> {
     values.iter().map(literal_expr_value).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{OrderByClause, WindowOrderItem, WindowSpec};
+
+    fn field(name: &str) -> FieldRef {
+        FieldRef::column("", name)
+    }
+
+    fn col(name: &str) -> Expr {
+        Expr::Column {
+            field: field(name),
+            span: Span::synthetic(),
+        }
+    }
+
+    fn lit(value: Value) -> Expr {
+        Expr::Literal {
+            value,
+            span: Span::synthetic(),
+        }
+    }
+
+    fn parameter(index: usize) -> Expr {
+        Expr::Parameter {
+            index,
+            span: Span::synthetic(),
+        }
+    }
+
+    fn bin(op: BinOp, lhs: Expr, rhs: Expr) -> Expr {
+        Expr::BinaryOp {
+            op,
+            lhs: Box::new(lhs),
+            rhs: Box::new(rhs),
+            span: Span::synthetic(),
+        }
+    }
+
+    #[test]
+    fn expr_contains_parameter_walks_nested_expression_shapes() {
+        assert!(expr_contains_parameter(&bin(
+            BinOp::Add,
+            col("age"),
+            parameter(1)
+        )));
+
+        let case = Expr::Case {
+            branches: vec![(col("active"), lit(Value::Integer(1)))],
+            else_: Some(Box::new(parameter(2))),
+            span: Span::synthetic(),
+        };
+        assert!(expr_contains_parameter(&case));
+
+        let window = Expr::WindowFunctionCall {
+            name: "row_number".to_string(),
+            args: Vec::new(),
+            window: WindowSpec {
+                partition_by: vec![col("tenant_id")],
+                order_by: vec![WindowOrderItem {
+                    expr: parameter(3),
+                    ascending: true,
+                    nulls_first: false,
+                }],
+                frame: None,
+            },
+            span: Span::synthetic(),
+        };
+        assert!(expr_contains_parameter(&window));
+
+        let no_parameter = Expr::FunctionCall {
+            name: "lower".to_string(),
+            args: vec![col("name")],
+            span: Span::synthetic(),
+        };
+        assert!(!expr_contains_parameter(&no_parameter));
+    }
+
+    #[test]
+    fn expressions_lower_to_legacy_projections_with_aliases_preserved() {
+        assert!(matches!(
+            expr_to_projection(&col("*")),
+            Some(Projection::All)
+        ));
+
+        let param_projection = expr_to_projection(&parameter(7)).unwrap();
+        assert!(matches!(
+            param_projection,
+            Projection::Column(value) if value == format!("{PARAMETER_PROJECTION_PREFIX}7")
+        ));
+
+        let arithmetic = bin(BinOp::Add, col("age"), lit(Value::Integer(1)));
+        let projection = select_item_to_projection(&SelectItem::Expr {
+            expr: arithmetic,
+            alias: Some("age_plus_one".to_string()),
+        })
+        .unwrap();
+        assert!(matches!(
+            projection,
+            Projection::Function(ref name, ref args)
+                if name == "ADD:age_plus_one" && args.len() == 2
+        ));
+
+        let negated = Expr::UnaryOp {
+            op: UnaryOp::Neg,
+            operand: Box::new(col("age")),
+            span: Span::synthetic(),
+        };
+        assert!(matches!(
+            expr_to_projection(&negated),
+            Some(Projection::Function(name, args)) if name == "SUB" && args.len() == 2
+        ));
+
+        let cast = Expr::Cast {
+            inner: Box::new(col("age")),
+            target: reddb_types::types::DataType::Text,
+            span: Span::synthetic(),
+        };
+        assert!(matches!(
+            expr_to_projection(&cast),
+            Some(Projection::Function(name, args)) if name == "CAST" && args.len() == 2
+        ));
+
+        let window = Expr::WindowFunctionCall {
+            name: "sum".to_string(),
+            args: vec![col("amount")],
+            window: WindowSpec::default(),
+            span: Span::synthetic(),
+        };
+        assert!(matches!(
+            select_item_to_projection(&SelectItem::Expr {
+                expr: window,
+                alias: Some("running_sum".to_string()),
+            }),
+            Some(Projection::Window { name, alias, .. })
+                if name == "SUM" && alias.as_deref() == Some("running_sum")
+        ));
+    }
+
+    #[test]
+    fn projections_raise_back_to_select_items_and_expression_nodes() {
+        assert!(matches!(
+            projection_to_select_item(&Projection::All),
+            Some(SelectItem::Wildcard)
+        ));
+
+        let literal = projection_to_expr(&Projection::Column("LIT:42".to_string())).unwrap();
+        assert!(matches!(
+            literal,
+            (
+                Expr::Literal {
+                    value: Value::Integer(42),
+                    ..
+                },
+                None
+            )
+        ));
+
+        let float_literal = projection_to_expr(&Projection::Column("LIT:3.5".to_string())).unwrap();
+        assert!(matches!(
+            float_literal,
+            (Expr::Literal { value: Value::Float(v), .. }, None) if (v - 3.5).abs() < f64::EPSILON
+        ));
+
+        let null_literal = projection_to_expr(&Projection::Column("LIT:".to_string())).unwrap();
+        assert!(matches!(
+            null_literal,
+            (
+                Expr::Literal {
+                    value: Value::Null,
+                    ..
+                },
+                None
+            )
+        ));
+
+        let function = Projection::Function(
+            "LOWER:lower_name".to_string(),
+            vec![Projection::Field(field("name"), None)],
+        );
+        let (expr, alias) = projection_to_expr(&function).unwrap();
+        assert_eq!(alias.as_deref(), Some("lower_name"));
+        assert!(
+            matches!(expr, Expr::FunctionCall { name, args, .. } if name == "LOWER" && args.len() == 1)
+        );
+
+        let window = Projection::Window {
+            name: "ROW_NUMBER".to_string(),
+            args: Vec::new(),
+            window: Box::new(WindowSpec::default()),
+            alias: Some("rn".to_string()),
+        };
+        let (expr, alias) = projection_to_expr(&window).unwrap();
+        assert_eq!(alias.as_deref(), Some("rn"));
+        assert!(matches!(expr, Expr::WindowFunctionCall { name, .. } if name == "ROW_NUMBER"));
+    }
+
+    #[test]
+    fn filters_round_trip_through_expression_forms() {
+        let filters = vec![
+            Filter::Compare {
+                field: field("age"),
+                op: CompareOp::Ge,
+                value: Value::Integer(18),
+            },
+            Filter::CompareFields {
+                left: field("updated_at"),
+                op: CompareOp::Gt,
+                right: field("created_at"),
+            },
+            Filter::And(
+                Box::new(Filter::IsNotNull(field("email"))),
+                Box::new(Filter::Like {
+                    field: field("email"),
+                    pattern: "%@example.com".to_string(),
+                }),
+            ),
+            Filter::Or(
+                Box::new(Filter::StartsWith {
+                    field: field("path"),
+                    prefix: "infra/".to_string(),
+                }),
+                Box::new(Filter::EndsWith {
+                    field: field("path"),
+                    suffix: ".log".to_string(),
+                }),
+            ),
+            Filter::Not(Box::new(Filter::Contains {
+                field: field("body"),
+                substring: "secret".to_string(),
+            })),
+            Filter::IsNull(field("deleted_at")),
+            Filter::In {
+                field: field("status"),
+                values: vec![Value::text("open"), Value::text("pending")],
+            },
+            Filter::Between {
+                field: field("score"),
+                low: Value::Integer(10),
+                high: Value::Integer(20),
+            },
+        ];
+
+        for filter in filters {
+            let expr = filter_to_expr(&filter);
+            assert_eq!(expr_to_filter(&expr), filter);
+        }
+    }
+
+    #[test]
+    fn expression_filters_specialize_common_predicates_and_fallbacks() {
+        let flipped = expr_to_filter(&bin(BinOp::Lt, lit(Value::Integer(10)), col("age")));
+        assert_eq!(
+            flipped,
+            Filter::Compare {
+                field: field("age"),
+                op: CompareOp::Gt,
+                value: Value::Integer(10),
+            }
+        );
+
+        let field_to_field = expr_to_filter(&bin(BinOp::Eq, col("lhs"), col("rhs")));
+        assert_eq!(
+            field_to_field,
+            Filter::CompareFields {
+                left: field("lhs"),
+                op: CompareOp::Eq,
+                right: field("rhs"),
+            }
+        );
+
+        let arithmetic = expr_to_filter(&bin(BinOp::Add, col("age"), lit(Value::Integer(1))));
+        assert!(matches!(
+            arithmetic,
+            Filter::CompareExpr {
+                op: CompareOp::Eq,
+                rhs: Expr::Literal {
+                    value: Value::Boolean(true),
+                    ..
+                },
+                ..
+            }
+        ));
+
+        let negated_in = Expr::InList {
+            target: Box::new(col("status")),
+            values: vec![lit(Value::text("closed"))],
+            negated: true,
+            span: Span::synthetic(),
+        };
+        assert!(matches!(
+            expr_to_filter(&negated_in),
+            Filter::CompareExpr {
+                op: CompareOp::Eq,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn table_effective_helpers_prefer_canonical_expr_fields() {
+        let mut query = TableQuery::new("users");
+        query.select_items = vec![
+            SelectItem::Expr {
+                expr: col("name"),
+                alias: Some("display_name".to_string()),
+            },
+            SelectItem::Expr {
+                expr: bin(BinOp::Add, col("age"), lit(Value::Integer(1))),
+                alias: Some("next_age".to_string()),
+            },
+        ];
+        query.where_expr = Some(bin(BinOp::Eq, col("active"), lit(Value::Boolean(true))));
+        query.group_by_exprs = vec![col("name")];
+        query.group_by = vec!["legacy_group".to_string()];
+        query.having_expr = Some(bin(BinOp::Gt, col("age"), lit(Value::Integer(18))));
+
+        let projections = effective_table_projections(&query);
+        assert_eq!(projections.len(), 2);
+        assert!(matches!(
+            &projections[0],
+            Projection::Field(FieldRef::TableColumn { column, .. }, Some(alias))
+                if column == "name" && alias == "display_name"
+        ));
+
+        assert!(matches!(
+            effective_table_filter(&query),
+            Some(Filter::Compare {
+                field: FieldRef::TableColumn { column, .. },
+                op: CompareOp::Eq,
+                value: Value::Boolean(true)
+            }) if column == "active"
+        ));
+        assert_eq!(effective_table_group_by_exprs(&query), vec![col("name")]);
+        assert!(matches!(
+            effective_table_having_filter(&query),
+            Some(Filter::Compare {
+                field: FieldRef::TableColumn { column, .. },
+                op: CompareOp::Gt,
+                value: Value::Integer(18)
+            }) if column == "age"
+        ));
+
+        let mut legacy = TableQuery::new("users");
+        legacy.columns = vec![Projection::column("id")];
+        legacy.group_by = vec!["tenant_id".to_string()];
+        assert!(matches!(
+            effective_table_projections(&legacy).as_slice(),
+            [Projection::Column(column)] if column == "id"
+        ));
+        assert_eq!(
+            effective_table_group_by_exprs(&legacy),
+            vec![Expr::Column {
+                field: field("tenant_id"),
+                span: Span::synthetic(),
+            }]
+        );
+
+        let default_projection = TableQuery::new("users");
+        assert!(matches!(
+            effective_table_projections(&default_projection).as_slice(),
+            [Projection::All]
+        ));
+    }
+
+    #[test]
+    fn insert_update_delete_helpers_fold_canonical_expressions() {
+        let insert = InsertQuery {
+            table: "users".to_string(),
+            entity_type: crate::ast::InsertEntityType::Row,
+            columns: vec!["name".to_string(), "password".to_string()],
+            value_exprs: vec![vec![
+                lit(Value::text("ada")),
+                Expr::FunctionCall {
+                    name: "PASSWORD".to_string(),
+                    args: vec![lit(Value::text("pw"))],
+                    span: Span::synthetic(),
+                },
+            ]],
+            values: Vec::new(),
+            returning: None,
+            ttl_ms: None,
+            expires_at_ms: None,
+            with_metadata: Vec::new(),
+            auto_embed: None,
+            suppress_events: false,
+        };
+        let rows = effective_insert_rows(&insert).unwrap();
+        assert!(matches!(
+            rows.as_slice(),
+            [row] if row[0] == Value::text("ada")
+                && matches!(&row[1], Value::Password(value) if value == "@@plain@@pw")
+        ));
+
+        let update = UpdateQuery {
+            table: "users".to_string(),
+            target: crate::ast::UpdateTarget::Rows,
+            assignment_exprs: Vec::new(),
+            compound_assignment_ops: Vec::new(),
+            assignments: Vec::new(),
+            where_expr: Some(bin(BinOp::Eq, col("id"), lit(Value::Integer(1)))),
+            filter: None,
+            ttl_ms: None,
+            expires_at_ms: None,
+            with_metadata: Vec::new(),
+            returning: None,
+            order_by: vec![OrderByClause::asc(field("id"))],
+            limit: Some(1),
+            suppress_events: false,
+        };
+        assert!(matches!(
+            effective_update_filter(&update),
+            Some(Filter::Compare {
+                field: FieldRef::TableColumn { column, .. },
+                value: Value::Integer(1),
+                ..
+            }) if column == "id"
+        ));
+
+        let delete = DeleteQuery {
+            table: "users".to_string(),
+            where_expr: Some(Expr::IsNull {
+                operand: Box::new(col("deleted_at")),
+                negated: false,
+                span: Span::synthetic(),
+            }),
+            filter: None,
+            returning: None,
+            suppress_events: false,
+        };
+        assert!(matches!(
+            effective_delete_filter(&delete),
+            Some(Filter::IsNull(FieldRef::TableColumn { column, .. })) if column == "deleted_at"
+        ));
+    }
+
+    #[test]
+    fn fold_expr_to_value_handles_secret_constructors_unary_and_errors() {
+        assert_eq!(
+            fold_expr_to_value(Expr::UnaryOp {
+                op: UnaryOp::Neg,
+                operand: Box::new(lit(Value::UnsignedInteger(7))),
+                span: Span::synthetic(),
+            })
+            .unwrap(),
+            Value::Integer(-7)
+        );
+        assert_eq!(
+            fold_expr_to_value(Expr::UnaryOp {
+                op: UnaryOp::Not,
+                operand: Box::new(lit(Value::Boolean(false))),
+                span: Span::synthetic(),
+            })
+            .unwrap(),
+            Value::Boolean(true)
+        );
+
+        let secret = fold_expr_to_value(Expr::FunctionCall {
+            name: "SECRET".to_string(),
+            args: vec![lit(Value::text("token"))],
+            span: Span::synthetic(),
+        })
+        .unwrap();
+        assert!(matches!(secret, Value::Secret(bytes) if bytes == b"@@plain@@token"));
+
+        let casted = fold_expr_to_value(Expr::Cast {
+            inner: Box::new(lit(Value::Integer(5))),
+            target: reddb_types::types::DataType::Text,
+            span: Span::synthetic(),
+        })
+        .unwrap();
+        assert_eq!(casted, Value::Integer(5));
+
+        assert!(fold_expr_to_value(bin(BinOp::Add, col("age"), lit(Value::Integer(1)))).is_err());
+        assert!(fold_expr_to_value(Expr::FunctionCall {
+            name: "PASSWORD".to_string(),
+            args: vec![lit(Value::Integer(1))],
+            span: Span::synthetic(),
+        })
+        .is_err());
+    }
+}

--- a/crates/reddb-rql/src/sql_lowering.rs
+++ b/crates/reddb-rql/src/sql_lowering.rs
@@ -1109,7 +1109,10 @@ fn all_literal_values(values: &[Expr]) -> Option<Vec<Value>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::{OrderByClause, WindowOrderItem, WindowSpec};
+    use crate::ast::{
+        GraphPattern, GraphQuery, JoinCondition, JoinQuery, NodeSelector, OrderByClause, PathQuery,
+        QueryExpr, VectorQuery, VectorSource, WindowOrderItem, WindowSpec,
+    };
 
     fn field(name: &str) -> FieldRef {
         FieldRef::column("", name)
@@ -1472,6 +1475,68 @@ mod tests {
     }
 
     #[test]
+    fn non_table_effective_helpers_preserve_existing_query_fields() {
+        let mut join = JoinQuery::new(
+            QueryExpr::Table(TableQuery::new("users")),
+            QueryExpr::Graph(GraphQuery::new(GraphPattern::new())),
+            JoinCondition::new(field("id"), FieldRef::node_id("n")),
+        );
+        join.filter = Some(Filter::IsNotNull(field("id")));
+        join.return_items = vec![SelectItem::Expr {
+            expr: col("name"),
+            alias: Some("display_name".to_string()),
+        }];
+        join.return_ = vec![Projection::Column("legacy_name".to_string())];
+
+        assert_eq!(
+            effective_join_filter(&join),
+            Some(Filter::IsNotNull(field("id")))
+        );
+        assert!(matches!(
+            effective_join_projections(&join).as_slice(),
+            [Projection::Field(FieldRef::TableColumn { column, .. }, Some(alias))]
+                if column == "name" && alias == "display_name"
+        ));
+
+        join.return_items.clear();
+        assert_eq!(
+            effective_join_projections(&join),
+            vec![Projection::Column("legacy_name".to_string())]
+        );
+
+        let graph_filter = Filter::StartsWith {
+            field: FieldRef::node_prop("n", "path"),
+            prefix: "infra/".to_string(),
+        };
+        let graph_return = vec![Projection::Field(FieldRef::node_prop("n", "name"), None)];
+        let mut graph = GraphQuery::new(GraphPattern::new());
+        graph.filter = Some(graph_filter.clone());
+        graph.return_ = graph_return.clone();
+        assert_eq!(effective_graph_filter(&graph), Some(graph_filter));
+        assert_eq!(effective_graph_projections(&graph), graph_return);
+
+        let path_filter = Filter::Contains {
+            field: FieldRef::edge_prop("e", "label"),
+            substring: "depends".to_string(),
+        };
+        let path_return = vec![Projection::Column("path".to_string())];
+        let mut path = PathQuery::new(NodeSelector::by_id("start"), NodeSelector::by_id("end"));
+        path.filter = Some(path_filter.clone());
+        path.return_ = path_return.clone();
+        assert_eq!(effective_path_filter(&path), Some(path_filter));
+        assert_eq!(effective_path_projections(&path), path_return);
+
+        let mut vector = VectorQuery::new("embeddings", VectorSource::literal(vec![0.1, 0.2]));
+        assert!(effective_vector_filter(&vector).is_none());
+        vector.filter = Some(MetadataFilter::eq("source", "nmap"));
+        assert!(matches!(
+            effective_vector_filter(&vector),
+            Some(MetadataFilter::Eq(key, reddb_types::vector_metadata::MetadataValue::String(value)))
+                if key == "source" && value == "nmap"
+        ));
+    }
+
+    #[test]
     fn insert_update_delete_helpers_fold_canonical_expressions() {
         let insert = InsertQuery {
             table: "users".to_string(),
@@ -1586,5 +1651,256 @@ mod tests {
             span: Span::synthetic(),
         })
         .is_err());
+    }
+
+    #[test]
+    fn render_label_and_literal_helpers_cover_private_round_trip_paths() {
+        assert_eq!(
+            render_expr_label(&lit(Value::text("O'Reilly"))),
+            "'O''Reilly'"
+        );
+        assert_eq!(render_expr_label(&parameter(4)), "$4");
+        assert_eq!(
+            render_expr_label(&bin(
+                BinOp::Mul,
+                bin(BinOp::Add, col("a"), col("b")),
+                col("c")
+            )),
+            "(a + b) * c"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::UnaryOp {
+                op: UnaryOp::Not,
+                operand: Box::new(col("active")),
+                span: Span::synthetic(),
+            }),
+            "NOT active"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::Cast {
+                inner: Box::new(col("age")),
+                target: reddb_types::types::DataType::Text,
+                span: Span::synthetic(),
+            }),
+            "CAST(age AS TEXT)"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::FunctionCall {
+                name: "lower".to_string(),
+                args: vec![col("name")],
+                span: Span::synthetic(),
+            }),
+            "lower(name)"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::Case {
+                branches: vec![(col("active"), lit(Value::text("yes")))],
+                else_: Some(Box::new(lit(Value::text("no")))),
+                span: Span::synthetic(),
+            }),
+            "CASE WHEN active THEN 'yes' ELSE 'no' END"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::IsNull {
+                operand: Box::new(col("deleted_at")),
+                negated: true,
+                span: Span::synthetic(),
+            }),
+            "deleted_at IS NOT NULL"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::InList {
+                target: Box::new(col("status")),
+                values: vec![lit(Value::text("closed"))],
+                negated: true,
+                span: Span::synthetic(),
+            }),
+            "status NOT IN ('closed')"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::Between {
+                target: Box::new(col("age")),
+                low: Box::new(lit(Value::Integer(18))),
+                high: Box::new(lit(Value::Integer(65))),
+                negated: false,
+                span: Span::synthetic(),
+            }),
+            "age BETWEEN 18 AND 65"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::Subquery {
+                query: crate::ast::ExprSubquery {
+                    query: Box::new(QueryExpr::Table(TableQuery::new("users"))),
+                },
+                span: Span::synthetic(),
+            }),
+            "subquery"
+        );
+        assert_eq!(
+            render_expr_label(&Expr::WindowFunctionCall {
+                name: "sum".to_string(),
+                args: vec![col("amount")],
+                window: WindowSpec::default(),
+                span: Span::synthetic(),
+            }),
+            "sum(amount) OVER (...)"
+        );
+
+        assert_eq!(render_field_label(&FieldRef::node_id("n")), "n.id");
+        assert_eq!(
+            render_field_label(&FieldRef::edge_prop("e", "weight")),
+            "e.weight"
+        );
+        assert_eq!(render_binop_label(BinOp::Concat), "||");
+        assert_eq!(render_sql_literal_label(&Value::Float(3.0)), "3");
+        assert_eq!(
+            render_projection_literal(&Value::Array(vec![Value::Integer(1), Value::text("x"),])),
+            "@RL:[1,\"x\"]"
+        );
+        assert_eq!(
+            render_projection_literal(&Value::Vector(vec![1.0, 2.5])),
+            "@RL:V[1,2.5]"
+        );
+        assert_eq!(
+            render_projection_literal(&Value::Json(br#"{"a":1}"#.to_vec())),
+            "@RL:\"<json 7 bytes>\""
+        );
+        assert!(matches!(
+            projection_from_literal(&Value::Boolean(true)),
+            Some(Projection::Expression(_, None))
+        ));
+        assert_eq!(
+            split_projection_function_alias("LOWER:name").1.as_deref(),
+            Some("name")
+        );
+        assert_eq!(split_projection_function_alias(":bad").1, None);
+    }
+
+    #[test]
+    fn lowering_fallbacks_cover_alias_legacy_and_non_specialized_paths() {
+        for (op, name) in [
+            (BinOp::Sub, "SUB"),
+            (BinOp::Div, "DIV"),
+            (BinOp::Mod, "MOD"),
+            (BinOp::Concat, "CONCAT"),
+        ] {
+            assert!(matches!(
+                expr_to_projection(&bin(op, col("lhs"), col("rhs"))),
+                Some(Projection::Function(function, args))
+                    if function == name && args.len() == 2
+            ));
+        }
+
+        assert!(matches!(
+            select_item_to_projection(&SelectItem::Expr {
+                expr: lit(Value::Integer(1)),
+                alias: Some("one".to_string()),
+            }),
+            Some(Projection::Alias(column, alias)) if column == "LIT:1" && alias == "one"
+        ));
+        assert!(matches!(
+            select_item_to_projection(&SelectItem::Expr {
+                expr: Expr::UnaryOp {
+                    op: UnaryOp::Not,
+                    operand: Box::new(col("active")),
+                    span: Span::synthetic(),
+                },
+                alias: Some("inactive".to_string()),
+            }),
+            Some(Projection::Expression(_, Some(alias))) if alias == "inactive"
+        ));
+
+        let legacy_insert = InsertQuery {
+            table: "users".to_string(),
+            entity_type: crate::ast::InsertEntityType::Row,
+            columns: vec!["id".to_string()],
+            value_exprs: Vec::new(),
+            values: vec![vec![Value::Integer(1)]],
+            returning: None,
+            ttl_ms: None,
+            expires_at_ms: None,
+            with_metadata: Vec::new(),
+            auto_embed: None,
+            suppress_events: false,
+        };
+        assert_eq!(
+            effective_insert_rows(&legacy_insert).unwrap(),
+            vec![vec![Value::Integer(1)]]
+        );
+
+        assert!(matches!(
+            expr_to_filter(&Expr::IsNull {
+                operand: Box::new(lit(Value::Null)),
+                negated: false,
+                span: Span::synthetic(),
+            }),
+            Filter::CompareExpr { .. }
+        ));
+        assert!(matches!(
+            expr_to_filter(&Expr::InList {
+                target: Box::new(col("status")),
+                values: vec![col("other_status")],
+                negated: false,
+                span: Span::synthetic(),
+            }),
+            Filter::CompareExpr { .. }
+        ));
+        assert!(matches!(
+            expr_to_filter(&Expr::Between {
+                target: Box::new(col("age")),
+                low: Box::new(lit(Value::Integer(18))),
+                high: Box::new(lit(Value::Integer(65))),
+                negated: true,
+                span: Span::synthetic(),
+            }),
+            Filter::CompareExpr { .. }
+        ));
+        assert!(matches!(
+            expr_to_filter(&Expr::FunctionCall {
+                name: "UNKNOWN".to_string(),
+                args: vec![col("name"), lit(Value::text("a"))],
+                span: Span::synthetic(),
+            }),
+            Filter::CompareExpr { .. }
+        ));
+        assert!(matches!(
+            expr_to_filter(&Expr::FunctionCall {
+                name: "LIKE".to_string(),
+                args: vec![lit(Value::text("not_field")), lit(Value::text("a"))],
+                span: Span::synthetic(),
+            }),
+            Filter::CompareExpr { .. }
+        ));
+
+        assert_eq!(
+            fold_expr_to_value(Expr::UnaryOp {
+                op: UnaryOp::Neg,
+                operand: Box::new(lit(Value::Float(1.5))),
+                span: Span::synthetic(),
+            })
+            .unwrap(),
+            Value::Float(-1.5)
+        );
+        assert!(fold_expr_to_value(Expr::UnaryOp {
+            op: UnaryOp::Not,
+            operand: Box::new(lit(Value::Integer(1))),
+            span: Span::synthetic(),
+        })
+        .is_err());
+        assert!(fold_expr_to_value(Expr::FunctionCall {
+            name: "LOWER".to_string(),
+            args: vec![lit(Value::text("Ada"))],
+            span: Span::synthetic(),
+        })
+        .is_err());
+
+        assert_eq!(render_projection_literal(&Value::Null), "");
+        assert_eq!(render_projection_literal(&Value::UnsignedInteger(7)), "7");
+        assert_eq!(render_projection_literal(&Value::Boolean(false)), "false");
+        assert_eq!(
+            render_projection_literal(&Value::Blob(vec![1, 2, 3])),
+            "@RL:\"<blob 3 bytes>\""
+        );
+        assert_eq!(serialize_value_json(&Value::Null), "null");
     }
 }

--- a/crates/reddb-server/tests/rql_shims.rs
+++ b/crates/reddb-server/tests/rql_shims.rs
@@ -1,0 +1,41 @@
+use reddb_server::storage::query as server_query;
+
+fn assert_same_type<T>(_: &T, _: &T) {}
+
+#[test]
+fn server_query_frontend_is_backed_by_reddb_rql() {
+    let mut server_lexer = server_query::Lexer::new("SELECT * FROM users");
+    let mut rql_lexer = reddb_rql::Lexer::new("SELECT * FROM users");
+    let server_tokens = server_lexer.tokenize().expect("server shim lexes");
+    let rql_tokens = rql_lexer.tokenize().expect("rql crate lexes");
+    assert_same_type(&server_tokens, &rql_tokens);
+    let server_token_kinds: Vec<_> = server_tokens
+        .into_iter()
+        .map(|spanned| spanned.token)
+        .collect();
+    let rql_token_kinds: Vec<_> = rql_tokens
+        .into_iter()
+        .map(|spanned| spanned.token)
+        .collect();
+    assert_eq!(server_token_kinds, rql_token_kinds);
+
+    let server_query = server_query::parse("SELECT * FROM users").expect("server shim parses");
+    let rql_query = reddb_rql::parse("SELECT * FROM users").expect("rql crate parses");
+    assert_same_type(&server_query, &rql_query);
+    assert_eq!(format!("{server_query:?}"), format!("{rql_query:?}"));
+
+    let server_frontend =
+        server_query::parse_frontend("RESET TENANT").expect("server shim routes frontend command");
+    let rql_frontend =
+        reddb_rql::parse_frontend("RESET TENANT").expect("rql crate routes frontend command");
+    assert_same_type(&server_frontend, &rql_frontend);
+    assert_eq!(format!("{server_frontend:?}"), format!("{rql_frontend:?}"));
+
+    let server_expr: server_query::QueryExpr = server_frontend.into_query_expr();
+    let rql_expr: reddb_rql::ast::QueryExpr = rql_frontend.into_query_expr();
+    assert_same_type(&server_expr, &rql_expr);
+    assert!(matches!(
+        server_expr,
+        server_query::QueryExpr::SetTenant(None)
+    ));
+}

--- a/tests/rql_conformance.rs
+++ b/tests/rql_conformance.rs
@@ -1,14 +1,14 @@
 //! sqllogictest-format conformance harness (ADR 0053, S1 tracer bullet).
 //!
-//! Drives every `.slt` script under `tests/corpus/` end-to-end against the
-//! current **in-server engine** (`reddb-server`'s `RedDBRuntime`). The corpus
-//! is the standard-SQL slice sourced from the public SQLite sqllogictest
-//! corpus; this run is the behavioral net later extraction slices must keep
-//! green.
+//! Drives every `.slt` script under `crates/reddb-rql/tests/corpus/`
+//! end-to-end against the current **in-server engine** (`reddb-server`'s
+//! `RedDBRuntime`). The corpus is the standard-SQL slice sourced from the
+//! public SQLite sqllogictest corpus; this run is the behavioral net later
+//! extraction slices must keep green.
 //!
-//! The engine lives behind a dev-dependency so the published `reddb-io-rql`
-//! crate graph keeps its single edge to `reddb-io-types` — only this test
-//! target reaches `reddb-server`.
+//! The harness lives at the workspace umbrella level so the `reddb-io-rql`
+//! crate's own test graph stays focused on the language front-end and never
+//! pulls `reddb-server`/gRPC into pure lexer/parser/AST coverage.
 
 use std::path::{Path, PathBuf};
 
@@ -89,7 +89,7 @@ impl DB for EngineDb {
 }
 
 fn corpus_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/corpus")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/reddb-rql/tests/corpus")
 }
 
 fn slt_files(dir: &Path) -> Vec<PathBuf> {

--- a/tests/rql_reddb_conformance.rs
+++ b/tests/rql_reddb_conformance.rs
@@ -1,11 +1,12 @@
 //! sqllogictest-format conformance harness for the **RedDB-only query
 //! surfaces** that have no external oracle (ADR 0053, S3).
 //!
-//! Where the standard-SQL slice (`tests/conformance.rs` over `tests/corpus/`)
-//! draws its truth from the public SQLite corpus, the surfaces covered here —
-//! vector search, the native `GRAPH` command family, the four graph DSL modes
-//! (Gremlin / Cypher / SPARQL / Path), natural-language, and vector
-//! extensions — are RedDB inventions. Their expected results are
+//! Where the standard-SQL slice (`tests/rql_conformance.rs` over
+//! `crates/reddb-rql/tests/corpus/`) draws its truth from the public SQLite
+//! corpus, the surfaces covered here — vector search, the native `GRAPH`
+//! command family, the four graph DSL modes (Gremlin / Cypher / SPARQL /
+//! Path), natural-language, and vector extensions — are RedDB inventions.
+//! Their expected results are
 //! **hand-authored**: each value in a `query` block is what the surface's
 //! semantics dictate (cosine ranking, neighbourhood reachability, shortest-path
 //! hop counts), never blindly copied from engine output. Engine output is the
@@ -147,7 +148,7 @@ impl DB for EngineDb {
 }
 
 fn corpus_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/reddb_corpus")
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("crates/reddb-rql/tests/reddb_corpus")
 }
 
 fn slt_files(dir: &Path) -> Vec<PathBuf> {


### PR DESCRIPTION
## Summary
- make `reddb-io-rql` the pure RQL front-end authority for lexer, parser, AST, SQL/RQL frontend routing, mode translators, analyzer/typing, storage-agnostic optimizer, renderer, and sqllogictest-format conformance helpers
- keep the `reddb-io-rql` crate graph pure (`reddb-io-rql -> reddb-io-types`) by moving server-backed conformance drivers to the umbrella integration-test layer and removing server/gRPC dev-dependencies from the RQL crate
- expand focused pure-RQL coverage across analyzer, AST/builders, parser surfaces, expression typing, pathkeys, rewriter, optimizer, SQL lowering, and multimode frontends
- wire `reddb-server` to import the RQL authority through compatibility shims under `storage::query`, with an integration guard proving the server paths and `reddb_rql` paths are the same types
- fix the frontend routing gap for `RESET TENANT` while preserving the existing `QueryExpr::SetTenant(None)` runtime shape
- fix the RQL coverage workflow so the PR comment reports real JSON totals instead of a false `0.00%`

## Verification
- `cargo fmt --all --check`
- `cargo check -p reddb-io-rql`
- `cargo check -p reddb-io-server`
- `cargo test -p reddb-io-rql --lib` — 742 passed
- `cargo test -p reddb-io-server --test rql_shims`
- `cargo llvm-cov --no-report -p reddb-io-rql --lib` — 742 passed
- `cargo llvm-cov report --json --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90`
- PR CI: RQL Coverage Report, KV p99 gate, CodeRabbit all passing

## Coverage
- RQL Coverage Report: line coverage **90.00%**
- Latest CI total: `24650` lines, `2466` missed lines, `90.00%` line coverage

## Notes
- The RQL crate remains storage/server independent: normal dependency is only `reddb-io-types`; server-backed corpus execution lives outside the RQL crate.
- The server still preserves historical `storage::query::*` import paths, but those paths now reexport the canonical `reddb_rql` modules for the language front-end.<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783899675&installation_id=129708444&pr_number=1139&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1139&signature=e46b1819f3e301e74f7e606b159b79ffb27c21e0337e5d0da230db0460221b10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit and conformance test coverage across the RQL parser, analyzer, planner and query lowering to improve reliability.

* **Chores**
  * Updated CI Rust toolchain and improved coverage collection/reporting workflow.
  * Reorganized test corpus locations under the RQL crate and adjusted dev dependencies to support the harness.

* **Documentation**
  * Clarified crate-level documentation and updated local run instructions for coverage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->