### PR TITLE
test(types): raise authority coverage baseline

### DIFF
--- a/crates/reddb-types/src/catalog.rs
+++ b/crates/reddb-types/src/catalog.rs
@@ -140,3 +140,65 @@ pub struct AnalyticsViewDescriptor {
     /// `tolerance = <f64>` — convergence tolerance for iterative centralities.
     pub tolerance: Option<f64>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscription_operations_round_trip_canonical_names() {
+        for (op, name) in [
+            (SubscriptionOperation::Insert, "INSERT"),
+            (SubscriptionOperation::Update, "UPDATE"),
+            (SubscriptionOperation::Delete, "DELETE"),
+        ] {
+            assert_eq!(op.as_str(), name);
+            assert_eq!(
+                SubscriptionOperation::from_str(&name.to_ascii_lowercase()),
+                Some(op)
+            );
+        }
+        assert_eq!(SubscriptionOperation::from_str("UPSERT"), None);
+    }
+
+    #[test]
+    fn analytics_outputs_round_trip_lowercase_names() {
+        for (output, name) in [
+            (AnalyticsOutput::Communities, "communities"),
+            (AnalyticsOutput::Components, "components"),
+            (AnalyticsOutput::Centrality, "centrality"),
+        ] {
+            assert_eq!(output.as_str(), name);
+            assert_eq!(
+                AnalyticsOutput::from_str(&name.to_ascii_uppercase()),
+                Some(output)
+            );
+        }
+        assert_eq!(AnalyticsOutput::from_str("pagerank"), None);
+    }
+
+    #[test]
+    fn descriptors_are_plain_data_carriers() {
+        let subscription = SubscriptionDescriptor {
+            name: "audit".to_string(),
+            source: "orders".to_string(),
+            target_queue: "events".to_string(),
+            ops_filter: vec![SubscriptionOperation::Insert, SubscriptionOperation::Delete],
+            where_filter: Some("amount > 0".to_string()),
+            redact_fields: vec!["secret".to_string()],
+            enabled: true,
+            all_tenants: false,
+        };
+        assert_eq!(subscription.ops_filter[1].as_str(), "DELETE");
+
+        let view = AnalyticsViewDescriptor {
+            output: AnalyticsOutput::Centrality,
+            algorithm: Some("pagerank".to_string()),
+            resolution: Some(1.0),
+            max_iterations: Some(20),
+            tolerance: Some(0.001),
+        };
+        assert_eq!(view.output.as_str(), "centrality");
+        assert_eq!(view.algorithm.as_deref(), Some("pagerank"));
+    }
+}

--- a/crates/reddb-types/src/conversions.rs
+++ b/crates/reddb-types/src/conversions.rs
@@ -50,3 +50,19 @@ impl From<bool> for Value {
         Value::Boolean(b)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_conversions_construct_expected_value_variants() {
+        assert_eq!(Value::from("red"), Value::text("red"));
+        assert_eq!(Value::from("db".to_string()), Value::text("db"));
+        assert_eq!(Value::from(7_i32), Value::Integer(7));
+        assert_eq!(Value::from(9_i64), Value::Integer(9));
+        assert_eq!(Value::from(1.5_f32), Value::Float(1.5));
+        assert_eq!(Value::from(2.25_f64), Value::Float(2.25));
+        assert_eq!(Value::from(true), Value::Boolean(true));
+    }
+}

--- a/crates/reddb-types/src/function_catalog.rs
+++ b/crates/reddb-types/src/function_catalog.rs
@@ -986,3 +986,48 @@ pub fn lookup(name: &str) -> Vec<&'static FunctionEntry> {
 pub fn resolve(name: &str, arg_types: &[DataType]) -> Option<&'static FunctionEntry> {
     crate::coercion_spine::resolve_function(name, arg_types).map(|(entry, _)| entry)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_is_case_insensitive_and_returns_overloads() {
+        let count = lookup("count");
+        assert!(count.len() >= 3);
+        assert!(count.iter().all(|entry| entry.name == "COUNT"));
+        assert!(lookup("missing_function").is_empty());
+    }
+
+    #[test]
+    fn catalog_pins_key_function_kinds_and_variadic_flags() {
+        let now = lookup("NOW").into_iter().next().expect("NOW");
+        assert_eq!(now.kind, FunctionKind::Volatile);
+        assert!(now.arg_types.is_empty());
+        assert_eq!(now.return_type, DataType::TimestampMs);
+
+        let coalesce = lookup("COALESCE").into_iter().next().expect("COALESCE");
+        assert_eq!(coalesce.kind, FunctionKind::Scalar);
+        assert!(coalesce.variadic);
+        assert_eq!(coalesce.return_type, DataType::Text);
+
+        let sum = lookup("SUM")
+            .into_iter()
+            .find(|entry| entry.arg_types == [DataType::BigInt])
+            .expect("SUM(bigint)");
+        assert_eq!(sum.kind, FunctionKind::Aggregate);
+        assert_eq!(sum.return_type, DataType::BigInt);
+    }
+
+    #[test]
+    fn resolve_delegates_to_coercion_spine() {
+        let abs_int = resolve("ABS", &[DataType::Integer]).expect("ABS(int)");
+        assert_eq!(abs_int.return_type, DataType::Integer);
+
+        let abs_float = resolve("ABS", &[DataType::Float]).expect("ABS(float)");
+        assert_eq!(abs_float.return_type, DataType::Float);
+
+        assert!(resolve("ABS", &[DataType::Text]).is_none());
+        assert!(resolve("DOES_NOT_EXIST", &[DataType::Integer]).is_none());
+    }
+}

--- a/crates/reddb-types/src/operator.rs
+++ b/crates/reddb-types/src/operator.rs
@@ -55,3 +55,31 @@ impl BinOp {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn precedence_groups_match_parser_contract() {
+        assert_eq!(BinOp::Or.precedence(), 10);
+        assert_eq!(BinOp::And.precedence(), 20);
+        for op in [
+            BinOp::Eq,
+            BinOp::Ne,
+            BinOp::Lt,
+            BinOp::Le,
+            BinOp::Gt,
+            BinOp::Ge,
+        ] {
+            assert_eq!(op.precedence(), 30, "{op:?}");
+        }
+        assert_eq!(BinOp::Concat.precedence(), 40);
+        for op in [BinOp::Add, BinOp::Sub] {
+            assert_eq!(op.precedence(), 50, "{op:?}");
+        }
+        for op in [BinOp::Mul, BinOp::Div, BinOp::Mod] {
+            assert_eq!(op.precedence(), 60, "{op:?}");
+        }
+    }
+}

--- a/crates/reddb-types/src/operator_catalog.rs
+++ b/crates/reddb-types/src/operator_catalog.rs
@@ -246,3 +246,53 @@ pub fn resolve(
 
     best.map(|(_, entry)| entry)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_returns_all_overloads_for_symbol() {
+        let plus = lookup("+");
+        assert!(plus.len() >= 6);
+        assert!(plus.iter().all(|entry| entry.name == "+"));
+        assert!(lookup("??").is_empty());
+    }
+
+    #[test]
+    fn resolve_picks_exact_infix_and_prefix_overloads() {
+        let add = resolve("+", OperatorKind::Infix, DataType::Integer, DataType::Float)
+            .expect("int + float overload");
+        assert_eq!(add.return_type, DataType::Float);
+        assert_eq!(add.kind, OperatorKind::Infix);
+
+        let not = resolve(
+            "NOT",
+            OperatorKind::Prefix,
+            DataType::Nullable,
+            DataType::Boolean,
+        )
+        .expect("NOT boolean overload");
+        assert_eq!(not.lhs_type, DataType::Nullable);
+        assert_eq!(not.return_type, DataType::Boolean);
+    }
+
+    #[test]
+    fn resolve_rejects_unknown_and_mismatched_overloads() {
+        assert!(resolve(
+            "??",
+            OperatorKind::Infix,
+            DataType::Integer,
+            DataType::Integer
+        )
+        .is_none());
+        assert!(resolve(
+            "+",
+            OperatorKind::Postfix,
+            DataType::Integer,
+            DataType::Integer
+        )
+        .is_none());
+        assert!(resolve("+", OperatorKind::Infix, DataType::Boolean, DataType::Text).is_none());
+    }
+}

--- a/crates/reddb-types/src/parametric.rs
+++ b/crates/reddb-types/src/parametric.rs
@@ -228,3 +228,116 @@ pub fn parse_decimal_modifier(sql_type: &SqlTypeName) -> Result<(u8, u8), Parame
     }
     Ok((precision, scale))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_varchar_rejects_or_truncates_by_mode() {
+        let value = Value::text("abcdef");
+        let err = validate_varchar(&value, 3, VarcharMode::Reject).unwrap_err();
+        assert_eq!(err.to_string(), "string of length 6 exceeds VARCHAR(3)");
+
+        let truncated = validate_varchar(&value, 3, VarcharMode::Truncate).unwrap();
+        assert_eq!(truncated, Value::text("abc"));
+
+        let non_text = validate_varchar(&Value::Integer(123), 3, VarcharMode::Reject).unwrap();
+        assert_eq!(non_text, Value::text("123"));
+    }
+
+    #[test]
+    fn validate_decimal_checks_precision_scale_and_syntax() {
+        assert_eq!(
+            validate_decimal(&Value::Decimal(12_3400), 6, 4).unwrap(),
+            Value::Decimal(12_3400)
+        );
+
+        assert!(matches!(
+            validate_decimal(&Value::Decimal(12_3400), 5, 4),
+            Err(ParametricError::DecimalPrecisionOverflow { .. })
+        ));
+        assert!(matches!(
+            validate_decimal(&Value::Decimal(12_3400), 6, 2),
+            Err(ParametricError::DecimalScaleOverflow { .. })
+        ));
+        assert!(matches!(
+            validate_decimal(&Value::text("not decimal"), 10, 2),
+            Err(ParametricError::NotADecimal(_))
+        ));
+    }
+
+    #[test]
+    fn varchar_modifier_parses_defaults_and_errors() {
+        assert_eq!(
+            parse_varchar_modifier(&SqlTypeName::new("varchar")).unwrap(),
+            u32::MAX
+        );
+        assert_eq!(
+            parse_varchar_modifier(
+                &SqlTypeName::new("varchar").with_modifiers(vec![TypeModifier::Number(42)])
+            )
+            .unwrap(),
+            42
+        );
+        assert!(matches!(
+            parse_varchar_modifier(
+                &SqlTypeName::new("varchar")
+                    .with_modifiers(vec![TypeModifier::Number(1), TypeModifier::Number(2)])
+            ),
+            Err(ParametricError::BadModifier(_))
+        ));
+        assert!(matches!(
+            parse_varchar_modifier(
+                &SqlTypeName::new("varchar")
+                    .with_modifiers(vec![TypeModifier::Ident("x".to_string())])
+            ),
+            Err(ParametricError::BadModifier(_))
+        ));
+    }
+
+    #[test]
+    fn decimal_modifier_parses_defaults_and_errors() {
+        assert_eq!(
+            parse_decimal_modifier(&SqlTypeName::new("decimal")).unwrap(),
+            (38, 0)
+        );
+        assert_eq!(
+            parse_decimal_modifier(
+                &SqlTypeName::new("decimal").with_modifiers(vec![TypeModifier::Number(10)])
+            )
+            .unwrap(),
+            (10, 0)
+        );
+        assert_eq!(
+            parse_decimal_modifier(
+                &SqlTypeName::new("decimal")
+                    .with_modifiers(vec![TypeModifier::Number(10), TypeModifier::Number(2)])
+            )
+            .unwrap(),
+            (10, 2)
+        );
+
+        for modifiers in [
+            vec![
+                TypeModifier::Number(1),
+                TypeModifier::Number(2),
+                TypeModifier::Number(3),
+            ],
+            vec![TypeModifier::Ident("p".to_string())],
+            vec![TypeModifier::Number(300)],
+            vec![
+                TypeModifier::Number(10),
+                TypeModifier::Ident("s".to_string()),
+            ],
+            vec![TypeModifier::Number(10), TypeModifier::Number(300)],
+            vec![TypeModifier::Number(2), TypeModifier::Number(3)],
+        ] {
+            let ty = SqlTypeName::new("decimal").with_modifiers(modifiers);
+            assert!(matches!(
+                parse_decimal_modifier(&ty),
+                Err(ParametricError::BadModifier(_))
+            ));
+        }
+    }
+}

--- a/crates/reddb-types/src/polymorphic.rs
+++ b/crates/reddb-types/src/polymorphic.rs
@@ -251,3 +251,158 @@ fn bind(
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitution_apply_returns_bound_or_concrete_types() {
+        let sub = Substitution {
+            any_element: Some(DataType::Integer),
+            any_array: Some(DataType::Array),
+            any_nonarray: Some(DataType::Text),
+            any_compatible: Some(DataType::Float),
+        };
+        assert_eq!(
+            sub.apply(ArgSlot::Concrete(DataType::Boolean)),
+            Some(DataType::Boolean)
+        );
+        assert_eq!(
+            sub.apply(ArgSlot::Poly(PseudoType::AnyElement)),
+            Some(DataType::Integer)
+        );
+        assert_eq!(
+            sub.apply(ArgSlot::Poly(PseudoType::AnyArray)),
+            Some(DataType::Array)
+        );
+        assert_eq!(
+            sub.apply(ArgSlot::Poly(PseudoType::AnyNonArray)),
+            Some(DataType::Text)
+        );
+        assert_eq!(
+            sub.apply(ArgSlot::Poly(PseudoType::AnyCompatible)),
+            Some(DataType::Float)
+        );
+        assert_eq!(
+            Substitution::default().apply(ArgSlot::Poly(PseudoType::AnyElement)),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_accepts_concrete_and_poly_slots() {
+        let sub = resolve(
+            &[
+                ArgSlot::Concrete(DataType::Float),
+                ArgSlot::Poly(PseudoType::AnyElement),
+                ArgSlot::Poly(PseudoType::AnyArray),
+                ArgSlot::Poly(PseudoType::AnyNonArray),
+            ],
+            &[
+                DataType::Integer,
+                DataType::Text,
+                DataType::Array,
+                DataType::Boolean,
+            ],
+        )
+        .unwrap();
+        assert_eq!(sub.any_element, Some(DataType::Text));
+        assert_eq!(sub.any_array, Some(DataType::Array));
+        assert_eq!(sub.any_nonarray, Some(DataType::Boolean));
+    }
+
+    #[test]
+    fn resolve_reports_arity_and_kind_errors() {
+        assert!(matches!(
+            resolve(&[ArgSlot::Poly(PseudoType::AnyElement)], &[]),
+            Err(ResolveError::ArityMismatch {
+                expected: 1,
+                got: 0
+            })
+        ));
+        assert!(matches!(
+            resolve(&[ArgSlot::Poly(PseudoType::AnyArray)], &[DataType::Text]),
+            Err(ResolveError::ArrayGotScalar)
+        ));
+        assert!(matches!(
+            resolve(
+                &[ArgSlot::Poly(PseudoType::AnyNonArray)],
+                &[DataType::Array]
+            ),
+            Err(ResolveError::NonArrayGotArray)
+        ));
+        assert!(matches!(
+            resolve(&[ArgSlot::Concrete(DataType::Boolean)], &[DataType::Text]),
+            Err(ResolveError::Conflict { .. })
+        ));
+    }
+
+    #[test]
+    fn repeated_pseudo_slots_must_be_consistent() {
+        let ok = resolve(
+            &[
+                ArgSlot::Poly(PseudoType::AnyElement),
+                ArgSlot::Poly(PseudoType::AnyElement),
+            ],
+            &[DataType::Integer, DataType::Integer],
+        )
+        .unwrap();
+        assert_eq!(ok.any_element, Some(DataType::Integer));
+
+        let err = resolve(
+            &[
+                ArgSlot::Poly(PseudoType::AnyElement),
+                ArgSlot::Poly(PseudoType::AnyElement),
+            ],
+            &[DataType::Integer, DataType::Text],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ResolveError::Conflict {
+                pseudo: PseudoType::AnyElement,
+                first: DataType::Integer,
+                other: DataType::Text,
+            }
+        ));
+        assert!(err.to_string().contains("AnyElement"));
+    }
+
+    #[test]
+    fn anycompatible_uses_cast_catalog_to_resolve_binding() {
+        let int_then_float = resolve(
+            &[
+                ArgSlot::Poly(PseudoType::AnyCompatible),
+                ArgSlot::Poly(PseudoType::AnyCompatible),
+            ],
+            &[DataType::Integer, DataType::Float],
+        )
+        .unwrap();
+        assert_eq!(int_then_float.any_compatible, Some(DataType::Integer));
+
+        let float_then_int = resolve(
+            &[
+                ArgSlot::Poly(PseudoType::AnyCompatible),
+                ArgSlot::Poly(PseudoType::AnyCompatible),
+            ],
+            &[DataType::Float, DataType::Integer],
+        )
+        .unwrap();
+        assert_eq!(float_then_int.any_compatible, Some(DataType::Float));
+
+        assert!(matches!(
+            resolve(
+                &[
+                    ArgSlot::Poly(PseudoType::AnyCompatible),
+                    ArgSlot::Poly(PseudoType::AnyCompatible),
+                ],
+                &[DataType::Boolean, DataType::Json],
+            ),
+            Err(ResolveError::Conflict {
+                pseudo: PseudoType::AnyCompatible,
+                ..
+            })
+        ));
+    }
+}

--- a/crates/reddb-types/src/queue_mode.rs
+++ b/crates/reddb-types/src/queue_mode.rs
@@ -27,3 +27,21 @@ impl QueueMode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn queue_modes_parse_aliases_and_render_canonical_names() {
+        assert_eq!(QueueMode::default(), QueueMode::Work);
+        assert_eq!(QueueMode::Fanout.as_str(), "fanout");
+        assert_eq!(QueueMode::Work.as_str(), "work");
+
+        assert_eq!(QueueMode::parse("fanout"), Some(QueueMode::Fanout));
+        for alias in ["work", "STANDARD", "fifo"] {
+            assert_eq!(QueueMode::parse(alias), Some(QueueMode::Work), "{alias}");
+        }
+        assert_eq!(QueueMode::parse("broadcast"), None);
+    }
+}

--- a/crates/reddb-types/src/vector_metadata.rs
+++ b/crates/reddb-types/src/vector_metadata.rs
@@ -373,3 +373,122 @@ impl MetadataFilter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn metadata_values_compare_and_match_by_type() {
+        assert!(MetadataValue::from("red database").contains_str("data"));
+        assert!(MetadataValue::from("red database").starts_with("red"));
+        assert!(MetadataValue::from("red database").ends_with("base"));
+        assert!(!MetadataValue::from(42_i64).contains_str("42"));
+
+        assert!(MetadataValue::from(10_i64).matches_eq(&MetadataValue::from(10_i64)));
+        assert!(!MetadataValue::from(10_i64).matches_eq(&MetadataValue::from(11_i64)));
+        assert_eq!(
+            MetadataValue::from(10_i64).compare(&MetadataValue::from(11_i64)),
+            Some(Ordering::Less)
+        );
+        assert_eq!(
+            MetadataValue::from(true).compare(&MetadataValue::from("true")),
+            None
+        );
+    }
+
+    #[test]
+    fn metadata_values_convert_to_canonical_keys() {
+        assert!(metadata_value_to_canonical_key(&MetadataValue::from("alpha")).is_some());
+        assert!(metadata_value_to_canonical_key(&MetadataValue::from(7_i64)).is_some());
+        assert!(metadata_value_to_canonical_key(&MetadataValue::from(1.5_f64)).is_some());
+        assert!(metadata_value_to_canonical_key(&MetadataValue::from(true)).is_some());
+    }
+
+    #[test]
+    fn metadata_entry_inserts_gets_keys_and_removes_nulls() {
+        let mut entry = MetadataEntry::new();
+        assert!(entry.is_empty());
+
+        entry.insert("title", MetadataValue::from("Graph Guide"));
+        entry.insert("pages", MetadataValue::from(100_i64));
+        entry.insert("score", MetadataValue::from(0.75_f64));
+        entry.insert("published", MetadataValue::from(true));
+
+        assert_eq!(entry.get("title"), Some(MetadataValue::from("Graph Guide")));
+        assert_eq!(entry.get("pages"), Some(MetadataValue::from(100_i64)));
+        assert_eq!(entry.get("score"), Some(MetadataValue::from(0.75_f64)));
+        assert_eq!(entry.get("published"), Some(MetadataValue::from(true)));
+        assert!(entry.contains_key("title"));
+        assert!(!entry.is_empty());
+
+        let mut keys = entry.keys();
+        keys.sort();
+        assert_eq!(keys, vec!["pages", "published", "score", "title"]);
+
+        entry.insert("title", MetadataValue::Null);
+        assert_eq!(entry.get("title"), None);
+        assert!(!entry.contains_key("title"));
+    }
+
+    #[test]
+    fn metadata_filters_cover_comparison_membership_and_strings() {
+        let mut entry = MetadataEntry::new();
+        entry.insert("title", MetadataValue::from("Graph Guide"));
+        entry.insert("pages", MetadataValue::from(100_i64));
+
+        assert!(MetadataFilter::eq("title", "Graph Guide").matches(&entry));
+        assert!(!MetadataFilter::eq("title", "Other").matches(&entry));
+        assert!(MetadataFilter::ne("title", "Other").matches(&entry));
+        assert!(MetadataFilter::ne("missing", "anything").matches(&entry));
+
+        assert!(MetadataFilter::gt("pages", 99_i64).matches(&entry));
+        assert!(MetadataFilter::gte("pages", 100_i64).matches(&entry));
+        assert!(MetadataFilter::lt("pages", 101_i64).matches(&entry));
+        assert!(MetadataFilter::lte("pages", 100_i64).matches(&entry));
+        assert!(!MetadataFilter::gt("missing", 1_i64).matches(&entry));
+
+        assert!(MetadataFilter::In(
+            "pages".to_string(),
+            vec![MetadataValue::from(1_i64), MetadataValue::from(100_i64)]
+        )
+        .matches(&entry));
+        assert!(MetadataFilter::NotIn(
+            "pages".to_string(),
+            vec![MetadataValue::from(1_i64), MetadataValue::from(2_i64)]
+        )
+        .matches(&entry));
+        assert!(
+            MetadataFilter::NotIn("missing".to_string(), vec![MetadataValue::from(1_i64)])
+                .matches(&entry)
+        );
+
+        assert!(MetadataFilter::Contains("title".to_string(), "Guide".to_string()).matches(&entry));
+        assert!(
+            MetadataFilter::StartsWith("title".to_string(), "Graph".to_string()).matches(&entry)
+        );
+        assert!(MetadataFilter::EndsWith("title".to_string(), "Guide".to_string()).matches(&entry));
+    }
+
+    #[test]
+    fn metadata_filters_cover_existence_and_boolean_composition() {
+        let mut entry = MetadataEntry::new();
+        entry.insert("title", MetadataValue::from("Graph Guide"));
+        entry.insert("pages", MetadataValue::from(100_i64));
+
+        assert!(MetadataFilter::Exists("title".to_string()).matches(&entry));
+        assert!(MetadataFilter::NotExists("missing".to_string()).matches(&entry));
+        assert!(MetadataFilter::and(vec![
+            MetadataFilter::eq("title", "Graph Guide"),
+            MetadataFilter::gte("pages", 100_i64),
+        ])
+        .matches(&entry));
+        assert!(MetadataFilter::or(vec![
+            MetadataFilter::eq("title", "Other"),
+            MetadataFilter::eq("pages", 100_i64),
+        ])
+        .matches(&entry));
+        assert!(MetadataFilter::not(MetadataFilter::eq("title", "Other")).matches(&entry));
+    }
+}


### PR DESCRIPTION
## Summary
- add focused tests for types catalog/operator/queue/vector metadata helpers
- cover parametric and polymorphic helper behavior around validation, modifiers, arity, and current cast semantics
- raise reddb-io-types local line coverage from 60.68% to 72.08%

## Verification
- cargo fmt --check
- cargo test -p reddb-io-types
- cargo llvm-cov -p reddb-io-types --summary-only

Note: this does not claim the 90% gate for reddb-io-types yet; remaining low-coverage modules include canonical_key, serde_json, types, utils/json, value_codec, and value_compare.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783955236&installation_id=129708444&pr_number=1146&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1146&signature=9325bf14ce3f7d5500ffe580b6f0bf6981d07a8c5b061bdad42933c04a834d3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->