### PR TITLE
ci: install protoc for parser fuzz nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -645,7 +645,7 @@ jobs:
     needs: gate
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 25
+    timeout-minutes: 40
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -33,6 +33,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@nightly
 
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: parser-fuzz-nightly

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -146,3 +146,23 @@ test("wire coverage gate installs protoc and preserves llvm-cov failures", () =>
   assert.match(workflow, /set -o pipefail[\s\S]*cargo llvm-cov -p reddb-io-wire/);
   assert.match(workflow, /cargo llvm-cov -p reddb-io-wire[\s\S]*\| tee coverage-summary\.txt/);
 });
+
+test("parser fuzz nightly installs protoc before fuzz builds", () => {
+  const workflow = read(".github/workflows/parser-fuzz-nightly.yml");
+
+  assert.match(workflow, /uses: \.\/\.github\/actions\/install-protoc[\s\S]*version: '28\.3'/);
+  assert.match(
+    workflow,
+    /uses: dtolnay\/rust-toolchain@nightly[\s\S]*uses: \.\/\.github\/actions\/install-protoc[\s\S]*name: Run \$\{\{ matrix\.target \}\}/,
+  );
+});
+
+test("per-PR parser fuzz job has enough timeout for three fixed fuzz windows", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const job = workflow.match(/\n  fuzz-parsers:[\s\S]*?(?=\n  package:)/)?.[0] ?? "";
+
+  assert.match(job, /timeout-minutes: 40/);
+  assert.match(job, /cargo \+nightly fuzz run sql_parser -- -max_total_time=300/);
+  assert.match(job, /cargo \+nightly fuzz run migration_parser -- -max_total_time=300/);
+  assert.match(job, /cargo \+nightly fuzz run conn_string_parser -- -max_total_time=300/);
+});


### PR DESCRIPTION
## Summary
- installs the shared protoc setup action in Parser Fuzz Nightly before cargo-fuzz builds
- adds a release tooling contract so the workflow keeps protoc ahead of fuzz execution

## Verification
- node --test scripts/release_tooling_contract.test.mjs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784035982&installation_id=129708444&pr_number=1200&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1200&signature=a25c46b17b7ec4d731e7a25db644c42709027378243c4d623830302100fbe87a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to install required Protobuf toolchain for nightly fuzz testing builds.
  * Added contract test to verify correct Protobuf toolchain configuration in CI workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->