### PR TITLE
test(config): group system config vault harness

### DIFF
--- a/tests/grouped/config_tier/e2e_system_config_vault.rs
+++ b/tests/grouped/config_tier/e2e_system_config_vault.rs
@@ -1,4 +1,5 @@
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::sync::Arc;
@@ -6,7 +7,7 @@ use std::sync::Arc;
 use reddb::auth::{AuthConfig, AuthStore, Role, UserId};
 use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
 use reddb::storage::schema::Value;
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 fn runtime(name: &str) -> (support::TempDbFile, RedDBRuntime) {
     let path = support::temp_db_file(name);
@@ -19,7 +20,11 @@ fn runtime_with_vault(
     name: &str,
     passphrase: &str,
 ) -> (support::TempDbFile, RedDBRuntime, Arc<AuthStore>) {
-    let (path, rt) = runtime(name);
+    let path = support::temp_db_file(name);
+    let options = RedDBOptions::persistent(path.path())
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should expose pager");
+    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/grouped_config_tier.rs
+++ b/tests/grouped_config_tier.rs
@@ -18,5 +18,8 @@ mod e2e_issue_480_tier_default_promotion_contract;
 #[path = "grouped/config_tier/e2e_shm_provisioning.rs"]
 mod e2e_shm_provisioning;
 
+#[path = "grouped/config_tier/e2e_system_config_vault.rs"]
+mod e2e_system_config_vault;
+
 #[path = "grouped/config_tier/e2e_tier_wiring.rs"]
 mod e2e_tier_wiring;


### PR DESCRIPTION
Fixes one remaining #966 red target and folds it into the config grouped harness.

Root cause:
- `runtime_with_vault` required a pager-backed runtime for `AuthStore::with_vault`, but reused the default persistent runtime helper.
- The default embedded profile does not expose the pager required by the vault-backed system capability test.

Changes:
- Use the serverless storage profile only for the vault-backed helper.
- Move `e2e_system_config_vault` into `grouped_config_tier`.

Validation:
- `cargo test --no-default-features --test e2e_system_config_vault -- --nocapture`
- `cargo test --no-default-features --test grouped_config_tier -- --nocapture`
- `cargo test --no-run --no-default-features --test grouped_config_tier`
- `cargo fmt --check`
- `git diff --check`
- `make check`

Top-level Rust integration targets: 56 -> 55.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783993786&installation_id=129708444&pr_number=1189&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1189&signature=ca7f2e624a22efc48ec30e284dc757a61b29073fa607034b52fda9249dfbfc1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->