### PR TITLE
test(config): group vault observation harness

### DIFF
--- a/tests/grouped/config_tier/e2e_config_vault_observation.rs
+++ b/tests/grouped/config_tier/e2e_config_vault_observation.rs
@@ -5,9 +5,10 @@ use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::replication::cdc::ChangeOperation;
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::storage::schema::Value;
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 fn rt() -> RedDBRuntime {
@@ -15,8 +16,10 @@ fn rt() -> RedDBRuntime {
 }
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
-    let rt =
-        RedDBRuntime::with_options(RedDBOptions::persistent(path)).expect("runtime should open");
+    let options = RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should expose pager");
+    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/grouped_config_tier.rs
+++ b/tests/grouped_config_tier.rs
@@ -9,6 +9,9 @@ mod e2e_config_matrix;
 #[path = "grouped/config_tier/e2e_config_secret_ref.rs"]
 mod e2e_config_secret_ref;
 
+#[path = "grouped/config_tier/e2e_config_vault_observation.rs"]
+mod e2e_config_vault_observation;
+
 #[path = "grouped/config_tier/e2e_issue_480_tier_default_promotion_contract.rs"]
 mod e2e_issue_480_tier_default_promotion_contract;
 


### PR DESCRIPTION
Fixes one remaining #966 red target and folds it into the config grouped harness.

Root cause:
- The vault observation helper required a pager-backed runtime but opened `RedDBOptions::persistent` with the default embedded profile.
- Embedded single-file mode does not expose the pager required by `AuthStore::with_vault`.

Changes:
- Use the serverless storage profile for the vault-backed observation helper, matching the existing config secret-ref harness.
- Move `e2e_config_vault_observation` into `grouped_config_tier`.

Validation:
- `cargo test --no-default-features --test e2e_config_vault_observation -- --nocapture`
- `cargo test --no-default-features --test grouped_config_tier -- --nocapture`
- `cargo test --no-run --no-default-features --test grouped_config_tier`
- `cargo fmt --check`
- `git diff --check`
- `make check`

Top-level Rust integration targets: 57 -> 56.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993434&installation_id=129708444&pr_number=1188&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1188&signature=266b7abc0af6a8044b1ed5e56227f0264f08d6a3b78b0432a395400b01f2cc20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->