### PR TITLE
fix(drill): restore nightly backup drill

### DIFF
--- a/scripts/drill-nightly.sh
+++ b/scripts/drill-nightly.sh
@@ -20,7 +20,9 @@ fi
 
 CMD="cargo test --locked --test 'drill_*' --no-fail-fast"
 START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-LOG="$(mktemp -t reddb-drill-nightly.XXXXXX.log)"
+# Keep the runner log out of the `reddb-*` temp namespace: the drills
+# intentionally clean that namespace while checking for leaked DB files.
+LOG="$(mktemp -t drill-nightly.XXXXXX.log)"
 
 # Run the drill in the current shell so that PATH (sccache, mold, rustup
 # shims) and RUSTC_WRAPPER stay consistent with the runner environment.

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -122,6 +122,8 @@ test("nightly DR drill workflow uses the current-shell runner and public make ta
 
   assert.match(makefile, /\ndrill-nightly:\n\t@\.\/scripts\/drill-nightly\.sh/);
   assert.match(script, /CMD="cargo test --locked --test 'drill_\*' --no-fail-fast"/);
+  assert.match(script, /mktemp -t drill-nightly\.XXXXXX\.log/);
+  assert.doesNotMatch(script, /mktemp -t reddb-drill-nightly/);
   assert.match(script, /eval "\$CMD" >"\$LOG" 2>&1/);
   assert.doesNotMatch(script, /bash -lc "\$CMD"/);
   assert.match(script, /issue #116/);

--- a/tests/chaos_wal_chain_break.rs
+++ b/tests/chaos_wal_chain_break.rs
@@ -8,9 +8,10 @@
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_change_records, load_wal_segment_manifest, publish_snapshot_manifest,
-    publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
+    publish_wal_segment_manifest, PointInTimeRecovery,
 };
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/chaos_wal_segment_corruption.rs
+++ b/tests/chaos_wal_segment_corruption.rs
@@ -8,9 +8,10 @@
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_change_records, load_wal_segment_manifest, publish_snapshot_manifest,
-    publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
+    publish_wal_segment_manifest, PointInTimeRecovery,
 };
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/chaos_wal_segment_missing.rs
+++ b/tests/chaos_wal_segment_missing.rs
@@ -6,11 +6,9 @@
 //! segment 1's, so the chain check fires.
 
 use reddb::storage::backend::LocalBackend;
-use reddb::storage::wal::{
-    archive_change_records, publish_snapshot_manifest, wal_segment_manifest_key,
-    PointInTimeRecovery, SnapshotManifest,
-};
+use reddb::storage::wal::{archive_change_records, publish_snapshot_manifest, PointInTimeRecovery};
 use reddb::storage::RedDB;
+use reddb_file::{wal_segment_manifest_key, SnapshotManifest};
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/drill_backup_restore_round_trip.rs
+++ b/tests/drill_backup_restore_round_trip.rs
@@ -19,9 +19,10 @@ use reddb::replication::cdc::ChangeRecord;
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_change_records, archive_snapshot, publish_snapshot_manifest,
-    publish_unified_manifest_for_prefix, PointInTimeRecovery, SnapshotManifest,
+    publish_unified_manifest_for_prefix, PointInTimeRecovery,
 };
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/drill_pitr_byte_identical.rs
+++ b/tests/drill_pitr_byte_identical.rs
@@ -17,10 +17,9 @@
 
 use reddb::api::REDDB_FORMAT_VERSION;
 use reddb::storage::backend::LocalBackend;
-use reddb::storage::wal::{
-    archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery, SnapshotManifest,
-};
+use reddb::storage::wal::{archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery};
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::collections::BTreeSet;
 use std::sync::Arc;
 

--- a/tests/drill_pitr_chain_break_within_window.rs
+++ b/tests/drill_pitr_chain_break_within_window.rs
@@ -22,9 +22,10 @@ use reddb::replication::cdc::ChangeRecord;
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_change_records, archive_snapshot, load_wal_segment_manifest, publish_snapshot_manifest,
-    publish_wal_segment_manifest, PointInTimeRecovery, SnapshotManifest,
+    publish_wal_segment_manifest, PointInTimeRecovery,
 };
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/drill_pitr_target_time.rs
+++ b/tests/drill_pitr_target_time.rs
@@ -12,9 +12,9 @@ use reddb::replication::cdc::ChangeRecord;
 use reddb::storage::backend::LocalBackend;
 use reddb::storage::wal::{
     archive_change_records, archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery,
-    SnapshotManifest,
 };
 use reddb::storage::RedDB;
+use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]

--- a/tests/e2e_backup_restore.rs
+++ b/tests/e2e_backup_restore.rs
@@ -15,9 +15,8 @@
 mod support;
 
 use reddb::storage::backend::LocalBackend;
-use reddb::storage::wal::{
-    archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery, SnapshotManifest,
-};
+use reddb::storage::wal::{archive_snapshot, publish_snapshot_manifest, PointInTimeRecovery};
+use reddb_file::SnapshotManifest;
 use std::fs::OpenOptions;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- update backup/PITR drill and chaos tests to import `SnapshotManifest` from `reddb-file`, where the manifest authority now lives
- update the remaining `wal_segment_manifest_key` test import to use `reddb-file`
- keep the nightly drill runner log out of the `reddb-*` temp namespace so drill cleanup cannot delete the failure log before it is printed

Fixes #1141.

## Validation
- make drill-nightly
- cargo test --locked --test chaos_wal_chain_break --test chaos_wal_segment_corruption --test chaos_wal_segment_missing --test e2e_backup_restore --no-fail-fast
- node --test --test-name-pattern "nightly DR drill" scripts/release_tooling_contract.test.mjs
- cargo fmt --check
- git diff --check
- make check