### PR TITLE
test(runtime): group fold dwb policy harness

### DIFF
--- a/tests/grouped/runtime_persistence/e2e_fold_dwb_into_wal_policy.rs
+++ b/tests/grouped/runtime_persistence/e2e_fold_dwb_into_wal_policy.rs
@@ -12,12 +12,16 @@
 //! issue notes).
 
 #[allow(dead_code)]
+#[path = "../../support/mod.rs"]
 mod support;
 
 use reddb::storage::wal::reader::WalReader;
 use reddb::storage::wal::record::WalRecord;
 use reddb::storage::wal::writer::WalWriter;
-use reddb::{fold_dwb_into_wal_enabled, set_fold_dwb_into_wal_enabled, RedDBOptions, RedDBRuntime};
+use reddb::{
+    fold_dwb_into_wal_enabled, set_fold_dwb_into_wal_enabled, RedDBOptions, RedDBRuntime,
+    StorageDeployPreset,
+};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Duration;
@@ -34,7 +38,10 @@ fn dwb_path(data: &Path) -> PathBuf {
 fn open_persistent(path: &Path) -> RedDBRuntime {
     let mut last_error = String::new();
     for _ in 0..20 {
-        match RedDBRuntime::with_options(RedDBOptions::persistent(path)) {
+        let options = RedDBOptions::persistent(path)
+            .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+            .expect("production HA profile should expose DWB sidecar behavior");
+        match RedDBRuntime::with_options(options) {
             Ok(rt) => return rt,
             Err(err) if err.to_string().contains("Database is locked") => {
                 last_error = err.to_string();

--- a/tests/grouped_runtime_persistence.rs
+++ b/tests/grouped_runtime_persistence.rs
@@ -9,6 +9,9 @@ mod e2e_issue_859_columnar_chunk_eviction;
 #[path = "grouped/runtime_persistence/e2e_fold_pager_meta_policy.rs"]
 mod e2e_fold_pager_meta_policy;
 
+#[path = "grouped/runtime_persistence/e2e_fold_dwb_into_wal_policy.rs"]
+mod e2e_fold_dwb_into_wal_policy;
+
 #[path = "grouped/runtime_persistence/e2e_materialized_view_refresh_every.rs"]
 mod e2e_materialized_view_refresh_every;
 


### PR DESCRIPTION
## Summary
- move e2e_fold_dwb_into_wal_policy into grouped_runtime_persistence
- run DWB sidecar assertions with the operational physical-metadata profile

Part of #966.

## Verification
- cargo test --no-default-features --test e2e_fold_dwb_into_wal_policy -- --nocapture
- cargo test --no-default-features --test grouped_runtime_persistence -- --nocapture
- cargo test --no-default-features --no-run --test grouped_runtime_persistence
- cargo fmt --check
- git diff --check
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783998313&installation_id=129708444&pr_number=1195&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1195&signature=74faedf7e03a6edd597a4fe15300752cd0b4ce251520c338cdedc816a15e2fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->