### PR TITLE
fix(storage): avoid embedded snapshot on paged reopen

### DIFF
--- a/crates/reddb-server/src/storage/unified/devx/reddb.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb.rs
@@ -151,6 +151,7 @@ impl Drop for RedDB {
         if self.options.storage_profile.deploy_profile == crate::storage::DeployProfile::Embedded
             && self.options.storage_profile.packaging
                 == crate::storage::StoragePackaging::SingleFile
+            && !self.paged_mode
             && !self.options.read_only
         {
             if let Some(path) = &self.path {

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -393,10 +393,10 @@ impl RedDB {
         }
 
         let path_buf = options.resolved_path(reddb_file::default_database_path());
-        let mut store_config = store_config_from_options(options);
-        if embedded_single_file_selected(options) {
-            store_config = store_config.with_embedded_wal_path(path_buf.clone());
-        }
+        let store_config = store_config_from_options(options);
+        let embedded_store_config = store_config
+            .clone()
+            .with_embedded_wal_path(path_buf.clone());
         let embedded_open = if embedded_single_file_selected(options) {
             if path_buf.exists() {
                 match crate::storage::EmbeddedRdbArtifact::open(&path_buf) {
@@ -405,9 +405,9 @@ impl RedDB {
                             match crate::storage::EmbeddedRdbArtifact::read_snapshot(&artifact)? {
                                 Some(snapshot) => UnifiedStore::load_from_bytes_with_config(
                                     &snapshot,
-                                    store_config.clone(),
+                                    embedded_store_config.clone(),
                                 )?,
-                                None => UnifiedStore::with_config(store_config.clone()),
+                                None => UnifiedStore::with_config(embedded_store_config.clone()),
                             };
                         for payload in
                             crate::storage::EmbeddedRdbArtifact::read_wal_payloads(&artifact)?
@@ -450,7 +450,7 @@ impl RedDB {
                     format!("create embedded rdb artifact {}: {err}", path_buf.display())
                 })?;
                 Some((
-                    UnifiedStore::with_config(store_config.clone()),
+                    UnifiedStore::with_config(embedded_store_config),
                     Some(path_buf.clone()),
                     false,
                 ))

--- a/tests/grouped/config_tier/e2e_config_matrix.rs
+++ b/tests/grouped/config_tier/e2e_config_matrix.rs
@@ -5,6 +5,7 @@
 //! keys stay silent until a user `SET CONFIG` writes them.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::{RedDBOptions, RedDBRuntime};

--- a/tests/grouped_config_tier.rs
+++ b/tests/grouped_config_tier.rs
@@ -3,6 +3,9 @@
 #[path = "grouped/config_tier/e2e_config_crud.rs"]
 mod e2e_config_crud;
 
+#[path = "grouped/config_tier/e2e_config_matrix.rs"]
+mod e2e_config_matrix;
+
 #[path = "grouped/config_tier/e2e_config_secret_ref.rs"]
 mod e2e_config_secret_ref;
 


### PR DESCRIPTION
Fixes one remaining #966 red target and folds it into the config grouped harness.

Root cause:
- Reopening a database file created under an operational-directory profile with default embedded options fell back to paged storage, but `RedDB` drop still used the requested embedded profile to decide whether to write an embedded snapshot.
- That attempted an embedded snapshot write against the same paged file while the pager was still open, blocking on the file lock during test teardown.
- The open path also now keeps embedded WAL config scoped to actual embedded artifact opens/creates, not paged fallback opens.

Changes:
- Skip embedded snapshot-on-drop unless the runtime actually opened non-paged embedded storage.
- Keep `embedded_wal_path` only on embedded artifact stores.
- Move `e2e_config_matrix` into `grouped_config_tier` after fixing it.

Validation:
- `cargo test --no-default-features --test e2e_config_matrix -- --nocapture`
- `cargo test --no-default-features --test grouped_config_tier -- --nocapture`
- `cargo test --no-run --no-default-features --test grouped_config_tier`
- `cargo fmt --check`
- `git diff --check`
- `make check`

Top-level Rust integration targets: 59 -> 58.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783992334&installation_id=129708444&pr_number=1186&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1186&signature=b14ec41ca64e5894fc6fab201dbab80f8e0480995c3cdb0f24f993c8a13a50ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot handling in embedded single-file mode to prevent unintended snapshot writes.
  * Fixed embedded storage configuration to ensure proper WAL path settings during initialization.

* **Tests**
  * Enhanced test infrastructure to improve coverage of configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->