### PR TITLE
test(crypto): gate coverage above ninety percent

### DIFF
--- a/.github/workflows/crypto-coverage.yml
+++ b/.github/workflows/crypto-coverage.yml
@@ -1,0 +1,74 @@
+name: Crypto Coverage Gate
+
+# Hard coverage gate for the reddb-io-crypto authority crate.
+# ADR 0054 makes this crate the canonical per-page encryption envelope
+# and key parser. Unlike the older advisory reports, this job fails the
+# PR if the crate drops below 90% line coverage.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/reddb-crypto/**'
+      - '.github/workflows/crypto-coverage.yml'
+  pull_request:
+    paths:
+      - 'crates/reddb-crypto/**'
+      - '.github/workflows/crypto-coverage.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: crypto-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  crypto-coverage:
+    name: Crypto Coverage Gate
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    timeout-minutes: 15
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          components: llvm-tools-preview
+
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-rust-1.95.0-llvm-cov-crypto
+          cache-on-failure: "true"
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage gate (reddb-io-crypto)
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          cargo llvm-cov -p reddb-io-crypto --summary-only --fail-under-lines 90 | tee coverage-summary.txt
+
+          {
+            echo "## Crypto Coverage Gate"
+            echo ""
+            echo "Crate: \`reddb-io-crypto\` — hard minimum: **90% line coverage**"
+            echo ""
+            echo '```'
+            cat coverage-summary.txt
+            echo '```'
+            echo ""
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-crypto --summary-only --fail-under-lines 90\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/crates/reddb-crypto/src/key.rs
+++ b/crates/reddb-crypto/src/key.rs
@@ -141,4 +141,24 @@ mod tests {
         let key = parse_key(&out).unwrap();
         assert_eq!(key, [0xABu8; 32]);
     }
+
+    #[test]
+    fn decode_base64_accepts_symbols_whitespace_and_padding() {
+        assert_eq!(decode_base64(" +/+/==\n").unwrap(), vec![251, 255, 191]);
+    }
+
+    #[test]
+    fn decode_base64_rejects_invalid_chars_by_position() {
+        for input in [
+            "!AAA", "A!AA", "AA!A", "AAA!", "!A", "A!", "!AA", "A!A", "AA!",
+        ] {
+            assert!(decode_base64(input).is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn decode_base64_rejects_single_char_remainder() {
+        let err = decode_base64("A").unwrap_err();
+        assert!(err.contains("invalid base64 length remainder 1"));
+    }
 }

--- a/crates/reddb-crypto/src/os_random.rs
+++ b/crates/reddb-crypto/src/os_random.rs
@@ -55,3 +55,14 @@ fn fill_bytes_windows(buf: &mut [u8]) -> Result<(), String> {
 extern "system" {
     fn SystemFunction036(RandomBuffer: *mut u8, RandomBufferLength: u32) -> u8;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_buffer_is_a_noop() {
+        let mut buf = [];
+        fill_bytes(&mut buf).unwrap();
+    }
+}

--- a/crates/reddb-crypto/src/page_envelope.rs
+++ b/crates/reddb-crypto/src/page_envelope.rs
@@ -192,4 +192,20 @@ mod tests {
         bad[last] ^= 1;
         assert!(decrypt_page(&key(), 9, &bad).is_err());
     }
+
+    #[test]
+    fn error_display_is_specific_to_failure_class() {
+        assert_eq!(
+            PageEnvelopeError::Truncated.to_string(),
+            "encrypted page: truncated frame"
+        );
+        assert_eq!(
+            PageEnvelopeError::KeyMismatch("bad tag".to_string()).to_string(),
+            "encrypted page: key mismatch or tampering (bad tag)"
+        );
+        assert_eq!(
+            PageEnvelopeError::RandomFailure("no entropy".to_string()).to_string(),
+            "encrypted page: nonce generation failed (no entropy)"
+        );
+    }
 }


### PR DESCRIPTION
Summary
- add focused reddb-io-crypto tests for key parsing, OS random empty-buffer behavior, and page-envelope error formatting
- raise reddb-io-crypto line coverage above the 90% hard target
- add a crypto coverage workflow that fails below 90% line coverage on crypto changes

Verification
- cargo fmt --check
- cargo test -p reddb-io-crypto
- cargo llvm-cov -p reddb-io-crypto --summary-only --fail-under-lines 90
- git diff --check

Notes
- This hardens reddb-io-crypto only. reddb-io-types and reddb-io-file still need separate coverage work before we can honestly claim all authority packages meet the 90% target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783953845&installation_id=129708444&pr_number=1144&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1144&signature=7fdecada65a8040652d8869f681d7a0dc2b013e2092ffcd33e54b10d5b7f7993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->