### PR TITLE
fix(ci): start minio chaos backend explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,18 +562,6 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     timeout-minutes: 25
     needs: tests
-    services:
-      minio:
-        image: minio/minio:latest
-        ports: ['9000:9000']
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        options: >-
-          --health-cmd "curl -f http://localhost:9000/minio/health/ready || exit 1"
-          --health-interval 5s
-          --health-timeout 3s
-          --health-retries 10
     env:
       RED_BACKEND: s3
       RED_S3_ENDPOINT: http://localhost:9000
@@ -592,12 +580,22 @@ jobs:
         with:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
+      - name: Start MinIO
+        run: |
+          docker run -d --name reddb-ci-minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
       - name: Wait for MinIO + create bucket
         run: |
           curl -fsS --retry 10 --retry-delay 2 http://localhost:9000/minio/health/ready
           docker run --rm --network host minio/mc:latest \
             sh -c "mc alias set ci http://localhost:9000 minioadmin minioadmin && mc mb -p ci/reddb-ci || true"
       - run: cargo test --locked --test 'chaos_*' --no-fail-fast
+      - name: Stop MinIO
+        if: always()
+        run: docker rm -f reddb-ci-minio || true
 
   windows:
     # Phase 3.6 PG parity — verify RedDB compiles + passes the core unit


### PR DESCRIPTION
## Summary
- replace the MinIO service container with an explicit docker run command
- keep the S3 chaos backend test on port 9000 and clean up the container after the job

## Verification
- git diff --check
- actionlint -ignore 'label ".+" is unknown' .github/workflows/ci.yml
- make check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784110974&installation_id=129708444&pr_number=1214&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1214&signature=0eb9ecd9187f6aaedc8fcafbcd029a27598c50053b2504ee2116cea8d7bf4cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to improve test execution reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->