### PR TITLE
ci: harden changesets and wire coverage gates

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -26,10 +26,6 @@ jobs:
           # Full history so `changesets/action` can rewrite tags / detect
           # changes against main.
           fetch-depth: 0
-          # Use a PAT so the version-bump commit pushed by this workflow
-          # can re-trigger downstream tag-driven workflows (release.yml).
-          # Falls back to GITHUB_TOKEN if no PAT is configured.
-          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -69,4 +65,7 @@ jobs:
           # that as part of the `publish-github` job once binaries are built.
           createGithubReleases: false
         env:
+          # Use a PAT so the version-bump commit pushed by this workflow
+          # can re-trigger downstream tag-driven workflows (release.yml).
+          # Falls back to GITHUB_TOKEN if no PAT is configured.
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/wire-coverage.yml
+++ b/.github/workflows/wire-coverage.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
       - uses: rui314/setup-mold@v1
       - uses: mozilla-actions/sccache-action@v0.0.10
 
@@ -58,6 +61,7 @@ jobs:
         env:
           RUSTC_WRAPPER: ""
         run: |
+          set -o pipefail
           cargo llvm-cov -p reddb-io-wire --summary-only \
             --ignore-filename-regex 'crates/reddb-types/' \
             --fail-under-lines 90 \

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -26,7 +26,7 @@ test("red_client size guard is wired to a documented local and CI budget check",
 test("red_client container release contract uses the thin client Dockerfile and package", () => {
   const dockerfile = read("Dockerfile.client");
   const releaseWorkflow = read(".github/workflows/release.yml");
-  const adr = read("docs/adr/0004-red-client-container-image.md");
+  const adr = read(".red/adr/0004-red-client-container-image.md");
 
   assert.match(dockerfile, /--bin red_client -p reddb-io-client\s+--no-default-features/);
   assert.match(dockerfile, /FROM gcr\.io\/distroless\/static-debian12:nonroot AS runtime/);
@@ -43,7 +43,7 @@ test("Docker release images publish from GitHub Actions under reddb-io GHCR only
   const releaseDockerfile = read("Dockerfile.release");
   const dockerHubHost = new RegExp(["docker", "io"].join("\\."));
   const dockerHubSecretPrefix = new RegExp(["DOCKER", "HUB_"].join(""));
-  const legacyPersonalNamespace = new RegExp(["foratt", "ini"].join(""), "i");
+  const legacyPersonalGhcrNamespace = new RegExp(["ghcr\\.io/[^\\s'\"]*foratt", "ini"].join(""), "i");
 
   assert.match(releaseWorkflow, /publish-docker:/);
   assert.match(releaseWorkflow, /ghcr\.io\/\$\{\{ github\.repository \}\}/);
@@ -52,7 +52,7 @@ test("Docker release images publish from GitHub Actions under reddb-io GHCR only
   assert.doesNotMatch(releaseDockerfile, /cargo build/);
   assert.doesNotMatch(releaseWorkflow, dockerHubHost);
   assert.doesNotMatch(releaseWorkflow, dockerHubSecretPrefix);
-  assert.doesNotMatch(releaseWorkflow, legacyPersonalNamespace);
+  assert.doesNotMatch(releaseWorkflow, legacyPersonalGhcrNamespace);
 
   const publishDocker = releaseWorkflow.match(/publish-docker:[\s\S]*?(?=\n  publish-client-image:)/)?.[0] ?? "";
   assert.match(publishDocker, /actions\/download-artifact@v8[\s\S]*name: linux-x86_64/);
@@ -128,4 +128,21 @@ test("nightly DR drill workflow uses the current-shell runner and public make ta
   assert.doesNotMatch(script, /bash -lc "\$CMD"/);
   assert.match(script, /issue #116/);
   assert.match(workflow, /run: make drill-nightly/);
+});
+
+test("changesets checkout uses the default token before release PAT handoff", () => {
+  const workflow = read(".github/workflows/changesets.yml");
+  const checkoutStep = workflow.match(/- uses: actions\/checkout@v5[\s\S]*?(?=\n\n      - uses: pnpm\/action-setup@v4)/)?.[0] ?? "";
+
+  assert.match(checkoutStep, /fetch-depth: 0/);
+  assert.doesNotMatch(checkoutStep, /\n\s+token:/);
+  assert.match(workflow, /GITHUB_TOKEN: \$\{\{ secrets\.RELEASE_PAT \|\| secrets\.GITHUB_TOKEN \}\}/);
+});
+
+test("wire coverage gate installs protoc and preserves llvm-cov failures", () => {
+  const workflow = read(".github/workflows/wire-coverage.yml");
+
+  assert.match(workflow, /uses: \.\/\.github\/actions\/install-protoc[\s\S]*version: '28\.3'/);
+  assert.match(workflow, /set -o pipefail[\s\S]*cargo llvm-cov -p reddb-io-wire/);
+  assert.match(workflow, /cargo llvm-cov -p reddb-io-wire[\s\S]*\| tee coverage-summary\.txt/);
 });


### PR DESCRIPTION
## Summary
- let the Changesets checkout use the default checkout token, keeping the release PAT handoff on the changesets action
- install protoc in the wire coverage workflow and make the llvm-cov pipe fail correctly
- refresh release tooling contract tests for ADR location, GHCR namespace matching, and the two CI regressions

## Verification
- node --test scripts/release_tooling_contract.test.mjs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784033183&installation_id=129708444&pr_number=1199&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1199&signature=c051d7efa3ff52ad30c99741e30a95f6b17a199bf6e56345402b96d723bd473e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->