### PR TITLE
test(ci): group queue lifecycle telemetry integration target

### DIFF
--- a/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
+++ b/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
@@ -6,6 +6,7 @@
 //! and the audit log (`operator/queue_dlq_promoted`) reflect the
 //! promotion.
 
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::time::Duration;

--- a/tests/grouped_docs_kv_queue.rs
+++ b/tests/grouped_docs_kv_queue.rs
@@ -33,6 +33,9 @@ mod e2e_issue_555_documents_sql_aggregates;
 #[path = "grouped/docs_kv_queue/e2e_kv_namespaced_keys.rs"]
 mod e2e_kv_namespaced_keys;
 
+#[path = "grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs"]
+mod e2e_queue_lifecycle_telemetry;
+
 #[path = "grouped/docs_kv_queue/e2e_red_queue_pending.rs"]
 mod e2e_red_queue_pending;
 


### PR DESCRIPTION
## Summary
- Move e2e_queue_lifecycle_telemetry into the docs/kv/queue grouped integration target.
- Register the moved test in grouped_docs_kv_queue.
- Reduce top-level integration test binaries from 245 to 244 for #966.

## Verification
- cargo test --test grouped_docs_kv_queue --no-default-features
- cargo fmt --check
- git diff --check
- make check

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783968991&installation_id=129708444&pr_number=1155&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1155&signature=3e8278616d23b7ce6f8d637b80943a7407cb7cae618e13651d1d184ef8848053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->