### PR TITLE
test(ci): pilot grouped cli transport integration target

### DIFF
--- a/tests/grouped/cli_transport/cli_migrate_from_redis.rs
+++ b/tests/grouped/cli_transport/cli_migrate_from_redis.rs
@@ -3,6 +3,7 @@
 //! exit status, and JSON envelopes stay wired through main().
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::net::TcpListener;

--- a/tests/grouped/cli_transport/cli_query_param.rs
+++ b/tests/grouped/cli_transport/cli_query_param.rs
@@ -9,6 +9,7 @@
 //!   - arity errors surface clearly
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::path::PathBuf;

--- a/tests/grouped/cli_transport/e2e_issue_545_transport_listener_readiness.rs
+++ b/tests/grouped/cli_transport/e2e_issue_545_transport_listener_readiness.rs
@@ -20,6 +20,7 @@
 //! mirroring the discipline used by the #540 / #541 / #542 / #543 /
 //! #544 regression commits.
 
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::io::{Read, Write};

--- a/tests/grouped/cli_transport/http_batch_insert.rs
+++ b/tests/grouped/cli_transport/http_batch_insert.rs
@@ -8,6 +8,7 @@
 //! * oversize batches reject with 413 before any storage write.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::io::{Read, Write};

--- a/tests/grouped_cli_transport.rs
+++ b/tests/grouped_cli_transport.rs
@@ -1,0 +1,19 @@
+//! Grouped integration-test harness for CLI and small transport handlers.
+//!
+//! Cargo links one binary per top-level integration-test file. Keep the
+//! original domain tests as modules under `tests/grouped/` so their function
+//! names remain visible while this pilot reduces six linked binaries to one.
+
+#![allow(dead_code)]
+
+#[path = "grouped/cli_transport/cli_migrate_from_redis.rs"]
+mod cli_migrate_from_redis;
+
+#[path = "grouped/cli_transport/cli_query_param.rs"]
+mod cli_query_param;
+
+#[path = "grouped/cli_transport/e2e_issue_545_transport_listener_readiness.rs"]
+mod e2e_issue_545_transport_listener_readiness;
+
+#[path = "grouped/cli_transport/http_batch_insert.rs"]
+mod http_batch_insert;


### PR DESCRIPTION
## Summary
- pilots the #966 integration-test binary consolidation with a small CLI/transport slice
- moves four green integration tests under `tests/grouped/cli_transport/` and runs them through one top-level `grouped_cli_transport` target
- reduces top-level integration test files from 275 to 272 for this slice while preserving test function names under module scope

## Notes
- I intentionally left pre-existing red tests (`cli_bootstrap`, `cli_ui_deeplink`, `http_handler_deadline`, `http_handler_metrics`) out of this pilot. They fail on current `main` when run standalone, so grouping them here would make this consolidation PR carry unrelated fixes.

## Local validation
- `cargo fmt --check`
- `cargo test --test grouped_cli_transport --no-default-features` -> 16 passed
- `cargo test --no-run --test grouped_cli_transport --no-default-features`
- `make check`
- `git diff --check`

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783960314&installation_id=129708444&pr_number=1148&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1148&signature=64761ff69738c488cbee2ac0c258f9f83cc5b20ec7c38d38e4f69f17a663892c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->