### PR TITLE
test(ci): group audit integration target

### DIFF
--- a/tests/grouped/audit/audit_rotation.rs
+++ b/tests/grouped/audit/audit_rotation.rs
@@ -7,6 +7,7 @@
 //! `audit_query_endpoint.rs`.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::path::PathBuf;

--- a/tests/grouped/audit/audit_structured.rs
+++ b/tests/grouped/audit/audit_structured.rs
@@ -6,6 +6,7 @@
 //! per-site exceptions.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::time::Duration;

--- a/tests/grouped/audit/e2e_audit_slow_routing.rs
+++ b/tests/grouped/audit/e2e_audit_slow_routing.rs
@@ -16,6 +16,7 @@ use reddb::{
 };
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 // Tier toggles + global audit sink are process-globals — serialise the

--- a/tests/grouped_audit.rs
+++ b/tests/grouped_audit.rs
@@ -1,0 +1,16 @@
+//! Grouped integration-test harness for audit logging and routing coverage.
+//!
+//! Cargo links one binary per top-level integration-test file. Keep the
+//! original domain tests as modules under `tests/grouped/` so their function
+//! names remain visible while this slice reduces three linked binaries to one.
+
+#![allow(dead_code)]
+
+#[path = "grouped/audit/audit_rotation.rs"]
+mod audit_rotation;
+
+#[path = "grouped/audit/audit_structured.rs"]
+mod audit_structured;
+
+#[path = "grouped/audit/e2e_audit_slow_routing.rs"]
+mod e2e_audit_slow_routing;


### PR DESCRIPTION
## Summary
- continues #966 integration-test binary consolidation with an audit slice
- moves three green audit/log routing integration tests under `tests/grouped/audit/`
- adds one top-level `grouped_audit` target, reducing top-level integration test files from 269 to 267

## Notes
- I intentionally left `audit_query_endpoint` out of this slice because it fails standalone on current `main`; that regression should be fixed separately rather than folded into a consolidation PR.

## Local validation
- `cargo test --test audit_rotation --no-default-features` -> 2 passed
- `cargo test --test audit_structured --no-default-features` -> 5 passed
- `cargo test --test e2e_audit_slow_routing --no-default-features` -> 2 passed
- `cargo fmt --check`
- `cargo test --test grouped_audit --no-default-features` -> 9 passed
- `cargo test --no-run --test grouped_audit --no-default-features`
- `make check`
- `git diff --check`

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783961398&installation_id=129708444&pr_number=1150&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1150&signature=9bdaf2f1fb4c37e23e88de365c3699c824ba5166cc4b25c20b47f2b46e1a1e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->