### PR TITLE
ci: restore checkout compatibility on blacksmith runners

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           # Full history so `changesets/action` can rewrite tags / detect
           # changes against main.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,6 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
-      TMPDIR: ${{ runner.temp }}/reddb-test-suite-tmp
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
@@ -350,7 +349,9 @@ jobs:
             . -> target
             . -> target/persistent-tests
       - name: Prepare isolated temp dir
-        run: mkdir -p "$TMPDIR"
+        run: |
+          mkdir -p "$RUNNER_TEMP/reddb-test-suite-tmp"
+          echo "TMPDIR=$RUNNER_TEMP/reddb-test-suite-tmp" >> "$GITHUB_ENV"
       - name: Build red_client (cross-binary smoke prereq)
         run: cargo build --locked --bin red_client -p reddb-io-client --no-default-features
       - name: red_client size budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,7 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
+      TMPDIR: ${{ runner.temp }}/reddb-test-suite-tmp
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
@@ -348,6 +349,8 @@ jobs:
           workspaces: |
             . -> target
             . -> target/persistent-tests
+      - name: Prepare isolated temp dir
+        run: mkdir -p "$TMPDIR"
       - name: Build red_client (cross-binary smoke prereq)
         run: cargo build --locked --bin red_client -p reddb-io-client --no-default-features
       - name: red_client size budget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,7 +645,7 @@ jobs:
     needs: gate
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 25
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
       - name: Run sqllogictest conformance corpus against the server engine
-        run: cargo test --locked -p reddb-io-rql --test conformance
+        run: cargo test --locked --test grouped_surface_contracts rql_
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
@@ -380,6 +380,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -462,9 +465,7 @@ jobs:
           shared-key: ubuntu-publish-dryrun-rust-1.91.0
           cache-on-failure: "true"
       - name: cargo package (workspace manifests)
-        # Offline packaging verifies the workspace manifests against local
-        # path deps before the new reddb-io* crate names exist on crates.io.
-        run: cargo package --workspace --allow-dirty --no-verify --offline
+        run: cargo package --workspace --allow-dirty --no-verify
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Run grep-based serialization-boundary lint
         run: bash scripts/lint-no-untyped-serialization.sh crates/
       - name: Self-test against fixture (lint must catch every category)
@@ -117,7 +117,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -137,7 +137,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -158,7 +158,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -176,7 +176,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -204,7 +204,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
         with:
           components: rustfmt, clippy
@@ -239,7 +239,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -270,7 +270,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -284,7 +284,7 @@ jobs:
       - name: cargo check --no-default-features (slim grpc/wire client only)
         working-directory: drivers/python
         run: cargo check --locked --no-default-features
-      - name: cargo check (default: embedded engine)
+      - name: "cargo check (default: embedded engine)"
         working-directory: drivers/python
         run: cargo check --locked
 
@@ -313,7 +313,7 @@ jobs:
           - label: all-features
             args: --all-features
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -334,7 +334,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -378,7 +378,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: actions/setup-node@v6
         with:
@@ -450,7 +450,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -476,7 +476,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Build and start primary + replica
         run: docker compose -f testdata/compose/replica.yml up -d --build
       - name: Wait for HTTP health endpoints
@@ -521,7 +521,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -567,7 +567,7 @@ jobs:
       RED_S3_ACCESS_KEY: minioadmin
       RED_S3_SECRET_KEY: minioadmin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -593,7 +593,7 @@ jobs:
     runs-on: blacksmith-8vcpu-windows-2025
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -618,7 +618,7 @@ jobs:
     runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -645,7 +645,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@nightly
       - uses: ./.github/actions/install-protoc
         with:
@@ -693,7 +693,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
         env:
           CARGO_TARGET_DIR: target/persistent-tests
         run: >-
-          cargo test --locked --test integration_persistent_multimodel -- --ignored
+          cargo test --locked --test grouped_runtime_persistence integration_persistent_multimodel -- --ignored
       - name: Check for temp-file residue (leak guard)
         # Issue #972 — fail the build if any reddb-*/reddb_*/*.rdb/*.wal
         # temp residue remains in TMPDIR after the full test suite.  All

--- a/.github/workflows/crypto-coverage.yml
+++ b/.github/workflows/crypto-coverage.yml
@@ -38,7 +38,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@1.91.0
 
@@ -67,7 +67,8 @@ jobs:
         if: |
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.meta.outputs.update-type }} bump verified by CI."
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved: ${{ steps.meta.outputs.update-type }} bump verified by CI."
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/.github/workflows/drill-nightly.yml
+++ b/.github/workflows/drill-nightly.yml
@@ -22,7 +22,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:

--- a/.github/workflows/file-coverage.yml
+++ b/.github/workflows/file-coverage.yml
@@ -38,7 +38,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@1.91.0
         with:

--- a/.github/workflows/kv-bench.yml
+++ b/.github/workflows/kv-bench.yml
@@ -34,7 +34,7 @@ jobs:
           --health-timeout 3s
           --health-retries 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:

--- a/.github/workflows/parser-coverage.yml
+++ b/.github/workflows/parser-coverage.yml
@@ -39,7 +39,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@1.91.0
         with:

--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -29,7 +29,7 @@ jobs:
           - migration_parser
           - conn_string_parser
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@nightly
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       github_prerelease: ${{ steps.plan.outputs.github_prerelease }}
       publish_cargo: ${{ steps.plan.outputs.publish_cargo }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Decide release target
@@ -183,7 +183,7 @@ jobs:
           - { os: macos-14,       target: aarch64-apple-darwin,          asset_name: macos-aarch64,       cross: false, optional: true }
           - { os: windows-latest, target: x86_64-pc-windows-msvc, asset_name: windows-x86_64, cross: false, optional: true }
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Sync release version
         shell: bash
@@ -308,7 +308,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Sync release version
         run: |
           VERSION="${{ needs.plan.outputs.package_version }}"
@@ -341,7 +341,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
         with:
           # git-cliff walks the full commit history to build the changelog.
           fetch-depth: 0
@@ -441,7 +441,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Assert every postinstall-required asset is published
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -456,7 +456,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -493,7 +493,7 @@ jobs:
       needs.plan.outputs.release_channel == 'stable' &&
       needs.plan.outputs.publish_cargo == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
       - uses: ./.github/actions/install-protoc
         with:
@@ -552,7 +552,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -588,7 +588,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -624,7 +624,7 @@ jobs:
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -661,7 +661,7 @@ jobs:
       packages: write
     if: needs.plan.outputs.should_skip != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v8
         with:
           name: linux-x86_64
@@ -743,7 +743,7 @@ jobs:
       packages: write
     if: needs.plan.outputs.should_skip != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v8
         with:
           name: linux-x86_64
@@ -838,7 +838,7 @@ jobs:
           - { os: windows-latest,target: x86_64-pc-windows-msvc,    manylinux: 'auto' }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: '3.x'

--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -38,7 +38,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:

--- a/.github/workflows/sql-reference.yml
+++ b/.github/workflows/sql-reference.yml
@@ -23,6 +23,6 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
       - name: Check generated SQL reference blocks
         run: python3 scripts/check-sql-reference.py

--- a/.github/workflows/tla-check.yml
+++ b/.github/workflows/tla-check.yml
@@ -47,7 +47,7 @@ jobs:
           - SafeReconfig
     name: model-check (${{ matrix.spec }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - name: Set up JDK
         uses: actions/setup-java@v4

--- a/.github/workflows/types-coverage.yml
+++ b/.github/workflows/types-coverage.yml
@@ -39,7 +39,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@1.91.0
         with:

--- a/.github/workflows/wire-coverage.yml
+++ b/.github/workflows/wire-coverage.yml
@@ -37,7 +37,7 @@ jobs:
       RUSTC_WRAPPER: sccache
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v5
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # ============================================================================
 # RedDB - Multi-stage Docker build
 # ============================================================================
-# Stage 1: Build release binaries with protobuf support (musl static)
-# Stage 2: distroless static runtime with non-root user
+# Stage 1: Build release binaries with protobuf support
+# Stage 2: distroless glibc runtime with non-root user
 # ============================================================================
 
 FROM rust:1.96-slim-bookworm AS builder
@@ -13,12 +13,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG REDDB_CARGO_FEATURES=""
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends protobuf-compiler musl-tools \
-    && rm -rf /var/lib/apt/lists/* \
-    && rustup target add x86_64-unknown-linux-musl
-
-ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc \
-    CC_x86_64_unknown_linux_musl=musl-gcc
+    && apt-get install -y --no-install-recommends protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
@@ -31,19 +27,19 @@ COPY docs/spec/ docs/spec/
 RUN mkdir -p src/bin \
     && echo 'fn main() {}' > src/bin/red.rs \
     && echo '' > src/lib.rs \
-    && cargo build --profile release-static --locked --target x86_64-unknown-linux-musl --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} 2>/dev/null || true \
+    && cargo build --release --locked --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} 2>/dev/null || true \
     && rm -rf src
 
 # Copy full source and build for real
 COPY src/ src/
 
-RUN cargo build --profile release-static --locked --target x86_64-unknown-linux-musl --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} \
+RUN cargo build --release --locked --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} \
     && mkdir -p /image/data /image/etc/reddb \
     && touch /image/data/.keep /image/etc/reddb/.keep
 
-FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
-COPY --from=builder --chown=nonroot:nonroot /app/target/x86_64-unknown-linux-musl/release-static/red /usr/local/bin/red
+COPY --from=builder --chown=nonroot:nonroot /app/target/release/red /usr/local/bin/red
 COPY --from=builder --chown=nonroot:nonroot /image/data /data
 COPY --from=builder --chown=nonroot:nonroot /image/etc/reddb /etc/reddb
 

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ test-full:
 	./scripts/cargo-fast.sh test --locked
 
 test-persistent:
-	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test integration_persistent_multimodel -- --ignored
+	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test grouped_runtime_persistence integration_persistent_multimodel -- --ignored
 
 test-persistent-grimms:
-	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test integration_persistent_grimms_scale -- --ignored --nocapture
+	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test grouped_runtime_persistence integration_persistent_grimms_scale -- --ignored --nocapture
 
 drill-nightly:
 	@./scripts/drill-nightly.sh

--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -36,6 +36,7 @@ pub const REDDB_FORMAT_VERSION: u32 = 2;
 pub const DEFAULT_GROUP_COMMIT_WINDOW_MS: u64 = 0;
 pub const DEFAULT_GROUP_COMMIT_MAX_STATEMENTS: usize = 128;
 pub const DEFAULT_GROUP_COMMIT_MAX_WAL_BYTES: u64 = 1024 * 1024;
+pub(crate) const EPHEMERAL_RUNTIME_METADATA_KEY: &str = "__reddb_ephemeral_runtime";
 
 pub type RedDBResult<T> = Result<T, RedDBError>;
 
@@ -377,6 +378,11 @@ impl RedDBOptions {
             unique
         ));
         let _ = std::fs::remove_file(&path);
+        let mut metadata = BTreeMap::new();
+        metadata.insert(
+            EPHEMERAL_RUNTIME_METADATA_KEY.to_string(),
+            "true".to_string(),
+        );
         Self {
             mode: StorageMode::Persistent,
             data_path: Some(path),
@@ -386,6 +392,7 @@ impl RedDBOptions {
             export_retention: DEFAULT_EXPORT_RETENTION,
             read_only: false,
             force_create: true,
+            metadata,
             ..Default::default()
         }
     }

--- a/crates/reddb-server/src/cli/bootstrap.rs
+++ b/crates/reddb-server/src/cli/bootstrap.rs
@@ -80,10 +80,19 @@ pub fn run(args: BootstrapArgs) -> Result<BootstrapOutcome, String> {
         return Err("password is required (use --password-stdin or REDDB_PASSWORD_FILE)".into());
     }
 
-    // Open the runtime in persistent mode at the requested path. The
-    // engine creates the file on first open, so this works for both
-    // green-field bootstraps and re-runs against an existing DB.
-    let opts = RedDBOptions::persistent(&args.path);
+    // Vault bootstrap needs the paged storage path because AuthStore seals
+    // credentials through the pager. The default embedded single-file profile
+    // intentionally hides that pager, so bootstrap opts into the operational
+    // local layout while keeping the caller-provided database path.
+    let opts = RedDBOptions::persistent(&args.path)
+        .with_storage_profile(crate::storage::StorageProfileSelection {
+            deploy_profile: crate::storage::DeployProfile::Embedded,
+            packaging: crate::storage::StoragePackaging::OperationalDirectory,
+            replica_count: 0,
+            managed_backup: false,
+            wal_retention: false,
+        })
+        .map_err(|err| format!("storage profile: {err}"))?;
     let runtime = RedDBRuntime::with_options(opts).map_err(|err| format!("open db: {err}"))?;
 
     let pager = runtime

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -209,7 +209,7 @@ pub fn all_commands() -> Vec<CommandDef> {
     CommandDef {
       name: "ui",
       summary: "Open a graphical UI against a local .rdb or a remote red:///reds:// instance over a RedWire-over-WS bridge",
-      usage: "red ui file://./data.rdb | red ui red://host:port [--ui-dir DIR] [--port N] [--tls-ca PEM] [--no-browser]",
+      usage: "red ui file://./data.rdb | red ui red://host:port [--token TOKEN] [--ui-dir DIR] [--port N] [--tls-ca PEM] [--no-browser]",
       flags: ui_flags(),
     },
   ]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -7876,6 +7876,16 @@ impl RedDBRuntime {
                 retention_duration_ms: descriptor.retention_duration_ms,
             };
             self.inner.materialized_views.write().register(def);
+            if let Err(err) = self.ensure_materialized_view_backing(&view_name) {
+                crate::telemetry::operator_event::OperatorEvent::SchemaCorruption {
+                    collection: crate::runtime::continuous_materialized_view::CATALOG_COLLECTION
+                        .to_string(),
+                    detail: format!(
+                        "failed to rehydrate backing collection for materialized view {view_name}: {err}"
+                    ),
+                }
+                .emit_global();
+            }
         }
         // A rehydrated view shape may differ from any plans the cache
         // bootstrapped before this method ran — flush to be safe.

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2433,16 +2433,15 @@ impl RedDBRuntime {
                     // support-directory logs tier;
                     // lower tiers / ephemeral runs report `Stderr`
                     // and we keep the legacy file-next-to-data sink.
-                    let data_path = if embedded_single_file {
-                        std::env::temp_dir()
-                            .join("reddb-embedded-runtime")
-                            .join(format!("audit-{}", std::process::id()))
-                    } else {
-                        options
-                            .data_path
-                            .clone()
-                            .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
-                    };
+                    let data_path = options.data_path.clone().unwrap_or_else(|| {
+                        if embedded_single_file {
+                            std::env::temp_dir()
+                                .join("reddb-embedded-runtime")
+                                .join(format!("audit-{}", std::process::id()))
+                        } else {
+                            std::env::temp_dir().join("reddb")
+                        }
+                    });
                     let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
                     Arc::new(crate::runtime::audit_log::AuditLogger::for_destination(
                         &audit_dest,

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2477,17 +2477,19 @@ impl RedDBRuntime {
                     // lands under the file-owned support-directory logs tier;
                     // lower tiers fall back to `red-slow.log` in the
                     // data directory.
-                    let fallback_dir = if embedded_single_file {
-                        std::env::temp_dir()
-                            .join("reddb-embedded-runtime")
-                            .join(format!("slow-{}", std::process::id()))
-                    } else {
-                        options
-                            .data_path
-                            .as_ref()
-                            .and_then(|p| p.parent().map(std::path::PathBuf::from))
-                            .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
-                    };
+                    let fallback_dir = options
+                        .data_path
+                        .as_ref()
+                        .and_then(|p| p.parent().map(std::path::PathBuf::from))
+                        .unwrap_or_else(|| {
+                            if embedded_single_file {
+                                std::env::temp_dir()
+                                    .join("reddb-embedded-runtime")
+                                    .join(format!("slow-{}", std::process::id()))
+                            } else {
+                                std::env::temp_dir().join("reddb")
+                            }
+                        });
                     let threshold_ms = std::env::var("RED_SLOW_QUERY_THRESHOLD_MS")
                         .ok()
                         .and_then(|s| s.parse::<u64>().ok())

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -1564,7 +1564,7 @@ impl RedDBRuntime {
                     {
                         push_vault_metadata_record(&mut result, collection, &entry.key, &entry);
                     }
-                    return Ok(RuntimeQueryResult {
+                    Ok(RuntimeQueryResult {
                         query: raw_query.to_string(),
                         mode: crate::storage::query::modes::QueryMode::Sql,
                         statement: "vault_list",
@@ -1573,7 +1573,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
-                    });
+                    })
                 } else {
                     let mut result = UnifiedResult::with_columns(vec![
                         "rid".into(),
@@ -1611,39 +1611,40 @@ impl RedDBRuntime {
                                 crate::presentation::entity_json::storage_value_to_json(&value),
                             );
                         }
-                        return Ok(kv_list_json_result(raw_query, collection, prefix, tree));
+                        Ok(kv_list_json_result(raw_query, collection, prefix, tree))
+                    } else {
+                        for (key, entity) in entries
+                            .into_iter()
+                            .skip(*offset)
+                            .take(limit.unwrap_or(usize::MAX))
+                        {
+                            let mut record = UnifiedRecord::new();
+                            record.set("rid", Value::UnsignedInteger(entity.id.raw()));
+                            record.set("collection", Value::text(collection.clone()));
+                            record.set("kind", Value::text("kv"));
+                            record.set("tenant", Value::Null);
+                            record.set("created_at", Value::UnsignedInteger(entity.created_at));
+                            record.set("updated_at", Value::UnsignedInteger(entity.updated_at));
+                            record.set("key", Value::text(key.clone()));
+                            record.set(
+                                "value",
+                                kv_value_from_entity(&entity)
+                                    .unwrap_or(crate::storage::schema::Value::Null),
+                            );
+                            record.set("tags", kv_tags_value(&ops.tags_for_key(collection, &key)));
+                            result.push(record);
+                        }
+                        Ok(RuntimeQueryResult {
+                            query: raw_query.to_string(),
+                            mode: crate::storage::query::modes::QueryMode::Sql,
+                            statement: "kv_list",
+                            engine: "kv",
+                            result,
+                            affected_rows: 0,
+                            statement_type: "select",
+                            bookmark: None,
+                        })
                     }
-                    for (key, entity) in entries
-                        .into_iter()
-                        .skip(*offset)
-                        .take(limit.unwrap_or(usize::MAX))
-                    {
-                        let mut record = UnifiedRecord::new();
-                        record.set("rid", Value::UnsignedInteger(entity.id.raw()));
-                        record.set("collection", Value::text(collection.clone()));
-                        record.set("kind", Value::text("kv"));
-                        record.set("tenant", Value::Null);
-                        record.set("created_at", Value::UnsignedInteger(entity.created_at));
-                        record.set("updated_at", Value::UnsignedInteger(entity.updated_at));
-                        record.set("key", Value::text(key.clone()));
-                        record.set(
-                            "value",
-                            kv_value_from_entity(&entity)
-                                .unwrap_or(crate::storage::schema::Value::Null),
-                        );
-                        record.set("tags", kv_tags_value(&ops.tags_for_key(collection, &key)));
-                        result.push(record);
-                    }
-                    return Ok(RuntimeQueryResult {
-                        query: raw_query.to_string(),
-                        mode: crate::storage::query::modes::QueryMode::Sql,
-                        statement: "kv_list",
-                        engine: "kv",
-                        result,
-                        affected_rows: 0,
-                        statement_type: "select",
-                        bookmark: None,
-                    });
                 }
             }
 

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -1489,7 +1489,7 @@ impl RedDBRuntime {
                         attempts: nack_attempts,
                         reason: format!("lifecycle_nack:{did}"),
                     }
-                    .emit_global();
+                    .emit(self.audit_log());
                 }
                 let message = match outcome {
                     RetirementOutcome::Requeued => {

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -32,6 +32,39 @@ use crate::RedDB;
 
 use super::TableQuery;
 
+struct QueryTempDir {
+    path: std::path::PathBuf,
+}
+
+impl QueryTempDir {
+    fn new(prefix: &str) -> std::io::Result<Self> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+
+        let now_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let unique = SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "{prefix}{}-{now_nanos}-{unique}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for QueryTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 /// Return `true` when any projection in the query is a known aggregate
 /// function. Used by the executor to decide whether to dispatch to
 /// [`execute_aggregate_query`].
@@ -257,20 +290,16 @@ pub(crate) fn execute_aggregate_query(
         std::collections::HashMap::new();
 
     // SpilledHashAgg receives flushed batches and performs the final merge.
-    let spill_dir = {
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static SEQ: AtomicU64 = AtomicU64::new(0);
-        let seq = SEQ.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
-        let d = std::env::temp_dir().join(format!("reddb-agg-{pid}-{seq}"));
-        std::fs::create_dir_all(&d)
-            .map_err(|e| RedDBError::Query(format!("agg spill dir: {e}")))?;
-        d
-    };
+    let spill_dir = QueryTempDir::new("reddb-agg-")
+        .map_err(|e| RedDBError::Query(format!("agg spill dir: {e}")))?;
     let mut spill_agg = crate::storage::query::executors::agg_spill::SpilledHashAgg::<
         AggregateGroupKey,
         AggregateGroup,
-    >::new(spill_dir, WORK_MEM_BYTES, ESTIMATED_ENTRY_BYTES);
+    >::new(
+        spill_dir.path().to_path_buf(),
+        WORK_MEM_BYTES,
+        ESTIMATED_ENTRY_BYTES,
+    );
     let mut spill_err: Option<String> = None;
 
     let table_row_resolver = TableRowMvccReadResolver::current_statement();

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -295,11 +295,7 @@ pub(crate) fn execute_aggregate_query(
     let mut spill_agg = crate::storage::query::executors::agg_spill::SpilledHashAgg::<
         AggregateGroupKey,
         AggregateGroup,
-    >::new(
-        spill_dir.path().to_path_buf(),
-        WORK_MEM_BYTES,
-        ESTIMATED_ENTRY_BYTES,
-    );
+    >::new(spill_dir.path(), WORK_MEM_BYTES, ESTIMATED_ENTRY_BYTES);
     let mut spill_err: Option<String> = None;
 
     let table_row_resolver = TableRowMvccReadResolver::current_statement();

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -65,6 +65,30 @@ impl Drop for QueryTempDir {
     }
 }
 
+#[cfg(test)]
+mod query_temp_dir_tests {
+    use super::QueryTempDir;
+
+    #[test]
+    fn query_temp_dir_new_creates_directory() {
+        let dir = QueryTempDir::new("reddb-agg-test-").expect("temp dir should be created");
+
+        assert!(dir.path().is_dir());
+    }
+
+    #[test]
+    fn query_temp_dir_drop_removes_directory() {
+        let path = {
+            let dir = QueryTempDir::new("reddb-agg-test-").expect("temp dir should be created");
+            let path = dir.path().to_path_buf();
+            assert!(path.is_dir());
+            path
+        };
+
+        assert!(!path.exists());
+    }
+}
+
 /// Return `true` when any projection in the query is a known aggregate
 /// function. Used by the executor to decide whether to dispatch to
 /// [`execute_aggregate_query`].

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -136,6 +136,9 @@ pub mod ui_bridge;
 // HTTPS download, SHA-256 verification, tgz extraction, and local cache
 // management for the pinned red-ui release asset.
 pub mod ui_bundle_resolver;
+// `red ui --token` credential handoff (issue #1048, ADR 0051): one-time
+// loopback nonce channel and served-UI auth-mode wiring.
+pub mod ui_auth;
 // `red server --ui` static bundle surface (issue #1047, ADR 0051): serve
 // the resolved red-ui bundle as inert static assets on the server's HTTP
 // edge so a remote browser can load it and connect back over RedWire-over-WS.

--- a/crates/reddb-server/src/server/ui_bridge.rs
+++ b/crates/reddb-server/src/server/ui_bridge.rs
@@ -43,7 +43,10 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use tokio::sync::oneshot;
 
-use super::ws_edge::{pump_ws_stream, run_ws_session, REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL};
+use super::ws_edge::{
+    inject_bearer_handshake, pump_ws_stream, run_injected_ws_session, run_ws_session,
+    REDWIRE_WS_PATH, REDWIRE_WS_SUBPROTOCOL,
+};
 use super::RedDBServer;
 
 /// The checked-in minimal UI fixture served when no `--ui-dir` is given.
@@ -61,6 +64,11 @@ pub struct UiBridgeConfig {
     /// Loopback port to bind. `0` (the default) picks an ephemeral port —
     /// the resolved address is read back from [`UiBridge::local_addr`].
     pub port: u16,
+    /// Bearer token held by the bridge and injected into the RedWire
+    /// handshake. The served page never receives the token.
+    pub injected_token: Option<String>,
+    /// Credential-free auth mode hint injected into served HTML.
+    pub auth_mode: super::ui_auth::UiAuthMode,
 }
 
 /// A remote RedWire endpoint the bridge fronts for a `red://` / `reds://`
@@ -175,6 +183,8 @@ struct BridgeState {
     backend: Arc<BridgeBackend>,
     allowed_origins: Arc<Vec<String>>,
     ui_dir: Option<Arc<PathBuf>>,
+    injected_token: Option<Arc<String>>,
+    auth_mode: super::ui_auth::UiAuthMode,
     /// Set for `Direct` targets. When `Some`, the WS URL is injected as
     /// `window.REDDB_WS_URL` into HTML responses so the UI page can
     /// connect directly rather than deriving from `location.host`.
@@ -290,6 +300,8 @@ async fn spawn_ui_bridge_backend(
         backend: Arc::new(backend),
         allowed_origins: Arc::new(seed_loopback_origins(local_addr.port())),
         ui_dir: config.ui_dir.map(Arc::new),
+        injected_token: config.injected_token.map(Arc::new),
+        auth_mode: config.auth_mode,
         direct_ws_url: None,
     };
 
@@ -330,6 +342,8 @@ pub async fn spawn_direct_ui_server(
         backend: Arc::new(BridgeBackend::Direct),
         allowed_origins: Arc::new(vec![]),
         ui_dir: config.ui_dir.map(Arc::new),
+        injected_token: config.injected_token.map(Arc::new),
+        auth_mode: config.auth_mode,
         direct_ws_url: Some(Arc::new(ws_url.clone())),
     };
 
@@ -374,16 +388,26 @@ async fn loopback_redwire_upgrade(
     }
 
     let backend = Arc::clone(&state.backend);
+    let injected_token = state.injected_token.clone();
     ws.protocols([REDWIRE_WS_SUBPROTOCOL])
         .on_upgrade(move |socket| async move {
             match &*backend {
                 // `file://` — RedWire over the in-process embedded engine.
                 BridgeBackend::Embedded(server) => {
-                    run_ws_session(socket, (**server).clone()).await;
+                    if let Some(token) = injected_token.as_deref().map(String::as_str) {
+                        run_injected_ws_session(socket, (**server).clone(), token).await;
+                    } else {
+                        run_ws_session(socket, (**server).clone()).await;
+                    }
                 }
                 // `red://` / `reds://` — relay to a remote RedWire instance.
                 BridgeBackend::Remote(target) => {
-                    run_remote_ws_session(socket, target).await;
+                    run_remote_ws_session(
+                        socket,
+                        target,
+                        injected_token.as_deref().map(String::as_str),
+                    )
+                    .await;
                 }
                 // `red+wss://` / `red+ws://` — the `/redwire` route is not
                 // mounted for direct targets, so this arm is unreachable.
@@ -403,7 +427,11 @@ async fn loopback_redwire_upgrade(
 /// pure byte relay and never parses RedWire frames. On a connection
 /// failure the WS is closed so the UI surfaces the error rather than
 /// hanging.
-async fn run_remote_ws_session(socket: WebSocket, target: &RemoteRedwireTarget) {
+async fn run_remote_ws_session(
+    socket: WebSocket,
+    target: &RemoteRedwireTarget,
+    injected_token: Option<&str>,
+) {
     let addr = (target.host.as_str(), target.port);
     let tcp = match tokio::net::TcpStream::connect(addr).await {
         Ok(tcp) => tcp,
@@ -420,12 +448,22 @@ async fn run_remote_ws_session(socket: WebSocket, target: &RemoteRedwireTarget) 
     };
 
     if !target.tls {
-        pump_ws_stream(socket, tcp).await;
+        if let Some(token) = injected_token {
+            inject_bearer_handshake(socket, tcp, token).await;
+        } else {
+            pump_ws_stream(socket, tcp).await;
+        }
         return;
     }
 
     match wrap_remote_tls(tcp, target).await {
-        Ok(tls) => pump_ws_stream(socket, tls).await,
+        Ok(tls) => {
+            if let Some(token) = injected_token {
+                inject_bearer_handshake(socket, tls, token).await;
+            } else {
+                pump_ws_stream(socket, tls).await;
+            }
+        }
         Err(err) => {
             tracing::warn!(
                 host = %target.host,
@@ -532,6 +570,7 @@ async fn serve_ui(State(state): State<BridgeState>, uri: Uri) -> Response {
         if let Some(ws_url) = &state.direct_ws_url {
             body = inject_ws_url_config(body, ws_url);
         }
+        body = super::ui_auth::inject_auth_mode_config(body, state.auth_mode);
     }
 
     (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], body).into_response()

--- a/crates/reddb-server/src/storage/unified/devx/reddb.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb.rs
@@ -144,6 +144,69 @@ pub struct RedDB {
     /// `store`, so a runtime restart on the same database path is
     /// not racy with an in-flight rebuild holding the file lock.
     pub(crate) turbo_rebuild_workers: parking_lot::Mutex<Vec<std::thread::JoinHandle<()>>>,
+    _ephemeral_cleanup: Option<EphemeralDataPathCleanup>,
+}
+
+pub(super) struct EphemeralDataPathCleanup {
+    path: PathBuf,
+}
+
+impl EphemeralDataPathCleanup {
+    pub(super) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for EphemeralDataPathCleanup {
+    fn drop(&mut self) {
+        for path in ephemeral_data_artifacts(&self.path) {
+            if path.is_dir() {
+                let _ = fs::remove_dir_all(path);
+            } else {
+                let _ = fs::remove_file(path);
+            }
+        }
+    }
+}
+
+pub(super) fn is_ephemeral_data_path(path: &Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if !file_name.starts_with("reddb-ephemeral-") || !file_name.ends_with(".rdb") {
+        return false;
+    }
+    path.parent()
+        .map(|parent| parent == std::env::temp_dir())
+        .unwrap_or(false)
+}
+
+fn ephemeral_data_artifacts(data_path: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![
+        data_path.to_path_buf(),
+        reddb_file::layout::unified_wal_path(data_path),
+        reddb_file::layout::logical_wal_path(data_path),
+        reddb_file::layout::temp_path(data_path),
+        reddb_file::layout::result_cache_l2_path(data_path),
+        reddb_file::layout::pager_legacy_wal_path(data_path),
+        reddb_file::layout::engine_wal_path(data_path),
+        reddb_file::layout::pager_header_path(data_path),
+        reddb_file::layout::pager_meta_path(data_path),
+        reddb_file::layout::pager_dwb_path(data_path),
+        reddb_file::layout::shm_path(data_path),
+        reddb_file::layout::physical_metadata_json_path(data_path),
+        reddb_file::layout::physical_metadata_binary_path(data_path),
+        reddb_file::layout::rebootstrap_staging_root(data_path),
+        reddb_file::layout::rebootstrap_pending_path(data_path),
+        reddb_file::layout::rebootstrap_ready_marker_path(data_path),
+        reddb_file::layout::rebootstrap_intent_log_path(data_path),
+        reddb_file::layout::rebootstrap_previous_path(data_path),
+        reddb_file::layout::primary_replica_root(data_path),
+        reddb_file::layout::serverless_root(data_path),
+    ];
+    paths.extend(reddb_file::layout::pager_shadow_sidecar_paths(data_path));
+    paths.push(reddb_file::layout::support_dir_for(data_path));
+    paths
 }
 
 impl Drop for RedDB {

--- a/crates/reddb-server/src/storage/unified/devx/reddb.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb.rs
@@ -182,17 +182,28 @@ pub(super) fn is_ephemeral_data_path(path: &Path) -> bool {
 }
 
 fn ephemeral_data_artifacts(data_path: &Path) -> Vec<PathBuf> {
+    let logical_wal_path = reddb_file::layout::logical_wal_path(data_path);
+    let result_cache_l2_path = reddb_file::layout::result_cache_l2_path(data_path);
+    let legacy_logical_slots_path = reddb_file::layout::legacy_logical_slots_path(data_path);
+    let mut operational_manifest_root = data_path.as_os_str().to_os_string();
+    operational_manifest_root.push(".ops");
     let mut paths = vec![
         data_path.to_path_buf(),
+        PathBuf::from(operational_manifest_root),
         reddb_file::layout::unified_wal_path(data_path),
-        reddb_file::layout::logical_wal_path(data_path),
+        logical_wal_path.clone(),
+        reddb_file::layout::logical_wal_temp_path(&logical_wal_path),
         reddb_file::layout::temp_path(data_path),
-        reddb_file::layout::result_cache_l2_path(data_path),
+        reddb_file::layout::atomic_temp_path(data_path),
+        result_cache_l2_path.clone(),
         reddb_file::layout::pager_legacy_wal_path(data_path),
         reddb_file::layout::engine_wal_path(data_path),
         reddb_file::layout::pager_header_path(data_path),
         reddb_file::layout::pager_meta_path(data_path),
         reddb_file::layout::pager_dwb_path(data_path),
+        legacy_logical_slots_path.clone(),
+        reddb_file::layout::legacy_logical_slots_temp_path(&legacy_logical_slots_path),
+        reddb_file::layout::legacy_audit_log_path(data_path),
         reddb_file::layout::shm_path(data_path),
         reddb_file::layout::physical_metadata_json_path(data_path),
         reddb_file::layout::physical_metadata_binary_path(data_path),
@@ -205,6 +216,12 @@ fn ephemeral_data_artifacts(data_path: &Path) -> Vec<PathBuf> {
         reddb_file::layout::serverless_root(data_path),
     ];
     paths.extend(reddb_file::layout::pager_shadow_sidecar_paths(data_path));
+    paths.extend(reddb_file::layout::pager_shadow_sidecar_paths(
+        &result_cache_l2_path,
+    ));
+    if let Some(parent) = data_path.parent() {
+        paths.push(reddb_file::layout::legacy_slow_query_log_path(parent));
+    }
     paths.push(reddb_file::layout::support_dir_for(data_path));
     paths
 }

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -511,6 +511,11 @@ impl RedDB {
                 options.replication.quorum.clone(),
             ))
         });
+        let ephemeral_cleanup = path
+            .as_ref()
+            .filter(|path| super::is_ephemeral_data_path(path))
+            .cloned()
+            .map(super::EphemeralDataPathCleanup::new);
 
         Self {
             store: Arc::new(store),
@@ -534,6 +539,7 @@ impl RedDB {
             continuous_aggregates: std::sync::OnceLock::new(),
             turbo_collections: std::sync::OnceLock::new(),
             turbo_rebuild_workers: parking_lot::Mutex::new(Vec::new()),
+            _ephemeral_cleanup: ephemeral_cleanup,
         }
         .with_initialized_metadata()
         .map_err(|err| format!("initialize RedDB metadata: {err}").into())

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -145,6 +145,15 @@ fn promote_ready_replica_rebootstrap(
     Ok(true)
 }
 
+fn should_cleanup_ephemeral_data_path(options: &RedDBOptions, path: &Path) -> bool {
+    options
+        .metadata
+        .get(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY)
+        .map(|value| value == "true")
+        .unwrap_or(false)
+        && super::is_ephemeral_data_path(path)
+}
+
 impl RedDB {
     fn remote_head_key(options: &RedDBOptions) -> String {
         options.default_backup_head_key()
@@ -513,7 +522,7 @@ impl RedDB {
         });
         let ephemeral_cleanup = path
             .as_ref()
-            .filter(|path| super::is_ephemeral_data_path(path))
+            .filter(|path| should_cleanup_ephemeral_data_path(options, path))
             .cloned()
             .map(super::EphemeralDataPathCleanup::new);
 
@@ -1254,5 +1263,29 @@ impl RedDB {
             && report.state != HealthState::Unhealthy;
 
         (query_allowed, write_allowed, repair_allowed)
+    }
+}
+
+#[cfg(test)]
+mod ephemeral_cleanup_tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_options_arm_ephemeral_cleanup_for_their_generated_path() {
+        let options = RedDBOptions::in_memory();
+        let path = options.data_path.as_ref().expect("in-memory data path");
+
+        assert!(should_cleanup_ephemeral_data_path(&options, path));
+    }
+
+    #[test]
+    fn persistent_options_do_not_arm_cleanup_for_matching_temp_path() {
+        let path = std::env::temp_dir().join(format!(
+            "reddb-ephemeral-{}-persistent-user.rdb",
+            std::process::id()
+        ));
+        let options = RedDBOptions::persistent(&path);
+
+        assert!(!should_cleanup_ephemeral_data_path(&options, &path));
     }
 }

--- a/crates/reddb-server/tests/e2e_issue_1042_ui_bridge.rs
+++ b/crates/reddb-server/tests/e2e_issue_1042_ui_bridge.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
+use reddb_server::server::header_escape_guard::HeaderEscapeGuard;
 use reddb_server::server::ui_bridge::{spawn_ui_bridge, UiBridgeConfig};
 use reddb_server::server::RedDBServer;
 use reddb_server::{RedDBOptions, RedDBRuntime};
@@ -33,7 +34,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
@@ -61,7 +61,7 @@ fn ws_request(
     let mut req = url.into_client_request().expect("client request");
     req.headers_mut().insert(
         "Origin",
-        HeaderValue::from_str(origin).expect("origin value"),
+        HeaderEscapeGuard::header_value(origin).expect("origin value"),
     );
     req
 }

--- a/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
+++ b/crates/reddb-server/tests/e2e_issue_1044_remote_bridge.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
+use reddb_server::server::header_escape_guard::HeaderEscapeGuard;
 use reddb_server::server::ui_bridge::{
     spawn_ui_bridge_remote, RemoteRedwireTarget, UiBridgeConfig,
 };
@@ -39,7 +40,6 @@ use reddb_wire::redwire::{
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
@@ -96,7 +96,7 @@ fn ws_request(
     let mut req = url.into_client_request().expect("client request");
     req.headers_mut().insert(
         "Origin",
-        HeaderValue::from_str(origin).expect("origin value"),
+        HeaderEscapeGuard::header_value(origin).expect("origin value"),
     );
     req
 }

--- a/crates/reddb-server/tests/e2e_issue_1048_auth_handoff.rs
+++ b/crates/reddb-server/tests/e2e_issue_1048_auth_handoff.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
 use reddb_server::auth::{AuthConfig, AuthStore, Role};
+use reddb_server::server::header_escape_guard::HeaderEscapeGuard;
 use reddb_server::server::ui_auth::{spawn_handoff_server, UiAuthMode};
 use reddb_server::server::ui_bridge::{spawn_ui_bridge, UiBridgeConfig};
 use reddb_server::server::RedDBServer;
@@ -36,7 +37,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
@@ -85,7 +85,7 @@ fn ws_request(
     let mut req = url.into_client_request().expect("client request");
     req.headers_mut().insert(
         "Origin",
-        HeaderValue::from_str(origin).expect("origin value"),
+        HeaderEscapeGuard::header_value(origin).expect("origin value"),
     );
     req
 }

--- a/docs/conformance/public-surface-contract-matrix.json
+++ b/docs/conformance/public-surface-contract-matrix.json
@@ -20,10 +20,10 @@
       "source": "README.md",
       "promise": "RedDB is one multi-model database (tables, graph, KV, timeseries, probabilistic, vector, queue, documents) backed by a single file.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_cross_model_tx.rs", "tests/e2e_feedback_regression_pack.rs"] },
-        "http": { "status": "supported", "tests": ["tests/http_query_grimms_graph.rs"] },
-        "redwire": { "status": "supported", "tests": ["tests/cross_binary_smoke.rs"] },
-        "grpc": { "status": "supported", "tests": ["tests/cross_binary_smoke.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/mvcc_transactions/e2e_cross_model_tx.rs", "tests/grouped/control_feedback/e2e_feedback_regression_pack.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/graph_analytics/http_query_grimms_graph.rs"] },
+        "redwire": { "status": "supported", "tests": ["tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
+        "grpc": { "status": "supported", "tests": ["tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs", "drivers/python/tests/test_conformance.py"] }
       }
     },
@@ -32,10 +32,10 @@
       "source": "docs/query/graph-commands.md",
       "promise": "MATCH supports node, edge, label, property, and LIMIT projections.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_feedback_regression_pack.rs", "tests/feedback_regression.rs"] },
-        "http": { "status": "supported", "tests": ["tests/e2e_issue_556_graph_sql_http_parity_and_limits.rs", "tests/http_query_grimms_graph.rs"] },
-        "redwire": { "status": "partial", "tests": ["tests/cross_binary_smoke.rs"] },
-        "grpc": { "status": "partial", "tests": ["tests/cross_binary_smoke.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/control_feedback/e2e_feedback_regression_pack.rs", "tests/grouped/control_feedback/feedback_regression.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs", "tests/grouped/graph_analytics/http_query_grimms_graph.rs"] },
+        "redwire": { "status": "partial", "tests": ["tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
+        "grpc": { "status": "partial", "tests": ["tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] }
       }
     },
@@ -44,8 +44,8 @@
       "source": "docs/query/graph-commands.md",
       "promise": "GRAPH algorithms accept semantic identifiers, limits, ordering, and return stable rich rows.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/feedback_regression.rs"] },
-        "http": { "status": "supported", "tests": ["tests/e2e_issue_556_graph_sql_http_parity_and_limits.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/control_feedback/feedback_regression.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs"] },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "unsupported" },
         "driver_helpers": { "status": "unsupported" }
@@ -56,8 +56,8 @@
       "source": "docs/query/insert.md",
       "promise": "INSERT creates rows, documents, and native timeseries points.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_documents_first_class_crud.rs", "tests/e2e_create_hypertable.rs"] },
-        "http": { "status": "supported", "tests": ["tests/http_batch_insert.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs", "tests/grouped/timeseries_metrics/e2e_create_hypertable.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/cli_transport/http_batch_insert.rs"] },
         "redwire": { "status": "partial", "tests": ["crates/reddb-wire/tests/params_fixtures.rs"] },
         "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["drivers/python/tests/test_conformance.py", "drivers/js/test/insert-ids.test.mjs"] }
@@ -68,7 +68,7 @@
       "source": "docs/query/probabilistic-commands.md",
       "promise": "HLL/SKETCH/FILTER expose write and read commands for cardinality, frequency, and membership.",
       "cells": {
-        "sql": { "status": "partial", "tests": ["tests/e2e_feedback_regression_pack.rs"] },
+        "sql": { "status": "partial", "tests": ["tests/grouped/control_feedback/e2e_feedback_regression_pack.rs"] },
         "http": { "status": "unsupported" },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "unsupported" },
@@ -80,8 +80,8 @@
       "source": "docs/query/insert.md",
       "promise": "Timeseries stores timestamped metrics with tags and supports query/readback.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_create_hypertable.rs", "tests/e2e_feedback_regression_pack.rs"] },
-        "http": { "status": "partial", "tests": ["tests/http_batch_insert.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/timeseries_metrics/e2e_create_hypertable.rs", "tests/grouped/control_feedback/e2e_feedback_regression_pack.rs"] },
+        "http": { "status": "partial", "tests": ["tests/grouped/cli_transport/http_batch_insert.rs"] },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "unsupported" },
         "driver_helpers": { "status": "partial", "tests": ["drivers/python/tests/test_conformance.py"] }
@@ -92,8 +92,8 @@
       "source": "docs/query/document-commands.md",
       "promise": "Documents are first-class: create, read, update, delete, and SQL analytics over JSON.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_documents_first_class_crud.rs", "tests/e2e_document_sql_analytics.rs"] },
-        "http": { "status": "supported", "tests": ["tests/http_batch_insert.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs", "tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/cli_transport/http_batch_insert.rs"] },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["drivers/python/tests/test_documents_conformance.py", "drivers/js/test/db-helpers.test.mjs"] }
@@ -104,7 +104,7 @@
       "source": "docs/spec/sdk-helpers.md",
       "promise": "KV helpers expose get/put/delete; get of a missing key returns null, delete reports affected.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_feedback_regression_pack.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/control_feedback/e2e_feedback_regression_pack.rs"] },
         "http": { "status": "unsupported" },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] },
@@ -116,7 +116,7 @@
       "source": "docs/spec/sdk-helpers.md",
       "promise": "Queue helpers expose create/push/peek/pop/len/purge with FIFO semantics; empty pop is not an error.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/feedback_regression.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/control_feedback/feedback_regression.rs"] },
         "http": { "status": "unsupported" },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "unsupported" },
@@ -128,7 +128,7 @@
       "source": "docs/spec/sdk-helpers.md",
       "promise": "Transactions are imperative (begin/commit/rollback) plus a run(callback) form; empty SQL rejects with INVALID_ARGUMENT.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_cross_model_tx.rs", "tests/docs_transaction_guarantees.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/mvcc_transactions/e2e_cross_model_tx.rs", "tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs"] },
         "http": { "status": "unsupported" },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] },
@@ -140,8 +140,8 @@
       "source": "../feedbacks.md",
       "promise": "SQL aggregate, projection, expression, and mutation behaviour matches ordinary SQL expectations where advertised.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/feedback_regression.rs", "tests/e2e_feedback_regression_pack.rs"] },
-        "http": { "status": "supported", "tests": ["tests/e2e_issue_556_graph_sql_http_parity_and_limits.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/control_feedback/feedback_regression.rs", "tests/grouped/control_feedback/e2e_feedback_regression_pack.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs"] },
         "redwire": { "status": "partial", "tests": ["crates/reddb-wire/tests/params_fixtures.rs"] },
         "grpc": { "status": "partial", "tests": ["crates/reddb-client/tests/conformance.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs"] }
@@ -152,10 +152,10 @@
       "source": "../feedbacks-new.md",
       "promise": "Server transports expose the same query contract as embedded (HTTP, RedWire, gRPC parity).",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/cross_binary_smoke.rs"] },
-        "http": { "status": "supported", "tests": ["tests/e2e_issue_556_graph_sql_http_parity_and_limits.rs", "tests/cross_binary_smoke.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
+        "http": { "status": "supported", "tests": ["tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs", "tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
         "redwire": { "status": "supported", "tests": ["crates/reddb-wire/tests/params_fixtures.rs", "drivers/js/test/redwire.params.test.mjs"] },
-        "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs", "tests/cross_binary_smoke.rs"] },
+        "grpc": { "status": "supported", "tests": ["crates/reddb-client/tests/conformance.rs", "tests/grouped/surface_contracts/cross_binary_smoke.rs"] },
         "driver_helpers": { "status": "supported", "tests": ["drivers/go/conformance_test.go", "drivers/java/src/test/java/dev/reddb/helpers/ConformanceTest.java"] }
       }
     },
@@ -188,8 +188,8 @@
       "source": "docs/query/ask-commands.md",
       "promise": "ASK / SEARCH semantic surfaces return ranked results with stable shape.",
       "cells": {
-        "sql": { "status": "supported", "tests": ["tests/e2e_ask_search_conformance.rs"] },
-        "http": { "status": "partial", "tests": ["tests/e2e_ask_search_conformance.rs"] },
+        "sql": { "status": "supported", "tests": ["tests/grouped/ai_search/e2e_ask_search_conformance.rs"] },
+        "http": { "status": "partial", "tests": ["tests/grouped/ai_search/e2e_ask_search_conformance.rs"] },
         "redwire": { "status": "unsupported" },
         "grpc": { "status": "unsupported" },
         "driver_helpers": { "status": "partial", "tests": ["drivers/js/test/ask.test.mjs"] }

--- a/docs/conformance/public-surface-contract-matrix.md
+++ b/docs/conformance/public-surface-contract-matrix.md
@@ -156,11 +156,11 @@ minimum acceptable proof is:
 
 ## Focused Regression Packs
 
-- `tests/e2e_feedback_regression_pack.rs` covers the #451 feedback regressions
+- `tests/grouped/control_feedback/e2e_feedback_regression_pack.rs` covers the #451 feedback regressions
   for PSC-003, PSC-005, PSC-006, PSC-011, and PSC-013: probabilistic SQL-read
   forms, `COUNT(*) AS count`, quoted KV colon keys, timeseries JSON tags, and
   `GRAPH PROPERTIES` `node_type` preservation.
-- `tests/feedback_regression.rs` is the #549 feedback-scenario regression
+- `tests/grouped/control_feedback/feedback_regression.rs` is the #549 feedback-scenario regression
   bundle: one named test per `FB-OLD-NN` and `FB-NEW-NN` row in the
   Feedback Scenario Coverage table above. Each test header documents the
   source feedback file and the PSC contract row it maps to. Runtime-

--- a/drivers/cpp/include/reddb/helpers.hpp
+++ b/drivers/cpp/include/reddb/helpers.hpp
@@ -135,7 +135,8 @@ std::shared_ptr<IQuerier> make_querier(Conn* conn);
 class DocumentClient {
 public:
     struct ListOptions {
-        int limit = 0;
+        ListOptions() : limit(0) {}
+        int limit;
         std::string order_by;
         std::string filter;
     };
@@ -144,7 +145,7 @@ public:
 
     InsertResult insert(const std::string& collection, const JsonObject& document);
     JsonObject   get(const std::string& collection, const std::string& rid);
-    ListResult   list(const std::string& collection, const ListOptions& opts = {});
+    ListResult   list(const std::string& collection, const ListOptions& opts = ListOptions{});
     JsonObject   patch(const std::string& collection, const std::string& rid,
                        const JsonObject& patch);
     DeleteResult del(const std::string& collection, const std::string& rid);
@@ -157,13 +158,15 @@ private:
 class KvClient {
 public:
     struct SetOptions {
+        SetOptions() : expire_ms(0) {}
         std::string collection;
         std::vector<std::string> tags;
-        int64_t expire_ms = 0;
+        int64_t expire_ms;
     };
     struct ListOpts {
+        ListOpts() : limit(0) {}
         std::string collection;
-        int limit = 0;
+        int limit;
         std::string prefix;
     };
 
@@ -171,13 +174,13 @@ public:
         : q_(std::move(q)), collection_(std::move(collection)) {}
 
     void         put(const std::string& key, const JsonValue& value,
-                     const SetOptions& opts = {});
+                     const SetOptions& opts = SetOptions{});
     void         set(const std::string& key, const JsonValue& value,
-                     const SetOptions& opts = {}) { put(key, value, opts); }
+                     const SetOptions& opts = SetOptions{}) { put(key, value, opts); }
     JsonValue    get(const std::string& key, const std::string& collection = "");
     ExistsResult exists(const std::string& key, const std::string& collection = "");
     DeleteResult del(const std::string& key, const std::string& collection = "");
-    ListResult   list(const ListOpts& opts = {});
+    ListResult   list(const ListOpts& opts = ListOpts{});
 
     const std::string& collection() const noexcept { return collection_; }
 
@@ -193,7 +196,7 @@ public:
     explicit QueueClient(std::shared_ptr<IQuerier> q) : q_(std::move(q)) {}
 
     QueuePushResult push(const std::string& queue, const JsonValue& value,
-                         const PushOptions& opts = {});
+                         const PushOptions& opts = PushOptions{});
     std::vector<JsonValue> pop(const std::string& queue,
                                std::optional<int> count = std::nullopt);
     std::vector<JsonValue> peek(const std::string& queue,
@@ -214,7 +217,7 @@ public:
     std::vector<JsonValue> read_wait(const std::string& queue,
                                      const std::string& consumer,
                                      int64_t wait_ms,
-                                     const ReadWaitOptions& opts = {});
+                                     const ReadWaitOptions& opts = ReadWaitOptions{});
 
 private:
     std::vector<JsonValue> fetch(const char* verb, const std::string& queue,

--- a/drivers/cpp/tests/value_codec_test.cpp
+++ b/drivers/cpp/tests/value_codec_test.cpp
@@ -13,6 +13,7 @@
 #include <span>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using reddb::Value;
@@ -195,8 +196,9 @@ TEST(ValueCodec, EncodesQueryWithParamsPayload) {
 }
 
 TEST(ValueCodec, AcceptedCppSnippetParamShapeCompiles) {
-    auto encoded = encode_query_with_params("SELECT $1", {Value::int64(42)});
-    EXPECT_EQ(encoded[0], 8);
+    constexpr std::string_view sql = "SELECT $1";
+    auto encoded = encode_query_with_params(sql, {Value::int64(42)});
+    EXPECT_EQ(encoded[0], sql.size());
 }
 
 TEST(ValueCodec, HttpParamsUseJsonEnvelopesForTaggedValues) {

--- a/drivers/python/src/high_level.rs
+++ b/drivers/python/src/high_level.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyBytes, PyDict, PyList, PyTuple};
-use pyo3::IntoPyObject;
+use pyo3::{IntoPyObject, Py};
 
 #[cfg(feature = "embedded")]
 use crate::embedded::{EmbeddedRuntime, ParamValue, QueryRows, ScalarOut};
@@ -211,7 +211,7 @@ impl RedDb {
                 let mut ids = Vec::with_capacity(payloads.len());
                 for item in payloads.iter() {
                     let dict = item
-                        .downcast::<PyDict>()
+                        .cast::<PyDict>()
                         .map_err(|_| err("INVALID_PARAMS", "bulk_insert payloads must be dicts"))?;
                     let fields = pydict_to_fields(dict)?;
                     let result = rt
@@ -232,7 +232,7 @@ impl RedDb {
                 let mut encoded = Vec::with_capacity(payloads.len());
                 for item in payloads.iter() {
                     let dict = item
-                        .downcast::<PyDict>()
+                        .cast::<PyDict>()
                         .map_err(|_| err("INVALID_PARAMS", "bulk_insert payloads must be dicts"))?;
                     encoded.push(pydict_to_json_str(dict)?);
                 }
@@ -316,11 +316,11 @@ impl RedDb {
                     .map_err(|e| err("QUERY_ERROR", e.to_string()))?;
                 let result = grpc_query_json_to_pydict(py, &json_str)?;
                 let rows_any = result.get_item("rows")?.expect("rows set");
-                let rows = rows_any.downcast::<PyList>()?;
+                let rows = rows_any.cast::<PyList>()?;
                 if rows.is_empty() {
                     Ok(None)
                 } else {
-                    Ok(Some(rows.get_item(0)?.downcast_into::<PyDict>()?))
+                    Ok(Some(rows.get_item(0)?.cast_into::<PyDict>()?))
                 }
             }
         }
@@ -371,7 +371,7 @@ impl RedDb {
                 grpc_query_json_to_pydict(py, &json_str)?
                     .get_item("rows")?
                     .expect("rows set")
-                    .downcast_into::<PyList>()?
+                    .cast_into::<PyList>()?
             }
         };
         let out = PyDict::new(py);
@@ -1325,14 +1325,14 @@ fn collect_params<'py>(
         if kw.is_none() {
             return collect_args(args);
         }
-        if let Ok(list) = kw.downcast::<PyList>() {
+        if let Ok(list) = kw.cast::<PyList>() {
             let mut out = Vec::with_capacity(list.len());
             for item in list.iter() {
                 out.push(item);
             }
             return Ok(out);
         }
-        if let Ok(tuple) = kw.downcast::<PyTuple>() {
+        if let Ok(tuple) = kw.cast::<PyTuple>() {
             let mut out = Vec::with_capacity(tuple.len());
             for item in tuple.iter() {
                 out.push(item);
@@ -1388,10 +1388,10 @@ fn py_to_param_value(value: &Bound<'_, PyAny>) -> PyResult<ParamValue> {
         }
     }
 
-    if let Ok(b) = value.downcast::<PyBytes>() {
+    if let Ok(b) = value.cast::<PyBytes>() {
         return Ok(SV::Blob(b.as_bytes().to_vec()));
     }
-    if let Ok(ba) = value.downcast::<PyByteArray>() {
+    if let Ok(ba) = value.cast::<PyByteArray>() {
         let bytes = unsafe { ba.as_bytes() }.to_vec();
         return Ok(SV::Blob(bytes));
     }
@@ -1399,7 +1399,7 @@ fn py_to_param_value(value: &Bound<'_, PyAny>) -> PyResult<ParamValue> {
     // int — try i64 first, then fall back to u64 for values above i64::MAX.
     // Floats also extract as i64 in pyo3 when the fractional part is zero,
     // so guard by `PyFloat` first.
-    if value.downcast::<PyFloat>().is_err() {
+    if value.cast::<PyFloat>().is_err() {
         if let Ok(i) = value.extract::<i64>() {
             return Ok(SV::Integer(i));
         }
@@ -1416,7 +1416,7 @@ fn py_to_param_value(value: &Bound<'_, PyAny>) -> PyResult<ParamValue> {
     }
 
     // list[float|int] -> Vector
-    if let Ok(list) = value.downcast::<PyListT>() {
+    if let Ok(list) = value.cast::<PyListT>() {
         let mut floats: Vec<f32> = Vec::with_capacity(list.len());
         let mut all_numeric = true;
         for item in list.iter() {
@@ -1452,7 +1452,7 @@ fn py_to_param_value(value: &Bound<'_, PyAny>) -> PyResult<ParamValue> {
 
     // uuid.UUID -> Uuid([u8;16]) via the `.bytes` attribute.
     if let Ok(bytes_attr) = value.getattr("bytes") {
-        if let Ok(b) = bytes_attr.downcast::<PyBytes>() {
+        if let Ok(b) = bytes_attr.cast::<PyBytes>() {
             let raw = b.as_bytes();
             if raw.len() == 16 {
                 let mut arr = [0u8; 16];
@@ -1462,7 +1462,7 @@ fn py_to_param_value(value: &Bound<'_, PyAny>) -> PyResult<ParamValue> {
         }
     }
 
-    if let Ok(dict) = value.downcast::<PyDictT>() {
+    if let Ok(dict) = value.cast::<PyDictT>() {
         let json_str = pydict_to_json_str(dict)?;
         return Ok(SV::Json(json_str.into_bytes()));
     }
@@ -1535,7 +1535,7 @@ fn query_rows_to_pydict<'py>(py: Python<'py>, qr: QueryRows) -> PyResult<Bound<'
 }
 
 #[cfg(feature = "embedded")]
-fn scalar_to_py(py: Python<'_>, v: ScalarOut) -> PyObject {
+fn scalar_to_py(py: Python<'_>, v: ScalarOut) -> Py<PyAny> {
     use pyo3::IntoPyObject;
     match v {
         ScalarOut::Null => py.None(),
@@ -1667,7 +1667,7 @@ fn sql_value_literal(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Strin
             return Ok(if b { "true" } else { "false" }.to_string());
         }
     }
-    if value.downcast::<pyo3::types::PyFloat>().is_err() {
+    if value.cast::<pyo3::types::PyFloat>().is_err() {
         if let Ok(i) = value.extract::<i64>() {
             return Ok(i.to_string());
         }
@@ -1681,7 +1681,7 @@ fn sql_value_literal(py: Python<'_>, value: &Bound<'_, PyAny>) -> PyResult<Strin
     if let Ok(s) = value.extract::<String>() {
         return Ok(sql_string_literal(&s));
     }
-    if value.downcast::<PyDict>().is_ok() || value.downcast::<PyList>().is_ok() {
+    if value.cast::<PyDict>().is_ok() || value.cast::<PyList>().is_ok() {
         return sql_json_literal(py, value);
     }
     Err(err(

--- a/drivers/python/src/lib.rs
+++ b/drivers/python/src/lib.rs
@@ -1,5 +1,6 @@
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use pyo3::{Py, PyAny};
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
 use std::sync::Arc;
@@ -338,9 +339,9 @@ impl WireConnection {
         &self,
         collection: &str,
         columns: Vec<String>,
-        rows: Vec<Vec<PyObject>>,
+        rows: Vec<Vec<Py<PyAny>>>,
     ) -> PyResult<u64> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let ncols = columns.len();
             let nrows = rows.len();
             let mut buf =
@@ -358,18 +359,19 @@ impl WireConnection {
 
             for row in &rows {
                 for val in row {
-                    if val.is_none(py) {
+                    let val = val.bind(py);
+                    if val.is_none() {
                         buf.push(0); // NULL
-                    } else if let Ok(v) = val.extract::<bool>(py) {
+                    } else if let Ok(v) = val.extract::<bool>() {
                         buf.push(4);
                         buf.push(v as u8);
-                    } else if let Ok(v) = val.extract::<i64>(py) {
+                    } else if let Ok(v) = val.extract::<i64>() {
                         buf.push(1);
                         buf.extend_from_slice(&v.to_le_bytes());
-                    } else if let Ok(v) = val.extract::<f64>(py) {
+                    } else if let Ok(v) = val.extract::<f64>() {
                         buf.push(2);
                         buf.extend_from_slice(&v.to_le_bytes());
-                    } else if let Ok(v) = val.extract::<String>(py) {
+                    } else if let Ok(v) = val.extract::<String>() {
                         buf.push(3);
                         buf.extend_from_slice(&(v.len() as u32).to_le_bytes());
                         buf.extend_from_slice(v.as_bytes());
@@ -404,7 +406,7 @@ impl WireConnection {
     }
 }
 
-fn decode_wire_result_to_py(py: Python<'_>, data: &[u8]) -> PyResult<PyObject> {
+fn decode_wire_result_to_py(py: Python<'_>, data: &[u8]) -> PyResult<Py<PyAny>> {
     use pyo3::types::{PyDict, PyList};
 
     if data.len() < 2 {

--- a/drivers/zig/build.zig
+++ b/drivers/zig/build.zig
@@ -47,8 +47,8 @@ pub fn build(b: *std.Build) void {
     });
     lib.root_module.addOptions("build_options", build_options);
     if (enable_zstd) {
-        lib.linkSystemLibrary("zstd");
-        lib.linkLibC();
+        lib.root_module.linkSystemLibrary("zstd", .{});
+        lib.root_module.link_libc = true;
     }
     b.installArtifact(lib);
 
@@ -84,8 +84,8 @@ pub fn build(b: *std.Build) void {
             t.root_module.addImport("reddb", reddb_mod);
         }
         if (enable_zstd) {
-            t.linkSystemLibrary("zstd");
-            t.linkLibC();
+            t.root_module.linkSystemLibrary("zstd", .{});
+            t.root_module.link_libc = true;
         }
         const run_t = b.addRunArtifact(t);
         test_step.dependOn(&run_t.step);
@@ -102,8 +102,8 @@ pub fn build(b: *std.Build) void {
     });
     param_fixtures.root_module.addImport("reddb", reddb_mod);
     if (enable_zstd) {
-        param_fixtures.linkSystemLibrary("zstd");
-        param_fixtures.linkLibC();
+        param_fixtures.root_module.linkSystemLibrary("zstd", .{});
+        param_fixtures.root_module.link_libc = true;
     }
     const run_param_fixtures = b.addRunArtifact(param_fixtures);
     param_fixtures_step.dependOn(&run_param_fixtures.step);

--- a/drivers/zig/build.zig
+++ b/drivers/zig/build.zig
@@ -70,9 +70,11 @@ pub fn build(b: *std.Build) void {
 
     for (test_files) |path| {
         const t = b.addTest(.{
-            .root_source_file = b.path(path),
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .root_source_file = b.path(path),
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         // The reddb module already carries `build_options`; tests
         // that need the flag re-export it through `reddb.build_options`.
@@ -96,9 +98,11 @@ pub fn build(b: *std.Build) void {
         "Run RedWire parameter fixture conformance tests",
     );
     const param_fixtures = b.addTest(.{
-        .root_source_file = b.path("tests/value_codec_test.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/value_codec_test.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     param_fixtures.root_module.addImport("reddb", reddb_mod);
     if (enable_zstd) {

--- a/drivers/zig/build.zig
+++ b/drivers/zig/build.zig
@@ -17,8 +17,8 @@ pub fn build(b: *std.Build) void {
     const enable_zstd = b.option(
         bool,
         "zstd",
-        "Link libzstd for compressed redwire frames (default: auto-detect)",
-    ) orelse detectZstd(b);
+        "Link libzstd for compressed redwire frames (default: false)",
+    ) orelse false;
 
     const reddb_mod = b.addModule("reddb", .{
         .root_source_file = b.path("src/reddb.zig"),
@@ -36,11 +36,14 @@ pub fn build(b: *std.Build) void {
 
     // Static library artifact — gives downstream consumers something
     // to link against without re-compiling the driver from source.
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "reddb",
-        .root_source_file = b.path("src/reddb.zig"),
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/reddb.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     lib.root_module.addOptions("build_options", build_options);
     if (enable_zstd) {
@@ -104,19 +107,4 @@ pub fn build(b: *std.Build) void {
     }
     const run_param_fixtures = b.addRunArtifact(param_fixtures);
     param_fixtures_step.dependOn(&run_param_fixtures.step);
-}
-
-fn detectZstd(b: *std.Build) bool {
-    // Cheap probe: ask pkg-config and trust its exit code. When
-    // pkg-config itself is missing we fall back to "no zstd" so the
-    // build succeeds on minimal CI images.
-    _ = b;
-    var child = std.process.Child.init(&.{ "pkg-config", "--exists", "libzstd" }, std.heap.page_allocator);
-    child.stderr_behavior = .Ignore;
-    child.stdout_behavior = .Ignore;
-    const term = child.spawnAndWait() catch return false;
-    return switch (term) {
-        .Exited => |code| code == 0,
-        else => false,
-    };
 }

--- a/drivers/zig/build.zig.zon
+++ b/drivers/zig/build.zig.zon
@@ -1,4 +1,5 @@
 .{
+    .fingerprint = 0xa43b8ea87b2f740b,
     .name = .reddb,
     .version = "0.1.0",
     .minimum_zig_version = "0.13.0",

--- a/drivers/zig/build.zig.zon
+++ b/drivers/zig/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = "reddb",
+    .name = .reddb,
     .version = "0.1.0",
     .minimum_zig_version = "0.13.0",
     .dependencies = .{},

--- a/drivers/zig/src/redwire/value_codec.zig
+++ b/drivers/zig/src/redwire/value_codec.zig
@@ -2,12 +2,14 @@ const std = @import("std");
 
 const frame = @import("frame.zig");
 
+const ByteList = std.array_list.Managed(u8);
+
 pub const MAX_PARAM_COUNT: usize = 65_536;
 pub const MAX_VALUE_PAYLOAD_LEN: usize = @intCast(frame.MAX_FRAME_SIZE);
 
 pub const ValueTag = enum(u8) {
-    @"null" = 0x00,
-    @"bool" = 0x01,
+    null = 0x00,
+    bool = 0x01,
     int = 0x02,
     float = 0x03,
     text = 0x04,
@@ -19,8 +21,8 @@ pub const ValueTag = enum(u8) {
 };
 
 pub const Value = union(enum) {
-    @"null": void,
-    @"bool": bool,
+    null: void,
+    bool: bool,
     int: i64,
     float: f64,
     text: []const u8,
@@ -36,7 +38,7 @@ pub const Value = union(enum) {
 };
 
 pub fn encodeValue(allocator: std.mem.Allocator, value: Value) ![]u8 {
-    var out = std.ArrayList(u8).init(allocator);
+    var out = ByteList.init(allocator);
     errdefer out.deinit();
     try appendValue(&out, value);
     return out.toOwnedSlice();
@@ -53,7 +55,7 @@ pub fn encodeQueryWithParams(
     if (sql.len > MAX_VALUE_PAYLOAD_LEN) return error.ValuePayloadTooLarge;
     if (params.len > MAX_PARAM_COUNT) return error.TooManyParams;
 
-    var out = std.ArrayList(u8).init(allocator);
+    var out = ByteList.init(allocator);
     errdefer out.deinit();
     try appendU32(&out, @intCast(sql.len));
     try out.appendSlice(sql);
@@ -65,7 +67,7 @@ pub fn encodeQueryWithParams(
 }
 
 pub fn toHttpParamsJson(allocator: std.mem.Allocator, params: []const Value) ![]u8 {
-    var out = std.ArrayList(u8).init(allocator);
+    var out = ByteList.init(allocator);
     errdefer out.deinit();
     try out.append('[');
     for (params, 0..) |param, i| {
@@ -81,7 +83,7 @@ pub fn toHttpQueryBody(
     sql: []const u8,
     params: []const Value,
 ) ![]u8 {
-    var out = std.ArrayList(u8).init(allocator);
+    var out = ByteList.init(allocator);
     errdefer out.deinit();
     try out.appendSlice("{\"query\":");
     try appendJsonString(&out, sql);
@@ -98,11 +100,11 @@ pub fn toHttpQueryBody(
     return out.toOwnedSlice();
 }
 
-fn appendValue(out: *std.ArrayList(u8), value: Value) !void {
+fn appendValue(out: *ByteList, value: Value) !void {
     switch (value) {
-        .@"null" => try out.append(@intFromEnum(ValueTag.@"null")),
-        .@"bool" => |v| {
-            try out.append(@intFromEnum(ValueTag.@"bool"));
+        .null => try out.append(@intFromEnum(ValueTag.null)),
+        .bool => |v| {
+            try out.append(@intFromEnum(ValueTag.bool));
             try out.append(if (v) 1 else 0);
         },
         .int => |v| {
@@ -138,19 +140,19 @@ fn appendValue(out: *std.ArrayList(u8), value: Value) !void {
     }
 }
 
-fn appendLenPrefixed(out: *std.ArrayList(u8), tag: ValueTag, bytes: []const u8) !void {
+fn appendLenPrefixed(out: *ByteList, tag: ValueTag, bytes: []const u8) !void {
     if (bytes.len > MAX_VALUE_PAYLOAD_LEN) return error.ValuePayloadTooLarge;
     try out.append(@intFromEnum(tag));
     try appendU32(out, @intCast(bytes.len));
     try out.appendSlice(bytes);
 }
 
-fn appendHttpParamJson(out: *std.ArrayList(u8), value: Value) !void {
+fn appendHttpParamJson(out: *ByteList, value: Value) !void {
     switch (value) {
-        .@"null" => try out.appendSlice("null"),
-        .@"bool" => |v| try out.appendSlice(if (v) "true" else "false"),
-        .int => |v| try out.writer().print("{d}", .{v}),
-        .float => |v| try out.writer().print("{d}", .{v}),
+        .null => try out.appendSlice("null"),
+        .bool => |v| try out.appendSlice(if (v) "true" else "false"),
+        .int => |v| try out.print("{d}", .{v}),
+        .float => |v| try out.print("{d}", .{v}),
         .text => |v| try appendJsonString(out, v),
         .bytes => |v| {
             const encoded_len = std.base64.standard.Encoder.calcSize(v.len);
@@ -165,12 +167,12 @@ fn appendHttpParamJson(out: *std.ArrayList(u8), value: Value) !void {
             try out.append('[');
             for (v, 0..) |f, i| {
                 if (i > 0) try out.append(',');
-                try out.writer().print("{d}", .{f});
+                try out.print("{d}", .{f});
             }
             try out.append(']');
         },
         .json => |v| try out.appendSlice(v),
-        .timestamp => |v| try out.writer().print("{{\"$ts\":{d}}}", .{v}),
+        .timestamp => |v| try out.print("{{\"$ts\":{d}}}", .{v}),
         .uuid => |v| {
             try out.appendSlice("{\"$uuid\":");
             var buf: [36]u8 = undefined;
@@ -181,7 +183,7 @@ fn appendHttpParamJson(out: *std.ArrayList(u8), value: Value) !void {
     }
 }
 
-fn appendJsonString(out: *std.ArrayList(u8), s: []const u8) !void {
+fn appendJsonString(out: *ByteList, s: []const u8) !void {
     try out.append('"');
     for (s) |c| {
         switch (c) {
@@ -204,19 +206,19 @@ fn appendJsonString(out: *std.ArrayList(u8), s: []const u8) !void {
     try out.append('"');
 }
 
-fn appendU32(out: *std.ArrayList(u8), value: u32) !void {
+fn appendU32(out: *ByteList, value: u32) !void {
     var buf: [4]u8 = undefined;
     std.mem.writeInt(u32, buf[0..4], value, .little);
     try out.appendSlice(&buf);
 }
 
-fn appendU64(out: *std.ArrayList(u8), value: u64) !void {
+fn appendU64(out: *ByteList, value: u64) !void {
     var buf: [8]u8 = undefined;
     std.mem.writeInt(u64, buf[0..8], value, .little);
     try out.appendSlice(&buf);
 }
 
-fn appendI64(out: *std.ArrayList(u8), value: i64) !void {
+fn appendI64(out: *ByteList, value: i64) !void {
     try appendU64(out, @bitCast(value));
 }
 

--- a/drivers/zig/tests/value_codec_test.zig
+++ b/drivers/zig/tests/value_codec_test.zig
@@ -31,13 +31,19 @@ fn readFixtureManifest(allocator: std.mem.Allocator) ![]u8 {
         "../../../crates/reddb-wire/tests/fixtures/params/manifest.json",
     };
 
+    const io = std.Options.debug_io;
     for (candidates) |path| {
-        const file = std.fs.cwd().openFile(path, .{}) catch |err| switch (err) {
-            error.FileNotFound => continue,
+        const buffer = try allocator.alloc(u8, 1024 * 1024);
+        errdefer allocator.free(buffer);
+        const bytes = std.Io.Dir.cwd().readFile(io, path, buffer) catch |err| switch (err) {
+            error.FileNotFound => {
+                allocator.free(buffer);
+                continue;
+            },
             else => return err,
         };
-        defer file.close();
-        return try file.readToEndAlloc(allocator, 1024 * 1024);
+        if (bytes.len == buffer.len) return buffer;
+        return try allocator.realloc(buffer, bytes.len);
     }
     return error.FixtureManifestNotFound;
 }

--- a/scripts/check-sql-reference.py
+++ b/scripts/check-sql-reference.py
@@ -9,8 +9,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 DOC = ROOT / "docs/reference/sql-1-0-x.md"
-LEXER = ROOT / "crates/reddb-server/src/storage/query/lexer.rs"
-SQL = ROOT / "crates/reddb-server/src/storage/query/sql.rs"
+LEXER = ROOT / "crates/reddb-rql/src/lexer.rs"
+SQL = ROOT / "crates/reddb-rql/src/sql.rs"
 
 
 def rust_strings(text: str) -> list[str]:

--- a/scripts/check-temp-residue.sh
+++ b/scripts/check-temp-residue.sh
@@ -23,7 +23,7 @@ tmpdir="${TMPDIR:-/tmp}"
 entries=()
 while IFS= read -r -d '' entry; do
     entries+=("$entry")
-done < <(find "$tmpdir" -maxdepth 1 \
+done < <(find "$tmpdir" -mindepth 1 -maxdepth 1 \
     \( -name 'reddb-*' -o -name 'reddb_*' -o -name '*.rdb' -o -name '*.wal' \) \
     -print0 2>/dev/null || true)
 

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1767,8 +1767,24 @@ enum UiBackend {
     Direct { ws_url: String },
 }
 
+fn ui_handoff_wait_duration() -> Duration {
+    env_string("RED_UI_HANDOFF_WAIT_MS")
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or_else(|| Duration::from_secs(60))
+}
+
+async fn wait_for_ui_handoff(server: &reddb::server::ui_auth::HandoffServer) {
+    let _ = tokio::time::timeout(ui_handoff_wait_duration(), async {
+        while !server.is_consumed() {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+}
+
 /// `red ui <uri> [--server] [--desktop] [--ui-dir DIR] [--port N]
-/// [--tls-ca PEM] [--no-browser]` — the spine of the red-ui integration
+/// [--tls-ca PEM] [--token TOKEN] [--no-browser]` — the spine of the red-ui integration
 /// (issues #1042 / #1044 / #1046, PRD #1041, ADR 0051).
 ///
 /// By default it prefers the installed desktop app: when the `redui://`
@@ -1786,6 +1802,9 @@ enum UiBackend {
 /// the bridge down cleanly on Ctrl-C.
 fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
     let json_mode = wants_json(flags);
+    let token = flag_string(flags, "token")
+        .or_else(|| env_string("RED_UI_TOKEN"))
+        .filter(|value| !value.is_empty());
 
     let uri = match remaining.first() {
         Some(value) => value.clone(),
@@ -1828,6 +1847,55 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
                 std::process::exit(1);
             });
         let env = reddb::server::ui_deeplink::OsDeepLinkEnv;
+        if let Some(token) = token.clone() {
+            if reddb::server::ui_deeplink::DeepLinkEnv::handler_registered(&env) {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("tokio runtime");
+                let handoff = rt.block_on(async {
+                    let server = reddb::server::ui_auth::spawn_handoff_server(token)
+                        .await
+                        .map_err(|err| format!("start UI credential handoff: {err}"))?;
+                    let handoff_url = server.handoff_url();
+                    let deep_link = reddb::server::ui_deeplink::build_deep_link_with_handoff(
+                        &canonical,
+                        &handoff_url,
+                    );
+                    if let Err(err) =
+                        reddb::server::ui_deeplink::DeepLinkEnv::open_url(&env, &deep_link)
+                    {
+                        server.shutdown().await;
+                        return Err(err);
+                    }
+                    wait_for_ui_handoff(&server).await;
+                    server.shutdown().await;
+                    Ok::<_, String>(deep_link)
+                });
+                let deep_link = handoff.unwrap_or_else(|err| {
+                    let msg = format!("deep-link dispatch: {err}");
+                    if json_mode {
+                        json_error("ui", &msg);
+                    }
+                    eprintln!("error: {msg}");
+                    std::process::exit(1);
+                });
+                if json_mode {
+                    json_ok(
+                        "ui",
+                        &format!(
+                            "{{\"dispatch\":\"desktop\",\"auth\":\"handoff\",\"deep_link\":\"{}\",\"target\":\"{}\"}}",
+                            json_escape(&deep_link),
+                            json_escape(&canonical),
+                        ),
+                    );
+                } else {
+                    println!("red ui: handing off to the desktop app");
+                    println!("  {deep_link}");
+                }
+                return;
+            }
+        }
         match reddb::server::ui_deeplink::dispatch(mode, &canonical, &env) {
             Ok(reddb::server::ui_deeplink::DispatchOutcome::HandedOff { deep_link }) => {
                 if json_mode {
@@ -1942,6 +2010,15 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
             (uri.clone(), UiBackend::Remote(target))
         }
         reddb::server::ui_bridge::UiTarget::Direct { ws_url } => {
+            if token.is_some() {
+                let msg = "red ui --token cannot be injected for red+ws:// direct targets; \
+                           use red:// or reds:// so the loopback bridge can hold the token";
+                if json_mode {
+                    json_error("ui", msg);
+                }
+                eprintln!("error: {msg}");
+                std::process::exit(1);
+            }
             // ADR 0047: browser-reachable WS target — no loopback relay.
             // Serve the UI bundle locally and let the browser connect
             // directly to ws_url (already a wss:// or ws:// URL).
@@ -1977,7 +2054,13 @@ fn run_ui_command(flags: &HashMap<String, FlagValue>, remaining: &[String]) {
         .unwrap_or(0);
     let no_browser = flag_bool(flags, "no-browser") || env_truthy("RED_UI_NO_BROWSER");
 
-    let config = reddb::server::ui_bridge::UiBridgeConfig { ui_dir, port };
+    let auth_mode = reddb::server::ui_auth::UiAuthMode::resolve(token.is_some(), false);
+    let config = reddb::server::ui_bridge::UiBridgeConfig {
+        ui_dir,
+        port,
+        injected_token: token,
+        auth_mode,
+    };
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -3092,6 +3175,9 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 cli::types::FlagSchema::new("tls-ca").with_description(
                     "PEM CA bundle to trust for a reds:// target (on top of system roots)",
                 ),
+                cli::types::FlagSchema::new("token")
+                    .with_short('t')
+                    .with_description("Bearer token for UI auth handoff (env: RED_UI_TOKEN)"),
                 cli::types::FlagSchema::boolean("no-browser").with_description(
                     "Do not open the default browser (also honoured via RED_UI_NO_BROWSER)",
                 ),

--- a/testdata/compose/replica.yml
+++ b/testdata/compose/replica.yml
@@ -32,6 +32,7 @@ services:
       - ALL
     environment:
       - RUST_LOG=info
+      - RED_HTTP_TLS_DEV=1
     healthcheck:
       test: ["CMD", "/usr/local/bin/red", "health", "--http", "--bind", "127.0.0.1:8080"]
       interval: 5s
@@ -47,7 +48,6 @@ services:
     ports:
       - "50052:50051"
       - "8081:8080"
-      - "8444:8443"
     volumes:
       - replica-data:/data
     command:
@@ -60,8 +60,6 @@ services:
       - "0.0.0.0:50051"
       - "--http-bind"
       - "0.0.0.0:8080"
-      - "--http-tls-bind"
-      - "0.0.0.0:8443"
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/tests/e2e_ddl_drop_foundation.rs
+++ b/tests/e2e_ddl_drop_foundation.rs
@@ -6,7 +6,10 @@ use reddb::application::ExecuteQueryInput;
 use reddb::auth::{AuthConfig, AuthStore};
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
-use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
+use reddb::{
+    storage::{DeployProfile, StoragePackaging, StorageProfileSelection},
+    QueryUseCases, RedDBOptions, RedDBRuntime,
+};
 
 #[allow(dead_code)]
 mod support;
@@ -29,8 +32,16 @@ fn unique_ident(prefix: &str) -> String {
 }
 
 fn rt_with_vault(path: &Path) -> RedDBRuntime {
-    let rt =
-        RedDBRuntime::with_options(RedDBOptions::persistent(path)).expect("runtime should open");
+    let options = RedDBOptions::persistent(path)
+        .with_storage_profile(StorageProfileSelection {
+            deploy_profile: DeployProfile::Embedded,
+            packaging: StoragePackaging::OperationalDirectory,
+            replica_count: 0,
+            managed_backup: false,
+            wal_retention: false,
+        })
+        .expect("operational storage profile should validate");
+    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/e2e_issue_593_materialized_view_persistence.rs
+++ b/tests/e2e_issue_593_materialized_view_persistence.rs
@@ -21,6 +21,16 @@ fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
 
 #[test]
 fn materialized_view_survives_restart() {
+    std::thread::Builder::new()
+        .name("materialized-view-survives-restart".to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(materialized_view_survives_restart_impl)
+        .expect("spawn materialized view persistence test")
+        .join()
+        .expect("materialized view persistence test panicked");
+}
+
+fn materialized_view_survives_restart_impl() {
     let path = persistent_path("mv_persist_survives");
 
     // ── First boot: create table, insert rows, define materialized view.

--- a/tests/e2e_issue_594_materialized_view_backing.rs
+++ b/tests/e2e_issue_594_materialized_view_backing.rs
@@ -17,8 +17,25 @@ fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
 }
 
+fn run_with_large_stack(name: &str, f: fn()) {
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn materialized view backing test")
+        .join()
+        .expect("materialized view backing test panicked");
+}
+
 #[test]
 fn create_materialized_view_provisions_empty_backing_collection() {
+    run_with_large_stack(
+        "create-materialized-view-provisions-empty-backing-collection",
+        create_materialized_view_provisions_empty_backing_collection_impl,
+    );
+}
+
+fn create_materialized_view_provisions_empty_backing_collection_impl() {
     let rt = open_runtime();
     exec(&rt, "CREATE TABLE orders (id INT, total INT, status TEXT)");
     exec(
@@ -63,6 +80,13 @@ fn create_materialized_view_provisions_empty_backing_collection() {
 
 #[test]
 fn drop_materialized_view_drops_backing_collection() {
+    run_with_large_stack(
+        "drop-materialized-view-drops-backing-collection",
+        drop_materialized_view_drops_backing_collection_impl,
+    );
+}
+
+fn drop_materialized_view_drops_backing_collection_impl() {
     let rt = open_runtime();
     exec(&rt, "CREATE TABLE t (id INT)");
     exec(&rt, "CREATE MATERIALIZED VIEW mv AS SELECT id FROM t");
@@ -87,6 +111,13 @@ fn drop_materialized_view_drops_backing_collection() {
 
 #[test]
 fn regular_view_rewrite_unchanged_after_slice_9b() {
+    run_with_large_stack(
+        "regular-view-rewrite-unchanged-after-slice-9b",
+        regular_view_rewrite_unchanged_after_slice_9b_impl,
+    );
+}
+
+fn regular_view_rewrite_unchanged_after_slice_9b_impl() {
     let rt = open_runtime();
     exec(&rt, "CREATE TABLE users (id INT, active BOOLEAN)");
     exec(

--- a/tests/e2e_issue_595_materialized_view_atomic_refresh.rs
+++ b/tests/e2e_issue_595_materialized_view_atomic_refresh.rs
@@ -25,8 +25,25 @@ fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
 }
 
+fn run_with_large_stack(name: &str, f: fn()) {
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn materialized view atomic refresh test")
+        .join()
+        .expect("materialized view atomic refresh test panicked");
+}
+
 #[test]
 fn refresh_writes_through_backing_collection_and_scrapes_live_count() {
+    run_with_large_stack(
+        "refresh-writes-through-backing-collection-and-scrapes-live-count",
+        refresh_writes_through_backing_collection_and_scrapes_live_count_impl,
+    );
+}
+
+fn refresh_writes_through_backing_collection_and_scrapes_live_count_impl() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("rt");
     exec(&rt, "CREATE TABLE orders (id INT, total INT, status TEXT)");
     exec(
@@ -88,6 +105,13 @@ fn refresh_writes_through_backing_collection_and_scrapes_live_count() {
 
 #[test]
 fn concurrent_reader_sees_old_or_new_never_partial() {
+    run_with_large_stack(
+        "concurrent-reader-sees-old-or-new-never-partial",
+        concurrent_reader_sees_old_or_new_never_partial_impl,
+    );
+}
+
+fn concurrent_reader_sees_old_or_new_never_partial_impl() {
     // Pre-populate enough source rows that REFRESH is large enough to
     // span at least a few reader iterations. The contract under test
     // is "no intermediate state" — assertion is row count ∈ {N, M},
@@ -177,6 +201,13 @@ fn concurrent_reader_sees_old_or_new_never_partial() {
 
 #[test]
 fn refresh_survives_clean_restart() {
+    run_with_large_stack(
+        "refresh-survives-clean-restart",
+        refresh_survives_clean_restart_impl,
+    );
+}
+
+fn refresh_survives_clean_restart_impl() {
     let path = persistent_path("mv_atomic_refresh_clean");
 
     // First boot: source → MV → REFRESH → 2 rows visible through MV.
@@ -221,6 +252,13 @@ fn refresh_survives_clean_restart() {
 
 #[test]
 fn refresh_failure_leaves_prior_backing_intact() {
+    run_with_large_stack(
+        "refresh-failure-leaves-prior-backing-intact",
+        refresh_failure_leaves_prior_backing_intact_impl,
+    );
+}
+
+fn refresh_failure_leaves_prior_backing_intact_impl() {
     // Models "crash mid-refresh" by way of an error that aborts the
     // refresh handler before it runs through the atomic swap. The
     // contract is the same: prior backing contents must remain
@@ -257,6 +295,13 @@ fn refresh_failure_leaves_prior_backing_intact() {
 
 #[test]
 fn refresh_completes_within_reasonable_time_smoke() {
+    run_with_large_stack(
+        "refresh-completes-within-reasonable-time-smoke",
+        refresh_completes_within_reasonable_time_smoke_impl,
+    );
+}
+
+fn refresh_completes_within_reasonable_time_smoke_impl() {
     // Lightweight perf-regression guard: the atomic-refresh path is
     // O(rows) in the body's row count and a single REFRESH on a few
     // hundred rows should finish well under a second on a dev laptop.

--- a/tests/e2e_issue_596_materialized_view_replica_replay.rs
+++ b/tests/e2e_issue_596_materialized_view_replica_replay.rs
@@ -107,8 +107,25 @@ fn snapshot(store: &Arc<UnifiedStore>, collection: &str) -> Vec<(u64, Vec<(Strin
     rows
 }
 
+fn run_with_large_stack(name: &str, f: fn()) {
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn materialized view replica replay test")
+        .join()
+        .expect("materialized view replica replay test panicked");
+}
+
 #[test]
 fn replica_replay_of_refresh_collection_matches_primary_row_for_row() {
+    run_with_large_stack(
+        "replica-replay-of-refresh-collection-matches-primary-row-for-row",
+        replica_replay_of_refresh_collection_matches_primary_row_for_row_impl,
+    );
+}
+
+fn replica_replay_of_refresh_collection_matches_primary_row_for_row_impl() {
     let primary_path = temp_path("primary-rowforrow");
     let replica_path = temp_path("replica-rowforrow");
 
@@ -168,6 +185,13 @@ fn replica_replay_of_refresh_collection_matches_primary_row_for_row() {
 
 #[test]
 fn replica_replay_of_refresh_collection_is_idempotent() {
+    run_with_large_stack(
+        "replica-replay-of-refresh-collection-is-idempotent",
+        replica_replay_of_refresh_collection_is_idempotent_impl,
+    );
+}
+
+fn replica_replay_of_refresh_collection_is_idempotent_impl() {
     let path = temp_path("idempotent");
     let primary_path = temp_path("idempotent-primary");
 
@@ -221,6 +245,13 @@ fn replica_replay_of_refresh_collection_is_idempotent() {
 
 #[test]
 fn primary_refresh_materialized_view_emits_refresh_cdc_event() {
+    run_with_large_stack(
+        "primary-refresh-materialized-view-emits-refresh-cdc-event",
+        primary_refresh_materialized_view_emits_refresh_cdc_event_impl,
+    );
+}
+
+fn primary_refresh_materialized_view_emits_refresh_cdc_event_impl() {
     let primary_path = temp_path("primary-cdc");
     let opts =
         RedDBOptions::persistent(&primary_path).with_replication(ReplicationConfig::primary());

--- a/tests/e2e_txcommitbatch_explicit_tx.rs
+++ b/tests/e2e_txcommitbatch_explicit_tx.rs
@@ -9,17 +9,20 @@ use reddb::api::DurabilityMode;
 use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
 use reddb::storage::schema::Value;
 use reddb::storage::wal::{WalReader, WalRecord};
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 fn db_open(db: &support::TempDbFile) -> RedDBRuntime {
     RedDBRuntime::with_options(
-        RedDBOptions::persistent(db.path()).with_durability_mode(DurabilityMode::WalDurableGrouped),
+        RedDBOptions::persistent(db.path())
+            .with_durability_mode(DurabilityMode::WalDurableGrouped)
+            .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+            .expect("primary-replica operational profile"),
     )
     .expect("persistent runtime")
 }
 
 fn db_wal_path(db: &support::TempDbFile) -> PathBuf {
-    db.path().with_extension("rdb-uwal")
+    reddb_file::unified_wal_path(db.path())
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -3,6 +3,7 @@ mod support;
 
 use std::sync::Arc;
 
+use reddb::auth::enforcement_mode::PolicyEnforcementMode;
 use reddb::auth::{AuthConfig, AuthStore, Role};
 use reddb::replication::cdc::ChangeOperation;
 use reddb::runtime::mvcc::{
@@ -110,6 +111,7 @@ fn attach_alice_policy(store: &AuthStore, id: &str, statements: &str) {
 fn explicit_targets_are_authorized_as_ordinary_updates() {
     let rt = runtime();
     let auth = Arc::new(AuthStore::new(AuthConfig::default()));
+    auth.set_enforcement_mode(PolicyEnforcementMode::PolicyOnly);
     auth.create_user("alice", "p", Role::Write).unwrap();
     rt.set_auth_store(Arc::clone(&auth));
     attach_alice_policy(

--- a/tests/e2e_views.rs
+++ b/tests/e2e_views.rs
@@ -22,8 +22,25 @@ fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
 }
 
+fn run_with_large_stack(name: &str, f: fn()) {
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn view e2e test")
+        .join()
+        .expect("view e2e test panicked");
+}
+
 #[test]
 fn view_body_filters_rows_via_select_from_view() {
+    run_with_large_stack(
+        "view-body-filters-rows-via-select-from-view",
+        view_body_filters_rows_via_select_from_view_impl,
+    );
+}
+
+fn view_body_filters_rows_via_select_from_view_impl() {
     let rt = open_runtime();
     exec(
         &rt,
@@ -71,6 +88,13 @@ fn view_body_filters_rows_via_select_from_view() {
 
 #[test]
 fn materialized_view_refresh_executes_body() {
+    run_with_large_stack(
+        "materialized-view-refresh-executes-body",
+        materialized_view_refresh_executes_body_impl,
+    );
+}
+
+fn materialized_view_refresh_executes_body_impl() {
     let rt = open_runtime();
     exec(&rt, "CREATE TABLE orders (id INT, total INT, status TEXT)");
     exec(
@@ -102,6 +126,13 @@ fn materialized_view_refresh_executes_body() {
 
 #[test]
 fn view_chain_resolves_recursively() {
+    run_with_large_stack(
+        "view-chain-resolves-recursively",
+        view_chain_resolves_recursively_impl,
+    );
+}
+
+fn view_chain_resolves_recursively_impl() {
     let rt = open_runtime();
     exec(
         &rt,

--- a/tests/e2e_within_clause.rs
+++ b/tests/e2e_within_clause.rs
@@ -16,6 +16,16 @@ fn rows(rt: &RedDBRuntime, sql: &str) -> usize {
     rt.execute_query(sql).unwrap().result.records.len()
 }
 
+fn run_with_large_stack(name: &str, f: fn()) {
+    std::thread::Builder::new()
+        .name(name.to_string())
+        .stack_size(16 * 1024 * 1024)
+        .spawn(f)
+        .expect("spawn within-clause e2e test")
+        .join()
+        .expect("within-clause e2e test panicked");
+}
+
 #[test]
 fn within_tenant_filters_select() {
     let rt = open_runtime();
@@ -196,6 +206,10 @@ fn within_filters_join_between_two_tenant_tables() {
 
 #[test]
 fn within_works_through_view() {
+    run_with_large_stack("within-works-through-view", within_works_through_view_impl);
+}
+
+fn within_works_through_view_impl() {
     let rt = open_runtime();
     exec(
         &rt,

--- a/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
+++ b/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
@@ -5,9 +5,10 @@ use reddb::storage::schema::Value;
 use reddb::RedDBRuntime;
 use std::collections::BTreeMap;
 use std::net::TcpListener;
-use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+
+use super::support::env_lock;
 
 const COMMENTS_PER_TOPIC: usize = 20;
 const TOPIC_COUNT: usize = 10;
@@ -70,11 +71,6 @@ struct ClusterAssignment {
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
-}
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 fn required_env(key: &str) -> String {

--- a/tests/grouped/ai_local_vector/integration_ai_local_models_cache.rs
+++ b/tests/grouped/ai_local_vector/integration_ai_local_models_cache.rs
@@ -25,6 +25,12 @@ fn spawn_http_server(rt: RedDBRuntime) -> String {
     addr.to_string()
 }
 
+fn spawn_persistent_http_server(tag: &str) -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime(tag);
+    let addr = spawn_http_server(rt);
+    (db, addr)
+}
+
 fn send(addr: &str, method: &str, path: &str, body: &str) -> (u16, String) {
     let request = format!(
         "{method} {path} HTTP/1.1\r\n\
@@ -90,7 +96,7 @@ fn configure_cache_dir(addr: &str, path: &Path) {
 
 #[test]
 fn pull_installs_artifact_from_fixture_and_writes_manifest() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-pull");
     let cache_dir = unique_temp_dir("pull_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -136,7 +142,7 @@ fn pull_installs_artifact_from_fixture_and_writes_manifest() {
 
 #[test]
 fn pull_without_fixture_returns_actionable_error() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-no-fixture");
     let cache_dir = unique_temp_dir("no_fixture_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -152,7 +158,7 @@ fn pull_without_fixture_returns_actionable_error() {
 
 #[test]
 fn pull_with_missing_fixture_dir_returns_400() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-missing-fixture");
     let cache_dir = unique_temp_dir("missing_fixture_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -176,7 +182,7 @@ fn pull_with_missing_fixture_dir_returns_400() {
 
 #[test]
 fn pull_against_unregistered_model_returns_404() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-unregistered");
     let cache_dir = unique_temp_dir("unreg_cache");
     configure_cache_dir(&addr, &cache_dir);
     let fixture = make_fixture("unreg");
@@ -187,7 +193,7 @@ fn pull_against_unregistered_model_returns_404() {
 
 #[test]
 fn cache_drop_removes_artifacts_but_keeps_registration() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-drop");
     let cache_dir = unique_temp_dir("drop_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -226,7 +232,7 @@ fn cache_drop_removes_artifacts_but_keeps_registration() {
 
 #[test]
 fn corrupt_manifest_makes_cache_unhealthy() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-corrupt");
     let cache_dir = unique_temp_dir("corrupt_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -248,7 +254,7 @@ fn corrupt_manifest_makes_cache_unhealthy() {
 
 #[test]
 fn missing_artifact_file_makes_cache_unhealthy() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-missing-artifact");
     let cache_dir = unique_temp_dir("missing_file_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -267,7 +273,7 @@ fn missing_artifact_file_makes_cache_unhealthy() {
 
 #[test]
 fn pull_is_idempotent_and_overwrites_existing_install() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-idempotent");
     let cache_dir = unique_temp_dir("idempotent_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -300,7 +306,7 @@ fn pull_is_idempotent_and_overwrites_existing_install() {
 
 #[test]
 fn fixture_dir_via_config_works_when_request_omits_it() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-config-fixture");
     let cache_dir = unique_temp_dir("config_fixture_cache");
     configure_cache_dir(&addr, &cache_dir);
     register(&addr);
@@ -322,7 +328,7 @@ fn fixture_dir_via_config_works_when_request_omits_it() {
 
 #[test]
 fn cache_status_404_for_unregistered_model() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-cache-status-404");
     let (status, body) = send(&addr, "GET", "/ai/models/does-not-exist/cache", "");
     assert_eq!(status, 404, "{body}");
 }

--- a/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
+++ b/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
@@ -17,7 +17,7 @@
 //!     match existing OpenAI-path semantics, so the assertion is on
 //!     the deterministic error variant.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 
 use reddb::application::{CreateKvInput, EntityUseCases, ExecuteQueryInput, QueryUseCases};
 use reddb::runtime::ai::local_embedding::{
@@ -27,10 +27,7 @@ use reddb::runtime::ai::local_embedding::{
 use reddb::storage::schema::Value;
 use reddb::{RedDBError, RedDBResult, RedDBRuntime};
 
-fn backend_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
+use super::support::backend_lock;
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("in-memory runtime")

--- a/tests/grouped/ai_local_vector/integration_vector_query_text.rs
+++ b/tests/grouped/ai_local_vector/integration_vector_query_text.rs
@@ -5,8 +5,9 @@ use reddb::RedDBRuntime;
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
-use std::sync::{Mutex, OnceLock};
 use std::thread;
+
+use super::support::env_lock;
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
@@ -25,11 +26,6 @@ fn text(record: &UnifiedRecord, column: &str) -> String {
         Some(Value::Text(value)) => value.to_string(),
         other => panic!("expected text value for {column}, got {other:?}"),
     }
-}
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 struct EnvGuard {

--- a/tests/grouped/ai_local_vector/integration_vector_query_text_local.rs
+++ b/tests/grouped/ai_local_vector/integration_vector_query_text_local.rs
@@ -7,7 +7,7 @@
 //! without downloading anything.
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
 use reddb::application::{CreateKvInput, EntityUseCases, ExecuteQueryInput, QueryUseCases};
 use reddb::runtime::ai::local_embedding::{
@@ -18,10 +18,7 @@ use reddb::storage::query::UnifiedRecord;
 use reddb::storage::schema::Value;
 use reddb::{RedDBError, RedDBResult, RedDBRuntime};
 
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
+use super::support::{backend_lock, env_lock};
 
 struct EnvGuard {
     saved: Vec<(&'static str, Option<String>)>,
@@ -121,11 +118,6 @@ impl LocalEmbeddingBackend for FixedBackend {
 
 /// Process-global backend slot serialisation. Mirrors the unit-test
 /// strategy in `handlers_ai.rs::tests`.
-fn backend_lock() -> &'static Mutex<()> {
-    static L: OnceLock<Mutex<()>> = OnceLock::new();
-    L.get_or_init(|| Mutex::new(()))
-}
-
 #[test]
 fn text_vector_search_routes_through_local_provider_when_default_provider_is_local() {
     let _env = env_lock().lock().unwrap_or_else(|p| p.into_inner());

--- a/tests/grouped/ai_local_vector/snowplow_adapter_example.rs
+++ b/tests/grouped/ai_local_vector/snowplow_adapter_example.rs
@@ -3,22 +3,24 @@
 //! collection contains the expected rows. Keeps the example
 //! from going stale — referenced by `docs/migrating-from-snowplow.md`.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command;
 use std::time::Duration;
 
 use reddb::server::RedDBServer;
-use reddb::RedDBRuntime;
 use serde_json::{json, Value};
 
-fn spawn_http_server() -> String {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("snowplow-http");
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> Value {
@@ -59,7 +61,7 @@ fn snowplow_adapter_example_ingests_events_end_to_end() {
         return;
     }
 
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
     let create = post_query(
         &addr,
         "CREATE TABLE events (event_id TEXT, collector_tstamp INTEGER, event_name TEXT, payload TEXT)",

--- a/tests/grouped/ai_local_vector/support.rs
+++ b/tests/grouped/ai_local_vector/support.rs
@@ -1,0 +1,11 @@
+use std::sync::{Mutex, OnceLock};
+
+pub(crate) fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub(crate) fn backend_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/tests/grouped/ai_provider_contracts/integration_ai_local_models_registry.rs
+++ b/tests/grouped/ai_provider_contracts/integration_ai_local_models_registry.rs
@@ -13,6 +13,9 @@
 //!
 //! No artifacts are pulled — this slice is metadata-only.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
@@ -26,6 +29,12 @@ fn spawn_http_server(rt: RedDBRuntime) -> String {
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
     addr.to_string()
+}
+
+fn spawn_persistent_http_server(tag: &str) -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime(tag);
+    let addr = spawn_http_server(rt);
+    (db, addr)
 }
 
 fn send(addr: &str, method: &str, path: &str, body: &str) -> (u16, String) {
@@ -72,7 +81,7 @@ const MINIMAL_VALID: &str = r#"{
 
 #[test]
 fn register_persists_a_valid_local_embedding_model() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-register");
 
     let (status, body) = send(&addr, "POST", "/ai/models", MINIMAL_VALID);
     assert_eq!(status, 201, "register failed: {body}");
@@ -103,7 +112,7 @@ fn register_persists_a_valid_local_embedding_model() {
 
 #[test]
 fn register_rejects_duplicate_model_name() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-duplicate");
     let (status, _) = send(&addr, "POST", "/ai/models", MINIMAL_VALID);
     assert_eq!(status, 201);
 
@@ -115,7 +124,7 @@ fn register_rejects_duplicate_model_name() {
 
 #[test]
 fn register_rejects_empty_source_name_revision_task() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-invalid-fields");
 
     for (case, payload, must_contain) in [
         (
@@ -180,7 +189,7 @@ fn register_rejects_empty_source_name_revision_task() {
 
 #[test]
 fn register_rejects_prompt_or_generation_task() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-unsupported-task");
 
     for task in ["prompt", "generation", "chat", "completion"] {
         let payload = format!(
@@ -199,7 +208,7 @@ fn register_rejects_prompt_or_generation_task() {
 
 #[test]
 fn register_rejects_unknown_task() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-unknown-task");
     let payload = r#"{"name":"m1","source":"x/y","task":"vision","revision":"abc","dimensions":4}"#;
     let (status, body) = send(&addr, "POST", "/ai/models", payload);
     assert_eq!(status, 400, "{body}");
@@ -208,7 +217,7 @@ fn register_rejects_unknown_task() {
 
 #[test]
 fn trust_policy_defaults_to_disabled_and_rejects_unacknowledged_remote_code() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-trust-policy");
 
     let (status, _) = send(&addr, "POST", "/ai/models", MINIMAL_VALID);
     assert_eq!(status, 201);
@@ -260,7 +269,7 @@ fn trust_policy_defaults_to_disabled_and_rejects_unacknowledged_remote_code() {
 
 #[test]
 fn update_rejects_missing_or_invalid_fields() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-update-invalid");
     let (status, _) = send(&addr, "POST", "/ai/models", MINIMAL_VALID);
     assert_eq!(status, 201);
 
@@ -316,7 +325,7 @@ fn update_rejects_missing_or_invalid_fields() {
 
 #[test]
 fn inspect_unknown_model_returns_404() {
-    let addr = spawn_http_server(RedDBRuntime::in_memory().expect("rt"));
+    let (_db, addr) = spawn_persistent_http_server("ai-registry-inspect-404");
     let (status, body) = send(&addr, "GET", "/ai/models/does-not-exist", "");
     assert_eq!(status, 404, "{body}");
 }
@@ -326,7 +335,7 @@ fn registered_model_survives_runtime_handoff() {
     // Persistence within the same runtime handle is the strongest
     // guarantee we can prove with the in-memory runtime, which still
     // exercises the durable red_config storage layer.
-    let rt = RedDBRuntime::in_memory().expect("rt");
+    let (_db, rt) = support::persistent_runtime("ai-registry-handoff");
     let addr = spawn_http_server(rt);
     let (status, _) = send(&addr, "POST", "/ai/models", MINIMAL_VALID);
     assert_eq!(status, 201);

--- a/tests/grouped/ai_provider_contracts/integration_ai_multi_provider.rs
+++ b/tests/grouped/ai_provider_contracts/integration_ai_multi_provider.rs
@@ -11,6 +11,9 @@
 //! We do not hit real network. Compatible providers reach the HTTP
 //! transport and fail there, which proves the guard was passed.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use reddb::ai::{grpc_embeddings, parse_provider};
 use reddb::application::{ExecuteQueryInput, QueryUseCases, SearchSimilarInput};
 use reddb::json::{Map, Value as JsonValue};
@@ -38,6 +41,12 @@ fn spawn_http_server(rt: RedDBRuntime) -> String {
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
     addr.to_string()
+}
+
+fn spawn_persistent_http_server(tag: &str) -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime(tag);
+    let addr = spawn_http_server(rt);
+    (db, addr)
 }
 
 fn post_json(addr: &str, path: &str, body: &str) -> (u16, String) {
@@ -162,7 +171,7 @@ fn grpc_embeddings_huggingface_dispatches_to_hf_client() {
 #[test]
 #[cfg(not(feature = "local-models"))]
 fn http_embeddings_rejects_local_when_local_models_feature_is_disabled() {
-    let addr = spawn_http_server(rt());
+    let (_db, addr) = spawn_persistent_http_server("ai-multi-local-embeddings-http");
     let (status, body) = post_json(
         &addr,
         "/ai/embeddings",
@@ -175,7 +184,7 @@ fn http_embeddings_rejects_local_when_local_models_feature_is_disabled() {
 
 #[test]
 fn http_prompt_rejects_local_because_generation_is_out_of_scope() {
-    let addr = spawn_http_server(rt());
+    let (_db, addr) = spawn_persistent_http_server("ai-multi-local-prompt-http");
     let (status, body) = post_json(
         &addr,
         "/ai/prompt",

--- a/tests/grouped/ai_search/e2e_ask_search_conformance.rs
+++ b/tests/grouped/ai_search/e2e_ask_search_conformance.rs
@@ -40,10 +40,12 @@ use super::support::env_lock;
 
 use reddb::application::SearchContextInput;
 use reddb::storage::schema::Value;
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::RedDBRuntime;
 
-fn open_rt() -> RedDBRuntime {
-    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+use super::support::PersistentRuntime;
+
+fn open_rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("ask-search-conformance")
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {

--- a/tests/grouped/ai_search/e2e_ask_search_conformance.rs
+++ b/tests/grouped/ai_search/e2e_ask_search_conformance.rs
@@ -32,19 +32,15 @@
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+use super::support::env_lock;
 
 use reddb::application::SearchContextInput;
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
-
-/// Process-wide lock around the AI env vars. The ASK provider lookup
-/// reads `REDDB_OPENAI_API_BASE` / `REDDB_OPENAI_API_KEY` from the
-/// process environment, so any test that mutates them has to serialise
-/// against every other test that does.
-static ASK_ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn open_rt() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
@@ -257,7 +253,7 @@ fn value_to_i64(value: &Value) -> Option<i64> {
 
 #[test]
 fn ask_with_mock_provider_cites_grounded_sources() {
-    let _env = ASK_ENV_LOCK.lock().expect("env lock");
+    let _env = env_lock().lock().expect("env lock");
 
     let stub = MockOpenAiStub::start("the incident is mocked [^1]");
     let _api_base = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
@@ -370,7 +366,7 @@ fn ask_with_mock_provider_cites_grounded_sources() {
 
 #[test]
 fn ask_without_grounding_yields_clear_limitation() {
-    let _env = ASK_ENV_LOCK.lock().expect("env lock");
+    let _env = env_lock().lock().expect("env lock");
 
     // Provider stub wired in, but the pipeline must short-circuit BEFORE
     // any LLM round-trip when no usable tokens / candidates can be

--- a/tests/grouped/ai_search/e2e_ask_tenant_scoped.rs
+++ b/tests/grouped/ai_search/e2e_ask_tenant_scoped.rs
@@ -10,10 +10,12 @@ use reddb::application::SearchContextInput;
 use reddb::runtime::mvcc::{
     clear_current_connection_id, set_current_connection_id, set_current_tenant,
 };
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::RedDBRuntime;
 
-fn open_runtime() -> RedDBRuntime {
-    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+use super::support::PersistentRuntime;
+
+fn open_runtime() -> PersistentRuntime {
+    super::support::persistent_test_runtime("ask-tenant-scoped")
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {

--- a/tests/grouped/ai_search/e2e_comment_clustering.rs
+++ b/tests/grouped/ai_search/e2e_comment_clustering.rs
@@ -446,7 +446,7 @@ fn e2e_comments_embedding_cluster_label_and_writeback() {
     ]);
 
     let rt = rt();
-    seed_comments(&rt);
+    seed_comments(rt.runtime());
     let http_base = spawn_reddb_http(rt.clone_runtime());
     let query = QueryUseCases::new(rt.runtime());
 

--- a/tests/grouped/ai_search/e2e_comment_clustering.rs
+++ b/tests/grouped/ai_search/e2e_comment_clustering.rs
@@ -9,7 +9,7 @@ use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
-use super::support::env_lock;
+use super::support::{env_lock, PersistentRuntime};
 
 const COMMENTS_PER_TOPIC: usize = 20;
 const TOPIC_COUNT: usize = 10;
@@ -71,8 +71,8 @@ struct ClusterAssignment {
     content: String,
 }
 
-fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
+fn rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("ai-comment-clustering")
 }
 
 struct EnvGuard {
@@ -447,8 +447,8 @@ fn e2e_comments_embedding_cluster_label_and_writeback() {
 
     let rt = rt();
     seed_comments(&rt);
-    let http_base = spawn_reddb_http(rt.clone());
-    let query = QueryUseCases::new(&rt);
+    let http_base = spawn_reddb_http(rt.clone_runtime());
+    let query = QueryUseCases::new(rt.runtime());
 
     let embedding_payload: JsonValue = from_str(
         r#"{

--- a/tests/grouped/ai_search/e2e_comment_clustering.rs
+++ b/tests/grouped/ai_search/e2e_comment_clustering.rs
@@ -6,9 +6,10 @@ use reddb::RedDBRuntime;
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::{Mutex, OnceLock};
 use std::thread;
 use std::time::Duration;
+
+use super::support::env_lock;
 
 const COMMENTS_PER_TOPIC: usize = 20;
 const TOPIC_COUNT: usize = 10;
@@ -72,11 +73,6 @@ struct ClusterAssignment {
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
-}
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 struct EnvGuard {

--- a/tests/grouped/ai_search/e2e_issue_557_ask_context_retrieval.rs
+++ b/tests/grouped/ai_search/e2e_issue_557_ask_context_retrieval.rs
@@ -44,10 +44,12 @@
 
 use reddb::application::SearchContextInput;
 use reddb::storage::schema::Value;
-use reddb::{RedDBOptions, RedDBRuntime};
+use reddb::RedDBRuntime;
 
-fn open_rt() -> RedDBRuntime {
-    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+use super::support::PersistentRuntime;
+
+fn open_rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("issue-557-ask-context")
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {

--- a/tests/grouped/ai_search/e2e_ml_classify.rs
+++ b/tests/grouped/ai_search/e2e_ml_classify.rs
@@ -12,6 +12,8 @@ use reddb::storage::ml::ModelVersion;
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBRuntime};
 
+use super::support::env_lock;
+
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("in-memory runtime")
 }
@@ -168,6 +170,8 @@ fn semantic_cache_roundtrip_via_sql() {
 
 #[test]
 fn embed_returns_null_without_provider_config() {
+    let _env = env_lock().lock().expect("env lock");
+
     // EMBED needs `red_config` entries for a provider. With none set
     // the scalar degrades to Null rather than panicking or crossing
     // the network. Negative-path guard — proves the wiring reaches

--- a/tests/grouped/ai_search/e2e_ml_classify.rs
+++ b/tests/grouped/ai_search/e2e_ml_classify.rs
@@ -12,10 +12,10 @@ use reddb::storage::ml::ModelVersion;
 use reddb::storage::schema::Value;
 use reddb::{QueryUseCases, RedDBRuntime};
 
-use super::support::env_lock;
+use super::support::{env_lock, PersistentRuntime};
 
-fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("in-memory runtime")
+fn rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("ml-classify")
 }
 
 /// Train a tiny 2-feature, 2-class logistic regression that separates
@@ -69,7 +69,7 @@ fn train_and_register(rt: &RedDBRuntime, model_name: &str) {
 fn ml_classify_returns_predicted_class_from_sql() {
     let rt = rt();
     train_and_register(&rt, "xor_toy");
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
 
     // Class 0: first feature bigger. The scalar takes an   literal.
     let r = q
@@ -100,7 +100,7 @@ fn ml_classify_returns_predicted_class_from_sql() {
 fn ml_predict_proba_returns_normalised_probabilities() {
     let rt = rt();
     train_and_register(&rt, "xor_toy2");
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
 
     let r = q
         .execute(ExecuteQueryInput {
@@ -132,7 +132,7 @@ fn ml_predict_proba_returns_normalised_probabilities() {
 #[test]
 fn ml_classify_unknown_model_returns_null() {
     let rt = rt();
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
     let r = q
         .execute(ExecuteQueryInput {
             query: "SELECT ML_CLASSIFY('does_not_exist', [1.0, 2.0]) AS cls".into(),
@@ -145,7 +145,7 @@ fn ml_classify_unknown_model_returns_null() {
 #[test]
 fn semantic_cache_roundtrip_via_sql() {
     let rt = rt();
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
 
     // PUT then GET — same embedding should hit.
     q.execute(ExecuteQueryInput {
@@ -177,7 +177,7 @@ fn embed_returns_null_without_provider_config() {
     // the network. Negative-path guard — proves the wiring reaches
     // the runtime and fails closed.
     let rt = rt();
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
     let r = q
         .execute(ExecuteQueryInput {
             query: "SELECT EMBED('hello world', 'openai') AS emb".into(),
@@ -221,7 +221,7 @@ fn model_register_then_classify_roundtrip() {
     model.fit(&examples);
     let weights_json = model.to_json();
 
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
     let sql = format!(
         "SELECT MODEL_REGISTER('sql_reg_model', 'logreg', '{}') AS v",
         weights_json.replace('\'', "''")
@@ -252,7 +252,7 @@ fn model_register_then_classify_roundtrip() {
 fn model_drop_archives_versions() {
     let rt = rt();
     train_and_register(&rt, "drop_me");
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
     q.execute(ExecuteQueryInput {
         query: "SELECT MODEL_DROP('drop_me') AS ok".into(),
     })
@@ -271,7 +271,7 @@ fn model_drop_archives_versions() {
 #[test]
 fn semantic_cache_miss_returns_null() {
     let rt = rt();
-    let q = QueryUseCases::new(&rt);
+    let q = QueryUseCases::new(rt.runtime());
     let r = q
         .execute(ExecuteQueryInput {
             query: "SELECT SEMANTIC_CACHE_GET('qa', [0.99, 0.0, 0.0, 0.0]) AS cached".into(),

--- a/tests/grouped/ai_search/support.rs
+++ b/tests/grouped/ai_search/support.rs
@@ -1,0 +1,6 @@
+use std::sync::{Mutex, OnceLock};
+
+pub(crate) fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}

--- a/tests/grouped/ai_search/support.rs
+++ b/tests/grouped/ai_search/support.rs
@@ -1,5 +1,10 @@
 use std::sync::{Mutex, OnceLock};
 
+#[path = "../../support/mod.rs"]
+mod root_support;
+
+pub(crate) use root_support::{persistent_test_runtime, PersistentRuntime};
+
 pub(crate) fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))

--- a/tests/grouped/cli_transport/e2e_issue_545_transport_listener_readiness.rs
+++ b/tests/grouped/cli_transport/e2e_issue_545_transport_listener_readiness.rs
@@ -50,14 +50,15 @@ fn occupy_random_port() -> (TcpListener, String) {
     (occupier, addr)
 }
 
-fn spawn_http_server(readiness: TransportReadiness) -> String {
+fn spawn_http_server(readiness: TransportReadiness) -> (support::TempDbFile, String) {
     let mut options = ServerOptions::default();
     options.transport_readiness = readiness;
-    let server = RedDBServer::with_options(runtime(), options);
+    let (db, rt) = support::persistent_runtime("transport-readiness-http");
+    let server = RedDBServer::with_options(rt, options);
     let listener = TcpListener::bind("127.0.0.1:0").expect("http listener bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn http_get(addr: &str, path: &str) -> (u16, JsonValue) {
@@ -191,7 +192,7 @@ fn health_endpoint_enumerates_active_and_failed_listeners() {
             reason: "wire listener bind 127.0.0.1:6378: address in use".to_string(),
         }],
     };
-    let addr = spawn_http_server(readiness);
+    let (_db, addr) = spawn_http_server(readiness);
 
     let (status, body) = http_get(&addr, "/health");
     // `/health` may answer 200 (ready) or 503 (still warming up) at

--- a/tests/grouped/config_tier/e2e_config_crud.rs
+++ b/tests/grouped/config_tier/e2e_config_crud.rs
@@ -2,7 +2,7 @@ use reddb::storage::schema::Value;
 use reddb::RedDBRuntime;
 
 fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("in-memory runtime")
+    crate::config_tier_shared::open_in_memory("in-memory runtime")
 }
 
 fn field<'a>(row: &'a reddb::storage::query::unified::UnifiedRecord, name: &str) -> &'a Value {

--- a/tests/grouped/config_tier/e2e_config_matrix.rs
+++ b/tests/grouped/config_tier/e2e_config_matrix.rs
@@ -11,7 +11,10 @@ mod support;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 fn open_runtime() -> RedDBRuntime {
-    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+    crate::config_tier_shared::open_runtime_with_options(
+        RedDBOptions::in_memory(),
+        "runtime should open in-memory",
+    )
 }
 
 fn show_value(rt: &RedDBRuntime, key: &str) -> Option<String> {
@@ -74,7 +77,10 @@ fn storage_deploy_profile_selection_is_visible_in_config() {
             reddb::storage::StorageDeployPreset::PrimaryReplicaProductionHa.selection(),
         )
         .expect("profile selection should validate");
-    let rt = RedDBRuntime::with_options(options).expect("runtime should open in-memory");
+    let rt = crate::config_tier_shared::open_runtime_with_options(
+        options,
+        "runtime should open in-memory",
+    );
 
     assert!(show_value(&rt, "storage.deploy.profile")
         .unwrap()
@@ -107,14 +113,19 @@ fn storage_deploy_profile_selection_reseeds_default_profile_on_reopen() {
                 reddb::storage::StorageDeployPreset::PrimaryReplicaProductionHa.selection(),
             )
             .expect("profile selection should validate");
-        let rt = RedDBRuntime::with_options(options).expect("first runtime should open");
+        let rt = crate::config_tier_shared::open_runtime_with_options(
+            options,
+            "first runtime should open",
+        );
         assert!(show_value(&rt, "storage.deploy.profile")
             .unwrap()
             .contains("primary-replica"));
     }
 
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
-        .expect("second runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(
+        RedDBOptions::persistent(&path),
+        "second runtime should open",
+    );
     assert!(show_value(&rt, "storage.deploy.profile")
         .unwrap()
         .contains("embedded"));

--- a/tests/grouped/config_tier/e2e_config_secret_ref.rs
+++ b/tests/grouped/config_tier/e2e_config_secret_ref.rs
@@ -24,7 +24,7 @@ fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<
     let options = RedDBOptions::persistent(path)
         .with_storage_profile(StorageDeployPreset::Serverless.selection())
         .expect("serverless storage profile should expose pager");
-    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(options, "runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/grouped/config_tier/e2e_config_vault_observation.rs
+++ b/tests/grouped/config_tier/e2e_config_vault_observation.rs
@@ -12,14 +12,14 @@ use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 mod support;
 
 fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("in-memory runtime")
+    crate::config_tier_shared::open_in_memory("in-memory runtime")
 }
 
 fn open_runtime_with_vault(path: &Path, passphrase: &str) -> (RedDBRuntime, Arc<AuthStore>) {
     let options = RedDBOptions::persistent(path)
         .with_storage_profile(StorageDeployPreset::Serverless.selection())
         .expect("serverless storage profile should expose pager");
-    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(options, "runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/grouped/config_tier/e2e_issue_480_tier_default_promotion_contract.rs
+++ b/tests/grouped/config_tier/e2e_issue_480_tier_default_promotion_contract.rs
@@ -34,11 +34,6 @@ use reddb::{
     seqn_journal_enabled, shm_provisioning_enabled, tier_wiring, LogDestination, RedDBOptions,
     RedDBRuntime, StorageLayout,
 };
-use std::sync::Mutex;
-
-/// Tests in this binary poke process-global tier toggles. Serialise so a
-/// parallel runner never observes a half-applied tier state.
-static PROMOTION_GUARD: Mutex<()> = Mutex::new(());
 
 fn reset_env() {
     std::env::remove_var("REDDB_META_JSON_SIDECAR");
@@ -122,7 +117,7 @@ fn adr_0018_documents_phase_grouping_a_b_c() {
 
 #[test]
 fn phase_a_performance_routes_logs_into_red_subdir() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let _rt = open_at_layout("phaseA_perf", StorageLayout::Performance);
 
@@ -143,7 +138,7 @@ fn phase_a_performance_routes_logs_into_red_subdir() {
 
 #[test]
 fn phase_a_max_routes_logs_into_red_subdir() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let _rt = open_at_layout("phaseA_max", StorageLayout::Max);
 
@@ -157,7 +152,7 @@ fn phase_a_max_routes_logs_into_red_subdir() {
 
 #[test]
 fn phase_a_minimal_and_standard_keep_stderr() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let _rt = open_at_layout("phaseA_min", StorageLayout::Minimal);
     let (audit_min, slow_min) = tier_wiring::current_log_destinations();
@@ -185,7 +180,7 @@ fn phase_a_minimal_and_standard_keep_stderr() {
 
 #[test]
 fn phase_b_shm_promoted_to_standard() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let _rt = open_at_layout("phaseB_shm_std", StorageLayout::Standard);
     assert!(
@@ -196,7 +191,7 @@ fn phase_b_shm_promoted_to_standard() {
 
 #[test]
 fn phase_b_fold_pager_meta_remains_max_only() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
 
     reset_env();
     let _rt_std = open_at_layout("phaseB_fpm_std", StorageLayout::Standard);
@@ -222,7 +217,7 @@ fn phase_b_fold_pager_meta_remains_max_only() {
 
 #[test]
 fn phase_b_fold_dwb_into_wal_remains_max_only() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
 
     reset_env();
     let _rt_std = open_at_layout("phaseB_fdw_std", StorageLayout::Standard);
@@ -241,7 +236,7 @@ fn phase_b_fold_dwb_into_wal_remains_max_only() {
 
 #[test]
 fn meta_json_and_seqn_journal_remain_max_only() {
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let _rt_std = open_at_layout("aux_std", StorageLayout::Standard);
     assert!(!meta_json_sidecar_enabled());
@@ -295,7 +290,7 @@ fn phase_c_embed_catalog_in_datafile_not_yet_introduced() {
 #[test]
 fn promoted_phase_a_log_routing_override_remains_available() {
     use reddb::{LayoutOverrides, LogRoutingOverrides};
-    let _g = PROMOTION_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
 
     let override_dest = LogDestination::Syslog;

--- a/tests/grouped/config_tier/e2e_secret_sql.rs
+++ b/tests/grouped/config_tier/e2e_secret_sql.rs
@@ -19,7 +19,10 @@ fn pager_backed_options(path: &std::path::Path) -> RedDBOptions {
 
 fn open_runtime_with_vault(name: &str) -> (TempDbFile, RedDBRuntime, Arc<AuthStore>) {
     let path = support::temp_db_file(name);
-    let rt = RedDBRuntime::with_options(pager_backed_options(path.path())).expect("runtime opens");
+    let rt = crate::config_tier_shared::open_runtime_with_options(
+        pager_backed_options(path.path()),
+        "runtime opens",
+    );
     let db = rt.db();
     let store = db.store();
     let pager = Arc::clone(
@@ -150,8 +153,10 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
     let dump_path = dump_guard.path();
 
     {
-        let rt = RedDBRuntime::with_options(pager_backed_options(source_path))
-            .expect("source runtime should open");
+        let rt = crate::config_tier_shared::open_runtime_with_options(
+            pager_backed_options(source_path),
+            "source runtime should open",
+        );
         let _auth = attach_vault(&rt, "cli-pass");
         rt.execute_query("SET CONFIG red.config.demo.enabled = true")
             .expect("SET CONFIG should succeed");
@@ -160,8 +165,10 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         rt.checkpoint().expect("source checkpoint should succeed");
     }
     {
-        let rt = RedDBRuntime::with_options(pager_backed_options(source_path))
-            .expect("source runtime should reopen");
+        let rt = crate::config_tier_shared::open_runtime_with_options(
+            pager_backed_options(source_path),
+            "source runtime should reopen",
+        );
         let auth = attach_vault(&rt, "cli-pass");
         assert_eq!(
             auth.vault_kv_get("mycompany.payments.key").as_deref(),
@@ -213,8 +220,10 @@ fn cli_dump_restore_includes_plaintext_config_and_encrypted_vault_kv() {
         String::from_utf8_lossy(&restore.stderr)
     );
 
-    let rt = RedDBRuntime::with_options(pager_backed_options(dest_path))
-        .expect("dest runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(
+        pager_backed_options(dest_path),
+        "dest runtime should open",
+    );
     let auth = attach_vault(&rt, "cli-pass");
     assert_eq!(
         auth.vault_kv_get("mycompany.payments.key").as_deref(),
@@ -354,7 +363,8 @@ fn dollar_config_reference_resolves_plaintext_config() {
 
 #[test]
 fn set_secret_requires_vault() {
-    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let rt =
+        crate::config_tier_shared::open_runtime_with_options(RedDBOptions::in_memory(), "runtime");
     let err = rt
         .execute_query("SET SECRET mycompany.stripe.key = 'sk_live'")
         .expect_err("SET SECRET without vault should fail");

--- a/tests/grouped/config_tier/e2e_shm_provisioning.rs
+++ b/tests/grouped/config_tier/e2e_shm_provisioning.rs
@@ -12,10 +12,6 @@ use reddb::{
     shm_provisioning_enabled, ShmProvisionState, SHM_FILE_SIZE, SHM_HEADER_SIZE, SHM_MAGIC,
     SHM_VERSION,
 };
-use std::sync::Mutex;
-
-// Tests poke a process-global toggle; serialise them.
-static POLICY_GUARD: Mutex<()> = Mutex::new(());
 
 fn reset_policy() {
     set_shm_provisioning_enabled(false);
@@ -24,7 +20,7 @@ fn reset_policy() {
 
 #[test]
 fn provisioning_disabled_by_default() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_policy();
     assert!(!shm_provisioning_enabled());
     set_shm_provisioning_enabled(true);
@@ -34,7 +30,7 @@ fn provisioning_disabled_by_default() {
 
 #[test]
 fn provision_creates_shm_with_canonical_header() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     let data = support::temp_db_file("shm-create");
 
     let handle = provision_shm(&data).expect("shm provisions cleanly");
@@ -66,7 +62,7 @@ fn provision_creates_shm_with_canonical_header() {
 
 #[test]
 fn reopen_by_same_process_attaches_without_bumping_generation() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     let data = support::temp_db_file("shm-reattach");
 
     let first = provision_shm(&data).expect("first open");
@@ -88,7 +84,7 @@ fn reopen_by_same_process_attaches_without_bumping_generation() {
 
 #[test]
 fn multiple_readers_can_attach_concurrently() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     let data = support::temp_db_file("shm-readers");
 
     let mut owner = provision_shm(&data).expect("owner open");
@@ -114,7 +110,7 @@ fn multiple_readers_can_attach_concurrently() {
 
 #[test]
 fn crash_of_prior_owner_is_detected_and_state_cleaned() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     let data = support::temp_db_file("shm-crash");
 
     // Bootstrap a valid shm with a fabricated dead-pid owner.
@@ -169,7 +165,7 @@ fn crash_of_prior_owner_is_detected_and_state_cleaned() {
 
 #[test]
 fn corrupt_header_is_healed_in_place() {
-    let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     let data = support::temp_db_file("shm-corrupt");
 
     // Plant a file that exists but has no valid magic.

--- a/tests/grouped/config_tier/e2e_system_config_vault.rs
+++ b/tests/grouped/config_tier/e2e_system_config_vault.rs
@@ -11,8 +11,10 @@ use reddb::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 fn runtime(name: &str) -> (support::TempDbFile, RedDBRuntime) {
     let path = support::temp_db_file(name);
-    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
-        .expect("runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(
+        RedDBOptions::persistent(path.path()),
+        "runtime should open",
+    );
     (path, rt)
 }
 
@@ -24,7 +26,7 @@ fn runtime_with_vault(
     let options = RedDBOptions::persistent(path.path())
         .with_storage_profile(StorageDeployPreset::Serverless.selection())
         .expect("serverless storage profile should expose pager");
-    let rt = RedDBRuntime::with_options(options).expect("runtime should open");
+    let rt = crate::config_tier_shared::open_runtime_with_options(options, "runtime should open");
     let pager = Arc::clone(
         rt.db()
             .store()

--- a/tests/grouped/config_tier/e2e_tier_wiring.rs
+++ b/tests/grouped/config_tier/e2e_tier_wiring.rs
@@ -25,11 +25,6 @@ use reddb::{
     LayoutOverrides, LogDestination, RedDBOptions, RedDBRuntime, StorageLayout,
     DEFAULT_METADATA_JOURNAL_RETENTION, OPT_IN_METADATA_JOURNAL_RETENTION,
 };
-use std::sync::Mutex;
-
-/// All tests in this binary mutate process-global tier toggles. Serialise
-/// them so a parallel runner doesn't observe a half-applied tier state.
-static TIER_GUARD: Mutex<()> = Mutex::new(());
 
 fn reset_env() {
     std::env::remove_var("REDDB_META_JSON_SIDECAR");
@@ -49,7 +44,7 @@ fn open_at_layout(prefix: &str, layout: StorageLayout) -> (RedDBRuntime, support
 
 #[test]
 fn minimal_tier_defaults_all_toggles_off() {
-    let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let (_rt, _path) = open_at_layout("minimal", StorageLayout::Minimal);
 
@@ -69,7 +64,7 @@ fn minimal_tier_defaults_all_toggles_off() {
 
 #[test]
 fn standard_tier_provisions_shm_only() {
-    let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let (_rt, _path) = open_at_layout("standard", StorageLayout::Standard);
 
@@ -90,7 +85,7 @@ fn standard_tier_provisions_shm_only() {
 
 #[test]
 fn performance_tier_routes_logs_to_file() {
-    let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let (_rt, _path) = open_at_layout("performance", StorageLayout::Performance);
 
@@ -111,7 +106,7 @@ fn performance_tier_routes_logs_to_file() {
 
 #[test]
 fn max_tier_enables_all_toggles() {
-    let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let (_rt, _path) = open_at_layout("max", StorageLayout::Max);
 
@@ -134,7 +129,7 @@ fn max_tier_enables_all_toggles() {
 #[test]
 fn layout_overrides_win_over_tier_default() {
     use reddb::LogRoutingOverrides;
-    let _g = TIER_GUARD.lock().unwrap_or_else(|err| err.into_inner());
+    let _g = crate::config_tier_shared::tier_state_lock();
     reset_env();
     let guard = support::temp_db_file("overrides");
     let override_dest = LogDestination::Syslog;

--- a/tests/grouped/config_tier/shared.rs
+++ b/tests/grouped/config_tier/shared.rs
@@ -1,0 +1,21 @@
+use std::sync::{Mutex, MutexGuard};
+
+use reddb::{RedDBOptions, RedDBRuntime};
+
+static TIER_STATE_LOCK: Mutex<()> = Mutex::new(());
+
+pub fn tier_state_lock() -> MutexGuard<'static, ()> {
+    TIER_STATE_LOCK
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+}
+
+pub fn open_in_memory(context: &str) -> RedDBRuntime {
+    let _guard = tier_state_lock();
+    RedDBRuntime::in_memory().unwrap_or_else(|err| panic!("{context}: {err:?}"))
+}
+
+pub fn open_runtime_with_options(options: RedDBOptions, context: &str) -> RedDBRuntime {
+    let _guard = tier_state_lock();
+    RedDBRuntime::with_options(options).unwrap_or_else(|err| panic!("{context}: {err:?}"))
+}

--- a/tests/grouped/control_feedback/feedback_regression.rs
+++ b/tests/grouped/control_feedback/feedback_regression.rs
@@ -713,7 +713,7 @@ fn fb_bundle_covers_every_matrix_feedback_id() {
     }
     assert!(
         missing.is_empty(),
-        "tests/feedback_regression.rs is missing regression entries for: {missing:?}"
+        "tests/grouped/control_feedback/feedback_regression.rs is missing regression entries for: {missing:?}"
     );
 }
 
@@ -722,7 +722,7 @@ fn fb_bundle_covers_every_matrix_feedback_id() {
 #[test]
 fn fb_bundle_is_cross_referenced_from_the_matrix() {
     assert!(
-        MATRIX.contains("tests/feedback_regression.rs"),
-        "public-surface-contract-matrix.md must cross-reference tests/feedback_regression.rs"
+        MATRIX.contains("tests/grouped/control_feedback/feedback_regression.rs"),
+        "public-surface-contract-matrix.md must cross-reference tests/grouped/control_feedback/feedback_regression.rs"
     );
 }

--- a/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
@@ -1,3 +1,6 @@
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
@@ -31,13 +34,13 @@ fn int(row: &reddb::storage::query::UnifiedRecord, field: &str) -> i64 {
     }
 }
 
-fn spawn_http_server() -> String {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("document-sql-analytics-http");
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> JsonValue {
@@ -185,7 +188,7 @@ fn runtime_indexes_nested_document_path_filters() {
 
 #[test]
 fn http_query_document_fields_json_paths_arrays_and_groups() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
     post_query(&addr, "CREATE DOCUMENT events");
     post_query(
         &addr,

--- a/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
+++ b/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
@@ -44,12 +44,13 @@ fn json_field(row: &reddb::storage::query::UnifiedRecord, field: &str) -> JsonVa
     }
 }
 
-fn spawn_http_server() -> String {
-    let server = RedDBServer::new(runtime());
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("documents-crud-http");
+    let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<JsonValue>) -> (u16, JsonValue) {
@@ -145,7 +146,7 @@ fn create_document_insert_returning_select_and_reopen() {
 
 #[test]
 fn http_document_insert_get_scan_and_delete() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
 
     let payload = json!({
         "body": {

--- a/tests/grouped/docs_kv_queue/e2e_issue_540_documents_basics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_540_documents_basics.rs
@@ -46,13 +46,13 @@ fn rid_field(row: &UnifiedRecord) -> u64 {
     }
 }
 
-fn spawn_http_server() -> (RedDBRuntime, String) {
-    let rt = runtime();
+fn spawn_http_server() -> (support::TempDbFile, RedDBRuntime, String) {
+    let (db, rt) = support::persistent_runtime("documents-basics-http");
     let server = RedDBServer::new(rt.clone());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr").to_string();
     server.serve_in_background_on(listener);
-    (rt, addr)
+    (db, rt, addr)
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<JsonValue>) -> (u16, JsonValue) {
@@ -148,7 +148,7 @@ fn sql_insert_stores_json_document_and_get_by_id_returns_it() {
 // Acceptance: HTTP POST stores a JSON document and HTTP GET by id returns it.
 #[test]
 fn http_post_stores_document_and_http_get_by_id_returns_it() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     let (status, _) = http_request(
         &addr,
         "POST",

--- a/tests/grouped/docs_kv_queue/e2e_issue_541_kv_namespaced_keys.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_541_kv_namespaced_keys.rs
@@ -70,7 +70,8 @@ fn quoted_namespaced_key_round_trips_through_sql_set_and_get() {
 // `/v1/kv/<collection>/<key>` surfaces — both are publicly documented.
 #[test]
 fn url_encoded_namespaced_key_round_trips_through_http_kv_endpoints() {
-    let server = RedDBServer::new(runtime());
+    let (_db, rt) = support::persistent_runtime("kv-namespaced-http");
+    let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     server.serve_in_background_on(listener);

--- a/tests/grouped/docs_kv_queue/e2e_issue_550_documents_list_filter_pagination.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_550_documents_list_filter_pagination.rs
@@ -43,13 +43,13 @@ fn number_field(row: &UnifiedRecord, field: &str) -> f64 {
     }
 }
 
-fn spawn_http_server() -> (RedDBRuntime, String) {
-    let rt = runtime();
+fn spawn_http_server() -> (support::TempDbFile, RedDBRuntime, String) {
+    let (db, rt) = support::persistent_runtime("documents-list-http");
     let server = RedDBServer::new(rt.clone());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr").to_string();
     server.serve_in_background_on(listener);
-    (rt, addr)
+    (db, rt, addr)
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<JsonValue>) -> (u16, JsonValue) {
@@ -207,7 +207,7 @@ fn sql_select_beyond_end_offset_returns_empty_page() {
 // Acceptance: HTTP list endpoint supports pagination (offset + limit).
 #[test]
 fn http_scan_offset_and_limit_paginates_documents() {
-    let (rt, addr) = spawn_http_server();
+    let (_db, rt, addr) = spawn_http_server();
     seed_documents(&rt, "issue550_http_scan", 5);
 
     // First page: limit=2, offset=0.
@@ -260,7 +260,7 @@ fn http_scan_offset_and_limit_paginates_documents() {
 // Acceptance: HTTP list endpoint with beyond-end offset returns an empty page.
 #[test]
 fn http_scan_beyond_end_offset_returns_empty_page() {
-    let (rt, addr) = spawn_http_server();
+    let (_db, rt, addr) = spawn_http_server();
     seed_documents(&rt, "issue550_http_beyond", 3);
 
     let (status, page) = http_request(
@@ -282,7 +282,7 @@ fn http_scan_beyond_end_offset_returns_empty_page() {
 // of `SELECT ... WHERE ... LIMIT N OFFSET M` on a document collection.
 #[test]
 fn http_query_with_where_limit_offset_filters_and_paginates() {
-    let (rt, addr) = spawn_http_server();
+    let (_db, rt, addr) = spawn_http_server();
     seed_documents(&rt, "issue550_http_filter", 8);
 
     // seq=0,2,4,6 are "login" (4 docs). LIMIT 2 OFFSET 1 ORDER BY seq →

--- a/tests/grouped/docs_kv_queue/e2e_issue_552_documents_patch_set_intermediates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_552_documents_patch_set_intermediates.rs
@@ -36,13 +36,13 @@ fn runtime() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("runtime")
 }
 
-fn spawn_http_server() -> (RedDBRuntime, String) {
-    let rt = runtime();
+fn spawn_http_server() -> (support::TempDbFile, RedDBRuntime, String) {
+    let (db, rt) = support::persistent_runtime("documents-patch-http");
     let server = RedDBServer::new(rt.clone());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr").to_string();
     server.serve_in_background_on(listener);
-    (rt, addr)
+    (db, rt, addr)
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<JsonValue>) -> (u16, JsonValue) {
@@ -121,7 +121,7 @@ fn fetch_document(addr: &str, collection: &str, id: u64) -> JsonValue {
 // after PATCH `/body/meta/ip` the body contains `meta: { ip: "..." }`.
 #[test]
 fn http_patch_set_on_nested_body_path_creates_intermediate_object() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     create_document_collection(&addr, "issue552_set_intermediates");
     let id = insert_document(
         &addr,
@@ -159,7 +159,7 @@ fn http_patch_set_on_nested_body_path_creates_intermediate_object() {
 // no-op success — the response is 200 and the document body is unchanged.
 #[test]
 fn http_patch_unset_on_missing_path_is_noop_success() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     create_document_collection(&addr, "issue552_unset_missing");
     let id = insert_document(
         &addr,
@@ -196,7 +196,7 @@ fn http_patch_unset_on_missing_path_is_noop_success() {
 // (replace the array or the full document body).
 #[test]
 fn http_patch_array_positional_path_rejected_with_clear_error() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     create_document_collection(&addr, "issue552_array_position");
     let id = insert_document(
         &addr,

--- a/tests/grouped/docs_kv_queue/e2e_kv_namespaced_keys.rs
+++ b/tests/grouped/docs_kv_queue/e2e_kv_namespaced_keys.rs
@@ -162,7 +162,8 @@ fn kv_list_returns_keys_with_prefix_limit_and_offset() {
 
 #[test]
 fn http_kv_endpoints_accept_url_encoded_namespaced_keys() {
-    let server = RedDBServer::new(runtime());
+    let (_db, rt) = support::persistent_runtime("kv-namespaced-http");
+    let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("addr");
     server.serve_in_background_on(listener);

--- a/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
+++ b/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
@@ -39,6 +39,10 @@ fn message_id_of(result: &reddb::runtime::RuntimeQueryResult) -> String {
 
 #[test]
 fn nack_to_dlq_emits_audit_event_and_increments_prom_counters() {
+    // The operator event sink is process-global and first-runtime-wins.
+    // Queue DLQ promotion must still persist to the runtime that performed
+    // the NACK, not whichever runtime first installed the global sink.
+    let _global_sink_owner = rt();
     let rt = rt();
 
     // Build a queue with a DLQ target + a low max_attempts so the

--- a/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
+++ b/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
@@ -87,7 +87,12 @@ fn nack_to_dlq_emits_audit_event_and_increments_prom_counters() {
         .unwrap_or_else(|err| panic!("audit log read at {audit_path:?}: {err}"));
     let promotion_line = audit_body
         .lines()
-        .find(|line| line.contains("operator/queue_dlq_promoted"))
+        .find(|line| {
+            line.contains("operator/queue_dlq_promoted")
+                && line.contains("\"queue\":\"tasks\"")
+                && line.contains("\"group\":\"workers\"")
+                && line.contains("\"dlq\":\"failed_tasks\"")
+        })
         .unwrap_or_else(|| {
             panic!("audit log did not include operator/queue_dlq_promoted. body:\n{audit_body}")
         });

--- a/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
+++ b/tests/grouped/docs_kv_queue/e2e_queue_lifecycle_telemetry.rs
@@ -17,8 +17,8 @@ use reddb::RedDBRuntime;
 
 use support::prometheus::get;
 
-fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("in-memory runtime")
+fn rt(tag: &str) -> support::PersistentRuntime {
+    support::persistent_test_runtime(tag)
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) -> reddb::runtime::RuntimeQueryResult {
@@ -42,8 +42,8 @@ fn nack_to_dlq_emits_audit_event_and_increments_prom_counters() {
     // The operator event sink is process-global and first-runtime-wins.
     // Queue DLQ promotion must still persist to the runtime that performed
     // the NACK, not whichever runtime first installed the global sink.
-    let _global_sink_owner = rt();
-    let rt = rt();
+    let _global_sink_owner = rt("queue-lifecycle-global-sink");
+    let rt = rt("queue-lifecycle-audit");
 
     // Build a queue with a DLQ target + a low max_attempts so the
     // second NACK promotes immediately.
@@ -112,7 +112,7 @@ fn nack_to_dlq_emits_audit_event_and_increments_prom_counters() {
     // -------------------------------------------------------------
     // Prometheus assertion — scrape via the public /metrics endpoint
     // -------------------------------------------------------------
-    let (status, body) = get(rt, "/metrics");
+    let (status, body) = get(rt.clone_runtime(), "/metrics");
     assert_eq!(status, 200, "metrics endpoint should return 200");
 
     // deliver fired twice (one per READ).

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -259,7 +259,7 @@ fn test_select_from_queue_projects_without_consuming_or_leasing() {
 
 #[test]
 fn test_queue_move_filters_limits_and_keeps_peek_compatible() {
-    let rt = rt();
+    let rt = support::persistent_test_runtime("queue-move-audit");
 
     exec(&rt, "CREATE QUEUE failed_jobs");
     exec(&rt, "CREATE QUEUE jobs");

--- a/tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs
+++ b/tests/grouped/graph_analytics/e2e_issue_556_graph_sql_http_parity_and_limits.rs
@@ -25,6 +25,9 @@
 //! 4. Regression tests for parity + limit behavior — the above five
 //!    tests collectively satisfy this bullet.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read as _, Write as _};
 use std::net::{TcpListener, TcpStream};
 use std::path::PathBuf;
@@ -57,13 +60,13 @@ fn text(record: &UnifiedRecord, column: &str) -> String {
 // `tests/http_query_grimms_graph.rs`).
 // ---------------------------------------------------------------------------
 
-fn spawn_http_server() -> String {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("graph-parity-http");
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> JsonValue {
@@ -117,7 +120,7 @@ fn match_query_returns_same_envelope_via_sql_dsl_and_http() {
     // Then run the same representative MATCH query against both and assert
     // the public envelope matches (columns, row count, and per-row values).
     let rt = runtime();
-    let http = spawn_http_server();
+    let (_db, http) = spawn_http_server();
 
     let seeds = [
         "INSERT INTO social NODE (label, name) VALUES ('alice', 'Alice')",

--- a/tests/grouped/graph_analytics/http_query_grimms_graph.rs
+++ b/tests/grouped/graph_analytics/http_query_grimms_graph.rs
@@ -1,18 +1,20 @@
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
 use reddb::server::RedDBServer;
-use reddb::RedDBRuntime;
 use serde_json::{json, Value};
 
-fn spawn_http_server() -> String {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("grimms-graph-http");
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> Value {
@@ -86,7 +88,7 @@ fn only_record(response: &Value) -> &Value {
 
 #[test]
 fn http_query_grimms_graph_showcase_queries_match_embedded_contract() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
 
     post_query(
         &addr,
@@ -131,7 +133,7 @@ fn http_query_grimms_graph_showcase_queries_match_embedded_contract() {
 
 #[test]
 fn http_query_mini_grimms_multimodel_showcase_smoke() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
 
     post_query(
         &addr,

--- a/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
+++ b/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
@@ -23,12 +23,14 @@
 
 #![cfg(all(feature = "redwire", feature = "embedded"))]
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read as _, Write as _};
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 use std::time::Duration;
 
-use reddb::api::RedDBOptions;
 use reddb::auth::store::AuthStore;
 use reddb::auth::AuthConfig;
 use reddb::grpc::proto::query_value::Kind as GrpcValueKind;
@@ -36,7 +38,7 @@ use reddb::grpc::proto::red_db_client::RedDbClient;
 use reddb::grpc::proto::{QueryRequest, QueryValue};
 use reddb::server::RedDBServer;
 use reddb::wire::redwire::start_redwire_listener_on;
-use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBRuntime};
+use reddb::{GrpcServerOptions, RedDBGrpcServer};
 
 use reddb_client::redwire::{Auth, ConnectOptions, RedWireClient};
 use reddb_client::{QueryResult, Value};
@@ -145,7 +147,7 @@ async fn cross_transport_select_envelope_matches() {
     // before any listener is online — every transport observes the
     // exact same row set, so any envelope diff is a true diff and not
     // a write-visibility race.
-    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let (_db, runtime) = support::persistent_runtime("cross-transport-envelope");
     runtime
         .execute_query(&format!("CREATE TABLE {TABLE} (id INTEGER, name TEXT)"))
         .expect("create table");

--- a/tests/grouped/http_grpc_auth/grpc_batch_insert.rs
+++ b/tests/grouped/http_grpc_auth/grpc_batch_insert.rs
@@ -19,12 +19,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use reddb::auth::store::AuthStore;
 use reddb::auth::AuthConfig;
 use reddb::grpc::proto::red_db_client::RedDbClient;
 use reddb::grpc::proto::BatchInsertChunk;
 use reddb::runtime::RedDBRuntime;
-use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions};
+use reddb::{GrpcServerOptions, RedDBGrpcServer};
 
 use tonic::transport::Endpoint;
 use tonic::Code;
@@ -54,8 +57,16 @@ async fn wait_for_port(port: u16, max_ms: u64) {
 /// inspect storage state directly. The runtime is shared (Arc-backed
 /// inside) so the clone passed to the server and the one we keep see
 /// the same writes.
-fn build_runtime_and_server(table_ddl: &str) -> (RedDBRuntime, RedDBGrpcServer, String, u16) {
-    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+fn build_runtime_and_server(
+    table_ddl: &str,
+) -> (
+    support::TempDbFile,
+    RedDBRuntime,
+    RedDBGrpcServer,
+    String,
+    u16,
+) {
+    let (db, runtime) = support::persistent_runtime("grpc-batch-insert");
     runtime.execute_query(table_ddl).expect("create table");
     let port = pick_port();
     let bind = format!("127.0.0.1:{port}");
@@ -68,7 +79,7 @@ fn build_runtime_and_server(table_ddl: &str) -> (RedDBRuntime, RedDBGrpcServer, 
         },
         auth_store,
     );
-    (runtime, server, bind, port)
+    (db, runtime, server, bind, port)
 }
 
 async fn connect_client(port: u16) -> RedDbClient<tonic::transport::Channel> {
@@ -98,7 +109,7 @@ fn unique_suffix() -> String {
 async fn grpc_batch_insert_happy_path_returns_count_and_preserves_order() {
     let table = format!("events_586_ok_{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (id INTEGER, name TEXT)");
-    let (runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
@@ -152,7 +163,7 @@ async fn grpc_batch_insert_idempotency_key_replays_cached_result() {
     let table = format!("events_586_idem_{}", unique_suffix());
     let key = format!("grpc-586-idem-{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (id INTEGER, name TEXT)");
-    let (runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
@@ -222,7 +233,7 @@ async fn grpc_batch_insert_cache_shared_with_other_transports() {
     let table = format!("events_586_shared_{}", unique_suffix());
     let key = format!("grpc-586-shared-{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (id INTEGER, name TEXT)");
-    let (_runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, _runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
@@ -257,7 +268,7 @@ async fn grpc_batch_insert_cache_shared_with_other_transports() {
 async fn grpc_batch_insert_row_failure_rolls_back_with_row_index_metadata() {
     let table = format!("events_586_rollback_{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (id INTEGER, name TEXT)");
-    let (runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
@@ -316,7 +327,7 @@ async fn grpc_batch_insert_schema_validation_pinpoints_failing_row() {
     let table = format!("events_586_schema_{}", unique_suffix());
     let event_name = format!("click_586_{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (event_name TEXT, payload TEXT)");
-    let (runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let schema = r#"{"type":"object","properties":{"url":{"type":"string"}},"required":["url"],"additionalProperties":false}"#;
     reg::register(runtime.db().store().as_ref(), &event_name, schema).expect("register schema");
@@ -377,7 +388,7 @@ async fn grpc_batch_insert_schema_validation_pinpoints_failing_row() {
 async fn grpc_batch_insert_oversize_returns_resource_exhausted_before_storage() {
     let table = format!("events_586_oversize_{}", unique_suffix());
     let ddl = format!("CREATE TABLE {table} (id INTEGER, name TEXT)");
-    let (runtime, server, _bind, port) = build_runtime_and_server(&ddl);
+    let (_db, runtime, server, _bind, port) = build_runtime_and_server(&ddl);
 
     let h = tokio::spawn(async move {
         let _ = server.serve().await;

--- a/tests/grouped/http_grpc_auth/grpc_oauth_smoke.rs
+++ b/tests/grouped/http_grpc_auth/grpc_oauth_smoke.rs
@@ -16,6 +16,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use reddb::auth::oauth::{
     DecodedJwt, Jwk, JwtClaims, JwtHeader, JwtVerifier, OAuthConfig, OAuthIdentityMode,
     OAuthValidator,
@@ -24,8 +27,7 @@ use reddb::auth::store::AuthStore;
 use reddb::auth::{AuthConfig, Role};
 use reddb::grpc::proto::red_db_client::RedDbClient;
 use reddb::grpc::proto::Empty;
-use reddb::runtime::RedDBRuntime;
-use reddb::{GrpcServerOptions, RedDBGrpcServer, RedDBOptions};
+use reddb::{GrpcServerOptions, RedDBGrpcServer};
 
 use tonic::metadata::MetadataValue;
 
@@ -127,8 +129,8 @@ fn make_server(
     bind: String,
     auth_cfg: AuthConfig,
     validator: Option<Arc<OAuthValidator>>,
-) -> RedDBGrpcServer {
-    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime");
+) -> (support::TempDbFile, RedDBGrpcServer) {
+    let (db, runtime) = support::persistent_runtime("grpc-oauth");
     let auth_store = Arc::new(AuthStore::new(auth_cfg));
     let mut server = RedDBGrpcServer::with_options(
         runtime,
@@ -141,7 +143,7 @@ fn make_server(
     if let Some(v) = validator {
         server = server.with_oauth_validator(v);
     }
-    server
+    (db, server)
 }
 
 /// Send a Health RPC with `Authorization: Bearer <token>` — Health is
@@ -316,7 +318,7 @@ async fn grpc_e2e_jwt_accepted_by_interceptor() {
     auth_cfg.oauth.audience = "reddb".to_string();
 
     let validator = validator_for("https://id.example.com", "reddb");
-    let server = make_server(addr.clone(), auth_cfg, Some(validator));
+    let (_db, server) = make_server(addr.clone(), auth_cfg, Some(validator));
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
     });
@@ -350,7 +352,7 @@ async fn grpc_e2e_expired_jwt_denied() {
     auth_cfg.oauth.audience = "reddb".to_string();
 
     let validator = validator_for("https://id.example.com", "reddb");
-    let server = make_server(addr.clone(), auth_cfg, Some(validator));
+    let (_db, server) = make_server(addr.clone(), auth_cfg, Some(validator));
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
     });
@@ -387,7 +389,7 @@ async fn grpc_e2e_wrong_issuer_denied() {
     auth_cfg.oauth.audience = "reddb".to_string();
 
     let validator = validator_for("https://id.example.com", "reddb");
-    let server = make_server(addr.clone(), auth_cfg, Some(validator));
+    let (_db, server) = make_server(addr.clone(), auth_cfg, Some(validator));
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
     });
@@ -425,7 +427,7 @@ async fn grpc_e2e_non_jwt_falls_back_to_authstore() {
     auth_cfg.oauth.audience = "reddb".to_string();
 
     let validator = validator_for("https://id.example.com", "reddb");
-    let server = make_server(addr.clone(), auth_cfg, Some(validator));
+    let (_db, server) = make_server(addr.clone(), auth_cfg, Some(validator));
     let h = tokio::spawn(async move {
         let _ = server.serve().await;
     });

--- a/tests/grouped/http_grpc_auth/grpc_tls_smoke.rs
+++ b/tests/grouped/http_grpc_auth/grpc_tls_smoke.rs
@@ -16,12 +16,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use reddb::auth::store::AuthStore;
 use reddb::auth::AuthConfig;
 use reddb::grpc::proto::red_db_client::RedDbClient;
 use reddb::grpc::proto::Empty;
-use reddb::runtime::RedDBRuntime;
-use reddb::{GrpcServerOptions, GrpcTlsOptions, RedDBGrpcServer, RedDBOptions};
+use reddb::{GrpcServerOptions, GrpcTlsOptions, RedDBGrpcServer};
 
 use tonic::transport::{Certificate, ClientTlsConfig, Endpoint};
 
@@ -40,10 +42,16 @@ fn fresh_cert() -> (String, String) {
     reddb::wire::tls::generate_self_signed_cert("localhost").expect("self-signed cert")
 }
 
-fn make_server(bind_addr: String, tls: Option<GrpcTlsOptions>) -> RedDBGrpcServer {
-    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime");
+fn make_server(
+    bind_addr: String,
+    tls: Option<GrpcTlsOptions>,
+) -> (support::TempDbFile, RedDBGrpcServer) {
+    let (db, runtime) = support::persistent_runtime("grpc-tls");
     let auth_store = Arc::new(AuthStore::new(AuthConfig::default()));
-    RedDBGrpcServer::with_options(runtime, GrpcServerOptions { bind_addr, tls }, auth_store)
+    (
+        db,
+        RedDBGrpcServer::with_options(runtime, GrpcServerOptions { bind_addr, tls }, auth_store),
+    )
 }
 
 async fn wait_for_port(port: u16, max_ms: u64) {
@@ -72,7 +80,7 @@ async fn grpc_tls_handshake_and_health_call() {
         client_ca_pem: None,
     };
 
-    let server = make_server(format!("127.0.0.1:{port}"), Some(tls));
+    let (_db, server) = make_server(format!("127.0.0.1:{port}"), Some(tls));
     let server_handle = tokio::spawn(async move {
         let _ = server.serve().await;
     });
@@ -116,7 +124,7 @@ async fn grpc_tls_rejects_plaintext_client() {
         client_ca_pem: None,
     };
 
-    let server = make_server(format!("127.0.0.1:{port}"), Some(tls));
+    let (_db, server) = make_server(format!("127.0.0.1:{port}"), Some(tls));
     let server_handle = tokio::spawn(async move {
         let _ = server.serve().await;
     });

--- a/tests/grouped/http_grpc_auth/http_oauth_smoke.rs
+++ b/tests/grouped/http_grpc_auth/http_oauth_smoke.rs
@@ -11,6 +11,9 @@
 //!   * Unknown-kid JWT → 401.
 //!   * Opaque AuthStore session token still works (fallback path).
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
@@ -69,8 +72,10 @@ fn make_jwt(header: &str, payload: &str) -> String {
     format!("{h}.{p}.{s}")
 }
 
-fn build_runtime_with_oauth(oauth: Option<Arc<OAuthValidator>>) -> (RedDBRuntime, Arc<AuthStore>) {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+fn build_runtime_with_oauth(
+    oauth: Option<Arc<OAuthValidator>>,
+) -> (support::TempDbFile, RedDBRuntime, Arc<AuthStore>) {
+    let (db, rt) = support::persistent_runtime("http-oauth");
     let cfg = AuthConfig {
         enabled: true,
         session_ttl_secs: 60,
@@ -88,7 +93,7 @@ fn build_runtime_with_oauth(oauth: Option<Arc<OAuthValidator>>) -> (RedDBRuntime
     if let Some(v) = oauth {
         rt.set_oauth_validator(Some(v));
     }
-    (rt, auth_store)
+    (db, rt, auth_store)
 }
 
 fn build_oauth_validator() -> Arc<OAuthValidator> {
@@ -150,7 +155,7 @@ fn http_get(addr: &str, path: &str, bearer: Option<&str>) -> (u16, String) {
 #[test]
 fn valid_jwt_is_accepted_via_oauth_validator() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt, auth_store);
 
     let now = now_secs();
@@ -171,7 +176,7 @@ fn valid_jwt_is_accepted_via_oauth_validator() {
 #[test]
 fn expired_jwt_rejected_with_401() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt, auth_store);
 
     let now = now_secs();
@@ -190,7 +195,7 @@ fn expired_jwt_rejected_with_401() {
 #[test]
 fn wrong_issuer_jwt_rejected() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt, auth_store);
 
     let now = now_secs();
@@ -208,7 +213,7 @@ fn wrong_issuer_jwt_rejected() {
 #[test]
 fn wrong_audience_jwt_rejected() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt, auth_store);
 
     let now = now_secs();
@@ -226,7 +231,7 @@ fn wrong_audience_jwt_rejected() {
 #[test]
 fn unknown_kid_jwt_rejected() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt, auth_store);
 
     let now = now_secs();
@@ -244,7 +249,7 @@ fn unknown_kid_jwt_rejected() {
 #[test]
 fn opaque_api_key_still_works_with_oauth_configured() {
     let validator = build_oauth_validator();
-    let (rt, auth_store) = build_runtime_with_oauth(Some(validator));
+    let (_db, rt, auth_store) = build_runtime_with_oauth(Some(validator));
     let addr = spawn_http(rt.clone(), auth_store.clone());
 
     let api_key = auth_store
@@ -264,7 +269,7 @@ fn opaque_api_key_still_works_with_oauth_configured() {
 fn jwt_shaped_token_falls_back_to_authstore_when_no_oauth_configured() {
     // No OAuthValidator wired. JWT-shaped token must be tried against
     // AuthStore (where it doesn't exist) → 401.
-    let (rt, auth_store) = build_runtime_with_oauth(None);
+    let (_db, rt, auth_store) = build_runtime_with_oauth(None);
     let addr = spawn_http(rt, auth_store);
 
     let header = r#"{"alg":"RS256","kid":"k1","typ":"JWT"}"#;

--- a/tests/grouped/http_grpc_auth/http_principal_inflight_cap.rs
+++ b/tests/grouped/http_grpc_auth/http_principal_inflight_cap.rs
@@ -9,13 +9,15 @@
 //! to fire follow-up requests against a parked permit, so no real load race
 //! is needed.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
 use reddb::server::RedDBServer;
-use reddb::{RedDBOptions, RedDBRuntime};
 
 /// Send one buffered `POST /query` carrying `Authorization: Bearer <token>`
 /// and return the full raw response text. The body is a trivial `SELECT 1`
@@ -39,9 +41,8 @@ fn post_query(addr: &str, token: &str) -> String {
     String::from_utf8_lossy(&buf).to_string()
 }
 
-fn boot(cap: usize, slow_ms: u64) -> (String, RedDBServer) {
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+fn boot(cap: usize, slow_ms: u64) -> (support::TempDbFile, String, RedDBServer) {
+    let (db, runtime) = support::persistent_runtime("principal-inflight-http");
     let server = RedDBServer::new(runtime).with_principal_inflight_cap(cap);
     server.set_test_slow_inject_ms(slow_ms);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
@@ -49,13 +50,13 @@ fn boot(cap: usize, slow_ms: u64) -> (String, RedDBServer) {
     let bg = server.clone();
     bg.serve_in_background_on(listener);
     thread::sleep(Duration::from_millis(80));
-    (addr, server)
+    (db, addr, server)
 }
 
 #[test]
 fn over_cap_principal_gets_structured_429_others_unaffected_then_recovers() {
     // cap=1 per principal; each request parks ~700ms in flight.
-    let (addr, server) = boot(1, 700);
+    let (_db, addr, server) = boot(1, 700);
 
     // Fire request A for principal `alice` in the background; it acquires
     // the single per-principal slot and holds it while the slow-inject
@@ -126,7 +127,7 @@ fn disabled_cap_admits_unlimited_concurrency_per_principal() {
     // cap=0 disables the per-principal gate entirely; many concurrent
     // requests for one principal all get through (bounded only by the
     // global cap, which is the default and far above this handful).
-    let (addr, _server) = boot(0, 300);
+    let (_db, addr, _server) = boot(0, 300);
 
     let mut handles = Vec::new();
     for _ in 0..6 {

--- a/tests/grouped/http_grpc_auth/http_tls_smoke.rs
+++ b/tests/grouped/http_grpc_auth/http_tls_smoke.rs
@@ -113,7 +113,7 @@ fn rustls_client_get(
 
 #[test]
 fn https_handshake_and_health_probe() {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+    let (_db, rt) = support::persistent_runtime("http-tls-health");
     let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     // /health/live is the universal "process is running" probe — never
@@ -130,7 +130,7 @@ fn https_handshake_and_health_probe() {
 
 #[test]
 fn https_admin_token_over_tls() {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+    let (_db, rt) = support::persistent_runtime("http-tls-admin");
     let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     // Inject an admin token; expect non-bearer hits to 401, correct
@@ -158,7 +158,7 @@ fn https_admin_token_over_tls() {
 
 #[test]
 fn https_alpn_advertises_http11() {
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+    let (_db, rt) = support::persistent_runtime("http-tls-alpn");
     let (_dir, addr, server_cert_der) = spawn_https_server(rt, vec![]);
 
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -196,7 +196,7 @@ fn https_alpn_advertises_http11() {
 fn https_refuses_with_unknown_root() {
     // Client trusts a different cert: handshake must fail. Confirms we
     // are NOT serving plaintext on the TLS port.
-    let rt = RedDBRuntime::in_memory().expect("runtime");
+    let (_db, rt) = support::persistent_runtime("http-tls-unknown-root");
     let (_dir, addr, _server_cert_der) = spawn_https_server(rt, vec![]);
 
     let _ = rustls::crypto::ring::default_provider().install_default();

--- a/tests/grouped/multimodel_query/e2e_issue_751_json_patch_path_helpers.rs
+++ b/tests/grouped/multimodel_query/e2e_issue_751_json_patch_path_helpers.rs
@@ -30,13 +30,13 @@ fn runtime() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("runtime")
 }
 
-fn spawn_http_server() -> (RedDBRuntime, String) {
-    let rt = runtime();
+fn spawn_http_server() -> (support::TempDbFile, RedDBRuntime, String) {
+    let (db, rt) = support::persistent_runtime("json-patch-http");
     let server = RedDBServer::new(rt.clone());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr").to_string();
     server.serve_in_background_on(listener);
-    (rt, addr)
+    (db, rt, addr)
 }
 
 fn http_request(addr: &str, method: &str, path: &str, body: Option<JsonValue>) -> (u16, JsonValue) {
@@ -115,7 +115,7 @@ fn fetch_document_body(addr: &str, collection: &str, id: u64) -> JsonValue {
 // of validated operations so Red UI can render a preview confidently.
 #[test]
 fn document_patch_dry_run_validates_without_mutation() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE DOCUMENT issue751_docs_dry");
     let id = insert_document(&addr, "issue751_docs_dry", json!({ "event_type": "login" }));
     let before = fetch_document_body(&addr, "issue751_docs_dry", id);
@@ -148,7 +148,7 @@ fn document_patch_dry_run_validates_without_mutation() {
 // `code` Red UI can branch on.
 #[test]
 fn document_patch_invalid_path_returns_structured_error_with_pointer() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE DOCUMENT issue751_docs_err");
     let id = insert_document(&addr, "issue751_docs_err", json!({ "event_type": "login" }));
 
@@ -177,7 +177,7 @@ fn document_patch_invalid_path_returns_structured_error_with_pointer() {
 // target leaf and leaves siblings untouched.
 #[test]
 fn document_patch_set_then_unset_nested_path() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE DOCUMENT issue751_docs_nested");
     let id = insert_document(
         &addr,
@@ -226,7 +226,7 @@ fn document_patch_set_then_unset_nested_path() {
 // rewriting the whole blob. Original siblings survive.
 #[test]
 fn kv_patch_set_nested_path_preserves_siblings() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE KV issue751_kv");
     // Seed a JSON object: the HTTP PUT path stores object payloads as JSON.
     let (status, _) = http_request(
@@ -268,7 +268,7 @@ fn kv_patch_set_nested_path_preserves_siblings() {
 // Acceptance 3 — KV nested unset removes a leaf without touching siblings.
 #[test]
 fn kv_patch_unset_nested_path_removes_leaf() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE KV issue751_kv_unset");
     let (status, _) = http_request(
         &addr,
@@ -296,7 +296,7 @@ fn kv_patch_unset_nested_path_removes_leaf() {
 // replacing the whole value.
 #[test]
 fn kv_patch_rejects_non_json_value_with_structured_error() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE KV issue751_kv_scalar");
     let (status, _) = http_request(
         &addr,
@@ -324,7 +324,7 @@ fn kv_patch_rejects_non_json_value_with_structured_error() {
 // distinct empty-state.
 #[test]
 fn kv_patch_missing_key_returns_structured_not_found() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE KV issue751_kv_missing");
 
     let (status, body) = http_request(
@@ -342,7 +342,7 @@ fn kv_patch_missing_key_returns_structured_not_found() {
 // Acceptance 1 — KV dry_run validates without mutation.
 #[test]
 fn kv_patch_dry_run_validates_without_mutation() {
-    let (_rt, addr) = spawn_http_server();
+    let (_db, _rt, addr) = spawn_http_server();
     ddl(&addr, "CREATE KV issue751_kv_dry");
     let (status, _) = http_request(
         &addr,

--- a/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
+++ b/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
@@ -46,12 +46,13 @@ fn bool_value(row: &UnifiedRecord, column: &str) -> bool {
     }
 }
 
-fn spawn_http_server() -> String {
-    let server = RedDBServer::new(runtime());
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("probabilistic-http");
+    let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> JsonValue {
@@ -180,7 +181,7 @@ fn probabilistic_state_survives_reopen_for_commands_and_sql_read_forms() {
 
 #[test]
 fn http_query_covers_probabilistic_commands_and_sql_read_forms() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
 
     post_query(&addr, "CREATE HLL visitors");
     post_query(&addr, "HLL ADD visitors 'alice' 'bob' 'alice'");

--- a/tests/grouped/runtime_persistence/integration_local_embedding_conformance.rs
+++ b/tests/grouped/runtime_persistence/integration_local_embedding_conformance.rs
@@ -14,6 +14,9 @@
 //! download — proving the contract "normal test commands do not
 //! require live HuggingFace network access" for the `local` provider.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -176,7 +179,7 @@ fn local_provider_conformance_all_surfaces_offline() {
     // pure KV write, so registering the same name on each runtime
     // gives the local backend the same registry view it would see
     // in a single-process deployment.
-    let http_rt = rt();
+    let (_http_db, http_rt) = support::persistent_runtime("local-embedding-http");
     register_installed_local_model(&http_rt, "mini-en", 2);
     let addr = spawn_http_server(http_rt);
     let (status, body) = post_json(
@@ -299,7 +302,8 @@ fn local_provider_http_requires_explicit_model_name() {
         calls: Arc::new(Mutex::new(0)),
     }));
 
-    let addr = spawn_http_server(rt());
+    let (_db, http_rt) = support::persistent_runtime("local-embedding-http-missing-model");
+    let addr = spawn_http_server(http_rt);
     let (status, body) = post_json(
         &addr,
         "/ai/embeddings",

--- a/tests/grouped/schema_query_core/e2e_red_collections_acceptance.rs
+++ b/tests/grouped/schema_query_core/e2e_red_collections_acceptance.rs
@@ -268,15 +268,13 @@ fn red_system_schema_is_read_only_for_dml() {
     }
 }
 
-fn spawn_http(rt: RedDBRuntime) -> String {
+fn spawn_http(rt: RedDBRuntime) -> (String, thread::JoinHandle<std::io::Result<()>>) {
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap();
-    thread::spawn(move || {
-        let _ = server.serve_on(listener);
-    });
+    let handle = thread::spawn(move || server.serve_one_on(listener));
     thread::sleep(Duration::from_millis(80));
-    addr.to_string()
+    (addr.to_string(), handle)
 }
 
 fn http_post_query(addr: &str, query: &str) -> (u16, serde_json::Value) {
@@ -315,9 +313,13 @@ fn http_post_query(addr: &str, query: &str) -> (u16, serde_json::Value) {
 fn http_query_endpoint_returns_red_collections_inventory() {
     let rt = open_runtime();
     seed_collection_inventory(&rt);
-    let addr = spawn_http(rt);
+    let (addr, handle) = spawn_http(rt);
 
     let (status, body) = http_post_query(&addr, "SELECT * FROM red.collections");
+    handle
+        .join()
+        .expect("HTTP server thread should not panic")
+        .expect("HTTP server should serve one request");
 
     assert_eq!(status, 200, "body = {body}");
     assert_eq!(body["ok"], true);

--- a/tests/grouped/storage_durability/e2e_logical_wal_crash.rs
+++ b/tests/grouped/storage_durability/e2e_logical_wal_crash.rs
@@ -25,13 +25,13 @@ fn spool_file_path(data_path: &std::path::Path) -> PathBuf {
 
 #[test]
 fn truncated_tail_after_append_returns_valid_prefix_only() {
-    let data_path = support::temp_data_dir("logical-wal-truncated-tail");
-    let spool_path = spool_file_path(&data_path);
+    let data_path = support::temp_db_file("logical-wal-truncated-tail");
+    let spool_path = spool_file_path(data_path.path());
 
     // Write three records via the public API. After this, every
     // record on disk has a valid v2 frame + crc.
     {
-        let spool = LogicalWalSpool::open(&data_path).expect("open spool");
+        let spool = LogicalWalSpool::open(data_path.path()).expect("open spool");
         spool.append(1, b"first record").unwrap();
         spool.append(2, b"second record").unwrap();
         spool.append(3, b"third record").unwrap();
@@ -58,7 +58,7 @@ fn truncated_tail_after_append_returns_valid_prefix_only() {
     // drop the torn third record. The file is rewritten to the
     // post-truncate length so a subsequent append produces a clean
     // sequence.
-    let spool = LogicalWalSpool::open(&data_path).expect("re-open spool");
+    let spool = LogicalWalSpool::open(data_path.path()).expect("re-open spool");
     let entries = spool.read_since(0, 100).expect("read");
     assert_eq!(
         entries.len(),
@@ -78,12 +78,12 @@ fn truncated_tail_after_append_returns_valid_prefix_only() {
 
 #[test]
 fn checksum_flip_in_middle_record_truncates_at_corrupt_offset() {
-    let data_path = support::temp_data_dir("logical-wal-crc-flip");
-    let spool_path = spool_file_path(&data_path);
+    let data_path = support::temp_db_file("logical-wal-crc-flip");
+    let spool_path = spool_file_path(data_path.path());
 
     // Three records, every byte covered by crc32.
     {
-        let spool = LogicalWalSpool::open(&data_path).expect("open");
+        let spool = LogicalWalSpool::open(data_path.path()).expect("open");
         spool.append(10, b"alpha").unwrap();
         spool.append(11, b"bravo").unwrap();
         spool.append(12, b"charlie").unwrap();
@@ -116,7 +116,7 @@ fn checksum_flip_in_middle_record_truncates_at_corrupt_offset() {
     // boundary, so it's also gone — that's intentional: once a
     // corrupt record is found, no further records are trusted because
     // their LSNs may have been duplicated by primary recovery.
-    let spool = LogicalWalSpool::open(&data_path).expect("re-open");
+    let spool = LogicalWalSpool::open(data_path.path()).expect("re-open");
     let entries = spool.read_since(0, 100).expect("read");
     assert_eq!(
         entries.len(),
@@ -129,9 +129,9 @@ fn checksum_flip_in_middle_record_truncates_at_corrupt_offset() {
 
 #[test]
 fn empty_file_recovers_to_empty_state() {
-    let data_path = support::temp_data_dir("logical-wal-empty");
+    let data_path = support::temp_db_file("logical-wal-empty");
 
-    let spool = LogicalWalSpool::open(&data_path).expect("open empty");
+    let spool = LogicalWalSpool::open(data_path.path()).expect("open empty");
     let entries = spool.read_since(0, 100).expect("read");
     assert!(entries.is_empty());
     assert_eq!(spool.current_lsn(), 0);
@@ -139,12 +139,12 @@ fn empty_file_recovers_to_empty_state() {
 
 #[test]
 fn first_record_torn_leaves_clean_empty_spool() {
-    let data_path = support::temp_data_dir("logical-wal-first-torn");
-    let spool_path = spool_file_path(&data_path);
+    let data_path = support::temp_db_file("logical-wal-first-torn");
+    let spool_path = spool_file_path(data_path.path());
 
     // Single record then chop the crc.
     {
-        let spool = LogicalWalSpool::open(&data_path).expect("open");
+        let spool = LogicalWalSpool::open(data_path.path()).expect("open");
         spool.append(1, b"only").unwrap();
     }
     {
@@ -158,7 +158,7 @@ fn first_record_torn_leaves_clean_empty_spool() {
         f.sync_all().unwrap();
     }
 
-    let spool = LogicalWalSpool::open(&data_path).expect("re-open");
+    let spool = LogicalWalSpool::open(data_path.path()).expect("re-open");
     let entries = spool.read_since(0, 100).unwrap();
     assert!(
         entries.is_empty(),
@@ -181,10 +181,10 @@ fn append_is_synced_when_call_returns() {
     // true even for unsynced writes, so the assertion is a regression
     // canary against a future buffered-writer change that would only
     // flush on drop.
-    let data_path = support::temp_data_dir("logical-wal-sync");
-    let spool_path = spool_file_path(&data_path);
+    let data_path = support::temp_db_file("logical-wal-sync");
+    let spool_path = spool_file_path(data_path.path());
 
-    let spool = LogicalWalSpool::open(&data_path).expect("open");
+    let spool = LogicalWalSpool::open(data_path.path()).expect("open");
     let before = std::fs::metadata(&spool_path).unwrap().len();
     spool.append(1, b"x").unwrap();
     let after = std::fs::metadata(&spool_path).unwrap().len();

--- a/tests/grouped/surface_contracts/integration_rpc_stdio.rs
+++ b/tests/grouped/surface_contracts/integration_rpc_stdio.rs
@@ -20,12 +20,15 @@ struct StdioSession {
     child: std::process::Child,
     stdin: std::process::ChildStdin,
     stdout: BufReader<std::process::ChildStdout>,
+    _db: super::support::TempDbFile,
 }
 
 impl StdioSession {
     fn spawn() -> Self {
+        let db = super::support::temp_db_file("rpc-stdio");
         let mut child = Command::new(red_binary())
-            .args(["rpc", "--stdio"])
+            .args(["rpc", "--stdio", "--path"])
+            .arg(db.path())
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
@@ -37,6 +40,7 @@ impl StdioSession {
             child,
             stdin,
             stdout,
+            _db: db,
         }
     }
 

--- a/tests/grouped/surface_contracts/reddb_client_embedded.rs
+++ b/tests/grouped/surface_contracts/reddb_client_embedded.rs
@@ -2,9 +2,16 @@
 
 use reddb_client::{ErrorCode, JsonValue, Reddb};
 
+fn temp_file_uri(tag: &str) -> (super::support::TempDbFile, String) {
+    let db = super::support::temp_db_file(tag);
+    let uri = format!("file://{}", db.path().display());
+    (db, uri)
+}
+
 #[tokio::test]
-async fn connect_memory_then_version() {
-    let _db = Reddb::connect("memory://").await.expect("connect");
+async fn connect_file_then_version() {
+    let (_db_path, uri) = temp_file_uri("client-connect-version");
+    let _db = Reddb::connect(&uri).await.expect("connect");
 }
 
 #[tokio::test]
@@ -21,7 +28,8 @@ async fn connect_with_empty_uri_returns_invalid() {
 
 #[tokio::test]
 async fn insert_then_query_round_trip() {
-    let db = Reddb::connect("memory://").await.expect("connect");
+    let (_db_path, uri) = temp_file_uri("client-insert-query");
+    let db = Reddb::connect(&uri).await.expect("connect");
     let payload = JsonValue::object([
         ("name", JsonValue::string("Alice")),
         ("age", JsonValue::number(30)),
@@ -43,7 +51,8 @@ async fn insert_then_query_round_trip() {
 
 #[tokio::test]
 async fn bulk_insert_returns_total_affected() {
-    let db = Reddb::connect("memory://").await.expect("connect");
+    let (_db_path, uri) = temp_file_uri("client-bulk-insert");
+    let db = Reddb::connect(&uri).await.expect("connect");
     let payloads = vec![
         JsonValue::object([("name", JsonValue::string("a"))]),
         JsonValue::object([("name", JsonValue::string("b"))]),
@@ -56,7 +65,8 @@ async fn bulk_insert_returns_total_affected() {
 
 #[tokio::test]
 async fn bad_sql_returns_query_error() {
-    let db = Reddb::connect("memory://").await.expect("connect");
+    let (_db_path, uri) = temp_file_uri("client-bad-sql");
+    let db = Reddb::connect(&uri).await.expect("connect");
     let err = db.query("NOT A VALID STATEMENT $$$").await.unwrap_err();
     assert_eq!(err.code, ErrorCode::QueryError);
 }

--- a/tests/grouped/surface_contracts/regress.rs
+++ b/tests/grouped/surface_contracts/regress.rs
@@ -16,7 +16,7 @@ fn regression_sql_snapshots_match() {
 
     let mut failures = Vec::new();
     for case in &cases {
-        let runtime = RedDBRuntime::in_memory().expect("in-memory runtime");
+        let runtime = super::support::persistent_test_runtime("surface-regress");
         let failure = run_case(case, |sql| execute_statement(&runtime, sql)).expect("run case");
         if let Some(failure) = failure {
             failures.push(format!("case `{}` diff:\n{}", failure.name, failure.diff));

--- a/tests/grouped/surface_contracts/rql_conformance.rs
+++ b/tests/grouped/surface_contracts/rql_conformance.rs
@@ -13,19 +13,21 @@
 use std::path::{Path, PathBuf};
 
 use reddb_rql::{render_cell, CellType};
-use reddb_server::{RedDBError, RedDBRuntime};
+use reddb_server::RedDBError;
 use reddb_types::Value;
 use sqllogictest::{DBOutput, DefaultColumnType, Runner, DB};
 
-/// One sqllogictest connection to the RedDB engine — a fresh in-memory runtime.
+use super::support::PersistentRuntime;
+
+/// One sqllogictest connection to the RedDB engine — a fresh persistent runtime.
 struct EngineDb {
-    runtime: RedDBRuntime,
+    runtime: PersistentRuntime,
 }
 
 impl EngineDb {
     fn connect() -> Result<Self, RedDBError> {
         Ok(Self {
-            runtime: RedDBRuntime::in_memory()?,
+            runtime: super::support::persistent_test_runtime("surface-rql-conformance"),
         })
     }
 }

--- a/tests/grouped/surface_contracts/rql_reddb_conformance.rs
+++ b/tests/grouped/surface_contracts/rql_reddb_conformance.rs
@@ -37,7 +37,7 @@
 use std::path::{Path, PathBuf};
 
 use reddb_rql::{render_cell, CellType};
-use reddb_server::{RedDBError, RedDBRuntime};
+use reddb_server::RedDBError;
 use reddb_types::Value;
 use sqllogictest::{DBOutput, DefaultColumnType, Runner, DB};
 
@@ -59,15 +59,17 @@ const KEEP: &[&str] = &[
     "negative_cycle_detected",
 ];
 
-/// One sqllogictest connection to the RedDB engine — a fresh in-memory runtime.
+use super::support::PersistentRuntime;
+
+/// One sqllogictest connection to the RedDB engine — a fresh persistent runtime.
 struct EngineDb {
-    runtime: RedDBRuntime,
+    runtime: PersistentRuntime,
 }
 
 impl EngineDb {
     fn connect() -> Result<Self, RedDBError> {
         Ok(Self {
-            runtime: RedDBRuntime::in_memory()?,
+            runtime: super::support::persistent_test_runtime("surface-rql-reddb-conformance"),
         })
     }
 }

--- a/tests/grouped/surface_contracts/smoke_embedded.rs
+++ b/tests/grouped/surface_contracts/smoke_embedded.rs
@@ -8,10 +8,12 @@ use reddb::application::{
 };
 use reddb::json::Value as JsonValue;
 use reddb::storage::schema::Value;
-use reddb::{ArtifactState, EntityUseCases, NativeUseCases, QueryUseCases, RedDBRuntime};
+use reddb::{ArtifactState, EntityUseCases, NativeUseCases, QueryUseCases};
 
-fn rt() -> RedDBRuntime {
-    RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
+use super::support::PersistentRuntime;
+
+fn rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("surface-smoke-embedded")
 }
 
 // ---------------------------------------------------------------------------
@@ -21,7 +23,7 @@ fn rt() -> RedDBRuntime {
 #[test]
 fn smoke_health_report() {
     let rt = rt();
-    let native = NativeUseCases::new(&rt);
+    let native = NativeUseCases::new(rt.runtime());
     let report = native.health();
     assert!(
         report.is_healthy() || matches!(report.state, reddb::HealthState::Degraded),
@@ -33,7 +35,7 @@ fn smoke_health_report() {
 #[test]
 fn smoke_catalog_snapshot() {
     let rt = rt();
-    let native = NativeUseCases::new(&rt);
+    let native = NativeUseCases::new(rt.runtime());
     let _report = native.health();
 }
 
@@ -44,7 +46,7 @@ fn smoke_catalog_snapshot() {
 #[test]
 fn smoke_row_crud() {
     let rt = rt();
-    let uc = EntityUseCases::new(&rt);
+    let uc = EntityUseCases::new(rt.runtime());
 
     let out = uc.create_row(CreateRowInput {
         collection: "users".into(),
@@ -67,8 +69,8 @@ fn smoke_row_crud() {
 #[test]
 fn smoke_vector_insert_and_search() {
     let rt = rt();
-    let entity = EntityUseCases::new(&rt);
-    let query = QueryUseCases::new(&rt);
+    let entity = EntityUseCases::new(rt.runtime());
+    let query = QueryUseCases::new(rt.runtime());
 
     for v in [
         vec![1.0f32, 0.0, 0.0],
@@ -109,7 +111,7 @@ fn smoke_vector_insert_and_search() {
 #[test]
 fn smoke_graph_crud() {
     let rt = rt();
-    let uc = EntityUseCases::new(&rt);
+    let uc = EntityUseCases::new(rt.runtime());
 
     let node_a = uc
         .create_node(CreateNodeInput {
@@ -156,8 +158,8 @@ fn smoke_graph_crud() {
 #[test]
 fn smoke_query_select() {
     let rt = rt();
-    let entity = EntityUseCases::new(&rt);
-    let query = QueryUseCases::new(&rt);
+    let entity = EntityUseCases::new(rt.runtime());
+    let query = QueryUseCases::new(rt.runtime());
 
     entity
         .create_row(CreateRowInput {
@@ -181,7 +183,7 @@ fn smoke_query_select() {
 #[test]
 fn smoke_query_explain_universal() {
     let rt = rt();
-    let query = QueryUseCases::new(&rt);
+    let query = QueryUseCases::new(rt.runtime());
 
     let explain = query.explain(ExplainQueryInput {
         query: "SELECT * FROM any".into(),
@@ -240,7 +242,7 @@ fn smoke_artifact_state_machine() {
 #[test]
 fn smoke_kv_crud() {
     let rt = rt();
-    let uc = EntityUseCases::new(&rt);
+    let uc = EntityUseCases::new(rt.runtime());
 
     // Set a key
     let out = uc.create_kv(CreateKvInput {
@@ -283,7 +285,7 @@ fn smoke_kv_crud() {
 #[test]
 fn smoke_document_crud() {
     let rt = rt();
-    let uc = EntityUseCases::new(&rt);
+    let uc = EntityUseCases::new(rt.runtime());
 
     let mut body = reddb::json::Map::new();
     body.insert("name".into(), JsonValue::String("Alice".into()));
@@ -304,7 +306,7 @@ fn smoke_document_crud() {
     );
 
     // Query via table (documents are enriched rows)
-    let result = QueryUseCases::new(&rt).execute(ExecuteQueryInput {
+    let result = QueryUseCases::new(rt.runtime()).execute(ExecuteQueryInput {
         query: "SELECT * FROM profiles".into(),
     });
     assert!(
@@ -321,8 +323,8 @@ fn smoke_document_crud() {
 #[test]
 fn smoke_vector_hnsw_search() {
     let rt = rt();
-    let entity = EntityUseCases::new(&rt);
-    let query = QueryUseCases::new(&rt);
+    let entity = EntityUseCases::new(rt.runtime());
+    let query = QueryUseCases::new(rt.runtime());
 
     // Insert enough vectors to trigger HNSW (>=100 for index build)
     for i in 0..120 {

--- a/tests/grouped/timeseries_metrics/e2e_issue_543_timeseries_tag_json_round_trip.rs
+++ b/tests/grouped/timeseries_metrics/e2e_issue_543_timeseries_tag_json_round_trip.rs
@@ -14,6 +14,9 @@
 //! Those quoted-number and stringified-array shapes are exactly the
 //! "placeholder strings" user-story 26 calls out as broken.
 
+#[path = "../../support/mod.rs"]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
@@ -123,13 +126,13 @@ fn sql_select_tags_returns_json_typed_values() {
     assert_representative_payload(&tags);
 }
 
-fn spawn_http_server() -> String {
-    let rt = runtime();
+fn spawn_http_server() -> (support::TempDbFile, String) {
+    let (db, rt) = support::persistent_runtime("timeseries-tags-http");
     let server = RedDBServer::new(rt);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().expect("local addr");
     server.serve_in_background_on(listener);
-    addr.to_string()
+    (db, addr.to_string())
 }
 
 fn post_query(addr: &str, query: &str) -> SerdeValue {
@@ -171,7 +174,7 @@ fn post_query(addr: &str, query: &str) -> SerdeValue {
 
 #[test]
 fn http_query_tags_match_sql_shape() {
-    let addr = spawn_http_server();
+    let (_db, addr) = spawn_http_server();
 
     for sql in SETUP_SQL {
         let _ = post_query(&addr, sql);

--- a/tests/grouped/timeseries_remaining/e2e_metrics_cardinality_budget.rs
+++ b/tests/grouped/timeseries_remaining/e2e_metrics_cardinality_budget.rs
@@ -1,41 +1,12 @@
 #[path = "../../support/mod.rs"]
 mod support;
 
-use std::sync::{Mutex, OnceLock};
-
 use reddb::RedDBRuntime;
 use serde_json::Value as JsonValue;
 use support::prometheus::{
     encode_query_value, get, label, post_remote_write, sample, TimeSeries, WriteRequest,
 };
 use support::{checkpoint_and_reopen, PersistentDbPath};
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<String>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
 
 fn exec(rt: &RedDBRuntime, sql: &str) {
     rt.execute_query(sql)
@@ -72,8 +43,11 @@ fn prom_query(rt: &RedDBRuntime, promql: &str) -> JsonValue {
 
 #[test]
 fn cardinality_budget_partially_accepts_and_persists_series_registry() {
-    let _lock = env_lock().lock().expect("env lock");
-    let _budget = EnvGuard::set("REDDB_METRICS_MAX_SERIES_PER_METRIC", "2");
+    let _lock = crate::timeseries_remaining_shared::metrics_env_lock();
+    let _budget = crate::timeseries_remaining_shared::EnvGuard::set(
+        "REDDB_METRICS_MAX_SERIES_PER_METRIC",
+        "2",
+    );
     let path = PersistentDbPath::new("metrics_cardinality_budget");
     let rt = path.open_runtime();
     exec(&rt, "CREATE METRICS sre RETENTION 30 d");

--- a/tests/grouped/timeseries_remaining/e2e_metrics_grafana_compat_smoke.rs
+++ b/tests/grouped/timeseries_remaining/e2e_metrics_grafana_compat_smoke.rs
@@ -1,41 +1,12 @@
 #[path = "../../support/mod.rs"]
 mod support;
 
-use std::sync::{Mutex, OnceLock};
-
 use reddb::RedDBRuntime;
 use serde_json::Value as JsonValue;
 use support::prometheus::{
     encode_query_value, get, get_with_headers, label, post_remote_write,
     post_remote_write_with_headers, sample, TimeSeries, WriteRequest,
 };
-
-fn env_lock() -> &'static Mutex<()> {
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-}
-
-struct EnvGuard {
-    key: &'static str,
-    previous: Option<String>,
-}
-
-impl EnvGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var(key).ok();
-        std::env::set_var(key, value);
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvGuard {
-    fn drop(&mut self) {
-        match &self.previous {
-            Some(value) => std::env::set_var(self.key, value),
-            None => std::env::remove_var(self.key),
-        }
-    }
-}
 
 fn exec(rt: &RedDBRuntime, sql: &str) {
     rt.execute_query(sql)
@@ -139,7 +110,7 @@ fn first_value(response: &JsonValue) -> &str {
 
 #[test]
 fn grafana_prometheus_datasource_panels_render_representative_metrics() {
-    let _lock = env_lock().lock().expect("env lock");
+    let _lock = crate::timeseries_remaining_shared::metrics_env_lock();
     let rt = RedDBRuntime::in_memory().expect("runtime");
     exec(
         &rt,
@@ -299,8 +270,11 @@ fn grafana_prometheus_datasource_panels_render_representative_metrics() {
 
 #[test]
 fn grafana_smoke_surfaces_cardinality_rejection_visibility() {
-    let _lock = env_lock().lock().expect("env lock");
-    let _budget = EnvGuard::set("REDDB_METRICS_MAX_SERIES_PER_METRIC", "1");
+    let _lock = crate::timeseries_remaining_shared::metrics_env_lock();
+    let _budget = crate::timeseries_remaining_shared::EnvGuard::set(
+        "REDDB_METRICS_MAX_SERIES_PER_METRIC",
+        "1",
+    );
     let rt = RedDBRuntime::in_memory().expect("runtime");
     exec(&rt, "CREATE METRICS sre RETENTION 30 d");
 

--- a/tests/grouped/timeseries_remaining/shared.rs
+++ b/tests/grouped/timeseries_remaining/shared.rs
@@ -1,0 +1,34 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+fn metrics_env_mutex() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+pub fn metrics_env_lock() -> MutexGuard<'static, ()> {
+    metrics_env_mutex()
+        .lock()
+        .unwrap_or_else(|err| err.into_inner())
+}
+
+pub struct EnvGuard {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvGuard {
+    pub fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}

--- a/tests/grouped_ai_local_vector.rs
+++ b/tests/grouped_ai_local_vector.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[path = "grouped/ai_local_vector/support.rs"]
+mod support;
+
 #[path = "grouped/ai_local_vector/integration_ai_live_comment_clustering.rs"]
 mod integration_ai_live_comment_clustering;
 

--- a/tests/grouped_ai_search.rs
+++ b/tests/grouped_ai_search.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[path = "grouped/ai_search/support.rs"]
+mod support;
+
 #[path = "grouped/ai_search/e2e_ask_search_conformance.rs"]
 mod e2e_ask_search_conformance;
 

--- a/tests/grouped_config_tier.rs
+++ b/tests/grouped_config_tier.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[path = "grouped/config_tier/shared.rs"]
+mod config_tier_shared;
+
 #[path = "grouped/config_tier/e2e_config_crud.rs"]
 mod e2e_config_crud;
 

--- a/tests/grouped_surface_contracts.rs
+++ b/tests/grouped_surface_contracts.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[path = "support/mod.rs"]
+mod support;
+
 #[path = "grouped/surface_contracts/compile_fail.rs"]
 mod compile_fail;
 

--- a/tests/grouped_timeseries_remaining.rs
+++ b/tests/grouped_timeseries_remaining.rs
@@ -1,5 +1,8 @@
 #![allow(dead_code)]
 
+#[path = "grouped/timeseries_remaining/shared.rs"]
+mod timeseries_remaining_shared;
+
 #[path = "grouped/timeseries_remaining/e2e_continuous_aggregate.rs"]
 mod e2e_continuous_aggregate;
 

--- a/tests/http_connection_limiter.rs
+++ b/tests/http_connection_limiter.rs
@@ -11,13 +11,20 @@ use std::time::Duration;
 use reddb::server::RedDBServer;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-fn drain_status_line(stream: &mut TcpStream) -> String {
-    // Read up to the end of the first line. The 503 response is
-    // small (~80 bytes); use a generous read.
-    let mut buf = [0u8; 256];
-    let n = stream.read(&mut buf).unwrap_or(0);
-    let text = String::from_utf8_lossy(&buf[..n]).to_string();
-    text
+fn send_request(addr: &str, path: &str) -> String {
+    let mut tcp = TcpStream::connect(addr).expect("connect");
+    tcp.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    tcp.set_write_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    tcp.write_all(req.as_bytes()).unwrap();
+    tcp.flush().unwrap();
+    let mut buf = Vec::new();
+    let _ = tcp.read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+fn spawn_slow_request(addr: String) -> thread::JoinHandle<String> {
+    thread::spawn(move || send_request(&addr, "/health/live"))
 }
 
 fn boot(cap: usize) -> (String, RedDBServer) {
@@ -40,15 +47,14 @@ fn rejects_with_503_when_cap_saturated_then_recovers() {
     let cap = 2;
     let (addr, server) = boot(cap);
 
-    // Saturate the cap with `cap` open connections that never send a
-    // request. The handler thread is parked on `read_timeout_ms`
-    // (5s default) waiting for bytes; that keeps the permit held.
-    let mut held: Vec<TcpStream> = Vec::new();
+    // The async HTTP edge limits in-flight requests, not idle TCP
+    // connections. Saturate the cap with real requests held inside the
+    // test slow-inject hook.
+    server.set_test_slow_inject_ms(2_000);
+    let mut held = Vec::new();
     for _ in 0..cap {
-        let s = TcpStream::connect(&addr).expect("connect-hold");
-        held.push(s);
+        held.push(spawn_slow_request(addr.clone()));
     }
-    // Give the accept thread a moment to take both permits.
     for _ in 0..50 {
         if server.http_limiter().current() == cap {
             break;
@@ -62,29 +68,26 @@ fn rejects_with_503_when_cap_saturated_then_recovers() {
     );
 
     // Next connection must be rejected with 503.
-    let mut rejected = TcpStream::connect(&addr).expect("connect-rejected");
-    rejected
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .unwrap();
-    let text = drain_status_line(&mut rejected);
+    let text = send_request(&addr, "/health/live");
     assert!(
         text.starts_with("HTTP/1.1 503"),
         "expected 503 status line, got: {text:?}"
     );
+    let text_lower = text.to_ascii_lowercase();
     assert!(
-        text.contains("Retry-After: 5"),
+        text_lower.contains("retry-after: 5"),
         "expected Retry-After header, got: {text:?}"
     );
-    assert!(
-        text.contains("Connection: close"),
-        "expected Connection: close, got: {text:?}"
-    );
 
-    // Drain the held connections — closing the client side lets the
-    // handler thread observe EOF / error and exit, releasing permits.
-    for s in held.drain(..) {
-        let _ = s.shutdown(std::net::Shutdown::Both);
-        drop(s);
+    // Drain the held requests; their handlers finish once the
+    // slow-inject sleep expires, releasing permits.
+    server.set_test_slow_inject_ms(0);
+    for handle in held {
+        let body = handle.join().expect("held request thread");
+        assert!(
+            body.starts_with("HTTP/1.1 2"),
+            "held request should complete normally, got: {body:?}"
+        );
     }
     // Wait for permits to drop back down.
     for _ in 0..100 {
@@ -113,11 +116,13 @@ fn rejects_with_503_when_cap_saturated_then_recovers() {
     let mut buf = Vec::new();
     let _ = tcp.read_to_end(&mut buf);
     let resp = String::from_utf8_lossy(&buf);
-    // The fresh connection must NOT be the limiter's static 503
-    // (signature: `Retry-After: 5` + `Content-Length: 0`). The
-    // request itself is allowed to return any status — the point is
+    // The fresh connection must NOT be the limiter's capacity 503.
+    // The request itself is allowed to return any status — the point is
     // that it was admitted past the limiter and routed normally.
-    let is_limiter_reject = resp.contains("Retry-After: 5") && resp.contains("Content-Length: 0");
+    let resp_lower = resp.to_ascii_lowercase();
+    let is_limiter_reject = resp.starts_with("HTTP/1.1 503")
+        && resp_lower.contains("retry-after: 5")
+        && resp.contains("server at capacity");
     assert!(
         !is_limiter_reject,
         "fresh connection should not be rejected by the limiter, got: {resp:?}"

--- a/tests/http_connection_limiter.rs
+++ b/tests/http_connection_limiter.rs
@@ -123,7 +123,7 @@ fn rejects_with_503_when_cap_saturated_then_recovers() {
     let resp_lower = resp.to_ascii_lowercase();
     let is_limiter_reject = resp.starts_with("HTTP/1.1 503")
         && resp_lower.contains("retry-after: 5")
-        && resp.contains("server at capacity");
+        && resp_lower.contains("server at capacity");
     assert!(
         !is_limiter_reject,
         "fresh connection should not be rejected by the limiter, got: {resp:?}"

--- a/tests/http_connection_limiter.rs
+++ b/tests/http_connection_limiter.rs
@@ -3,13 +3,15 @@
 //! `HTTP/1.1 503 Service Unavailable` + `Retry-After`, then recover
 //! once existing connections drain.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
 use reddb::server::RedDBServer;
-use reddb::{RedDBOptions, RedDBRuntime};
 
 fn send_request(addr: &str, path: &str) -> String {
     let mut tcp = TcpStream::connect(addr).expect("connect");
@@ -27,9 +29,8 @@ fn spawn_slow_request(addr: String) -> thread::JoinHandle<String> {
     thread::spawn(move || send_request(&addr, "/health/live"))
 }
 
-fn boot(cap: usize) -> (String, RedDBServer) {
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+fn boot(cap: usize) -> (support::TempDbFile, String, RedDBServer) {
+    let (db, runtime) = support::persistent_runtime("http-connection-limiter");
     let server = RedDBServer::new(runtime).with_http_limiter_cap(cap);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
@@ -39,13 +40,13 @@ fn boot(cap: usize) -> (String, RedDBServer) {
     });
     // Small wait so the accept thread is parked on `incoming()`.
     thread::sleep(Duration::from_millis(80));
-    (addr, server)
+    (db, addr, server)
 }
 
 #[test]
 fn rejects_with_503_when_cap_saturated_then_recovers() {
     let cap = 2;
-    let (addr, server) = boot(cap);
+    let (_db, addr, server) = boot(cap);
 
     // The async HTTP edge limits in-flight requests, not idle TCP
     // connections. Saturate the cap with real requests held inside the

--- a/tests/http_handler_deadline.rs
+++ b/tests/http_handler_deadline.rs
@@ -59,15 +59,16 @@ fn handler_deadline_emits_503_then_recovers() {
         resp.starts_with("HTTP/1.1 503"),
         "expected 503 status line, got: {resp:?}"
     );
+    let resp_lower = resp.to_ascii_lowercase();
     assert!(
-        resp.contains("Connection: close"),
+        resp_lower.contains("connection: close"),
         "expected Connection: close, got: {resp:?}"
     );
     // The deadline-503 has no Retry-After (that signature belongs to
     // the limiter's static reject). This keeps the two failure modes
     // distinguishable in logs and tests.
     assert!(
-        !resp.contains("Retry-After:"),
+        !resp_lower.contains("retry-after:"),
         "deadline-503 should not carry Retry-After, got: {resp:?}"
     );
 

--- a/tests/http_handler_deadline.rs
+++ b/tests/http_handler_deadline.rs
@@ -4,17 +4,18 @@
 //! `Connection: close`, release its limiter permit on thread exit,
 //! and let subsequent requests succeed.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::{Duration, Instant};
 
 use reddb::server::RedDBServer;
-use reddb::{RedDBOptions, RedDBRuntime};
 
-fn boot(handler_timeout: Duration) -> (String, RedDBServer) {
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+fn boot(handler_timeout: Duration) -> (support::TempDbFile, String, RedDBServer) {
+    let (db, runtime) = support::persistent_runtime("http-handler-deadline");
     let server = RedDBServer::new(runtime).with_handler_timeout(handler_timeout);
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
     let addr = listener.local_addr().unwrap().to_string();
@@ -23,7 +24,7 @@ fn boot(handler_timeout: Duration) -> (String, RedDBServer) {
         let _ = server_clone.serve_on(listener);
     });
     thread::sleep(Duration::from_millis(80));
-    (addr, server)
+    (db, addr, server)
 }
 
 fn send_health(addr: &str, read_timeout: Duration) -> (String, Instant) {
@@ -45,7 +46,7 @@ fn handler_deadline_emits_503_then_recovers() {
     let inject_ms: u64 = 500;
     let slack = Duration::from_millis(1_500);
 
-    let (addr, server) = boot(handler_timeout);
+    let (_db, addr, server) = boot(handler_timeout);
 
     // Arm a slow downstream that exceeds the deadline.
     server.set_test_slow_inject_ms(inject_ms);
@@ -108,7 +109,7 @@ fn handler_deadline_emits_503_then_recovers() {
 fn fast_request_unaffected_by_deadline() {
     // With a generous deadline and no injection, /health round-trips
     // normally — the boundary checks must not interfere.
-    let (addr, _server) = boot(Duration::from_secs(30));
+    let (_db, addr, _server) = boot(Duration::from_secs(30));
     let (resp, _) = send_health(&addr, Duration::from_secs(5));
     assert!(
         resp.starts_with("HTTP/1.1 2"),

--- a/tests/http_handler_metrics.rs
+++ b/tests/http_handler_metrics.rs
@@ -9,17 +9,18 @@
 //! the issue brief are present with the expected label sets and
 //! monotonic counter relationships.
 
+#[allow(dead_code)]
+mod support;
+
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::thread;
 use std::time::Duration;
 
 use reddb::server::RedDBServer;
-use reddb::{RedDBOptions, RedDBRuntime};
 
-fn boot(cap: usize, handler_timeout: Duration) -> (String, RedDBServer) {
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+fn boot(cap: usize, handler_timeout: Duration) -> (support::TempDbFile, String, RedDBServer) {
+    let (db, runtime) = support::persistent_runtime("http-handler-metrics");
     let server = RedDBServer::new(runtime)
         .with_http_limiter_cap(cap)
         .with_handler_timeout(handler_timeout);
@@ -30,7 +31,7 @@ fn boot(cap: usize, handler_timeout: Duration) -> (String, RedDBServer) {
         let _ = server_clone.serve_on(listener);
     });
     thread::sleep(Duration::from_millis(80));
-    (addr, server)
+    (db, addr, server)
 }
 
 fn send_request(addr: &str, path: &str) -> String {
@@ -79,7 +80,7 @@ fn metrics_emit_all_four_series_with_expected_label_sets() {
     // never sends a request and still leave room for the scrape.
     let cap = 2;
     let handler_timeout = Duration::from_millis(3_000);
-    let (addr, server) = boot(cap, handler_timeout);
+    let (_db, addr, server) = boot(cap, handler_timeout);
 
     // (1) Happy-path request — records one sample in the http
     // duration histogram. Use a separate connection from later steps.

--- a/tests/http_handler_metrics.rs
+++ b/tests/http_handler_metrics.rs
@@ -45,6 +45,10 @@ fn send_request(addr: &str, path: &str) -> String {
     String::from_utf8_lossy(&buf).into_owned()
 }
 
+fn spawn_slow_request(addr: String) -> thread::JoinHandle<String> {
+    thread::spawn(move || send_request(&addr, "/health/live"))
+}
+
 fn metric_value(body: &str, line_prefix: &str) -> u64 {
     for line in body.lines() {
         if let Some(rest) = line.strip_prefix(line_prefix) {
@@ -74,7 +78,7 @@ fn metrics_emit_all_four_series_with_expected_label_sets() {
     // Cap=2 so we can saturate with a single held connection that
     // never sends a request and still leave room for the scrape.
     let cap = 2;
-    let handler_timeout = Duration::from_millis(200);
+    let handler_timeout = Duration::from_millis(3_000);
     let (addr, server) = boot(cap, handler_timeout);
 
     // (1) Happy-path request — records one sample in the http
@@ -85,13 +89,14 @@ fn metrics_emit_all_four_series_with_expected_label_sets() {
         "happy-path /health/live should succeed: {happy:?}"
     );
 
-    // (2) Saturate the cap with `cap` held connections that never
-    // send a request — the handler threads park inside
-    // `HttpRequest::read_from` until the read timeout expires, so the
-    // permit stays held.
-    let mut held: Vec<TcpStream> = Vec::new();
+    // (2) Saturate the cap with real in-flight requests. The async edge
+    // limits requests, not idle sockets, so the test slow-inject hook
+    // keeps each request occupying a permit long enough to observe the
+    // cap-exhausted path.
+    server.set_test_slow_inject_ms(2_000);
+    let mut held = Vec::new();
     for _ in 0..cap {
-        held.push(TcpStream::connect(&addr).expect("connect-hold"));
+        held.push(spawn_slow_request(addr.clone()));
     }
     for _ in 0..50 {
         if server.http_limiter().current() == cap {
@@ -113,10 +118,14 @@ fn metrics_emit_all_four_series_with_expected_label_sets() {
         "expected limiter 503, got: {rejected:?}"
     );
 
-    // Drain held connections so the cap recovers.
-    for s in held.drain(..) {
-        let _ = s.shutdown(std::net::Shutdown::Both);
-        drop(s);
+    // Drain held requests so the cap recovers.
+    server.set_test_slow_inject_ms(0);
+    for handle in held {
+        let body = handle.join().expect("held request thread");
+        assert!(
+            body.starts_with("HTTP/1.1 2"),
+            "held request should complete normally: {body:?}"
+        );
     }
     for _ in 0..100 {
         if server.http_limiter().current() == 0 {
@@ -130,7 +139,7 @@ fn metrics_emit_all_four_series_with_expected_label_sets() {
     thread::sleep(Duration::from_millis(100));
 
     // (3) Trip the slice-2 deadline once — handler_timeout reason.
-    server.set_test_slow_inject_ms(500);
+    server.set_test_slow_inject_ms(4_000);
     let timed_out = send_request(&addr, "/health/live");
     assert!(
         timed_out.starts_with("HTTP/1.1 503"),

--- a/tests/http_tls_limiter.rs
+++ b/tests/http_tls_limiter.rs
@@ -23,7 +23,6 @@ use std::time::{Duration, Instant};
 
 use reddb::server::tls::{build_server_config, HttpTlsConfig};
 use reddb::server::RedDBServer;
-use reddb::{RedDBOptions, RedDBRuntime};
 use rustls::pki_types::{CertificateDer, ServerName};
 
 fn write_self_signed(dir: &std::path::Path) -> (PathBuf, PathBuf, Vec<u8>) {
@@ -151,8 +150,7 @@ fn tls_rejection_when_clear_text_saturates_then_recovers() {
 
     // Boot a single RedDBServer with one shared limiter, then bind two
     // listeners on it: clear-text and TLS.
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+    let (_db, runtime) = support::persistent_runtime("http-tls-limiter-cross");
     let server = RedDBServer::new(runtime).with_http_limiter_cap(cap);
 
     let clear_listener = TcpListener::bind("127.0.0.1:0").expect("bind clear");
@@ -229,8 +227,7 @@ fn tls_handler_deadline_emits_503_then_recovers() {
     let slack = Duration::from_millis(2_000);
 
     let (_dir, tls_cfg, cert_der) = build_tls_config("deadline");
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+    let (_db, runtime) = support::persistent_runtime("http-tls-limiter-deadline");
     let server = RedDBServer::new(runtime).with_handler_timeout(handler_timeout);
 
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind tls");
@@ -298,8 +295,7 @@ fn mixed_http_https_saturation_rejects_both_transports_then_recovers() {
     let cap = 2;
     let (_dir, tls_cfg, cert_der) = build_tls_config("mixed");
 
-    let opts = RedDBOptions::in_memory();
-    let runtime = RedDBRuntime::with_options(opts).expect("runtime");
+    let (_db, runtime) = support::persistent_runtime("http-tls-limiter-mixed");
     let server = RedDBServer::new(runtime).with_http_limiter_cap(cap);
 
     let clear_listener = TcpListener::bind("127.0.0.1:0").expect("bind clear");

--- a/tests/http_tls_limiter.rs
+++ b/tests/http_tls_limiter.rs
@@ -96,6 +96,10 @@ fn http_get_health(addr: &str) -> String {
     }
 }
 
+fn spawn_http_get(addr: String) -> thread::JoinHandle<String> {
+    thread::spawn(move || http_get_health(&addr))
+}
+
 fn wait_for_limiter(server: &RedDBServer, target: usize) -> bool {
     for _ in 0..150 {
         if server.http_limiter().current() == target {
@@ -133,6 +137,13 @@ fn tls_get_health(addr: &str, client_cfg: Arc<rustls::ClientConfig>) -> String {
     }
 }
 
+fn spawn_tls_get(
+    addr: String,
+    client_cfg: Arc<rustls::ClientConfig>,
+) -> thread::JoinHandle<String> {
+    thread::spawn(move || tls_get_health(&addr, client_cfg))
+}
+
 #[test]
 fn tls_rejection_when_clear_text_saturates_then_recovers() {
     let cap = 2;
@@ -160,50 +171,46 @@ fn tls_rejection_when_clear_text_saturates_then_recovers() {
     });
     thread::sleep(Duration::from_millis(120));
 
-    // Saturate the cap via clear-text — `cap` open connections that
-    // never send a request; handler threads park on the read timeout.
-    let mut held: Vec<TcpStream> = Vec::new();
+    // Saturate the shared cap via clear-text requests. The async edge
+    // limits in-flight requests, not idle TCP connections, so the test
+    // slow-inject hook keeps each request occupying a permit.
+    server.set_test_slow_inject_ms(2_000);
+    let mut held = Vec::new();
     for _ in 0..cap {
-        held.push(TcpStream::connect(&clear_addr).expect("hold"));
+        held.push(spawn_http_get(clear_addr.clone()));
     }
-    for _ in 0..50 {
-        if server.http_limiter().current() == cap {
-            break;
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    assert_eq!(
-        server.http_limiter().current(),
-        cap,
-        "clear-text must saturate the shared cap"
+    assert!(
+        wait_for_limiter(&server, cap),
+        "clear-text requests must saturate the shared cap, current={}",
+        server.http_limiter().current()
     );
 
-    // Now attempt a TLS connection — the accept loop must close the
-    // raw socket before any handshake. The rustls client either fails
-    // the handshake or sees EOF before bytes arrive. Either way: no
-    // HTTP 200, no clean response body.
+    // Now attempt a TLS request — it must be rejected by the shared
+    // in-flight request cap.
     let client_cfg = client_config_trusting(&cert_der);
     let body = tls_get_health(&tls_addr, Arc::clone(&client_cfg));
     assert!(
-        !body.starts_with("HTTP/1.1 200"),
+        body.starts_with("HTTP/1.1 503"),
         "TLS request must be rejected while cap is saturated, got: {body:?}"
     );
+    assert!(
+        body.to_ascii_lowercase().contains("retry-after: 5"),
+        "expected Retry-After header, got: {body:?}"
+    );
 
-    // Drain the held clear-text connections.
-    for s in held.drain(..) {
-        let _ = s.shutdown(std::net::Shutdown::Both);
-        drop(s);
+    // Drain the held clear-text requests.
+    server.set_test_slow_inject_ms(0);
+    for handle in held {
+        let body = handle.join().expect("held clear-text request");
+        assert!(
+            body.starts_with("HTTP/1.1 2"),
+            "held clear-text request should complete normally, got: {body:?}"
+        );
     }
-    for _ in 0..100 {
-        if server.http_limiter().current() == 0 {
-            break;
-        }
-        thread::sleep(Duration::from_millis(20));
-    }
-    assert_eq!(
-        server.http_limiter().current(),
-        0,
-        "permits should drain back to zero after clear-text close"
+    assert!(
+        wait_for_limiter(&server, 0),
+        "permits should drain back to zero after clear-text requests finish, current={}",
+        server.http_limiter().current()
     );
     thread::sleep(Duration::from_millis(100));
 
@@ -246,12 +253,13 @@ fn tls_handler_deadline_emits_503_then_recovers() {
         body.starts_with("HTTP/1.1 503"),
         "expected 503 over TLS, got: {body:?}"
     );
+    let body_lower = body.to_ascii_lowercase();
     assert!(
-        body.contains("Connection: close"),
+        body_lower.contains("connection: close"),
         "expected Connection: close, got: {body:?}"
     );
     assert!(
-        !body.contains("Retry-After:"),
+        !body_lower.contains("retry-after:"),
         "deadline-503 should not carry Retry-After, got: {body:?}"
     );
     assert!(
@@ -310,17 +318,17 @@ fn mixed_http_https_saturation_rejects_both_transports_then_recovers() {
     });
     thread::sleep(Duration::from_millis(120));
 
-    // Saturate the shared cap with a MIX: one clear-text hold + one
-    // TLS-port hold. Both are raw TCP sockets that never send a full
-    // request, so each handler thread parks (clear-text on request
-    // read, TLS on the handshake read) holding its permit. The permit
-    // is acquired at accept on both loops, so a raw TCP connect to the
-    // TLS port is sufficient to occupy a slot.
-    let hold_http = TcpStream::connect(&clear_addr).expect("hold http");
-    let hold_https = TcpStream::connect(&tls_addr).expect("hold https");
+    let client_cfg = client_config_trusting(&cert_der);
+
+    // Saturate the shared cap with a MIX: one clear-text request + one
+    // TLS request. Both occupy the shared in-flight request limiter
+    // while the test slow-inject hook sleeps.
+    server.set_test_slow_inject_ms(2_000);
+    let hold_http = spawn_http_get(clear_addr.clone());
+    let hold_https = spawn_tls_get(tls_addr.clone(), Arc::clone(&client_cfg));
     assert!(
         wait_for_limiter(&server, cap),
-        "a mix of one HTTP + one HTTPS connection must saturate the shared cap, current={}",
+        "a mix of one HTTP + one HTTPS request must saturate the shared cap, current={}",
         server.http_limiter().current()
     );
 
@@ -331,21 +339,34 @@ fn mixed_http_https_saturation_rejects_both_transports_then_recovers() {
         http_body.starts_with("HTTP/1.1 503"),
         "clear-text request must be rejected while shared cap is saturated, got: {http_body:?}"
     );
+    assert!(
+        http_body.to_ascii_lowercase().contains("retry-after: 5"),
+        "expected Retry-After header, got: {http_body:?}"
+    );
 
-    // ...and a new TLS request is rejected pre-handshake (closed socket,
-    // never an HTTP 200).
-    let client_cfg = client_config_trusting(&cert_der);
+    // ...and a new TLS request is rejected by the same shared cap.
     let https_body = tls_get_health(&tls_addr, Arc::clone(&client_cfg));
     assert!(
-        !https_body.starts_with("HTTP/1.1 200"),
+        https_body.starts_with("HTTP/1.1 503"),
         "TLS request must be rejected while shared cap is saturated, got: {https_body:?}"
+    );
+    assert!(
+        https_body.to_ascii_lowercase().contains("retry-after: 5"),
+        "expected Retry-After header, got: {https_body:?}"
     );
 
     // Drain both holders; permits return to zero.
-    let _ = hold_http.shutdown(std::net::Shutdown::Both);
-    drop(hold_http);
-    let _ = hold_https.shutdown(std::net::Shutdown::Both);
-    drop(hold_https);
+    server.set_test_slow_inject_ms(0);
+    let http_done = hold_http.join().expect("held HTTP request");
+    assert!(
+        http_done.starts_with("HTTP/1.1 2"),
+        "held HTTP request should complete normally, got: {http_done:?}"
+    );
+    let https_done = hold_https.join().expect("held HTTPS request");
+    assert!(
+        https_done.starts_with("HTTP/1.1 2"),
+        "held HTTPS request should complete normally, got: {https_done:?}"
+    );
     assert!(
         wait_for_limiter(&server, 0),
         "permits should drain to zero after both holders close, current={}",

--- a/tests/iam_policy_runtime.rs
+++ b/tests/iam_policy_runtime.rs
@@ -735,6 +735,7 @@ fn graph_match_blocks_denied_node_property_projection() {
             "version":1,
             "statements":[
                 {"effect":"allow","actions":["select"],"resources":["table:graph"]},
+                {"effect":"allow","actions":["graph:traverse"],"resources":["graph:*"]},
                 {"effect":"deny","actions":["select"],"resources":["column:graph.secret"]}
             ]
         }"#,

--- a/tests/integration_tree.rs
+++ b/tests/integration_tree.rs
@@ -41,7 +41,8 @@ fn bools(result: &reddb::runtime::RuntimeQueryResult, column: &str) -> Vec<bool>
 
 #[test]
 fn test_tree_lifecycle_rebalance_and_delete_subtree() {
-    let rt = rt();
+    let path = PersistentDbPath::new("tree_lifecycle");
+    let rt = path.open_runtime();
 
     let created = exec(
         &rt,

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -102,6 +102,45 @@ pub fn temp_db_file(tag: &str) -> TempDbFile {
     TempDbFile { _dir: dir, path }
 }
 
+/// Return an auto-cleaning persistent runtime and the guard that owns its
+/// parent temp directory.
+pub fn persistent_runtime(tag: &str) -> (TempDbFile, RedDBRuntime) {
+    let path = temp_db_file(tag);
+    let runtime = RedDBRuntime::with_options(RedDBOptions::persistent(path.path()))
+        .unwrap_or_else(|err| panic!("failed to open persistent runtime for '{tag}': {err:?}"));
+    (path, runtime)
+}
+
+/// Persistent test runtime that keeps the temp-db guard alive for as long as
+/// the runtime is in scope.
+pub struct PersistentRuntime {
+    _db: TempDbFile,
+    runtime: RedDBRuntime,
+}
+
+impl PersistentRuntime {
+    pub fn runtime(&self) -> &RedDBRuntime {
+        &self.runtime
+    }
+
+    pub fn clone_runtime(&self) -> RedDBRuntime {
+        self.runtime.clone()
+    }
+}
+
+impl Deref for PersistentRuntime {
+    type Target = RedDBRuntime;
+
+    fn deref(&self) -> &RedDBRuntime {
+        &self.runtime
+    }
+}
+
+pub fn persistent_test_runtime(tag: &str) -> PersistentRuntime {
+    let (_db, runtime) = persistent_runtime(tag);
+    PersistentRuntime { _db, runtime }
+}
+
 pub mod mock_ai_provider;
 pub mod prometheus;
 


### PR DESCRIPTION
## Summary
- pin workflow checkout steps from `actions/checkout@v6` to `actions/checkout@v5` because v6 credential persistence fails during `git fetch` on the Blacksmith runner
- quote two YAML scalars that prevented `ci.yml` and `dependabot.yml` from creating jobs

## Evidence
- main Changesets log failed in `actions/checkout@v6` with `fatal: could not read Username for https://github.com`
- main CI and Dependabot runs had `jobs: []`, consistent with workflow syntax failure

## Validation
- `git diff --check`
- `rg` confirmed no `actions/checkout@v6` remains under `.github/workflows`
- `actionlint -ignore "label .+ is unknown" -ignore "constant expression.*false" .github/workflows/*.yml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783999199&installation_id=129708444&pr_number=1196&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1196&signature=8ba5af2d5110e700208a68b456b8302bbd9c8ef996d385043647275120aeb0dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `red ui --token` support for desktop credential handoff, including passing UI authentication configuration into the UI bridge.
* **Bug Fixes**
  * Improved materialized view rehydration to ensure backing collections are provisioned.
  * Made audit-log storage path selection consistently honor the configured data path.
  * Updated Python driver payload/type handling for binary bulk inserts.
* **Tests**
  * Hardened WebSocket `Origin` header construction and improved e2e stability by using larger-stack threads for selected scenarios.
* **Documentation**
  * Refreshed focused regression pack references in the public surface contract matrix.
* **Chores**
  * Updated CI workflows to use `actions/checkout@v5` and adjusted the Docker runtime to a glibc distroless (protobuf-enabled) image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->