### PR TITLE
ci(packages): gate rql and wire coverage at ninety percent

### DIFF
--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -1,10 +1,8 @@
 name: RQL Coverage
 
-# Report-only llvm-cov signal for the reddb-io-rql language front-end crate
-# (ADR 0053, PRD #1098). Aspirational target is ~95%+, but this workflow
-# NEVER blocks merge — it only surfaces the number in the job summary and,
-# on PRs, as an advisory comment. A hard merge gate is explicitly out of
-# scope (mirrors the reddb-io-types posture, PRD #1060).
+# Hard llvm-cov gate for the reddb-io-rql language front-end crate
+# (ADR 0053, PRD #1098). The aspirational target remains ~95%+, but
+# this workflow now blocks merge below 90% line coverage.
 
 on:
   push:
@@ -71,6 +69,7 @@ jobs:
           # profile data between a separate collection and report phase.
           cargo llvm-cov -p reddb-io-rql --lib --json --summary-only \
             --ignore-filename-regex 'crates/reddb-types/' \
+            --fail-under-lines 90 \
             --output-path coverage-summary.json
 
       - name: Build report
@@ -180,14 +179,13 @@ jobs:
           {
             echo "## RQL Coverage Report"
             echo ""
-            echo "Crate: \`reddb-io-rql\` — line coverage: **${total_line}** (target ~95%, advisory)"
+            echo "Crate: \`reddb-io-rql\` — line coverage: **${total_line}** (hard minimum 90%, target ~95%)"
             echo ""
             echo '```'
             cat coverage-summary.txt
             echo '```'
             echo ""
-            echo "> ℹ️ Report-only — this never blocks merge (ADR 0053 / PRD #1098)."
-            echo "> Run locally: \`cargo llvm-cov -p reddb-io-rql --lib --summary-only --ignore-filename-regex 'crates/reddb-types/'\`"
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-rql --lib --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90\`"
           } > coverage-report.md
 
           # Mirror to the job summary so the signal is visible without a PR.

--- a/.github/workflows/wire-coverage.yml
+++ b/.github/workflows/wire-coverage.yml
@@ -1,0 +1,76 @@
+name: Wire Coverage Gate
+
+# Hard coverage gate for the reddb-io-wire authority crate.
+# ADR 0046 makes this crate the protocol-contract authority. This job
+# fails the PR if the isolated wire crate drops below 90% line coverage.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/reddb-wire/**'
+      - '.github/workflows/wire-coverage.yml'
+  pull_request:
+    paths:
+      - 'crates/reddb-wire/**'
+      - '.github/workflows/wire-coverage.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: wire-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  wire-coverage:
+    name: Wire Coverage Gate
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    timeout-minutes: 25
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          components: llvm-tools-preview
+
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-rust-1.95.0-llvm-cov-wire
+          cache-on-failure: "true"
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage gate (reddb-io-wire)
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          cargo llvm-cov -p reddb-io-wire --summary-only \
+            --ignore-filename-regex 'crates/reddb-types/' \
+            --fail-under-lines 90 \
+            | tee coverage-summary.txt
+
+          {
+            echo "## Wire Coverage Gate"
+            echo ""
+            echo "Crate: \`reddb-io-wire\` — hard minimum: **90% line coverage**"
+            echo ""
+            echo '```'
+            cat coverage-summary.txt
+            echo '```'
+            echo ""
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-wire --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.red/adr/0053-reddb-io-rql-boundary.md
+++ b/.red/adr/0053-reddb-io-rql-boundary.md
@@ -27,8 +27,10 @@ surfaces but are never promoted to "truth".
 
 Quality posture: full parser pyramid (proptest AST→print→re-parse round-trip,
 cargo-fuzz no-panic, corpus goldens including error-message-with-position
-snapshots, differential accept/reject vs `sqlparser-rs`), with **~95%+
-aspirational `cargo llvm-cov` coverage reported in CI — no hard merge gate**.
+snapshots, differential accept/reject vs `sqlparser-rs`). The aspirational
+coverage target remains **~95%+**, and CI now enforces a **90% line-coverage
+floor** for the pure `reddb-io-rql` library scope (`--lib`, excluding
+`reddb-io-types` from totals).
 
 Sequencing: three phases (types re-home → conformance-suite-before-move → rql
 extraction → pyramid), each a PRD drained by `/afk`, queued after the current


### PR DESCRIPTION
Summary
- convert RQL coverage from advisory to a hard 90% line coverage gate
- add a hard 90% line coverage gate for reddb-io-wire
- update ADR 0053 so the RQL coverage posture matches the new CI behavior

Verification
- cargo llvm-cov clean --workspace
- cargo llvm-cov -p reddb-io-rql --lib --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90 -> 90.13% lines\n- cargo llvm-cov clean --workspace\n- cargo llvm-cov -p reddb-io-wire --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90 -> 90.14% lines\n- cargo llvm-cov -p reddb-io-rql --lib --json --summary-only --ignore-filename-regex 'crates/reddb-types/' --fail-under-lines 90 --output-path /tmp/reddb-rql-coverage-summary.json\n- cargo fmt --check\n- git diff --check\n- actionlint -ignore 'label "blacksmith-[^\\"]+" is unknown' .github/workflows/rql-coverage.yml .github/workflows/wire-coverage.yml\n\nNotes\n- This hardens RQL and Wire. reddb-io-types and reddb-io-file remain below 90% and need separate coverage work before the package-authority goal is complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783954461&installation_id=129708444&pr_number=1145&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1145&signature=9ebb1ed9c4e2f75743e6710518b7ca927d114ba6c40e5654a4f88c02ee8786a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->