### PR TITLE
test(replication): use file path for read-only replica harness

### DIFF
--- a/tests/grouped/replication/e2e_replica_readonly.rs
+++ b/tests/grouped/replication/e2e_replica_readonly.rs
@@ -18,6 +18,7 @@
 //! gate fires at the right layer.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::application::{CreateRowInput, DeleteEntityInput, EntityUseCases};
@@ -42,7 +43,7 @@ fn assert_read_only_err<T: std::fmt::Debug>(
 
 #[test]
 fn replica_rejects_sql_ddl_and_dml_on_every_surface() {
-    let primary_path = support::temp_data_dir("replica-primary");
+    let primary_path = support::temp_db_file("replica-primary");
 
     // 1. Boot a standalone primary, create a table, insert one row.
     {
@@ -125,7 +126,7 @@ fn replica_rejects_sql_ddl_and_dml_on_every_surface() {
 
 #[test]
 fn explicit_read_only_flag_rejects_writes_on_standalone() {
-    let path = support::temp_data_dir("readonly-flag");
+    let path = support::temp_db_file("readonly-flag");
 
     // Seed a table on a writable instance so the read-only re-open has
     // something to read.
@@ -154,7 +155,7 @@ fn explicit_read_only_flag_rejects_writes_on_standalone() {
 
 #[test]
 fn standalone_primary_default_is_writable() {
-    let path = support::temp_data_dir("primary-writable");
+    let path = support::temp_db_file("primary-writable");
 
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("primary open");
     rt.execute_query("CREATE TABLE writable (id INT)")
@@ -179,7 +180,7 @@ fn replica_internal_apply_path_remains_privileged() {
     // it succeeds even after the gate has rejected client writes.
     use reddb::storage::{EntityData, EntityKind, RowData, UnifiedEntity};
 
-    let path = support::temp_data_dir("replica-privileged");
+    let path = support::temp_db_file("replica-privileged");
     {
         let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("primary open");
         rt.execute_query("CREATE TABLE shipped (id INT, payload TEXT)")

--- a/tests/grouped_replication.rs
+++ b/tests/grouped_replication.rs
@@ -35,3 +35,6 @@ mod e2e_issue_833_replication_failover;
 
 #[path = "grouped/replication/e2e_issue_840_replication_auto_rollback.rs"]
 mod e2e_issue_840_replication_auto_rollback;
+
+#[path = "grouped/replication/e2e_replica_readonly.rs"]
+mod e2e_replica_readonly;


### PR DESCRIPTION
## Summary
- Fix `e2e_replica_readonly` to use an auto-cleaning `.rdb` file path instead of passing a temp directory to `RedDBOptions::persistent`.
- Move the now-green read-only replica tests into the existing `grouped_replication` harness.

## Count
- Top-level Rust integration targets: `63 -> 62`.

## Reproduction
- Before the fix, `cargo test --no-default-features --test e2e_replica_readonly` failed all four tests with `Internal("Is a directory (os error 21)")` while opening the runtime.

## Verification
- `cargo test --no-default-features --test e2e_replica_readonly`: 4 passed before grouping.
- `cargo test --no-default-features --test grouped_replication`: 28 passed.
- `cargo test --no-run --no-default-features --test grouped_replication`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `make check`: passed.

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783988416&installation_id=129708444&pr_number=1183&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1183&signature=a6498cb240eee7f39fb384ed8d8fa63995f3a0b4336841e3e2d758f9082a695e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->