### PR TITLE
fix(cli): honor storage preset for dump restore

### DIFF
--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -4804,10 +4804,14 @@ impl RedDBRuntime {
             QueryExpr::TreeCommand(ref cmd) => self.execute_tree_command(query, cmd),
             // SET CONFIG key = value
             QueryExpr::SetConfig { ref key, ref value } => {
-                if key.starts_with("red.secret.") || key.starts_with("red.secrets.") {
+                if key.starts_with("red.secret.") {
                     return Err(RedDBError::Query(
-                        "red.secret.* / red.secrets.* are reserved for vault secrets; use SET SECRET"
-                            .to_string(),
+                        "red.secret.* is reserved for vault secrets; use SET SECRET".to_string(),
+                    ));
+                }
+                if key.starts_with("red.secrets.") {
+                    return Err(RedDBError::Query(
+                        "red.secrets.* is reserved for vault secrets; use SET SECRET".to_string(),
                     ));
                 }
                 match self.check_managed_config_write_for_set_config(key) {

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -42,8 +42,11 @@ fn json_ok(command: &str, data: &str) {
 fn open_local_runtime(flags: &HashMap<String, FlagValue>) -> Result<reddb::RedDBRuntime, String> {
     match flag_string(flags, "path") {
         Some(path) if !path.is_empty() => {
-            reddb::RedDBRuntime::with_options(reddb::api::RedDBOptions::persistent(&path))
-                .map_err(|e| format!("open {path}: {e}"))
+            let storage_profile = resolve_storage_profile(flags, "local")?;
+            let options = reddb::api::RedDBOptions::persistent(&path)
+                .with_storage_profile(storage_profile)
+                .map_err(|e| format!("storage profile: {e}"))?;
+            reddb::RedDBRuntime::with_options(options).map_err(|e| format!("open {path}: {e}"))
         }
         _ => reddb::RedDBRuntime::in_memory().map_err(|e| e.to_string()),
     }
@@ -2913,6 +2916,12 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 cli::types::FlagSchema::new("path")
                     .with_description("Local database file to dump from")
                     .with_default("./data/reddb.rdb"),
+                cli::types::FlagSchema::new("storage-profile")
+                    .with_description("Storage profile for local --path (embedded|serverless|primary-replica|cluster)"),
+                cli::types::FlagSchema::new("storage-packaging")
+                    .with_description("Storage packaging for local --path (single-file|operational-directory)"),
+                cli::types::FlagSchema::new("storage-preset")
+                    .with_description("Storage preset for local --path (embedded|serverless|primary-replica-dev|primary-replica-small|primary-replica-production-ha|primary-replica-backup|primary-replica-wal-retention|cluster)"),
                 cli::types::FlagSchema::new("collection")
                     .with_short('c')
                     .with_description("Single collection to dump"),
@@ -2926,6 +2935,12 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 cli::types::FlagSchema::new("path")
                     .with_description("Local database file to restore into")
                     .with_default("./data/reddb.rdb"),
+                cli::types::FlagSchema::new("storage-profile")
+                    .with_description("Storage profile for local --path (embedded|serverless|primary-replica|cluster)"),
+                cli::types::FlagSchema::new("storage-packaging")
+                    .with_description("Storage packaging for local --path (single-file|operational-directory)"),
+                cli::types::FlagSchema::new("storage-preset")
+                    .with_description("Storage preset for local --path (embedded|serverless|primary-replica-dev|primary-replica-small|primary-replica-production-ha|primary-replica-backup|primary-replica-wal-retention|cluster)"),
                 cli::types::FlagSchema::new("input")
                     .with_short('i')
                     .with_description("Dump file to read"),

--- a/tests/grouped/config_tier/e2e_secret_sql.rs
+++ b/tests/grouped/config_tier/e2e_secret_sql.rs
@@ -1,3 +1,4 @@
+#[path = "../../support/mod.rs"]
 mod support;
 
 use std::sync::Arc;
@@ -174,6 +175,8 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         .arg("dump")
         .arg("--path")
         .arg(&source_path)
+        .arg("--storage-preset")
+        .arg("serverless")
         .arg("--output")
         .arg(&dump_path)
         .output()
@@ -198,6 +201,8 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         .arg("restore")
         .arg("--path")
         .arg(&dest_path)
+        .arg("--storage-preset")
+        .arg("serverless")
         .arg("--input")
         .arg(&dump_path)
         .output()

--- a/tests/grouped_config_tier.rs
+++ b/tests/grouped_config_tier.rs
@@ -12,6 +12,9 @@ mod e2e_config_secret_ref;
 #[path = "grouped/config_tier/e2e_config_vault_observation.rs"]
 mod e2e_config_vault_observation;
 
+#[path = "grouped/config_tier/e2e_secret_sql.rs"]
+mod e2e_secret_sql;
+
 #[path = "grouped/config_tier/e2e_issue_480_tier_default_promotion_contract.rs"]
 mod e2e_issue_480_tier_default_promotion_contract;
 


### PR DESCRIPTION
## Summary
- make local CLI runtime opens honor resolved storage profiles
- expose storage profile flags on dump/restore
- group the secret SQL harness under grouped_config_tier

Part of #966.

## Verification
- cargo test --no-default-features --test e2e_secret_sql -- --nocapture
- cargo test --no-default-features --test grouped_config_tier -- --nocapture
- cargo test --no-default-features --no-run --test grouped_config_tier
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783995156&installation_id=129708444&pr_number=1190&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1190&signature=c2b6693fe669bea043bf7d8fa650f6a9db5cbc65cb76b3f888fa1fec54421a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->