### PR TITLE
test(packages): gate types and file coverage above ninety percent

### DIFF
--- a/.github/workflows/file-coverage.yml
+++ b/.github/workflows/file-coverage.yml
@@ -1,0 +1,75 @@
+name: File Coverage Gate
+
+# Hard coverage gate for the reddb-io-file authority crate.
+#
+# File owns persistent artifact contracts. This workflow fails the PR if the
+# isolated crate drops below 90% line coverage.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/reddb-file/**'
+      - '.github/workflows/file-coverage.yml'
+  pull_request:
+    paths:
+      - 'crates/reddb-file/**'
+      - '.github/workflows/file-coverage.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: file-coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  file-coverage:
+    name: File Coverage Gate
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@1.91.0
+        with:
+          components: llvm-tools-preview
+
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-rust-1.91.0-llvm-cov
+          cache-on-failure: "true"
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Run coverage gate (reddb-io-file)
+        run: |
+          set -o pipefail
+          cargo llvm-cov -p reddb-io-file --summary-only --ignore-filename-regex 'tests\.rs$' --fail-under-lines 90 | tee coverage-summary.txt
+
+      - name: Publish summary
+        run: |
+          {
+            echo "## File Coverage Gate"
+            echo ""
+            echo "Crate: \`reddb-io-file\` — hard minimum: **90% line coverage**"
+            echo ""
+            echo '```'
+            cat coverage-summary.txt
+            echo '```'
+            echo ""
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-file --summary-only --ignore-filename-regex 'tests\\.rs$' --fail-under-lines 90\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/types-coverage.yml
+++ b/.github/workflows/types-coverage.yml
@@ -1,10 +1,9 @@
 name: Types Coverage
 
-# Report-only llvm-cov signal for the reddb-io-types keystone crate
-# (ADR 0052, PRD #1060). Aspirational target is ~95%+, but this workflow
-# NEVER blocks merge — it only surfaces the number in the job summary and,
-# on PRs, as an advisory comment. A hard merge gate is explicitly out of
-# scope per the PRD's Human Decisions.
+# Hard coverage gate for the reddb-io-types keystone crate.
+#
+# The type system is an authority crate. This workflow fails the PR if
+# isolated line coverage drops below 90%.
 
 on:
   push:
@@ -28,7 +27,7 @@ env:
 
 jobs:
   types-coverage:
-    name: Types Coverage Report
+    name: Types Coverage Gate
     if: github.actor != 'dependabot[bot]'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
@@ -57,33 +56,24 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
 
-      - name: Run coverage (reddb-io-types)
+      - name: Run coverage gate (reddb-io-types)
         run: |
-          # Collect profdata once, then render it twice (text table + JSON
-          # totals) without re-running the tests. reddb-io-types depends on no
-          # other workspace crate, so this is a fast, self-contained measure.
-          cargo llvm-cov --no-report -p reddb-io-types
-          cargo llvm-cov report --summary-only | tee coverage-summary.txt
-          cargo llvm-cov report --json --summary-only > coverage-summary.json
+          set -o pipefail
+          cargo llvm-cov -p reddb-io-types --summary-only --fail-under-lines 90 | tee coverage-summary.txt
 
       - name: Build report
         id: report
         run: |
-          # Pull the headline line-coverage percentage straight from the JSON
-          # totals — robust against column-layout changes in the text table.
-          total_line=$(python3 -c "import json; print(f\"{json.load(open('coverage-summary.json'))['data'][0]['totals']['lines']['percent']:.2f}%\")" 2>/dev/null || echo "n/a")
-
           {
-            echo "## Types Coverage Report"
+            echo "## Types Coverage Gate"
             echo ""
-            echo "Crate: \`reddb-io-types\` — line coverage: **${total_line}** (target ~95%, advisory)"
+            echo "Crate: \`reddb-io-types\` — hard minimum: **90% line coverage**"
             echo ""
             echo '```'
             cat coverage-summary.txt
             echo '```'
             echo ""
-            echo "> ℹ️ Report-only — this never blocks merge (ADR 0052 / PRD #1060)."
-            echo "> Run locally: \`cargo llvm-cov -p reddb-io-types --summary-only\`"
+            echo "> Run locally: \`cargo llvm-cov -p reddb-io-types --summary-only --fail-under-lines 90\`"
           } > coverage-report.md
 
           # Mirror to the job summary so the signal is visible without a PR.

--- a/crates/reddb-file/src/backup_temp.rs
+++ b/crates/reddb-file/src/backup_temp.rs
@@ -156,4 +156,42 @@ mod tests {
 
         let _ = fs::remove_dir_all(&root);
     }
+
+    #[test]
+    fn temp_json_constructors_use_distinct_prefixes_and_cleanup_on_drop() {
+        let object = BackupTempJsonFile::json_object();
+        let object_read = BackupTempJsonFile::json_object_read();
+        let archived = BackupTempJsonFile::archived_change_records(10, 20);
+        let archived_read = BackupTempJsonFile::archived_change_records_read();
+
+        assert!(object
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with(BACKUP_JSON_OBJECT_TEMP_PREFIX));
+        assert!(object_read
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with(BACKUP_JSON_OBJECT_READ_TEMP_PREFIX));
+        assert!(archived
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("-10-20-"));
+        assert!(archived_read
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with(ARCHIVED_CHANGE_RECORDS_READ_TEMP_PREFIX));
+
+        object.write_bytes(b"drop").unwrap();
+        let path = object.path().to_path_buf();
+        drop(object);
+        assert!(!path.exists());
+    }
 }

--- a/crates/reddb-file/src/local_backend.rs
+++ b/crates/reddb-file/src/local_backend.rs
@@ -45,3 +45,55 @@ pub fn local_backend_atomic_upload(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_backend_download_reports_missing_or_copies_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.bin");
+        let dest = dir.path().join("dest.bin");
+
+        assert!(!local_backend_download(missing.to_str().unwrap(), &dest).unwrap());
+        assert!(!dest.exists());
+
+        let source = dir.path().join("source.bin");
+        fs::write(&source, b"payload").unwrap();
+        assert!(local_backend_download(source.to_str().unwrap(), &dest).unwrap());
+        assert_eq!(fs::read(&dest).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn local_backend_atomic_upload_creates_parent_and_replaces_destination() {
+        let dir = tempfile::tempdir().unwrap();
+        let local = dir.path().join("local.bin");
+        let remote = dir.path().join("nested").join("remote.bin");
+        fs::write(&local, b"new").unwrap();
+
+        local_backend_atomic_upload(&local, remote.to_str().unwrap(), 123, 456).unwrap();
+
+        assert_eq!(fs::read(&remote).unwrap(), b"new");
+        let temp = crate::layout::local_upload_temp_path(&remote, 123, 456);
+        assert!(!temp.exists());
+
+        fs::write(&local, b"replacement").unwrap();
+        local_backend_atomic_upload(&local, remote.to_str().unwrap(), 123, 457).unwrap();
+        assert_eq!(fs::read(&remote).unwrap(), b"replacement");
+    }
+
+    #[test]
+    fn local_backend_atomic_upload_cleans_temp_when_copy_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing_local = dir.path().join("missing.bin");
+        let remote = dir.path().join("remote.bin");
+
+        assert!(
+            local_backend_atomic_upload(&missing_local, remote.to_str().unwrap(), 1, 2).is_err()
+        );
+        let temp = crate::layout::local_upload_temp_path(&remote, 1, 2);
+        assert!(!temp.exists());
+        assert!(!remote.exists());
+    }
+}

--- a/crates/reddb-file/src/logical_wal.rs
+++ b/crates/reddb-file/src/logical_wal.rs
@@ -463,4 +463,126 @@ mod tests {
 
         let _ = std::fs::remove_file(path);
     }
+
+    #[test]
+    fn missing_paths_read_as_empty_wal() {
+        let path = temp_path("missing");
+        assert!(read_and_repair_logical_wal_entries(&path)
+            .unwrap()
+            .is_empty());
+        assert!(read_logical_wal_entries_from(&path, 0).unwrap().is_empty());
+        assert_eq!(
+            build_logical_wal_seek_index(&path).unwrap(),
+            (Vec::new(), 0, 0)
+        );
+    }
+
+    #[test]
+    fn read_from_seek_index_and_rewrite_round_trip_many_entries() {
+        let path = temp_path("index");
+        let mut bytes = Vec::new();
+        let mut offset_64 = 0u64;
+        for lsn in 1..=70u64 {
+            if lsn == 65 {
+                offset_64 = bytes.len() as u64;
+            }
+            bytes.extend_from_slice(
+                &encode_logical_wal_v3(2, lsn, 1_000 + lsn, format!("p{lsn}").as_bytes()).unwrap(),
+            );
+        }
+        std::fs::write(&path, bytes).unwrap();
+
+        let (index, write_offset, ordinal) = build_logical_wal_seek_index(&path).unwrap();
+        assert_eq!(ordinal, 70);
+        assert_eq!(write_offset, std::fs::metadata(&path).unwrap().len());
+        assert_eq!(index, vec![(1, 0), (65, offset_64)]);
+
+        let tail = read_logical_wal_entries_from(&path, offset_64).unwrap();
+        assert_eq!(tail.first().unwrap().lsn, 65);
+        assert_eq!(tail.len(), 6);
+
+        let rewritten = temp_path("rewrite");
+        let max_lsn = rewrite_logical_wal_entries(&path, &rewritten, &tail).unwrap();
+        assert_eq!(max_lsn, 70);
+        assert!(!rewritten.exists());
+        assert_eq!(read_and_repair_logical_wal_entries(&path).unwrap(), tail);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn v1_legacy_frame_decodes_with_zero_term_and_timestamp() {
+        let path = temp_path("v1");
+        let mut frame = Vec::new();
+        frame.extend_from_slice(LOGICAL_WAL_SPOOL_MAGIC);
+        frame.push(LOGICAL_WAL_SPOOL_VERSION_V1);
+        frame.extend_from_slice(&42u64.to_le_bytes());
+        frame.extend_from_slice(&3u64.to_le_bytes());
+        frame.extend_from_slice(b"old");
+        std::fs::write(&path, frame).unwrap();
+
+        let entries = read_and_repair_logical_wal_entries(&path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].term, 0);
+        assert_eq!(entries[0].timestamp_ms, 0);
+        assert_eq!(entries[0].lsn, 42);
+        assert_eq!(entries[0].data, b"old");
+        assert_eq!(entries[0].version, LOGICAL_WAL_SPOOL_VERSION_V1);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn corruption_modes_truncate_to_last_good_record() {
+        let valid = encode_logical_wal_v3(1, 1, 1, b"ok").unwrap();
+
+        for (name, tail) in [
+            ("bad-magic", b"NOPE".to_vec()),
+            (
+                "unknown-version",
+                [LOGICAL_WAL_SPOOL_MAGIC.as_slice(), &[99]].concat(),
+            ),
+            ("torn-version", LOGICAL_WAL_SPOOL_MAGIC.to_vec()),
+        ] {
+            let path = temp_path(name);
+            let mut bytes = valid.clone();
+            bytes.extend_from_slice(&tail);
+            std::fs::write(&path, bytes).unwrap();
+            let entries = read_and_repair_logical_wal_entries(&path).unwrap();
+            assert_eq!(entries.len(), 1, "{name}");
+            assert_eq!(std::fs::metadata(&path).unwrap().len(), valid.len() as u64);
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn checksum_and_implausible_payload_are_repaired_away() {
+        let valid = encode_logical_wal_v3(1, 1, 1, b"ok").unwrap();
+
+        let path = temp_path("bad-crc");
+        let mut bad_crc = valid.clone();
+        let mut corrupt = encode_logical_wal_v3(1, 2, 2, b"bad").unwrap();
+        let last = corrupt.len() - 1;
+        corrupt[last] ^= 0xff;
+        bad_crc.extend_from_slice(&corrupt);
+        std::fs::write(&path, bad_crc).unwrap();
+        let entries = read_and_repair_logical_wal_entries(&path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), valid.len() as u64);
+        let _ = std::fs::remove_file(&path);
+
+        let path = temp_path("implausible");
+        let mut implausible = valid.clone();
+        implausible.extend_from_slice(LOGICAL_WAL_SPOOL_MAGIC);
+        implausible.push(LOGICAL_WAL_SPOOL_VERSION_V3);
+        implausible.extend_from_slice(&1u64.to_le_bytes());
+        implausible.extend_from_slice(&2u64.to_le_bytes());
+        implausible.extend_from_slice(&3u64.to_le_bytes());
+        implausible.extend_from_slice(&(MAX_PLAUSIBLE_PAYLOAD as u32 + 1).to_le_bytes());
+        std::fs::write(&path, implausible).unwrap();
+        let entries = read_and_repair_logical_wal_entries(&path).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(std::fs::metadata(&path).unwrap().len(), valid.len() as u64);
+        let _ = std::fs::remove_file(path);
+    }
 }

--- a/crates/reddb-file/src/native_store/tests.rs
+++ b/crates/reddb-file/src/native_store/tests.rs
@@ -285,3 +285,525 @@ fn native_manifest_summary_page_round_trips_sample() {
     assert_eq!(decoded.recent_events.len(), NATIVE_MANIFEST_SAMPLE_LIMIT);
     assert_eq!(decoded.recent_events[0].object_key, "k4");
 }
+
+#[test]
+fn native_store_header_and_crc_reject_bad_inputs() {
+    assert!(decode_native_store_header(b"short").is_err());
+
+    let mut bad_magic = encode_native_store_header(STORE_VERSION_CURRENT);
+    bad_magic[0] = b'X';
+    assert!(decode_native_store_header(&bad_magic).is_err());
+
+    let unsupported = encode_native_store_header(STORE_VERSION_CURRENT + 1);
+    assert!(decode_native_store_header(&unsupported).is_err());
+    assert!(is_supported_store_version(STORE_VERSION_V1));
+    assert!(is_supported_store_version(STORE_VERSION_V9));
+    assert!(!is_supported_store_version(STORE_VERSION_CURRENT + 1));
+
+    let mut legacy = encode_native_store_header(STORE_VERSION_V2);
+    legacy.extend_from_slice(b"payload");
+    verify_native_store_crc32_footer(&mut legacy, STORE_VERSION_V2).unwrap();
+    assert_eq!(&legacy[8..], b"payload");
+
+    let mut too_short = encode_native_store_header(STORE_VERSION_CURRENT);
+    assert!(verify_native_store_crc32_footer(&mut too_short, STORE_VERSION_CURRENT).is_err());
+}
+
+#[test]
+fn native_metadata_overflow_headers_reject_short_buffers() {
+    let mut short = [0u8; METADATA_OVERFLOW_HEADER_BYTES - 1];
+    assert!(encode_native_metadata_overflow_header(
+        &mut short,
+        NativeMetadataOverflowHeader {
+            format_version: 1,
+            total_payload_bytes: 2,
+            next_overflow_page_id: 3,
+        },
+    )
+    .is_err());
+    assert!(decode_native_metadata_overflow_header(b"RDM3short").is_err());
+    assert!(decode_native_metadata_overflow_header(b"NOPE")
+        .unwrap()
+        .is_none());
+
+    let mut continuation = [0u8; METADATA_OVERFLOW_CONTINUATION_HEADER_BYTES - 1];
+    assert!(encode_native_metadata_overflow_continuation_header(
+        &mut continuation,
+        NativeMetadataOverflowContinuationHeader {
+            next_overflow_page_id: 1,
+            chunk_bytes: 2,
+        },
+    )
+    .is_err());
+    assert!(decode_native_metadata_overflow_continuation_header(&continuation).is_err());
+}
+
+#[test]
+fn native_low_level_decoders_reject_invalid_utf8_and_varints() {
+    let mut invalid_utf8 = Vec::new();
+    encode_native_len_prefixed_bytes(&mut invalid_utf8, &[0xff]);
+    let mut pos = 0;
+    assert!(decode_native_len_prefixed_string(&invalid_utf8, &mut pos).is_err());
+
+    let mut invalid_collection = vec![0x01];
+    invalid_collection.extend_from_slice(&[0xff]);
+    invalid_collection.push(0);
+    let mut pos = 0;
+    assert!(decode_native_dump_collection_header(&invalid_collection, &mut pos).is_err());
+
+    let invalid_varu32 = [0x80, 0x80, 0x80, 0x80, 0x80];
+    let mut pos = 0;
+    assert!(decode_native_dump_count(&invalid_varu32, &mut pos).is_err());
+
+    let mut invalid_varu64 = vec![0x80; 10];
+    invalid_varu64.push(0);
+    let mut pos = 0;
+    assert!(decode_native_dump_cross_ref(&invalid_varu64, &mut pos).is_err());
+}
+
+#[test]
+fn native_collection_roots_decode_tolerates_partial_tail_and_rejects_bad_utf8() {
+    assert!(decode_native_collection_roots_page(b"NOPE").is_err());
+
+    let mut roots = BTreeMap::new();
+    roots.insert("users".to_string(), 1);
+    roots.insert("events".to_string(), 2);
+    let mut bytes = encode_native_collection_roots_page(&roots);
+    bytes.truncate(bytes.len() - 3);
+    let decoded = decode_native_collection_roots_page(&bytes).unwrap();
+    assert_eq!(decoded.len(), 1);
+
+    let mut invalid = Vec::new();
+    invalid.extend_from_slice(NATIVE_COLLECTION_ROOTS_MAGIC);
+    invalid.extend_from_slice(&1u32.to_le_bytes());
+    invalid.extend_from_slice(&1u32.to_le_bytes());
+    invalid.push(0xff);
+    invalid.extend_from_slice(&1u64.to_le_bytes());
+    assert!(decode_native_collection_roots_page(&invalid).is_err());
+}
+
+#[test]
+fn native_manifest_summary_covers_all_kinds_none_and_unknown_snapshot_flags() {
+    let events = vec![
+        ManifestEvent {
+            collection: "c".to_string(),
+            object_key: "i".to_string(),
+            kind: ManifestEventKind::Insert,
+            block: BlockReference {
+                index: 1,
+                checksum: 11,
+            },
+            snapshot_min: 1,
+            snapshot_max: None,
+        },
+        ManifestEvent {
+            collection: "c".to_string(),
+            object_key: "u".to_string(),
+            kind: ManifestEventKind::Update,
+            block: BlockReference {
+                index: 2,
+                checksum: 22,
+            },
+            snapshot_min: 2,
+            snapshot_max: Some(12),
+        },
+        ManifestEvent {
+            collection: "c".to_string(),
+            object_key: "r".to_string(),
+            kind: ManifestEventKind::Remove,
+            block: BlockReference {
+                index: 3,
+                checksum: 33,
+            },
+            snapshot_min: 3,
+            snapshot_max: None,
+        },
+        ManifestEvent {
+            collection: "c".to_string(),
+            object_key: "ck".to_string(),
+            kind: ManifestEventKind::Checkpoint,
+            block: BlockReference {
+                index: 4,
+                checksum: 44,
+            },
+            snapshot_min: 4,
+            snapshot_max: Some(14),
+        },
+    ];
+
+    let bytes = encode_native_manifest_summary_page(9, &events);
+    let decoded = decode_native_manifest_summary_page(&bytes).unwrap();
+    assert_eq!(decoded.sequence, 9);
+    assert!(decoded.events_complete);
+    assert_eq!(
+        decoded
+            .recent_events
+            .iter()
+            .map(|event| event.kind.as_str())
+            .collect::<Vec<_>>(),
+        vec!["insert", "update", "remove", "checkpoint"]
+    );
+    assert_eq!(decoded.recent_events[0].snapshot_max, None);
+    assert_eq!(decoded.recent_events[1].snapshot_max, Some(12));
+
+    assert!(decode_native_manifest_summary_page(b"NOPE").is_err());
+
+    let mut unknown_kind = bytes.clone();
+    unknown_kind[25] = 99;
+    assert_eq!(
+        decode_native_manifest_summary_page(&unknown_kind)
+            .unwrap()
+            .recent_events[0]
+            .kind,
+        "unknown"
+    );
+
+    let mut unknown_snapshot_flag = bytes.clone();
+    let flag_pos = 25 + 1 + 2 + 1 + 2 + 1 + 8 + 16 + 8;
+    unknown_snapshot_flag[flag_pos] = 7;
+    assert_eq!(
+        decode_native_manifest_summary_page(&unknown_snapshot_flag)
+            .unwrap()
+            .recent_events[0]
+            .snapshot_max,
+        None
+    );
+
+    let mut truncated_snapshot_max = bytes.clone();
+    let second_flag = flag_pos + 1 + (1 + 2 + 1 + 2 + 1 + 8 + 16 + 8);
+    truncated_snapshot_max[second_flag] = 1;
+    truncated_snapshot_max.truncate(second_flag + 1);
+    assert!(decode_native_manifest_summary_page(&truncated_snapshot_max).is_err());
+}
+
+#[test]
+fn native_registry_summary_round_trips_full_samples() {
+    let mut metadata = BTreeMap::new();
+    metadata.insert("window".to_string(), "daily".to_string());
+
+    let summary = NativeRegistrySummary {
+        collection_count: 2,
+        index_count: 2,
+        graph_projection_count: 1,
+        analytics_job_count: 1,
+        vector_artifact_count: 1,
+        collections_complete: true,
+        indexes_complete: false,
+        graph_projections_complete: true,
+        analytics_jobs_complete: false,
+        vector_artifacts_complete: true,
+        omitted_collection_count: 0,
+        omitted_index_count: 1,
+        omitted_graph_projection_count: 0,
+        omitted_analytics_job_count: 2,
+        omitted_vector_artifact_count: 0,
+        collection_names: vec!["users".to_string(), "events".to_string()],
+        indexes: vec![
+            NativeRegistryIndexSummary {
+                name: "idx_users_email".to_string(),
+                kind: "btree".to_string(),
+                collection: Some("users".to_string()),
+                enabled: true,
+                entries: 10,
+                estimated_memory_bytes: 2048,
+                last_refresh_ms: Some(123),
+                backend: "native".to_string(),
+            },
+            NativeRegistryIndexSummary {
+                name: "idx_global".to_string(),
+                kind: "vector".to_string(),
+                collection: None,
+                enabled: false,
+                entries: 0,
+                estimated_memory_bytes: 0,
+                last_refresh_ms: None,
+                backend: "cold".to_string(),
+            },
+        ],
+        graph_projections: vec![NativeRegistryProjectionSummary {
+            name: "social".to_string(),
+            source: "users".to_string(),
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            node_labels: vec!["User".to_string()],
+            node_types: vec!["person".to_string()],
+            edge_labels: vec!["FOLLOWS".to_string()],
+            last_materialized_sequence: Some(77),
+        }],
+        analytics_jobs: vec![NativeRegistryJobSummary {
+            id: "job-1".to_string(),
+            kind: "rollup".to_string(),
+            projection: Some("social".to_string()),
+            state: "ready".to_string(),
+            created_at_unix_ms: 3,
+            updated_at_unix_ms: 4,
+            last_run_sequence: Some(88),
+            metadata,
+        }],
+        vector_artifacts: vec![NativeVectorArtifactSummary {
+            collection: "vectors".to_string(),
+            artifact_kind: "hnsw".to_string(),
+            vector_count: 100,
+            dimension: 384,
+            max_layer: 4,
+            serialized_bytes: 4096,
+            checksum: 55,
+        }],
+    };
+
+    let bytes = encode_native_registry_summary_page(&summary);
+    assert_eq!(
+        decode_native_registry_summary_page(&bytes).unwrap(),
+        summary
+    );
+    assert!(decode_native_registry_summary_page(b"NOPE").is_err());
+
+    let mut truncated_tail = bytes.clone();
+    truncated_tail.truncate(truncated_tail.len() - 1);
+    assert!(decode_native_registry_summary_page(&truncated_tail).is_ok());
+}
+
+#[test]
+fn native_recovery_catalog_metadata_blob_and_vector_pages_round_trip() {
+    let recovery = NativeRecoverySummary {
+        snapshot_count: 2,
+        export_count: 2,
+        snapshots_complete: true,
+        exports_complete: false,
+        omitted_snapshot_count: 0,
+        omitted_export_count: 1,
+        snapshots: vec![NativeSnapshotSummary {
+            snapshot_id: 1,
+            created_at_unix_ms: 2,
+            superblock_sequence: 3,
+            collection_count: 4,
+            total_entities: 5,
+        }],
+        exports: vec![
+            NativeExportSummary {
+                name: "exp-a".to_string(),
+                created_at_unix_ms: 6,
+                snapshot_id: Some(7),
+                superblock_sequence: 8,
+                collection_count: 9,
+                total_entities: 10,
+            },
+            NativeExportSummary {
+                name: "exp-b".to_string(),
+                created_at_unix_ms: 11,
+                snapshot_id: None,
+                superblock_sequence: 12,
+                collection_count: 13,
+                total_entities: 14,
+            },
+        ],
+    };
+    let bytes = encode_native_recovery_summary_page(&recovery);
+    assert_eq!(
+        decode_native_recovery_summary_page(&bytes).unwrap(),
+        recovery
+    );
+    assert!(decode_native_recovery_summary_page(b"NOPE").is_err());
+
+    let catalog = NativeCatalogSummary {
+        collection_count: 1,
+        total_entities: 10,
+        collections_complete: true,
+        omitted_collection_count: 0,
+        collections: vec![NativeCatalogCollectionSummary {
+            name: "users".to_string(),
+            entities: 10,
+            cross_refs: 2,
+            segments: 3,
+        }],
+    };
+    let bytes = encode_native_catalog_summary_page(&catalog);
+    assert_eq!(decode_native_catalog_summary_page(&bytes).unwrap(), catalog);
+    assert!(decode_native_catalog_summary_page(b"NOPE").is_err());
+
+    let metadata = NativeMetadataStateSummary {
+        protocol_version: "v1".to_string(),
+        generated_at_unix_ms: 1,
+        last_loaded_from: Some("disk".to_string()),
+        last_healed_at_unix_ms: Some(2),
+    };
+    let bytes = encode_native_metadata_state_summary_page(&metadata);
+    assert_eq!(
+        decode_native_metadata_state_summary_page(&bytes).unwrap(),
+        metadata
+    );
+    assert!(decode_native_metadata_state_summary_page(b"NOPE").is_err());
+
+    let no_optional_metadata = NativeMetadataStateSummary {
+        protocol_version: "v1".to_string(),
+        generated_at_unix_ms: 1,
+        last_loaded_from: None,
+        last_healed_at_unix_ms: None,
+    };
+    let bytes = encode_native_metadata_state_summary_page(&no_optional_metadata);
+    assert_eq!(
+        decode_native_metadata_state_summary_page(&bytes).unwrap(),
+        no_optional_metadata
+    );
+
+    assert_eq!(native_blob_chunk_capacity(128, 16), 100);
+    let blob = encode_native_blob_page(42, b"chunk");
+    assert_eq!(
+        decode_native_blob_page(&blob).unwrap(),
+        (42, b"chunk".to_vec())
+    );
+    assert!(decode_native_blob_page(b"NOPE").is_err());
+    let mut truncated_blob = blob.clone();
+    truncated_blob.pop();
+    assert!(decode_native_blob_page(&truncated_blob).is_err());
+
+    let artifacts = vec![NativeVectorArtifactPageSummary {
+        collection: "vectors".to_string(),
+        artifact_kind: "ivf".to_string(),
+        root_page: 4,
+        page_count: 5,
+        byte_len: 6,
+        checksum: 7,
+    }];
+    let bytes = encode_native_vector_artifact_store_page(&artifacts);
+    assert_eq!(
+        decode_native_vector_artifact_store_page(&bytes).unwrap(),
+        artifacts
+    );
+    assert!(decode_native_vector_artifact_store_page(b"NOPE").is_err());
+}
+
+#[test]
+fn native_summary_decoders_tolerate_partial_samples_without_panics() {
+    let registry = NativeRegistrySummary {
+        collection_count: 1,
+        index_count: 1,
+        graph_projection_count: 1,
+        analytics_job_count: 1,
+        vector_artifact_count: 1,
+        collections_complete: false,
+        indexes_complete: false,
+        graph_projections_complete: false,
+        analytics_jobs_complete: false,
+        vector_artifacts_complete: false,
+        omitted_collection_count: 0,
+        omitted_index_count: 0,
+        omitted_graph_projection_count: 0,
+        omitted_analytics_job_count: 0,
+        omitted_vector_artifact_count: 0,
+        collection_names: vec!["users".to_string()],
+        indexes: vec![NativeRegistryIndexSummary {
+            name: "idx".to_string(),
+            kind: "btree".to_string(),
+            collection: Some("users".to_string()),
+            enabled: true,
+            entries: 1,
+            estimated_memory_bytes: 2,
+            last_refresh_ms: None,
+            backend: "native".to_string(),
+        }],
+        graph_projections: vec![NativeRegistryProjectionSummary {
+            name: "p".to_string(),
+            source: "users".to_string(),
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            node_labels: vec![],
+            node_types: vec![],
+            edge_labels: vec![],
+            last_materialized_sequence: None,
+        }],
+        analytics_jobs: vec![NativeRegistryJobSummary {
+            id: "j".to_string(),
+            kind: "rollup".to_string(),
+            projection: None,
+            state: "new".to_string(),
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            last_run_sequence: None,
+            metadata: BTreeMap::new(),
+        }],
+        vector_artifacts: vec![NativeVectorArtifactSummary {
+            collection: "vectors".to_string(),
+            artifact_kind: "hnsw".to_string(),
+            vector_count: 1,
+            dimension: 2,
+            max_layer: 3,
+            serialized_bytes: 4,
+            checksum: 5,
+        }],
+    };
+
+    let mut bytes = encode_native_registry_summary_page(&registry);
+    bytes.truncate(90);
+    assert!(decode_native_registry_summary_page(&bytes).is_err());
+
+    let mut recovery = encode_native_recovery_summary_page(&NativeRecoverySummary {
+        snapshot_count: 1,
+        export_count: 1,
+        snapshots_complete: false,
+        exports_complete: false,
+        omitted_snapshot_count: 0,
+        omitted_export_count: 0,
+        snapshots: vec![NativeSnapshotSummary {
+            snapshot_id: 1,
+            created_at_unix_ms: 2,
+            superblock_sequence: 3,
+            collection_count: 4,
+            total_entities: 5,
+        }],
+        exports: vec![NativeExportSummary {
+            name: "exp".to_string(),
+            created_at_unix_ms: 6,
+            snapshot_id: Some(7),
+            superblock_sequence: 8,
+            collection_count: 9,
+            total_entities: 10,
+        }],
+    });
+    recovery.truncate(40);
+    assert!(decode_native_recovery_summary_page(&recovery)
+        .unwrap()
+        .snapshots
+        .is_empty());
+
+    let mut catalog = encode_native_catalog_summary_page(&NativeCatalogSummary {
+        collection_count: 1,
+        total_entities: 1,
+        collections_complete: false,
+        omitted_collection_count: 0,
+        collections: vec![NativeCatalogCollectionSummary {
+            name: "users".to_string(),
+            entities: 1,
+            cross_refs: 2,
+            segments: 3,
+        }],
+    });
+    catalog.truncate(catalog.len() - 2);
+    assert!(decode_native_catalog_summary_page(&catalog)
+        .unwrap()
+        .collections
+        .is_empty());
+
+    let mut metadata = encode_native_metadata_state_summary_page(&NativeMetadataStateSummary {
+        protocol_version: "v1".to_string(),
+        generated_at_unix_ms: 1,
+        last_loaded_from: None,
+        last_healed_at_unix_ms: Some(2),
+    });
+    metadata.truncate(metadata.len() - 1);
+    assert!(decode_native_metadata_state_summary_page(&metadata).is_err());
+
+    let mut vector_page =
+        encode_native_vector_artifact_store_page(&[NativeVectorArtifactPageSummary {
+            collection: "vectors".to_string(),
+            artifact_kind: "hnsw".to_string(),
+            root_page: 1,
+            page_count: 2,
+            byte_len: 3,
+            checksum: 4,
+        }]);
+    vector_page.truncate(vector_page.len() - 1);
+    assert!(decode_native_vector_artifact_store_page(&vector_page)
+        .unwrap()
+        .is_empty());
+}

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -488,4 +488,104 @@ mod tests {
         assert!(!manifest.collection_path_for_test("orphan").exists());
         assert!(manifest.quarantine_path_for_test("orphan.rcol").exists());
     }
+
+    #[test]
+    fn create_and_drop_collection_are_idempotent_and_escape_names() {
+        let path = temp_db_path("create_drop");
+        let manifest = OperationalManifest::for_db_path(&path);
+
+        manifest.create_collection("tenant/a b").unwrap();
+        let first_generation = manifest.read_generation_for_test().unwrap();
+        manifest.create_collection("tenant/a b").unwrap();
+        assert_eq!(
+            manifest.read_generation_for_test().unwrap(),
+            first_generation
+        );
+        assert!(manifest.collection_path_for_test("tenant/a b").exists());
+        assert!(manifest
+            .collection_path_for_test("tenant/a b")
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("%2F"));
+
+        manifest.begin_drop_collection("missing").unwrap();
+        assert_eq!(
+            manifest.read_generation_for_test().unwrap(),
+            first_generation
+        );
+        manifest.begin_drop_collection("tenant/a b").unwrap();
+        manifest.finish_drop_collection("missing").unwrap();
+        manifest.finish_drop_collection("tenant/a b").unwrap();
+        assert!(!manifest.collection_path_for_test("tenant/a b").exists());
+        assert!(manifest.read_generation_for_test().unwrap() > first_generation);
+    }
+
+    #[test]
+    fn next_manifest_helper_writes_next_file_without_publishing() {
+        let path = temp_db_path("next");
+        let manifest = OperationalManifest::for_db_path(&path);
+        manifest.recover_or_bootstrap(&[]).unwrap();
+        manifest.write_next_manifest_for_test("future").unwrap();
+
+        assert!(manifest.root.join(NEXT_MANIFEST_FILE).exists());
+        assert!(manifest
+            .load_current()
+            .unwrap()
+            .unwrap()
+            .collections
+            .is_empty());
+    }
+
+    #[test]
+    fn manifest_parser_rejects_malformed_shapes() {
+        assert!(manifest_from_bytes(b"[]").is_err());
+        assert!(manifest_from_bytes(br#"{"format_version":1}"#).is_err());
+        assert!(CollectionState::parse("bad").is_err());
+
+        let mut object = Map::new();
+        object.insert("format_version".to_string(), Value::from(2));
+        object.insert("generation".to_string(), Value::from(0));
+        object.insert("collections".to_string(), Value::Object(Map::new()));
+        assert!(manifest_from_object(&object).is_err());
+
+        object.insert("format_version".to_string(), Value::from(FORMAT_VERSION));
+        object.remove("generation");
+        assert!(manifest_from_object(&object).is_err());
+
+        object.insert("generation".to_string(), Value::from(0));
+        object.remove("collections");
+        assert!(manifest_from_object(&object).is_err());
+
+        let mut collections = Map::new();
+        collections.insert("users".to_string(), Value::String("bad".to_string()));
+        object.insert("collections".to_string(), Value::Object(collections));
+        assert!(manifest_from_object(&object).is_err());
+
+        let mut entry = Map::new();
+        entry.insert("path".to_string(), Value::String("users.rcol".to_string()));
+        let mut collections = Map::new();
+        collections.insert("users".to_string(), Value::Object(entry));
+        object.insert("collections".to_string(), Value::Object(collections));
+        assert!(manifest_from_object(&object).is_err());
+
+        let mut entry = Map::new();
+        entry.insert("state".to_string(), Value::String("active".to_string()));
+        let mut collections = Map::new();
+        collections.insert("users".to_string(), Value::Object(entry));
+        object.insert("collections".to_string(), Value::Object(collections));
+        assert!(manifest_from_object(&object).is_err());
+    }
+
+    #[test]
+    fn unique_quarantine_path_adds_suffix_when_needed() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("orphan.rcol"), b"one").unwrap();
+        fs::write(dir.path().join("orphan.rcol.1"), b"two").unwrap();
+
+        assert_eq!(
+            unique_quarantine_path(dir.path(), "orphan.rcol"),
+            dir.path().join("orphan.rcol.2")
+        );
+    }
 }

--- a/crates/reddb-file/src/physical_metadata_policy.rs
+++ b/crates/reddb-file/src/physical_metadata_policy.rs
@@ -126,3 +126,106 @@ fn env_flag(name: &str) -> bool {
         .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
         .unwrap_or(false)
 }
+
+#[cfg(test)]
+fn reset_physical_metadata_policy_for_test() {
+    META_JSON_SIDECAR_POLICY.store(0, Ordering::Relaxed);
+    SEQN_JOURNAL_POLICY.store(0, Ordering::Relaxed);
+    FOLD_PAGER_META_POLICY.store(0, Ordering::Relaxed);
+    FOLD_DWB_INTO_WAL_POLICY.store(0, Ordering::Relaxed);
+    SEQN_JOURNAL_RETENTION.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static POLICY_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn set_env(name: &str, value: &str) {
+        unsafe {
+            std::env::set_var(name, value);
+        }
+    }
+
+    fn remove_env(name: &str) {
+        unsafe {
+            std::env::remove_var(name);
+        }
+    }
+
+    #[test]
+    fn env_flags_and_explicit_overrides_drive_sidecar_policies() {
+        let _guard = POLICY_TEST_LOCK.lock().unwrap();
+        reset_physical_metadata_policy_for_test();
+
+        for value in ["1", "true", "TRUE", "yes", "on"] {
+            set_env("REDDB_META_JSON_SIDECAR", value);
+            assert!(meta_json_sidecar_enabled(), "{value}");
+        }
+        set_env("REDDB_META_JSON_SIDECAR", "false");
+        assert!(!meta_json_sidecar_enabled());
+
+        set_meta_json_sidecar_enabled(true);
+        set_env("REDDB_META_JSON_SIDECAR", "false");
+        assert!(meta_json_sidecar_enabled());
+        set_meta_json_sidecar_enabled(false);
+        set_env("REDDB_META_JSON_SIDECAR", "1");
+        assert!(!meta_json_sidecar_enabled());
+        remove_env("REDDB_META_JSON_SIDECAR");
+    }
+
+    #[test]
+    fn journal_and_fold_policy_overrides_are_independent() {
+        let _guard = POLICY_TEST_LOCK.lock().unwrap();
+        reset_physical_metadata_policy_for_test();
+
+        set_env("REDDB_SEQN_JOURNAL", "1");
+        assert!(seqn_journal_enabled());
+        set_seqn_journal_enabled(false);
+        assert!(!seqn_journal_enabled());
+        set_seqn_journal_enabled(true);
+        assert!(seqn_journal_enabled());
+        remove_env("REDDB_SEQN_JOURNAL");
+
+        set_env("REDDB_FOLD_PAGER_META", "yes");
+        assert!(fold_pager_meta_enabled());
+        set_fold_pager_meta_enabled(false);
+        assert!(!fold_pager_meta_enabled());
+        set_fold_pager_meta_enabled(true);
+        assert!(fold_pager_meta_enabled());
+        remove_env("REDDB_FOLD_PAGER_META");
+
+        set_env("REDDB_FOLD_DWB_INTO_WAL", "on");
+        assert!(fold_dwb_into_wal_enabled());
+        set_fold_dwb_into_wal_enabled(false);
+        assert!(!fold_dwb_into_wal_enabled());
+        set_fold_dwb_into_wal_enabled(true);
+        assert!(fold_dwb_into_wal_enabled());
+        remove_env("REDDB_FOLD_DWB_INTO_WAL");
+    }
+
+    #[test]
+    fn seqn_journal_retention_prefers_override_then_env_then_default() {
+        let _guard = POLICY_TEST_LOCK.lock().unwrap();
+        reset_physical_metadata_policy_for_test();
+        remove_env("REDDB_SEQN_JOURNAL_RETENTION");
+
+        assert_eq!(seqn_journal_retention(), OPT_IN_METADATA_JOURNAL_RETENTION);
+
+        set_env("REDDB_SEQN_JOURNAL_RETENTION", "12");
+        assert_eq!(seqn_journal_retention(), 12);
+        set_env("REDDB_SEQN_JOURNAL_RETENTION", "0");
+        assert_eq!(seqn_journal_retention(), OPT_IN_METADATA_JOURNAL_RETENTION);
+        set_env("REDDB_SEQN_JOURNAL_RETENTION", "bad");
+        assert_eq!(seqn_journal_retention(), OPT_IN_METADATA_JOURNAL_RETENTION);
+
+        set_seqn_journal_retention(99);
+        assert_eq!(seqn_journal_retention(), 99);
+        set_seqn_journal_retention(0);
+        assert_eq!(seqn_journal_retention(), OPT_IN_METADATA_JOURNAL_RETENTION);
+
+        remove_env("REDDB_SEQN_JOURNAL_RETENTION");
+    }
+}

--- a/crates/reddb-file/src/profile.rs
+++ b/crates/reddb-file/src/profile.rs
@@ -45,3 +45,40 @@ impl FileArtifactKind {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_profiles_render_canonical_labels() {
+        let profiles = [
+            (FileProfile::Embedded, "embedded"),
+            (FileProfile::Serverless, "serverless"),
+            (FileProfile::PrimaryReplica, "primary-replica"),
+            (FileProfile::Cluster, "cluster"),
+        ];
+
+        for (profile, label) in profiles {
+            assert_eq!(profile.as_str(), label);
+        }
+    }
+
+    #[test]
+    fn artifact_kinds_render_canonical_labels() {
+        let kinds = [
+            (FileArtifactKind::SingleRdb, "single-rdb"),
+            (FileArtifactKind::Manifest, "manifest"),
+            (FileArtifactKind::Wal, "wal"),
+            (FileArtifactKind::Snapshot, "snapshot"),
+            (FileArtifactKind::BootIndex, "boot-index"),
+            (FileArtifactKind::Pack, "pack"),
+            (FileArtifactKind::BaseBackup, "base-backup"),
+            (FileArtifactKind::Timeline, "timeline"),
+        ];
+
+        for (kind, label) in kinds {
+            assert_eq!(kind.as_str(), label);
+        }
+    }
+}

--- a/crates/reddb-file/src/serverless/mod.rs
+++ b/crates/reddb-file/src/serverless/mod.rs
@@ -1287,6 +1287,190 @@ mod tests {
     }
 
     #[test]
+    fn file_plan_derives_cache_generation_and_hot_boot_paths() {
+        let plan = ServerlessFilePlan::for_data_path("/tmp/reddb/main.rdb", 41);
+        assert_eq!(plan.root, PathBuf::from("/tmp/reddb/main.serverless"));
+        assert_eq!(plan.namespace, "main");
+
+        let next = plan
+            .for_generation(42)
+            .with_cache_policy(ServerlessCachePolicy {
+                keep_boot_index_local: true,
+                keep_hot_snapshot_local: true,
+                max_hot_bytes: 4096,
+            });
+        assert_eq!(next.root, plan.root);
+        assert_eq!(next.namespace, plan.namespace);
+        assert_eq!(next.generation, 42);
+
+        let cache = next.local_cache();
+        assert_eq!(
+            cache.root,
+            PathBuf::from("/tmp/reddb/main.serverless/main/cache")
+        );
+        assert_eq!(cache.generation, 42);
+
+        let hot = ServerlessBootPlan::hot(&next);
+        assert_eq!(
+            hot.required_first,
+            vec![
+                next.boot_index_path(),
+                next.hot_snapshot_path(),
+                next.wal_tail_path(),
+            ]
+        );
+        assert_eq!(
+            hot.lazy_after_open,
+            vec![
+                next.manifest_path(),
+                next.collection_data_path(),
+                next.secondary_index_path(),
+            ]
+        );
+    }
+
+    #[test]
+    fn publish_generation_pointer_rejects_manifest_identity_mismatch() {
+        let root = temp_root("serverless-pointer-identity");
+        let plan = ServerlessFilePlan::new(&root, "db", 10);
+
+        let wrong_namespace = ServerlessManifest::new("other", 10);
+        let err = plan
+            .publish_generation_pointer(&wrong_namespace)
+            .expect_err("namespace mismatch rejected before publish");
+        assert!(err.to_string().contains("namespace"), "{err}");
+
+        let wrong_generation = ServerlessManifest::new("db", 11);
+        let err = plan
+            .publish_generation_pointer(&wrong_generation)
+            .expect_err("generation mismatch rejected before publish");
+        assert!(err.to_string().contains("generation"), "{err}");
+
+        assert!(!plan.current_pointer_path().exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn verified_current_pointer_rejects_pointer_shape_and_manifest_identity() {
+        let root = temp_root("serverless-current-pointer-shape");
+        let plan = ServerlessFilePlan::new(&root, "db", 10);
+        let manifest = ServerlessManifest::new("db", 10);
+        let manifest_bytes = manifest.encode();
+
+        let namespace_mismatch = ServerlessGenerationPointer {
+            namespace: "other".to_string(),
+            generation: 10,
+            manifest_relative_path: PathBuf::from("g00000000000000000010/manifest.redpack"),
+            manifest_bytes: manifest_bytes.len() as u64,
+            manifest_checksum: crc32(&manifest_bytes),
+            manifest_content_hash: ServerlessContentHash::from_bytes(&manifest_bytes),
+        };
+        namespace_mismatch
+            .write_to_path(plan.current_pointer_path())
+            .expect("write namespace mismatch pointer");
+        let err = plan
+            .read_current_pointer_verified()
+            .expect_err("pointer namespace mismatch rejected");
+        assert!(err.to_string().contains("namespace"), "{err}");
+
+        let path_mismatch = ServerlessGenerationPointer {
+            namespace: "db".to_string(),
+            generation: 10,
+            manifest_relative_path: PathBuf::from("g00000000000000000010/boot-index.redpack"),
+            manifest_bytes: manifest_bytes.len() as u64,
+            manifest_checksum: crc32(&manifest_bytes),
+            manifest_content_hash: ServerlessContentHash::from_bytes(&manifest_bytes),
+        };
+        path_mismatch
+            .write_to_path(plan.current_pointer_path())
+            .expect("write path mismatch pointer");
+        let err = plan
+            .read_current_pointer_verified()
+            .expect_err("pointer manifest path mismatch rejected");
+        assert!(err.to_string().contains("manifest path"), "{err}");
+
+        let wrong_manifest_namespace = ServerlessManifest::new("other", 10);
+        wrong_manifest_namespace
+            .write_to_path(plan.manifest_path())
+            .expect("write namespace mismatched manifest");
+        let pointer = ServerlessGenerationPointer::from_manifest(&plan, &wrong_manifest_namespace);
+        pointer
+            .write_to_path(plan.current_pointer_path())
+            .expect("write pointer");
+        let err = plan
+            .read_current_pointer_verified()
+            .expect_err("manifest namespace mismatch rejected");
+        assert!(err.to_string().contains("manifest namespace"), "{err}");
+
+        let wrong_generation_manifest = ServerlessManifest::new("db", 11);
+        let wrong_generation_bytes = wrong_generation_manifest.encode();
+        std::fs::write(plan.manifest_path(), &wrong_generation_bytes).expect("write manifest");
+        let generation_mismatch = ServerlessGenerationPointer {
+            namespace: "db".to_string(),
+            generation: 10,
+            manifest_relative_path: PathBuf::from("g00000000000000000010/manifest.redpack"),
+            manifest_bytes: wrong_generation_bytes.len() as u64,
+            manifest_checksum: crc32(&wrong_generation_bytes),
+            manifest_content_hash: ServerlessContentHash::from_bytes(&wrong_generation_bytes),
+        };
+        generation_mismatch
+            .write_to_path(plan.current_pointer_path())
+            .expect("write generation mismatch pointer");
+        let err = plan
+            .read_current_pointer_verified()
+            .expect_err("manifest generation mismatch rejected");
+        assert!(err.to_string().contains("manifest generation"), "{err}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn validate_complete_generation_rejects_pack_and_manifest_metadata_mismatch() {
+        let root = temp_root("serverless-validate-metadata");
+        let plan = ServerlessFilePlan::new(&root, "db", 16);
+        let mut extent_index = ServerlessExtentIndex::new(16);
+        extent_index.push(
+            ServerlessExtentRef::new(
+                "events",
+                b"a".to_vec(),
+                b"z".to_vec(),
+                "collection-data.redpack",
+                0,
+                b"collection-bytes",
+                true,
+            )
+            .expect("extent"),
+        );
+        plan.publish_core_generation(&extent_index, b"collection-bytes", b"secondary-bytes")
+            .expect("publish complete generation");
+        let manifest =
+            ServerlessManifest::read_from_path(plan.manifest_path()).expect("read manifest");
+
+        let mut wrong_bytes = manifest.clone();
+        wrong_bytes.entries[0].bytes += 1;
+        let err = plan
+            .validate_complete_generation(&wrong_bytes)
+            .expect_err("pack byte length mismatch rejected");
+        assert!(err.to_string().contains("expected"), "{err}");
+
+        let mut wrong_hash = manifest.clone();
+        wrong_hash.entries[0].content_hash = ServerlessContentHash([1; CONTENT_HASH_LEN]);
+        let err = plan
+            .validate_complete_generation(&wrong_hash)
+            .expect_err("pack content hash mismatch rejected");
+        assert!(err.to_string().contains("content hash mismatch"), "{err}");
+
+        let mut manifest_mismatch = manifest.clone();
+        manifest_mismatch.namespace = "other".to_string();
+        let err = plan
+            .validate_complete_generation(&manifest_mismatch)
+            .expect_err("manifest-on-disk mismatch rejected");
+        assert!(err.to_string().contains("manifest on disk"), "{err}");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn writer_lease_json_round_trips_and_preserves_fencing_token() {
         let lease = ServerlessWriterLease {
             database_key: "main".to_string(),

--- a/crates/reddb-file/src/ui_bundle_cache.rs
+++ b/crates/reddb-file/src/ui_bundle_cache.rs
@@ -212,4 +212,64 @@ mod tests {
             Path::new("/tmp/reddb/ui/.purge/1.2.3-abc")
         );
     }
+
+    #[test]
+    fn ui_bundle_manifest_rejects_invalid_json_and_missing_fields() {
+        assert!(decode_ui_bundle_manifest_json(b"not json").is_err());
+        assert!(decode_ui_bundle_manifest_json(b"[]").is_err());
+        assert!(decode_ui_bundle_manifest_json(br#"{"version":"1"}"#).is_err());
+        assert!(decode_ui_bundle_manifest_json(
+            br#"{"version":"1","sha256":"abc","tgz_size_bytes":"big","cached_at_unix_ms":1}"#
+        )
+        .is_err());
+        assert!(decode_ui_bundle_manifest_json(
+            br#"{"version":"1","sha256":"abc","tgz_size_bytes":1,"cached_at_unix_ms":"now"}"#
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn ui_bundle_manifest_write_and_promote_staging_are_atomic() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_root = ui_bundle_cache_root(dir.path());
+        let version_dir = ui_bundle_version_dir(&cache_root, "1.2.3");
+        fs::create_dir_all(&version_dir).unwrap();
+
+        write_ui_bundle_manifest(&version_dir, br#"{"ok":true}"#).unwrap();
+        assert_eq!(
+            fs::read(ui_bundle_manifest_path(&version_dir)).unwrap(),
+            br#"{"ok":true}"#
+        );
+        assert!(!ui_bundle_manifest_temp_path(&version_dir).exists());
+
+        let staging = ui_bundle_staging_dir(&cache_root, "1.2.3", "new");
+        fs::create_dir_all(&staging).unwrap();
+        fs::write(staging.join("bundle.js"), b"new").unwrap();
+        fs::write(version_dir.join("bundle.js"), b"old").unwrap();
+        promote_ui_bundle_staging(&cache_root, "1.2.3", "new", &staging, &version_dir).unwrap();
+        assert_eq!(fs::read(version_dir.join("bundle.js")).unwrap(), b"new");
+        assert!(!ui_bundle_purge_dir(&cache_root, "1.2.3", "new").exists());
+    }
+
+    #[test]
+    fn promote_ui_bundle_staging_rolls_back_existing_version_on_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_root = ui_bundle_cache_root(dir.path());
+        let version_dir = ui_bundle_version_dir(&cache_root, "1.2.3");
+        fs::create_dir_all(&version_dir).unwrap();
+        fs::write(version_dir.join("bundle.js"), b"old").unwrap();
+
+        let missing_staging = ui_bundle_staging_dir(&cache_root, "1.2.3", "missing");
+        assert!(promote_ui_bundle_staging(
+            &cache_root,
+            "1.2.3",
+            "missing",
+            &missing_staging,
+            &version_dir
+        )
+        .is_err());
+
+        assert_eq!(fs::read(version_dir.join("bundle.js")).unwrap(), b"old");
+        assert!(!missing_staging.exists());
+    }
 }

--- a/crates/reddb-types/src/canonical_key.rs
+++ b/crates/reddb-types/src/canonical_key.rs
@@ -414,6 +414,7 @@ fn ipaddr_to_bytes(value: IpAddr) -> [u8; 16] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
     fn canonical_keys_are_ordered_inside_their_family() {
@@ -432,5 +433,235 @@ mod tests {
         let text = value_to_canonical_key(&Value::text("alice".to_string())).unwrap();
         let email = value_to_canonical_key(&Value::Email("alice@example.com".to_string())).unwrap();
         assert_ne!(text.family(), email.family());
+    }
+
+    #[test]
+    fn value_to_canonical_key_covers_supported_families() {
+        let samples = [
+            (Value::Null, CanonicalKeyFamily::Null),
+            (Value::Boolean(true), CanonicalKeyFamily::Boolean),
+            (Value::Integer(-7), CanonicalKeyFamily::Integer),
+            (Value::BigInt(-9), CanonicalKeyFamily::BigInt),
+            (
+                Value::UnsignedInteger(7),
+                CanonicalKeyFamily::UnsignedInteger,
+            ),
+            (Value::Float(1.5), CanonicalKeyFamily::Float),
+            (Value::text("text"), CanonicalKeyFamily::Text),
+            (Value::Blob(vec![1, 2]), CanonicalKeyFamily::Blob),
+            (Value::Timestamp(10), CanonicalKeyFamily::Timestamp),
+            (Value::Duration(11), CanonicalKeyFamily::Duration),
+            (
+                Value::IpAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+                CanonicalKeyFamily::IpAddr,
+            ),
+            (
+                Value::IpAddr(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+                CanonicalKeyFamily::IpAddr,
+            ),
+            (
+                Value::MacAddr([1, 2, 3, 4, 5, 6]),
+                CanonicalKeyFamily::MacAddr,
+            ),
+            (
+                Value::Json(br#"{"a":1}"#.to_vec()),
+                CanonicalKeyFamily::Json,
+            ),
+            (Value::Uuid([7; 16]), CanonicalKeyFamily::Uuid),
+            (
+                Value::NodeRef("n1".to_string()),
+                CanonicalKeyFamily::NodeRef,
+            ),
+            (
+                Value::EdgeRef("e1".to_string()),
+                CanonicalKeyFamily::EdgeRef,
+            ),
+            (
+                Value::VectorRef("vecs".to_string(), 9),
+                CanonicalKeyFamily::VectorRef,
+            ),
+            (
+                Value::RowRef("rows".to_string(), 10),
+                CanonicalKeyFamily::RowRef,
+            ),
+            (Value::Color([0xAA, 0xBB, 0xCC]), CanonicalKeyFamily::Color),
+            (
+                Value::Email("a@example.com".to_string()),
+                CanonicalKeyFamily::Email,
+            ),
+            (
+                Value::Url("https://example.com".to_string()),
+                CanonicalKeyFamily::Url,
+            ),
+            (Value::Phone(5511999), CanonicalKeyFamily::Phone),
+            (Value::Semver(1_002_003), CanonicalKeyFamily::Semver),
+            (Value::Cidr(10 << 24, 8), CanonicalKeyFamily::Cidr),
+            (Value::Date(20_000), CanonicalKeyFamily::Date),
+            (Value::Time(43_200_000), CanonicalKeyFamily::Time),
+            (Value::Decimal(123_456), CanonicalKeyFamily::Decimal),
+            (Value::EnumValue(3), CanonicalKeyFamily::EnumValue),
+            (Value::TimestampMs(123_456), CanonicalKeyFamily::TimestampMs),
+            (Value::Ipv4(0x7f000001), CanonicalKeyFamily::Ipv4),
+            (Value::Ipv6([1; 16]), CanonicalKeyFamily::Ipv6),
+            (
+                Value::Subnet(10 << 24, 0xff000000),
+                CanonicalKeyFamily::Subnet,
+            ),
+            (Value::Port(5432), CanonicalKeyFamily::Port),
+            (Value::Latitude(-23_550_520), CanonicalKeyFamily::Latitude),
+            (Value::Longitude(-46_633_308), CanonicalKeyFamily::Longitude),
+            (
+                Value::GeoPoint(-23_550_520, -46_633_308),
+                CanonicalKeyFamily::GeoPoint,
+            ),
+            (Value::Country2(*b"BR"), CanonicalKeyFamily::Country2),
+            (Value::Country3(*b"BRA"), CanonicalKeyFamily::Country3),
+            (Value::Lang2(*b"pt"), CanonicalKeyFamily::Lang2),
+            (Value::Lang5(*b"pt-BR"), CanonicalKeyFamily::Lang5),
+            (Value::Currency(*b"USD"), CanonicalKeyFamily::Currency),
+            (
+                Value::AssetCode("BTC".to_string()),
+                CanonicalKeyFamily::Text,
+            ),
+            (
+                Value::ColorAlpha([0xAA, 0xBB, 0xCC, 0xDD]),
+                CanonicalKeyFamily::ColorAlpha,
+            ),
+            (
+                Value::KeyRef("kv".to_string(), "key".to_string()),
+                CanonicalKeyFamily::KeyRef,
+            ),
+            (
+                Value::DocRef("docs".to_string(), 42),
+                CanonicalKeyFamily::DocRef,
+            ),
+            (
+                Value::TableRef("users".to_string()),
+                CanonicalKeyFamily::TableRef,
+            ),
+            (Value::PageRef(12), CanonicalKeyFamily::PageRef),
+            (
+                Value::Password("$argon2id$v=19$hash".to_string()),
+                CanonicalKeyFamily::Password,
+            ),
+        ];
+
+        for (value, family) in samples {
+            let key = value_to_canonical_key(&value).expect("indexable value");
+            assert_eq!(key.family(), family, "{value:?}");
+        }
+    }
+
+    #[test]
+    fn canonical_keys_round_trip_to_values_by_shape() {
+        let keys = vec![
+            CanonicalKey::Null,
+            CanonicalKey::Boolean(false),
+            CanonicalKey::Signed(CanonicalKeyFamily::Integer, -1),
+            CanonicalKey::Signed(CanonicalKeyFamily::BigInt, -2),
+            CanonicalKey::Signed(CanonicalKeyFamily::Timestamp, 3),
+            CanonicalKey::Signed(CanonicalKeyFamily::Duration, 4),
+            CanonicalKey::Signed(CanonicalKeyFamily::Date, 5),
+            CanonicalKey::Signed(CanonicalKeyFamily::Decimal, 6),
+            CanonicalKey::Signed(CanonicalKeyFamily::TimestampMs, 7),
+            CanonicalKey::Signed(CanonicalKeyFamily::Latitude, 8),
+            CanonicalKey::Signed(CanonicalKeyFamily::Longitude, 9),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::UnsignedInteger, 10),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::Phone, 11),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::Semver, 12),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::Time, 13),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::EnumValue, 14),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::Port, 15),
+            CanonicalKey::Unsigned(CanonicalKeyFamily::PageRef, 16),
+            CanonicalKey::Float(1.25f64.to_bits()),
+            CanonicalKey::Text(CanonicalKeyFamily::Text, Arc::from("text")),
+            CanonicalKey::Text(CanonicalKeyFamily::NodeRef, Arc::from("node")),
+            CanonicalKey::Text(CanonicalKeyFamily::EdgeRef, Arc::from("edge")),
+            CanonicalKey::Text(CanonicalKeyFamily::Email, Arc::from("a@example.com")),
+            CanonicalKey::Text(CanonicalKeyFamily::Url, Arc::from("https://e.test")),
+            CanonicalKey::Text(CanonicalKeyFamily::TableRef, Arc::from("users")),
+            CanonicalKey::Text(CanonicalKeyFamily::Password, Arc::from("hash")),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Blob, vec![1, 2]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::MacAddr, vec![1, 2, 3, 4, 5, 6]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Json, br#"{"ok":true}"#.to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Uuid, vec![7; 16]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::IpAddr, vec![0; 16]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Ipv4, vec![127, 0, 0, 1]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Ipv6, vec![8; 16]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Color, vec![0xAA, 0xBB, 0xCC]),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Country2, b"BR".to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Country3, b"BRA".to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Lang2, b"pt".to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Lang5, b"pt-BR".to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::Currency, b"USD".to_vec()),
+            CanonicalKey::Bytes(CanonicalKeyFamily::ColorAlpha, vec![1, 2, 3, 4]),
+            CanonicalKey::PairTextU64(CanonicalKeyFamily::VectorRef, "v".to_string(), 1),
+            CanonicalKey::PairTextU64(CanonicalKeyFamily::RowRef, "r".to_string(), 2),
+            CanonicalKey::PairTextU64(CanonicalKeyFamily::DocRef, "d".to_string(), 3),
+            CanonicalKey::PairTextText(
+                CanonicalKeyFamily::KeyRef,
+                "kv".to_string(),
+                "key".to_string(),
+            ),
+            CanonicalKey::PairU32U8(CanonicalKeyFamily::Cidr, 10 << 24, 8),
+            CanonicalKey::PairU32U32(CanonicalKeyFamily::Subnet, 10 << 24, 0xff000000),
+            CanonicalKey::PairI32I32(CanonicalKeyFamily::GeoPoint, -1, 2),
+        ];
+
+        for key in keys {
+            let value = key.clone().into_value();
+            let recovered = value_to_canonical_key(&value).expect("round-tripped key is indexable");
+            assert_eq!(recovered.family(), key.family(), "{key:?}");
+        }
+    }
+
+    #[test]
+    fn non_indexable_values_do_not_produce_canonical_keys() {
+        let values = [
+            Value::Float(f64::INFINITY),
+            Value::Vector(vec![1.0, 2.0]),
+            Value::Array(vec![Value::Integer(1)]),
+            Value::Money {
+                asset_code: "USD".to_string(),
+                minor_units: 100,
+                scale: 2,
+            },
+            Value::Secret(vec![1, 2, 3]),
+        ];
+
+        for value in values {
+            assert!(value_to_canonical_key(&value).is_none(), "{value:?}");
+        }
+    }
+
+    #[test]
+    fn pair_key_ordering_uses_secondary_components() {
+        assert!(
+            CanonicalKey::PairTextU64(CanonicalKeyFamily::RowRef, "a".to_string(), 1)
+                < CanonicalKey::PairTextU64(CanonicalKeyFamily::RowRef, "a".to_string(), 2)
+        );
+        assert!(
+            CanonicalKey::PairTextText(
+                CanonicalKeyFamily::KeyRef,
+                "a".to_string(),
+                "a".to_string()
+            ) < CanonicalKey::PairTextText(
+                CanonicalKeyFamily::KeyRef,
+                "a".to_string(),
+                "b".to_string()
+            )
+        );
+        assert!(
+            CanonicalKey::PairU32U8(CanonicalKeyFamily::Cidr, 1, 24)
+                < CanonicalKey::PairU32U8(CanonicalKeyFamily::Cidr, 2, 8)
+        );
+        assert!(
+            CanonicalKey::PairU32U32(CanonicalKeyFamily::Subnet, 1, 1)
+                < CanonicalKey::PairU32U32(CanonicalKeyFamily::Subnet, 1, 2)
+        );
+        assert!(
+            CanonicalKey::PairI32I32(CanonicalKeyFamily::GeoPoint, -1, 0)
+                < CanonicalKey::PairI32I32(CanonicalKeyFamily::GeoPoint, 0, -1)
+        );
     }
 }

--- a/crates/reddb-types/src/serde_json.rs
+++ b/crates/reddb-types/src/serde_json.rs
@@ -206,6 +206,9 @@ fn escape_string(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::json;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
 
     fn encode(s: &str) -> String {
         Value::String(s.to_string()).to_string_compact()
@@ -280,6 +283,150 @@ mod tests {
         // Round trip through the in-house parser must reproduce the original bytes.
         let parsed: String = from_str(&encoded).expect("audit payload must parse");
         assert_eq!(parsed, payload);
+    }
+
+    #[test]
+    fn value_accessors_indexing_and_pretty_printing_cover_all_shapes() {
+        let mut object = Map::new();
+        object.insert("null".to_string(), Value::Null);
+        object.insert("bool".to_string(), Value::Bool(true));
+        object.insert("number".to_string(), Value::Number(42.5));
+        object.insert("string".to_string(), Value::String("reddb".to_string()));
+        object.insert(
+            "array".to_string(),
+            Value::Array(vec![Value::Number(1.0), Value::String("two".to_string())]),
+        );
+        let value = Value::Object(object);
+
+        assert_eq!(value.get("string").and_then(Value::as_str), Some("reddb"));
+        assert_eq!(value.get("number").and_then(Value::as_f64), Some(42.5));
+        assert_eq!(value.get("number").and_then(Value::as_i64), Some(42));
+        assert_eq!(value.get("number").and_then(Value::as_u64), Some(42));
+        assert_eq!(value.get("bool").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            value.get("array").and_then(Value::as_array).map(<[_]>::len),
+            Some(2)
+        );
+        assert_eq!(value.as_object().map(Map::len), Some(5));
+        assert!(Value::Number(-1.0).as_u64().is_none());
+        assert!(Value::Null.as_str().is_none());
+
+        assert_eq!(value["missing"], Value::Null);
+        assert_eq!(value["string"], Value::String("reddb".to_string()));
+        let pretty = value.to_string_pretty();
+        assert!(pretty.contains('\n'));
+        assert!(pretty.contains("\"array\": ["));
+        assert_eq!(Value::Array(Vec::new()).to_string_pretty(), "[]");
+        assert_eq!(Value::Object(Map::new()).to_string_pretty(), "{}");
+
+        let mut created_from_index = Value::Null;
+        created_from_index["created"] = Value::Bool(true);
+        assert_eq!(created_from_index["created"], Value::Bool(true));
+    }
+
+    #[test]
+    fn json_encode_decode_traits_cover_scalars_collections_and_errors() {
+        assert_eq!(to_value(&true), Value::Bool(true));
+        assert_eq!(to_value(&-7i64), Value::Number(-7.0));
+        assert_eq!(to_value(&-3i32), Value::Number(-3.0));
+        assert_eq!(to_value(&7u8), Value::Number(7.0));
+        assert_eq!(to_value(&8u16), Value::Number(8.0));
+        assert_eq!(to_value(&9u32), Value::Number(9.0));
+        assert_eq!(to_value(&10u64), Value::Number(10.0));
+        assert_eq!(to_value(&11usize), Value::Number(11.0));
+        assert_eq!(to_value(&1.5f64), Value::Number(1.5));
+        assert_eq!(to_value(&2.5f32), Value::Number(2.5));
+        assert_eq!(to_value(&"borrowed"), Value::String("borrowed".to_string()));
+        assert_eq!(
+            to_value(&"owned".to_string()),
+            Value::String("owned".to_string())
+        );
+        let cow: Cow<'_, str> = Cow::Borrowed("cow");
+        assert_eq!(to_value(&cow), Value::String("cow".to_string()));
+        assert_eq!(
+            to_value(&vec![1u8, 2, 3]),
+            Value::Array(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+                Value::Number(3.0)
+            ])
+        );
+        assert_eq!(
+            to_value(&[4u8, 5, 6]),
+            Value::Array(vec![
+                Value::Number(4.0),
+                Value::Number(5.0),
+                Value::Number(6.0)
+            ])
+        );
+        assert_eq!(to_value(&Some(12u16)), Value::Number(12.0));
+        assert_eq!(to_value(&Option::<u16>::None), Value::Null);
+
+        let mut hash = HashMap::new();
+        hash.insert("a".to_string(), 1u8);
+        let Value::Object(map) = to_value(&hash) else {
+            panic!("hash map should encode to object");
+        };
+        assert_eq!(map.get("a"), Some(&Value::Number(1.0)));
+
+        assert_eq!(
+            from_value::<String>(Value::String("x".to_string())).unwrap(),
+            "x"
+        );
+        assert!(from_value::<String>(Value::Bool(true)).is_err());
+        assert_eq!(from_value::<bool>(Value::Bool(false)).unwrap(), false);
+        assert!(from_value::<bool>(Value::String("no".to_string())).is_err());
+        assert_eq!(from_value::<u8>(Value::Number(255.0)).unwrap(), 255);
+        assert_eq!(from_value::<u16>(Value::Number(256.0)).unwrap(), 256);
+        assert_eq!(from_value::<u32>(Value::Number(257.0)).unwrap(), 257);
+        assert_eq!(from_value::<u64>(Value::Number(258.0)).unwrap(), 258);
+        assert_eq!(from_value::<usize>(Value::Number(259.0)).unwrap(), 259);
+        assert_eq!(from_value::<i64>(Value::Number(-260.0)).unwrap(), -260);
+        assert_eq!(from_value::<i32>(Value::Number(-261.0)).unwrap(), -261);
+        assert_eq!(from_value::<f32>(Value::Number(1.25)).unwrap(), 1.25);
+        assert!(from_value::<u8>(Value::String("no".to_string())).is_err());
+        assert!(from_value::<Vec<u8>>(Value::Bool(false)).is_err());
+        assert_eq!(
+            from_value::<Vec<u8>>(Value::Array(vec![Value::Number(1.0), Value::Number(2.0)]))
+                .unwrap(),
+            vec![1, 2]
+        );
+
+        let mut object = Map::new();
+        object.insert("x".to_string(), Value::Number(7.0));
+        let decoded: HashMap<String, u8> = from_value(Value::Object(object)).unwrap();
+        assert_eq!(decoded.get("x"), Some(&7));
+        assert!(from_value::<HashMap<String, u8>>(Value::Null).is_err());
+
+        assert_eq!(from_value::<Option<u8>>(Value::Null).unwrap(), None);
+        assert_eq!(
+            from_value::<Option<u8>>(Value::Number(9.0)).unwrap(),
+            Some(9)
+        );
+        assert_eq!(
+            from_value::<[u8; 3]>(Value::Array(vec![
+                Value::Number(1.0),
+                Value::Number(2.0),
+                Value::Number(3.0),
+            ]))
+            .unwrap(),
+            [1, 2, 3]
+        );
+        assert!(from_value::<[u8; 3]>(Value::Array(vec![Value::Number(1.0)])).is_err());
+        assert!(from_value::<[u8; 3]>(Value::Null).is_err());
+    }
+
+    #[test]
+    fn string_and_byte_entry_points_round_trip_and_reject_bad_inputs() {
+        let bytes = to_vec(&vec![1u8, 2, 3]).unwrap();
+        assert_eq!(from_slice::<Vec<u8>>(&bytes).unwrap(), vec![1, 2, 3]);
+        assert!(from_slice::<Value>(&[0xff]).is_err());
+
+        let compact = to_string(&json!({ "b": true, "n": 2 })).unwrap();
+        assert_eq!(from_str::<Value>(&compact).unwrap()["b"], Value::Bool(true));
+
+        let pretty = to_string_pretty(&json!([1, 2])).unwrap();
+        assert!(pretty.contains('\n'));
     }
 }
 

--- a/crates/reddb-types/src/types.rs
+++ b/crates/reddb-types/src/types.rs
@@ -1674,6 +1674,8 @@ impl IntoIterator for Row {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
@@ -2388,5 +2390,683 @@ mod tests {
         let (recovered, size) = Row::from_bytes(&bytes).unwrap();
         assert_eq!(row, recovered);
         assert_eq!(size, bytes.len());
+    }
+
+    #[test]
+    fn sql_type_name_parses_modifiers_and_helpers() {
+        let decimal = SqlTypeName::parse_declared("decimal(10, 2)");
+        assert_eq!(decimal.base_name(), "DECIMAL");
+        assert_eq!(decimal.decimal_precision(), Some(10));
+        assert_eq!(decimal.to_string(), "DECIMAL(10,2)");
+
+        let enum_type = SqlTypeName::parse_declared("enum('red','blue')");
+        assert_eq!(
+            enum_type.enum_variants(),
+            Some(vec!["red".to_string(), "blue".to_string()])
+        );
+
+        let bad_enum = SqlTypeName::new("enum").with_modifiers(vec![TypeModifier::Number(1)]);
+        assert_eq!(bad_enum.enum_variants(), None);
+        assert_eq!(SqlTypeName::new("text").enum_variants(), None);
+
+        let array = SqlTypeName::parse_declared("array(varchar(12))");
+        assert_eq!(array.array_element_type(), Some("VARCHAR(12)".to_string()));
+        let array_ident =
+            SqlTypeName::new("array").with_modifiers(vec![TypeModifier::Ident("int".to_string())]);
+        assert_eq!(array_ident.array_element_type(), Some("INT".to_string()));
+        assert_eq!(SqlTypeName::new("text").array_element_type(), None);
+        assert_eq!(SqlTypeName::new("text").decimal_precision(), None);
+
+        assert_eq!(
+            SqlTypeName::parse_declared("enum('a,b', array(int))").to_string(),
+            "ENUM('a,b',ARRAY(INT))"
+        );
+        assert_eq!(SqlTypeName::parse_declared("").to_string(), "");
+    }
+
+    #[test]
+    fn datatype_category_preference_display_and_storage_traits_cover_all_variants() {
+        let cases = [
+            (
+                DataType::Unknown,
+                TypeCategory::Unknown,
+                "UNKNOWN",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Integer,
+                TypeCategory::Numeric,
+                "INTEGER",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::UnsignedInteger,
+                TypeCategory::Numeric,
+                "UNSIGNED INTEGER",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::Float,
+                TypeCategory::Numeric,
+                "FLOAT",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::Text,
+                TypeCategory::String,
+                "TEXT",
+                None,
+                true,
+                true,
+            ),
+            (
+                DataType::Blob,
+                TypeCategory::String,
+                "BLOB",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Boolean,
+                TypeCategory::Boolean,
+                "BOOLEAN",
+                Some(1),
+                false,
+                false,
+            ),
+            (
+                DataType::Timestamp,
+                TypeCategory::DateTime,
+                "TIMESTAMP",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::Duration,
+                TypeCategory::TimeSpan,
+                "DURATION",
+                Some(8),
+                false,
+                true,
+            ),
+            (
+                DataType::IpAddr,
+                TypeCategory::Network,
+                "IPADDR",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::MacAddr,
+                TypeCategory::Network,
+                "MACADDR",
+                Some(6),
+                false,
+                false,
+            ),
+            (
+                DataType::Vector,
+                TypeCategory::Vector,
+                "VECTOR",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Nullable,
+                TypeCategory::Unknown,
+                "NULLABLE",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Json,
+                TypeCategory::Json,
+                "JSON",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Uuid,
+                TypeCategory::Uuid,
+                "UUID",
+                Some(16),
+                true,
+                false,
+            ),
+            (
+                DataType::NodeRef,
+                TypeCategory::Reference,
+                "NODEREF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::EdgeRef,
+                TypeCategory::Reference,
+                "EDGEREF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::VectorRef,
+                TypeCategory::Reference,
+                "VECTORREF",
+                Some(8),
+                true,
+                false,
+            ),
+            (
+                DataType::RowRef,
+                TypeCategory::Reference,
+                "ROWREF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::Color,
+                TypeCategory::Domain,
+                "COLOR",
+                Some(3),
+                false,
+                false,
+            ),
+            (
+                DataType::Email,
+                TypeCategory::Domain,
+                "EMAIL",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::Url,
+                TypeCategory::Domain,
+                "URL",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::Phone,
+                TypeCategory::Domain,
+                "PHONE",
+                Some(8),
+                true,
+                false,
+            ),
+            (
+                DataType::Semver,
+                TypeCategory::Domain,
+                "SEMVER",
+                Some(4),
+                true,
+                true,
+            ),
+            (
+                DataType::Cidr,
+                TypeCategory::Network,
+                "CIDR",
+                Some(5),
+                false,
+                false,
+            ),
+            (
+                DataType::Date,
+                TypeCategory::DateTime,
+                "DATE",
+                Some(4),
+                true,
+                true,
+            ),
+            (
+                DataType::Time,
+                TypeCategory::DateTime,
+                "TIME",
+                Some(4),
+                true,
+                true,
+            ),
+            (
+                DataType::Decimal,
+                TypeCategory::Numeric,
+                "DECIMAL",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::Enum,
+                TypeCategory::Domain,
+                "ENUM",
+                Some(1),
+                true,
+                false,
+            ),
+            (
+                DataType::Array,
+                TypeCategory::Array,
+                "ARRAY",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::TimestampMs,
+                TypeCategory::DateTime,
+                "TIMESTAMP_MS",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::Ipv4,
+                TypeCategory::Network,
+                "IPV4",
+                Some(4),
+                true,
+                false,
+            ),
+            (
+                DataType::Ipv6,
+                TypeCategory::Network,
+                "IPV6",
+                Some(16),
+                true,
+                false,
+            ),
+            (
+                DataType::Subnet,
+                TypeCategory::Network,
+                "SUBNET",
+                Some(8),
+                false,
+                false,
+            ),
+            (
+                DataType::Port,
+                TypeCategory::Numeric,
+                "PORT",
+                Some(2),
+                true,
+                true,
+            ),
+            (
+                DataType::Latitude,
+                TypeCategory::Numeric,
+                "LATITUDE",
+                Some(4),
+                true,
+                true,
+            ),
+            (
+                DataType::Longitude,
+                TypeCategory::Numeric,
+                "LONGITUDE",
+                Some(4),
+                true,
+                true,
+            ),
+            (
+                DataType::GeoPoint,
+                TypeCategory::Geo,
+                "GEOPOINT",
+                Some(8),
+                true,
+                false,
+            ),
+            (
+                DataType::Country2,
+                TypeCategory::Domain,
+                "COUNTRY2",
+                Some(2),
+                true,
+                false,
+            ),
+            (
+                DataType::Country3,
+                TypeCategory::Domain,
+                "COUNTRY3",
+                Some(3),
+                true,
+                false,
+            ),
+            (
+                DataType::Lang2,
+                TypeCategory::Domain,
+                "LANG2",
+                Some(2),
+                true,
+                false,
+            ),
+            (
+                DataType::Lang5,
+                TypeCategory::Domain,
+                "LANG5",
+                Some(5),
+                true,
+                false,
+            ),
+            (
+                DataType::Currency,
+                TypeCategory::Domain,
+                "CURRENCY",
+                Some(3),
+                true,
+                false,
+            ),
+            (
+                DataType::ColorAlpha,
+                TypeCategory::Domain,
+                "COLOR_ALPHA",
+                Some(4),
+                false,
+                false,
+            ),
+            (
+                DataType::BigInt,
+                TypeCategory::Numeric,
+                "BIGINT",
+                Some(8),
+                true,
+                true,
+            ),
+            (
+                DataType::KeyRef,
+                TypeCategory::Reference,
+                "KEY_REF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::DocRef,
+                TypeCategory::Reference,
+                "DOC_REF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::TableRef,
+                TypeCategory::Reference,
+                "TABLE_REF",
+                None,
+                true,
+                false,
+            ),
+            (
+                DataType::PageRef,
+                TypeCategory::Reference,
+                "PAGE_REF",
+                Some(4),
+                true,
+                false,
+            ),
+            (
+                DataType::Secret,
+                TypeCategory::Opaque,
+                "SECRET",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::Password,
+                TypeCategory::Opaque,
+                "PASSWORD",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::TextZstd,
+                TypeCategory::String,
+                "TEXT",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::BlobZstd,
+                TypeCategory::String,
+                "BLOB",
+                None,
+                false,
+                false,
+            ),
+            (
+                DataType::AssetCode,
+                TypeCategory::Domain,
+                "ASSET_CODE",
+                None,
+                true,
+                true,
+            ),
+            (
+                DataType::Money,
+                TypeCategory::Domain,
+                "MONEY",
+                None,
+                false,
+                false,
+            ),
+        ];
+
+        for (data_type, category, display, fixed, indexable, orderable) in cases {
+            assert_eq!(data_type.category(), category, "{data_type:?}");
+            assert_eq!(data_type.to_string(), display);
+            assert_eq!(data_type.fixed_size(), fixed, "{data_type:?}");
+            assert_eq!(data_type.is_indexable(), indexable, "{data_type:?}");
+            assert_eq!(data_type.is_orderable(), orderable, "{data_type:?}");
+        }
+
+        for preferred in [
+            DataType::Float,
+            DataType::Text,
+            DataType::TimestampMs,
+            DataType::IpAddr,
+            DataType::Boolean,
+            DataType::Uuid,
+        ] {
+            assert!(preferred.is_preferred(), "{preferred:?}");
+        }
+        assert!(!DataType::Integer.is_preferred());
+    }
+
+    #[test]
+    fn sql_aliases_cover_domain_reference_and_unknown_paths() {
+        let aliases = [
+            ("BOOL", DataType::Boolean),
+            ("SMALLINT", DataType::Integer),
+            ("BIGSERIAL", DataType::BigInt),
+            ("UNSIGNED INTEGER", DataType::UnsignedInteger),
+            ("DOUBLE", DataType::Float),
+            ("VARCHAR(20)", DataType::Text),
+            ("BYTEA", DataType::Blob),
+            ("TIMESTAMP_MS", DataType::TimestampMs),
+            ("INTERVAL", DataType::Duration),
+            ("NUMERIC(10,2)", DataType::Decimal),
+            ("JSONB", DataType::Json),
+            ("INET", DataType::IpAddr),
+            ("COLOR_ALPHA", DataType::ColorAlpha),
+            ("GEO_POINT", DataType::GeoPoint),
+            ("ASSET_CODE", DataType::AssetCode),
+            ("KEYREF", DataType::KeyRef),
+            ("DOCREF", DataType::DocRef),
+            ("TABLEREF", DataType::TableRef),
+            ("PAGEREF", DataType::PageRef),
+            ("PASSWORD", DataType::Password),
+            ("VECTOR", DataType::Vector),
+        ];
+
+        for (alias, expected) in aliases {
+            assert_eq!(DataType::from_sql_name(alias), Some(expected), "{alias}");
+        }
+        assert_eq!(DataType::from_sql_name("definitely_not_a_type"), None);
+        assert_eq!(DataType::from_byte(0), None);
+        assert_eq!(DataType::from_byte(55), None);
+    }
+
+    #[test]
+    fn value_accessors_hash_and_display_cover_remaining_variants() {
+        let values = vec![
+            Value::Null,
+            Value::Integer(-1),
+            Value::UnsignedInteger(2),
+            Value::Float(3.5),
+            Value::text("hello"),
+            Value::Blob(vec![1, 2, 3]),
+            Value::Boolean(true),
+            Value::Timestamp(4),
+            Value::Duration(5),
+            Value::IpAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            Value::IpAddr(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            Value::MacAddr([1, 2, 3, 4, 5, 6]),
+            Value::Vector(vec![1.0, 2.0]),
+            Value::Json(br#"{"ok":true}"#.to_vec()),
+            Value::Uuid([7; 16]),
+            Value::NodeRef("node".to_string()),
+            Value::EdgeRef("edge".to_string()),
+            Value::VectorRef("vectors".to_string(), 8),
+            Value::RowRef("rows".to_string(), 9),
+            Value::Color([0xAA, 0xBB, 0xCC]),
+            Value::Email("a@example.com".to_string()),
+            Value::Url("https://example.com".to_string()),
+            Value::Phone(5511999),
+            Value::Semver(1_002_003),
+            Value::Cidr(10 << 24, 8),
+            Value::Date(20_000),
+            Value::Time(43_200_000),
+            Value::Decimal(123_456),
+            Value::EnumValue(3),
+            Value::Array(vec![Value::Integer(1), Value::text("two")]),
+            Value::TimestampMs(123_456),
+            Value::Ipv4(0x7f000001),
+            Value::Ipv6([1; 16]),
+            Value::Subnet(10 << 24, 0xff00ff00),
+            Value::Port(5432),
+            Value::Latitude(-23_550_520),
+            Value::Longitude(-46_633_308),
+            Value::GeoPoint(-23_550_520, -46_633_308),
+            Value::Country2(*b"BR"),
+            Value::Country3(*b"BRA"),
+            Value::Lang2(*b"pt"),
+            Value::Lang5(*b"pt-BR"),
+            Value::Currency(*b"USD"),
+            Value::AssetCode("BTC".to_string()),
+            Value::Money {
+                asset_code: "USD".to_string(),
+                minor_units: -1234,
+                scale: 2,
+            },
+            Value::ColorAlpha([1, 2, 3, 4]),
+            Value::BigInt(-10),
+            Value::KeyRef("kv".to_string(), "key".to_string()),
+            Value::DocRef("docs".to_string(), 42),
+            Value::TableRef("users".to_string()),
+            Value::PageRef(99),
+            Value::Secret(vec![9, 8, 7]),
+            Value::Password("$argon2id$v=19$hash".to_string()),
+        ];
+
+        for value in &values {
+            let mut hasher = DefaultHasher::new();
+            value.hash(&mut hasher);
+            let _ = hasher.finish();
+            assert_eq!(value.data_type(), value.data_type());
+            assert!(!value.display_string().is_empty());
+            assert!(!value.plain_text().is_empty());
+        }
+
+        assert!(Value::Null.is_null());
+        assert_eq!(Value::Integer(-1).as_integer(), Some(-1));
+        assert_eq!(
+            Value::UnsignedInteger(i64::MAX as u64).as_integer(),
+            Some(i64::MAX)
+        );
+        assert_eq!(
+            Value::UnsignedInteger(i64::MAX as u64 + 1).as_integer(),
+            None
+        );
+        assert_eq!(Value::Timestamp(1).as_integer(), Some(1));
+        assert_eq!(Value::Duration(2).as_integer(), Some(2));
+        assert_eq!(Value::Float(1.5).as_float(), Some(1.5));
+        assert_eq!(Value::Integer(2).as_float(), Some(2.0));
+        assert_eq!(Value::UnsignedInteger(3).as_float(), Some(3.0));
+        assert_eq!(Value::text("x").as_text(), Some("x"));
+        assert_eq!(Value::Boolean(true).as_boolean(), Some(true));
+        assert_eq!(
+            Value::IpAddr(IpAddr::V4(Ipv4Addr::LOCALHOST)).as_ip_addr(),
+            Some(IpAddr::V4(Ipv4Addr::LOCALHOST))
+        );
+        assert_eq!(Value::Vector(vec![1.0]).as_vector(), Some(&[1.0][..]));
+        assert_eq!(Value::Null.as_integer(), None);
+        assert_eq!(Value::Null.as_float(), None);
+        assert_eq!(Value::Null.as_text(), None);
+        assert_eq!(Value::Null.as_boolean(), None);
+        assert_eq!(Value::Null.as_ip_addr(), None);
+        assert_eq!(Value::Null.as_vector(), None);
+    }
+
+    #[test]
+    fn row_accessors_iteration_and_error_paths() {
+        let empty = Row::new(Vec::new());
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+        assert_eq!(empty.get(0), None);
+
+        let row = Row::from(vec![Value::Integer(1), Value::text("two")]);
+        assert_eq!(row.len(), 2);
+        assert_eq!(row.get(1), Some(&Value::text("two")));
+        assert_eq!(row.values().len(), 2);
+        assert_eq!(row.iter().count(), 2);
+        assert_eq!(row.clone().into_values().len(), 2);
+        assert_eq!(row.into_iter().count(), 2);
+
+        assert_eq!(Row::from_bytes(&[]).unwrap_err(), ValueError::EmptyData);
+        assert_eq!(
+            Row::from_bytes(&[0x80]).unwrap_err(),
+            ValueError::TruncatedData
+        );
+    }
+
+    #[test]
+    fn value_error_display_covers_every_variant() {
+        let errors = [
+            (ValueError::EmptyData, "empty data"),
+            (ValueError::InvalidType(99), "invalid type byte: 99"),
+            (ValueError::TruncatedData, "truncated data"),
+            (ValueError::InvalidUtf8, "invalid UTF-8"),
+            (ValueError::InvalidIpVersion(5), "invalid IP version: 5"),
+            (ValueError::VarintOverflow, "varint overflow"),
+            (
+                ValueError::TypeMismatch {
+                    expected: DataType::Text,
+                    found: DataType::Integer,
+                },
+                "type mismatch: expected TEXT, found INTEGER",
+            ),
+        ];
+
+        for (error, message) in errors {
+            assert_eq!(error.to_string(), message);
+        }
     }
 }

--- a/crates/reddb-types/src/utils/json.rs
+++ b/crates/reddb-types/src/utils/json.rs
@@ -592,4 +592,110 @@ mod tests {
         let output = value.to_json_string();
         assert!(output.contains("hello"));
     }
+
+    #[test]
+    fn constructors_accessors_mutators_and_display_cover_all_shapes() {
+        let mut value = JsonValue::object(vec![
+            ("name".to_string(), JsonValue::from("reddb")),
+            ("active".to_string(), JsonValue::from(true)),
+            ("count".to_string(), JsonValue::from(3usize)),
+            ("ratio".to_string(), JsonValue::from(1.5f64)),
+            (
+                "items".to_string(),
+                JsonValue::array(vec![JsonValue::Null, JsonValue::from(2i64)]),
+            ),
+        ]);
+
+        assert_eq!(value.get("name").and_then(JsonValue::as_str), Some("reddb"));
+        assert_eq!(value.get("active").and_then(JsonValue::as_bool), Some(true));
+        assert_eq!(value.get("count").and_then(JsonValue::as_f64), Some(3.0));
+        assert_eq!(
+            value
+                .get("items")
+                .and_then(JsonValue::as_array)
+                .map(<[_]>::len),
+            Some(2)
+        );
+        assert_eq!(value.as_object().map(<[_]>::len), Some(5));
+        assert!(JsonValue::Null.as_str().is_none());
+        assert!(JsonValue::Null.as_bool().is_none());
+        assert!(JsonValue::Null.as_array().is_none());
+        assert!(JsonValue::Null.as_object().is_none());
+
+        value
+            .get_mut("count")
+            .map(|slot| *slot = JsonValue::from(4usize))
+            .unwrap();
+        assert_eq!(value.get("count").and_then(JsonValue::as_f64), Some(4.0));
+
+        value
+            .as_object_mut()
+            .unwrap()
+            .push(("extra".to_string(), JsonValue::from("ok".to_string())));
+        let mut array = JsonValue::array(vec![JsonValue::from(1usize)]);
+        array.as_array_mut().unwrap().push(JsonValue::from(2usize));
+        assert_eq!(array.as_array().unwrap().len(), 2);
+
+        #[allow(deprecated)]
+        let encoded =
+            JsonValue::String("quote\" slash\\ tab\t ctrl\x01".to_string()).to_json_string();
+        assert!(encoded.contains("\\\""));
+        assert!(encoded.contains("\\\\"));
+        assert!(encoded.contains("\\t"));
+        assert!(encoded.contains("\\u0001"));
+        assert_eq!(format!("{}", JsonValue::Bool(false)), "false");
+    }
+
+    #[test]
+    fn parser_accepts_scalars_escapes_empty_containers_and_trailing_space() {
+        assert_eq!(parse_json(" null \n").unwrap(), JsonValue::Null);
+        assert_eq!(parse_json("true").unwrap(), JsonValue::Bool(true));
+        assert_eq!(parse_json("false").unwrap(), JsonValue::Bool(false));
+        assert_eq!(parse_json("-12.5e+2").unwrap(), JsonValue::Number(-1250.0));
+        assert_eq!(parse_json("[]").unwrap(), JsonValue::Array(Vec::new()));
+        assert_eq!(parse_json("{}").unwrap(), JsonValue::Object(Vec::new()));
+
+        let escaped = parse_json(r#""\"\\\/\b\f\n\r\t\u00e9\uD83D\uDCA9""#).unwrap();
+        let text = escaped.as_str().unwrap();
+        assert!(text.contains('"'));
+        assert!(text.contains('\\'));
+        assert!(text.contains('/'));
+        assert!(text.contains('\x08'));
+        assert!(text.contains('\x0c'));
+        assert!(text.contains('\n'));
+        assert!(text.contains('\r'));
+        assert!(text.contains('\t'));
+        assert!(text.chars().any(|ch| ch as u32 == 0x00E9));
+        assert_eq!(text.chars().last(), char::from_u32(0x1F4A9));
+    }
+
+    #[test]
+    fn parser_rejects_invalid_tokens_numbers_strings_and_separators() {
+        let cases = [
+            "",
+            "truth",
+            "nul",
+            "-",
+            "01",
+            "1.",
+            "1e",
+            r#""unterminated"#,
+            r#""\x""#,
+            r#""\u12""#,
+            r#""\u12zz""#,
+            r#""\uD800""#,
+            r#""\uD800\u0000""#,
+            r#""\uDC00""#,
+            "[1 2]",
+            "[1,]",
+            r#"{"a" 1}"#,
+            r#"{"a":1 "b":2}"#,
+            "{} trailing",
+            "?",
+        ];
+
+        for case in cases {
+            assert!(parse_json(case).is_err(), "{case:?}");
+        }
+    }
 }

--- a/crates/reddb-types/src/value_codec.rs
+++ b/crates/reddb-types/src/value_codec.rs
@@ -957,6 +957,7 @@ pub fn decode(data: &[u8]) -> Result<(Value, usize), ValueError> {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     /// Pinned on-disk byte layout for the canonical [`Value`]
     /// variants. **If this test breaks, callers with persisted data
@@ -1064,6 +1065,207 @@ mod tests {
         write_varint(&mut buf, 5);
         buf.extend_from_slice(b"ab");
         assert!(matches!(decode(&buf), Err(ValueError::TruncatedData)));
+    }
+
+    #[test]
+    fn type_for_tag_handles_null_registered_and_unknown_tags() {
+        assert_eq!(type_for_tag(0), Some(DataType::Nullable));
+        assert_eq!(
+            type_for_tag(DataType::Money.to_byte()),
+            Some(DataType::Money)
+        );
+        assert_eq!(type_for_tag(0xFF), None);
+    }
+
+    #[test]
+    fn round_trip_every_value_variant_directly_through_registry() {
+        let values = vec![
+            Value::Null,
+            Value::Integer(-1),
+            Value::UnsignedInteger(2),
+            Value::Float(3.5),
+            Value::text("hello"),
+            Value::Blob(vec![1, 2, 3]),
+            Value::Boolean(true),
+            Value::Timestamp(4),
+            Value::Duration(5),
+            Value::IpAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
+            Value::IpAddr(IpAddr::V6(Ipv6Addr::LOCALHOST)),
+            Value::MacAddr([1, 2, 3, 4, 5, 6]),
+            Value::Vector(vec![1.0, 2.0]),
+            Value::Json(br#"{"ok":true}"#.to_vec()),
+            Value::Uuid([7; 16]),
+            Value::NodeRef("node".to_string()),
+            Value::EdgeRef("edge".to_string()),
+            Value::VectorRef("vectors".to_string(), 8),
+            Value::RowRef("rows".to_string(), 9),
+            Value::Color([0xAA, 0xBB, 0xCC]),
+            Value::Email("a@example.com".to_string()),
+            Value::Url("https://example.com".to_string()),
+            Value::Phone(5511999),
+            Value::Semver(1_002_003),
+            Value::Cidr(10 << 24, 8),
+            Value::Date(20_000),
+            Value::Time(43_200_000),
+            Value::Decimal(123_456),
+            Value::EnumValue(3),
+            Value::Array(vec![Value::Integer(1), Value::text("two")]),
+            Value::TimestampMs(123_456),
+            Value::Ipv4(0x7f000001),
+            Value::Ipv6([1; 16]),
+            Value::Subnet(10 << 24, 0xff000000),
+            Value::Port(5432),
+            Value::Latitude(-23_550_520),
+            Value::Longitude(-46_633_308),
+            Value::GeoPoint(-23_550_520, -46_633_308),
+            Value::Country2(*b"BR"),
+            Value::Country3(*b"BRA"),
+            Value::Lang2(*b"pt"),
+            Value::Lang5(*b"pt-BR"),
+            Value::Currency(*b"USD"),
+            Value::AssetCode("BTC".to_string()),
+            Value::Money {
+                asset_code: "USD".to_string(),
+                minor_units: 1234,
+                scale: 2,
+            },
+            Value::ColorAlpha([1, 2, 3, 4]),
+            Value::BigInt(-10),
+            Value::KeyRef("kv".to_string(), "key".to_string()),
+            Value::DocRef("docs".to_string(), 42),
+            Value::TableRef("users".to_string()),
+            Value::PageRef(99),
+            Value::Secret(vec![9, 8, 7]),
+            Value::Password("$argon2id$v=19$hash".to_string()),
+        ];
+
+        for original in values {
+            let mut bytes = Vec::new();
+            encode(&original, &mut bytes);
+            let (decoded, consumed) = decode(&bytes).expect("decode");
+            assert_eq!(consumed, bytes.len());
+            assert_eq!(decoded, original, "{bytes:?}");
+        }
+    }
+
+    #[test]
+    fn compressed_text_and_blob_decode_to_plain_values() {
+        let text = Value::text("reddb ".repeat(700));
+        let mut bytes = Vec::new();
+        encode(&text, &mut bytes);
+        assert_eq!(bytes[0], DataType::TextZstd.to_byte());
+        let (decoded, consumed) = decode(&bytes).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded, text);
+
+        let blob = Value::Blob(vec![0xAB; TOAST_THRESHOLD + 512]);
+        let mut bytes = Vec::new();
+        encode(&blob, &mut bytes);
+        assert_eq!(bytes[0], DataType::BlobZstd.to_byte());
+        let (decoded, consumed) = decode(&bytes).unwrap();
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded, blob);
+    }
+
+    #[test]
+    fn decode_rejects_short_payload_for_registered_tags() {
+        let truncated_tags = [
+            DataType::Integer,
+            DataType::UnsignedInteger,
+            DataType::Float,
+            DataType::Text,
+            DataType::Blob,
+            DataType::Boolean,
+            DataType::Timestamp,
+            DataType::Duration,
+            DataType::IpAddr,
+            DataType::MacAddr,
+            DataType::Vector,
+            DataType::Json,
+            DataType::Uuid,
+            DataType::NodeRef,
+            DataType::EdgeRef,
+            DataType::VectorRef,
+            DataType::RowRef,
+            DataType::Color,
+            DataType::Email,
+            DataType::Url,
+            DataType::Phone,
+            DataType::Semver,
+            DataType::Cidr,
+            DataType::Date,
+            DataType::Time,
+            DataType::Decimal,
+            DataType::Enum,
+            DataType::Array,
+            DataType::TimestampMs,
+            DataType::Ipv4,
+            DataType::Ipv6,
+            DataType::Subnet,
+            DataType::Port,
+            DataType::Latitude,
+            DataType::Longitude,
+            DataType::GeoPoint,
+            DataType::Country2,
+            DataType::Country3,
+            DataType::Lang2,
+            DataType::Lang5,
+            DataType::Currency,
+            DataType::AssetCode,
+            DataType::Money,
+            DataType::ColorAlpha,
+            DataType::BigInt,
+            DataType::KeyRef,
+            DataType::DocRef,
+            DataType::TableRef,
+            DataType::PageRef,
+            DataType::Secret,
+            DataType::Password,
+            DataType::TextZstd,
+            DataType::BlobZstd,
+        ];
+
+        for data_type in truncated_tags {
+            let err = decode(&[data_type.to_byte()]).expect_err("short payload must error");
+            assert_eq!(err, ValueError::TruncatedData, "{data_type:?}");
+        }
+
+        assert_eq!(
+            decode(&[DataType::Nullable.to_byte()]).unwrap().0,
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn decode_rejects_invalid_embedded_tags_and_utf8_payloads() {
+        assert_eq!(
+            decode(&[DataType::IpAddr.to_byte(), 5]).expect_err("bad ip version"),
+            ValueError::InvalidIpVersion(5)
+        );
+
+        let invalid_text = [DataType::Text.to_byte(), 1, 0xff];
+        assert_eq!(
+            decode(&invalid_text).expect_err("invalid utf8"),
+            ValueError::InvalidUtf8
+        );
+
+        let invalid_email = [DataType::Email.to_byte(), 1, 0xff];
+        assert_eq!(
+            decode(&invalid_email).expect_err("invalid utf8"),
+            ValueError::InvalidUtf8
+        );
+
+        let invalid_url = [DataType::Url.to_byte(), 1, 0xff];
+        assert_eq!(
+            decode(&invalid_url).expect_err("invalid utf8"),
+            ValueError::InvalidUtf8
+        );
+
+        let invalid_asset = [DataType::AssetCode.to_byte(), 1, 0xff];
+        assert_eq!(
+            decode(&invalid_asset).expect_err("invalid utf8"),
+            ValueError::InvalidUtf8
+        );
     }
 
     /// Round-trip: encode then decode must recover the original

--- a/crates/reddb-types/src/value_compare.rs
+++ b/crates/reddb-types/src/value_compare.rs
@@ -85,4 +85,77 @@ mod tests {
             assert_ne!(total_compare_values(a, b), Ordering::Equal);
         }
     }
+
+    #[test]
+    fn same_type_partial_comparisons_cover_registered_orderings() {
+        let pairs = [
+            (Value::Null, Value::Null, Ordering::Equal),
+            (Value::Integer(1), Value::Integer(2), Ordering::Less),
+            (
+                Value::UnsignedInteger(3),
+                Value::UnsignedInteger(2),
+                Ordering::Greater,
+            ),
+            (Value::Float(1.0), Value::Float(1.0), Ordering::Equal),
+            (Value::text("a"), Value::text("b"), Ordering::Less),
+            (Value::Boolean(false), Value::Boolean(true), Ordering::Less),
+            (Value::Timestamp(10), Value::Timestamp(9), Ordering::Greater),
+            (Value::Duration(4), Value::Duration(4), Ordering::Equal),
+            (
+                Value::Blob(vec![1]),
+                Value::Blob(vec![1, 2]),
+                Ordering::Less,
+            ),
+            (Value::Uuid([1; 16]), Value::Uuid([2; 16]), Ordering::Less),
+        ];
+
+        for (left, right, expected) in pairs {
+            assert_eq!(partial_compare_values(&left, &right), Some(expected));
+            assert_eq!(total_compare_values(&left, &right), expected);
+        }
+    }
+
+    #[test]
+    fn numeric_cross_type_comparisons_use_numeric_value() {
+        let pairs = [
+            (Value::Integer(2), Value::Float(2.5), Ordering::Less),
+            (Value::Float(3.5), Value::Integer(3), Ordering::Greater),
+            (
+                Value::UnsignedInteger(4),
+                Value::Float(4.0),
+                Ordering::Equal,
+            ),
+            (Value::Float(5.0), Value::UnsignedInteger(6), Ordering::Less),
+            (
+                Value::Integer(-1),
+                Value::UnsignedInteger(1),
+                Ordering::Less,
+            ),
+            (
+                Value::UnsignedInteger(9),
+                Value::Integer(8),
+                Ordering::Greater,
+            ),
+        ];
+
+        for (left, right, expected) in pairs {
+            assert_eq!(partial_compare_values(&left, &right), Some(expected));
+        }
+    }
+
+    #[test]
+    fn nan_partial_compare_falls_back_to_total_tag_order() {
+        assert_eq!(
+            partial_compare_values(&Value::Float(f64::NAN), &Value::Float(1.0)),
+            None
+        );
+        assert_eq!(
+            total_compare_values(&Value::Float(f64::NAN), &Value::Float(1.0)),
+            Ordering::Equal
+        );
+        assert_eq!(
+            partial_compare_values(&Value::Json(vec![]), &Value::Json(vec![])),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- converts `reddb-io-types` coverage from advisory reporting to a hard 90% line coverage gate
- adds a new hard 90% line coverage workflow for `reddb-io-file`
- adds focused tests across types canonical keys, JSON/type codecs, value comparison, and file-owned WAL/native-store/manifest/cache-policy/serverless contracts

## Local validation
- `cargo fmt --check`
- `cargo test -p reddb-io-types` -> 284 passed
- `cargo test -p reddb-io-file` -> 352 passed
- `cargo llvm-cov -p reddb-io-types --summary-only --fail-under-lines 90` -> 94.71% line coverage
- `cargo llvm-cov -p reddb-io-file --summary-only --ignore-filename-regex tests\.rs$ --fail-under-lines 90` -> 90.25% line coverage
- `git diff --check`
