### PR TITLE
test(runtime): group seqn journal policy harness

### DIFF
--- a/tests/grouped/runtime_persistence/e2e_seqn_journal_policy.rs
+++ b/tests/grouped/runtime_persistence/e2e_seqn_journal_policy.rs
@@ -6,11 +6,13 @@
 //! viable source without panicking).
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::{
     seqn_journal_enabled, seqn_journal_retention, set_seqn_journal_enabled,
     set_seqn_journal_retention, PhysicalMetadataFile, RedDBOptions, RedDBRuntime,
+    StorageDeployPreset,
 };
 use std::path::Path;
 use std::sync::Mutex;
@@ -29,9 +31,14 @@ fn reset_policy() {
     std::env::remove_var("REDDB_SEQN_JOURNAL_RETENTION");
 }
 
+fn sidecar_options(path: &Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("production HA profile should write physical metadata sidecars")
+}
+
 fn run_a_few_saves(path: &Path, table: &str, n: usize) {
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
-        .expect("persistent runtime opens");
+    let rt = RedDBRuntime::with_options(sidecar_options(path)).expect("persistent runtime opens");
     rt.execute_query(&format!("CREATE TABLE {table} (name TEXT)"))
         .expect("ddl");
     for i in 0..n {

--- a/tests/grouped_runtime_persistence.rs
+++ b/tests/grouped_runtime_persistence.rs
@@ -15,6 +15,9 @@ mod e2e_meta_json_sidecar_policy;
 #[path = "grouped/runtime_persistence/e2e_query_audit.rs"]
 mod e2e_query_audit;
 
+#[path = "grouped/runtime_persistence/e2e_seqn_journal_policy.rs"]
+mod e2e_seqn_journal_policy;
+
 #[path = "grouped/runtime_persistence/e2e_vault_sealed_storage.rs"]
 mod e2e_vault_sealed_storage;
 


### PR DESCRIPTION
## Summary
- move e2e_seqn_journal_policy into grouped_runtime_persistence
- run seq-N metadata journal assertions with the operational physical-metadata profile

Part of #966.

## Verification
- cargo test --no-default-features --test e2e_seqn_journal_policy -- --nocapture
- cargo test --no-default-features --test grouped_runtime_persistence -- --nocapture
- cargo test --no-default-features --no-run --test grouped_runtime_persistence
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783996950&installation_id=129708444&pr_number=1193&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1193&signature=957f264187e863149d446e6aa690a5ba78251040762c6a124183a303f4482d92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->