### PR TITLE
test(runtime): group meta json sidecar policy

### DIFF
--- a/tests/grouped/runtime_persistence/e2e_meta_json_sidecar_policy.rs
+++ b/tests/grouped/runtime_persistence/e2e_meta_json_sidecar_policy.rs
@@ -5,9 +5,13 @@
 //! `REDDB_META_JSON_SIDECAR=1` env escape hatch.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
-use reddb::{set_meta_json_sidecar_enabled, PhysicalMetadataFile, RedDBOptions, RedDBRuntime};
+use reddb::{
+    set_meta_json_sidecar_enabled, PhysicalMetadataFile, RedDBOptions, RedDBRuntime,
+    StorageDeployPreset,
+};
 use std::sync::Mutex;
 
 // Serialises the two tests because they mutate a process-global toggle.
@@ -15,6 +19,12 @@ static POLICY_GUARD: Mutex<()> = Mutex::new(());
 
 fn persistent_path(prefix: &str) -> support::TempDbFile {
     support::temp_db_file(prefix)
+}
+
+fn sidecar_options(path: &std::path::Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("production HA profile should write physical metadata sidecars")
 }
 
 #[test]
@@ -26,7 +36,7 @@ fn standard_tier_default_does_not_write_json_sidecar() {
     let path = persistent_path("meta_sidecar_off");
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
+        let rt = RedDBRuntime::with_options(sidecar_options(path.path()))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE sidecar_off (name TEXT)")
             .expect("ddl");
@@ -65,7 +75,7 @@ fn max_opt_in_writes_json_sidecar() {
     let path = persistent_path("meta_sidecar_on");
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
+        let rt = RedDBRuntime::with_options(sidecar_options(path.path()))
             .expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE sidecar_on (name TEXT)")
             .expect("ddl");

--- a/tests/grouped_runtime_persistence.rs
+++ b/tests/grouped_runtime_persistence.rs
@@ -9,6 +9,9 @@ mod e2e_issue_859_columnar_chunk_eviction;
 #[path = "grouped/runtime_persistence/e2e_materialized_view_refresh_every.rs"]
 mod e2e_materialized_view_refresh_every;
 
+#[path = "grouped/runtime_persistence/e2e_meta_json_sidecar_policy.rs"]
+mod e2e_meta_json_sidecar_policy;
+
 #[path = "grouped/runtime_persistence/e2e_query_audit.rs"]
 mod e2e_query_audit;
 


### PR DESCRIPTION
## Summary
- move e2e_meta_json_sidecar_policy into grouped_runtime_persistence
- run sidecar assertions with the operational physical-metadata profile

Part of #966.

## Verification
- cargo test --no-default-features --test e2e_meta_json_sidecar_policy -- --nocapture
- cargo test --no-default-features --test grouped_runtime_persistence -- --nocapture
- cargo test --no-default-features --no-run --test grouped_runtime_persistence
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783996290&installation_id=129708444&pr_number=1192&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1192&signature=ffbcedaf85364797c67f0cef06312f5498c5560b98c64bfe248f4d1d71f29584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored runtime persistence tests to use standardized helper functions for runtime option construction.
  * Added new test module for validating metadata sidecar writing policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->