### PR TITLE
fix(rql): bound parser fuzz recursion

### DIFF
--- a/crates/reddb-rql/src/limits.rs
+++ b/crates/reddb-rql/src/limits.rs
@@ -9,11 +9,13 @@
 //!
 //! | Limit                 | Default | Rationale                                       |
 //! |-----------------------|---------|-------------------------------------------------|
-//! | `max_depth`           | 128     | Recursive descent + Pratt; well above hand-     |
-//! |                       |         | written queries (typical ≤ 12).                  |
+//! | `max_depth`           | 32      | Recursive descent + Pratt; above typical        |
+//! |                       |         | hand-written queries (≤ 12).                     |
 //! | `max_input_bytes`     | 1 MiB   | Hard cap on the token stream input.              |
 //! | `max_identifier_chars`| 256     | Long enough for legitimate UUID-tagged names,    |
 //! |                       |         | short enough to bound HashMap pressure.          |
+//! | `max_tokens`          | 8192    | Bounds token-driven parser work even when input  |
+//! |                       |         | bytes and recursion depth stay below their caps. |
 //!
 //! `ParserLimits` is consumed both by the [`crate::lexer`] (identifier and
 //! input-byte caps, checked during tokenization) and by the parser proper
@@ -36,14 +38,19 @@ pub struct ParserLimits {
     /// Maximum identifier length in characters. Checked when an
     /// identifier token is constructed in the lexer.
     pub max_identifier_chars: usize,
+    /// Maximum number of tokens the parser may consume. This bounds
+    /// flat adversarial inputs such as long operator chains that do
+    /// not trip byte, identifier, or recursion-depth limits.
+    pub max_tokens: usize,
 }
 
 impl Default for ParserLimits {
     fn default() -> Self {
         Self {
-            max_depth: 128,
+            max_depth: 32,
             max_input_bytes: 1024 * 1024, // 1 MiB
             max_identifier_chars: 256,
+            max_tokens: 8192,
         }
     }
 }
@@ -56,6 +63,7 @@ impl ParserLimits {
             max_depth: 1024,
             max_input_bytes: 16 * 1024 * 1024,
             max_identifier_chars: 4096,
+            max_tokens: 65_536,
         }
     }
 }

--- a/crates/reddb-rql/src/parser/error.rs
+++ b/crates/reddb-rql/src/parser/error.rs
@@ -42,6 +42,11 @@ pub enum ParseErrorKind {
         limit_name: &'static str,
         value: usize,
     },
+    /// Parser consumed more tokens than the configured cap.
+    TokenLimit {
+        limit_name: &'static str,
+        value: usize,
+    },
     /// A literal value (integer / float) parsed cleanly but lies
     /// outside the semantic range expected for its slot — e.g.
     /// `MAX_SIZE 0`, `lat = 91.0`, `K = 0`, or a negative integer
@@ -140,6 +145,16 @@ impl ParseError {
             position,
             expected: Vec::new(),
             kind: ParseErrorKind::IdentifierTooLong { limit_name, value },
+        }
+    }
+
+    /// Token budget exceeded during parsing.
+    pub fn token_limit(limit_name: &'static str, value: usize, position: Position) -> Self {
+        Self {
+            message: format!("parser token limit exceeded ({} = {})", limit_name, value),
+            position,
+            expected: Vec::new(),
+            kind: ParseErrorKind::TokenLimit { limit_name, value },
         }
     }
 

--- a/crates/reddb-rql/src/parser/limits.rs
+++ b/crates/reddb-rql/src/parser/limits.rs
@@ -9,11 +9,13 @@
 //!
 //! | Limit                 | Default | Rationale                                       |
 //! |-----------------------|---------|-------------------------------------------------|
-//! | `max_depth`           | 128     | Recursive descent + Pratt; well above hand-     |
-//! |                       |         | written queries (typical ≤ 12).                  |
+//! | `max_depth`           | 32      | Recursive descent + Pratt; above typical        |
+//! |                       |         | hand-written queries (≤ 12).                     |
 //! | `max_input_bytes`     | 1 MiB   | Hard cap on the token stream input.              |
 //! | `max_identifier_chars`| 256     | Long enough for legitimate UUID-tagged names,    |
 //! |                       |         | short enough to bound HashMap pressure.          |
+//! | `max_tokens`          | 8192    | Bounds token-driven parser work even when input  |
+//! |                       |         | bytes and recursion depth stay below their caps. |
 //!
 //! Callers that need different limits (replication apply, admin DDL
 //! migrations) construct a custom [`ParserLimits`] and pass it to

--- a/crates/reddb-rql/src/parser/migration.rs
+++ b/crates/reddb-rql/src/parser/migration.rs
@@ -57,7 +57,7 @@ impl<'a> Parser<'a> {
         let _ = self.consume(&Token::As)?;
 
         // Everything remaining until EOF is the body
-        let body = self.collect_remaining_input();
+        let body = self.collect_remaining_input()?;
 
         Ok(QueryExpr::CreateMigration(CreateMigrationQuery {
             name,
@@ -134,19 +134,16 @@ impl<'a> Parser<'a> {
 
     /// Collect all remaining tokens into a single string (joined with spaces).
     /// Used to capture the raw SQL body of a migration.
-    pub fn collect_remaining_input(&mut self) -> String {
+    pub fn collect_remaining_input(&mut self) -> Result<String, ParseError> {
         let mut parts: Vec<String> = Vec::new();
         loop {
             if self.check(&Token::Eof) {
                 break;
             }
             parts.push(self.current.token.to_string());
-            // Advance, ignoring errors (at worst we stop early)
-            if self.advance().is_err() {
-                break;
-            }
+            self.advance()?;
         }
-        parts.join(" ")
+        Ok(parts.join(" "))
     }
 
     /// Try to consume a bare identifier or a single-quoted string literal.

--- a/crates/reddb-rql/src/parser/mod.rs
+++ b/crates/reddb-rql/src/parser/mod.rs
@@ -91,6 +91,10 @@ pub struct Parser<'a> {
     /// Counter for `?` positional placeholders, numbered 1-based
     /// in source. Unused when mode is `Dollar` or `None`.
     pub(crate) question_count: usize,
+    /// Number of tokens consumed through `advance`.
+    pub(crate) tokens_consumed: usize,
+    /// Maximum token budget for this parse.
+    pub(crate) max_tokens: usize,
 }
 
 /// Placeholder style locked in by the first placeholder seen.
@@ -128,6 +132,8 @@ impl<'a> Parser<'a> {
             depth: DepthCounter::new(limits.max_depth),
             placeholder_mode: PlaceholderMode::None,
             question_count: 0,
+            tokens_consumed: 0,
+            max_tokens: limits.max_tokens,
         })
     }
 
@@ -163,6 +169,14 @@ impl<'a> Parser<'a> {
 
     /// Advance to next token
     pub fn advance(&mut self) -> Result<Token, ParseError> {
+        self.tokens_consumed += 1;
+        if self.tokens_consumed > self.max_tokens {
+            return Err(ParseError::token_limit(
+                "max_tokens",
+                self.max_tokens,
+                self.position(),
+            ));
+        }
         let old = std::mem::replace(&mut self.current, self.lexer.next_token()?);
         Ok(old.token)
     }

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -6491,6 +6491,118 @@ fn dos_limit_recursion_depth_is_structured() {
 }
 
 #[test]
+fn dos_limit_token_budget_is_structured() {
+    use super::limits::ParserLimits;
+    let limits = ParserLimits {
+        max_tokens: 8,
+        ..ParserLimits::default()
+    };
+    let input = format!("SELECT a{} FROM t", " + a".repeat(16));
+    let mut parser = super::Parser::with_limits(&input, limits).expect("ctor ok");
+    let err = parser.parse().err().expect("token budget must error");
+    assert!(matches!(
+        err.kind,
+        super::ParseErrorKind::TokenLimit {
+            limit_name: "max_tokens",
+            value: 8,
+        }
+    ));
+}
+
+#[test]
+fn dos_limit_flat_operator_chain_hits_default_token_budget() {
+    let input = format!(
+        "SELECT a{} FROM t",
+        " + a".repeat(super::ParserLimits::default().max_tokens)
+    );
+    let err = super::parse(&input)
+        .err()
+        .expect("flat operator chain must hit token budget");
+    assert!(
+        matches!(
+            err.kind,
+            super::ParseErrorKind::TokenLimit {
+                limit_name: "max_tokens",
+                ..
+            }
+        ),
+        "kind: {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn fuzz_regression_sql_oom_shape_hits_default_token_budget() {
+    let input = format!(
+        "SELECT secreany.pay5{} FROM t",
+        " / tmpa + r".repeat(super::ParserLimits::default().max_tokens)
+    );
+    let err = super::parse(&input)
+        .err()
+        .expect("fuzzed flat SQL shape must hit token budget");
+    assert!(
+        matches!(
+            err.kind,
+            super::ParseErrorKind::TokenLimit {
+                limit_name: "max_tokens",
+                ..
+            }
+        ),
+        "kind: {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn fuzz_regression_migration_body_token_budget_is_not_swallowed() {
+    let body = "SELECT\nKV(INSERTCATESE, ApTLTEttt, ETOPOLOGICALSORT, "
+        .repeat(super::ParserLimits::default().max_tokens);
+    let input = format!("CREATE MIGRATION m AS {body}");
+    let err = super::parse(&input)
+        .err()
+        .expect("long migration body must hit token budget");
+    assert!(
+        matches!(
+            err.kind,
+            super::ParseErrorKind::TokenLimit {
+                limit_name: "max_tokens",
+                ..
+            }
+        ),
+        "kind: {:?}",
+        err.kind
+    );
+}
+
+#[test]
+fn fuzz_regression_nested_select_kv_shape_hits_default_depth_limit() {
+    let levels = super::ParserLimits::default().max_depth + 8;
+    let mut input = String::from("SELECT ");
+    for _ in 0..levels {
+        input.push_str("KV(INSERTCATESE, ApTLTEttt, ETOPOLOGICALSORT, (SELECT ");
+    }
+    input.push('1');
+    for _ in 0..levels {
+        input.push_str("))");
+    }
+
+    let err = super::parse(&input)
+        .err()
+        .expect("nested SELECT/KV fuzz shape must hit recursion depth");
+    assert!(
+        matches!(
+            err.kind,
+            super::ParseErrorKind::DepthLimit {
+                limit_name: "max_depth",
+                ..
+            }
+        ),
+        "kind: {:?}",
+        err.kind
+    );
+}
+
+#[test]
 fn dos_limit_no_panic_on_pathological_input() {
     // Adversarial inputs return Err but never panic / OOM.
     let mut adversarial = "(".repeat(2_000);
@@ -6515,7 +6627,7 @@ fn dos_limit_chained_not_in_where_does_not_overflow_stack() {
     // `parse_not_expr` recursed into itself for `NOT NOT NOT … x`
     // without entering the depth counter — only the leaf reached
     // `parse_expr_prec`'s `enter_depth()`, so a 10k-NOT payload
-    // overflowed the Rust stack BEFORE `max_depth=128` could fire.
+    // overflowed the Rust stack before the default depth guard could fire.
     //
     // We run on a generous-stack thread so that, in the unfixed
     // build, the test reliably reports the overflow as a panic

--- a/crates/reddb-server/tests/support/parser_hardening/mod.rs
+++ b/crates/reddb-server/tests/support/parser_hardening/mod.rs
@@ -49,6 +49,7 @@ pub fn test_safe_limits() -> ParserLimits {
         max_depth: 32,
         max_input_bytes: 1024 * 1024,
         max_identifier_chars: 256,
+        max_tokens: 8192,
     }
 }
 

--- a/docs/security/parser-limits.md
+++ b/docs/security/parser-limits.md
@@ -1,7 +1,7 @@
 # Parser DoS Limits
 
 The RedDB query parser ships with hard limits on input size,
-recursion depth, and identifier length. The limits exist to keep
+recursion depth, identifier length, and consumed token count. The limits exist to keep
 adversarial query strings — a small payload that triggers
 unbounded recursion or memory growth — bounded by structured
 errors instead of process panics or OOM.
@@ -10,19 +10,19 @@ errors instead of process panics or OOM.
 
 | Limit                  | Default | Configured by               |
 |------------------------|---------|-----------------------------|
-| `max_depth`            | 128     | `ParserLimits::max_depth`   |
+| `max_depth`            | 32      | `ParserLimits::max_depth`   |
 | `max_input_bytes`      | 1 MiB   | `ParserLimits::max_input_bytes` |
 | `max_identifier_chars` | 256     | `ParserLimits::max_identifier_chars` |
+| `max_tokens`           | 8192    | `ParserLimits::max_tokens`  |
 
-Source: `crates/reddb-server/src/storage/query/parser/limits.rs`.
+Source: `crates/reddb-rql/src/limits.rs`.
 
 ## Rationale
 
-- **`max_depth = 128`**. Hand-written queries top out around
-  10–12 levels (CTE → subquery → expression). 128 leaves an order
-  of magnitude of headroom for tools that machine-generate
-  queries while still bounding recursion well below typical
-  thread-stack ceilings (8 MiB on tokio worker threads).
+- **`max_depth = 32`**. Hand-written queries top out around
+  10–12 levels (CTE → subquery → expression). 32 leaves headroom
+  for generated queries while keeping nested SELECT/function-call
+  payloads below the default test/fuzz thread stack.
 - **`max_input_bytes = 1 MiB`**. Queries that exceed 1 MiB are
   almost always tooling regressions — even bulk INSERT statements
   belong on the binary `INSERT … VALUES (?, ?, ?)` path, not as a
@@ -32,6 +32,10 @@ Source: `crates/reddb-server/src/storage/query/parser/limits.rs`.
   exist on every code path that walks an AST; capping identifier
   length keeps that pressure predictable. 256 chars covers
   legitimate UUID-tagged column names with room to spare.
+- **`max_tokens = 8192`**. Flat adversarial inputs can stay under
+  byte, identifier, and recursion-depth limits while still forcing
+  long token streams and large expression/projection trees. Capping
+  consumed tokens keeps parser work bounded for those cases.
 
 ## Error surface
 
@@ -41,6 +45,7 @@ of:
 - `ParseErrorKind::DepthLimit { limit_name, value }`
 - `ParseErrorKind::InputTooLarge { limit_name, value }`
 - `ParseErrorKind::IdentifierTooLong { limit_name, value }`
+- `ParseErrorKind::TokenLimit { limit_name, value }`
 
 Callers that want to differentiate DoS refusals from grammar
 errors pattern-match on `kind`. The harness (issue #87) and the


### PR DESCRIPTION
## Summary
- add a parser token budget and structured `TokenLimit` errors for flat fuzz inputs
- propagate migration body token-limit errors instead of silently truncating remaining input
- lower default parser recursion depth to 32 so nested `SELECT`/`KV` fuzz shapes hit `DepthLimit` before stack overflow
- keep the default token budget at 8192 so legitimate bulk `INSERT ... VALUES` statements in the default test layer still parse

Closes #1201
Closes #1202

## Verification
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz cargo test -p reddb-io-rql fuzz_regression -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz cargo test -p reddb-io-rql dos_limit -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz cargo test -p reddb-io-rql`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz cargo check -p reddb-io-server`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz CARGO_BUILD_JOBS=2 cargo test -p reddb-io-server --test parser_hardening --no-run`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz CARGO_BUILD_JOBS=2 cargo test --test e2e_issue_595_materialized_view_atomic_refresh`
- `CARGO_TARGET_DIR=/tmp/reddb-target-fix-parser-fuzz CARGO_BUILD_JOBS=2 cargo test -p reddb-io-server --test e2e_issue_805_query_stream query_stream_backpressure_slow_reader_gets_full_stream_in_multiple_chunks -- --nocapture`
- `cargo fmt --check`
- `git diff --check`