### PR TITLE
merge: #1240 feat(store): publish per-collection on_disk_bytes telemetry

### DIFF
--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -2478,6 +2478,12 @@ fn render_field_for_catalog(field: &FieldRef) -> String {
     }
 }
 
+fn on_disk_bytes_value(store: &crate::storage::unified::UnifiedStore, collection: &str) -> Value {
+    crate::storage::disk_accountant::bytes_on_disk_for(store, collection)
+        .map(Value::UnsignedInteger)
+        .unwrap_or(Value::Null)
+}
+
 fn collections_snapshot(
     runtime: &RedDBRuntime,
     tenant: Option<&str>,
@@ -2514,10 +2520,7 @@ fn collections_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let queue_mode = if collection.model == CollectionModel::Queue {
                 Value::text(super::impl_queue::queue_mode_str(
                     store.as_ref(),
@@ -2553,7 +2556,7 @@ fn collections_snapshot(
                     Value::UnsignedInteger(collection.segments as u64),
                     Value::UnsignedInteger(collection.indices.len() as u64),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     Value::Boolean(internal),
                     visible_tenant.map(Value::text).unwrap_or(Value::Null),
                     queue_mode,
@@ -2612,10 +2615,7 @@ fn tables_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let owner_tenant = collection_tenant(store.as_ref(), &collection.name);
             let visible_tenant = owner_tenant.as_deref().or(tenant);
             let internal = internal_registry.is_internal(&collection.name);
@@ -2629,7 +2629,7 @@ fn tables_snapshot(
                     Value::UnsignedInteger(collection.indices.len() as u64),
                     Value::Boolean(has_primary_key),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     visible_tenant.map(Value::text).unwrap_or(Value::Null),
                     Value::Boolean(internal),
                 ],
@@ -2675,10 +2675,7 @@ fn documents_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let internal = internal_registry.is_internal(&collection.name);
             UnifiedRecord::with_schema(
                 Arc::clone(&schema),
@@ -2689,7 +2686,7 @@ fn documents_snapshot(
                     Value::UnsignedInteger(inferred_field_count),
                     Value::Boolean(true),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     Value::Boolean(internal),
                 ],
             )
@@ -2767,10 +2764,7 @@ fn kv_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let internal = internal_registry.is_internal(&collection.name);
             UnifiedRecord::with_schema(
                 Arc::clone(&schema),
@@ -2781,7 +2775,7 @@ fn kv_snapshot(
                     Value::text(value_type),
                     Value::Boolean(true),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     Value::Boolean(internal),
                 ],
             )
@@ -2830,10 +2824,7 @@ fn vectors_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let owner_tenant = collection_tenant(store.as_ref(), &collection.name);
             let visible_tenant = owner_tenant.as_deref().or(tenant);
             let internal = internal_registry.is_internal(&collection.name);
@@ -2860,7 +2851,7 @@ fn vectors_snapshot(
                     Value::Boolean(search_capable),
                     Value::text(artifact_state),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     visible_tenant.map(Value::text).unwrap_or(Value::Null),
                     Value::Boolean(internal),
                 ],
@@ -2954,10 +2945,7 @@ fn timeseries_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let owner_tenant = collection_tenant(store.as_ref(), &collection.name);
             let visible_tenant = owner_tenant.as_deref().or(tenant);
             let internal = internal_registry.is_internal(&collection.name);
@@ -3024,7 +3012,7 @@ fn timeseries_snapshot(
                         .map(Value::UnsignedInteger)
                         .unwrap_or(Value::Null),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     visible_tenant.map(Value::text).unwrap_or(Value::Null),
                     Value::Boolean(internal),
                     downsample_policies_value,
@@ -3375,10 +3363,7 @@ fn graphs_snapshot(
                 .get_collection(&collection.name)
                 .map(|manager| manager.stats().total_memory_bytes as u64)
                 .unwrap_or(0);
-            let on_disk_bytes = crate::storage::disk_accountant::bytes_on_disk_for(
-                store.as_ref(),
-                &collection.name,
-            );
+            let on_disk_bytes = on_disk_bytes_value(store.as_ref(), &collection.name);
             let internal = internal_registry.is_internal(&collection.name);
             UnifiedRecord::with_schema(
                 Arc::clone(&schema),
@@ -3391,7 +3376,7 @@ fn graphs_snapshot(
                     Value::Boolean(true),
                     Value::Boolean(true),
                     Value::UnsignedInteger(in_memory_bytes),
-                    Value::UnsignedInteger(on_disk_bytes),
+                    on_disk_bytes,
                     Value::Boolean(internal),
                 ],
             )

--- a/crates/reddb-server/src/storage/disk_accountant.rs
+++ b/crates/reddb-server/src/storage/disk_accountant.rs
@@ -1,65 +1,24 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::{Mutex, OnceLock};
-use std::time::{Duration, Instant};
+use std::collections::HashSet;
 
 use crate::storage::engine::{PageType, HEADER_SIZE, PAGE_SIZE};
 use crate::storage::unified::UnifiedStore;
 
-const CACHE_TTL: Duration = Duration::from_secs(30);
 const INTERIOR_DATA_OFFSET: usize = HEADER_SIZE;
 
-type Cache = HashMap<String, (u64, Instant)>;
-
-static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
-
-pub(crate) fn bytes_on_disk_for(store: &UnifiedStore, collection: &str) -> u64 {
-    let key = cache_key(store, collection);
-    let now = Instant::now();
-
-    if let Some(bytes) = cached_bytes(&key, now) {
-        return bytes;
-    }
-
-    let bytes = estimate_bytes_on_disk(store, collection);
-    let mut cache = CACHE
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    cache.insert(key, (bytes, now));
-    bytes
+pub(crate) fn bytes_on_disk_for(store: &UnifiedStore, collection: &str) -> Option<u64> {
+    estimate_bytes_on_disk(store, collection)
 }
 
-fn cached_bytes(key: &str, now: Instant) -> Option<u64> {
-    let mut cache = CACHE
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    match cache.get(key).copied() {
-        Some((bytes, measured_at)) if now.duration_since(measured_at) < CACHE_TTL => Some(bytes),
-        Some(_) => {
-            cache.remove(key);
-            None
-        }
-        None => None,
-    }
-}
-
-fn cache_key(store: &UnifiedStore, collection: &str) -> String {
-    let db = store
-        .db_path()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|| "<memory>".to_string());
-    format!("{db}\0{collection}")
-}
-
-fn estimate_bytes_on_disk(store: &UnifiedStore, collection: &str) -> u64 {
+fn estimate_bytes_on_disk(store: &UnifiedStore, collection: &str) -> Option<u64> {
+    store.db_path()?;
+    store.pager()?;
     let Some(root_page) = store.collection_root_page(collection) else {
-        return 0;
+        return Some(0);
     };
     let Some(pages) = reachable_btree_pages(store, root_page) else {
-        return 0;
+        return None;
     };
-    pages.saturating_mul(PAGE_SIZE as u64)
+    Some(pages.saturating_mul(PAGE_SIZE as u64))
 }
 
 fn reachable_btree_pages(store: &UnifiedStore, root_page: u32) -> Option<u64> {

--- a/tests/grouped/schema_query_core/e2e_red_collections_acceptance.rs
+++ b/tests/grouped/schema_query_core/e2e_red_collections_acceptance.rs
@@ -13,6 +13,7 @@ use reddb::runtime::within_clause::{FieldOverride, ScopeOverride};
 use reddb::server::RedDBServer;
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
+use reddb::storage::StorageDeployPreset;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 const COLLECTION_COLUMNS: [&str; 15] = [
@@ -131,13 +132,7 @@ fn select_star_from_red_collections_returns_collection_inventory() {
         matches!(acme.get("schema_mode"), Some(Value::Text(_))),
         "schema_mode should be present: {acme:?}"
     );
-    for numeric in [
-        "entities",
-        "segments",
-        "indices",
-        "in_memory_bytes",
-        "on_disk_bytes",
-    ] {
+    for numeric in ["entities", "segments", "indices", "in_memory_bytes"] {
         assert!(
             matches!(
                 acme.get(numeric),
@@ -146,6 +141,11 @@ fn select_star_from_red_collections_returns_collection_inventory() {
             "{numeric} should be an integer metric: {acme:?}"
         );
     }
+    assert_eq!(
+        acme.get("on_disk_bytes"),
+        Some(&Value::Null),
+        "in-memory collections should not fabricate on-disk bytes: {acme:?}"
+    );
     assert!(
         matches!(
             acme.get("queue_mode"),
@@ -309,6 +309,32 @@ fn http_post_query(addr: &str, query: &str) -> (u16, serde_json::Value) {
     (status, json)
 }
 
+fn http_get(addr: &str, path: &str) -> (u16, serde_json::Value) {
+    let mut tcp = TcpStream::connect(addr).expect("connect");
+    tcp.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    tcp.set_write_timeout(Some(Duration::from_secs(5))).unwrap();
+    let req = format!(
+        "GET {path} HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Connection: close\r\n\
+         \r\n"
+    );
+    tcp.write_all(req.as_bytes()).unwrap();
+    tcp.flush().unwrap();
+    let mut buf = Vec::new();
+    let _ = tcp.read_to_end(&mut buf);
+    let resp = String::from_utf8_lossy(&buf).to_string();
+    let status = resp
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse::<u16>().ok())
+        .unwrap_or(0);
+    let body_idx = resp.find("\r\n\r\n").map(|i| i + 4).unwrap_or(resp.len());
+    let json = serde_json::from_str(&resp[body_idx..])
+        .unwrap_or_else(|err| panic!("HTTP body should be JSON: {err}: {resp}"));
+    (status, json)
+}
+
 #[test]
 fn http_query_endpoint_returns_red_collections_inventory() {
     let rt = open_runtime();
@@ -331,5 +357,54 @@ fn http_query_endpoint_returns_red_collections_inventory() {
     assert!(
         encoded.contains("acme_orders") && encoded.contains("globex_orders"),
         "HTTP /query should return collection rows, got {body}"
+    );
+}
+
+#[test]
+fn persistent_collection_disk_bytes_fit_cluster_status_db_size() {
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-red-collections-cluster-size-")
+        .tempdir()
+        .expect("temp db dir");
+    let path = dir.path().join("data.rdb");
+    let options = RedDBOptions::persistent(&path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should be valid");
+    let rt = RedDBRuntime::with_options(options).expect("persistent runtime should open");
+    exec(&rt, "CREATE TABLE orders (id INT, tenant_id TEXT)");
+    exec(&rt, "INSERT INTO orders (id, tenant_id) VALUES (1, 'acme')");
+    rt.checkpoint().expect("checkpoint should flush pages");
+
+    let catalog = rt
+        .execute_query("SELECT on_disk_bytes FROM red.collections WHERE name = 'orders'")
+        .expect("red.collections should expose collection bytes");
+    let collection_bytes: u64 = catalog
+        .result
+        .records
+        .iter()
+        .map(|row| match row.get("on_disk_bytes") {
+            Some(Value::UnsignedInteger(bytes)) => *bytes,
+            other => panic!("expected measured on_disk_bytes, got {other:?}"),
+        })
+        .sum();
+
+    let (addr, handle) = spawn_http(rt);
+    let (status, body) = http_get(&addr, "/cluster/status");
+    handle
+        .join()
+        .expect("HTTP server thread should not panic")
+        .expect("HTTP server should serve one request");
+
+    assert_eq!(status, 200, "body = {body}");
+    let db_size_bytes = body["storage"]["db_size_bytes"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("cluster status should report db_size_bytes: {body}"));
+    assert!(
+        collection_bytes > 0,
+        "persistent collection should report measured bytes"
+    );
+    assert!(
+        collection_bytes <= db_size_bytes,
+        "collection bytes ({collection_bytes}) should fit within cluster db_size_bytes ({db_size_bytes})"
     );
 }

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -8,6 +8,7 @@ use reddb::runtime::mvcc::{
     set_current_auth_identity, set_current_connection_id, set_current_tenant,
 };
 use reddb::storage::schema::Value;
+use reddb::storage::StorageDeployPreset;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 const INDEX_COLUMNS: [&str; 10] = [
@@ -356,11 +357,46 @@ fn select_from_red_collections_materializes_catalog_rows() {
         row.get("in_memory_bytes"),
         Some(Value::UnsignedInteger(_))
     ));
-    assert!(matches!(
-        row.get("on_disk_bytes"),
-        Some(Value::UnsignedInteger(_))
-    ));
+    assert_eq!(row.get("on_disk_bytes"), Some(&Value::Null));
     assert_eq!(row.get("internal"), Some(&Value::Boolean(false)));
+
+    cleanup_scope();
+}
+
+#[test]
+fn red_collections_reports_persistent_collection_on_disk_bytes() {
+    cleanup_scope();
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-red-collections-disk-bytes-")
+        .tempdir()
+        .expect("temp db dir");
+    let path = dir.path().join("data.rdb");
+    let options = RedDBOptions::persistent(&path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless storage profile should be valid");
+    let rt = RedDBRuntime::with_options(options).expect("persistent runtime should open");
+    exec(&rt, "CREATE TABLE users (id INT, name TEXT)");
+    exec(&rt, "INSERT INTO users (id, name) VALUES (1, 'alice')");
+    rt.checkpoint().expect("checkpoint should flush pages");
+
+    let result = rt
+        .execute_query("SELECT name, on_disk_bytes FROM red.collections WHERE name = 'users'")
+        .expect("red.collections select");
+
+    assert_eq!(result.result.records.len(), 1);
+    let row = &result.result.records[0];
+    let on_disk_bytes = uint_field(row, "on_disk_bytes");
+    let db_size_bytes = std::fs::metadata(&path)
+        .expect("database file should exist")
+        .len();
+    assert!(
+        on_disk_bytes > 0,
+        "persistent collection should report measured bytes, got {row:?}"
+    );
+    assert!(
+        on_disk_bytes <= db_size_bytes,
+        "collection bytes ({on_disk_bytes}) should fit within db file size ({db_size_bytes})"
+    );
 
     cleanup_scope();
 }


### PR DESCRIPTION
Automated AFK landing for #1240. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1240

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784419641&installation_id=129708444&pr_number=1248&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1248&signature=dbb1d702914921d993366d98fc14cdfc689aec202a31109a87618bc2b4f7a8c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->