### PR TITLE
test(ci): group pitr drill integration targets

### DIFF
--- a/tests/grouped/pitr_drills/drill_backup_restore_round_trip.rs
+++ b/tests/grouped/pitr_drills/drill_backup_restore_round_trip.rs
@@ -26,6 +26,7 @@ use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 fn temp_dir(tag: &str) -> support::TempDataDir {

--- a/tests/grouped/pitr_drills/drill_pitr_byte_identical.rs
+++ b/tests/grouped/pitr_drills/drill_pitr_byte_identical.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 fn temp_dir(tag: &str) -> support::TempDataDir {

--- a/tests/grouped/pitr_drills/drill_pitr_chain_break_within_window.rs
+++ b/tests/grouped/pitr_drills/drill_pitr_chain_break_within_window.rs
@@ -29,6 +29,7 @@ use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 fn temp_dir(tag: &str) -> support::TempDataDir {

--- a/tests/grouped/pitr_drills/drill_pitr_target_time.rs
+++ b/tests/grouped/pitr_drills/drill_pitr_target_time.rs
@@ -18,6 +18,7 @@ use reddb_file::SnapshotManifest;
 use std::sync::Arc;
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 fn temp_dir(tag: &str) -> support::TempDataDir {

--- a/tests/grouped_pitr_drills.rs
+++ b/tests/grouped_pitr_drills.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+#[path = "grouped/pitr_drills/drill_backup_restore_round_trip.rs"]
+mod drill_backup_restore_round_trip;
+
+#[path = "grouped/pitr_drills/drill_pitr_byte_identical.rs"]
+mod drill_pitr_byte_identical;
+
+#[path = "grouped/pitr_drills/drill_pitr_chain_break_within_window.rs"]
+mod drill_pitr_chain_break_within_window;
+
+#[path = "grouped/pitr_drills/drill_pitr_target_time.rs"]
+mod drill_pitr_target_time;


### PR DESCRIPTION
## Summary
- Group 4 PITR/backup drill integration targets under tests/grouped/pitr_drills/
- Add tests/grouped_pitr_drills.rs as the single top-level cargo test target
- Preserve tests/support access through explicit #[path] attributes after moving nested files

## Count
- Top-level Rust integration targets: 92 -> 89

## Verification
- cargo test --no-default-features --test drill_backup_restore_round_trip --test drill_pitr_byte_identical --test drill_pitr_chain_break_within_window --test drill_pitr_target_time
- cargo test --test grouped_pitr_drills --no-default-features
- cargo test --no-run --test grouped_pitr_drills --no-default-features
- cargo fmt --check
- git diff --check
- make check

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783984823&installation_id=129708444&pr_number=1177&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1177&signature=cc71fb794c9b2f5b787ea345571bdccbc47173ed12e871bd0147d932d08c555c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->