### PR TITLE
feat(rql): support nested multimodel query semantics

### DIFF
--- a/.github/workflows/parser-coverage.yml
+++ b/.github/workflows/parser-coverage.yml
@@ -66,7 +66,8 @@ jobs:
             --lib \
             -p reddb-io-server \
             --lcov \
-            --output-path lcov.info
+            --output-path lcov.info \
+            -- storage::query
 
       # Restore the most recent main-branch snapshot for delta calculation.
       # Missing cache is non-fatal — delta column shows "n/a" instead.
@@ -182,10 +183,12 @@ jobs:
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          PARSER_COVERAGE_BODY: ${{ steps.report.outputs.body }}
         with:
           script: |
             const marker = '<!-- parser-coverage-comment -->';
-            const body = `${{ steps.report.outputs.body }}`;
+            const body = process.env.PARSER_COVERAGE_BODY;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/.github/workflows/types-coverage.yml
+++ b/.github/workflows/types-coverage.yml
@@ -100,10 +100,12 @@ jobs:
       - name: Post or update PR comment
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        env:
+          TYPES_COVERAGE_BODY: ${{ steps.report.outputs.body }}
         with:
           script: |
             const marker = '<!-- types-coverage-comment -->';
-            const body = `${{ steps.report.outputs.body }}`;
+            const body = process.env.TYPES_COVERAGE_BODY;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,

--- a/crates/reddb-rql/src/builders.rs
+++ b/crates/reddb-rql/src/builders.rs
@@ -315,6 +315,7 @@ impl JoinQueryBuilder {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -73,9 +73,9 @@ pub enum QueryExpr {
     CreateSlo(CreateSloQuery),
     /// DROP TIMESERIES name
     DropTimeSeries(DropTimeSeriesQuery),
-    /// CREATE QUEUE name [MAX_SIZE n] [PRIORITY] [WITH TTL duration]
+    /// CREATE QUEUE name [WORK|STANDARD|FIFO|FANOUT] [MAX_SIZE n] [PRIORITY] [WITH TTL duration]
     CreateQueue(CreateQueueQuery),
-    /// ALTER QUEUE name SET MODE [FANOUT|WORK]
+    /// ALTER QUEUE name SET MODE [FANOUT|WORK|STANDARD|FIFO]
     AlterQueue(AlterQueueQuery),
     /// DROP QUEUE name
     DropQueue(DropQueueQuery),
@@ -95,8 +95,11 @@ pub enum QueryExpr {
     TreeCommand(TreeCommand),
     /// SET CONFIG key = value
     SetConfig { key: String, value: Value },
-    /// SHOW CONFIG [prefix]
-    ShowConfig { prefix: Option<String> },
+    /// SHOW CONFIG [prefix] [AS JSON|FORMAT JSON]
+    ShowConfig {
+        prefix: Option<String>,
+        as_json: bool,
+    },
     /// SET SECRET key = value
     SetSecret { key: String, value: Value },
     /// DELETE SECRET key
@@ -220,6 +223,8 @@ pub enum QueryExpr {
     /// `ALTER USER name [VALID UNTIL 'ts'] [CONNECTION LIMIT n]
     ///   [ENABLE | DISABLE] [SET search_path = ...]`
     AlterUser(AlterUserStmt),
+    /// `CREATE USER [tenant.]name [WITH] PASSWORD 'plaintext' [ROLE read|write|admin]`
+    CreateUser(CreateUserStmt),
     // ----- IAM policy DDL (Agent #28 / IAM kernel integration) -----
     /// `CREATE POLICY '<id>' AS '<json>'` — installs an IAM policy
     /// document in the AuthStore. Distinct from the RLS-flavoured
@@ -424,6 +429,15 @@ pub struct AlterUserStmt {
     pub tenant: Option<String>,
     pub username: String,
     pub attributes: Vec<AlterUserAttribute>,
+}
+
+/// `CREATE USER` statement AST.
+#[derive(Debug, Clone)]
+pub struct CreateUserStmt {
+    pub tenant: Option<String>,
+    pub username: String,
+    pub password: String,
+    pub role: String,
 }
 
 #[derive(Debug, Clone)]
@@ -2817,7 +2831,7 @@ pub struct CreateQueueQuery {
 }
 
 /// ALTER QUEUE name SET <clause>
-///   MODE [FANOUT|WORK]
+///   MODE [FANOUT|WORK|STANDARD|FIFO]
 ///   MAX_ATTEMPTS n
 ///   LOCK_DEADLINE_MS n
 ///   IN_FLIGHT_CAP_PER_GROUP n
@@ -3080,6 +3094,7 @@ pub enum KvCommand {
         prefix: Option<String>,
         limit: Option<usize>,
         offset: usize,
+        as_json: bool,
     },
     Purge {
         collection: String,

--- a/crates/reddb-rql/src/modes/detect.rs
+++ b/crates/reddb-rql/src/modes/detect.rs
@@ -108,6 +108,7 @@ pub fn detect_mode(input: &str) -> QueryMode {
         || lower.starts_with("rotate vault ")
         || lower.starts_with("history vault ")
         || lower.starts_with("list vault ")
+        || lower.starts_with("list kv ")
         || lower.starts_with("watch vault ")
         || lower.starts_with("delete vault ")
         || lower.starts_with("purge vault ")
@@ -326,6 +327,10 @@ mod tests {
         assert_eq!(detect_mode("SHOW SECRET red.secret"), QueryMode::Sql);
         assert_eq!(detect_mode("SHOW SECRETS"), QueryMode::Sql);
         assert_eq!(detect_mode("VAULT PUT secrets.api = 'x'"), QueryMode::Sql);
+        assert_eq!(
+            detect_mode("LIST KV settings PREFIX feature LIMIT 10"),
+            QueryMode::Sql
+        );
         assert_eq!(detect_mode("SHOW SAMPLE users"), QueryMode::Sql);
         assert_eq!(detect_mode("SHOW TABLES"), QueryMode::Sql);
         assert_eq!(detect_mode("SHOW QUEUES"), QueryMode::Sql);

--- a/crates/reddb-rql/src/parser/auth_ddl.rs
+++ b/crates/reddb-rql/src/parser/auth_ddl.rs
@@ -32,13 +32,51 @@
 //! principal.
 
 use crate::ast::{
-    AlterUserAttribute, AlterUserStmt, GrantObject, GrantObjectKind, GrantPrincipalRef, GrantStmt,
-    LintPolicySource, PolicyPrincipalRef, PolicyResourceRef, PolicyUserRef, QueryExpr, RevokeStmt,
+    AlterUserAttribute, AlterUserStmt, CreateUserStmt, GrantObject, GrantObjectKind,
+    GrantPrincipalRef, GrantStmt, LintPolicySource, PolicyPrincipalRef, PolicyResourceRef,
+    PolicyUserRef, QueryExpr, RevokeStmt,
 };
 use crate::lexer::Token;
 use crate::parser::{ParseError, Parser};
 
 impl<'a> Parser<'a> {
+    /// Parse `CREATE USER name [WITH] PASSWORD 'plaintext' [ROLE role]`.
+    /// `role` defaults to `read`, the least-privileged RedDB role.
+    pub fn parse_create_user_statement(&mut self) -> Result<CreateUserStmt, ParseError> {
+        if !self.consume_ident_ci("USER")? {
+            return Err(ParseError::expected(
+                vec!["USER"],
+                self.peek(),
+                self.position(),
+            ));
+        }
+        let (tenant, username) = self.parse_user_name()?;
+
+        let mut password = None;
+        let mut role = "read".to_string();
+
+        let _ = self.consume(&Token::With)? || self.consume_ident_ci("WITH")?;
+        loop {
+            if self.consume_ident_ci("PASSWORD")? {
+                password = Some(self.parse_string()?);
+            } else if self.consume_ident_ci("ROLE")? {
+                role = self.expect_ident()?.to_ascii_lowercase();
+            } else {
+                break;
+            }
+        }
+
+        let password = password
+            .ok_or_else(|| ParseError::expected(vec!["PASSWORD"], self.peek(), self.position()))?;
+
+        Ok(CreateUserStmt {
+            tenant,
+            username,
+            password,
+            role,
+        })
+    }
+
     /// Parse a `GRANT` statement. Caller must have already verified the
     /// current token is the `GRANT` ident (it is not a lexer keyword —
     /// the lexer maps it to `Token::Ident("GRANT")`).
@@ -864,6 +902,29 @@ mod tests {
         p.expect(Token::Alter).expect("ALTER");
         let err = p.parse_alter_user_statement().unwrap_err();
         assert!(err.to_string().contains("expected: GROUP"), "{err}");
+    }
+
+    #[test]
+    fn parse_create_user_statement_covers_role_and_password_errors() {
+        let mut p = parser("CREATE USER tenant.alice WITH PASSWORD 'pw' ROLE admin");
+        p.expect(Token::Create).expect("CREATE");
+        let stmt = p.parse_create_user_statement().expect("create user");
+        assert_eq!(stmt.tenant.as_deref(), Some("tenant"));
+        assert_eq!(stmt.username, "alice");
+        assert_eq!(stmt.password, "pw");
+        assert_eq!(stmt.role, "admin");
+
+        let mut p = parser("CREATE USER bob PASSWORD 'pw'");
+        p.expect(Token::Create).expect("CREATE");
+        let stmt = p.parse_create_user_statement().expect("create user");
+        assert_eq!(stmt.tenant, None);
+        assert_eq!(stmt.username, "bob");
+        assert_eq!(stmt.role, "read");
+
+        let mut p = parser("CREATE USER alice ROLE write");
+        p.expect(Token::Create).expect("CREATE");
+        let err = p.parse_create_user_statement().unwrap_err();
+        assert!(err.to_string().contains("expected: PASSWORD"), "{err}");
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -375,8 +375,10 @@ impl<'a> Parser<'a> {
             let path_lc = path.to_ascii_lowercase();
             let (name, key) = if let Some(rest) = path_lc.strip_prefix("secret.") {
                 ("__SECRET_REF", format!("red.vault/{rest}"))
-            } else if path_lc.starts_with("red.secret.") {
-                let rest = path_lc.trim_start_matches("red.secret.");
+            } else if let Some(rest) = path_lc
+                .strip_prefix("red.secret.")
+                .or_else(|| path_lc.strip_prefix("red.secrets."))
+            {
                 ("__SECRET_REF", format!("red.vault/{rest}"))
             } else if let Some(rest) = path_lc.strip_prefix("config.") {
                 ("CONFIG", format!("red.config/{rest}"))
@@ -386,7 +388,7 @@ impl<'a> Parser<'a> {
             } else {
                 return Err(ParseError::new(
                     format!(
-                        "unknown $ reference `${path}`; expected $secret.*, $red.secret.*, $config.*, or $red.config.*"
+                        "unknown $ reference `${path}`; expected $secret.*, $red.secret.*, $red.secrets.*, $config.*, or $red.config.*"
                     ),
                     self.position(),
                 ));
@@ -1737,6 +1739,7 @@ mod tests {
         for (input, expected_name, expected_key) in [
             ("$secret.api_key", "__SECRET_REF", "red.vault/api_key"),
             ("$red.secret.api_key", "__SECRET_REF", "red.vault/api_key"),
+            ("$red.secrets.api_key", "__SECRET_REF", "red.vault/api_key"),
             ("$config.ai.provider", "CONFIG", "red.config/ai.provider"),
             (
                 "$red.config.ai.provider",

--- a/crates/reddb-rql/src/parser/graph.rs
+++ b/crates/reddb-rql/src/parser/graph.rs
@@ -87,7 +87,8 @@ impl<'a> Parser<'a> {
         // Label filter is a free-form string; resolution against the
         // graph's `LabelRegistry` happens at execution time, not here.
         let node_label = if self.consume(&Token::Colon)? {
-            Some(self.expect_ident_or_keyword()?.to_lowercase())
+            let label = self.expect_ident_or_keyword()?;
+            Some(self.parse_node_label(&label)?)
         } else {
             None
         };
@@ -130,7 +131,8 @@ impl<'a> Parser<'a> {
         };
 
         let edge_label = if self.consume(&Token::Colon)? {
-            Some(self.expect_ident_or_keyword()?.to_lowercase())
+            let label = self.expect_ident_or_keyword()?;
+            Some(self.parse_edge_label(&label)?)
         } else {
             None
         };

--- a/crates/reddb-rql/src/parser/index_ddl.rs
+++ b/crates/reddb-rql/src/parser/index_ddl.rs
@@ -29,7 +29,7 @@ impl<'a> Parser<'a> {
         self.expect(Token::LParen)?;
         let mut columns = Vec::new();
         loop {
-            columns.push(self.expect_ident_or_keyword()?);
+            columns.push(self.parse_index_column_path()?);
             if !self.consume(&Token::Comma)? {
                 break;
             }
@@ -114,6 +114,15 @@ impl<'a> Parser<'a> {
             )),
         }
     }
+
+    fn parse_index_column_path(&mut self) -> Result<String, ParseError> {
+        let mut column = self.expect_ident_or_keyword()?;
+        while self.consume(&Token::Dot)? {
+            column.push('.');
+            column.push_str(&self.expect_ident_or_keyword()?);
+        }
+        Ok(column)
+    }
 }
 
 #[cfg(test)]
@@ -169,6 +178,15 @@ mod tests {
         let query = parse_create_index("CREATE UNIQUE INDEX idx_orders ON orders (id) USING HASH");
         assert!(query.unique);
         assert_eq!(query.method, IndexMethod::Hash);
+    }
+
+    #[test]
+    fn parse_create_index_on_document_path() {
+        let query = parse_create_index("CREATE INDEX idx_docs_tier ON docs (body.service.tier)");
+        assert_eq!(query.name, "idx_docs_tier");
+        assert_eq!(query.table, "docs");
+        assert_eq!(query.columns, vec!["body.service.tier"]);
+        assert_eq!(query.method, IndexMethod::BTree);
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/kv.rs
+++ b/crates/reddb-rql/src/parser/kv.rs
@@ -129,6 +129,10 @@ impl<'a> Parser<'a> {
                 let (collection, key) = self.parse_kv_key(model)?;
                 Ok(QueryExpr::KvCommand(KvCommand::Purge { collection, key }))
             }
+            Token::List => {
+                self.advance()?;
+                self.parse_keyed_list(model)
+            }
             Token::Ident(ref name) if name.eq_ignore_ascii_case("LIST") => {
                 self.advance()?;
                 self.parse_keyed_list(model)
@@ -181,6 +185,7 @@ impl<'a> Parser<'a> {
                     vec![
                         "PUT",
                         "GET",
+                        "LIST",
                         "WATCH",
                         "DELETE",
                         "INCR",
@@ -204,6 +209,11 @@ impl<'a> Parser<'a> {
             ));
         }
         self.parse_keyed_list(CollectionModel::Vault)
+    }
+
+    pub(crate) fn parse_kv_list_after_list(&mut self) -> Result<QueryExpr, ParseError> {
+        self.expect(Token::Kv)?;
+        self.parse_keyed_list(CollectionModel::Kv)
     }
 
     pub(crate) fn parse_vault_watch_after_watch(&mut self) -> Result<QueryExpr, ParseError> {
@@ -433,7 +443,7 @@ impl<'a> Parser<'a> {
             }
             if lower_segments.len() >= 3
                 && lower_segments[0] == "red"
-                && lower_segments[1] == "secret"
+                && (lower_segments[1] == "secret" || lower_segments[1] == "secrets")
             {
                 return Ok(("red.vault".to_string(), lower_segments[2..].join(".")));
             }
@@ -468,13 +478,23 @@ impl<'a> Parser<'a> {
         let mut prefix = None;
         let mut limit = None;
         let mut offset = 0usize;
+        let mut as_json = false;
         loop {
             if self.consume_ident_ci("PREFIX")? {
-                prefix = Some(self.expect_ident_or_keyword()?.to_string());
+                prefix = Some(self.parse_kv_key_part()?);
             } else if self.consume(&Token::Limit)? || self.consume_ident_ci("LIMIT")? {
                 limit = Some(self.parse_float()?.round().max(0.0) as usize);
             } else if self.consume(&Token::Offset)? || self.consume_ident_ci("OFFSET")? {
                 offset = self.parse_float()?.round().max(0.0) as usize;
+            } else if self.consume(&Token::As)? || self.consume(&Token::Format)? {
+                if !self.consume(&Token::Json)? {
+                    return Err(ParseError::expected(
+                        vec!["JSON"],
+                        self.peek(),
+                        self.position(),
+                    ));
+                }
+                as_json = true;
             } else {
                 break;
             }
@@ -485,6 +505,7 @@ impl<'a> Parser<'a> {
             prefix,
             limit,
             offset,
+            as_json,
         }))
     }
 
@@ -728,6 +749,11 @@ mod tests {
         assert_eq!(collection, "red.vault");
         assert_eq!(key, "prod.api_key");
 
+        let mut p = parser("red.secrets.prod.api_key");
+        let (collection, key) = p.parse_kv_key(CollectionModel::Vault).unwrap();
+        assert_eq!(collection, "red.vault");
+        assert_eq!(key, "prod.api_key");
+
         let mut p = parser("secret.prod.api_key");
         let (collection, key) = p.parse_kv_key(CollectionModel::Vault).unwrap();
         assert_eq!(collection, "red.vault");
@@ -749,6 +775,7 @@ mod tests {
             prefix,
             limit,
             offset,
+            as_json,
         }) = p.parse_keyed_list(CollectionModel::Kv).unwrap()
         else {
             panic!("expected kv list");
@@ -758,6 +785,15 @@ mod tests {
         assert_eq!(prefix.as_deref(), Some("tenant"));
         assert_eq!(limit, Some(0));
         assert_eq!(offset, 0);
+        assert!(!as_json);
+
+        let mut p = parser("items PREFIX tenant FORMAT JSON");
+        let QueryExpr::KvCommand(KvCommand::List { as_json, .. }) =
+            p.parse_keyed_list(CollectionModel::Kv).unwrap()
+        else {
+            panic!("expected kv list");
+        };
+        assert!(as_json);
 
         let mut p = parser("secrets.env PREFIX api FROM LSN 12");
         let QueryExpr::KvCommand(KvCommand::Watch {

--- a/crates/reddb-rql/src/parser/queue.rs
+++ b/crates/reddb-rql/src/parser/queue.rs
@@ -81,7 +81,7 @@ impl<'a> Parser<'a> {
     /// Parse ALTER QUEUE body (after ALTER QUEUE consumed)
     ///
     /// Syntax: `ALTER QUEUE <name> SET <clause>` where `<clause>` is one of
-    ///   `MODE <WORK|FANOUT>`
+    ///   `MODE <WORK|STANDARD|FIFO|FANOUT>`
     ///   `MAX_ATTEMPTS <int>`
     ///   `LOCK_DEADLINE_MS <int>`
     ///   `IN_FLIGHT_CAP_PER_GROUP <int>`
@@ -568,7 +568,7 @@ impl<'a> Parser<'a> {
         match self.consume_queue_mode()? {
             Some(mode) => Ok(mode),
             None => Err(ParseError::expected(
-                vec!["FANOUT", "WORK"],
+                vec!["FANOUT", "WORK", "STANDARD", "FIFO"],
                 self.peek(),
                 self.position(),
             )),

--- a/crates/reddb-rql/src/parser/table.rs
+++ b/crates/reddb-rql/src/parser/table.rs
@@ -341,6 +341,7 @@ impl<'a> Parser<'a> {
         // table-valued function calls such as `components(g)` (issue #795);
         // plain tables leave this `None` and rely on the legacy `table` slot.
         let mut table_source: Option<crate::ast::TableSource> = None;
+        let mut from_subquery: Option<QueryExpr> = None;
         let table = if has_from {
             if self.consume(&Token::Queue)? {
                 let queue = self.expect_ident()?;
@@ -360,6 +361,17 @@ impl<'a> Parser<'a> {
                     filter,
                     limit,
                 }));
+            } else if self.check(&Token::LParen) {
+                self.advance()?; // consume '('
+                if !self.check(&Token::Select) {
+                    return Err(ParseError::new(
+                        "subquery in FROM must start with SELECT".to_string(),
+                        self.position(),
+                    ));
+                }
+                from_subquery = Some(self.parse_select_query()?);
+                self.expect(Token::RParen)?;
+                "__subq_pending".to_string()
             } else if self.consume(&Token::Star)? {
                 "*".to_string()
             } else if self.consume(&Token::All)? {
@@ -451,27 +463,35 @@ impl<'a> Parser<'a> {
                 None
             };
 
-        let mut query = TableQuery {
-            table,
-            source: table_source,
-            alias,
-            select_items,
-            columns,
-            where_expr: None,
-            filter: None,
-            group_by_exprs: Vec::new(),
-            group_by: Vec::new(),
-            having_expr: None,
-            having: None,
-            order_by: Vec::new(),
-            limit: None,
-            limit_param: None,
-            offset: None,
-            offset_param: None,
-            expand: None,
-            as_of: None,
-            sessionize: None,
-            distinct,
+        let mut query = if let Some(inner) = from_subquery {
+            let mut query = TableQuery::from_subquery(inner, alias);
+            query.select_items = select_items;
+            query.columns = columns;
+            query.distinct = distinct;
+            query
+        } else {
+            TableQuery {
+                table,
+                source: table_source,
+                alias,
+                select_items,
+                columns,
+                where_expr: None,
+                filter: None,
+                group_by_exprs: Vec::new(),
+                group_by: Vec::new(),
+                having_expr: None,
+                having: None,
+                order_by: Vec::new(),
+                limit: None,
+                limit_param: None,
+                offset: None,
+                offset_param: None,
+                expand: None,
+                as_of: None,
+                sessionize: None,
+                distinct,
+            }
         };
 
         if self.is_join_keyword() {
@@ -1546,7 +1566,19 @@ mod tests {
         assert!(matches!(table.source, Some(TableSource::Subquery(_))));
         assert_eq!(table.select_items.len(), 1);
 
+        let parsed = crate::parser::parse("SELECT id FROM (SELECT id FROM users) AS u")
+            .unwrap()
+            .query;
+        let QueryExpr::Table(table) = parsed else {
+            panic!("expected table query");
+        };
+        assert_eq!(table.table, "__subq_u");
+        assert_eq!(table.alias.as_deref(), Some("u"));
+        assert!(matches!(table.source, Some(TableSource::Subquery(_))));
+        assert_eq!(table.select_items.len(), 1);
+
         assert!(crate::parser::parse("FROM (MATCH (n) RETURN n) AS g").is_err());
+        assert!(crate::parser::parse("SELECT * FROM (MATCH (n) RETURN n) AS g").is_err());
     }
 
     // ── Table-valued function arguments (issues #795 / #796) ──

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -1015,6 +1015,20 @@ fn test_parse_match_with_edge() {
 }
 
 #[test]
+fn test_parse_match_canonicalizes_edge_label_aliases() {
+    let query = parse("MATCH (a)-[:CONNECTS]->(b) RETURN a, b").unwrap();
+    if let QueryExpr::Graph(gq) = query {
+        assert_eq!(gq.pattern.edges.len(), 1);
+        assert_eq!(
+            gq.pattern.edges[0].edge_label.as_deref(),
+            Some("connects_to")
+        );
+    } else {
+        panic!("Expected GraphQuery");
+    }
+}
+
+#[test]
 fn test_parse_match_variable_length() {
     let query = parse("MATCH (a)-[*1..5]->(b) RETURN a, b").unwrap();
     if let QueryExpr::Graph(gq) = query {
@@ -4559,10 +4573,34 @@ fn test_parse_queue_mode_ddl() {
         QueryExpr::CreateQueue(q) if q.name == "work_tasks" && q.mode == QueueMode::Work
     ));
 
+    let query = parse("CREATE QUEUE standard_tasks STANDARD").unwrap();
+    assert!(matches!(
+        query,
+        QueryExpr::CreateQueue(q) if q.name == "standard_tasks" && q.mode == QueueMode::Work
+    ));
+
+    let query = parse("CREATE QUEUE fifo_tasks FIFO").unwrap();
+    assert!(matches!(
+        query,
+        QueryExpr::CreateQueue(q) if q.name == "fifo_tasks" && q.mode == QueueMode::Work
+    ));
+
     let query = parse("ALTER QUEUE fanout_tasks SET MODE FANOUT").unwrap();
     assert!(matches!(
         query,
         QueryExpr::AlterQueue(q) if q.name == "fanout_tasks" && q.mode == Some(QueueMode::Fanout)
+    ));
+
+    let query = parse("ALTER QUEUE standard_tasks SET MODE STANDARD").unwrap();
+    assert!(matches!(
+        query,
+        QueryExpr::AlterQueue(q) if q.name == "standard_tasks" && q.mode == Some(QueueMode::Work)
+    ));
+
+    let query = parse("ALTER QUEUE fifo_tasks SET MODE FIFO").unwrap();
+    assert!(matches!(
+        query,
+        QueryExpr::AlterQueue(q) if q.name == "fifo_tasks" && q.mode == Some(QueueMode::Work)
     ));
 }
 
@@ -5166,6 +5204,15 @@ fn test_parse_hll_commands() {
 #[test]
 fn test_parse_auth_grant_revoke_and_alter_user_forms() {
     use crate::ast::{AlterUserAttribute, GrantObjectKind, GrantPrincipalRef};
+
+    let query = parse("CREATE USER tenant1.alice WITH PASSWORD 'pw' ROLE write").unwrap();
+    let QueryExpr::CreateUser(stmt) = query else {
+        panic!("Expected CreateUser");
+    };
+    assert_eq!(stmt.tenant.as_deref(), Some("tenant1"));
+    assert_eq!(stmt.username, "alice");
+    assert_eq!(stmt.password, "pw");
+    assert_eq!(stmt.role, "write");
 
     let query =
         parse("GRANT ALL PRIVILEGES ON DATABASE maindb TO PUBLIC WITH GRANT OPTION").unwrap();
@@ -7151,6 +7198,38 @@ fn test_parse_vault_lifecycle_commands() {
 #[test]
 fn test_parse_vault_list_and_watch() {
     assert!(matches!(
+        parse("KV LIST settings PREFIX 'feature.' LIMIT 10 OFFSET 2").unwrap(),
+        QueryExpr::KvCommand(KvCommand::List {
+            model: reddb_types::catalog::CollectionModel::Kv,
+            collection,
+            prefix: Some(prefix),
+            limit: Some(10),
+            offset: 2,
+            as_json: false,
+        }) if collection == "settings" && prefix == "feature."
+    ));
+    assert!(matches!(
+        parse("LIST KV settings PREFIX feature LIMIT 10 OFFSET 2").unwrap(),
+        QueryExpr::KvCommand(KvCommand::List {
+            model: reddb_types::catalog::CollectionModel::Kv,
+            collection,
+            prefix: Some(prefix),
+            limit: Some(10),
+            offset: 2,
+            as_json: false,
+        }) if collection == "settings" && prefix == "feature"
+    ));
+    assert!(matches!(
+        parse("KV LIST settings PREFIX feature AS JSON").unwrap(),
+        QueryExpr::KvCommand(KvCommand::List {
+            model: reddb_types::catalog::CollectionModel::Kv,
+            collection,
+            prefix: Some(prefix),
+            as_json: true,
+            ..
+        }) if collection == "settings" && prefix == "feature"
+    ));
+    assert!(matches!(
         parse("LIST VAULT secrets PREFIX api LIMIT 10 OFFSET 2").unwrap(),
         QueryExpr::KvCommand(KvCommand::List {
             model: reddb_types::catalog::CollectionModel::Vault,
@@ -7158,6 +7237,18 @@ fn test_parse_vault_list_and_watch() {
             prefix: Some(prefix),
             limit: Some(10),
             offset: 2,
+            as_json: false,
+        }) if collection == "secrets" && prefix == "api"
+    ));
+    assert!(matches!(
+        parse("VAULT LIST secrets PREFIX api LIMIT 10 OFFSET 2").unwrap(),
+        QueryExpr::KvCommand(KvCommand::List {
+            model: reddb_types::catalog::CollectionModel::Vault,
+            collection,
+            prefix: Some(prefix),
+            limit: Some(10),
+            offset: 2,
+            as_json: false,
         }) if collection == "secrets" && prefix == "api"
     ));
     assert!(matches!(

--- a/crates/reddb-rql/src/planner/optimizer.rs
+++ b/crates/reddb-rql/src/planner/optimizer.rs
@@ -345,6 +345,7 @@ impl JoinReorderingPass {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-rql/src/planner/rewriter.rs
+++ b/crates/reddb-rql/src/planner/rewriter.rs
@@ -244,6 +244,7 @@ impl RewriteRule for NormalizeRule {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }
@@ -377,6 +378,7 @@ impl RewriteRule for SimplifyFiltersRule {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }
@@ -469,6 +471,7 @@ impl RewriteRule for SimplifyFiltersRule {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -3,16 +3,17 @@ use crate::ast::{
     AskQuery, BinOp, CompareOp, ConfigCommand, CopyFormat, CopyFromQuery, CreateCollectionQuery,
     CreateForeignTableQuery, CreateIndexQuery, CreateMetricQuery, CreateMigrationQuery,
     CreatePolicyQuery, CreateQueueQuery, CreateSchemaQuery, CreateSequenceQuery, CreateServerQuery,
-    CreateSloQuery, CreateTableQuery, CreateTimeSeriesQuery, CreateTreeQuery, CreateVectorQuery,
-    CreateViewQuery, DeleteQuery, DropCollectionQuery, DropDocumentQuery, DropForeignTableQuery,
-    DropGraphQuery, DropIndexQuery, DropKvQuery, DropPolicyQuery, DropQueueQuery, DropSchemaQuery,
-    DropSequenceQuery, DropServerQuery, DropTableQuery, DropTimeSeriesQuery, DropTreeQuery,
-    DropVectorQuery, DropViewQuery, EventsBackfillQuery, ExplainAlterQuery, ExplainMigrationQuery,
-    Expr, FieldRef, Filter, ForeignColumnDef, GrantStmt, GraphCommand, GraphQuery, HybridQuery,
-    InsertQuery, JoinQuery, KvCommand, MaintenanceCommand, PathQuery, PolicyAction,
-    ProbabilisticCommand, QueryExpr, QueueCommand, QueueSelectQuery, RankOfQuery, RankRangeQuery,
-    RefreshMaterializedViewQuery, RevokeStmt, RollbackMigrationQuery, SearchCommand, Span,
-    TableQuery, TreeCommand, TruncateQuery, TxnControl, UpdateQuery, VectorQuery,
+    CreateSloQuery, CreateTableQuery, CreateTimeSeriesQuery, CreateTreeQuery, CreateUserStmt,
+    CreateVectorQuery, CreateViewQuery, DeleteQuery, DropCollectionQuery, DropDocumentQuery,
+    DropForeignTableQuery, DropGraphQuery, DropIndexQuery, DropKvQuery, DropPolicyQuery,
+    DropQueueQuery, DropSchemaQuery, DropSequenceQuery, DropServerQuery, DropTableQuery,
+    DropTimeSeriesQuery, DropTreeQuery, DropVectorQuery, DropViewQuery, EventsBackfillQuery,
+    ExplainAlterQuery, ExplainMigrationQuery, Expr, FieldRef, Filter, ForeignColumnDef, GrantStmt,
+    GraphCommand, GraphQuery, HybridQuery, InsertQuery, JoinQuery, KvCommand, MaintenanceCommand,
+    PathQuery, PolicyAction, ProbabilisticCommand, QueryExpr, QueueCommand, QueueSelectQuery,
+    RankOfQuery, RankRangeQuery, RefreshMaterializedViewQuery, RevokeStmt, RollbackMigrationQuery,
+    SearchCommand, Span, TableQuery, TreeCommand, TruncateQuery, TxnControl, UpdateQuery,
+    VectorQuery,
 };
 use crate::lexer::Token;
 use crate::parser::{ParseError, Parser, SafeTokenDisplay};
@@ -92,6 +93,7 @@ pub enum SqlCommand {
     },
     ShowConfig {
         prefix: Option<String>,
+        as_json: bool,
     },
     SetSecret {
         key: String,
@@ -127,6 +129,8 @@ pub enum SqlCommand {
     Revoke(RevokeStmt),
     /// `ALTER USER name <attrs>`
     AlterUser(AlterUserStmt),
+    /// `CREATE USER name PASSWORD '...' [ROLE read|write|admin]`
+    CreateUser(CreateUserStmt),
     /// IAM policy DDL (CREATE POLICY '...' AS '...', DROP POLICY '...',
     /// ATTACH/DETACH POLICY, SHOW POLICIES, SIMULATE, SHOW EFFECTIVE
     /// PERMISSIONS). Stored as a pre-built QueryExpr so the dispatcher
@@ -285,11 +289,25 @@ mod tests {
 
         assert!(matches!(
             expr("SHOW CONFIG durability.mode"),
-            QueryExpr::ShowConfig { prefix: Some(prefix) } if prefix == "durability.mode"
+            QueryExpr::ShowConfig { prefix: Some(prefix), as_json: false } if prefix == "durability.mode"
         ));
         assert!(matches!(
             expr("SHOW CONFIG"),
-            QueryExpr::ShowConfig { prefix: None }
+            QueryExpr::ShowConfig {
+                prefix: None,
+                as_json: false
+            }
+        ));
+        assert!(matches!(
+            expr("SHOW CONFIG runtime.result_cache AS JSON"),
+            QueryExpr::ShowConfig { prefix: Some(prefix), as_json: true } if prefix == "runtime.result_cache"
+        ));
+        assert!(matches!(
+            expr("SHOW CONFIG FORMAT JSON"),
+            QueryExpr::ShowConfig {
+                prefix: None,
+                as_json: true
+            }
         ));
 
         let QueryExpr::SetConfig { key, value } = expr("SET CONFIG durability.mode = 'sync'")
@@ -305,14 +323,26 @@ mod tests {
         };
         assert_eq!(key, "provider.api_key");
         assert_text(&value, "sk_test");
+        assert!(matches!(
+            expr("SET SECRET red.secrets.provider.api_key = 'sk_test'"),
+            QueryExpr::SetSecret { key, .. } if key == "red.secret.provider.api_key"
+        ));
 
         assert!(matches!(
             expr("DELETE SECRET provider.api_key"),
             QueryExpr::DeleteSecret { key } if key == "provider.api_key"
         ));
         assert!(matches!(
+            expr("DELETE SECRET red.secrets.provider.api_key"),
+            QueryExpr::DeleteSecret { key } if key == "red.secret.provider.api_key"
+        ));
+        assert!(matches!(
             expr("SHOW SECRETS provider"),
             QueryExpr::ShowSecrets { prefix: Some(prefix) } if prefix == "provider"
+        ));
+        assert!(matches!(
+            expr("SHOW SECRETS red.secrets.provider"),
+            QueryExpr::ShowSecrets { prefix: Some(prefix) } if prefix == "red.secret.provider"
         ));
         assert!(matches!(
             expr("SET TENANT 'acme'"),
@@ -487,6 +517,14 @@ mod tests {
             QueryExpr::AlterUser(user)
                 if user.username == "bob" && user.attributes.len() == 2
         ));
+        assert!(matches!(
+            expr("CREATE USER tenant1.alice WITH PASSWORD 'pw' ROLE write"),
+            QueryExpr::CreateUser(user)
+                if user.tenant.as_deref() == Some("tenant1")
+                    && user.username == "alice"
+                    && user.password == "pw"
+                    && user.role == "write"
+        ));
 
         assert!(matches!(
             expr("CREATE POLICY 'readonly' AS '{\"Statement\":[]}'"),
@@ -603,6 +641,57 @@ mod tests {
         assert_eq!(limit, Some(3));
         assert_eq!(offset, 1);
 
+        let QueryExpr::KvCommand(KvCommand::List {
+            model,
+            collection,
+            prefix,
+            limit,
+            offset,
+            as_json,
+        }) = expr("KV LIST settings PREFIX 'feature.' LIMIT 10 OFFSET 2")
+        else {
+            panic!("KV LIST should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "settings");
+        assert_eq!(prefix.as_deref(), Some("feature."));
+        assert_eq!(limit, Some(10));
+        assert_eq!(offset, 2);
+        assert!(!as_json);
+
+        let QueryExpr::KvCommand(KvCommand::List {
+            model,
+            collection,
+            prefix,
+            limit,
+            offset,
+            as_json,
+        }) = expr("LIST KV settings PREFIX feature LIMIT 10 OFFSET 2")
+        else {
+            panic!("LIST KV should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "settings");
+        assert_eq!(prefix.as_deref(), Some("feature"));
+        assert_eq!(limit, Some(10));
+        assert_eq!(offset, 2);
+        assert!(!as_json);
+
+        let QueryExpr::KvCommand(KvCommand::List {
+            model,
+            collection,
+            prefix,
+            as_json,
+            ..
+        }) = expr("KV LIST settings PREFIX feature AS JSON")
+        else {
+            panic!("KV LIST AS JSON should route to FrontendStatement::KvCommand");
+        };
+        assert_eq!(model, CollectionModel::Kv);
+        assert_eq!(collection, "settings");
+        assert_eq!(prefix.as_deref(), Some("feature"));
+        assert!(as_json);
+
         let QueryExpr::KvCommand(KvCommand::Watch {
             model,
             collection,
@@ -641,6 +730,7 @@ mod tests {
             prefix,
             limit,
             offset,
+            as_json,
         }) = expr("LIST VAULT secrets PREFIX api LIMIT 10 OFFSET 2")
         else {
             panic!("LIST VAULT should route to FrontendStatement::KvCommand");
@@ -650,6 +740,7 @@ mod tests {
         assert_eq!(prefix.as_deref(), Some("api"));
         assert_eq!(limit, Some(10));
         assert_eq!(offset, 2);
+        assert!(!as_json);
 
         assert!(matches!(
             expr("INVALIDATE CONFIG app feature_flag"),
@@ -1269,11 +1360,24 @@ pub enum SqlSchemaCommand {
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum SqlAdminCommand {
-    SetConfig { key: String, value: Value },
-    ShowConfig { prefix: Option<String> },
-    SetSecret { key: String, value: Value },
-    DeleteSecret { key: String },
-    ShowSecrets { prefix: Option<String> },
+    SetConfig {
+        key: String,
+        value: Value,
+    },
+    ShowConfig {
+        prefix: Option<String>,
+        as_json: bool,
+    },
+    SetSecret {
+        key: String,
+        value: Value,
+    },
+    DeleteSecret {
+        key: String,
+    },
+    ShowSecrets {
+        prefix: Option<String>,
+    },
     SetTenant(Option<String>),
     ShowTenant,
     TransactionControl(TxnControl),
@@ -1281,6 +1385,7 @@ pub enum SqlAdminCommand {
     Grant(GrantStmt),
     Revoke(RevokeStmt),
     AlterUser(AlterUserStmt),
+    CreateUser(CreateUserStmt),
     IamPolicy(QueryExpr),
 }
 
@@ -1364,8 +1469,8 @@ impl SqlStatement {
             SqlStatement::Admin(SqlAdminCommand::SetConfig { key, value }) => {
                 SqlCommand::SetConfig { key, value }
             }
-            SqlStatement::Admin(SqlAdminCommand::ShowConfig { prefix }) => {
-                SqlCommand::ShowConfig { prefix }
+            SqlStatement::Admin(SqlAdminCommand::ShowConfig { prefix, as_json }) => {
+                SqlCommand::ShowConfig { prefix, as_json }
             }
             SqlStatement::Admin(SqlAdminCommand::SetSecret { key, value }) => {
                 SqlCommand::SetSecret { key, value }
@@ -1407,6 +1512,7 @@ impl SqlStatement {
             SqlStatement::Admin(SqlAdminCommand::Grant(s)) => SqlCommand::Grant(s),
             SqlStatement::Admin(SqlAdminCommand::Revoke(s)) => SqlCommand::Revoke(s),
             SqlStatement::Admin(SqlAdminCommand::AlterUser(s)) => SqlCommand::AlterUser(s),
+            SqlStatement::Admin(SqlAdminCommand::CreateUser(s)) => SqlCommand::CreateUser(s),
             SqlStatement::Admin(SqlAdminCommand::IamPolicy(e)) => SqlCommand::IamPolicy(e),
             SqlStatement::Schema(SqlSchemaCommand::CreateMigration(q)) => {
                 SqlCommand::CreateMigration(q)
@@ -1506,7 +1612,7 @@ impl SqlCommand {
             SqlCommand::DropTree(query) => QueryExpr::DropTree(query),
             SqlCommand::Probabilistic(command) => QueryExpr::ProbabilisticCommand(command),
             SqlCommand::SetConfig { key, value } => QueryExpr::SetConfig { key, value },
-            SqlCommand::ShowConfig { prefix } => QueryExpr::ShowConfig { prefix },
+            SqlCommand::ShowConfig { prefix, as_json } => QueryExpr::ShowConfig { prefix, as_json },
             SqlCommand::SetSecret { key, value } => QueryExpr::SetSecret { key, value },
             SqlCommand::DeleteSecret { key } => QueryExpr::DeleteSecret { key },
             SqlCommand::ShowSecrets { prefix } => QueryExpr::ShowSecrets { prefix },
@@ -1531,6 +1637,7 @@ impl SqlCommand {
             SqlCommand::Grant(s) => QueryExpr::Grant(s),
             SqlCommand::Revoke(s) => QueryExpr::Revoke(s),
             SqlCommand::AlterUser(s) => QueryExpr::AlterUser(s),
+            SqlCommand::CreateUser(s) => QueryExpr::CreateUser(s),
             SqlCommand::IamPolicy(e) => e,
             SqlCommand::CreateMigration(q) => QueryExpr::CreateMigration(q),
             SqlCommand::ApplyMigration(q) => QueryExpr::ApplyMigration(q),
@@ -1618,8 +1725,8 @@ impl SqlCommand {
             SqlCommand::SetConfig { key, value } => {
                 SqlStatement::Admin(SqlAdminCommand::SetConfig { key, value })
             }
-            SqlCommand::ShowConfig { prefix } => {
-                SqlStatement::Admin(SqlAdminCommand::ShowConfig { prefix })
+            SqlCommand::ShowConfig { prefix, as_json } => {
+                SqlStatement::Admin(SqlAdminCommand::ShowConfig { prefix, as_json })
             }
             SqlCommand::SetSecret { key, value } => {
                 SqlStatement::Admin(SqlAdminCommand::SetSecret { key, value })
@@ -1661,6 +1768,7 @@ impl SqlCommand {
             SqlCommand::Grant(s) => SqlStatement::Admin(SqlAdminCommand::Grant(s)),
             SqlCommand::Revoke(s) => SqlStatement::Admin(SqlAdminCommand::Revoke(s)),
             SqlCommand::AlterUser(s) => SqlStatement::Admin(SqlAdminCommand::AlterUser(s)),
+            SqlCommand::CreateUser(s) => SqlStatement::Admin(SqlAdminCommand::CreateUser(s)),
             SqlCommand::IamPolicy(e) => SqlStatement::Admin(SqlAdminCommand::IamPolicy(e)),
             SqlCommand::CreateMigration(q) => {
                 SqlStatement::Schema(SqlSchemaCommand::CreateMigration(q))
@@ -1935,6 +2043,14 @@ impl<'a> Parser<'a> {
                             self.position(),
                         )),
                     }
+                } else if matches!(self.peek(), Token::Kv) {
+                    match self.parse_kv_list_after_list()? {
+                        QueryExpr::KvCommand(command) => Ok(FrontendStatement::KvCommand(command)),
+                        other => Err(ParseError::new(
+                            format!("internal: LIST KV produced unexpected query kind {other:?}"),
+                            self.position(),
+                        )),
+                    }
                 } else if matches!(
                     self.peek(),
                     Token::Ident(name) if name.eq_ignore_ascii_case("VAULT")
@@ -1950,7 +2066,7 @@ impl<'a> Parser<'a> {
                     }
                 } else {
                     Err(ParseError::expected(
-                        vec!["CONFIG", "VAULT"],
+                        vec!["CONFIG", "KV", "VAULT"],
                         self.peek(),
                         self.position(),
                     ))
@@ -1973,6 +2089,14 @@ impl<'a> Parser<'a> {
                             self.position(),
                         )),
                     }
+                } else if matches!(self.peek(), Token::Kv) {
+                    match self.parse_kv_list_after_list()? {
+                        QueryExpr::KvCommand(command) => Ok(FrontendStatement::KvCommand(command)),
+                        other => Err(ParseError::new(
+                            format!("internal: LIST KV produced unexpected query kind {other:?}"),
+                            self.position(),
+                        )),
+                    }
                 } else if matches!(
                     self.peek(),
                     Token::Ident(name) if name.eq_ignore_ascii_case("VAULT")
@@ -1988,7 +2112,7 @@ impl<'a> Parser<'a> {
                     }
                 } else {
                     Err(ParseError::expected(
-                        vec!["CONFIG", "VAULT"],
+                        vec!["CONFIG", "KV", "VAULT"],
                         self.peek(),
                         self.position(),
                     ))
@@ -2393,6 +2517,16 @@ impl<'a> Parser<'a> {
         })
     }
 
+    fn normalize_secret_admin_path(path: String) -> String {
+        if let Some(rest) = path.strip_prefix("red.secrets.") {
+            format!("red.secret.{rest}")
+        } else if path == "red.secrets" {
+            "red.secret".to_string()
+        } else {
+            path
+        }
+    }
+
     /// Parse any SQL/RQL-style command through a single frontend module.
     /// Parse a `CREATE ...` statement. Split out of
     /// [`parse_sql_command`] so its very large per-arm locals
@@ -2506,7 +2640,10 @@ impl<'a> Parser<'a> {
             ));
         }
 
-        if self.check(&Token::Index) || self.check(&Token::Unique) {
+        if matches!(self.peek(), Token::Ident(name) if name.eq_ignore_ascii_case("USER")) {
+            let stmt = self.parse_create_user_statement()?;
+            Ok(SqlCommand::CreateUser(stmt))
+        } else if self.check(&Token::Index) || self.check(&Token::Unique) {
             match self.parse_create_index_query()? {
                 QueryExpr::CreateIndex(query) => Ok(SqlCommand::CreateIndex(query)),
                 other => Err(ParseError::new(
@@ -2890,6 +3027,7 @@ impl<'a> Parser<'a> {
                     "FILTER",
                     "SCHEMA",
                     "SEQUENCE",
+                    "USER",
                     "MIGRATION",
                 ],
                 self.peek(),
@@ -2935,7 +3073,8 @@ impl<'a> Parser<'a> {
                 {
                     self.advance()?; // DELETE
                     self.advance()?; // SECRET
-                    let key = self.parse_dotted_admin_path(true)?;
+                    let key =
+                        Self::normalize_secret_admin_path(self.parse_dotted_admin_path(true)?);
                     Ok(SqlCommand::DeleteSecret { key })
                 } else {
                     match self.parse_delete_query()? {
@@ -3442,7 +3581,8 @@ impl<'a> Parser<'a> {
                         value,
                     })
                 } else if self.consume_ident_ci("SECRET")? {
-                    let key = self.parse_dotted_admin_path(true)?;
+                    let key =
+                        Self::normalize_secret_admin_path(self.parse_dotted_admin_path(true)?);
                     self.expect(Token::Eq)?;
                     let value = self.parse_literal_value()?;
                     Ok(SqlCommand::SetSecret { key, value })
@@ -3540,7 +3680,10 @@ impl<'a> Parser<'a> {
                     // Accept dotted prefixes the same way SET CONFIG does
                     // (`SHOW CONFIG durability.mode`), and empty prefix
                     // (`SHOW CONFIG`) for a catalog-wide listing.
-                    let prefix = if !self.check(&Token::Eof) {
+                    let prefix = if !(self.check(&Token::Eof)
+                        || self.check(&Token::As)
+                        || self.check(&Token::Format))
+                    {
                         let first = self.expect_ident()?;
                         let mut full = first;
                         while self.consume(&Token::Dot)? {
@@ -3553,7 +3696,19 @@ impl<'a> Parser<'a> {
                     } else {
                         None
                     };
-                    Ok(SqlCommand::ShowConfig { prefix })
+                    let as_json = if self.consume(&Token::As)? || self.consume(&Token::Format)? {
+                        if !self.consume(&Token::Json)? {
+                            return Err(ParseError::expected(
+                                vec!["JSON"],
+                                self.peek(),
+                                self.position(),
+                            ));
+                        }
+                        true
+                    } else {
+                        false
+                    };
+                    Ok(SqlCommand::ShowConfig { prefix, as_json })
                 } else if self.consume_ident_ci("COLLECTIONS")? {
                     let mut query = TableQuery::new("red.collections");
                     let include_internal = if self.consume_ident_ci("INCLUDING")? {
@@ -3749,7 +3904,9 @@ impl<'a> Parser<'a> {
                     Ok(SqlCommand::Select(query))
                 } else if self.consume_ident_ci("SECRET")? || self.consume_ident_ci("SECRETS")? {
                     let prefix = if !self.check(&Token::Eof) {
-                        Some(self.parse_dotted_admin_path(true)?)
+                        Some(Self::normalize_secret_admin_path(
+                            self.parse_dotted_admin_path(true)?,
+                        ))
                     } else {
                         None
                     };

--- a/crates/reddb-server/src/runtime/graph_dsl.rs
+++ b/crates/reddb-server/src/runtime/graph_dsl.rs
@@ -21,8 +21,8 @@ pub(super) fn materialize_graph_with_projection(
         .and_then(|projection| normalize_token_filter_list(projection.node_labels.clone()));
     let node_type_filters = projection
         .and_then(|projection| normalize_token_filter_list(projection.node_types.clone()));
-    let edge_label_filters = projection
-        .and_then(|projection| normalize_token_filter_list(projection.edge_labels.clone()));
+    let edge_label_filters =
+        projection.and_then(|projection| normalize_edge_filters(projection.edge_labels.clone()));
     let mut allowed_nodes = HashSet::new();
 
     for (_, entity) in &entities {
@@ -400,7 +400,7 @@ pub(super) fn normalize_edge_filters(edge_labels: Option<Vec<String>>) -> Option
         .map(|labels| {
             labels
                 .into_iter()
-                .map(|label| normalize_graph_token(&label))
+                .map(|label| normalize_graph_token(&graph_edge_label(&label)))
                 .filter(|label| !label.is_empty())
                 .collect()
         })
@@ -417,8 +417,8 @@ pub(super) fn merge_edge_filters(
         merged.extend(filters);
     }
 
-    if let Some(filters) = projection
-        .and_then(|projection| normalize_token_filter_list(projection.edge_labels.clone()))
+    if let Some(filters) =
+        projection.and_then(|projection| normalize_edge_filters(projection.edge_labels.clone()))
     {
         merged.extend(filters);
     }

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -76,6 +76,74 @@ fn secret_sql_value_to_string(value: &Value) -> RedDBResult<String> {
     }
 }
 
+fn insert_config_json_path(
+    root: &mut crate::serde_json::Value,
+    path: &str,
+    value: crate::serde_json::Value,
+) {
+    let segments: Vec<&str> = path
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    insert_config_json_segments(root, &segments, value);
+}
+
+fn insert_config_json_segments(
+    root: &mut crate::serde_json::Value,
+    segments: &[&str],
+    value: crate::serde_json::Value,
+) {
+    if segments.is_empty() {
+        *root = value;
+        return;
+    }
+
+    if !matches!(root, crate::serde_json::Value::Object(_)) {
+        *root = crate::serde_json::Value::Object(crate::serde_json::Map::new());
+    }
+
+    let crate::serde_json::Value::Object(map) = root else {
+        return;
+    };
+    if segments.len() == 1 {
+        map.insert(segments[0].to_string(), value);
+        return;
+    }
+    let entry = map
+        .entry(segments[0].to_string())
+        .or_insert_with(|| crate::serde_json::Value::Object(crate::serde_json::Map::new()));
+    insert_config_json_segments(entry, &segments[1..], value);
+}
+
+fn show_config_json_result(
+    query: &str,
+    mode: crate::storage::query::modes::QueryMode,
+    prefix: &Option<String>,
+    value: crate::serde_json::Value,
+) -> RuntimeQueryResult {
+    let mut result = UnifiedResult::with_columns(vec!["key".into(), "value".into()]);
+    let mut record = UnifiedRecord::new();
+    record.set(
+        "key",
+        prefix
+            .as_ref()
+            .map(|key| Value::text(key.clone()))
+            .unwrap_or(Value::Null),
+    );
+    record.set("value", Value::Json(value.to_string_compact().into_bytes()));
+    result.push(record);
+    RuntimeQueryResult {
+        query: query.to_string(),
+        mode,
+        statement: "show_config_json",
+        engine: "runtime-config",
+        result,
+        affected_rows: 0,
+        statement_type: "select",
+        bookmark: None,
+    }
+}
+
 #[derive(Clone)]
 struct QueryControlEventSpec {
     kind: crate::runtime::control_events::EventKind,
@@ -774,6 +842,14 @@ fn query_control_event_specs(expr: &QueryExpr) -> Vec<QueryControlEventSpec> {
                 fields: Vec::new(),
             });
         }
+        QueryExpr::CreateUser(stmt) => {
+            specs.push(QueryControlEventSpec {
+                kind: EventKind::UserCreate,
+                action: "create_user",
+                resource: Some(format!("user:{}", stmt.username)),
+                fields: Vec::new(),
+            });
+        }
         _ => {}
     }
     specs
@@ -1420,6 +1496,7 @@ fn collect_query_expr_result_cache_scopes(scopes: &mut HashSet<String>, expr: &Q
         | QueryExpr::Grant(_)
         | QueryExpr::Revoke(_)
         | QueryExpr::AlterUser(_)
+        | QueryExpr::CreateUser(_)
         | QueryExpr::CreateIamPolicy { .. }
         | QueryExpr::DropIamPolicy { .. }
         | QueryExpr::AttachPolicy { .. }
@@ -4727,9 +4804,10 @@ impl RedDBRuntime {
             QueryExpr::TreeCommand(ref cmd) => self.execute_tree_command(query, cmd),
             // SET CONFIG key = value
             QueryExpr::SetConfig { ref key, ref value } => {
-                if key.starts_with("red.secret.") {
+                if key.starts_with("red.secret.") || key.starts_with("red.secrets.") {
                     return Err(RedDBError::Query(
-                        "red.secret.* is reserved for vault secrets; use SET SECRET".to_string(),
+                        "red.secret.* / red.secrets.* are reserved for vault secrets; use SET SECRET"
+                            .to_string(),
                     ));
                 }
                 match self.check_managed_config_write_for_set_config(key) {
@@ -4856,11 +4934,22 @@ impl RedDBRuntime {
                     bookmark: None,
                 })
             }
-            // SHOW CONFIG [prefix]
-            QueryExpr::ShowConfig { ref prefix } => {
+            // SHOW CONFIG [prefix] [AS JSON|FORMAT JSON]
+            QueryExpr::ShowConfig {
+                ref prefix,
+                as_json,
+            } => {
                 let store = self.inner.db.store();
                 let all_collections = store.list_collections();
                 if !all_collections.contains(&"red_config".to_string()) {
+                    if as_json {
+                        return Ok(show_config_json_result(
+                            query,
+                            mode,
+                            prefix,
+                            crate::serde_json::Value::Object(crate::serde_json::Map::new()),
+                        ));
+                    }
                     let result = UnifiedResult::with_columns(vec!["key".into(), "value".into()]);
                     return Ok(RuntimeQueryResult {
                         query: query.to_string(),
@@ -4901,6 +4990,25 @@ impl RedDBRuntime {
                             }
                         }
                     }
+                }
+                if as_json {
+                    let mut tree = crate::serde_json::Value::Object(crate::serde_json::Map::new());
+                    for (key, (_, _, val)) in latest {
+                        let relative = match prefix {
+                            Some(pfx) if key == *pfx => "",
+                            Some(pfx) => key
+                                .strip_prefix(pfx.as_str())
+                                .and_then(|tail| tail.strip_prefix('.'))
+                                .unwrap_or(key.as_str()),
+                            None => key.as_str(),
+                        };
+                        insert_config_json_path(
+                            &mut tree,
+                            relative,
+                            crate::presentation::entity_json::storage_value_to_json(&val),
+                        );
+                    }
+                    return Ok(show_config_json_result(query, mode, prefix, tree));
                 }
                 let mut result = UnifiedResult::with_columns(vec!["key".into(), "value".into()]);
                 for (_, key_val, val) in latest.into_values() {
@@ -5901,6 +6009,7 @@ impl RedDBRuntime {
             QueryExpr::Grant(ref g) => self.execute_grant_statement(query, g),
             QueryExpr::Revoke(ref r) => self.execute_revoke_statement(query, r),
             QueryExpr::AlterUser(ref a) => self.execute_alter_user_statement(query, a),
+            QueryExpr::CreateUser(ref u) => self.execute_create_user_statement(query, u),
             QueryExpr::CreateIamPolicy { ref id, ref json } => {
                 self.execute_create_iam_policy(query, id, json)
             }
@@ -6242,12 +6351,14 @@ impl RedDBRuntime {
                     | KvCommand::Cas {
                         collection, model, ..
                     }
+                    | KvCommand::List {
+                        collection, model, ..
+                    }
                     | KvCommand::Delete {
                         collection, model, ..
                     } => (collection.as_str(), *model),
                     KvCommand::Rotate { collection, .. }
                     | KvCommand::History { collection, .. }
-                    | KvCommand::List { collection, .. }
                     | KvCommand::Purge { collection, .. } => {
                         (collection.as_str(), CollectionModel::Vault)
                     }
@@ -9376,9 +9487,12 @@ impl RedDBRuntime {
             // table — for now we emit a single Select on the database
             // (admins bypass; non-admins need a Database/Schema grant).
             QueryExpr::Join(_) => (Action::Select, Resource::Database),
-            // GRANT / REVOKE / ALTER USER are authority statements;
+            // GRANT / REVOKE / USER DDL are authority statements;
             // require Admin (the helper methods enforce).
-            QueryExpr::Grant(_) | QueryExpr::Revoke(_) | QueryExpr::AlterUser(_) => {
+            QueryExpr::Grant(_)
+            | QueryExpr::Revoke(_)
+            | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_) => {
                 return if role == crate::auth::Role::Admin {
                     Ok(())
                 } else {
@@ -10670,6 +10784,51 @@ impl RedDBRuntime {
             query.to_string(),
             &format!("REVOKE removed {} grant(s)", total_removed),
             "revoke",
+        ))
+    }
+
+    /// Translate the parsed [`CreateUserStmt`] into an AuthStore user.
+    fn execute_create_user_statement(
+        &self,
+        query: &str,
+        stmt: &crate::storage::query::ast::CreateUserStmt,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let auth_store = self
+            .inner
+            .auth_store
+            .read()
+            .clone()
+            .ok_or_else(|| RedDBError::Query("auth store not configured".to_string()))?;
+
+        let (_gname, grole) = current_auth_identity().ok_or_else(|| {
+            RedDBError::Query("CREATE USER requires an authenticated principal".to_string())
+        })?;
+        if grole != crate::auth::Role::Admin {
+            return Err(RedDBError::Query(
+                "CREATE USER requires Admin role".to_string(),
+            ));
+        }
+
+        let role = crate::auth::Role::from_str(&stmt.role)
+            .ok_or_else(|| RedDBError::Query(format!("invalid role `{}`", stmt.role)))?;
+        let user = auth_store
+            .create_user_in_tenant(stmt.tenant.as_deref(), &stmt.username, &stmt.password, role)
+            .map_err(|e| RedDBError::Query(e.to_string()))?;
+
+        self.invalidate_result_cache();
+        let target = crate::auth::UserId::from_parts(user.tenant_id.as_deref(), &user.username);
+        tracing::info!(
+            target: "audit",
+            principal = %target,
+            role = %role,
+            action = "create_user",
+            "CREATE USER applied"
+        );
+
+        Ok(RuntimeQueryResult::ok_message(
+            query.to_string(),
+            &format!("CREATE USER {} applied", target),
+            "create_user",
         ))
     }
 

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1281,11 +1281,7 @@ impl RedDBRuntime {
                                 &query.with_metadata,
                             );
                             let (columns, values) = pairwise_columns_values(&document_values);
-                            let body_str = find_column_value_string(&columns, &values, "body")?;
-                            let body: crate::json::Value = crate::json::from_str(&body_str)
-                                .map_err(|e| {
-                                    RedDBError::Query(format!("invalid JSON body: {e}"))
-                                })?;
+                            let body = find_document_body_json(&columns, &values)?;
                             let input = CreateDocumentInput {
                                 collection: query.table.clone(),
                                 body,
@@ -3527,6 +3523,28 @@ fn find_column_value_string(
         Value::Float(n) => Ok(n.to_string()),
         other => Err(RedDBError::Query(format!(
             "column '{name}' expected text, got {other:?}"
+        ))),
+    }
+}
+
+fn find_document_body_json(
+    columns: &[String],
+    values: &[Value],
+) -> RedDBResult<crate::json::Value> {
+    let val = find_column_value(columns, values, "body")?;
+    match val {
+        Value::Json(bytes) | Value::Blob(bytes) => crate::json::from_slice(&bytes)
+            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        Value::Text(text) => crate::json::from_str(text.as_ref())
+            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        Value::Integer(value) => crate::json::from_str(&value.to_string())
+            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        Value::UnsignedInteger(value) => crate::json::from_str(&value.to_string())
+            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        Value::Float(value) => crate::json::from_str(&value.to_string())
+            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        other => Err(RedDBError::Query(format!(
+            "column 'body' expected JSON body, got {other:?}"
         ))),
     }
 }

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -600,6 +600,47 @@ impl<'a> KvAtomicOps<'a> {
         Ok(None)
     }
 
+    fn latest_kv_entries(
+        &self,
+        collection: &str,
+        prefix: Option<&str>,
+    ) -> RedDBResult<Vec<(String, crate::storage::UnifiedEntity)>> {
+        self.ensure_declared_model(crate::catalog::CollectionModel::Kv, collection)?;
+        let store = self.runtime.inner.db.store();
+        let Some(manager) = store.get_collection(collection) else {
+            return Ok(Vec::new());
+        };
+        let mut entries: std::collections::BTreeMap<String, crate::storage::UnifiedEntity> =
+            std::collections::BTreeMap::new();
+        for entity in manager.query_all(|_| true) {
+            let key = match &entity.data {
+                crate::storage::EntityData::Row(row) => row
+                    .named
+                    .as_ref()
+                    .and_then(|named| named.get("key"))
+                    .and_then(|value| match value {
+                        crate::storage::schema::Value::Text(key) => Some(key.to_string()),
+                        _ => None,
+                    }),
+                _ => None,
+            };
+            let Some(key) = key else {
+                continue;
+            };
+            if prefix.is_some_and(|prefix| !key.starts_with(prefix)) {
+                continue;
+            }
+            let should_replace = match entries.get(&key) {
+                Some(existing) => entity.id.raw() >= existing.id.raw(),
+                None => true,
+            };
+            if should_replace {
+                entries.insert(key, entity);
+            }
+        }
+        Ok(entries.into_iter().collect())
+    }
+
     fn get_vault_entry(&self, collection: &str, key: &str) -> RedDBResult<Option<VaultEntry>> {
         self.vault_versions(collection, key)
             .map(super::keyed_spine::latest_version)
@@ -1459,74 +1500,151 @@ impl RedDBRuntime {
                 prefix,
                 limit,
                 offset,
+                as_json,
             } => {
-                if *model != crate::catalog::CollectionModel::Vault {
-                    return Err(RedDBError::InvalidOperation(
-                        "LIST is not supported through normal KV command execution".to_string(),
-                    ));
-                }
-                let mut entries = ops.latest_vault_entries(collection, prefix.as_deref())?;
-                entries.sort_by(|left, right| left.key.cmp(&right.key));
-                let mut result = UnifiedResult::with_columns(vec![
-                    "collection".into(),
-                    "key".into(),
-                    "version".into(),
-                    "fingerprint".into(),
-                    "tags".into(),
-                    "created_at".into(),
-                    "updated_at".into(),
-                    "status".into(),
-                    "tombstone".into(),
-                    "op".into(),
-                ]);
-                let mut visible = Vec::new();
-                for entry in entries {
-                    match self.check_vault_capability("vault:read_metadata", collection, &entry.key)
-                    {
-                        Ok(()) => {
-                            self.emit_vault_control_event(
-                                crate::runtime::control_events::EventKind::VaultMetadataRead,
-                                crate::runtime::control_events::Outcome::Allowed,
-                                "vault:read_metadata",
-                                collection,
-                                &entry.key,
-                                "ok",
-                                Some(&entry),
-                                Vec::new(),
-                            )?;
-                            visible.push(entry);
-                        }
-                        Err(reason) => {
-                            self.emit_vault_control_event(
-                                crate::runtime::control_events::EventKind::VaultMetadataRead,
-                                crate::runtime::control_events::Outcome::Denied,
-                                "vault:read_metadata",
-                                collection,
-                                &entry.key,
-                                &reason,
-                                Some(&entry),
-                                Vec::new(),
-                            )?;
+                if *model == crate::catalog::CollectionModel::Vault {
+                    if *as_json {
+                        return Err(RedDBError::Query(
+                            "LIST VAULT AS JSON is not supported; vault list only exposes metadata"
+                                .to_string(),
+                        ));
+                    }
+                    let mut entries = ops.latest_vault_entries(collection, prefix.as_deref())?;
+                    entries.sort_by(|left, right| left.key.cmp(&right.key));
+                    let mut result = UnifiedResult::with_columns(vec![
+                        "collection".into(),
+                        "key".into(),
+                        "version".into(),
+                        "fingerprint".into(),
+                        "tags".into(),
+                        "created_at".into(),
+                        "updated_at".into(),
+                        "status".into(),
+                        "tombstone".into(),
+                        "op".into(),
+                    ]);
+                    let mut visible = Vec::new();
+                    for entry in entries {
+                        match self.check_vault_capability(
+                            "vault:read_metadata",
+                            collection,
+                            &entry.key,
+                        ) {
+                            Ok(()) => {
+                                self.emit_vault_control_event(
+                                    crate::runtime::control_events::EventKind::VaultMetadataRead,
+                                    crate::runtime::control_events::Outcome::Allowed,
+                                    "vault:read_metadata",
+                                    collection,
+                                    &entry.key,
+                                    "ok",
+                                    Some(&entry),
+                                    Vec::new(),
+                                )?;
+                                visible.push(entry);
+                            }
+                            Err(reason) => {
+                                self.emit_vault_control_event(
+                                    crate::runtime::control_events::EventKind::VaultMetadataRead,
+                                    crate::runtime::control_events::Outcome::Denied,
+                                    "vault:read_metadata",
+                                    collection,
+                                    &entry.key,
+                                    &reason,
+                                    Some(&entry),
+                                    Vec::new(),
+                                )?;
+                            }
                         }
                     }
+                    for entry in visible
+                        .into_iter()
+                        .skip(*offset)
+                        .take(limit.unwrap_or(usize::MAX))
+                    {
+                        push_vault_metadata_record(&mut result, collection, &entry.key, &entry);
+                    }
+                    return Ok(RuntimeQueryResult {
+                        query: raw_query.to_string(),
+                        mode: crate::storage::query::modes::QueryMode::Sql,
+                        statement: "vault_list",
+                        engine: "vault",
+                        result,
+                        affected_rows: 0,
+                        statement_type: "select",
+                        bookmark: None,
+                    });
+                } else {
+                    let mut result = UnifiedResult::with_columns(vec![
+                        "rid".into(),
+                        "collection".into(),
+                        "kind".into(),
+                        "tenant".into(),
+                        "created_at".into(),
+                        "updated_at".into(),
+                        "key".into(),
+                        "value".into(),
+                        "tags".into(),
+                    ]);
+                    let entries = ops.latest_kv_entries(collection, prefix.as_deref())?;
+                    if *as_json {
+                        let mut tree = crate::json::Value::Object(crate::json::Map::new());
+                        for (key, entity) in entries
+                            .into_iter()
+                            .skip(*offset)
+                            .take(limit.unwrap_or(usize::MAX))
+                        {
+                            let Some(value) = kv_value_from_entity(&entity) else {
+                                continue;
+                            };
+                            let relative = match prefix {
+                                Some(pfx) if key == *pfx => "",
+                                Some(pfx) => key
+                                    .strip_prefix(pfx.as_str())
+                                    .map(|tail| tail.strip_prefix('.').unwrap_or(tail))
+                                    .unwrap_or(key.as_str()),
+                                None => key.as_str(),
+                            };
+                            insert_kv_json_path(
+                                &mut tree,
+                                relative,
+                                crate::presentation::entity_json::storage_value_to_json(&value),
+                            );
+                        }
+                        return Ok(kv_list_json_result(raw_query, collection, prefix, tree));
+                    }
+                    for (key, entity) in entries
+                        .into_iter()
+                        .skip(*offset)
+                        .take(limit.unwrap_or(usize::MAX))
+                    {
+                        let mut record = UnifiedRecord::new();
+                        record.set("rid", Value::UnsignedInteger(entity.id.raw()));
+                        record.set("collection", Value::text(collection.clone()));
+                        record.set("kind", Value::text("kv"));
+                        record.set("tenant", Value::Null);
+                        record.set("created_at", Value::UnsignedInteger(entity.created_at));
+                        record.set("updated_at", Value::UnsignedInteger(entity.updated_at));
+                        record.set("key", Value::text(key.clone()));
+                        record.set(
+                            "value",
+                            kv_value_from_entity(&entity)
+                                .unwrap_or(crate::storage::schema::Value::Null),
+                        );
+                        record.set("tags", kv_tags_value(&ops.tags_for_key(collection, &key)));
+                        result.push(record);
+                    }
+                    return Ok(RuntimeQueryResult {
+                        query: raw_query.to_string(),
+                        mode: crate::storage::query::modes::QueryMode::Sql,
+                        statement: "kv_list",
+                        engine: "kv",
+                        result,
+                        affected_rows: 0,
+                        statement_type: "select",
+                        bookmark: None,
+                    });
                 }
-                for entry in visible
-                    .into_iter()
-                    .skip(*offset)
-                    .take(limit.unwrap_or(usize::MAX))
-                {
-                    push_vault_metadata_record(&mut result, collection, &entry.key, &entry);
-                }
-                Ok(RuntimeQueryResult {
-                    query: raw_query.to_string(),
-                    mode: crate::storage::query::modes::QueryMode::Sql,
-                    statement: "vault_list",
-                    engine: "vault",
-                    result,
-                    affected_rows: 0,
-                    statement_type: "select",
-                    bookmark: None,
-                })
             }
 
             KvCommand::History { collection, key } => {
@@ -2506,6 +2624,72 @@ fn kv_value_from_entity(entity: &crate::storage::UnifiedEntity) -> Option<Value>
         }
     }
     None
+}
+
+fn insert_kv_json_path(root: &mut crate::json::Value, path: &str, value: crate::json::Value) {
+    let segments: Vec<&str> = path
+        .split('.')
+        .filter(|segment| !segment.is_empty())
+        .collect();
+    insert_kv_json_segments(root, &segments, value);
+}
+
+fn insert_kv_json_segments(
+    root: &mut crate::json::Value,
+    segments: &[&str],
+    value: crate::json::Value,
+) {
+    if segments.is_empty() {
+        *root = value;
+        return;
+    }
+
+    if !matches!(root, crate::json::Value::Object(_)) {
+        *root = crate::json::Value::Object(crate::json::Map::new());
+    }
+
+    let crate::json::Value::Object(map) = root else {
+        return;
+    };
+    if segments.len() == 1 {
+        map.insert(segments[0].to_string(), value);
+        return;
+    }
+    let entry = map
+        .entry(segments[0].to_string())
+        .or_insert_with(|| crate::json::Value::Object(crate::json::Map::new()));
+    insert_kv_json_segments(entry, &segments[1..], value);
+}
+
+fn kv_list_json_result(
+    raw_query: &str,
+    collection: &str,
+    prefix: &Option<String>,
+    value: crate::json::Value,
+) -> RuntimeQueryResult {
+    let mut result =
+        UnifiedResult::with_columns(vec!["collection".into(), "prefix".into(), "value".into()]);
+    let mut record = UnifiedRecord::new();
+    record.set("collection", Value::text(collection.to_string()));
+    record.set(
+        "prefix",
+        prefix
+            .as_ref()
+            .map(|prefix| Value::text(prefix.clone()))
+            .unwrap_or(Value::Null),
+    );
+    record.set("value", Value::Json(value.to_string_compact().into_bytes()));
+    result.push(record);
+    RuntimeQueryResult {
+        query: raw_query.to_string(),
+        mode: crate::storage::query::modes::QueryMode::Sql,
+        statement: "kv_list_json",
+        engine: "kv",
+        result,
+        affected_rows: 0,
+        statement_type: "select",
+        bookmark: None,
+    }
 }
 
 fn kv_collection_contract(name: &str) -> crate::physical::CollectionContract {

--- a/crates/reddb-server/src/runtime/impl_native.rs
+++ b/crates/reddb-server/src/runtime/impl_native.rs
@@ -11,12 +11,48 @@ impl RedDBRuntime {
 
     pub fn create_snapshot(&self) -> RedDBResult<SnapshotDescriptor> {
         self.checkpoint()?;
-        self.inner
-            .db
-            .snapshots()
-            .last()
-            .cloned()
-            .ok_or_else(|| RedDBError::Internal("snapshot metadata was not recorded".to_string()))
+        if let Some(snapshot) = self.inner.db.snapshots().last().cloned() {
+            return Ok(snapshot);
+        }
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        let (sequence, collection_count, total_entities) =
+            if let Some(state) = self.inner.db.native_physical_state() {
+                let (collection_count, total_entities) = state
+                    .catalog
+                    .as_ref()
+                    .map(|catalog| {
+                        (
+                            catalog.collection_count as usize,
+                            catalog.total_entities as usize,
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        let catalog = self.inner.db.catalog_snapshot();
+                        (catalog.total_collections, catalog.total_entities)
+                    });
+                (state.header.sequence, collection_count, total_entities)
+            } else {
+                let catalog = self.inner.db.catalog_snapshot();
+                let sequence = self
+                    .inner
+                    .db
+                    .physical_metadata()
+                    .map(|metadata| metadata.superblock.sequence)
+                    .unwrap_or(1);
+                (sequence, catalog.total_collections, catalog.total_entities)
+            };
+
+        Ok(SnapshotDescriptor {
+            snapshot_id: sequence,
+            created_at_unix_ms: now,
+            superblock_sequence: sequence,
+            collection_count,
+            total_entities,
+        })
     }
 
     pub fn exports(&self) -> RedDBResult<Vec<ExportDescriptor>> {

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -7,6 +7,7 @@
 //! the IndexStore finds the right index and returns matching entity IDs.
 
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ops::Bound::{Excluded, Included, Unbounded};
 
@@ -1166,6 +1167,11 @@ impl IndexStore {
         entities: &[(EntityId, Vec<(String, Value)>)],
     ) -> Result<usize, String> {
         let col = columns.first().map(|s| s.as_str()).unwrap_or("");
+        if columns.len() > 1 && columns.iter().any(|column| column.contains('.')) {
+            return Err(
+                "document path indexes currently support a single indexed column".to_string(),
+            );
+        }
 
         match method {
             IndexMethodKind::Hash => {
@@ -1181,14 +1187,12 @@ impl IndexStore {
                 // Index existing entities
                 let mut count = 0;
                 for (entity_id, fields) in entities {
-                    for (field_name, value) in fields {
-                        if field_name == col {
-                            let key = value_to_bytes(value);
-                            self.hash
-                                .insert(collection, name, key, *entity_id)
-                                .map_err(|err| err.to_string())?;
-                            count += 1;
-                        }
+                    if let Some(value) = index_field_value(fields, col) {
+                        let key = value_to_bytes(value.as_ref());
+                        self.hash
+                            .insert(collection, name, key, *entity_id)
+                            .map_err(|err| err.to_string())?;
+                        count += 1;
                     }
                 }
                 Ok(count)
@@ -1198,14 +1202,12 @@ impl IndexStore {
 
                 let mut count = 0;
                 for (entity_id, fields) in entities {
-                    for (field_name, value) in fields {
-                        if field_name == col {
-                            let key = value_to_bytes(value);
-                            self.bitmap
-                                .insert(collection, col, *entity_id, &key)
-                                .map_err(|err| err.to_string())?;
-                            count += 1;
-                        }
+                    if let Some(value) = index_field_value(fields, col) {
+                        let key = value_to_bytes(value.as_ref());
+                        self.bitmap
+                            .insert(collection, col, *entity_id, &key)
+                            .map_err(|err| err.to_string())?;
+                        count += 1;
                     }
                 }
                 Ok(count)
@@ -1226,7 +1228,14 @@ impl IndexStore {
                     return Ok(count);
                 }
                 // Build sorted in-memory index for range scans (single col)
-                let count = self.sorted.build_index(collection, col, entities);
+                let derived_entities;
+                let sorted_entities = if col.contains('.') {
+                    derived_entities = derive_index_entities_for_column(entities, col);
+                    derived_entities.as_slice()
+                } else {
+                    entities
+                };
+                let count = self.sorted.build_index(collection, col, sorted_entities);
                 // Also build hash index for equality lookups on same column
                 self.hash
                     .create_index(&HashIndexConfig {
@@ -1237,13 +1246,11 @@ impl IndexStore {
                     })
                     .map_err(|err| err.to_string())?;
                 for (entity_id, fields) in entities {
-                    for (field_name, value) in fields {
-                        if field_name == col {
-                            let key = value_to_bytes(value);
-                            self.hash
-                                .insert(collection, &format!("{name}_hash"), key, *entity_id)
-                                .map_err(|err| err.to_string())?;
-                        }
+                    if let Some(value) = index_field_value(fields, col) {
+                        let key = value_to_bytes(value.as_ref());
+                        self.hash
+                            .insert(collection, &format!("{name}_hash"), key, *entity_id)
+                            .map_err(|err| err.to_string())?;
                     }
                 }
                 Ok(count)
@@ -1439,11 +1446,8 @@ impl IndexStore {
             let btree_hash_name =
                 matches!(idx.method, IndexMethodKind::BTree).then(|| format!("{}_hash", idx.name));
             for (entity_id, fields) in rows {
-                for (field_name, value) in fields {
-                    if field_name != col {
-                        continue;
-                    }
-                    let key = value_to_bytes(value);
+                if let Some(value) = index_field_value(fields, col) {
+                    let key = value_to_bytes(value.as_ref());
                     match idx.method {
                         IndexMethodKind::Hash => {
                             self.hash
@@ -1461,7 +1465,8 @@ impl IndexStore {
                                     "sorted index for collection '{collection}' column '{col}' was not found"
                                 ));
                             }
-                            self.sorted.insert_one(collection, col, value, *entity_id);
+                            self.sorted
+                                .insert_one(collection, col, value.as_ref(), *entity_id);
                             let hash_name = btree_hash_name.as_deref().unwrap_or("");
                             self.hash
                                 .insert(collection, hash_name, key, *entity_id)
@@ -1469,9 +1474,6 @@ impl IndexStore {
                         }
                         IndexMethodKind::Spatial => {}
                     }
-                    // Column names are unique per row — early-exit
-                    // the inner field scan.
-                    break;
                 }
             }
         }
@@ -1503,33 +1505,32 @@ impl IndexStore {
             }
 
             let col = idx.columns.first().map(|s| s.as_str()).unwrap_or("");
-            for (field_name, value) in fields {
-                if field_name == col {
-                    let key = value_to_bytes(value);
-                    match idx.method {
-                        IndexMethodKind::Hash => {
-                            self.hash
-                                .insert(collection, &idx.name, key, entity_id)
-                                .map_err(|err| err.to_string())?;
-                        }
-                        IndexMethodKind::Bitmap => {
-                            self.bitmap
-                                .insert(collection, col, entity_id, &key)
-                                .map_err(|err| err.to_string())?;
-                        }
-                        IndexMethodKind::BTree => {
-                            if !self.sorted.has_index(collection, col) {
-                                return Err(format!(
-                                    "sorted index for collection '{collection}' column '{col}' was not found"
-                                ));
-                            }
-                            self.sorted.insert_one(collection, col, value, entity_id);
-                            self.hash
-                                .insert(collection, &format!("{}_hash", idx.name), key, entity_id)
-                                .map_err(|err| err.to_string())?;
-                        }
-                        IndexMethodKind::Spatial => {}
+            if let Some(value) = index_field_value(fields, col) {
+                let key = value_to_bytes(value.as_ref());
+                match idx.method {
+                    IndexMethodKind::Hash => {
+                        self.hash
+                            .insert(collection, &idx.name, key, entity_id)
+                            .map_err(|err| err.to_string())?;
                     }
+                    IndexMethodKind::Bitmap => {
+                        self.bitmap
+                            .insert(collection, col, entity_id, &key)
+                            .map_err(|err| err.to_string())?;
+                    }
+                    IndexMethodKind::BTree => {
+                        if !self.sorted.has_index(collection, col) {
+                            return Err(format!(
+                                "sorted index for collection '{collection}' column '{col}' was not found"
+                            ));
+                        }
+                        self.sorted
+                            .insert_one(collection, col, value.as_ref(), entity_id);
+                        self.hash
+                            .insert(collection, &format!("{}_hash", idx.name), key, entity_id)
+                            .map_err(|err| err.to_string())?;
+                    }
+                    IndexMethodKind::Spatial => {}
                 }
             }
         }
@@ -1567,28 +1568,27 @@ impl IndexStore {
             }
 
             let col = idx.columns.first().map(|s| s.as_str()).unwrap_or("");
-            for (field_name, value) in fields {
-                if field_name == col {
-                    let key = value_to_bytes(value);
-                    match idx.method {
-                        IndexMethodKind::Hash => {
-                            // Missing index on delete is non-fatal.
-                            let _ = self.hash.remove(collection, &idx.name, &key, entity_id);
-                        }
-                        IndexMethodKind::Bitmap => {
-                            let _ = self.bitmap.remove(collection, col, entity_id);
-                        }
-                        IndexMethodKind::BTree => {
-                            self.sorted.delete_one(collection, col, value, entity_id);
-                            let _ = self.hash.remove(
-                                collection,
-                                &format!("{}_hash", idx.name),
-                                &key,
-                                entity_id,
-                            );
-                        }
-                        IndexMethodKind::Spatial => {}
+            if let Some(value) = index_field_value(fields, col) {
+                let key = value_to_bytes(value.as_ref());
+                match idx.method {
+                    IndexMethodKind::Hash => {
+                        // Missing index on delete is non-fatal.
+                        let _ = self.hash.remove(collection, &idx.name, &key, entity_id);
                     }
+                    IndexMethodKind::Bitmap => {
+                        let _ = self.bitmap.remove(collection, col, entity_id);
+                    }
+                    IndexMethodKind::BTree => {
+                        self.sorted
+                            .delete_one(collection, col, value.as_ref(), entity_id);
+                        let _ = self.hash.remove(
+                            collection,
+                            &format!("{}_hash", idx.name),
+                            &key,
+                            entity_id,
+                        );
+                    }
+                    IndexMethodKind::Spatial => {}
                 }
             }
         }
@@ -1753,6 +1753,36 @@ impl SecondaryIndexBackend for IndexStore {
             IncMethodKind::Spatial => {}
         }
     }
+}
+
+fn index_field_value<'a>(fields: &'a [(String, Value)], column: &str) -> Option<Cow<'a, Value>> {
+    if let Some((_, value)) = fields.iter().find(|(field, _)| field == column) {
+        return Some(Cow::Borrowed(value));
+    }
+    if !column.contains('.') {
+        return None;
+    }
+
+    let segments = super::join_filter::parse_runtime_document_path(column);
+    let (root, tail) = segments.split_first()?;
+    if tail.is_empty() {
+        return None;
+    }
+    let (_, root_value) = fields.iter().find(|(field, _)| field == root)?;
+    super::join_filter::resolve_runtime_document_path_from_value(root_value, tail).map(Cow::Owned)
+}
+
+fn derive_index_entities_for_column(
+    entities: &[(EntityId, Vec<(String, Value)>)],
+    column: &str,
+) -> Vec<(EntityId, Vec<(String, Value)>)> {
+    entities
+        .iter()
+        .filter_map(|(entity_id, fields)| {
+            index_field_value(fields, column)
+                .map(|value| (*entity_id, vec![(column.to_string(), value.into_owned())]))
+        })
+        .collect()
 }
 
 /// Convert a Value to bytes for index key

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -1507,7 +1507,7 @@ pub(super) fn resolve_runtime_document_path(record: &UnifiedRecord, path: &str) 
     resolve_runtime_document_path_from_value(flattened_value, flattened_tail)
 }
 
-pub(super) fn resolve_runtime_document_path_from_value(
+pub(crate) fn resolve_runtime_document_path_from_value(
     value: &Value,
     path: &[String],
 ) -> Option<Value> {
@@ -1579,7 +1579,7 @@ pub(super) fn runtime_json_value_to_runtime_value(value: &JsonValue) -> Option<V
     }
 }
 
-pub(super) fn parse_runtime_document_path(path: &str) -> Vec<String> {
+pub(crate) fn parse_runtime_document_path(path: &str) -> Vec<String> {
     let mut segments = Vec::new();
     let mut current = String::new();
     let mut chars = path.chars().peekable();
@@ -2076,6 +2076,7 @@ pub(super) fn query_expr_name(expr: &QueryExpr) -> &'static str {
         QueryExpr::Grant(_) => "grant",
         QueryExpr::Revoke(_) => "revoke",
         QueryExpr::AlterUser(_) => "alter_user",
+        QueryExpr::CreateUser(_) => "create_user",
         QueryExpr::CreateIamPolicy { .. } => "create_iam_policy",
         QueryExpr::DropIamPolicy { .. } => "drop_iam_policy",
         QueryExpr::AttachPolicy { .. } => "attach_policy",
@@ -2902,7 +2903,9 @@ pub(super) fn eval_projection_value(proj: &Projection, source: &UnifiedRecord) -
             }
             source.get(col.as_str()).cloned()
         }
-        Projection::Alias(col, _) => source.get(col.as_str()).cloned(),
+        Projection::Alias(col, _) => {
+            eval_projection_value(&Projection::Column(col.clone()), source)
+        }
         Projection::Field(field, _) => resolve_runtime_field(source, field, None, None),
         Projection::Function(name, inner_args) => {
             crate::storage::query::sql_lowering::projection_to_expr(proj)

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -466,6 +466,12 @@ pub(super) fn execute_runtime_canonical_expr_node(
 ) -> RedDBResult<Vec<UnifiedRecord>> {
     match expr {
         QueryExpr::Table(table) => {
+            if matches!(
+                table.source,
+                Some(crate::storage::query::ast::TableSource::Subquery(_))
+            ) {
+                return execute_runtime_canonical_table_query_indexed(db, table, None);
+            }
             let table_name = table.table.as_str();
             let table_alias = table.alias.as_deref().unwrap_or(table_name);
             let context = RuntimeTableExecutionContext {

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -230,7 +230,9 @@ pub(crate) fn extract_zone_predicates(
     }
 }
 
-/// Extract simple column names from SELECT projections for projection pushdown.
+/// Extract source column names from SELECT projections for projection pushdown.
+/// Dotted JSON/document paths need their root column materialized so the
+/// projection phase can resolve the remaining path.
 /// Returns empty Vec for SELECT * or when projections contain expressions/functions.
 pub(crate) fn extract_select_column_names(projections: &[Projection]) -> Vec<String> {
     if projections.is_empty() || projections.iter().any(|p| matches!(p, Projection::All)) {
@@ -240,12 +242,26 @@ pub(crate) fn extract_select_column_names(projections: &[Projection]) -> Vec<Str
         .iter()
         .filter_map(|p| match p {
             Projection::Column(c) | Projection::Alias(c, _) if !c.starts_with("LIT:") => {
-                Some(c.clone())
+                Some(projection_source_column(c))
             }
-            Projection::Field(FieldRef::TableColumn { column: c, .. }, _) => Some(c.clone()),
+            Projection::Field(FieldRef::TableColumn { table, column }, _)
+                if !table.is_empty() && column.contains('.') =>
+            {
+                Some(table.clone())
+            }
+            Projection::Field(FieldRef::TableColumn { column, .. }, _) => {
+                Some(projection_source_column(column))
+            }
             _ => None,
         })
         .collect()
+}
+
+fn projection_source_column(column: &str) -> String {
+    column
+        .split_once('.')
+        .map(|(head, _)| head.to_string())
+        .unwrap_or_else(|| column.to_string())
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/reddb-server/src/runtime/query_exec/join.rs
+++ b/crates/reddb-server/src/runtime/query_exec/join.rs
@@ -326,6 +326,7 @@ pub(crate) fn runtime_join_table_context(
         | QueryExpr::Grant(_)
         | QueryExpr::Revoke(_)
         | QueryExpr::AlterUser(_)
+        | QueryExpr::CreateUser(_)
         | QueryExpr::CreateIamPolicy { .. }
         | QueryExpr::DropIamPolicy { .. }
         | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -45,6 +45,18 @@ fn resolve_table_row_by_logical_id(
     TableRowMvccReadResolver::current_statement().resolve_logical_id(&store, table, logical_id)
 }
 
+fn projections_require_runtime_eval(projections: &[Projection]) -> bool {
+    projections.iter().any(|projection| {
+        matches!(
+            projection,
+            Projection::Function(_, _) | Projection::Expression(_, _) | Projection::Window { .. }
+        ) || matches!(
+            projection,
+            Projection::Column(column) | Projection::Alias(column, _) if column.starts_with("LIT:")
+        )
+    })
+}
+
 pub(crate) fn execute_runtime_canonical_table_query_indexed(
     db: &RedDB,
     query: &TableQuery,
@@ -54,6 +66,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     let effective_filter = effective_table_filter(query);
     let effective_group_by = effective_table_group_by_exprs(query);
     let effective_having = effective_table_having_filter(query);
+    let requires_runtime_projection = projections_require_runtime_eval(&effective_projections);
+    let uses_document_projection =
+        runtime_projections_use_document_path(&effective_projections, query);
 
     // Hypertable chunk pruning (PRD #850, Phase 0): when this table is a
     // hypertable and the WHERE clause constrains the time column, consult
@@ -149,7 +164,28 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     records.truncate(limit as usize);
                 }
 
-                return Ok(records);
+                crate::runtime::window_phase::apply(
+                    Some(db),
+                    &mut records,
+                    &effective_projections,
+                    None,
+                    outer_alias,
+                )?;
+
+                return Ok(records
+                    .iter()
+                    .map(|record| {
+                        project_runtime_record_with_db(
+                            Some(db),
+                            record,
+                            &effective_projections,
+                            None,
+                            outer_alias,
+                            false,
+                            false,
+                        )
+                    })
+                    .collect());
             }
             other => {
                 return Err(RedDBError::Query(format!(
@@ -200,11 +236,13 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             extract_cross_index_predicates(filter, &query.table, idx_store)
         })
         .is_some();
-    if let (false, Some(idx_store), Some(ref filter), false) = (
+    if let (false, Some(idx_store), Some(ref filter), false, false, false) = (
         requires_mvcc_index_fallback,
         index_store,
         &effective_filter,
         has_cross_index_candidate,
+        requires_runtime_projection,
+        uses_document_projection,
     ) {
         let trace = std::env::var("REDDB_INDEX_TRACE").ok().as_deref() == Some("1");
         let sorted_res = try_sorted_index_lookup(
@@ -362,9 +400,13 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     // Equivalent to PG's bitmap heap scan where two bitmap indexes are AND-ed
     // at word level before touching heap pages. Here we use HashSet instead of
     // actual bitmaps but the reduction in entity fetches is the same.
-    if let (false, Some(idx_store), Some(ref filter)) =
-        (requires_mvcc_index_fallback, index_store, &effective_filter)
-    {
+    if let (false, Some(idx_store), Some(ref filter), false, false) = (
+        requires_mvcc_index_fallback,
+        index_store,
+        &effective_filter,
+        requires_runtime_projection,
+        uses_document_projection,
+    ) {
         if let Some((eq_col, eq_bytes, range_filter)) =
             extract_cross_index_predicates(filter, &query.table, idx_store)
         {
@@ -463,9 +505,13 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     // - Optionally narrow further via sorted range scan filtered by the intersection set
     // - Fetch only the surviving rows; re-apply full compiled filter for residual predicates
     // Only fires when ≥2 indexed equality columns exist in the filter.
-    if let (false, Some(idx_store), Some(ref filter)) =
-        (requires_mvcc_index_fallback, index_store, &effective_filter)
-    {
+    if let (false, Some(idx_store), Some(ref filter), false, false) = (
+        requires_mvcc_index_fallback,
+        index_store,
+        &effective_filter,
+        requires_runtime_projection,
+        uses_document_projection,
+    ) {
         let mut eq_candidates: Vec<(String, Vec<u8>, crate::storage::schema::Value)> = Vec::new();
         extract_all_eq_candidates(filter, &mut eq_candidates);
 
@@ -593,9 +639,13 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     }
 
     // ── INDEX-ASSISTED PATH: use hash index for O(1) equality lookups ──
-    if let (false, Some(idx_store), Some(ref filter)) =
-        (requires_mvcc_index_fallback, index_store, &effective_filter)
-    {
+    if let (false, Some(idx_store), Some(ref filter), false, false) = (
+        requires_mvcc_index_fallback,
+        index_store,
+        &effective_filter,
+        requires_runtime_projection,
+        uses_document_projection,
+    ) {
         if let Some((column, value_bytes)) = extract_index_candidate(filter) {
             if let Some(idx) = idx_store.find_index_for_column(&query.table, &column) {
                 let mut entity_ids = idx_store
@@ -726,9 +776,8 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         && effective_group_by.is_empty()
         && effective_having.is_none()
         && query.expand.is_none()
-        && !effective_projections
-            .iter()
-            .any(|p| matches!(p, Projection::Function(_, _) | Projection::Expression(_, _)))
+        && !requires_runtime_projection
+        && !uses_document_projection
         && !is_universal_query_source(&query.table)
     {
         let manager = db
@@ -1021,17 +1070,12 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     // Skipped when the projection list contains scalar function calls
     // (e.g. VERIFY_PASSWORD(...), UPPER(...)), since the fast path
     // returns raw records without running project_runtime_record.
-    let has_scalar_function = effective_projections.iter().any(|p| {
-        matches!(
-            p,
-            Projection::Function(_, _) | Projection::Expression(_, _) | Projection::Window { .. }
-        ) || matches!(p, Projection::Column(column) | Projection::Alias(column, _) if column.starts_with("LIT:"))
-    });
     if effective_filter.is_none()
         && effective_group_by.is_empty()
         && effective_having.is_none()
         && query.expand.is_none()
-        && !has_scalar_function
+        && !requires_runtime_projection
+        && !uses_document_projection
     {
         // LIMIT + OFFSET pushdown: pre-scan cap is `offset + limit` so
         // the scan loop stops once we have enough to skip + keep. ORDER
@@ -1098,6 +1142,9 @@ pub(crate) fn execute_runtime_canonical_table_node(
     context: &RuntimeTableExecutionContext<'_>,
 ) -> RedDBResult<Vec<UnifiedRecord>> {
     let effective_filter = effective_table_filter(context.query);
+    let effective_projections = effective_table_projections(context.query);
+    let uses_document_projection =
+        runtime_projections_use_document_path(&effective_projections, context.query);
     match node.operator.as_str() {
         "table_scan" | "index_seek" | "entity_scan" | "document_path_index_seek" => {
             // ── FAST PATH 1: Direct entity_id lookup (O(1) instead of full scan) ──
@@ -1131,12 +1178,11 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 && !effective_filter.as_ref().is_some_and(|filter| {
                     runtime_filter_uses_document_path(filter, context.query)
                 })
-                && !effective_table_projections(context.query)
-                    .iter()
-                    .any(|p| {
+                && !effective_projections.iter().any(|p| {
                         matches!(p, Projection::Function(_, _) | Projection::Expression(_, _))
                             || matches!(p, Projection::Column(column) | Projection::Alias(column, _) if column.starts_with("LIT:"))
                     })
+                && !uses_document_projection
                 && !is_universal_query_source(context.query.table.as_str())
             {
                 let manager = db
@@ -1153,7 +1199,6 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 let table_alias = context.table_alias;
                 let limit = context.query.limit.unwrap_or(10000) as usize;
 
-                let effective_projections = effective_table_projections(context.query);
                 let select_cols = extract_select_column_names(&effective_projections);
                 let schema_arc = manager.column_schema();
                 let compiled = match schema_arc.as_ref() {
@@ -1551,6 +1596,26 @@ fn collect_expr_document_path_roots(
         // Opaque shapes can't be proven to traverse a known root —
         // contribute an unresolvable marker so the gate stays strict.
         Expr::Subquery { .. } | Expr::WindowFunctionCall { .. } => out.push(None),
+    }
+}
+
+fn runtime_projections_use_document_path(projections: &[Projection], query: &TableQuery) -> bool {
+    projections
+        .iter()
+        .any(|projection| runtime_projection_uses_document_path(projection, query))
+}
+
+fn runtime_projection_uses_document_path(projection: &Projection, query: &TableQuery) -> bool {
+    match projection {
+        Projection::Column(name) | Projection::Alias(name, _) => {
+            name.split_once('.').is_some_and(|(head, tail)| {
+                tail.contains('.')
+                    || (head != query.table.as_str() && query.alias.as_deref() != Some(head))
+            })
+        }
+        Projection::Field(field, _) => runtime_field_ref_uses_document_path(field, query),
+        Projection::Expression(filter, _) => runtime_filter_uses_document_path(filter, query),
+        Projection::Function(_, _) | Projection::All | Projection::Window { .. } => false,
     }
 }
 

--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -656,10 +656,14 @@ pub(super) fn references_system_schema(query: &str) -> bool {
 
 pub(super) fn is_system_schema_write(query: &str) -> bool {
     let trimmed = query.trim_start();
-    let first = trimmed
-        .split(|c: char| c.is_whitespace() || c == '(' || c == ';')
-        .next()
-        .unwrap_or("");
+    let mut tokens = trimmed.split(|c: char| c.is_whitespace() || c == '(' || c == ';');
+    let first = tokens.next().unwrap_or("");
+    let second = tokens.next().unwrap_or("");
+    if first.eq_ignore_ascii_case("DELETE")
+        && matches_ignore_ascii_case(second, &["SECRET", "CONFIG", "VAULT"])
+    {
+        return false;
+    }
     matches_ignore_ascii_case(first, &["INSERT", "UPDATE", "DELETE", "TRUNCATE"])
         && references_system_schema(query)
 }

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -183,10 +183,27 @@ fn statement_kind(query: &str) -> &'static str {
     } else {
         trimmed
     };
-    let first = trimmed
-        .split(|c: char| c.is_whitespace() || c == '(' || c == ';')
-        .next()
-        .unwrap_or("");
+    let mut tokens = trimmed.split(|c: char| c.is_whitespace() || c == '(' || c == ';');
+    let first = tokens.next().unwrap_or("");
+    let second = tokens.next().unwrap_or("");
+    if first.eq_ignore_ascii_case("KV") {
+        if second.eq_ignore_ascii_case("GET")
+            || second.eq_ignore_ascii_case("LIST")
+            || second.eq_ignore_ascii_case("WATCH")
+        {
+            return "read";
+        }
+        return "write";
+    }
+    if first.eq_ignore_ascii_case("VAULT") {
+        if second.eq_ignore_ascii_case("LIST")
+            || second.eq_ignore_ascii_case("WATCH")
+            || second.eq_ignore_ascii_case("HISTORY")
+        {
+            return "read";
+        }
+        return "write";
+    }
     // ASCII-uppercase compare without allocating: SQL keywords are ASCII.
     let mut buf = [0u8; 16];
     let bytes = first.as_bytes();
@@ -196,12 +213,16 @@ fn statement_kind(query: &str) -> &'static str {
     }
     match &buf[..n] {
         b"SELECT" | b"WITH" | b"SHOW" | b"EXPLAIN" | b"DESCRIBE" | b"DESC" | b"RANK"
-        | b"APPROX" | b"APPROXIMATE" | b"ZRANK" | b"ZRANGE" => "read",
+        | b"APPROX" | b"APPROXIMATE" | b"ZRANK" | b"ZRANGE" | b"LIST" | b"WATCH" | b"GET"
+        | b"HISTORY" => "read",
         b"INSERT" | b"UPDATE" | b"DELETE" | b"UPSERT" | b"MERGE" | b"COPY" | b"TRUNCATE" => "write",
         b"CREATE" | b"ALTER" | b"DROP" | b"REINDEX" | b"VACUUM" | b"ANALYZE" => "ddl",
         b"GRANT" | b"REVOKE" => "admin",
         b"BEGIN" | b"START" | b"COMMIT" | b"ROLLBACK" | b"SAVEPOINT" | b"RELEASE" | b"END"
         | b"SET" | b"RESET" | b"PREPARE" | b"EXECUTE" | b"DEALLOCATE" | b"USE" => "control",
+        b"PUT" | b"INCR" | b"DECR" | b"ADD" | b"ROTATE" | b"PURGE" | b"UNSEAL" | b"INVALIDATE" => {
+            "write"
+        }
         _ => "unknown",
     }
 }
@@ -1240,8 +1261,25 @@ mod tests {
 
         let cases = [
             ("SELECT 1", Privilege::Read, LockIntent::Shared),
+            ("LIST KV settings", Privilege::Read, LockIntent::Shared),
+            (
+                "KV GET settings.feature",
+                Privilege::Read,
+                LockIntent::Shared,
+            ),
+            ("VAULT LIST secrets", Privilege::Read, LockIntent::Shared),
             (
                 "INSERT INTO t (id) VALUES (1)",
+                Privilege::Write,
+                LockIntent::Exclusive,
+            ),
+            (
+                "KV PUT settings.feature = 'on'",
+                Privilege::Write,
+                LockIntent::Exclusive,
+            ),
+            (
+                "VAULT PUT secrets.api = 'x'",
                 Privilege::Write,
                 LockIntent::Exclusive,
             ),

--- a/crates/reddb-server/src/storage/query/executors/cte.rs
+++ b/crates/reddb-server/src/storage/query/executors/cte.rs
@@ -27,7 +27,9 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::super::ast::{CteDefinition, QueryExpr, QueryWithCte};
+use super::super::ast::{
+    CteDefinition, Expr, Filter, Projection, QueryExpr, QueryWithCte, SelectItem, TableSource,
+};
 use super::super::unified::{ExecutionError, UnifiedRecord, UnifiedResult};
 use crate::storage::schema::Value;
 
@@ -607,7 +609,6 @@ pub fn inline_ctes(query: QueryWithCte) -> Result<QueryExpr, ExecutionError> {
 /// the CTE body so dispatchers that key off `QueryExpr::Table` (like
 /// the JOIN executor) see the right shape.
 fn rewrite(expr: &mut QueryExpr, ctes: &HashMap<String, QueryExpr>) {
-    use super::super::ast::TableSource;
     match expr {
         QueryExpr::Table(tq) => {
             let lookup_name = match &tq.source {
@@ -650,15 +651,185 @@ fn rewrite(expr: &mut QueryExpr, ctes: &HashMap<String, QueryExpr>) {
                 }
             }
 
-            if let Some(TableSource::Subquery(body)) = tq.source.as_mut() {
-                rewrite(body, ctes);
+            match tq.source.as_mut() {
+                Some(TableSource::Subquery(body)) => rewrite(body, ctes),
+                Some(TableSource::InlineGraphFunction { nodes, edges, .. }) => {
+                    rewrite(nodes, ctes);
+                    rewrite(edges, ctes);
+                }
+                _ => {}
             }
+            rewrite_table_query_parts(tq, ctes);
         }
         QueryExpr::Join(jq) => {
             rewrite(&mut jq.left, ctes);
             rewrite(&mut jq.right, ctes);
+            if let Some(filter) = jq.filter.as_mut() {
+                rewrite_filter(filter, ctes);
+            }
+            for item in &mut jq.order_by {
+                if let Some(expr) = item.expr.as_mut() {
+                    rewrite_expr(expr, ctes);
+                }
+            }
+            for item in &mut jq.return_items {
+                rewrite_select_item(item, ctes);
+            }
+            for projection in &mut jq.return_ {
+                rewrite_projection(projection, ctes);
+            }
+        }
+        QueryExpr::Graph(gq) => {
+            if let Some(filter) = gq.filter.as_mut() {
+                rewrite_filter(filter, ctes);
+            }
+            for projection in &mut gq.return_ {
+                rewrite_projection(projection, ctes);
+            }
         }
         _ => {}
+    }
+}
+
+fn rewrite_table_query_parts(
+    tq: &mut super::super::ast::TableQuery,
+    ctes: &HashMap<String, QueryExpr>,
+) {
+    for item in &mut tq.select_items {
+        rewrite_select_item(item, ctes);
+    }
+    for projection in &mut tq.columns {
+        rewrite_projection(projection, ctes);
+    }
+    if let Some(expr) = tq.where_expr.as_mut() {
+        rewrite_expr(expr, ctes);
+    }
+    if let Some(filter) = tq.filter.as_mut() {
+        rewrite_filter(filter, ctes);
+    }
+    for expr in &mut tq.group_by_exprs {
+        rewrite_expr(expr, ctes);
+    }
+    if let Some(expr) = tq.having_expr.as_mut() {
+        rewrite_expr(expr, ctes);
+    }
+    if let Some(filter) = tq.having.as_mut() {
+        rewrite_filter(filter, ctes);
+    }
+    for item in &mut tq.order_by {
+        if let Some(expr) = item.expr.as_mut() {
+            rewrite_expr(expr, ctes);
+        }
+    }
+}
+
+fn rewrite_select_item(item: &mut SelectItem, ctes: &HashMap<String, QueryExpr>) {
+    if let SelectItem::Expr { expr, .. } = item {
+        rewrite_expr(expr, ctes);
+    }
+}
+
+fn rewrite_projection(projection: &mut Projection, ctes: &HashMap<String, QueryExpr>) {
+    match projection {
+        Projection::Function(_, args) => {
+            for arg in args {
+                rewrite_projection(arg, ctes);
+            }
+        }
+        Projection::Expression(filter, _) => rewrite_filter(filter, ctes),
+        Projection::Window { args, window, .. } => {
+            for arg in args {
+                rewrite_projection(arg, ctes);
+            }
+            for expr in &mut window.partition_by {
+                rewrite_expr(expr, ctes);
+            }
+            for item in &mut window.order_by {
+                rewrite_expr(&mut item.expr, ctes);
+            }
+        }
+        Projection::All
+        | Projection::Column(_)
+        | Projection::Alias(_, _)
+        | Projection::Field(_, _) => {}
+    }
+}
+
+fn rewrite_filter(filter: &mut Filter, ctes: &HashMap<String, QueryExpr>) {
+    match filter {
+        Filter::CompareExpr { lhs, rhs, .. } => {
+            rewrite_expr(lhs, ctes);
+            rewrite_expr(rhs, ctes);
+        }
+        Filter::And(left, right) | Filter::Or(left, right) => {
+            rewrite_filter(left, ctes);
+            rewrite_filter(right, ctes);
+        }
+        Filter::Not(inner) => rewrite_filter(inner, ctes),
+        Filter::Compare { .. }
+        | Filter::CompareFields { .. }
+        | Filter::IsNull(_)
+        | Filter::IsNotNull(_)
+        | Filter::In { .. }
+        | Filter::Between { .. }
+        | Filter::Like { .. }
+        | Filter::StartsWith { .. }
+        | Filter::EndsWith { .. }
+        | Filter::Contains { .. } => {}
+    }
+}
+
+fn rewrite_expr(expr: &mut Expr, ctes: &HashMap<String, QueryExpr>) {
+    match expr {
+        Expr::BinaryOp { lhs, rhs, .. } => {
+            rewrite_expr(lhs, ctes);
+            rewrite_expr(rhs, ctes);
+        }
+        Expr::UnaryOp { operand, .. } => rewrite_expr(operand, ctes),
+        Expr::Cast { inner, .. } => rewrite_expr(inner, ctes),
+        Expr::FunctionCall { args, .. } => {
+            for arg in args {
+                rewrite_expr(arg, ctes);
+            }
+        }
+        Expr::Case {
+            branches, else_, ..
+        } => {
+            for (condition, value) in branches {
+                rewrite_expr(condition, ctes);
+                rewrite_expr(value, ctes);
+            }
+            if let Some(value) = else_ {
+                rewrite_expr(value, ctes);
+            }
+        }
+        Expr::IsNull { operand, .. } => rewrite_expr(operand, ctes),
+        Expr::InList { target, values, .. } => {
+            rewrite_expr(target, ctes);
+            for value in values {
+                rewrite_expr(value, ctes);
+            }
+        }
+        Expr::Between {
+            target, low, high, ..
+        } => {
+            rewrite_expr(target, ctes);
+            rewrite_expr(low, ctes);
+            rewrite_expr(high, ctes);
+        }
+        Expr::Subquery { query, .. } => rewrite(&mut query.query, ctes),
+        Expr::WindowFunctionCall { args, window, .. } => {
+            for arg in args {
+                rewrite_expr(arg, ctes);
+            }
+            for expr in &mut window.partition_by {
+                rewrite_expr(expr, ctes);
+            }
+            for item in &mut window.order_by {
+                rewrite_expr(&mut item.expr, ctes);
+            }
+        }
+        Expr::Literal { .. } | Expr::Column { .. } | Expr::Parameter { .. } => {}
     }
 }
 

--- a/crates/reddb-server/src/storage/query/executors/vector.rs
+++ b/crates/reddb-server/src/storage/query/executors/vector.rs
@@ -631,6 +631,7 @@ fn query_expr_name(expr: &QueryExpr) -> &'static str {
         QueryExpr::Grant(_) => "grant",
         QueryExpr::Revoke(_) => "revoke",
         QueryExpr::AlterUser(_) => "alter_user",
+        QueryExpr::CreateUser(_) => "create_user",
         QueryExpr::CreateIamPolicy { .. } => "create_iam_policy",
         QueryExpr::DropIamPolicy { .. } => "drop_iam_policy",
         QueryExpr::AttachPolicy { .. } => "attach_policy",

--- a/crates/reddb-server/src/storage/query/planner/cost.rs
+++ b/crates/reddb-server/src/storage/query/planner/cost.rs
@@ -350,6 +350,7 @@ impl CostEstimator {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }
@@ -443,6 +444,7 @@ impl CostEstimator {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-server/src/storage/query/planner/logical.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical.rs
@@ -664,6 +664,7 @@ pub(super) fn logical_plan_node_with_catalog(db: &RedDB, expr: &QueryExpr) -> Ca
         | QueryExpr::Grant(_)
         | QueryExpr::Revoke(_)
         | QueryExpr::AlterUser(_)
+        | QueryExpr::CreateUser(_)
         | QueryExpr::CreateMetric(_)
         | QueryExpr::AlterMetric(_)
         | QueryExpr::CreateSlo(_)

--- a/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
@@ -488,6 +488,7 @@ pub(crate) fn join_expr_exposes_field_table(expr: &QueryExpr, table: &str) -> bo
         | QueryExpr::Grant(_)
         | QueryExpr::Revoke(_)
         | QueryExpr::AlterUser(_)
+        | QueryExpr::CreateUser(_)
         | QueryExpr::CreateIamPolicy { .. }
         | QueryExpr::DropIamPolicy { .. }
         | QueryExpr::AttachPolicy { .. }
@@ -865,6 +866,7 @@ pub(crate) fn query_expr_kind(expr: &QueryExpr) -> &'static str {
         QueryExpr::Grant(_) => "grant",
         QueryExpr::Revoke(_) => "revoke",
         QueryExpr::AlterUser(_) => "alter_user",
+        QueryExpr::CreateUser(_) => "create_user",
         QueryExpr::CreateIamPolicy { .. } => "create_iam_policy",
         QueryExpr::DropIamPolicy { .. } => "drop_iam_policy",
         QueryExpr::AttachPolicy { .. } => "attach_policy",

--- a/crates/reddb-server/src/storage/query/unified/executor.rs
+++ b/crates/reddb-server/src/storage/query/unified/executor.rs
@@ -235,6 +235,7 @@ impl UnifiedExecutor {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }
@@ -477,6 +478,7 @@ impl UnifiedExecutor {
             | QueryExpr::Grant(_)
             | QueryExpr::Revoke(_)
             | QueryExpr::AlterUser(_)
+            | QueryExpr::CreateUser(_)
             | QueryExpr::CreateIamPolicy { .. }
             | QueryExpr::DropIamPolicy { .. }
             | QueryExpr::AttachPolicy { .. }

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_metadata.rs
@@ -1104,7 +1104,7 @@ impl RedDB {
         &self,
         native_state: &NativePhysicalState,
     ) -> Vec<crate::physical::SnapshotDescriptor> {
-        native_state
+        let snapshots: Vec<_> = native_state
             .recovery
             .as_ref()
             .map(|recovery| {
@@ -1120,7 +1120,36 @@ impl RedDB {
                     })
                     .collect()
             })
+            .unwrap_or_default();
+        if !snapshots.is_empty() {
+            return snapshots;
+        }
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
+            .as_millis();
+        let (collection_count, total_entities) = native_state
+            .catalog
+            .as_ref()
+            .map(|catalog| {
+                (
+                    catalog.collection_count as usize,
+                    catalog.total_entities as usize,
+                )
+            })
+            .unwrap_or_else(|| {
+                let catalog = self.catalog_snapshot();
+                (catalog.total_collections, catalog.total_entities)
+            });
+
+        vec![crate::physical::SnapshotDescriptor {
+            snapshot_id: native_state.header.sequence,
+            created_at_unix_ms: now,
+            superblock_sequence: native_state.header.sequence,
+            collection_count,
+            total_entities,
+        }]
     }
 
     fn index_kind_from_str(value: &str) -> Option<crate::index::IndexKind> {

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
@@ -417,12 +417,13 @@ impl RedDB {
 
     /// List recorded snapshots from the current physical metadata view.
     pub fn snapshots(&self) -> Vec<crate::physical::SnapshotDescriptor> {
-        self.physical_metadata()
-            .map(|metadata| metadata.snapshots)
-            .or_else(|| {
-                self.native_physical_state()
-                    .map(|state| self.snapshots_from_native_state(&state))
-            })
+        if let Some(metadata) = self.physical_metadata() {
+            if !metadata.snapshots.is_empty() {
+                return metadata.snapshots;
+            }
+        }
+        self.native_physical_state()
+            .map(|state| self.snapshots_from_native_state(&state))
             .unwrap_or_default()
     }
 

--- a/crates/reddb-server/src/storage/unified/segment.rs
+++ b/crates/reddb-server/src/storage/unified/segment.rs
@@ -678,13 +678,23 @@ impl GrowingSegment {
             for &id in ids {
                 let raw = id.raw();
                 if raw < self.base_entity_id {
+                    if let Some(entity) = self.entities.remove(&id) {
+                        self.unindex_entity(&entity);
+                        self.metadata.remove_all(id);
+                        self.deleted.insert(id);
+                        deleted_ids.push(id);
+                    }
                     continue;
                 }
                 let idx = (raw - self.base_entity_id) as usize;
-                if idx < self.flat_entities.len()
-                    && self.flat_entities[idx].id == id
-                    && !self.deleted.contains(&id)
-                {
+                if idx < self.flat_entities.len() && self.flat_entities[idx].id == id {
+                    if !self.deleted.contains(&id) {
+                        self.metadata.remove_all(id);
+                        self.deleted.insert(id);
+                        deleted_ids.push(id);
+                    }
+                } else if let Some(entity) = self.entities.remove(&id) {
+                    self.unindex_entity(&entity);
                     self.metadata.remove_all(id);
                     self.deleted.insert(id);
                     deleted_ids.push(id);
@@ -1452,6 +1462,12 @@ impl UnifiedSegment for GrowingSegment {
                     self.deleted.insert(id);
                     return Ok(true);
                 }
+            }
+            if let Some(entity) = self.entities.remove(&id) {
+                self.unindex_entity(&entity);
+                self.metadata.remove_all(id);
+                self.deleted.insert(id);
+                return Ok(true);
             }
             return Ok(false);
         }

--- a/crates/reddb-types/src/queue_mode.rs
+++ b/crates/reddb-types/src/queue_mode.rs
@@ -22,7 +22,7 @@ impl QueueMode {
     pub fn parse(value: &str) -> Option<Self> {
         match value.to_ascii_uppercase().as_str() {
             "FANOUT" => Some(Self::Fanout),
-            "WORK" => Some(Self::Work),
+            "WORK" | "STANDARD" | "FIFO" => Some(Self::Work),
             _ => None,
         }
     }

--- a/tests/e2e_config_secret_ref.rs
+++ b/tests/e2e_config_secret_ref.rs
@@ -5,6 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::storage::schema::Value;
+use reddb::storage::StorageDeployPreset;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 #[allow(dead_code)]
@@ -19,8 +20,10 @@ fn unique_ident(prefix: &str) -> String {
 }
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
-    let rt =
-        RedDBRuntime::with_options(RedDBOptions::persistent(path)).expect("runtime should open");
+    let options = RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should expose pager");
+    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/e2e_document_sql_analytics.rs
+++ b/tests/e2e_document_sql_analytics.rs
@@ -129,6 +129,61 @@ fn runtime_queries_document_fields_json_paths_arrays_and_groups() {
 }
 
 #[test]
+fn runtime_indexes_nested_document_path_filters() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT events");
+    exec(
+        &rt,
+        r#"INSERT INTO events DOCUMENT (body) VALUES
+        ('{"level":"error","service":{"name":"checkout","tier":"edge"},"latency_ms":42}'),
+        ('{"level":"info","service":{"name":"checkout","tier":"edge"},"latency_ms":7}'),
+        ('{"level":"error","service":{"name":"billing","tier":"core"},"latency_ms":99}')"#,
+    );
+    exec(
+        &rt,
+        "CREATE INDEX idx_events_service_tier ON events (body.service.tier)",
+    );
+
+    let indexes = exec(&rt, "SHOW INDEXES ON events");
+    let index = indexes
+        .result
+        .records
+        .iter()
+        .find(|record| text(record, "name") == "idx_events_service_tier")
+        .expect("idx_events_service_tier should be listed");
+    assert_eq!(int(index, "entries_indexed"), 3);
+
+    let explain = exec(
+        &rt,
+        "EXPLAIN SELECT body.level AS severity FROM events WHERE body.service.tier = 'edge'",
+    );
+    let plan_ops = explain
+        .result
+        .records
+        .iter()
+        .filter_map(|record| match record.get("op") {
+            Some(Value::Text(value)) => Some(value.to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    assert!(
+        plan_ops.contains("index_seek"),
+        "nested document path filter should plan through an index; ops={plan_ops}"
+    );
+
+    let filtered = exec(
+        &rt,
+        "SELECT body.level AS severity FROM events \
+         WHERE body.service.tier = 'edge' \
+         ORDER BY body.latency_ms",
+    );
+    assert_eq!(filtered.result.records.len(), 2);
+    assert_eq!(text(&filtered.result.records[0], "severity"), "info");
+    assert_eq!(text(&filtered.result.records[1], "severity"), "error");
+}
+
+#[test]
 fn http_query_document_fields_json_paths_arrays_and_groups() {
     let addr = spawn_http_server();
     post_query(&addr, "CREATE DOCUMENT events");

--- a/tests/e2e_issue_550_documents_list_filter_pagination.rs
+++ b/tests/e2e_issue_550_documents_list_filter_pagination.rs
@@ -131,6 +131,40 @@ fn sql_select_with_where_limit_offset_returns_expected_slice() {
     assert_eq!(number_field(&page.result.records[1], "seq"), 4.0);
 }
 
+// Acceptance: document top-level body attributes can be indexed through
+// the SQL DDL surface and remain queryable via the same attribute filter.
+#[test]
+fn sql_create_index_on_document_attribute_registers_and_filters() {
+    let rt = runtime();
+    seed_documents(&rt, "issue550_sql_indexed", 10);
+
+    rt.execute_query("CREATE INDEX idx_issue550_event_type ON issue550_sql_indexed (event_type)")
+        .expect("CREATE INDEX on document attribute should succeed");
+
+    let indices = rt
+        .execute_query(
+            "SELECT name, collection, columns FROM red.indices \
+             WHERE collection = 'issue550_sql_indexed'",
+        )
+        .expect("red.indices should expose document attribute index");
+    assert_eq!(indices.result.records.len(), 1);
+    assert_eq!(
+        text_field(&indices.result.records[0], "name"),
+        "idx_issue550_event_type"
+    );
+
+    let page = rt
+        .execute_query(
+            "SELECT event_type, seq FROM issue550_sql_indexed \
+             WHERE event_type = 'logout' ORDER BY seq LIMIT 2 OFFSET 1",
+        )
+        .expect("indexed document attribute filter should succeed");
+    assert_eq!(page.result.records.len(), 2);
+    assert_eq!(text_field(&page.result.records[0], "event_type"), "logout");
+    assert_eq!(number_field(&page.result.records[0], "seq"), 3.0);
+    assert_eq!(number_field(&page.result.records[1], "seq"), 5.0);
+}
+
 // Acceptance: empty filter (WHERE matches nothing) returns an empty page.
 #[test]
 fn sql_select_with_filter_that_matches_nothing_returns_empty_page() {

--- a/tests/e2e_kv_namespaced_keys.rs
+++ b/tests/e2e_kv_namespaced_keys.rs
@@ -103,6 +103,63 @@ fn namespaced_kv_keys_survive_reopen() {
 }
 
 #[test]
+fn kv_list_returns_keys_with_prefix_limit_and_offset() {
+    let rt = runtime();
+
+    exec(&rt, "KV PUT settings.feature.gamma = 'G'");
+    exec(&rt, "KV PUT settings.feature.alpha = 'A'");
+    exec(&rt, "KV PUT settings.other.delta = 'D'");
+    exec(&rt, "KV PUT settings.feature.beta = 'B'");
+
+    let listed = exec(&rt, "KV LIST settings PREFIX 'feature.' LIMIT 2 OFFSET 1");
+    assert_eq!(
+        listed.result.columns,
+        vec![
+            "rid".to_string(),
+            "collection".to_string(),
+            "kind".to_string(),
+            "tenant".to_string(),
+            "created_at".to_string(),
+            "updated_at".to_string(),
+            "key".to_string(),
+            "value".to_string(),
+            "tags".to_string(),
+        ]
+    );
+    assert_eq!(listed.result.records.len(), 2);
+    assert_eq!(text(&listed.result.records[0], "collection"), "settings");
+    assert_eq!(text(&listed.result.records[0], "kind"), "kv");
+    assert_eq!(text(&listed.result.records[0], "key"), "feature.beta");
+    assert_eq!(text(&listed.result.records[0], "value"), "B");
+    assert_eq!(text(&listed.result.records[1], "key"), "feature.gamma");
+    assert_eq!(text(&listed.result.records[1], "value"), "G");
+
+    let top_level = exec(&rt, "LIST KV settings PREFIX 'feature.' LIMIT 1");
+    assert_eq!(top_level.result.records.len(), 1);
+    assert_eq!(text(&top_level.result.records[0], "key"), "feature.alpha");
+
+    let tree = exec(&rt, "KV LIST settings PREFIX 'feature.' AS JSON");
+    assert_eq!(
+        tree.result.columns,
+        vec![
+            "collection".to_string(),
+            "prefix".to_string(),
+            "value".to_string(),
+        ]
+    );
+    let row = only_record(&tree);
+    assert_eq!(text(row, "collection"), "settings");
+    assert_eq!(text(row, "prefix"), "feature.");
+    let Some(Value::Json(bytes)) = row.get("value") else {
+        panic!("expected JSON value, got {row:?}");
+    };
+    let json: reddb::json::Value = reddb::json::from_slice(bytes).expect("valid kv tree json");
+    assert_eq!(json["alpha"].as_str(), Some("A"));
+    assert_eq!(json["beta"].as_str(), Some("B"));
+    assert_eq!(json["gamma"].as_str(), Some("G"));
+}
+
+#[test]
 fn http_kv_endpoints_accept_url_encoded_namespaced_keys() {
     let server = RedDBServer::new(runtime());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/tests/e2e_nested_queries_multimodel_json.rs
+++ b/tests/e2e_nested_queries_multimodel_json.rs
@@ -1,0 +1,262 @@
+//! Runtime contract for nested query composition across SQL, graph TVFs,
+//! joins, and JSON literals.
+
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
+}
+
+fn first_record<'a>(
+    result: &'a reddb::runtime::RuntimeQueryResult,
+) -> &'a reddb::storage::query::UnifiedRecord {
+    assert_eq!(
+        result.result.records.len(),
+        1,
+        "expected one row for `{}`; got {:?}",
+        result.query,
+        result.result.records
+    );
+    &result.result.records[0]
+}
+
+fn text_value(record: &reddb::storage::query::UnifiedRecord, names: &[&str]) -> String {
+    for name in names {
+        if let Some(value) = record.get(*name) {
+            return match value {
+                Value::Text(value) => value.to_string(),
+                Value::Integer(value) => value.to_string(),
+                Value::UnsignedInteger(value) => value.to_string(),
+                Value::Float(value) => value.to_string(),
+                other => panic!("expected text-compatible {name}, got {other:?} in {record:?}"),
+            };
+        }
+    }
+    panic!("missing any of {names:?} in {record:?}");
+}
+
+fn int_value(record: &reddb::storage::query::UnifiedRecord, names: &[&str]) -> i64 {
+    for name in names {
+        if let Some(value) = record.get(*name) {
+            return match value {
+                Value::Integer(value) => *value,
+                Value::UnsignedInteger(value) => *value as i64,
+                other => panic!("expected integer {name}, got {other:?} in {record:?}"),
+            };
+        }
+    }
+    panic!("missing any of {names:?} in {record:?}");
+}
+
+fn ids_from(rt: &RedDBRuntime, sql: &str) -> Vec<i64> {
+    exec(rt, sql)
+        .result
+        .records
+        .iter()
+        .map(|record| int_value(record, &["id", "u.id", "users.id", "c0"]))
+        .collect()
+}
+
+fn seed_users_orders_regions(rt: &RedDBRuntime) {
+    exec(
+        rt,
+        "CREATE TABLE users (id INT, name TEXT, status TEXT, region TEXT, profile_key TEXT)",
+    );
+    exec(
+        rt,
+        "INSERT INTO users (id, name, status, region, profile_key) VALUES \
+         (1, 'alice', 'active', 'west', 'alice'), \
+         (2, 'bob', 'inactive', 'east', 'bob'), \
+         (3, 'carol', 'active', 'west', 'carol'), \
+         (4, 'dave', 'active', 'south', 'dave')",
+    );
+    exec(rt, "CREATE TABLE regions (id INT, name TEXT, open BOOLEAN)");
+    exec(
+        rt,
+        "INSERT INTO regions (id, name, open) VALUES \
+         (10, 'west', true), (20, 'east', false), (30, 'south', true)",
+    );
+    exec(
+        rt,
+        "CREATE TABLE orders (id INT, user_id INT, region_id INT, total INT)",
+    );
+    exec(
+        rt,
+        "INSERT INTO orders (id, user_id, region_id, total) VALUES \
+         (101, 1, 10, 50), (102, 3, 10, 200), (103, 4, 30, 150), (104, 2, 20, 500)",
+    );
+}
+
+#[test]
+fn subquery_can_nest_inside_subquery() {
+    let rt = runtime();
+    seed_users_orders_regions(&rt);
+
+    let ids = ids_from(
+        &rt,
+        "SELECT id FROM users \
+         WHERE id IN ( \
+             SELECT user_id FROM orders \
+             WHERE region_id IN ( \
+                 SELECT id FROM regions WHERE open = true AND name = 'west' \
+             ) \
+         ) \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![1, 3]);
+}
+
+#[test]
+fn from_subquery_can_itself_contain_from_and_where_subqueries() {
+    let rt = runtime();
+    seed_users_orders_regions(&rt);
+
+    let ids = ids_from(
+        &rt,
+        "SELECT id FROM ( \
+             SELECT user_id AS id FROM ( \
+                 SELECT user_id, region_id, total FROM orders WHERE total > 100 \
+             ) AS rich_orders \
+             WHERE region_id IN (SELECT id FROM regions WHERE open = true) \
+         ) AS buyers \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![3, 4]);
+}
+
+#[test]
+fn join_accepts_subquery_side_and_kv_json_side() {
+    let rt = runtime();
+    seed_users_orders_regions(&rt);
+    exec(&rt, "CREATE KV profiles");
+    exec(
+        &rt,
+        "KV PUT profiles.alice = {\"user\":{\"plan\":\"free\",\"tier\":1}}",
+    );
+    exec(
+        &rt,
+        "KV PUT profiles.carol = {\"user\":{\"plan\":\"pro\",\"tier\":2}}",
+    );
+
+    let result = exec(
+        &rt,
+        "SELECT u.id, p.value.user.plan AS plan \
+         FROM (SELECT id, profile_key FROM users WHERE status = 'active') AS u \
+         JOIN profiles p ON u.profile_key = p.key \
+         WHERE p.value.user.tier = 2",
+    );
+    let row = first_record(&result);
+    assert_eq!(int_value(row, &["id", "u.id"]), 3);
+    assert_eq!(text_value(row, &["plan"]), "pro");
+}
+
+#[test]
+fn join_accepts_table_and_timeseries_collection() {
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE services (id INT, metric_name TEXT)");
+    exec(
+        &rt,
+        "INSERT INTO services (id, metric_name) VALUES \
+         (1, 'checkout.latency'), (2, 'billing.latency')",
+    );
+    exec(&rt, "CREATE TIMESERIES service_metrics RETENTION 7 d");
+    exec(
+        &rt,
+        "INSERT INTO service_metrics (metric, value, tags, timestamp) VALUES \
+         ('checkout.latency', 42.0, {\"service\":\"checkout\"}, 1704067200000000000), \
+         ('search.latency', 7.0, {\"service\":\"search\"}, 1704067200000000001)",
+    );
+
+    let result = exec(
+        &rt,
+        "SELECT s.id, m.value AS metric_value \
+         FROM services s JOIN service_metrics m ON s.metric_name = m.metric",
+    );
+    let row = first_record(&result);
+    assert_eq!(int_value(row, &["id", "s.id"]), 1);
+    assert_eq!(text_value(row, &["metric_value"]), "42");
+}
+
+#[test]
+fn graph_table_function_subqueries_can_reference_ctes_and_nested_subqueries() {
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE gnodes (id INT, enabled BOOLEAN)");
+    exec(
+        &rt,
+        "INSERT INTO gnodes (id, enabled) VALUES (1, true), (2, true), (3, true), (4, false)",
+    );
+    exec(&rt, "CREATE TABLE gedges (src INT, dst INT)");
+    exec(
+        &rt,
+        "INSERT INTO gedges (src, dst) VALUES (1, 2), (2, 3), (3, 4)",
+    );
+
+    let result = exec(
+        &rt,
+        "WITH enabled_nodes AS (SELECT id FROM gnodes WHERE enabled = true) \
+         SELECT * FROM components( \
+             nodes => (SELECT id FROM enabled_nodes), \
+             edges => ( \
+                 SELECT src, dst FROM gedges \
+                 WHERE src IN (SELECT id FROM enabled_nodes) \
+                   AND dst IN (SELECT id FROM enabled_nodes) \
+             ) \
+         )",
+    );
+
+    assert_eq!(result.engine, "runtime-graph-tvf-inline");
+    assert_eq!(
+        result.result.records.len(),
+        3,
+        "records={:?}",
+        result.result.records
+    );
+}
+
+#[test]
+fn bare_json_literals_insert_into_documents_kv_and_table_json_columns() {
+    let rt = runtime();
+
+    exec(&rt, "CREATE DOCUMENT docs_json");
+    exec(
+        &rt,
+        "INSERT INTO docs_json DOCUMENT (body) VALUES \
+         ({\"user\":{\"name\":\"Ada\",\"active\":true},\"tags\":[\"beta\"],\"score\":7})",
+    );
+    let doc = exec(
+        &rt,
+        "SELECT body.user.name AS name FROM docs_json WHERE body.user.active = true",
+    );
+    assert_eq!(text_value(first_record(&doc), &["name"]), "Ada");
+
+    exec(&rt, "CREATE KV kv_json");
+    exec(
+        &rt,
+        "KV PUT kv_json.profile = {\"user\":{\"name\":\"Ada\",\"plan\":\"pro\"}}",
+    );
+    let kv = exec(
+        &rt,
+        "SELECT value.user.plan AS plan FROM kv_json WHERE key = 'profile'",
+    );
+    assert_eq!(text_value(first_record(&kv), &["plan"]), "pro");
+
+    exec(&rt, "CREATE TABLE table_json (id INT, payload JSON)");
+    exec(
+        &rt,
+        "INSERT INTO table_json (id, payload) VALUES \
+         (1, {\"user\":{\"name\":\"Ada\",\"plan\":\"pro\"}})",
+    );
+    let table = exec(
+        &rt,
+        "SELECT payload.user.name AS name FROM table_json WHERE payload.user.plan = 'pro'",
+    );
+    assert_eq!(text_value(first_record(&table), &["name"]), "Ada");
+}

--- a/tests/e2e_secret_sql.rs
+++ b/tests/e2e_secret_sql.rs
@@ -5,13 +5,20 @@ use std::sync::Arc;
 use reddb::auth::vault::Vault;
 use reddb::auth::{AuthConfig, AuthStore};
 use reddb::storage::schema::Value;
+use reddb::storage::StorageDeployPreset;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-use support::PersistentDbPath;
+use support::TempDbFile;
 
-fn open_runtime_with_vault(name: &str) -> (PersistentDbPath, RedDBRuntime, Arc<AuthStore>) {
-    let path = PersistentDbPath::new(name);
-    let rt = path.open_runtime();
+fn pager_backed_options(path: &std::path::Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should expose pager")
+}
+
+fn open_runtime_with_vault(name: &str) -> (TempDbFile, RedDBRuntime, Arc<AuthStore>) {
+    let path = support::temp_db_file(name);
+    let rt = RedDBRuntime::with_options(pager_backed_options(path.path())).expect("runtime opens");
     let db = rt.db();
     let store = db.store();
     let pager = Arc::clone(
@@ -142,7 +149,7 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
     let dump_path = dump_guard.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(source_path))
+        let rt = RedDBRuntime::with_options(pager_backed_options(source_path))
             .expect("source runtime should open");
         let _auth = attach_vault(&rt, "cli-pass");
         rt.execute_query("SET CONFIG red.config.demo.enabled = true")
@@ -152,7 +159,7 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         rt.checkpoint().expect("source checkpoint should succeed");
     }
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(source_path))
+        let rt = RedDBRuntime::with_options(pager_backed_options(source_path))
             .expect("source runtime should reopen");
         let auth = attach_vault(&rt, "cli-pass");
         assert_eq!(
@@ -201,7 +208,7 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         String::from_utf8_lossy(&restore.stderr)
     );
 
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(dest_path))
+    let rt = RedDBRuntime::with_options(pager_backed_options(dest_path))
         .expect("dest runtime should open");
     let auth = attach_vault(&rt, "cli-pass");
     assert_eq!(
@@ -269,6 +276,49 @@ fn dollar_red_secret_reference_uses_full_red_secret_path() {
 }
 
 #[test]
+fn red_secrets_plural_alias_normalizes_to_red_secret() {
+    let (_path, rt, auth) = open_runtime_with_vault("secret_sql_red_secrets_plural");
+
+    rt.execute_query("CREATE TABLE tokens (id INT, token TEXT)")
+        .expect("create table");
+    rt.execute_query("INSERT INTO tokens (id, token) VALUES (1, 'plural-match'), (2, 'other')")
+        .expect("insert rows");
+    rt.execute_query("SET SECRET red.secrets.tokens.active = 'plural-match'")
+        .expect("set plural red secret");
+
+    assert_eq!(
+        auth.vault_kv_get("red.secret.tokens.active").as_deref(),
+        Some("plural-match")
+    );
+    assert!(
+        auth.vault_kv_get("red.secrets.tokens.active").is_none(),
+        "plural alias should not create a second physical namespace"
+    );
+
+    let shown = rt
+        .execute_query("SHOW SECRETS red.secrets.tokens")
+        .expect("show plural red secrets");
+    assert_eq!(shown.result.records.len(), 1);
+    assert_eq!(
+        shown.result.records[0].get("key"),
+        Some(&Value::Text("red.secret.tokens.active".into()))
+    );
+
+    let filtered = rt
+        .execute_query("SELECT id FROM tokens WHERE token = $red.secrets.tokens.active")
+        .expect("filter by plural red secret");
+    assert_eq!(filtered.result.records.len(), 1);
+    assert_eq!(
+        filtered.result.records[0].get("id"),
+        Some(&Value::Integer(1))
+    );
+
+    rt.execute_query("DELETE SECRET red.secrets.tokens.active")
+        .expect("delete plural red secret");
+    assert!(auth.vault_kv_get("red.secret.tokens.active").is_none());
+}
+
+#[test]
 fn dollar_config_reference_resolves_plaintext_config() {
     let (_path, rt, _auth) = open_runtime_with_vault("secret_sql_dollar_config_ref");
 
@@ -321,4 +371,9 @@ fn config_and_secret_reserved_prefixes_do_not_cross() {
         .execute_query("SET CONFIG red.secret.foo = 'x'")
         .expect_err("SET CONFIG must reject red.secret");
     assert!(err.to_string().contains("red.secret.* is reserved"));
+
+    let err = rt
+        .execute_query("SET CONFIG red.secrets.foo = 'x'")
+        .expect_err("SET CONFIG must reject red.secrets");
+    assert!(err.to_string().contains("red.secrets.*"));
 }

--- a/tests/e2e_sql_cte.rs
+++ b/tests/e2e_sql_cte.rs
@@ -4,6 +4,7 @@
 //! rows as the equivalent un-CTE'd query, and that `WITH RECURSIVE`
 //! errors out with a clear message rather than silently misparsing.
 
+use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 fn seed_users(rt: &RedDBRuntime) {
@@ -23,6 +24,33 @@ fn seed_users(rt: &RedDBRuntime) {
         ))
         .unwrap();
     }
+}
+
+fn seed_orders(rt: &RedDBRuntime) {
+    rt.execute_query("CREATE TABLE orders (id INT, user_id INT, total INT)")
+        .unwrap();
+    rt.execute_query(
+        "INSERT INTO orders (id, user_id, total) VALUES \
+         (1, 1, 50), (2, 3, 200), (3, 4, 150), (4, 5, 20)",
+    )
+    .unwrap();
+}
+
+fn selected_ids(rt: &RedDBRuntime, sql: &str) -> Vec<i64> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    result
+        .result
+        .records
+        .iter()
+        .map(
+            |record| match record.get("id").or_else(|| record.get("c0")) {
+                Some(Value::Integer(id)) => *id,
+                other => panic!("expected integer id, got {other:?} in record {record:?}"),
+            },
+        )
+        .collect()
 }
 
 #[test]
@@ -149,5 +177,115 @@ fn with_recursive_returns_clear_not_implemented_error() {
         msg.to_lowercase().contains("not yet supported")
             || msg.to_lowercase().contains("not supported"),
         "error should be a clear not-yet-supported message: got `{msg}`"
+    );
+}
+
+#[test]
+fn from_subquery_applies_outer_filter_and_ordering() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+
+    let ids = selected_ids(
+        &rt,
+        "SELECT id FROM \
+            (SELECT id, age FROM users WHERE status = 'active') AS active_users \
+         WHERE age < 35 \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![1, 4]);
+}
+
+#[test]
+fn where_in_subquery_materializes_first_column_values() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+    seed_orders(&rt);
+
+    let ids = selected_ids(
+        &rt,
+        "SELECT id FROM users \
+         WHERE id IN (SELECT user_id FROM orders WHERE total > 100) \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![3, 4]);
+}
+
+#[test]
+fn cte_from_subquery_and_where_subquery_compose_in_one_statement() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+    seed_orders(&rt);
+
+    let ids = selected_ids(
+        &rt,
+        "WITH \
+            active_users AS (SELECT id, age FROM users WHERE status = 'active'), \
+            high_value_buyers AS (SELECT user_id FROM orders WHERE total > 100) \
+         SELECT id FROM \
+            (SELECT id, age FROM active_users WHERE age >= 20) AS visible_users \
+         WHERE id IN (SELECT user_id FROM high_value_buyers) \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![3, 4]);
+}
+
+#[test]
+fn scalar_subquery_can_drive_where_comparison() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+
+    let ids = selected_ids(
+        &rt,
+        "SELECT id FROM users \
+         WHERE age > (SELECT age FROM users WHERE name = 'alice') \
+         ORDER BY id",
+    );
+
+    assert_eq!(ids, vec![3, 5]);
+}
+
+#[test]
+fn scalar_subquery_in_select_list_can_reference_named_cte() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+    seed_orders(&rt);
+
+    let result = rt
+        .execute_query(
+            "WITH high_value_buyers AS (SELECT user_id FROM orders WHERE total > 100) \
+             SELECT id, \
+                    (SELECT user_id FROM high_value_buyers WHERE user_id = 3) AS matched_user \
+             FROM users \
+             WHERE id = 3",
+        )
+        .unwrap();
+
+    assert_eq!(result.result.records.len(), 1);
+    assert_eq!(
+        result.result.records[0].get("matched_user"),
+        Some(&Value::Integer(3)),
+        "record={:?}",
+        result.result.records[0]
+    );
+}
+
+#[test]
+fn correlated_where_subquery_returns_clear_error() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_users(&rt);
+
+    let err = rt
+        .execute_query(
+            "SELECT id FROM users u \
+             WHERE age > (SELECT age FROM users WHERE id = u.id)",
+        )
+        .expect_err("correlated subquery should not silently execute");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("correlated subqueries are not supported"),
+        "expected correlated-subquery error, got `{msg}`"
     );
 }

--- a/tests/e2e_statement_execution_contract.rs
+++ b/tests/e2e_statement_execution_contract.rs
@@ -96,6 +96,50 @@ fn selected_text(rt: &RedDBRuntime, sql: &str) -> String {
     }
 }
 
+fn text_values(rt: &RedDBRuntime, sql: &str, column: &str) -> Vec<String> {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
+        .result
+        .records
+        .iter()
+        .map(|record| match record.get(column) {
+            Some(Value::Text(text)) => text.to_string(),
+            other => panic!("expected text column {column}, got {other:?} in {record:?}"),
+        })
+        .collect()
+}
+
+fn uint_value(rt: &RedDBRuntime, sql: &str, column: &str) -> u64 {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    let record = result
+        .result
+        .records
+        .first()
+        .unwrap_or_else(|| panic!("{sql}: expected one row"));
+    match record.get(column) {
+        Some(Value::UnsignedInteger(value)) => *value,
+        Some(Value::Integer(value)) if *value >= 0 => *value as u64,
+        other => panic!("expected unsigned integer column {column}, got {other:?} in {record:?}"),
+    }
+}
+
+fn bool_value(rt: &RedDBRuntime, sql: &str, column: &str) -> bool {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    let record = result
+        .result
+        .records
+        .first()
+        .unwrap_or_else(|| panic!("{sql}: expected one row"));
+    match record.get(column) {
+        Some(Value::Boolean(value)) => *value,
+        other => panic!("expected boolean column {column}, got {other:?} in {record:?}"),
+    }
+}
+
 fn seed_target_scan_fixture(rt: &RedDBRuntime) {
     exec(rt, "CREATE TABLE items (id INT, score INT, touched INT)");
     for id in 0..5 {
@@ -137,6 +181,207 @@ fn assert_update_and_delete_target_same_rows(predicate: &str, expected_ids: &[i6
         (0..5)
             .filter(|id| !expected_ids.contains(id))
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn table_command_matrix_executes_ddl_dml_index_alter_truncate_and_drop() {
+    let rt = runtime();
+
+    exec(
+        &rt,
+        "CREATE TABLE table_matrix (id INT, status TEXT, score INT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO table_matrix (id, status, score) VALUES \
+         (1, 'new', 10), (2, 'new', 20), (3, 'stale', 30)",
+    );
+    assert_eq!(
+        selected_ids(
+            &rt,
+            "SELECT id FROM table_matrix WHERE status = 'new' ORDER BY id"
+        ),
+        vec![1, 2]
+    );
+
+    exec(
+        &rt,
+        "CREATE INDEX idx_table_matrix_status ON table_matrix (status) USING HASH",
+    );
+    assert_eq!(
+        uint_value(
+            &rt,
+            "SHOW INDEXES ON table_matrix WHERE name = 'idx_table_matrix_status'",
+            "entries_indexed",
+        ),
+        3
+    );
+    let explain_ops = text_values(
+        &rt,
+        "EXPLAIN SELECT id FROM table_matrix WHERE status = 'new'",
+        "op",
+    );
+    assert!(
+        explain_ops.iter().any(|op| op == "index_seek"),
+        "expected table status predicate to use index_seek, got {explain_ops:?}"
+    );
+
+    exec(
+        &rt,
+        "UPDATE table_matrix SET status = 'done', score = 25 WHERE id = 2",
+    );
+    assert_eq!(
+        selected_ids(
+            &rt,
+            "SELECT id FROM table_matrix WHERE status = 'done' ORDER BY id"
+        ),
+        vec![2]
+    );
+
+    exec(&rt, "DELETE FROM table_matrix WHERE status = 'stale'");
+    assert_eq!(
+        selected_ids(&rt, "SELECT id FROM table_matrix ORDER BY id"),
+        vec![1, 2]
+    );
+
+    exec(&rt, "ALTER TABLE table_matrix ADD COLUMN urgency INT");
+    let columns = || {
+        text_values(
+            &rt,
+            "SELECT name FROM red.columns WHERE collection = 'table_matrix' ORDER BY name",
+            "name",
+        )
+    };
+    assert!(columns().contains(&"urgency".to_string()));
+
+    exec(
+        &rt,
+        "ALTER TABLE table_matrix RENAME COLUMN urgency TO rank",
+    );
+    let renamed = columns();
+    assert!(renamed.contains(&"rank".to_string()));
+    assert!(!renamed.contains(&"urgency".to_string()));
+
+    exec(&rt, "ALTER TABLE table_matrix DROP COLUMN rank");
+    assert!(!columns().contains(&"rank".to_string()));
+
+    exec(&rt, "DROP INDEX idx_table_matrix_status ON table_matrix");
+    let indexes_after_drop = text_values(&rt, "SHOW INDEXES ON table_matrix", "name");
+    assert!(
+        !indexes_after_drop.contains(&"idx_table_matrix_status".to_string()),
+        "DROP INDEX should remove the named index, got {indexes_after_drop:?}"
+    );
+
+    exec(&rt, "TRUNCATE TABLE table_matrix");
+    let ids_after_truncate = selected_ids(&rt, "SELECT id FROM table_matrix ORDER BY id");
+    assert_eq!(ids_after_truncate, Vec::<i64>::new());
+
+    exec(&rt, "DROP TABLE table_matrix");
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT name FROM red.collections WHERE name = 'table_matrix'"
+        ),
+        0
+    );
+}
+
+#[test]
+fn graph_command_matrix_executes_core_runtime_surface() {
+    let rt = runtime();
+
+    exec(&rt, "CREATE GRAPH graph_matrix");
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT name FROM red.graphs WHERE name = 'graph_matrix'"
+        ),
+        1
+    );
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix NODE (label, node_type, name) VALUES ('alpha', 'Service', 'Alpha')",
+    );
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix NODE (label, node_type, name) VALUES ('beta', 'Service', 'Beta')",
+    );
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix NODE (label, node_type, name) VALUES ('gamma', 'Database', 'Gamma')",
+    );
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix EDGE (label, from_rid, to_rid, weight) VALUES ('CONNECTS', 'alpha', 'beta', 1.0)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix EDGE (label, from_rid, to_rid, weight) VALUES ('CONNECTS', 'beta', 'gamma', 1.0)",
+    );
+
+    let matched = text_values(
+        &rt,
+        "MATCH (a)-[r:CONNECTS]->(b) \
+         WHERE a.label = 'alpha' \
+         RETURN a.name, b.name, r.label",
+        "b.name",
+    );
+    assert_eq!(matched, vec!["Beta".to_string()]);
+
+    assert_eq!(
+        text_values(&rt, "GRAPH PROPERTIES 'alpha'", "label"),
+        vec!["alpha".to_string()]
+    );
+
+    let neighborhood = text_values(
+        &rt,
+        "GRAPH NEIGHBORHOOD 'alpha' DEPTH 2 EDGES IN ('CONNECTS')",
+        "label",
+    );
+    assert!(
+        neighborhood.contains(&"gamma".to_string()),
+        "neighborhood should reach gamma through beta, got {neighborhood:?}"
+    );
+
+    let traversal = text_values(
+        &rt,
+        "GRAPH TRAVERSE FROM 'alpha' STRATEGY bfs DIRECTION outgoing MAX_DEPTH 2 EDGES IN ('CONNECTS')",
+        "label",
+    );
+    assert!(
+        traversal.contains(&"gamma".to_string()),
+        "traversal should reach gamma through beta, got {traversal:?}"
+    );
+
+    assert!(bool_value(
+        &rt,
+        "GRAPH SHORTEST_PATH FROM 'alpha' TO 'gamma' ALGORITHM dijkstra",
+        "path_found",
+    ));
+
+    assert_eq!(
+        row_count(&rt, "GRAPH CENTRALITY ALGORITHM degree LIMIT 3"),
+        3
+    );
+    assert!(row_count(&rt, "GRAPH COMMUNITY ALGORITHM label_propagation LIMIT 5") >= 1);
+    assert!(row_count(&rt, "GRAPH COMPONENTS MODE connected LIMIT 5") >= 1);
+    assert!(row_count(&rt, "GRAPH CLUSTERING") >= 1);
+    assert!(row_count(&rt, "GRAPH TOPOLOGICAL_SORT") >= 1);
+
+    exec(
+        &rt,
+        "INSERT INTO graph_matrix EDGE (label, from_rid, to_rid, weight) VALUES ('CONNECTS', 'gamma', 'alpha', 1.0)",
+    );
+    assert!(row_count(&rt, "GRAPH CYCLES MAX_LENGTH 4") >= 1);
+
+    exec(&rt, "DROP GRAPH graph_matrix");
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT name FROM red.graphs WHERE name = 'graph_matrix'"
+        ),
+        0
     );
 }
 
@@ -187,6 +432,38 @@ fn read_statement_context_observes_tenant_config_auth_and_policy_state() {
         "expected write privilege denial, got {err:?}"
     );
     clear_current_auth_identity();
+}
+
+#[test]
+fn show_config_as_json_reconstructs_config_subtree() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "SET CONFIG runtime.result_cache.backend = 'blob_cache'",
+    );
+    exec(
+        &rt,
+        "SET CONFIG runtime.result_cache.capacity_entries = 128",
+    );
+    exec(&rt, "SET CONFIG runtime.result_cache.enabled = true");
+    exec(&rt, "SET CONFIG runtime.result_cache.backend = 'shadow'");
+
+    let result = rt
+        .execute_query("SHOW CONFIG runtime.result_cache AS JSON")
+        .expect("SHOW CONFIG AS JSON");
+    assert_eq!(result.result.columns, vec!["key", "value"]);
+    let record = result.result.records.first().expect("config json row");
+    assert!(matches!(
+        record.get("key"),
+        Some(Value::Text(key)) if key.as_ref() == "runtime.result_cache"
+    ));
+    let Some(Value::Json(bytes)) = record.get("value") else {
+        panic!("expected JSON value, got {record:?}");
+    };
+    let json: reddb::json::Value = reddb::json::from_slice(bytes).expect("valid config json");
+    assert_eq!(json["backend"].as_str(), Some("shadow"));
+    assert_eq!(json["capacity_entries"].as_u64(), Some(128));
+    assert_eq!(json["enabled"].as_bool(), Some(true));
 }
 
 #[test]

--- a/tests/iam_policy_runtime.rs
+++ b/tests/iam_policy_runtime.rs
@@ -113,6 +113,52 @@ fn attach_policy(store: &AuthStore, user: reddb::auth::UserId, policy: &str) {
         .unwrap();
 }
 
+#[test]
+fn sql_create_attach_and_show_iam_policy_applies_at_runtime() {
+    let (_dir, rt, store) = runtime_with_auth();
+    rt.execute_query("CREATE TABLE orders (id INT)").unwrap();
+    rt.execute_query("INSERT INTO orders (id) VALUES (1)")
+        .unwrap();
+
+    let denied = as_user("alice", Role::Write, || {
+        rt.execute_query("SELECT * FROM orders")
+    });
+    assert!(
+        denied.is_err(),
+        "PolicyOnly user should not read without an attached policy"
+    );
+
+    let policy = r#"{"id":"sql-read-orders","version":1,"statements":[{"effect":"allow","actions":["select"],"resources":["table:orders"]}]}"#;
+    store.set_enforcement_mode(reddb::auth::enforcement_mode::PolicyEnforcementMode::LegacyRbac);
+    as_user("admin", Role::Admin, || {
+        rt.execute_query(&format!("CREATE POLICY 'sql-read-orders' AS '{}'", policy))
+            .unwrap();
+        rt.execute_query("ATTACH POLICY 'sql-read-orders' TO USER alice")
+            .unwrap();
+    });
+    store.set_enforcement_mode(reddb::auth::enforcement_mode::PolicyEnforcementMode::PolicyOnly);
+
+    let show = as_user("admin", Role::Admin, || {
+        rt.execute_query("SHOW POLICIES FOR USER alice").unwrap()
+    });
+    assert!(
+        show.result.records.iter().any(|record| {
+            matches!(
+                record.get("id"),
+                Some(reddb::storage::schema::Value::Text(id)) if id.as_ref() == "sql-read-orders"
+            )
+        }),
+        "SHOW POLICIES should expose the SQL-created policy: {:?}",
+        show.result.records
+    );
+
+    let allowed = as_user("alice", Role::Write, || {
+        rt.execute_query("SELECT * FROM orders")
+    })
+    .expect("attached SQL-created policy should allow SELECT");
+    assert_eq!(allowed.result.records.len(), 1);
+}
+
 fn seed_document(rt: &RedDBRuntime) {
     rt.execute_query(
         r#"INSERT INTO docs DOCUMENT (body) VALUES ('{"public":"ok","secret":"no","nested":{"public":"yes","secret":"hidden"}}')"#,

--- a/tests/integration_queue_timeseries.rs
+++ b/tests/integration_queue_timeseries.rs
@@ -940,6 +940,8 @@ fn test_queue_mode_visible_in_red_collections() {
 
     exec(&rt, "CREATE QUEUE notifications FANOUT");
     exec(&rt, "CREATE QUEUE tasks WORK");
+    exec(&rt, "CREATE QUEUE standard_tasks STANDARD");
+    exec(&rt, "CREATE QUEUE fifo_tasks FIFO");
 
     let result = exec(
         &rt,
@@ -959,6 +961,14 @@ fn test_queue_mode_visible_in_red_collections() {
         Some("fanout")
     );
     assert_eq!(queue_modes.get("tasks").map(String::as_str), Some("work"));
+    assert_eq!(
+        queue_modes.get("standard_tasks").map(String::as_str),
+        Some("work")
+    );
+    assert_eq!(
+        queue_modes.get("fifo_tasks").map(String::as_str),
+        Some("work")
+    );
 }
 
 #[test]

--- a/tests/sql_grant_revoke.rs
+++ b/tests/sql_grant_revoke.rs
@@ -10,11 +10,21 @@
 
 use reddb::auth::privileges::{Action, GrantPrincipal, Resource};
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
+use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::storage::query::{GrantObjectKind, GrantPrincipalRef, Parser, QueryExpr};
+use reddb::{RedDBOptions, RedDBRuntime};
+use std::sync::Arc;
 
 fn parse(sql: &str) -> QueryExpr {
     let mut p = Parser::new(sql).expect("parser construct");
     p.parse().expect("parse")
+}
+
+fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
+    set_current_auth_identity(name.to_string(), role);
+    let out = f();
+    clear_current_auth_identity();
+    out
 }
 
 #[test]
@@ -92,6 +102,25 @@ fn revoke_grant_option_for_parses() {
         other => panic!("expected Revoke, got {:?}", other),
     };
     assert!(r.grant_option_for);
+}
+
+#[test]
+fn create_user_rql_creates_tenant_scoped_user() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let store = Arc::new(AuthStore::new(AuthConfig::default()));
+    store.create_user("admin", "p", Role::Admin).unwrap();
+    rt.set_auth_store(Arc::clone(&store));
+
+    let result = as_user("admin", Role::Admin, || {
+        rt.execute_query("CREATE USER acme.alice WITH PASSWORD 'secret' ROLE write")
+    })
+    .expect("create user through RQL");
+
+    assert_eq!(result.statement, "create_user");
+    let alice = store.get_user(Some("acme"), "alice").expect("alice exists");
+    assert_eq!(alice.tenant_id.as_deref(), Some("acme"));
+    assert_eq!(alice.role, Role::Write);
+    assert!(alice.enabled);
 }
 
 #[test]

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -116,7 +116,9 @@ use reddb::json::{from_slice as json_from_slice, json, Value as JsonValue};
 use reddb::replication::cdc::{change_record_from_entity, ChangeOperation, ChangeRecord};
 use reddb::storage::query::UnifiedRecord;
 use reddb::storage::schema::Value;
-use reddb::storage::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
+use reddb::storage::{
+    EntityData, EntityId, EntityKind, RowData, StorageDeployPreset, UnifiedEntity,
+};
 use reddb::{CatalogUseCases, HealthState, RedDBOptions, RedDBRuntime};
 
 const ACCOUNTS_TTL_MS: u64 = 86_400_000;
@@ -194,7 +196,10 @@ impl PersistentDbPath {
 
     pub fn open_runtime(&self) -> RedDBRuntime {
         let path = self.path_string();
-        RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        let options = RedDBOptions::persistent(&path)
+            .with_storage_profile(StorageDeployPreset::Serverless.selection())
+            .unwrap_or_else(|err| panic!("serverless storage profile should be valid: {err}"));
+        RedDBRuntime::with_options(options)
             .unwrap_or_else(|err| panic!("failed to open persistent runtime at {path}: {err:?}"))
     }
 


### PR DESCRIPTION
## Summary
- support nested SQL subqueries across SELECT, FROM, WHERE, CTE and inline graph TVF paths
- materialize subquery sources in join execution instead of treating synthetic names as physical collections
- allow bare JSON literals for document bodies and preserve JSON root columns for nested projection paths
- add runtime E2E coverage for nested subqueries, multimodel joins, graph TVFs, KV/document/table JSON paths

## Verification
- rtk cargo test --test e2e_nested_queries_multimodel_json -- --nocapture
- rtk cargo test --test e2e_sql_cte -- --nocapture
- rtk cargo check -p reddb-io-rql
- rtk cargo check -p reddb-io-server
- rtk cargo fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783948479&installation_id=129708444&pr_number=1142&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1142&signature=839e63689a406c06ca516395ce14d3ec10e8250436b0b2452b875f41bc7be43f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `CREATE USER` statement for user account management
  * `SHOW CONFIG` and `KV LIST` now support `AS JSON` output format
  * Added `red.secrets` as an alias for `red.secret` in secret management
  * Introduced `STANDARD` and `FIFO` queue modes
  * Support for nested document field indexing and filtering (e.g., `body.service.tier`)
  * Added subquery support in `FROM` clauses

* **Improvements**
  * Enhanced JSON parsing for document body columns
  * Improved graph edge label normalization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->