### PR TITLE
test(schema): group reserved system field harness

### DIFF
--- a/tests/grouped/schema_query_core/e2e_reserved_system_fields.rs
+++ b/tests/grouped/schema_query_core/e2e_reserved_system_fields.rs
@@ -1,9 +1,12 @@
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
+
+use std::path::Path;
 
 use reddb::application::{CreateDocumentInput, EntityUseCases};
 use reddb::json::json;
-use reddb::{PhysicalMetadataFile, RedDBOptions, RedDBRuntime};
+use reddb::{PhysicalMetadataFile, RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
@@ -11,6 +14,12 @@ fn runtime() -> RedDBRuntime {
 
 fn persistent_path(prefix: &str) -> support::TempDbFile {
     support::temp_db_file(prefix)
+}
+
+fn physical_metadata_options(path: &Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("operational profile should persist physical metadata")
 }
 
 fn assert_reserved_error(message: &str, field: &str, context: &str) {
@@ -79,7 +88,7 @@ fn startup_rejects_persisted_table_contract_reserved_columns() {
     let path = persistent_path("reserved_startup");
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
+        let rt = RedDBRuntime::with_options(physical_metadata_options(path.path()))
             .expect("persistent runtime should open");
         rt.execute_query("CREATE TABLE persisted_rows (name TEXT)")
             .expect("table should be created");
@@ -112,7 +121,7 @@ fn startup_rejects_persisted_table_contract_reserved_columns() {
         .save_for_data_path(&path)
         .expect("metadata should be saved");
 
-    let err = match RedDBRuntime::with_options(RedDBOptions::persistent(path.path())) {
+    let err = match RedDBRuntime::with_options(physical_metadata_options(path.path())) {
         Ok(_) => panic!("reserved persisted contract should fail startup"),
         Err(err) => err,
     };

--- a/tests/grouped_schema_query_core.rs
+++ b/tests/grouped_schema_query_core.rs
@@ -18,6 +18,9 @@ mod e2e_red_schema;
 #[path = "grouped/schema_query_core/e2e_repro_stale_index_post_insert.rs"]
 mod e2e_repro_stale_index_post_insert;
 
+#[path = "grouped/schema_query_core/e2e_reserved_system_fields.rs"]
+mod e2e_reserved_system_fields;
+
 #[path = "grouped/schema_query_core/e2e_rid_row_envelope.rs"]
 mod e2e_rid_row_envelope;
 


### PR DESCRIPTION
Fixes one remaining #966 red target and folds it into the schema/query grouped harness.

Root cause:
- `startup_rejects_persisted_table_contract_reserved_columns` mutates `PhysicalMetadataFile`, but opened the database with the default embedded profile.
- Embedded single-file mode does not emit the external physical metadata sidecar, so the test failed before exercising reserved-field startup validation.

Changes:
- Use the primary-replica operational profile for the metadata-sidecar startup validation case.
- Move `e2e_reserved_system_fields` into `grouped_schema_query_core`.

Validation:
- `cargo test --no-default-features --test e2e_reserved_system_fields -- --nocapture`
- `cargo test --no-default-features --test grouped_schema_query_core -- --nocapture`
- `cargo test --no-run --no-default-features --test grouped_schema_query_core`
- `cargo fmt --check`
- `git diff --check`
- `make check`

Top-level Rust integration targets: 58 -> 57.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993007&installation_id=129708444&pr_number=1187&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1187&signature=48aca72e93be6a741c6890293b6076ca3745851543d4c5048f30260682dba5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->