### PR TITLE
fix(ci): use floci for s3 chaos backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,23 +553,23 @@ jobs:
       - name: Run drill tests
         run: cargo test --locked --test grouped_pitr_drills --no-fail-fast
 
-  chaos-minio:
+  chaos-floci:
     # PLAN.md Phase 8.4 — chaos suite against an S3-compatible
-    # backend (MinIO) so the LocalBackend coverage doesn't mask
+    # backend (Floci) so the LocalBackend coverage doesn't mask
     # backend-specific failure modes.
-    name: Chaos Suite (MinIO S3 backend)
+    name: Chaos Suite (Floci S3 backend)
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     timeout-minutes: 25
     needs: tests
     env:
       RED_BACKEND: s3
-      RED_S3_ENDPOINT: http://localhost:9000
+      RED_S3_ENDPOINT: http://localhost:4566
       RED_S3_BUCKET: reddb-ci
       RED_S3_REGION: us-east-1
       RED_S3_PATH_STYLE: "true"
-      RED_S3_ACCESS_KEY: minioadmin
-      RED_S3_SECRET_KEY: minioadmin
+      RED_S3_ACCESS_KEY: test
+      RED_S3_SECRET_KEY: test
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.91.0
@@ -580,44 +580,46 @@ jobs:
         with:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
-      - name: Start MinIO
+      - name: Start Floci
         run: |
-          docker run -d --name reddb-ci-minio \
-            -p 9000:9000 \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:latest server /data
-      - name: Wait for MinIO + create bucket
+          docker run -d --name reddb-ci-floci \
+            -p 4566:4566 \
+            floci/floci:latest
+      - name: Wait for Floci + create bucket
         run: |
           ready=false
           for _ in $(seq 1 30); do
-            if curl -fsS http://localhost:9000/minio/health/ready; then
+            if curl -fsS http://localhost:4566/_localstack/health; then
               ready=true
               break
             fi
             sleep 2
           done
           if [ "$ready" != "true" ]; then
-            docker logs reddb-ci-minio || true
+            docker logs reddb-ci-floci || true
             exit 1
           fi
           bucket=false
           for _ in $(seq 1 10); do
-            if docker run --rm --network host minio/mc:latest \
-              sh -c "mc alias set ci http://localhost:9000 minioadmin minioadmin && mc mb -p ci/reddb-ci || true"; then
+            if docker run --rm --network host \
+              -e AWS_ACCESS_KEY_ID=test \
+              -e AWS_SECRET_ACCESS_KEY=test \
+              -e AWS_DEFAULT_REGION=us-east-1 \
+              amazon/aws-cli:latest \
+              --endpoint-url http://localhost:4566 s3 mb s3://reddb-ci; then
               bucket=true
               break
             fi
             sleep 2
           done
           if [ "$bucket" != "true" ]; then
-            docker logs reddb-ci-minio || true
+            docker logs reddb-ci-floci || true
             exit 1
           fi
       - run: cargo test --locked --test 'chaos_*' --no-fail-fast
-      - name: Stop MinIO
+      - name: Stop Floci
         if: always()
-        run: docker rm -f reddb-ci-minio || true
+        run: docker rm -f reddb-ci-floci || true
 
   windows:
     # Phase 3.6 PG parity — verify RedDB compiles + passes the core unit


### PR DESCRIPTION
## Summary
- replace the S3 chaos backend emulator from MinIO to Floci
- run Floci on the AWS-compatible local endpoint at port 4566
- create the test bucket through AWS CLI against Floci before chaos tests

## Verification
- local Floci Docker smoke: health endpoint + aws-cli s3 mb
- git diff --check
- actionlint -ignore 'label ".+" is unknown' .github/workflows/ci.yml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784115207&installation_id=129708444&pr_number=1216&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1216&signature=98afb9fcc4bc58c6999b63bf7767d51af226d402037b4577779ddbbbd58ac719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to use Floci-based S3 backend for testing infrastructure, replacing the previous MinIO-based setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->