### PR TITLE
test(wire): route server frame fixtures through reddb-wire

### DIFF
--- a/crates/reddb-server/tests/e2e_issue_1042_ui_bridge.rs
+++ b/crates/reddb-server/tests/e2e_issue_1042_ui_bridge.rs
@@ -26,8 +26,8 @@ use reddb_server::server::RedDBServer;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 use reddb_wire::redwire::{
     build_auth_response_anonymous_payload, build_auth_response_frame, build_client_hello_frame,
-    build_query_frame, decode_frame, encode_frame, Frame, MessageKind, MAX_KNOWN_MINOR_VERSION,
-    REDWIRE_MAGIC,
+    build_query_frame, drain_next_frame, frame_to_bytes, Frame, MessageKind,
+    MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
@@ -67,7 +67,7 @@ fn ws_request(
 }
 
 async fn send_frame(ws: &mut WsStream, frame: &Frame) {
-    ws.send(Message::Binary(Bytes::from(encode_frame(frame))))
+    ws.send(Message::Binary(Bytes::from(frame_to_bytes(frame))))
         .await
         .expect("send frame");
 }
@@ -76,11 +76,8 @@ async fn send_frame(ws: &mut WsStream, frame: &Frame) {
 /// frame stream, returning the next decoded frame.
 async fn next_frame(ws: &mut WsStream, buf: &mut Vec<u8>) -> Frame {
     loop {
-        if buf.len() >= reddb_wire::redwire::FRAME_HEADER_SIZE {
-            if let Ok((frame, consumed)) = decode_frame(buf) {
-                buf.drain(..consumed);
-                return frame;
-            }
+        if let Some(frame) = drain_next_frame(buf).expect("decode frame") {
+            return frame;
         }
         let msg = timeout(TIMEOUT, ws.next())
             .await

--- a/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
+++ b/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
@@ -33,8 +33,8 @@ use reddb_server::wire::WireTlsConfig;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 use reddb_wire::redwire::{
     build_auth_response_anonymous_payload, build_auth_response_frame, build_client_hello_frame,
-    build_query_frame, decode_frame, encode_frame, Frame, MessageKind, MAX_KNOWN_MINOR_VERSION,
-    REDWIRE_MAGIC,
+    build_query_frame, drain_next_frame, frame_to_bytes, Frame, MessageKind,
+    MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC,
 };
 use tokio::net::TcpListener;
 use tokio::time::timeout;
@@ -102,7 +102,7 @@ fn ws_request(
 }
 
 async fn send_frame(ws: &mut WsStream, frame: &Frame) {
-    ws.send(Message::Binary(Bytes::from(encode_frame(frame))))
+    ws.send(Message::Binary(Bytes::from(frame_to_bytes(frame))))
         .await
         .expect("send frame");
 }
@@ -111,11 +111,8 @@ async fn send_frame(ws: &mut WsStream, frame: &Frame) {
 /// frame stream, returning the next decoded frame.
 async fn next_frame(ws: &mut WsStream, buf: &mut Vec<u8>) -> Frame {
     loop {
-        if buf.len() >= reddb_wire::redwire::FRAME_HEADER_SIZE {
-            if let Ok((frame, consumed)) = decode_frame(buf) {
-                buf.drain(..consumed);
-                return frame;
-            }
+        if let Some(frame) = drain_next_frame(buf).expect("decode frame") {
+            return frame;
         }
         let msg = timeout(TIMEOUT, ws.next())
             .await

--- a/crates/reddb-server/tests/e2e_issue_1048_auth_handoff.rs
+++ b/crates/reddb-server/tests/e2e_issue_1048_auth_handoff.rs
@@ -28,8 +28,8 @@ use reddb_server::server::RedDBServer;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 use reddb_wire::redwire::{
     build_auth_response_anonymous_payload, build_auth_response_frame, build_client_hello_frame,
-    build_query_frame, decode_frame, encode_frame, Frame, MessageKind, MAX_KNOWN_MINOR_VERSION,
-    REDWIRE_MAGIC,
+    build_query_frame, drain_next_frame, frame_to_bytes, Frame, MessageKind,
+    MAX_KNOWN_MINOR_VERSION, REDWIRE_MAGIC,
 };
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -91,18 +91,15 @@ fn ws_request(
 }
 
 async fn send_frame(ws: &mut WsStream, frame: &Frame) {
-    ws.send(Message::Binary(Bytes::from(encode_frame(frame))))
+    ws.send(Message::Binary(Bytes::from(frame_to_bytes(frame))))
         .await
         .expect("send frame");
 }
 
 async fn next_frame(ws: &mut WsStream, buf: &mut Vec<u8>) -> Frame {
     loop {
-        if buf.len() >= reddb_wire::redwire::FRAME_HEADER_SIZE {
-            if let Ok((frame, consumed)) = decode_frame(buf) {
-                buf.drain(..consumed);
-                return frame;
-            }
+        if let Some(frame) = drain_next_frame(buf).expect("decode frame") {
+            return frame;
         }
         let msg = timeout(TIMEOUT, ws.next())
             .await

--- a/crates/reddb-wire/src/redwire/io.rs
+++ b/crates/reddb-wire/src/redwire/io.rs
@@ -72,6 +72,35 @@ where
     Ok(())
 }
 
+/// Encode one frame for transports that move already-chunked binary payloads,
+/// such as RedWire-over-WebSocket.
+pub fn frame_to_bytes(frame: &Frame) -> Vec<u8> {
+    encode_frame(frame)
+}
+
+/// Drain the next complete RedWire frame from an accumulated byte buffer.
+///
+/// This gives chunked transports the same canonical frame parsing as
+/// [`read_frame_async`] without making callers know the header size or codec
+/// choreography.
+pub fn drain_next_frame(buffer: &mut Vec<u8>) -> Result<Option<Frame>, FrameError> {
+    if buffer.len() < FRAME_HEADER_SIZE {
+        return Ok(None);
+    }
+
+    let mut header = [0u8; FRAME_HEADER_SIZE];
+    header.copy_from_slice(&buffer[..FRAME_HEADER_SIZE]);
+    let length = frame_len_from_header(&header)?;
+    if buffer.len() < length {
+        return Ok(None);
+    }
+
+    let payload = &buffer[FRAME_HEADER_SIZE..length];
+    let frame = decode_frame_parts(&header, payload)?;
+    buffer.drain(..length);
+    Ok(Some(frame))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -86,5 +115,28 @@ mod tests {
         let decoded = read_frame_async(&mut right).await.unwrap();
 
         assert_eq!(decoded, frame);
+    }
+
+    #[test]
+    fn chunked_frame_io_drains_complete_frames_and_keeps_leftover() {
+        let first = Frame::new(MessageKind::Ping, 1, b"one".to_vec());
+        let second = Frame::new(MessageKind::Pong, 2, b"two".to_vec());
+        let mut bytes = frame_to_bytes(&first);
+        bytes.extend_from_slice(&frame_to_bytes(&second));
+        bytes.extend_from_slice(b"partial");
+
+        assert_eq!(drain_next_frame(&mut bytes).unwrap(), Some(first));
+        assert_eq!(drain_next_frame(&mut bytes).unwrap(), Some(second));
+        assert_eq!(drain_next_frame(&mut bytes).unwrap(), None);
+        assert_eq!(bytes, b"partial");
+    }
+
+    #[test]
+    fn chunked_frame_io_waits_for_complete_payload() {
+        let frame = Frame::new(MessageKind::Ping, 1, b"hello".to_vec());
+        let mut bytes = frame_to_bytes(&frame);
+        bytes.pop();
+
+        assert_eq!(drain_next_frame(&mut bytes).unwrap(), None);
     }
 }

--- a/crates/reddb-wire/src/redwire/mod.rs
+++ b/crates/reddb-wire/src/redwire/mod.rs
@@ -61,7 +61,9 @@ pub use handshake::{
     expect_auth_response_payload, AuthFail, AuthOk, AuthResponseKindError, Hello, HelloAck,
     SUPPORTED_METHODS,
 };
-pub use io::{read_frame_async, write_frame_async, RedWireIoError};
+pub use io::{
+    drain_next_frame, frame_to_bytes, read_frame_async, write_frame_async, RedWireIoError,
+};
 pub use operations::{
     decode_bulk_ok_count_payload, decode_bulk_ok_payload, decode_delete_ok_affected,
     decode_delete_payload, decode_error_payload, decode_get_payload, decode_get_result_payload,


### PR DESCRIPTION
Summary
- add RedWire chunked-transport helpers in reddb-wire
- make server E2E bridge tests consume frame encode/decode through the wire crate
- preserve the wire authority fence by removing direct frame codec/header knowledge from server tests

Verification
- cargo fmt --check
- cargo check -p reddb-io-wire
- cargo check -p reddb-io-server
- cargo test -p reddb-io-wire --test protocol_authority
- rg -n "Frame::new\(|FrameBuilder::|decode_frame\(|encode_frame\(|FRAME_HEADER_SIZE" crates/reddb-server/tests -g "*.rs" (no matches)
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783953140&installation_id=129708444&pr_number=1143&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1143&signature=5b804d4e0e73be6ab1357cf990d57657e7b5e6ac0110cfa50baa70e0fd9d1558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public functions `frame_to_bytes()` and `drain_next_frame()` to the RedWire API for encoding frames to bytes and parsing frames from buffered input without async I/O.

* **Tests**
  * Updated end-to-end tests to use the new frame serialization utilities.
  * Added unit tests validating frame extraction from accumulated buffers with partial payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->