### PR TITLE
test(timeseries): checkpoint descriptor persistence harnesses

### DIFF
--- a/tests/grouped/events_retention/e2e_collection_retention_policy.rs
+++ b/tests/grouped/events_retention/e2e_collection_retention_policy.rs
@@ -15,15 +15,12 @@
 //!    added in slice 12).
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::application::ExecuteQueryInput;
 use reddb::storage::schema::Value;
-use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-
-fn unique_dir(prefix: &str) -> support::TempDataDir {
-    support::temp_data_dir(prefix)
-}
+use reddb::{QueryUseCases, RedDBRuntime};
 
 #[test]
 fn lazy_filter_drops_expired_then_unset_reveals_them_again() {
@@ -113,12 +110,10 @@ fn alter_set_retention_without_timestamp_column_is_rejected() {
 
 #[test]
 fn retention_policy_persists_across_restart() {
-    let dir = unique_dir("retention-policy");
-    let data_path = dir.join("data.rdb");
+    let path = support::PersistentDbPath::new("retention-policy");
 
-    {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&data_path))
-            .expect("open persistent runtime");
+    let rt = {
+        let rt = path.open_runtime();
         let q = QueryUseCases::new(&rt);
         q.execute(ExecuteQueryInput {
             query: "CREATE TABLE events (id INTEGER, msg TEXT) WITH timestamps = true".into(),
@@ -135,11 +130,11 @@ fn retention_policy_persists_across_restart() {
             .find(|c| c.name == "events")
             .expect("events descriptor before restart");
         assert_eq!(desc.retention_duration_ms, Some(7 * 86_400_000));
-    }
+        rt
+    };
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&data_path))
-            .expect("reopen persistent runtime");
+        let rt = support::checkpoint_and_reopen(&path, rt);
         let snapshot = rt.db().catalog_model_snapshot();
         let desc = snapshot
             .collections

--- a/tests/grouped/timeseries_remaining/e2e_timeseries_session_descriptor.rs
+++ b/tests/grouped/timeseries_remaining/e2e_timeseries_session_descriptor.rs
@@ -4,26 +4,21 @@
 //! across an engine restart.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::application::ExecuteQueryInput;
-use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
-
-fn unique_dir(prefix: &str) -> support::TempDataDir {
-    support::temp_data_dir(prefix)
-}
+use reddb::{QueryUseCases, RedDBRuntime};
 
 #[test]
 fn session_clause_persists_across_restart() {
-    let dir = unique_dir("timeseries-session");
-    let data_path = dir.join("data.rdb");
+    let path = support::PersistentDbPath::new("timeseries-session");
 
-    // First boot — create a timeseries with the WITH clause and force a
-    // metadata flush so the contract is durable before the runtime
-    // drops.
-    {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&data_path))
-            .expect("open persistent runtime");
+    // First boot — create a timeseries with the WITH clause. The
+    // explicit checkpoint below is the durability boundary that makes
+    // the collection contract available to the reopened runtime.
+    let rt = {
+        let rt = path.open_runtime();
         let q = QueryUseCases::new(&rt);
         q.execute(ExecuteQueryInput {
             query: "CREATE TIMESERIES events WITH SESSION_KEY user_id SESSION_GAP 30 m".into(),
@@ -40,15 +35,15 @@ fn session_clause_persists_across_restart() {
         assert_eq!(descriptor.session_gap_ms, Some(30 * 60_000));
 
         // `execute_create_timeseries` already calls `persist_metadata`
-        // at the end of the DDL path, so the contract is durable by
-        // the time the runtime drops here.
-    }
+        // at the end of the DDL path; `checkpoint_and_reopen` below
+        // flushes the storage boundary before reopening.
+        rt
+    };
 
     // Second boot — descriptor is rehydrated from the persisted
     // contract; both fields survive the restart.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&data_path))
-            .expect("reopen persistent runtime");
+        let rt = support::checkpoint_and_reopen(&path, rt);
         let snapshot = rt.db().catalog_model_snapshot();
         let descriptor = snapshot
             .collections

--- a/tests/grouped_events_retention.rs
+++ b/tests/grouped_events_retention.rs
@@ -3,6 +3,9 @@
 #[path = "grouped/events_retention/e2e_events_backfill.rs"]
 mod e2e_events_backfill;
 
+#[path = "grouped/events_retention/e2e_collection_retention_policy.rs"]
+mod e2e_collection_retention_policy;
+
 #[path = "grouped/events_retention/e2e_events_cdc_rid.rs"]
 mod e2e_events_cdc_rid;
 

--- a/tests/grouped_timeseries_remaining.rs
+++ b/tests/grouped_timeseries_remaining.rs
@@ -26,3 +26,6 @@ mod e2e_metrics_tenant_isolation;
 
 #[path = "grouped/timeseries_remaining/e2e_sessionize_operator.rs"]
 mod e2e_sessionize_operator;
+
+#[path = "grouped/timeseries_remaining/e2e_timeseries_session_descriptor.rs"]
+mod e2e_timeseries_session_descriptor;


### PR DESCRIPTION
## Summary
- Update the retention-policy and timeseries-session restart tests to use the repository checkpoint/reopen persistence helper used by other metadata-sidecar tests.
- Move the now-green retention test into `grouped_events_retention` and the session descriptor test into `grouped_timeseries_remaining`.

## Count
- Top-level Rust integration targets: `61 -> 59`.

## Reproduction
- Before the fix, `cargo test --no-default-features --test e2e_collection_retention_policy` failed at `events descriptor after restart`.
- Before the fix, `cargo test --no-default-features --test e2e_timeseries_session_descriptor` failed at `events descriptor present after restart`.

## Verification
- `cargo test --no-default-features --test e2e_collection_retention_policy --test e2e_timeseries_session_descriptor`: 5 passed before grouping.
- `cargo test --no-default-features --test grouped_events_retention`: 30 passed.
- `cargo test --no-default-features --test grouped_timeseries_remaining`: 43 passed.
- `cargo test --no-run --no-default-features --test grouped_events_retention --test grouped_timeseries_remaining`: passed.
- `cargo fmt --check`: passed.
- `git diff --check`: passed.
- `make check`: passed.

Refs #966

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783989361&installation_id=129708444&pr_number=1185&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1185&signature=a4e0c12fbc0f5a24066b2749354091d0e27ae00ef763cddbb9c7c1d043707c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->