### PR TITLE
ci: restore nightly DR drill target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,8 +515,8 @@ jobs:
 
   chaos:
     # PLAN.md Phase 8.4 — chaos & crash hardening matrix.
-    # Runs the 8 chaos tests + 3 backup/restore drills shipped in
-    # tests/chaos_*.rs and tests/drill_*.rs. Failure is a release blocker.
+    # Runs the chaos tests plus backup/restore drills shipped in
+    # the consolidated grouped test binaries. Failure is a release blocker.
     name: Chaos & Drill Suite
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'workflow_dispatch' && inputs.full_ci
@@ -538,9 +538,9 @@ jobs:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
       - name: Run chaos tests
-        run: cargo test --locked --test 'chaos_*' --no-fail-fast
+        run: cargo test --locked --test grouped_chaos --no-fail-fast
       - name: Run drill tests
-        run: cargo test --locked --test 'drill_*' --no-fail-fast
+        run: cargo test --locked --test grouped_pitr_drills --no-fail-fast
 
   chaos-minio:
     # PLAN.md Phase 8.4 — chaos suite against an S3-compatible

--- a/scripts/drill-nightly.sh
+++ b/scripts/drill-nightly.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$HISTORY" ]]; then
   } > "$HISTORY"
 fi
 
-CMD="cargo test --locked --test 'drill_*' --no-fail-fast"
+CMD="cargo test --locked --test grouped_pitr_drills --no-fail-fast"
 START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # Keep the runner log out of the `reddb-*` temp namespace: the drills
 # intentionally clean that namespace while checking for leaked DB files.

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -121,7 +121,7 @@ test("nightly DR drill workflow uses the current-shell runner and public make ta
   const workflow = read(".github/workflows/drill-nightly.yml");
 
   assert.match(makefile, /\ndrill-nightly:\n\t@\.\/scripts\/drill-nightly\.sh/);
-  assert.match(script, /CMD="cargo test --locked --test 'drill_\*' --no-fail-fast"/);
+  assert.match(script, /CMD="cargo test --locked --test grouped_pitr_drills --no-fail-fast"/);
   assert.match(script, /mktemp -t drill-nightly\.XXXXXX\.log/);
   assert.doesNotMatch(script, /mktemp -t reddb-drill-nightly/);
   assert.match(script, /eval "\$CMD" >"\$LOG" 2>&1/);


### PR DESCRIPTION
## Summary
- point `make drill-nightly` at the consolidated `grouped_pitr_drills` test binary
- point the manual full-CI chaos/drill job at `grouped_chaos` and `grouped_pitr_drills`
- update the release tooling contract for the new drill command

Closes #1197

## Verification
- `git diff --check`
- `node --test --test-name-pattern "nightly DR drill" scripts/release_tooling_contract.test.mjs`
- `make drill-nightly`
- `cargo test --locked --test grouped_chaos --no-fail-fast`

Note: the full `node --test scripts/release_tooling_contract.test.mjs` suite still has unrelated pre-existing failures around `docs/adr/0004-red-client-container-image.md` and the release workflow `forattini` assertion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784030907&installation_id=129708444&pr_number=1198&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1198&signature=aa5453d699784337e89f80ea775c3a8152ba313354cf0e6e5f538ade29dcbea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated chaos and disaster recovery drill testing infrastructure to use grouped test binaries instead of wildcard patterns.

* **Chores**
  * Updated CI workflows and nightly drill scripts to invoke specific test targets for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->