### PR TITLE
test(runtime): group fold pager meta policy

### DIFF
--- a/tests/grouped/runtime_persistence/e2e_fold_pager_meta_policy.rs
+++ b/tests/grouped/runtime_persistence/e2e_fold_pager_meta_policy.rs
@@ -9,9 +9,13 @@
 //!  - tests cover massive allocation forcing overflow.
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
-use reddb::{fold_pager_meta_enabled, set_fold_pager_meta_enabled, RedDBOptions, RedDBRuntime};
+use reddb::{
+    fold_pager_meta_enabled, set_fold_pager_meta_enabled, RedDBOptions, RedDBRuntime,
+    StorageDeployPreset,
+};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -22,6 +26,12 @@ fn meta_shadow_path(data: &Path) -> PathBuf {
     let mut p = data.to_path_buf().into_os_string();
     p.push("-meta");
     PathBuf::from(p)
+}
+
+fn pager_meta_options(path: &Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("production HA profile should expose pager metadata")
 }
 
 #[test]
@@ -35,8 +45,8 @@ fn fold_off_default_preserves_meta_shadow() {
     let path = db.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
-            .expect("persistent runtime opens");
+        let rt =
+            RedDBRuntime::with_options(pager_meta_options(path)).expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE fold_off_a (name TEXT)")
             .expect("ddl");
         rt.checkpoint().expect("flush");
@@ -58,8 +68,8 @@ fn fold_on_skips_meta_shadow_and_data_round_trips() {
     let path = db.path();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
-            .expect("persistent runtime opens");
+        let rt =
+            RedDBRuntime::with_options(pager_meta_options(path)).expect("persistent runtime opens");
         rt.execute_query("CREATE TABLE fold_on_a (name TEXT)")
             .expect("ddl");
         rt.execute_query("INSERT INTO fold_on_a (name) VALUES ('alpha')")
@@ -75,7 +85,7 @@ fn fold_on_skips_meta_shadow_and_data_round_trips() {
 
     // Reopen: catalog and data must survive without the shadow.
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
+        let rt = RedDBRuntime::with_options(pager_meta_options(path))
             .expect("persistent runtime reopens");
         let _ = rt
             .execute_query("SELECT name FROM fold_on_a")
@@ -105,8 +115,8 @@ fn massive_catalog_forces_meta_overflow_chain() {
         .collect();
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
-            .expect("persistent runtime opens");
+        let rt =
+            RedDBRuntime::with_options(pager_meta_options(path)).expect("persistent runtime opens");
         for name in &names {
             rt.execute_query(&format!("CREATE TABLE {name} (id INTEGER)"))
                 .expect("ddl");
@@ -115,7 +125,7 @@ fn massive_catalog_forces_meta_overflow_chain() {
     }
 
     {
-        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path))
+        let rt = RedDBRuntime::with_options(pager_meta_options(path))
             .expect("persistent runtime reopens");
         for name in &names {
             // SELECT against the catalog: parse must succeed (no truncation).

--- a/tests/grouped_runtime_persistence.rs
+++ b/tests/grouped_runtime_persistence.rs
@@ -6,6 +6,9 @@ mod e2e_issue_795_components_tvf;
 #[path = "grouped/runtime_persistence/e2e_issue_859_columnar_chunk_eviction.rs"]
 mod e2e_issue_859_columnar_chunk_eviction;
 
+#[path = "grouped/runtime_persistence/e2e_fold_pager_meta_policy.rs"]
+mod e2e_fold_pager_meta_policy;
+
 #[path = "grouped/runtime_persistence/e2e_materialized_view_refresh_every.rs"]
 mod e2e_materialized_view_refresh_every;
 


### PR DESCRIPTION
## Summary
- move e2e_fold_pager_meta_policy into grouped_runtime_persistence
- run pager metadata fold assertions with the operational physical-metadata profile

Part of #966.

## Verification
- cargo test --no-default-features --test e2e_fold_pager_meta_policy -- --nocapture
- cargo test --no-default-features --test grouped_runtime_persistence -- --nocapture
- cargo test --no-default-features --no-run --test grouped_runtime_persistence
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783997686&installation_id=129708444&pr_number=1194&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1194&signature=7214e6fb389222d765ede14f900e60b6e3803236a8707f2c60f4447cb4e9712c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->