### PR TITLE
test(ci): group prometheus metrics integration targets

### DIFF
--- a/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_aggregation.rs
+++ b/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_aggregation.rs
@@ -1,3 +1,4 @@
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::RedDBRuntime;

--- a/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_counter_functions.rs
+++ b/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_counter_functions.rs
@@ -1,3 +1,4 @@
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::RedDBRuntime;

--- a/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_histogram.rs
+++ b/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_histogram.rs
@@ -1,3 +1,4 @@
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::storage::schema::Value;

--- a/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_query_range.rs
+++ b/tests/grouped/timeseries_metrics/e2e_metrics_prometheus_query_range.rs
@@ -1,3 +1,4 @@
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::RedDBRuntime;

--- a/tests/grouped_timeseries_metrics.rs
+++ b/tests/grouped_timeseries_metrics.rs
@@ -27,8 +27,20 @@ mod e2e_metric_descriptor_catalog;
 #[path = "grouped/timeseries_metrics/e2e_metrics_collection_contract.rs"]
 mod e2e_metrics_collection_contract;
 
+#[path = "grouped/timeseries_metrics/e2e_metrics_prometheus_aggregation.rs"]
+mod e2e_metrics_prometheus_aggregation;
+
+#[path = "grouped/timeseries_metrics/e2e_metrics_prometheus_counter_functions.rs"]
+mod e2e_metrics_prometheus_counter_functions;
+
+#[path = "grouped/timeseries_metrics/e2e_metrics_prometheus_histogram.rs"]
+mod e2e_metrics_prometheus_histogram;
+
 #[path = "grouped/timeseries_metrics/e2e_metrics_prometheus_query.rs"]
 mod e2e_metrics_prometheus_query;
+
+#[path = "grouped/timeseries_metrics/e2e_metrics_prometheus_query_range.rs"]
+mod e2e_metrics_prometheus_query_range;
 
 #[path = "grouped/timeseries_metrics/e2e_slo_descriptor_catalog.rs"]
 mod e2e_slo_descriptor_catalog;


### PR DESCRIPTION
## Summary
- Move four Prometheus metrics integration tests into the grouped_timeseries_metrics target.
- Register the moved tests under tests/grouped/timeseries_metrics/.
- Reduce top-level integration test binaries from 244 to 240 for #966.

## Verification
- cargo test --no-default-features --test e2e_metrics_prometheus_aggregation --test e2e_metrics_prometheus_counter_functions --test e2e_metrics_prometheus_histogram --test e2e_metrics_prometheus_query_range
- cargo test --test grouped_timeseries_metrics --no-default-features
- cargo test --no-run --test grouped_timeseries_metrics --no-default-features
- cargo fmt --check
- git diff --check
- make check

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783969577&installation_id=129708444&pr_number=1156&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1156&signature=54598d651b77265c038dd04545ceb529a7a1d23a7cc77bb45093e45492dcd7b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->