### PR TITLE
test(query): use file path for stale-index repro

### DIFF
--- a/tests/grouped/schema_query_core/e2e_repro_stale_index_post_insert.rs
+++ b/tests/grouped/schema_query_core/e2e_repro_stale_index_post_insert.rs
@@ -10,6 +10,7 @@
 //! Expect: all 2N rows considered; bench reports about half are missing.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::application::{CreateRowInput, CreateRowsBatchInput, RuntimeEntityPort};
@@ -218,7 +219,7 @@ fn post_create_index_update_keeps_index_in_sync() {
 /// to corrupt post-CREATE-INDEX entity lookups.
 #[test]
 fn post_create_index_inserts_at_scale_keeps_index_fresh() {
-    let p = support::temp_data_dir("scale-repro");
+    let p = support::temp_db_file("scale-repro");
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&p)).unwrap();
     rt.execute_query("CREATE TABLE users (id INT, age INT, city TEXT)")
         .unwrap();

--- a/tests/grouped_schema_query_core.rs
+++ b/tests/grouped_schema_query_core.rs
@@ -15,6 +15,9 @@ mod e2e_red_collections_acceptance;
 #[path = "grouped/schema_query_core/e2e_red_schema.rs"]
 mod e2e_red_schema;
 
+#[path = "grouped/schema_query_core/e2e_repro_stale_index_post_insert.rs"]
+mod e2e_repro_stale_index_post_insert;
+
 #[path = "grouped/schema_query_core/e2e_rid_row_envelope.rs"]
 mod e2e_rid_row_envelope;
 


### PR DESCRIPTION
## Summary
- Fix `e2e_repro_stale_index_post_insert` to use an auto-cleaning `.rdb` file path for its persistent scale repro instead of passing a temp directory to `RedDBOptions::persistent`.
- Move the now-green stale-index repro into the existing `grouped_schema_query_core` harness.

## Count
- Top-level Rust integration targets: `62 -> 61`.

## Reproduction
- Before the fix, `cargo test --no-default-features --test e2e_repro_stale_index_post_insert` failed the scale repro with `Internal("Is a directory (os error 21)")`.

## Verification
- `cargo test --no-default-features --test e2e_repro_stale_index_post_insert`: 6 passed before grouping.
- `cargo test --no-default-features --test grouped_schema_query_core`: 57 passed.
- `cargo test --no-run --no-default-features --test grouped_schema_query_core`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `make check`: passed.

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783988849&installation_id=129708444&pr_number=1184&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1184&signature=26f5cab197701720d552ed0e1d6425cc0b9fe38051001938e9abb0c0401c0c47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->