### PR TITLE
fix(queue): preserve nack telemetry context

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -9,9 +9,11 @@ use crate::runtime::impl_core::{
     clear_current_auth_identity, clear_current_tenant, current_auth_identity, current_tenant,
     set_current_auth_identity, set_current_tenant,
 };
+use crate::runtime::queue_telemetry::NackOutcomeLabel;
 use crate::storage::queue::QueueMode;
 use crate::storage::unified::entity::{QueueMessageData, RowData};
 use crate::storage::unified::{Metadata, MetadataValue, UnifiedStore};
+use crate::telemetry::operator_event::OperatorEvent;
 
 use super::*;
 
@@ -40,7 +42,8 @@ pub(super) fn runtime_lifecycle(
     let txn = primary_for_lifecycle.new_txn();
     let cfg = primary_for_lifecycle.lifecycle_config(queue);
     (
-        QueueLifecycle::new(primary_for_lifecycle, cfg),
+        QueueLifecycle::new(primary_for_lifecycle, cfg)
+            .with_telemetry(Arc::clone(&runtime.inner.queue_telemetry)),
         primary_for_lookup,
         txn,
     )
@@ -1435,6 +1438,8 @@ impl RedDBRuntime {
                 // override wins, then queue default, then zero
                 // (immediate requeue — pre-#723 behavior).
                 let effective_delay_ms = delay_ms.or(config.retry_delay_ms).unwrap_or(0);
+                let pending_attempt = ps.read_pending_attempt(&did).map_err(map_qse)?;
+                let nack_attempts = pending_attempt.attempts.saturating_add(1);
                 let outcome = lifecycle.nack(&txn, &did).map_err(map_qse)?;
                 // Apply delay only when the message was actually
                 // requeued — DLQ promotion / drop terminate the
@@ -1464,6 +1469,28 @@ impl RedDBRuntime {
                     config.retry_delay_ms,
                     &outcome,
                 );
+                let outcome_label = match &outcome {
+                    RetirementOutcome::Requeued => NackOutcomeLabel::Retry,
+                    RetirementOutcome::MovedToDlq(_) => NackOutcomeLabel::Dlq,
+                    RetirementOutcome::Dropped => NackOutcomeLabel::Drop,
+                };
+                self.queue_telemetry().record_nacked(
+                    queue,
+                    group_ref,
+                    config.mode.as_str(),
+                    outcome_label,
+                );
+                if let RetirementOutcome::MovedToDlq(dlq) = &outcome {
+                    OperatorEvent::QueueDlqPromoted {
+                        queue: queue.to_string(),
+                        group: group_ref.to_string(),
+                        dlq: dlq.clone(),
+                        message_id: pending_attempt.message_id,
+                        attempts: nack_attempts,
+                        reason: format!("lifecycle_nack:{did}"),
+                    }
+                    .emit_global();
+                }
                 let message = match outcome {
                     RetirementOutcome::Requeued => {
                         if effective_delay_ms > 0 {

--- a/crates/reddb-server/src/runtime/queue_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/queue_lifecycle.rs
@@ -21,14 +21,13 @@
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use crate::runtime::queue_telemetry::{NackOutcomeLabel, QueueTelemetryCounters};
+use crate::runtime::queue_telemetry::QueueTelemetryCounters;
 use crate::storage::queue::lifecycle::{
     DeliveryId, DlqTarget, MessageId, PendingDeliveryView, QueueSide, QueueStore, QueueStoreError,
     QueueTxn, Result,
 };
 use crate::storage::queue::mode::QueueMode;
 use crate::storage::schema::Value;
-use crate::telemetry::operator_event::OperatorEvent;
 
 /// Monotonic clock abstraction. The Module reads "now" through this so
 /// unit tests can drive lock-expiry transitions without `std::thread::sleep`.
@@ -344,7 +343,7 @@ impl<S: QueueStore> QueueLifecycle<S> {
     /// it. Callers never see the decision — observe outcomes via the test
     /// tap.
     pub(crate) fn nack(&self, txn: &QueueTxn, delivery_id: &str) -> Result<RetirementOutcome> {
-        let bumped = self.store.read_pending_attempt(delivery_id)?;
+        let bumped = self.store.bump_attempt(txn, delivery_id)?;
         let max_attempts = self
             .store
             .read_max_attempts(&bumped.queue, bumped.message_id);
@@ -361,23 +360,6 @@ impl<S: QueueStore> QueueLifecycle<S> {
                     self.store.enqueue_dlq(txn, target, payload)?;
                     outcome = RetirementOutcome::MovedToDlq(target.clone());
                     self.record(outcome.clone());
-                    // DLQ promotion is forensic — emit through the
-                    // process-wide audit sink (which also lays a
-                    // tracing::warn breadcrumb under
-                    // target=reddb::operator). The lifecycle surface
-                    // doesn't yet carry queue/group on the delivery
-                    // handle (slice 12 of issue #527); the production
-                    // path emits the populated event today via
-                    // `queue_delivery::move_message_to_dlq_or_drop`.
-                    OperatorEvent::QueueDlqPromoted {
-                        queue: String::new(),
-                        group: String::new(),
-                        dlq: target.clone(),
-                        message_id: 0,
-                        attempts,
-                        reason: format!("lifecycle_nack:{delivery_id}"),
-                    }
-                    .emit_global();
                 }
                 None => {
                     self.retire(txn, delivery_id)?;
@@ -389,27 +371,6 @@ impl<S: QueueStore> QueueLifecycle<S> {
             self.store.release_pending(txn, delivery_id)?;
             outcome = RetirementOutcome::Requeued;
             self.record(outcome.clone());
-        }
-        // Counter bumping when the telemetry handle is attached.
-        // Per-(queue, group, mode) labels stay accurate even though
-        // the lifecycle surface lacks queue/group on the nack handle
-        // today — the production wiring (slice 12) builds the
-        // lifecycle with the full descriptor and constructs the
-        // labels at that layer. Until then the lifecycle-only path
-        // bumps with placeholder labels so unit tests don't depend
-        // on absent context.
-        if let Some(telemetry) = self.telemetry.as_ref() {
-            let outcome = match self
-                .outcomes
-                .lock()
-                .unwrap_or_else(|p| p.into_inner())
-                .last()
-            {
-                Some(RetirementOutcome::MovedToDlq(_)) => NackOutcomeLabel::Dlq,
-                Some(RetirementOutcome::Dropped) => NackOutcomeLabel::Drop,
-                Some(RetirementOutcome::Requeued) | None => NackOutcomeLabel::Retry,
-            };
-            telemetry.record_nacked("", "", self.config.mode.as_str(), outcome);
         }
         Ok(outcome)
     }
@@ -528,10 +489,7 @@ impl<S: QueueStore> QueueLifecycle<S> {
             .store
             .pending_deliveries_for_queue(queue)
             .into_iter()
-            .filter(|p| {
-                let delivered_at = p.deadline - self.config.lock_duration;
-                delivered_at + threshold <= now
-            })
+            .filter(|p| p.deadline <= now && now.duration_since(p.deadline) >= threshold)
             .collect();
         // Stable ordering by deadline keeps the oldest delivery first
         // because all rows in a queue share the same lock duration.

--- a/tests/e2e_queue_lifecycle_telemetry.rs
+++ b/tests/e2e_queue_lifecycle_telemetry.rs
@@ -44,7 +44,7 @@ fn nack_to_dlq_emits_audit_event_and_increments_prom_counters() {
     // second NACK promotes immediately.
     exec(
         &rt,
-        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 2",
+        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 4",
     );
     exec(&rt, "QUEUE GROUP CREATE tasks workers");
     exec(&rt, "QUEUE PUSH tasks 'job-dlq'");

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -101,7 +101,7 @@ fn test_queue_group_pending_claim_and_ack_flow() {
 
     exec(
         &rt,
-        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 3",
+        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 3 LOCK_DEADLINE_MS 1",
     );
     exec(&rt, "QUEUE GROUP CREATE tasks workers");
 
@@ -129,6 +129,7 @@ fn test_queue_group_pending_claim_and_ack_flow() {
     );
     assert_eq!(text(&pending.result.records[0], "consumer"), "worker1");
 
+    sleep(Duration::from_millis(5));
     let claimed = exec(
         &rt,
         "QUEUE CLAIM tasks GROUP workers CONSUMER worker2 MIN_IDLE 0",
@@ -173,7 +174,7 @@ fn test_queue_nack_moves_message_to_dlq_after_max_attempts() {
 
     exec(
         &rt,
-        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 2",
+        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 4",
     );
     exec(&rt, "QUEUE GROUP CREATE tasks workers");
     exec(&rt, "QUEUE PUSH tasks 'job-dlq'");
@@ -238,7 +239,7 @@ fn test_select_from_queue_projects_without_consuming_or_leasing() {
     );
     assert_eq!(projection.result.records.len(), 1);
     assert_eq!(text(&projection.result.records[0], "payload"), "fresh");
-    assert_eq!(uint(&projection.result.records[0], "attempts"), 1);
+    assert_eq!(uint(&projection.result.records[0], "attempts"), 2);
     assert!(projection.result.records[0].contains_column("last_error"));
     assert!(uint(&projection.result.records[0], "enqueued_at") > 0);
 
@@ -271,12 +272,6 @@ fn test_queue_move_filters_limits_and_keeps_peek_compatible() {
     exec(
         &rt,
         &format!("QUEUE NACK failed_jobs GROUP _work_default '{}'", first_id),
-    );
-    let read_second = exec(&rt, "QUEUE READ failed_jobs CONSUMER worker1 COUNT 1");
-    let second_id = text(&read_second.result.records[0], "message_id");
-    exec(
-        &rt,
-        &format!("QUEUE NACK failed_jobs GROUP _work_default '{}'", second_id),
     );
 
     let moved = exec(

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -953,7 +953,7 @@ pub fn apply_end_to_end_mutations(rt: &RedDBRuntime) {
 
     exec(
         &query,
-        "CREATE QUEUE workflow WITH DLQ workflow_failed MAX_ATTEMPTS 3",
+        "CREATE QUEUE workflow WITH DLQ workflow_failed MAX_ATTEMPTS 3 LOCK_DEADLINE_MS 1",
     );
     exec(&query, "QUEUE GROUP CREATE workflow workers");
     exec(&query, "QUEUE PUSH workflow 'task-a'");
@@ -974,6 +974,7 @@ pub fn apply_end_to_end_mutations(rt: &RedDBRuntime) {
         "workflow read should bind the first consumer"
     );
 
+    std::thread::sleep(Duration::from_millis(5));
     let claimed = exec(
         &query,
         "QUEUE CLAIM workflow GROUP workers CONSUMER worker2 MIN_IDLE 0",


### PR DESCRIPTION
## Summary
- emit queue NACK telemetry and DLQ audit events from the runtime path with real queue/group/message context
- restore NACK attempt increments and align retry/DLQ tests with MAX_ATTEMPTS counting read + nack
- make lifecycle claim only steal deliveries whose lock deadline has expired

## Validation
- cargo test --test e2e_queue_lifecycle_telemetry --no-default-features
- cargo test -p reddb-io-server --test queue_retry_policy
- cargo test -p reddb-io-server runtime::queue_lifecycle::tests --lib
- cargo test -p reddb-io-server runtime::queue_telemetry::tests --lib
- cargo test --test grouped_docs_kv_queue --no-default-features
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783966697&installation_id=129708444&pr_number=1153&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1153&signature=5e27e56592a149b43b9e664090f32d6779e2444bdd2d043e685d69fc503c37e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced queue operation telemetry to track NACK (Not Acknowledged) commands and message handling outcomes.
  * Improved monitoring and event tracking for messages promoted to dead letter queues.
  * Refined pending delivery timeout detection logic for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->