### PR TITLE
fix(release): cascade workspace crate versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,10 +536,13 @@ jobs:
             fi
           }
 
+          publish_one reddb-io-types
+          publish_one reddb-io-crypto
+          publish_one reddb-io-file
+          publish_one reddb-io-rql
           publish_one reddb-io-wire
           publish_one reddb-io-grpc-proto
           publish_one reddb-io-client-connector
-          publish_one reddb-io-file
           publish_one reddb-io-server
           publish_one reddb-io-client
           publish_one reddb-io

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,14 +2490,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.0.0"
+version = "1.10.1"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.0.0"
+version = "1.10.1"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.0.0"
+version = "1.10.1"
 dependencies = [
  "proptest",
  "reddb-io-types",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.0.0"
+version = "1.10.1"
 dependencies = [
  "proptest",
  "zstd",

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-crypto"
-version = "1.0.0"
+version = "1.10.1"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB cryptographic authority: the canonical per-page encryption-at-rest envelope (AES-256-GCM), mandatory encrypt parameters, and key parsing."

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-file"
-version = "1.0.0"
+version = "1.10.1"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB file artifact layer: single-file .rdb layout, WAL, snapshots, checkpoints, locks, and recovery."

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-rql"
-version = "1.0.0"
+version = "1.10.1"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB Query Language (RQL) front-end + conformance authority (ADR 0053). Owns the sqllogictest-format conformance suite whose truth comes from the public SQLite corpus; depends only on reddb-io-types."

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-types"
-version = "1.0.0"
+version = "1.10.1"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB logical type system: the neutral keystone vocabulary — Value, DataType, SqlTypeName, TypeModifier, TypeCategory, ValueError, Row — depended on by every authority crate and depending on none."

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -39,13 +39,21 @@ lock_version() {
   ' "$lockfile"
 }
 
-# Lock-step with engine: workspace member crates, drivers, npm package
+# Lock-step with engine: publishable workspace member crates, drivers, npm package
+check "crates/reddb-types"       "$(grep -m1 '^version' crates/reddb-types/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+check "crates/reddb-crypto"      "$(grep -m1 '^version' crates/reddb-crypto/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+check "crates/reddb-file"        "$(grep -m1 '^version' crates/reddb-file/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
+check "crates/reddb-rql"         "$(grep -m1 '^version' crates/reddb-rql/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "crates/reddb-wire"        "$(grep -m1 '^version' crates/reddb-wire/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "crates/reddb-grpc-proto"  "$(grep -m1 '^version' crates/reddb-grpc-proto/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "crates/reddb-server"      "$(grep -m1 '^version' crates/reddb-server/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "crates/reddb-client"            "$(grep -m1 '^version' crates/reddb-client/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "crates/reddb-client-connector"  "$(grep -m1 '^version' crates/reddb-client-connector/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')"
 check "Cargo.lock reddb-io"         "$(lock_version Cargo.lock reddb-io)"
+check "Cargo.lock reddb-io-types"   "$(lock_version Cargo.lock reddb-io-types)"
+check "Cargo.lock reddb-io-crypto"  "$(lock_version Cargo.lock reddb-io-crypto)"
+check "Cargo.lock reddb-io-file"    "$(lock_version Cargo.lock reddb-io-file)"
+check "Cargo.lock reddb-io-rql"     "$(lock_version Cargo.lock reddb-io-rql)"
 check "Cargo.lock reddb-io-wire"    "$(lock_version Cargo.lock reddb-io-wire)"
 check "Cargo.lock reddb-io-grpc-proto" "$(lock_version Cargo.lock reddb-io-grpc-proto)"
 check "Cargo.lock reddb-io-server"  "$(lock_version Cargo.lock reddb-io-server)"

--- a/scripts/configure-crates-owners.sh
+++ b/scripts/configure-crates-owners.sh
@@ -6,8 +6,12 @@ CRATES=(
   reddb-io
   reddb-io-client
   reddb-io-client-connector
+  reddb-io-crypto
+  reddb-io-file
   reddb-io-grpc-proto
+  reddb-io-rql
   reddb-io-server
+  reddb-io-types
   reddb-io-wire
 )
 

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -21,7 +21,7 @@
  *   - package.json                    (@reddb-io/cli npm — source of truth)
  *   - Cargo.toml                      (engine crate)
  *   - Cargo.lock                      (workspace package versions)
- *   - crates/reddb-client-connector/Cargo.toml (workspace internal)
+ *   - crates/reddb-* Cargo.toml       (publishable workspace crates)
  *   - drivers/js/package.json         (@reddb-io/sdk npm)
  *   - drivers/js-client/package.json  (@reddb-io/client npm — optional, Lane T #136)
  *   - drivers/bun/package.json        (@reddb-io/client-bun npm)
@@ -59,9 +59,29 @@ const targets = [
     file: path.join(root, 'Cargo.toml'),
     type: 'cargo-toml',
   },
-  // Workspace members introduced by PRD #54. They publish (or stay
-  // pinned at) the same version as the umbrella reddb crate so the
-  // release workflow doesn't have to special-case them.
+  // Publishable workspace members stay at the same version as the
+  // umbrella reddb crate so the release workflow can publish them in
+  // dependency order without version drift.
+  {
+    label: 'crates/reddb-types/Cargo.toml',
+    file: path.join(root, 'crates', 'reddb-types', 'Cargo.toml'),
+    type: 'cargo-toml',
+  },
+  {
+    label: 'crates/reddb-crypto/Cargo.toml',
+    file: path.join(root, 'crates', 'reddb-crypto', 'Cargo.toml'),
+    type: 'cargo-toml',
+  },
+  {
+    label: 'crates/reddb-file/Cargo.toml',
+    file: path.join(root, 'crates', 'reddb-file', 'Cargo.toml'),
+    type: 'cargo-toml',
+  },
+  {
+    label: 'crates/reddb-rql/Cargo.toml',
+    file: path.join(root, 'crates', 'reddb-rql', 'Cargo.toml'),
+    type: 'cargo-toml',
+  },
   {
     label: 'crates/reddb-wire/Cargo.toml',
     file: path.join(root, 'crates', 'reddb-wire', 'Cargo.toml'),
@@ -167,6 +187,10 @@ if (failed > 0) {
 // release version bumps should not do that.
 syncCargoLock(path.join(root, 'Cargo.lock'), [
   'reddb-io',
+  'reddb-io-types',
+  'reddb-io-crypto',
+  'reddb-io-file',
+  'reddb-io-rql',
   'reddb-io-wire',
   'reddb-io-grpc-proto',
   'reddb-io-server',
@@ -181,6 +205,10 @@ const stageList = [
   'package.json',
   'Cargo.toml',
   'Cargo.lock',
+  'crates/reddb-types/Cargo.toml',
+  'crates/reddb-crypto/Cargo.toml',
+  'crates/reddb-file/Cargo.toml',
+  'crates/reddb-rql/Cargo.toml',
   'crates/reddb-wire/Cargo.toml',
   'crates/reddb-grpc-proto/Cargo.toml',
   'crates/reddb-server/Cargo.toml',


### PR DESCRIPTION
## Summary
- include types, crypto, file, and rql crates in release version sync and lock-step checks
- publish workspace crates in dependency order so first-publish authority crates land before dependents
- include the full crate set in the crates.io owner helper

## Verification
- node scripts/sync-version.js
- bash scripts/check-versions.sh
- git diff --check
- cargo check --locked --all
- cargo package --workspace --allow-dirty --no-verify

Note: cargo package without --no-verify is not a valid pre-release check while unreleased source changes still carry the already-published 1.10.1 version; it fails on published checksum drift before the release bump to 1.11.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784102707&installation_id=129708444&pr_number=1207&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1207&signature=7fe370499b494723197510f949e69ee26d2104c7b327224bc282d4660dcb417a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->