### PR TITLE
Clarify cluster sharding and AI query contracts

### DIFF
--- a/.red/adr/0055-cluster-slot-map-and-cross-shard-operations.md
+++ b/.red/adr/0055-cluster-slot-map-and-cross-shard-operations.md
@@ -1,0 +1,218 @@
+# ADR 0055 — Cluster slot map and bounded cross-shard operations
+
+Status: proposed
+Date: 2026-06-15
+
+Extends [ADR 0037](0037-shard-range-ownership-catalog.md),
+[ADR 0044](0044-primary-replica-runtime-boundary.md),
+[ADR 0045](0045-cluster-range-file-layout.md), and
+[ADR 0052](0052-cluster-supervisor-control-plane-consensus.md).
+
+RedDB cluster mode partitions user collections horizontally. The control-plane
+work already chose a versioned shard/range ownership catalog; this ADR fixes the
+user-data sharding model on top of it: how a row/document/key reaches a shard,
+how primary-replica HA composes with cluster partitioning, and what cross-shard
+queries may do in the first productive cluster cut.
+
+## Decision
+
+**Hash-partitioned collections route through fixed hash slots.** For hash-mode
+collections, routing is:
+
+```text
+collection/table -> shard key -> hash -> slot -> shard group -> owner node
+```
+
+The production slot count is 16,384. The slot count is a cluster-format constant,
+not `node_count`; adding or removing nodes must not remap the whole keyspace.
+Small slot counts may be used only in tests or throwaway development catalogs
+before cluster metadata becomes stable.
+
+**The user chooses the logical shard key; RedDB chooses physical ranges.** These
+are separate responsibilities:
+
+| Decision | Owner | Contract |
+|----------|-------|----------|
+| Which field/expression places a row/document/key | User DDL, or an explicit RedDB collection-kind default | Stable logical contract: `SHARD BY tenant_id`, primary key, document id, etc. |
+| Whether that key routes by hash slots or ordered key ranges | RedDB default plus optional advanced DDL | Hash is the default for distribution; ordered is opt-in for locality/scans. |
+| Which slot/range belongs to which shard group | RedDB Cluster Supervisor and shard ownership catalog | Internal control-plane state; may change through split/move/rebalance. |
+| Which node is current writer for a range | RedDB ownership transition | Internal and versioned by owner, epoch, replicas, and catalog version. |
+
+The operator should not hand-place ordinary data into "range 0 to 1000" or
+`hash(key) % node_count`. For a normal hash-partitioned table, the product
+contract is:
+
+```sql
+CREATE TABLE orders (
+  tenant_id TEXT,
+  order_id TEXT,
+  status TEXT
+) SHARD BY tenant_id;
+```
+
+At runtime RedDB maps that logical key internally:
+
+```text
+tenant_id='acme' -> hash -> slot 9381 -> range [8192, 12288) -> shard group B -> owner node
+```
+
+RedDB may later split `[8192, 12288)` or move it to another owner without
+changing the user's `SHARD BY tenant_id` contract.
+
+**The shard ownership catalog remains the source of truth.** A slot is the
+logical hash bucket. A range is still the cataloged ownership unit. In hash mode,
+a `RangeOwnership` entry represents a contiguous span of hash slots, and the
+catalog/cluster map records which shard group owns each span. RedDB may split or
+move ranges to rebalance slots, but ownership is never recalculated from live
+membership alone.
+
+**A shard group is a small primary-replica group.** Each shard group owns one or
+more slot spans and has exactly one write primary plus a configured set of
+replicas. Production HA groups use `N` replicas according to the replication
+factor; zero-replica groups are limited to development or explicitly non-HA
+postures. The group uses the same commit-watermark, replica-read, and promotion
+rules as primary-replica deployments. Cluster mode is therefore many
+independently-owned primary-replica groups under one control plane:
+primary-replica solves HA/read scaling inside a group; cluster mode solves
+horizontal partitioning across groups.
+
+**Cluster collections must have a shard key.** DDL must either declare `SHARD BY`
+or rely on a collection-kind default that is explicit in the product contract.
+Defaults are allowed only when they are stable, high-cardinality, and aligned
+with normal access patterns:
+
+- KV: key.
+- Documents: document id, or tenant id when tenancy is declared.
+- Tables: primary key, or explicit `SHARD BY`.
+- Queues: queue name or tenant id.
+- Timeseries/logs: tenant id plus a bucket; never timestamp alone.
+- Graph: tenant id or graph id until a graph-specific placement model exists.
+
+Examples:
+
+```sql
+CREATE TABLE orders (
+  tenant_id TEXT,
+  order_id TEXT,
+  status TEXT
+) SHARD BY tenant_id;
+
+CREATE COLLECTION events SHARD BY tenant_id;
+```
+
+**Single-shard reads and writes are the happy path.** When a query contains the
+shard key, the planner resolves the slot, routes to one shard group, and executes
+there. This is the only write path supported by default in the first productive
+cluster cut.
+
+**Cross-shard reads are explicit and bounded.** Queries without a usable shard
+key may scatter to multiple shard groups only when the request surface makes
+fanout explicit or the planner can prove the fanout is within configured budgets.
+The coordinator must enforce:
+
+- timeout per shard leg;
+- maximum shard-group count;
+- maximum rows or bytes per shard leg;
+- coordinator memory budget;
+- merge/sort/limit budget;
+- partial response only when the query explicitly allows partial results;
+- tracing that names participating shard groups, timeouts, retries, and partial
+  result status.
+
+Best-effort cross-shard reads do not claim global snapshot consistency.
+Consistent cross-shard reads require a safe global watermark that covers every
+participating range, matching the existing `GlobalReadWatermark` shape.
+
+**Cross-shard write transactions are rejected in v1.** A transaction whose write
+set spans shard groups owned by different writers fails with an explicit
+unsupported/cross-shard error. RedDB must not do partial commits and must not
+introduce two-phase commit in the first sharded cluster milestone. A future
+special API may support saga-style workflows or a narrower distributed
+transaction model, but that is a separate decision.
+
+**Cross-shard joins and global secondary indexes are out of scope initially.**
+Shard-local indexes are supported. Global secondary indexes, cross-shard joins,
+and global uniqueness constraints require separate design because they turn many
+ordinary writes into distributed writes.
+
+**Global aggregations use scatter-gather with partial state.** Aggregations such
+as global top-N, counts, maxima, leaderboards, and recent-events views may execute
+by asking each shard group for bounded partial results and merging them at the
+coordinator. The coordinator should merge partial aggregate state, not raw
+unbounded rows, whenever the query shape allows it.
+
+Example classifications:
+
+```sql
+-- orders is SHARD BY tenant_id: one slot, one shard group.
+SELECT * FROM orders WHERE tenant_id = 't1' AND order_id = 'o1';
+
+-- No shard key predicate: bounded cross-shard read if the request allows fanout.
+SELECT * FROM orders WHERE status = 'pending';
+
+-- Global top-N: cross-shard read using per-shard partial top-N plus coordinator merge.
+SELECT * FROM events ORDER BY created_at DESC LIMIT 100;
+```
+
+A transfer between users or accounts on different shard groups is a cross-shard
+write transaction and is rejected by default in v1.
+
+**Caching is layered and never an ownership authority.**
+
+- Routing cache: clients and nodes cache `(collection, slot) -> owner, replicas,
+  ownership epoch, cluster-map epoch/catalog version`. A stale route receives a
+  redirect/MOVED-like response carrying the slot, current owner address,
+  ownership epoch, and catalog version, for example
+  `MOVED slot=1234 owner=node-b:55055 epoch=42`. The cache updates and retries,
+  but correctness still depends on the owner's fencing gate.
+- Cross-shard result cache: expensive global reads may cache
+  `query_hash + catalog_version` with a short TTL such as 5s, 30s, or 5m depending
+  on freshness requirements. This cache is an optimization; a consistent read
+  must include the safe watermark in the cache key or bypass the entry.
+- Per-shard partial cache: shard groups may cache local top-N, counts, max
+  timestamp, and similar partials so coordinators merge small bounded results.
+
+**Hot-key splitting is explicit and deferred.** Plain `SHARD BY tenant_id` can
+create a hot shard when one tenant dominates traffic. The first cut relies on
+range split/move and operator visibility. A later DDL extension may opt a
+collection into compound hot-key striping, for example:
+
+```sql
+SHARD BY tenant_id SPLIT HOT KEY BY entity_id INTO 16 BUCKETS
+```
+
+That mode intentionally increases cross-shard work inside a tenant, so it must
+be explicit rather than a default.
+
+## Considered options
+
+- **`hash(shard_key) % node_count`.** Rejected because adding or removing a node
+  reshuffles most keys and makes rebalancing operationally expensive.
+- **Fixed hash slots with cataloged ownership spans (chosen).** Keeps routing
+  simple, gives the control plane a stable keyspace to move gradually, and still
+  compresses metadata as ranges instead of storing one row per slot.
+- **Pure hash-token ranges with no slot language.** Rejected as the product
+  contract because fixed slots are easier to explain, cache, redirect, and
+  operate. Internally, ranges may still be represented as slot spans.
+- **Directory-only sharding.** Rejected for the default path because every lookup
+  would depend on an extra directory read. The ownership catalog remains global
+  control-plane state, but point routing is formulaic: shard key -> hash -> slot.
+- **Two-phase commit for cross-shard writes.** Rejected for v1 because it adds
+  blocking coordinator failure modes before the single-shard and bounded-read
+  paths are mature.
+
+## Consequences
+
+- The query analyzer needs to identify shard-key predicates and mark a plan as
+  single-shard, bounded cross-shard read, or unsupported cross-shard write.
+- DDL needs a stable `SHARD BY` surface and collection-kind defaults.
+- Topology snapshots and routing hints need slot/span metadata in addition to
+  owner, replicas, ownership epoch, and catalog version.
+- The transport needs a redirect/MOVED-like payload for stale slot ownership.
+- Scatter-gather execution needs budgets, cancellation, partial-result semantics,
+  and trace fields before it is safe to expose broadly.
+- Result caching must include catalog generation and, for consistent reads, the
+  global read watermark; otherwise cached global results may be used only under
+  documented TTL staleness.
+- Placement and rebalancing should plan moves over slot spans/ranges, preserving
+  the range file layout from ADR 0045.

--- a/.red/context/clustering.md
+++ b/.red/context/clustering.md
@@ -18,10 +18,16 @@ Part of the [glossary map](../CONTEXT-MAP.md). Multi-writer clusters where data 
 
 ## Shard/range ownership
 
+- **Shard key** — collection/table field or key expression used to place user data in cluster mode. Cluster collections either declare `SHARD BY` or use an explicit collection-kind default. This is the user-facing logical choice; users choose `tenant_id`, primary key, document id, etc., not physical ranges or node numbers. A good shard key is high-cardinality, naturally spread out, and aligned with common point queries.
+- **Hash slot** — fixed logical bucket produced by hashing a shard key in hash-partitioned cluster collections. Slots are stable cluster-format units; they are not recalculated from the current member count and are not chosen directly by users.
+- **Cluster slot map** — operator/runtime view of which shard group owns each hash slot or contiguous slot span. In RedDB this is projected from the shard ownership catalog; it is routing metadata, not a separate authority.
+- **Routing cache** — driver or node-local cache from collection/range or collection/hash-slot to owner, replicas, ownership epoch, and cluster-map epoch/catalog version. It is an optimization over topology refresh and routing hints; ownership fencing below routing remains the correctness mechanism.
+- **Shard group** — one owned partition group in a cluster: a slot/range write primary plus its configured range replicas. A cluster is many shard groups under one control plane, and each shard group behaves like a small primary-replica group for HA, catch-up, read routing, and promotion safety.
 - **Shard/range ownership** — write authority for a bounded partition of collection data. In a multi-writer RedDB cluster, ownership is assigned at shard/range granularity rather than whole-collection granularity.
+- **Range placement** — internal RedDB control-plane decision that maps an ordered key span or hash-slot span to a shard group and current range owner. The Cluster Supervisor may split, move, or rebalance ranges without changing the collection's logical `SHARD BY` contract.
 - **Range owner** — current writer for one shard/range. In a multi-writer cluster, write authority is a per-range role rather than a global node role.
 - **Range replica** — read-only/catch-up copy of one shard/range that can be promoted to range owner if it covers the range commit watermark and wins the required ownership transition.
-- **Shard key mode** — collection-level partitioning mode for shard/range ownership. Hash mode is the default for uniform distribution; ordered mode is declared when range locality and ordered scans matter more than automatic hotspot resistance.
+- **Shard key mode** — collection-level partitioning mode for shard/range ownership. Hash mode is the default for uniform distribution: `shard key -> hash -> slot -> range`. Ordered mode is declared when range locality and ordered scans matter more than automatic hotspot resistance: `shard key -> range`.
 - **Shard ownership catalog** — explicit, versioned RedDB catalog state that records shard/range bounds, current writer owner, replicas, and ownership epoch/version. It is the source of truth for range routing, failover, split/merge, and rebalancing decisions. It is special global control-plane state replicated to all data members rather than sharded like ordinary user collections. Normal writes to it are performed by the Cluster Supervisor leader; administrative recovery may force transitions under the forced-ownership rules.
 - **Ownership transition** — fenced, audited change to shard/range ownership, requested either by the Cluster Supervisor or by an authorized administrative recovery command. Operators request transitions such as move, split, merge, or promote; they do not mutate shard ownership catalog rows arbitrarily.
 - **Forced ownership transition** — disaster-recovery form of an ownership transition that can proceed without ordinary cluster quorum. It requires a special administrative capability, explicit operator reason, audit evidence, and an ownership epoch bump that fences any old owner still alive.
@@ -35,12 +41,16 @@ Part of the [glossary map](../CONTEXT-MAP.md). Multi-writer clusters where data 
 
 ## Cross-range operations
 
+- **Cross-shard operation** — product-facing name for an operation whose target set spans multiple shard groups. The implementation-level term is cross-range because ownership and fencing are recorded at range granularity.
 - **Cross-range write transaction** — transaction whose write set spans shard/ranges owned by different writers. The first multi-writer cluster cut rejects these transactions rather than committing partial work or introducing two-phase commit in the ownership/failover milestone.
 - **Cross-range read** — read query whose target set spans shard/ranges that may be owned by different writers. The first multi-writer cluster cut supports a simple fanout mode without a global snapshot, while explicit consistent/transactional reads require a global causal watermark or equivalent safe snapshot point.
+- **Bounded scatter-gather** — cross-range read execution shape where a coordinator fans out to participating shard groups, collects partial results, and merges them under explicit timeout, shard-count, row/byte, memory, partial-response, and tracing budgets.
+- **Cross-shard result cache** — short-lived cache for expensive global read results keyed by query identity and catalog generation, with safe-snapshot/watermark identity included when the result claims consistency.
 - **Stale ownership response** — routing correction returned when a request uses an old shard/range ownership epoch. The response carries enough current epoch/owner information for clients or routers to refresh and retry; pushed topology updates are an optimization, not the correctness mechanism.
 
 ## Placement & rebalancing
 
+- **Hot-key splitting** — explicit future placement mode that stripes one logical shard-key value across additional buckets to relieve a dominant tenant/entity. It improves write distribution for a hot key but makes formerly single-shard tenant/entity queries cross-shard, so it is not a default.
 - **Range striping** — distribution of collection data across multiple shard/ranges so different writers can own different parts of the data set. This is analogous to RAID striping at the cluster-data level, not block-level disk striping.
 - **Range replication** — full-copy replication of each shard/range according to the cluster replication factor. The first multi-writer hot path uses full range replicas rather than parity or erasure coding.
 - **Weighted placement** — shard/range placement policy that accounts for advertised node capacity such as usable disk, health, and operator weights. Expanding a node's disk changes its placement weight; data moves only through explicit rebalancing transitions.

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -841,7 +841,7 @@ pub struct DropIndexQuery {
 
 /// ASK 'question' [USING provider] [MODEL 'model'] [DEPTH n] [LIMIT n] [MIN_SCORE x]
 ///                [COLLECTION col] [TEMPERATURE x] [SEED n] [STRICT ON|OFF] [STREAM]
-///                [CACHE TTL '5m' | NOCACHE]
+///                [CACHE TTL '5m' | NOCACHE] [AS RQL]
 ///
 /// `temperature` and `seed` are per-query overrides resolved by the
 /// `DeterminismDecider` (issue #400). The parser merely surfaces the
@@ -873,6 +873,9 @@ pub struct AskQuery {
     pub stream: bool,
     /// Per-query answer-cache override.
     pub cache: AskCacheClause,
+    /// `ASK '...' AS RQL` returns a validated RQL candidate instead of
+    /// calling an AI provider. The runtime owns translation and validation.
+    pub as_rql: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -543,7 +543,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse: ASK 'question' [USING provider] [MODEL 'model'] [DEPTH n]
-    /// [LIMIT n] [MIN_SCORE x] [COLLECTION col]
+    /// [LIMIT n] [MIN_SCORE x] [COLLECTION col] [AS RQL]
     pub fn parse_ask_query(&mut self) -> Result<QueryExpr, ParseError> {
         self.parse_ask_query_with_explain(false)
     }
@@ -590,10 +590,11 @@ impl<'a> Parser<'a> {
         let mut strict = true;
         let mut stream = false;
         let mut cache = AskCacheClause::Default;
+        let mut as_rql = false;
 
         // Parse optional clauses in any order. Loop bound = number of
         // clause kinds, so each can appear at most once.
-        for _ in 0..12 {
+        for _ in 0..13 {
             if self.consume(&Token::Using)? {
                 provider = Some(match &self.current.token {
                     Token::String(_) => self.parse_string()?,
@@ -647,6 +648,21 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 cache = AskCacheClause::NoCache;
+            } else if self.consume(&Token::As)? {
+                if as_rql {
+                    return Err(ParseError::new(
+                        "ASK AS RQL specified more than once",
+                        self.position(),
+                    ));
+                }
+                let output = self.expect_ident_or_keyword()?;
+                if !output.eq_ignore_ascii_case("RQL") {
+                    return Err(ParseError::new(
+                        "Expected RQL after ASK AS",
+                        self.position(),
+                    ));
+                }
+                as_rql = true;
             } else {
                 break;
             }
@@ -667,6 +683,7 @@ impl<'a> Parser<'a> {
             strict,
             stream,
             cache,
+            as_rql,
         }))
     }
 

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -1945,6 +1945,13 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
     };
     assert!(matches!(ask.cache, crate::ast::AskCacheClause::NoCache));
 
+    let query = parse("ASK 'who owns passport FDD-12313?' AS RQL").unwrap();
+    let QueryExpr::Ask(ask) = query else {
+        panic!("Expected AskQuery");
+    };
+    assert!(ask.as_rql);
+    assert!(!ask.explain);
+
     let query = parse("EXPLAIN ASK 'q' USING openai LIMIT 3 MIN_SCORE 0.7 DEPTH 2").unwrap();
     let QueryExpr::Ask(ask) = query else {
         panic!("Expected AskQuery");

--- a/crates/reddb-server/src/cluster/cross_range.rs
+++ b/crates/reddb-server/src/cluster/cross_range.rs
@@ -457,7 +457,7 @@ impl ShardOwnershipCatalog {
     ) -> Result<Vec<ResolvedTarget>, (CollectionId, Vec<u8>)> {
         let mut resolved = Vec::with_capacity(targets.len());
         for t in targets {
-            match self.route(t.collection(), t.key()) {
+            match self.route_shard_key(t.collection(), t.key()) {
                 Some(range) => resolved.push(ResolvedTarget {
                     collection: t.collection().clone(),
                     key: t.key().to_vec(),

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -13,6 +13,7 @@ pub mod ownership_lease;
 pub mod ownership_transition;
 pub mod placement;
 pub mod routing;
+pub mod slot;
 pub mod supervisor;
 pub mod topology;
 
@@ -68,6 +69,10 @@ pub use placement::{
 pub use routing::{
     RedirectReason, RequestOperation, RouteDecision, RoutedRequest, RoutingHint, RoutingPolicy,
     DEFAULT_MAX_FORWARD_PAYLOAD,
+};
+pub use slot::{
+    hash_shard_key_to_range_key, hash_shard_key_to_slot, HashSlot, HashSlotError,
+    PRODUCTION_HASH_SLOT_COUNT,
 };
 pub use supervisor::{
     BlockedFailover, BlockedReason, ClusterSignals, ClusterSupervisor, FailoverPlan, HealthClass,

--- a/crates/reddb-server/src/cluster/ownership.rs
+++ b/crates/reddb-server/src/cluster/ownership.rs
@@ -46,6 +46,7 @@
 use std::collections::BTreeMap;
 
 use super::identity::NodeIdentity;
+use super::slot::hash_shard_key_to_range_key;
 
 /// A user collection's stable identity, as recorded in the catalog.
 ///
@@ -794,6 +795,13 @@ impl ShardOwnershipCatalog {
                         attempted: entry.version(),
                     });
                 }
+                if let Some(existing) = self.overlapping_sibling(&entry) {
+                    return Err(CatalogError::OverlappingRange {
+                        collection: entry.collection().clone(),
+                        existing,
+                        attempted: entry.range_id(),
+                    });
+                }
                 self.collections
                     .insert(entry.collection().clone(), entry.shard_key_mode());
                 self.ranges.insert(key, entry);
@@ -802,13 +810,10 @@ impl ShardOwnershipCatalog {
             None => {
                 // Creating a range: it must not overlap any sibling range of the
                 // same collection, or routing would be ambiguous.
-                if let Some(existing) = self
-                    .ranges_for(entry.collection())
-                    .find(|r| r.bounds().overlaps(entry.bounds()))
-                {
+                if let Some(existing) = self.overlapping_sibling(&entry) {
                     return Err(CatalogError::OverlappingRange {
                         collection: entry.collection().clone(),
-                        existing: existing.range_id(),
+                        existing,
                         attempted: entry.range_id(),
                     });
                 }
@@ -818,6 +823,14 @@ impl ShardOwnershipCatalog {
                 Ok(UpdateOutcome::Created)
             }
         }
+    }
+
+    fn overlapping_sibling(&self, entry: &RangeOwnership) -> Option<RangeId> {
+        self.ranges_for(entry.collection())
+            .find(|range| {
+                range.range_id() != entry.range_id() && range.bounds().overlaps(entry.bounds())
+            })
+            .map(RangeOwnership::range_id)
     }
 
     /// The current ownership of one range, addressed directly by identity — no
@@ -838,13 +851,32 @@ impl ShardOwnershipCatalog {
             .map(|(_, r)| r)
     }
 
-    /// Route a key to the range that owns it — the catalog read every routing
-    /// decision makes. Returns the owning [`RangeOwnership`] (whose `owner`,
-    /// `epoch`, and `replicas` the caller uses to send and fence the write), or
-    /// `None` if no range covers the key yet.
+    /// Route a normalized range key to the range that owns it — the catalog read
+    /// every routing decision makes. Returns the owning [`RangeOwnership`] (whose
+    /// `owner`, `epoch`, and `replicas` the caller uses to send and fence the
+    /// write), or `None` if no range covers the key yet.
     pub fn route(&self, collection: &CollectionId, key: &[u8]) -> Option<&RangeOwnership> {
         self.ranges_for(collection)
             .find(|r| r.bounds().contains(key))
+    }
+
+    /// Route a logical shard key according to the collection's declared mode.
+    ///
+    /// Ordered collections route the shard key bytes directly. Hash collections
+    /// first map the shard key into a stable hash slot and route that slot's
+    /// range key through the same `collection -> range` catalog.
+    pub fn route_shard_key(
+        &self,
+        collection: &CollectionId,
+        shard_key: &[u8],
+    ) -> Option<&RangeOwnership> {
+        match self.shard_key_mode(collection)? {
+            ShardKeyMode::Ordered => self.route(collection, shard_key),
+            ShardKeyMode::Hash => {
+                let range_key = hash_shard_key_to_range_key(shard_key);
+                self.route(collection, &range_key)
+            }
+        }
     }
 
     /// This node's [`RangeRole`] for a directly-addressed range (issue #990).
@@ -883,11 +915,11 @@ impl ShardOwnershipCatalog {
         key: &[u8],
         expected_epoch: OwnershipEpoch,
     ) -> Result<&RangeOwnership, RangeWriteReject> {
-        let range = self
-            .route(collection, key)
-            .ok_or_else(|| RangeWriteReject::NoRange {
-                collection: collection.clone(),
-            })?;
+        let range =
+            self.route_shard_key(collection, key)
+                .ok_or_else(|| RangeWriteReject::NoRange {
+                    collection: collection.clone(),
+                })?;
         let role = range.role_of(node);
         if !role.may_write_public() {
             return Err(RangeWriteReject::NotOwner {
@@ -948,6 +980,18 @@ mod tests {
             [ident("CN=replica-1")],
             PlacementMetadata::with_replication_factor(3),
         )
+    }
+
+    fn single_hash_slot_bounds(key: &[u8]) -> RangeBounds {
+        let slot = super::super::slot::hash_shard_key_to_slot(key);
+        let lower = RangeBound::key(slot.range_key());
+        let upper = match slot.value().checked_add(1) {
+            Some(next) if next < super::super::slot::PRODUCTION_HASH_SLOT_COUNT => {
+                RangeBound::key(super::super::slot::HashSlot::new(next).unwrap().range_key())
+            }
+            _ => RangeBound::Max,
+        };
+        RangeBounds::new(lower, upper).unwrap()
     }
 
     #[test]
@@ -1011,6 +1055,26 @@ mod tests {
         let r = catalog.route(&orders, &[0x10]).unwrap();
         assert_eq!(r.replicas(), &[ident("CN=replica-1")]);
         assert_eq!(r.epoch(), OwnershipEpoch::initial());
+    }
+
+    #[test]
+    fn hash_mode_routes_logical_shard_key_through_hash_slot() {
+        let mut catalog = ShardOwnershipCatalog::new();
+        let orders = collection("orders");
+        let key = b"tenant:42";
+        catalog
+            .apply_update(hash_range(
+                &orders,
+                1,
+                single_hash_slot_bounds(key),
+                "CN=node-a",
+            ))
+            .unwrap();
+
+        let routed = catalog
+            .route_shard_key(&orders, key)
+            .expect("hash slot range covers the logical shard key");
+        assert_eq!(routed.owner(), &ident("CN=node-a"));
     }
 
     #[test]
@@ -1197,6 +1261,46 @@ mod tests {
     }
 
     #[test]
+    fn overlapping_range_update_is_rejected() {
+        let mut catalog = ShardOwnershipCatalog::new();
+        let orders = collection("orders");
+        catalog
+            .apply_update(hash_range(
+                &orders,
+                1,
+                bounds(&[0x00], &[0x80]),
+                "CN=node-a",
+            ))
+            .unwrap();
+        catalog
+            .apply_update(hash_range(
+                &orders,
+                2,
+                RangeBounds::new(RangeBound::key([0x80]), RangeBound::Max).unwrap(),
+                "CN=node-b",
+            ))
+            .unwrap();
+
+        let widened = catalog
+            .range(&orders, RangeId::new(1))
+            .unwrap()
+            .with_bounds(bounds(&[0x00], &[0xc0]));
+        let err = catalog.apply_update(widened).unwrap_err();
+        assert_eq!(
+            err,
+            CatalogError::OverlappingRange {
+                collection: orders.clone(),
+                existing: RangeId::new(2),
+                attempted: RangeId::new(1),
+            }
+        );
+        assert_eq!(
+            catalog.range(&orders, RangeId::new(1)).unwrap().bounds(),
+            &bounds(&[0x00], &[0x80])
+        );
+    }
+
+    #[test]
     fn catalog_replicates_to_data_members_with_read_visibility() {
         // Leader writes the catalog; a data member holds its own replica and
         // applies the same versioned updates — no user-data sharding involved.
@@ -1357,6 +1461,26 @@ mod tests {
             )
             .expect("owner at current epoch may write");
         assert_eq!(admitted.owner(), &ident("CN=node-a"));
+        assert_eq!(admitted.range_id(), RangeId::new(1));
+    }
+
+    #[test]
+    fn public_write_uses_hash_slot_routing_for_hash_collections() {
+        let mut catalog = ShardOwnershipCatalog::new();
+        let orders = collection("orders");
+        let key = b"tenant:42";
+        catalog
+            .apply_update(hash_range(
+                &orders,
+                1,
+                single_hash_slot_bounds(key),
+                "CN=node-a",
+            ))
+            .unwrap();
+
+        let admitted = catalog
+            .admit_public_write(&ident("CN=node-a"), &orders, key, OwnershipEpoch::initial())
+            .expect("hash owner admits write routed by shard-key slot");
         assert_eq!(admitted.range_id(), RangeId::new(1));
     }
 

--- a/crates/reddb-server/src/cluster/ownership_lease.rs
+++ b/crates/reddb-server/src/cluster/ownership_lease.rs
@@ -522,11 +522,12 @@ pub fn admit_durable_write<'c>(
     current_term: SupervisorTerm,
     now_ms: u64,
 ) -> Result<&'c RangeOwnership, DurableWriteReject> {
-    let range = catalog
-        .route(collection, key)
-        .ok_or_else(|| DurableWriteReject::NoRange {
-            collection: collection.clone(),
-        })?;
+    let range =
+        catalog
+            .route_shard_key(collection, key)
+            .ok_or_else(|| DurableWriteReject::NoRange {
+                collection: collection.clone(),
+            })?;
 
     let role = range.role_of(node);
     if !role.may_write_public() {

--- a/crates/reddb-server/src/cluster/routing.rs
+++ b/crates/reddb-server/src/cluster/routing.rs
@@ -351,7 +351,7 @@ impl ShardOwnershipCatalog {
         request: &RoutedRequest,
         policy: &RoutingPolicy,
     ) -> RouteDecision {
-        let range = match self.route(request.collection(), request.key()) {
+        let range = match self.route_shard_key(request.collection(), request.key()) {
             Some(range) => range,
             None => {
                 return RouteDecision::Unroutable {

--- a/crates/reddb-server/src/cluster/slot.rs
+++ b/crates/reddb-server/src/cluster/slot.rs
@@ -1,0 +1,108 @@
+//! Hash-slot routing primitives for cluster shard keys.
+//!
+//! The ownership catalog is still expressed as `collection -> range`: ranges are
+//! the move/fencing unit. In hash mode, those range bounds are over stable hash
+//! slots instead of the raw user shard key. This module is the explicit
+//! `shard_key -> hash -> slot -> range-key` layer shared by routing code.
+
+/// Fixed production hash-slot count, matching the cluster slot-map ADR.
+pub const PRODUCTION_HASH_SLOT_COUNT: u16 = 16_384;
+
+/// One logical hash bucket in the cluster slot map.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HashSlot(u16);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashSlotError {
+    attempted: u16,
+}
+
+impl HashSlotError {
+    pub fn attempted(self) -> u16 {
+        self.attempted
+    }
+}
+
+impl std::fmt::Display for HashSlotError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "hash slot {} is outside the valid 0..{} range",
+            self.attempted, PRODUCTION_HASH_SLOT_COUNT
+        )
+    }
+}
+
+impl std::error::Error for HashSlotError {}
+
+impl HashSlot {
+    /// Construct a slot, rejecting values outside `0..PRODUCTION_HASH_SLOT_COUNT`.
+    pub fn new(value: u16) -> Result<Self, HashSlotError> {
+        if value >= PRODUCTION_HASH_SLOT_COUNT {
+            return Err(HashSlotError { attempted: value });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn value(self) -> u16 {
+        self.0
+    }
+
+    /// The lexicographically-sortable range key used in [`RangeBounds`].
+    ///
+    /// Big-endian encoding preserves numeric slot order under byte comparison,
+    /// so `[slot_a, slot_b)` ranges work with the catalog's existing bounds
+    /// predicate.
+    ///
+    /// [`RangeBounds`]: super::ownership::RangeBounds
+    pub fn range_key(self) -> [u8; 2] {
+        self.0.to_be_bytes()
+    }
+}
+
+/// Hash a logical shard key into the fixed production slot map.
+pub fn hash_shard_key_to_slot(shard_key: &[u8]) -> HashSlot {
+    let digest = blake3::hash(shard_key);
+    let mut prefix = [0u8; 8];
+    prefix.copy_from_slice(&digest.as_bytes()[..8]);
+    let slot = (u64::from_be_bytes(prefix) % u64::from(PRODUCTION_HASH_SLOT_COUNT)) as u16;
+    HashSlot(slot)
+}
+
+/// Hash a logical shard key into the catalog range key used by hash-mode ranges.
+pub fn hash_shard_key_to_range_key(shard_key: &[u8]) -> [u8; 2] {
+    hash_shard_key_to_slot(shard_key).range_key()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_slots_are_bounded_by_the_production_slot_count() {
+        assert_eq!(HashSlot::new(0).unwrap().value(), 0);
+        assert_eq!(
+            HashSlot::new(PRODUCTION_HASH_SLOT_COUNT - 1)
+                .unwrap()
+                .value(),
+            PRODUCTION_HASH_SLOT_COUNT - 1
+        );
+        let err = HashSlot::new(PRODUCTION_HASH_SLOT_COUNT).unwrap_err();
+        assert_eq!(err.attempted(), PRODUCTION_HASH_SLOT_COUNT);
+    }
+
+    #[test]
+    fn range_key_preserves_numeric_slot_order() {
+        let before = HashSlot::new(255).unwrap().range_key();
+        let after = HashSlot::new(256).unwrap().range_key();
+        assert!(before < after);
+    }
+
+    #[test]
+    fn shard_key_hashing_is_stable_and_in_range() {
+        let first = hash_shard_key_to_slot(b"tenant:42");
+        let second = hash_shard_key_to_slot(b"tenant:42");
+        assert_eq!(first, second);
+        assert!(first.value() < PRODUCTION_HASH_SLOT_COUNT);
+    }
+}

--- a/crates/reddb-server/src/cluster/topology.rs
+++ b/crates/reddb-server/src/cluster/topology.rs
@@ -40,9 +40,10 @@ use std::collections::BTreeMap;
 use super::identity::NodeIdentity;
 use super::ownership::{
     CatalogVersion, CollectionId, OwnershipEpoch, RangeBounds, RangeId, RangeOwnership,
-    ShardOwnershipCatalog,
+    ShardKeyMode, ShardOwnershipCatalog,
 };
 use super::routing::RoutingHint;
+use super::slot::hash_shard_key_to_range_key;
 
 /// One range's routing metadata as a driver sees it.
 ///
@@ -56,6 +57,7 @@ use super::routing::RoutingHint;
 pub struct TopologyRange {
     collection: CollectionId,
     range_id: RangeId,
+    shard_key_mode: ShardKeyMode,
     bounds: RangeBounds,
     owner: NodeIdentity,
     replicas: Vec<NodeIdentity>,
@@ -68,6 +70,7 @@ impl TopologyRange {
         Self {
             collection: range.collection().clone(),
             range_id: range.range_id(),
+            shard_key_mode: range.shard_key_mode(),
             bounds: range.bounds().clone(),
             owner: range.owner().clone(),
             replicas: range.replicas().to_vec(),
@@ -82,6 +85,10 @@ impl TopologyRange {
 
     pub fn range_id(&self) -> RangeId {
         self.range_id
+    }
+
+    pub fn shard_key_mode(&self) -> ShardKeyMode {
+        self.shard_key_mode
     }
 
     pub fn bounds(&self) -> &RangeBounds {
@@ -115,12 +122,12 @@ impl TopologyRange {
 /// A point-in-time, driver-facing projection of the ownership catalog — the
 /// payload a topology poll returns.
 ///
-/// The [`version`](Self::version) is the snapshot's generation: the **maximum**
-/// catalog version across its ranges (or [`CatalogVersion::initial`] for an empty
-/// cluster). Because every accepted catalog edit strictly advances a range's
-/// version, this max is a monotonic high-water mark — a snapshot with a strictly
-/// greater version is strictly newer, which is exactly what a driver compares to
-/// decide whether to adopt a freshly polled or pushed snapshot.
+/// The [`version`](Self::version) is the snapshot's high-water mark: the
+/// **maximum** catalog version across its ranges (or [`CatalogVersion::initial`]
+/// for an empty cluster). It is monotonic, but not a complete generation number:
+/// two different ranges can independently advance to the same version. Drivers
+/// therefore use it as a cheap stale-snapshot guard and still compare per-range
+/// content for same-version full refreshes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TopologySnapshot {
     version: CatalogVersion,
@@ -145,13 +152,34 @@ impl TopologySnapshot {
             .find(|r| r.collection() == collection && r.range_id() == range_id)
     }
 
-    /// Route a key to the range that owns it, by the same half-open containment
-    /// predicate the server uses — so a driver can resolve owners locally without
-    /// a round trip.
+    /// Route a normalized range key to the range that owns it, by the same
+    /// half-open containment predicate the server uses.
     pub fn route(&self, collection: &CollectionId, key: &[u8]) -> Option<&TopologyRange> {
         self.ranges
             .iter()
             .find(|r| r.collection() == collection && r.bounds().contains(key))
+    }
+
+    /// Route a logical shard key through the collection's shard-key mode.
+    pub fn route_shard_key(
+        &self,
+        collection: &CollectionId,
+        shard_key: &[u8],
+    ) -> Option<&TopologyRange> {
+        match self.shard_key_mode(collection)? {
+            ShardKeyMode::Ordered => self.route(collection, shard_key),
+            ShardKeyMode::Hash => {
+                let range_key = hash_shard_key_to_range_key(shard_key);
+                self.route(collection, &range_key)
+            }
+        }
+    }
+
+    fn shard_key_mode(&self, collection: &CollectionId) -> Option<ShardKeyMode> {
+        self.ranges
+            .iter()
+            .find(|range| range.collection() == collection)
+            .map(TopologyRange::shard_key_mode)
     }
 }
 
@@ -271,8 +299,7 @@ impl ClientTopology {
         self.needs_refresh
     }
 
-    /// The cached range owning `key`, by the same half-open routing predicate the
-    /// server uses.
+    /// The cached range owning a normalized range key.
     pub fn route(&self, collection: &CollectionId, key: &[u8]) -> Option<&TopologyRange> {
         self.ranges
             .values()
@@ -281,7 +308,30 @@ impl ClientTopology {
 
     /// The owner a driver should send a request for `key` to — the routing answer.
     pub fn resolve(&self, collection: &CollectionId, key: &[u8]) -> Option<&NodeIdentity> {
-        self.route(collection, key).map(TopologyRange::owner)
+        self.route_shard_key(collection, key)
+            .map(TopologyRange::owner)
+    }
+
+    /// The cached range owning a logical shard key.
+    pub fn route_shard_key(
+        &self,
+        collection: &CollectionId,
+        shard_key: &[u8],
+    ) -> Option<&TopologyRange> {
+        match self.shard_key_mode(collection)? {
+            ShardKeyMode::Ordered => self.route(collection, shard_key),
+            ShardKeyMode::Hash => {
+                let range_key = hash_shard_key_to_range_key(shard_key);
+                self.route(collection, &range_key)
+            }
+        }
+    }
+
+    fn shard_key_mode(&self, collection: &CollectionId) -> Option<ShardKeyMode> {
+        self.ranges
+            .values()
+            .find(|range| range.collection() == collection)
+            .map(TopologyRange::shard_key_mode)
     }
 
     /// One cached range by identity.
@@ -291,14 +341,17 @@ impl ClientTopology {
 
     /// Adopt a freshly polled snapshot — the authoritative refresh path.
     ///
-    /// Monotonic: the snapshot is adopted only if its generation strictly advances
-    /// the cache's authoritative [`version`](Self::version) (or the cache is
-    /// empty). A newer snapshot replaces the cached ranges wholesale and clears
-    /// [`needs_refresh`](Self::needs_refresh); an equal-or-older one is
-    /// [`Ignored`](RefreshOutcome::Ignored), so a late or duplicated poll can never
-    /// roll the cache backwards.
+    /// Monotonic: the snapshot is adopted if its generation advances the cache's
+    /// authoritative [`version`](Self::version), or if it carries same-generation
+    /// range content that does not roll any cached range backwards. An adopted
+    /// snapshot replaces the cached ranges wholesale and clears
+    /// [`needs_refresh`](Self::needs_refresh); an older or duplicate one is
+    /// [`Ignored`](RefreshOutcome::Ignored).
     pub fn apply_refresh(&mut self, snapshot: TopologySnapshot) -> RefreshOutcome {
-        if !self.ranges.is_empty() && snapshot.version() <= self.version {
+        if !self.ranges.is_empty() && snapshot.version() < self.version {
+            return RefreshOutcome::Ignored;
+        }
+        if self.snapshot_rolls_back_any_range(&snapshot) {
             return RefreshOutcome::Ignored;
         }
         let mut changed = 0usize;
@@ -310,12 +363,23 @@ impl ClientTopology {
             }
             next.insert(key, range);
         }
+        if !self.ranges.is_empty() && snapshot.version <= self.version && changed == 0 {
+            return RefreshOutcome::Ignored;
+        }
         self.ranges = next;
         self.version = snapshot.version;
         self.needs_refresh = false;
         RefreshOutcome::Applied {
             ranges_changed: changed,
         }
+    }
+
+    fn snapshot_rolls_back_any_range(&self, snapshot: &TopologySnapshot) -> bool {
+        snapshot.ranges().iter().any(|incoming| {
+            self.ranges
+                .get(&incoming.key())
+                .is_some_and(|current| incoming.version() < current.version())
+        })
     }
 
     /// Fold a pushed topology update in — the optional push/subscription path.
@@ -423,6 +487,35 @@ mod tests {
         )
     }
 
+    fn single_hash_slot_bounds(key: &[u8]) -> RangeBounds {
+        let slot = super::super::slot::hash_shard_key_to_slot(key);
+        let lower = RangeBound::key(slot.range_key());
+        let upper = match slot.value().checked_add(1) {
+            Some(next) if next < super::super::slot::PRODUCTION_HASH_SLOT_COUNT => {
+                RangeBound::key(super::super::slot::HashSlot::new(next).unwrap().range_key())
+            }
+            _ => RangeBound::Max,
+        };
+        RangeBounds::new(lower, upper).unwrap()
+    }
+
+    fn hash_slot_range(
+        coll: &CollectionId,
+        id: u64,
+        shard_key: &[u8],
+        owner: &str,
+    ) -> RangeOwnership {
+        RangeOwnership::establish(
+            coll.clone(),
+            RangeId::new(id),
+            ShardKeyMode::Hash,
+            single_hash_slot_bounds(shard_key),
+            ident(owner),
+            Vec::<NodeIdentity>::new(),
+            PlacementMetadata::with_replication_factor(1),
+        )
+    }
+
     fn catalog_with(ranges: impl IntoIterator<Item = RangeOwnership>) -> ShardOwnershipCatalog {
         let mut catalog = ShardOwnershipCatalog::new();
         for range in ranges {
@@ -495,6 +588,20 @@ mod tests {
         assert!(!client.needs_refresh());
     }
 
+    #[test]
+    fn client_resolves_hash_collection_by_shard_key_slot() {
+        let orders = collection("orders");
+        let key = b"tenant:42";
+        let catalog = catalog_with([hash_slot_range(&orders, 1, key, "CN=node-a")]);
+        let client = ClientTopology::from_snapshot(catalog.topology_snapshot());
+
+        let routed = client
+            .route_shard_key(&orders, key)
+            .expect("hash slot range covers the logical shard key");
+        assert_eq!(routed.owner(), &ident("CN=node-a"));
+        assert_eq!(client.resolve(&orders, key).unwrap(), &ident("CN=node-a"));
+    }
+
     // AC #3 + polling baseline: refresh is monotonic — a newer poll is adopted, a
     // stale or duplicate poll is ignored and cannot roll the cache backwards.
     #[test]
@@ -520,6 +627,109 @@ mod tests {
 
         // Re-applying the same snapshot is a no-op.
         assert_eq!(client.apply_refresh(fresh), RefreshOutcome::Ignored);
+    }
+
+    #[test]
+    fn refresh_applies_same_generation_snapshot_when_another_range_changed() {
+        let parts = collection("parts");
+        let mut catalog = catalog_with([
+            split_range(
+                &parts,
+                1,
+                RangeBound::Min,
+                RangeBound::key(b"m"),
+                "CN=node-a",
+            ),
+            split_range(
+                &parts,
+                2,
+                RangeBound::key(b"m"),
+                RangeBound::Max,
+                "CN=node-b",
+            ),
+        ]);
+        let mut client = ClientTopology::from_snapshot(catalog.topology_snapshot());
+
+        let r1 = catalog.range(&parts, RangeId::new(1)).unwrap().clone();
+        catalog
+            .apply_update(r1.transfer_to(ident("CN=node-c"), Vec::<NodeIdentity>::new()))
+            .unwrap();
+        assert_eq!(
+            client.apply_refresh(catalog.topology_snapshot()),
+            RefreshOutcome::Applied { ranges_changed: 1 }
+        );
+        assert_eq!(
+            client.resolve(&parts, b"apple").unwrap(),
+            &ident("CN=node-c")
+        );
+
+        let r2 = catalog.range(&parts, RangeId::new(2)).unwrap().clone();
+        catalog
+            .apply_update(r2.transfer_to(ident("CN=node-d"), Vec::<NodeIdentity>::new()))
+            .unwrap();
+        let same_generation = catalog.topology_snapshot();
+        assert_eq!(same_generation.version(), client.version());
+
+        assert_eq!(
+            client.apply_refresh(same_generation),
+            RefreshOutcome::Applied { ranges_changed: 1 }
+        );
+        assert_eq!(
+            client.resolve(&parts, b"zebra").unwrap(),
+            &ident("CN=node-d")
+        );
+    }
+
+    #[test]
+    fn equal_generation_refresh_does_not_roll_back_a_newer_range() {
+        let parts = collection("parts");
+        let base = catalog_with([
+            split_range(
+                &parts,
+                1,
+                RangeBound::Min,
+                RangeBound::key(b"m"),
+                "CN=node-a",
+            ),
+            split_range(
+                &parts,
+                2,
+                RangeBound::key(b"m"),
+                RangeBound::Max,
+                "CN=node-b",
+            ),
+        ]);
+        let mut current_catalog = base.clone();
+        let mut stale_fork = base;
+        let mut client = ClientTopology::from_snapshot(current_catalog.topology_snapshot());
+
+        let r1 = current_catalog
+            .range(&parts, RangeId::new(1))
+            .unwrap()
+            .clone();
+        current_catalog
+            .apply_update(r1.transfer_to(ident("CN=node-c"), Vec::<NodeIdentity>::new()))
+            .unwrap();
+        assert!(client
+            .apply_refresh(current_catalog.topology_snapshot())
+            .was_applied());
+
+        let r2 = stale_fork.range(&parts, RangeId::new(2)).unwrap().clone();
+        stale_fork
+            .apply_update(r2.transfer_to(ident("CN=node-d"), Vec::<NodeIdentity>::new()))
+            .unwrap();
+        let fork_snapshot = stale_fork.topology_snapshot();
+        assert_eq!(fork_snapshot.version(), client.version());
+
+        assert_eq!(client.apply_refresh(fork_snapshot), RefreshOutcome::Ignored);
+        assert_eq!(
+            client.resolve(&parts, b"apple").unwrap(),
+            &ident("CN=node-c")
+        );
+        assert_eq!(
+            client.resolve(&parts, b"zebra").unwrap(),
+            &ident("CN=node-b")
+        );
     }
 
     // AC #2 + AC #3: a stale-ownership redirect hint corrects the cache without

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -219,6 +219,7 @@ fn ask_query_from_request(
         strict: request.strict.unwrap_or(true),
         stream,
         cache: crate::storage::query::ast::AskCacheClause::Default,
+        as_rql: false,
     })
 }
 

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -343,6 +343,7 @@ impl McpServer {
             } else {
                 crate::storage::query::ast::AskCacheClause::Default
             },
+            as_rql: false,
         };
         let result = self
             .runtime

--- a/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
@@ -1,0 +1,240 @@
+//! Deterministic `ASK ... AS RQL` planner.
+//!
+//! This is deliberately not text-to-SQL execution. It builds a small,
+//! read-only RQL candidate from the same token/schema vocabulary used by
+//! AskPipeline, validates the generated text through the parser, and returns
+//! the candidate for caller approval/execution.
+
+use std::collections::BTreeSet;
+
+use crate::api::{RedDBError, RedDBResult};
+use crate::runtime::ask_pipeline::{CandidateCollections, TokenSet};
+use crate::storage::query::ast::QueryExpr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskRqlPlan {
+    pub rql: String,
+    pub field: String,
+    pub value: String,
+    pub collection: Option<String>,
+    pub candidate_fields: Vec<String>,
+    pub candidate_collections: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+pub fn plan(
+    question: &str,
+    tokens: &TokenSet,
+    candidates: &CandidateCollections,
+    requested_collection: Option<&str>,
+) -> RedDBResult<AskRqlPlan> {
+    let candidate_fields = candidate_fields(tokens, candidates);
+    let field = candidate_fields.first().cloned().ok_or_else(|| {
+        RedDBError::Query(
+            "ASK AS RQL could not infer a WHERE field from the prompt and schema vocabulary"
+                .to_string(),
+        )
+    })?;
+    validate_ident("field", &field)?;
+
+    let value = literal_for_field(question, tokens, &field).ok_or_else(|| {
+        RedDBError::Query(
+            "ASK AS RQL could not infer a literal value for the generated WHERE clause".to_string(),
+        )
+    })?;
+
+    let collection = requested_collection.map(str::to_string);
+    if let Some(collection) = &collection {
+        validate_ident("collection", collection)?;
+    }
+
+    let rql = if let Some(collection) = &collection {
+        format!(
+            "SELECT * FROM {} WHERE {} = {}",
+            collection,
+            field,
+            sql_string_literal(&value)
+        )
+    } else {
+        format!("SELECT * WHERE {} = {}", field, sql_string_literal(&value))
+    };
+
+    validate_read_only_table_query(&rql)?;
+
+    let mut warnings = Vec::new();
+    if candidate_fields.len() > 1 {
+        warnings.push(format!(
+            "multiple candidate fields matched; selected `{}` from {:?}",
+            field, candidate_fields
+        ));
+    }
+    if tokens.literals.len() > 1 {
+        warnings.push(format!(
+            "multiple literal tokens matched; selected `{}` from {:?}",
+            value, tokens.literals
+        ));
+    }
+    if requested_collection.is_none() {
+        warnings.push(
+            "no COLLECTION was specified; generated RQL uses implicit universal source `any`"
+                .to_string(),
+        );
+    }
+
+    Ok(AskRqlPlan {
+        rql,
+        field,
+        value,
+        collection,
+        candidate_fields,
+        candidate_collections: candidates.collections.clone(),
+        warnings,
+    })
+}
+
+fn candidate_fields(tokens: &TokenSet, candidates: &CandidateCollections) -> Vec<String> {
+    let mut all: BTreeSet<String> = BTreeSet::new();
+    for columns in candidates.columns_by_collection.values() {
+        for column in columns {
+            all.insert(column.clone());
+        }
+    }
+
+    let mut ordered = Vec::new();
+    for keyword in &tokens.keywords {
+        for column in &all {
+            if column.eq_ignore_ascii_case(keyword) && !ordered.contains(column) {
+                ordered.push(column.clone());
+            }
+        }
+    }
+    for column in all {
+        if !ordered.contains(&column) {
+            ordered.push(column);
+        }
+    }
+    ordered
+}
+
+fn literal_for_field(question: &str, tokens: &TokenSet, field: &str) -> Option<String> {
+    if let Some(literal) = tokens.literals.first() {
+        return Some(literal.clone());
+    }
+
+    let terms = question_terms(question);
+    for (idx, term) in terms.iter().enumerate() {
+        if term.eq_ignore_ascii_case(field) {
+            if let Some(next) = terms.get(idx + 1) {
+                return Some(next.clone());
+            }
+        }
+    }
+
+    terms
+        .into_iter()
+        .find(|term| term.chars().any(|c| c.is_ascii_digit()) && term.len() >= 3)
+}
+
+fn question_terms(question: &str) -> Vec<String> {
+    let mut terms = Vec::new();
+    let mut buf = String::new();
+    for ch in question.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' || ch == ':' {
+            buf.push(ch);
+        } else if !buf.is_empty() {
+            terms.push(std::mem::take(&mut buf));
+        }
+    }
+    if !buf.is_empty() {
+        terms.push(buf);
+    }
+    terms
+}
+
+fn validate_ident(kind: &str, value: &str) -> RedDBResult<()> {
+    let mut chars = value.chars();
+    let valid = chars
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
+    if valid {
+        Ok(())
+    } else {
+        Err(RedDBError::Query(format!(
+            "ASK AS RQL inferred unsafe {kind} identifier `{value}`"
+        )))
+    }
+}
+
+fn sql_string_literal(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "''"))
+}
+
+fn validate_read_only_table_query(rql: &str) -> RedDBResult<()> {
+    let parsed = crate::storage::query::parser::parse(rql)
+        .map_err(|err| RedDBError::Query(err.to_string()))?;
+    match parsed.query {
+        QueryExpr::Table(table) if table.filter.is_some() => Ok(()),
+        QueryExpr::Table(_) => Err(RedDBError::Query(
+            "ASK AS RQL generated a table query without a WHERE clause".to_string(),
+        )),
+        other => Err(RedDBError::Query(format!(
+            "ASK AS RQL generated a non-table query: {other:?}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn candidates() -> CandidateCollections {
+        CandidateCollections {
+            collections: vec!["incidents".to_string(), "travelers".to_string()],
+            columns_by_collection: HashMap::from([
+                ("incidents".to_string(), vec!["host".to_string()]),
+                ("travelers".to_string(), vec!["passport".to_string()]),
+            ]),
+        }
+    }
+
+    #[test]
+    fn plans_universal_field_literal_query() {
+        let tokens = TokenSet {
+            keywords: vec!["who".to_string(), "passport".to_string()],
+            literals: vec!["FDD-12313".to_string()],
+        };
+        let plan = plan("who owns passport FDD-12313?", &tokens, &candidates(), None).unwrap();
+        assert_eq!(plan.rql, "SELECT * WHERE passport = 'FDD-12313'");
+        assert_eq!(plan.field, "passport");
+        assert_eq!(plan.value, "FDD-12313");
+    }
+
+    #[test]
+    fn plans_collection_scoped_query_with_ip_value() {
+        let tokens = TokenSet {
+            keywords: vec!["host".to_string()],
+            literals: Vec::new(),
+        };
+        let plan = plan("host 10.0.0.1", &tokens, &candidates(), Some("incidents")).unwrap();
+        assert_eq!(plan.rql, "SELECT * FROM incidents WHERE host = '10.0.0.1'");
+    }
+
+    #[test]
+    fn rejects_missing_field() {
+        let tokens = TokenSet {
+            keywords: vec!["anything".to_string()],
+            literals: vec!["FDD-12313".to_string()],
+        };
+        let err = plan(
+            "anything FDD-12313",
+            &tokens,
+            &CandidateCollections::default(),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("could not infer a WHERE field"));
+    }
+}

--- a/crates/reddb-server/src/runtime/ai/mod.rs
+++ b/crates/reddb-server/src/runtime/ai/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod answer_cache_key;
 pub mod ask_response_envelope;
+pub mod ask_rql_planner;
 pub mod audit_record_builder;
 pub mod batch_client;
 pub mod citation_parser;

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1228,6 +1228,10 @@ impl RedDBRuntime {
     ) -> RedDBResult<RuntimeQueryResult> {
         use crate::ai::{parse_provider, resolve_api_key_from_runtime};
 
+        if ask.as_rql {
+            return self.execute_ask_as_rql(raw_query, ask);
+        }
+
         // S3 / #711: planner-level provider gate. Runs as the first
         // step — before the AskPipeline and before the credential
         // resolver — so a policy-denied query never spends cycles on
@@ -1682,6 +1686,72 @@ impl RedDBRuntime {
             mode: QueryMode::Sql,
             statement: "ask",
             engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    fn execute_ask_as_rql(
+        &self,
+        raw_query: &str,
+        ask: &crate::storage::query::ast::AskQuery,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let scope = self.ai_scope();
+        let tokens = crate::runtime::ask_pipeline::extract_tokens(&ask.question);
+        if tokens.is_empty() {
+            return Err(RedDBError::Query(
+                "ASK AS RQL question yielded no usable tokens".to_string(),
+            ));
+        }
+        let candidates = crate::runtime::ask_pipeline::match_schema(self, &scope, &tokens)?;
+        let plan = crate::runtime::ai::ask_rql_planner::plan(
+            &ask.question,
+            &tokens,
+            &candidates,
+            ask.collection.as_deref(),
+        )?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "rql".into(),
+            "statement_type".into(),
+            "field".into(),
+            "value".into(),
+            "collection".into(),
+            "candidate_fields".into(),
+            "candidate_collections".into(),
+            "warnings".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("rql", Value::text(plan.rql));
+        record.set("statement_type", Value::text("select"));
+        record.set("field", Value::text(plan.field));
+        record.set("value", Value::text(plan.value));
+        if let Some(collection) = plan.collection {
+            record.set("collection", Value::text(collection));
+        } else {
+            record.set("collection", Value::Null);
+        }
+        record.set(
+            "candidate_fields",
+            Value::Json(json_string_array_bytes(&plan.candidate_fields)),
+        );
+        record.set(
+            "candidate_collections",
+            Value::Json(json_string_array_bytes(&plan.candidate_collections)),
+        );
+        record.set(
+            "warnings",
+            Value::Json(json_string_array_bytes(&plan.warnings)),
+        );
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask_as_rql",
+            engine: "runtime-ai-rql-planner",
             result,
             affected_rows: 0,
             statement_type: "select",
@@ -2652,6 +2722,16 @@ fn provider_list_from_json_value(value: &crate::json::Value) -> Option<Vec<Strin
         crate::json::Value::String(text) => parse_provider_list_text(text),
         _ => None,
     }
+}
+
+fn json_string_array_bytes(values: &[String]) -> Vec<u8> {
+    crate::json::to_vec(&crate::json::Value::Array(
+        values
+            .iter()
+            .map(|value| crate::json::Value::String(value.clone()))
+            .collect(),
+    ))
+    .unwrap_or_else(|_| b"[]".to_vec())
 }
 
 fn parse_provider_list_text(raw: &str) -> Option<Vec<String>> {
@@ -4069,6 +4149,37 @@ mod citation_wedge_tests {
                 .map(|v| matches!(v, crate::json::Value::Null))
                 .unwrap_or(false),
             "expected urn=null for out-of-range source_index"
+        );
+    }
+
+    #[test]
+    fn ask_as_rql_returns_validated_universal_select_without_provider() {
+        let rt = crate::runtime::RedDBRuntime::in_memory().expect("runtime");
+        rt.execute_query("CREATE TABLE travelers (passport TEXT, name TEXT)")
+            .expect("create table");
+        rt.execute_query("INSERT INTO travelers (passport, name) VALUES ('FDD-12313', 'Ada')")
+            .expect("insert row");
+
+        let planned = rt
+            .execute_query("ASK 'who owns passport FDD-12313?' AS RQL")
+            .expect("ASK AS RQL should not require an AI provider");
+        assert_eq!(planned.engine, "runtime-ai-rql-planner");
+
+        let record = planned.result.records.first().expect("one plan row");
+        let rql = match record.get("rql") {
+            Some(Value::Text(text)) => text.to_string(),
+            other => panic!("rql column should be text, got {other:?}"),
+        };
+        assert_eq!(rql, "SELECT * WHERE passport = 'FDD-12313'");
+
+        let selected = rt
+            .execute_query(&rql)
+            .expect("generated RQL should parse and execute");
+        assert_eq!(selected.engine, "runtime-table");
+        assert_eq!(selected.result.records.len(), 1);
+        assert_eq!(
+            selected.result.records[0].get("name"),
+            Some(&Value::text("Ada".to_string()))
         );
     }
 

--- a/crates/reddb-server/tests/sql_injection_audit.rs
+++ b/crates/reddb-server/tests/sql_injection_audit.rs
@@ -159,11 +159,11 @@ fn rls_policy_body_with_comment_metacharacters_parses_as_literal() {
 }
 
 /// V4 — `ASK '...'` parses into an `AskQuery` AST node whose only
-/// free-text field is the `question` string. The runtime executes ASK
-/// as RAG (search context + LLM Q&A), returning text in a result
-/// column — the LLM output is never re-parsed as SQL. This test pins
-/// the AST shape: any future refactor that introduces a `synthesised_sql`
-/// or similar field will need to revisit this audit.
+/// free-text field is the `question` string. Plain ASK executes as RAG
+/// (search context + LLM Q&A), returning text in a result column — the
+/// LLM output is never re-parsed as SQL. `ASK ... AS RQL` is represented
+/// by a boolean flag and uses a server-side deterministic planner, not a
+/// string field populated by the model.
 #[test]
 fn ask_path_does_not_re_execute_llm_output_as_sql() {
     let parsed = parse_multi("ASK 'who owns the users table'").expect("parse ASK");
@@ -184,7 +184,17 @@ fn ask_path_does_not_re_execute_llm_output_as_sql() {
         &ask.min_score,
         &ask.provider,
         &ask.model,
+        &ask.as_rql,
     );
+    assert!(!ask.as_rql);
+
+    let parsed =
+        parse_multi("ASK 'who owns passport FDD-12313?' AS RQL").expect("parse ASK AS RQL");
+    let ask = match parsed {
+        QueryExpr::Ask(a) => a,
+        other => panic!("expected Ask, got {:?}", other),
+    };
+    assert!(ask.as_rql);
 
     // Sanity: an injection-shaped question string is just text.
     let parsed = parse_multi("ASK '''; DROP TABLE users; --'").expect("parse ASK with payload");

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,9 +117,11 @@ Start with [Auth & Security Overview](/security/overview.md), then use the
 [Permission Recipes](/guides/permissions-cookbook.md) for copyable production
 patterns.
 
-## Six query languages
+## Query languages plus ASK
 
-Write queries in the style you already know. RedDB parses RQL, SQL, Gremlin, SPARQL, Cypher, and natural language.
+Write deterministic queries in explicit syntax, and use `ASK` when you want a
+grounded natural-language answer over retrieved context. `ASK` does not
+translate the prompt into RQL and execute it.
 
 ```sql
 -- RQL / SQL
@@ -128,8 +130,8 @@ SELECT name, email FROM users WHERE active = true LIMIT 10
 -- Gremlin
 g.V().hasLabel('user').has('active', true).values('name')
 
--- Natural language
-FIND users who logged in this week
+-- Natural-language answer over retrieved context
+ASK 'which users logged in this week?' USING groq
 ```
 
 ## Native time-series and queues

--- a/docs/README.md
+++ b/docs/README.md
@@ -120,8 +120,8 @@ patterns.
 ## Query languages plus ASK
 
 Write deterministic queries in explicit syntax, and use `ASK` when you want a
-grounded natural-language answer over retrieved context. `ASK` does not
-translate the prompt into RQL and execute it.
+grounded natural-language answer over retrieved context. Use `ASK ... AS RQL`
+when you want a prompt converted into a validated read-only RQL candidate.
 
 ```sql
 -- RQL / SQL
@@ -132,6 +132,9 @@ g.V().hasLabel('user').has('active', true).values('name')
 
 -- Natural-language answer over retrieved context
 ASK 'which users logged in this week?' USING groq
+
+-- Prompt to RQL candidate, not executed automatically
+ASK 'user alice' AS RQL
 ```
 
 ## Native time-series and queues

--- a/docs/architecture/distributed-roadmap.md
+++ b/docs/architecture/distributed-roadmap.md
@@ -1,9 +1,10 @@
 # Distributed Roadmap
 
-RedDB today is single-node with WAL-based replication + quorum
-semantics. Distributed query, automatic failover, and sharding are
-on the roadmap; this page is the honest state-of-the-art and what
-we're building toward.
+RedDB today is single-node or primary-replica at runtime, with
+WAL-based replication + quorum semantics. Distributed query,
+automatic failover, and productive cluster sharding are on the
+roadmap; this page is the honest state-of-the-art and what we're
+building toward.
 
 ## What exists today
 
@@ -15,39 +16,67 @@ we're building toward.
 * **Serialisable batches** — the `ColumnBatch` format introduced in
   B1 is explicitly laid out so a future network layer can ship
   batches between nodes without re-serialising.
+* **Cluster control-plane model** — ADR 0037 defines versioned
+  shard/range ownership, ADR 0045 defines range-oriented cluster file
+  layout, and ADR 0052 defines control-plane consensus boundaries.
+* **Pure cluster decision layers** — `crates/reddb-server/src/cluster/`
+  contains pure ownership, topology, routing, placement, move-range,
+  and cross-range planning models. These are not yet wired into the
+  production query/write runtime.
 
 ## What's missing
 
 | Capability | Status |
 |------------|--------|
-| Sharding (partition routing across nodes) | Not started |
-| Distributed query (plan → shards → merge) | Not started |
-| Automatic failover (leader election) | Not started |
+| Sharding model | Proposed in ADR 0055: shard key -> hash -> slot -> shard group -> owner |
+| Partition routing across nodes | Pure catalog/routing model exists; runtime integration missing |
+| Distributed query execution | Pure cross-range read/write planning exists; executor/coordinator missing |
+| Automatic failover | Control-plane consensus boundary accepted in ADR 0052; runtime log/leader integration missing |
 | Cross-region replication | Async log-shipping works; needs tooling |
-| Raft consensus for catalog | Not started |
+| Control-plane catalog consensus | Designed; durable replicated control-plane log missing |
 
 ## Target architecture
 
 ```
-              ┌─────────────────────────────┐
-              │      Coordinator node       │
-              │  planner + shard router     │
-              └──────────────┬──────────────┘
+              ┌──────────────────────────────┐
+              │       Coordinator node       │
+              │ planner + slot/range router  │
+              └──────────────┬───────────────┘
+                             │
+                 cluster slot map / catalog
                              │
       ┌──────────────────────┼──────────────────────┐
       ▼                      ▼                      ▼
-┌───────────┐          ┌───────────┐          ┌───────────┐
-│  Shard A  │          │  Shard B  │          │  Shard C  │
-│ data ⇢ local │       │ data ⇢ local │       │ data ⇢ local │
-└───────────┘          └───────────┘          └───────────┘
+┌──────────────┐       ┌──────────────┐       ┌──────────────┐
+│ Shard group A│       │ Shard group B│       │ Shard group C│
+│ owner + reps │       │ owner + reps │       │ owner + reps │
+└──────────────┘       └──────────────┘       └──────────────┘
 ```
+
+User-facing sharding and internal placement are intentionally separate:
+
+| Layer | Who chooses it | Example |
+|-------|----------------|---------|
+| Logical shard key | User DDL or explicit collection-kind default | `SHARD BY tenant_id`, primary key, document id |
+| Shard key mode | RedDB default, with advanced opt-in modes later | Hash by default; ordered only when locality/scans justify it |
+| Hash slot / range span | RedDB control plane | slot `9381` in range `[8192, 12288)` |
+| Shard group / owner node | RedDB control plane | shard group B, current owner `node-b` |
+
+For the normal hash path, a user writes `SHARD BY tenant_id`; RedDB maps each
+`tenant_id` to a stable hash slot, groups contiguous slots into catalog ranges,
+and moves or splits those ranges as the cluster rebalances. The user does not
+pick physical ranges, and RedDB does not use `hash(key) % node_count`.
 
 Query flow:
 
 1. Client sends SQL to any node (acts as coordinator).
-2. Planner decides whether the query needs fan-out.
-3. Sub-plans ship to owning shards, execute locally.
-4. Coordinator merges partial results.
+2. Planner extracts the shard key when possible.
+3. Hash-mode collections route `shard key -> hash -> slot -> shard
+   group -> owner`.
+4. Single-shard reads/writes execute on one shard group.
+5. Explicit bounded cross-shard reads scatter to participating shard
+   groups, collect partial results, and merge/sort/limit at the
+   coordinator.
 
 ## Pre-requisites the TS/CH parity sprint lays down
 
@@ -66,11 +95,12 @@ Query flow:
 
 | Phase | Content | Estimate |
 |-------|---------|----------|
-| D1 | Shard registry + consistent-hash router per table | 1 sprint |
-| D2 | Distributed scan: ship sub-plan, collect batches, local merge | 2 sprints |
-| D3 | Distributed aggregate: ship partial state, merge at coordinator | 1 sprint |
-| D4 | Raft catalog (schema changes globally consistent) | 2 sprints |
-| D5 | Auto-failover: leader lease + replica promotion | 1 sprint |
+| D1 | DDL shard key surface + slot map projected from the ownership catalog | 1 sprint |
+| D2 | Single-shard router: point read/write to owner, stale-route redirect, routing cache | 1 sprint |
+| D3 | Bounded distributed scan: fan-out sub-plans, collect batches, local merge | 2 sprints |
+| D4 | Distributed aggregate: ship partial state, merge at coordinator, cache partials | 1 sprint |
+| D5 | Control-plane catalog log: durable consensus for membership and ownership transitions | 2 sprints |
+| D6 | Auto-failover: ownership lease, commit watermark check, replica promotion | 1 sprint |
 
 Total: ~1 trimester of focused work **after** the TS/CH parity
 cycle closes. No commits to a ship date — this page is honest about
@@ -80,8 +110,12 @@ the gap so callers can plan.
 
 * Multi-leader writes — stays single-leader per shard. We avoid the
   conflict-resolution tarpit.
-* Global secondary indexes — indexes stay shard-local; cross-shard
-  uniqueness is enforced with a compensating write.
-* ACID across shards — each transaction remains shard-local.
-  Cross-shard atomicity arrives via saga patterns first; 2PC only
-  if data supports it.
+* Global secondary indexes — indexes stay shard-local in the first
+  cluster cut.
+* Cross-shard joins — not exposed until the planner and memory budgets
+  can enforce a safe distributed join contract.
+* ACID across shard groups — each write transaction remains
+  single-writer. Cross-shard atomicity arrives via explicit APIs or
+  saga patterns first; 2PC only if data supports it.
+* Timestamp-only sharding for logs/timeseries — use tenant/id plus a
+  bucket; timestamp-only creates hot newest ranges.

--- a/docs/guides/ask-your-database.md
+++ b/docs/guides/ask-your-database.md
@@ -570,9 +570,10 @@ ASK 'question'
   └─ Audit + optional cache             ← red_ask_audit, CACHE TTL / NOCACHE
 ```
 
-`ASK` does not translate English into RQL. It retrieves allowed context first,
-sends those sources to the model, and returns a single answer row. If you need
-deterministic cross-collection retrieval by field, use SQL/RQL directly:
+Plain `ASK` does not translate English into RQL. It retrieves allowed context
+first, sends those sources to the model, and returns a single answer row. If
+you need deterministic cross-collection retrieval by field, use SQL/RQL
+directly:
 
 ```sql
 SELECT * WHERE host = $1
@@ -580,6 +581,17 @@ SELECT * WHERE host = $1
 
 That form is parsed as the universal source `any`, equivalent in intent to
 `FROM ANY` plus a `WHERE` filter.
+
+When you want a prompt converted into a query candidate, request that contract
+explicitly:
+
+```sql
+ASK 'host 10.0.0.5' AS RQL
+```
+
+The `AS RQL` path does not call the LLM. It uses schema vocabulary and literal
+extraction, validates the generated read-only query through the parser, and
+returns the candidate in the `rql` column for the caller to execute or approve.
 
 ### SEARCH CONTEXT = 3-Tier Strategy
 
@@ -617,7 +629,7 @@ paths. The provider boundary is enforced as follows:
 | `SELECT … COUNT/SUM/AVG/MIN/MAX(…)` | SQL planner + executor | Exact, reproducible, no network call. |
 | `SEARCH CONTEXT 'term'` | Multi-tier index (field → token → scan) | Returns table rows, documents, KV entries, graph nodes/edges, and vectors when each backing collection exists. Empty result set when nothing matches &mdash; the contract is "ground or fall silent". |
 | `ASK '…'` | `AskPipeline` funnel + LLM synthesis | Pipeline grounds first (Stage 4 literal filter / Stage 3 BM25 + vector / Stage 3c graph), then the LLM rewrites the grounded rows into a citation-bearing sentence. |
-| Prompt-to-RQL / generated queries | Not part of `ASK` today | A generated query would need a separate parse, authorization, explain, and approval path. `ASK` deliberately never re-executes model output. |
+| `ASK '…' AS RQL` | Deterministic RQL planner | Uses schema vocabulary + literal extraction to return a parser-validated read-only query candidate. It does not call the LLM and does not execute the generated RQL. |
 | Missing or unsupported analytics inside an `ASK` question | Pipeline short-circuits with a structured error OR returns an answer that openly cites "no matching sources" | The LLM never invents a number; it can only quote what `sources_flat` contains. |
 
 A practical rule: if the question is a calculation (`how many incidents are

--- a/docs/guides/ask-your-database.md
+++ b/docs/guides/ask-your-database.md
@@ -570,6 +570,17 @@ ASK 'question'
   └─ Audit + optional cache             ← red_ask_audit, CACHE TTL / NOCACHE
 ```
 
+`ASK` does not translate English into RQL. It retrieves allowed context first,
+sends those sources to the model, and returns a single answer row. If you need
+deterministic cross-collection retrieval by field, use SQL/RQL directly:
+
+```sql
+SELECT * WHERE host = $1
+```
+
+That form is parsed as the universal source `any`, equivalent in intent to
+`FROM ANY` plus a `WHERE` filter.
+
 ### SEARCH CONTEXT = 3-Tier Strategy
 
 The context search uses three tiers, stopping when it has enough results:
@@ -606,6 +617,7 @@ paths. The provider boundary is enforced as follows:
 | `SELECT … COUNT/SUM/AVG/MIN/MAX(…)` | SQL planner + executor | Exact, reproducible, no network call. |
 | `SEARCH CONTEXT 'term'` | Multi-tier index (field → token → scan) | Returns table rows, documents, KV entries, graph nodes/edges, and vectors when each backing collection exists. Empty result set when nothing matches &mdash; the contract is "ground or fall silent". |
 | `ASK '…'` | `AskPipeline` funnel + LLM synthesis | Pipeline grounds first (Stage 4 literal filter / Stage 3 BM25 + vector / Stage 3c graph), then the LLM rewrites the grounded rows into a citation-bearing sentence. |
+| Prompt-to-RQL / generated queries | Not part of `ASK` today | A generated query would need a separate parse, authorization, explain, and approval path. `ASK` deliberately never re-executes model output. |
 | Missing or unsupported analytics inside an `ASK` question | Pipeline short-circuits with a structured error OR returns an answer that openly cites "no matching sources" | The LLM never invents a number; it can only quote what `sources_flat` contains. |
 
 A practical rule: if the question is a calculation (`how many incidents are

--- a/docs/query/multi-mode.md
+++ b/docs/query/multi-mode.md
@@ -76,7 +76,8 @@ curl -X POST http://127.0.0.1:8080/query \
 
 RedDB has a legacy best-effort natural mode for a small set of graph and lookup
 phrases. This is not the `ASK` command, and it is not a general prompt-to-RQL
-translator.
+translator. Use `ASK ... AS RQL` when you want a prompt converted into a
+parser-validated read-only query candidate.
 
 Example inputs:
 
@@ -134,4 +135,4 @@ The `mode` field tells you which parser was used.
 > Natural language queries are best-effort. For production workloads, use
 > explicit SQL, Gremlin, or SPARQL syntax for deterministic results. For
 > grounded natural-language answers, use `ASK`; for deterministic generated
-> queries, RedDB needs a separate text-to-RQL surface rather than reusing `ASK`.
+> query candidates, use `ASK ... AS RQL`.

--- a/docs/query/multi-mode.md
+++ b/docs/query/multi-mode.md
@@ -74,7 +74,11 @@ curl -X POST http://127.0.0.1:8080/query \
 
 ## Natural Language
 
-Write queries in plain English:
+RedDB has a legacy best-effort natural mode for a small set of graph and lookup
+phrases. This is not the `ASK` command, and it is not a general prompt-to-RQL
+translator.
+
+Example inputs:
 
 ```
 show me all hosts with critical alerts in the last 24 hours
@@ -127,4 +131,7 @@ All modes return the same unified envelope:
 The `mode` field tells you which parser was used.
 
 > [!NOTE]
-> Natural language queries are best-effort. For production workloads, use explicit SQL, Gremlin, or SPARQL syntax for deterministic results.
+> Natural language queries are best-effort. For production workloads, use
+> explicit SQL, Gremlin, or SPARQL syntax for deterministic results. For
+> grounded natural-language answers, use `ASK`; for deterministic generated
+> queries, RedDB needs a separate text-to-RQL surface rather than reusing `ASK`.

--- a/docs/query/search-commands.md
+++ b/docs/query/search-commands.md
@@ -234,6 +234,13 @@ citations. Markers map to the flat `sources_flat` array by position and carry
 stable URNs for UI deep-links. See
 [ADR 0013](../../.red/adr/0013-ask-grounding-citations.md) for the grounding contract.
 
+> [!IMPORTANT]
+> `ASK` is retrieval-grounded answer synthesis, not prompt-to-RQL. RedDB does
+> not convert the question into a `SELECT`, and LLM output is never parsed or
+> executed as RQL. Use explicit SQL/RQL for deterministic filters,
+> aggregations, and writes; use `ASK` when you want a cited natural-language
+> answer over retrieved context.
+
 ```sql
 ASK 'what happened on host 10.0.0.1?' USING groq
 ASK 'summarize all vulnerabilities' USING anthropic MODEL 'claude-sonnet-4-20250514'
@@ -277,9 +284,9 @@ ASK 'explain the network topology' USING ollama MODEL 'llama3' STRICT ON CACHE T
 
 ### How ASK Works
 
-ASK executes a three-phase pipeline:
+ASK executes a retrieval-then-synthesis pipeline:
 
-1. **Search Context** — Runs `SEARCH CONTEXT` with your question as the query. Finds all related entities across tables, graphs, vectors, documents, and key-values.
+1. **Grounded Retrieval** — `AskPipeline` extracts tokens, matches schema vocabulary, searches text/vector/graph surfaces scoped to visible collections, and filters literal values before any LLM call.
 
 2. **Build LLM Context** — Serializes the search results into a structured prompt. Includes:
    - Database schema (collection names and entity counts)
@@ -287,6 +294,16 @@ ASK executes a three-phase pipeline:
    - Graph edges and cross-references between found entities
 
 3. **LLM Synthesis** — Sends the context + your question to the configured AI provider. The LLM generates a natural-language answer with inline `[^N]` markers, and RedDB validates those markers against `sources_flat`.
+
+There is no generated query-plan step in this pipeline. If the right operation
+is "find records where a field has this value", write that directly:
+
+```sql
+SELECT * WHERE passport = $1
+```
+
+Missing `FROM` means the universal source `any`, so the engine searches
+eligible collections and applies the `WHERE` filter itself.
 
 If no provider is configured, ASK returns an error. Configure one with:
 

--- a/docs/query/search-commands.md
+++ b/docs/query/search-commands.md
@@ -235,11 +235,10 @@ stable URNs for UI deep-links. See
 [ADR 0013](../../.red/adr/0013-ask-grounding-citations.md) for the grounding contract.
 
 > [!IMPORTANT]
-> `ASK` is retrieval-grounded answer synthesis, not prompt-to-RQL. RedDB does
-> not convert the question into a `SELECT`, and LLM output is never parsed or
-> executed as RQL. Use explicit SQL/RQL for deterministic filters,
-> aggregations, and writes; use `ASK` when you want a cited natural-language
-> answer over retrieved context.
+> Plain `ASK` is retrieval-grounded answer synthesis. It does not convert the
+> question into a `SELECT`, and LLM output is never parsed or executed as RQL.
+> Use `ASK ... AS RQL` when you want RedDB to return a validated read-only RQL
+> candidate for caller approval/execution.
 
 ```sql
 ASK 'what happened on host 10.0.0.1?' USING groq
@@ -262,6 +261,7 @@ ASK 'list all users with admin access' USING ollama MODEL 'llama3'
 | `STREAM` | No | HTTP/SSE token stream; transports without SSE return non-streaming rows |
 | `CACHE TTL '5m'` | No | Cache this answer for the supplied TTL |
 | `NOCACHE` | No | Bypass the global ASK cache default |
+| `AS RQL` | No | Return a deterministic, parser-validated RQL candidate instead of calling an AI provider |
 
 ### Examples
 
@@ -274,6 +274,9 @@ ASK 'summarize all vulnerabilities' USING anthropic MODEL 'claude-sonnet-4-20250
 
 -- Scope to a collection with a result limit
 ASK 'what changed today?' COLLECTION audit_logs LIMIT 50
+
+-- Convert a field/literal prompt into validated RQL without an LLM call
+ASK 'who owns passport FDD-12313?' AS RQL
 
 -- All optional clauses combined
 ASK 'explain the network topology' USING ollama MODEL 'llama3' STRICT ON CACHE TTL '5m' DEPTH 3 LIMIT 100 COLLECTION network
@@ -302,8 +305,19 @@ is "find records where a field has this value", write that directly:
 SELECT * WHERE passport = $1
 ```
 
-Missing `FROM` means the universal source `any`, so the engine searches
-eligible collections and applies the `WHERE` filter itself.
+If you want RedDB to produce that query shape from a prompt, ask for an RQL
+candidate explicitly:
+
+```sql
+ASK 'passport FDD-12313' AS RQL
+```
+
+`ASK ... AS RQL` uses schema vocabulary and literal extraction to produce a
+read-only `SELECT`, validates the generated text through the parser, and
+returns it in the `rql` column. Missing `FROM` means the universal source
+`any`, so the eventual query searches eligible collections and applies the
+`WHERE` filter itself. This path does not call an AI provider and does not
+execute the generated RQL for you.
 
 If no provider is configured, ASK returns an error. Configure one with:
 

--- a/docs/query/select.md
+++ b/docs/query/select.md
@@ -18,7 +18,7 @@ The parameterized-query design is tracked in
 
 ```sql
 SELECT [columns | *]
-FROM table_name [AS alias]
+[FROM table_name [AS alias] | FROM ANY]
 [WHERE condition]
 [GROUP BY column [, ...]]
 [HAVING condition]
@@ -56,6 +56,20 @@ FROM wallets
 ```sql
 SELECT * FROM users WHERE age > $1 AND active = $2
 ```
+
+### Universal SELECT Without FROM
+
+```sql
+SELECT * WHERE passport = $1
+SELECT * WHERE host = $1 AND severity = 'critical'
+```
+
+When `FROM` is omitted, the parser uses the universal source `any`. For plain
+attribute filters, the executor first narrows candidate collections using
+declared columns/contracts when available, keeps dynamic collections whose
+shape is unknown, and then applies the real `WHERE` filter to the records. Use
+this form when you intentionally want to search all eligible collections by
+field. Use `FROM users` when the collection is known.
 
 ### Ordered Results
 

--- a/docs/query/universal.md
+++ b/docs/query/universal.md
@@ -19,6 +19,8 @@ The parameterized-query design is tracked in
 
 ```sql
 FROM ANY [WHERE condition] [ORDER BY field [ASC|DESC]] [LIMIT n] [OFFSET n]
+SELECT * FROM ANY [WHERE condition] [ORDER BY field [ASC|DESC]] [LIMIT n] [OFFSET n]
+SELECT * [WHERE condition] [ORDER BY field [ASC|DESC]] [LIMIT n] [OFFSET n]
 ```
 
 ## Basic Usage
@@ -50,6 +52,18 @@ FROM ANY WHERE collection = $1 LIMIT $2
 ```sql
 FROM ANY WHERE kind = $1 AND collection = $2 ORDER BY rid DESC LIMIT $3
 ```
+
+### Implicit ANY from SELECT
+
+```sql
+SELECT * WHERE passport = $1
+```
+
+`SELECT` without `FROM` is parsed as the universal source `any`. When the
+`WHERE` clause references simple attributes, RedDB can use those field names to
+reduce the candidate collection set before scanning; collections with dynamic
+or unknown shape remain eligible, and the final `WHERE` predicate is still
+applied to every returned record.
 
 ## Item Kinds
 

--- a/docs/security/sql-injection-audit.md
+++ b/docs/security/sql-injection-audit.md
@@ -164,12 +164,12 @@ fragment).
 ### Current state
 
 `ASK 'natural language question'` is parsed into an
-`AskQuery { question, collection, depth, limit, provider, model }` by
+`AskQuery { question, collection, depth, limit, provider, model, as_rql }` by
 `crates/reddb-server/src/storage/query/parser/dml.rs` `parse_ask_query`
 (L389-417). The runtime executor is
 `crates/reddb-server/src/runtime/impl_search.rs` `execute_ask` (L1122).
 
-**Critical observation:** `execute_ask` is RAG, not text-to-SQL. It does:
+**Critical observation:** plain `execute_ask` is RAG, not text-to-SQL. It does:
 
 1. Calls `self.search_context(...)` — a structured search across
    collections, vectors, and graph entities. The search step **enforces
@@ -186,16 +186,21 @@ fragment).
    `completion_tokens`, `sources_count`).
 
 The LLM output is **never** re-parsed as SQL and **never** drives a query
-execution. There is no text-to-SQL synthesis path in the codebase
-(verified by grepping for `synthesise|synthesize|llm.*sql|to_sql|generate.*query`
-across `ai.rs`, `runtime/`, and `storage/query/` — the only matches are
-unrelated comments).
+execution.
+
+`ASK '...' AS RQL` is a separate deterministic planner path. It does not call
+an AI provider. It uses AskPipeline token extraction plus schema vocabulary,
+builds a read-only `SELECT` candidate such as `SELECT * WHERE passport =
+'FDD-12313'`, validates that text through the parser, and returns it in the
+`rql` result column. The generated RQL is not executed automatically.
 
 ### Attacker model
 
 Authed user who can issue `ASK`. The historical concern from issue #95
 was "LLM prompt injection → SQL injection". That requires a path where
 LLM output flows into the parser; this codebase does not have that path.
+The `AS RQL` path parses only server-generated text from a constrained
+read-only planner, not model output.
 
 ### Observed risk
 
@@ -224,8 +229,9 @@ defence, schema disclosure toggle) rather than landed under #95's
 Pinned a regression test
 (`ask_path_does_not_re_execute_llm_output_as_sql`) that asserts
 `AskQuery` is the only frontend statement variant produced by parsing
-`ASK '...'` and that the AST has no field of type `String` that ever
-flows back into `parse_multi` or `execute_query_expr`.
+`ASK '...'`, that `ASK ... AS RQL` is represented by a boolean flag, and
+that no model-populated SQL string field flows back into `parse_multi` or
+`execute_query_expr`.
 
 ---
 


### PR DESCRIPTION
## Summary
- document the cluster sharding contract as deterministic hash slots mapped onto contiguous node-owned ranges, with bounded cross-shard reads
- clarify the two AI query surfaces: plain `ASK` is retrieval-grounded synthesis, while `ASK ... AS RQL` returns a validated read-only RQL candidate and does not execute it automatically
- confirm `SELECT * WHERE ...` without `FROM` uses the implicit universal source `any` and searches matching collections before applying the final predicate
- add parser/runtime support and security coverage for `ASK ... AS RQL`

## Verification
- `cargo fmt --package reddb-io-rql --package reddb-io-server`
- `cargo test -p reddb-io-rql ask_parses_all_optional_clauses_and_cache_modes --lib`
- `cargo test -p reddb-io-rql test_parse_dml_extended_literals_auto_embed_and_ask_forms --lib`
- `cargo test -p reddb-io-rql test_parse_select_without_from_with_where_defaults_to_any --lib`
- `cargo test -p reddb-io-server ask_rql_planner --lib`
- `cargo test -p reddb-io-server ask_as_rql_returns_validated_universal_select_without_provider --lib`
- `cargo test -p reddb-io-server global_attribute_candidates_use_declared_columns_but_keep_dynamic_collections --lib`
- `cargo test -p reddb-io-server ask_path_does_not_re_execute_llm_output_as_sql --test sql_injection_audit`
- `git diff --cached --check`