### PR TITLE
fix(ci): harden minio chaos readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -589,9 +589,31 @@ jobs:
             minio/minio:latest server /data
       - name: Wait for MinIO + create bucket
         run: |
-          curl -fsS --retry 10 --retry-delay 2 http://localhost:9000/minio/health/ready
-          docker run --rm --network host minio/mc:latest \
-            sh -c "mc alias set ci http://localhost:9000 minioadmin minioadmin && mc mb -p ci/reddb-ci || true"
+          ready=false
+          for _ in $(seq 1 30); do
+            if curl -fsS http://localhost:9000/minio/health/ready; then
+              ready=true
+              break
+            fi
+            sleep 2
+          done
+          if [ "$ready" != "true" ]; then
+            docker logs reddb-ci-minio || true
+            exit 1
+          fi
+          bucket=false
+          for _ in $(seq 1 10); do
+            if docker run --rm --network host minio/mc:latest \
+              sh -c "mc alias set ci http://localhost:9000 minioadmin minioadmin && mc mb -p ci/reddb-ci || true"; then
+              bucket=true
+              break
+            fi
+            sleep 2
+          done
+          if [ "$bucket" != "true" ]; then
+            docker logs reddb-ci-minio || true
+            exit 1
+          fi
       - run: cargo test --locked --test 'chaos_*' --no-fail-fast
       - name: Stop MinIO
         if: always()


### PR DESCRIPTION
## Summary
- retry MinIO readiness explicitly so connection resets during startup do not fail the job immediately
- retry bucket creation and print MinIO logs on failure

## Verification
- git diff --check
- actionlint -ignore 'label ".+" is unknown' .github/workflows/ci.yml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784113166&installation_id=129708444&pr_number=1215&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1215&signature=741ad262d9cec9e09b27f97fa48b4e1f562eeca89a591e598e8f99d637708d6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->