### PR TITLE
docs(style): TigerStyle-derived house style (STYLE.md + ADR 0056)

### DIFF
--- a/.red/adr/0056-tigerstyle-house-style.md
+++ b/.red/adr/0056-tigerstyle-house-style.md
@@ -1,0 +1,91 @@
+# ADR 0056 — Adopt a TigerStyle-derived house style
+
+Status: accepted
+Date: 2026-06-19
+
+## Decision
+
+We adopt a deliberately-scoped subset of TigerBeetle's
+[TigerStyle](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md) as
+reddb's house style. The day-to-day rules live in [`STYLE.md`](../../STYLE.md) at the repo
+root and are registered in `CLAUDE.md`. The rules that have real mechanical backing are
+enforced through `[workspace.lints]` / clippy / CI as **ratchets** (clean on existing code,
+enforced on new/changed code); the taste calls are written guidance only.
+
+This ADR exists primarily to record **what we rejected and why** — `STYLE.md` says what to do,
+not what we consciously chose *not* to do. A future contributor will reasonably ask why reddb
+declined TigerBeetle's signature rules; the answer is below.
+
+## Context
+
+reddb is a correctness-first, general-purpose database engine written in Rust. TigerStyle was
+written for TigerBeetle: a fixed-schema accounting ledger in Zig with bounded state. Much of its
+wisdom is language- and domain-agnostic and transfers directly; a few of its signature rules are
+specific to Zig or to a fixed-schema ledger and would fight Rust and our domain for no gain.
+
+Baseline at adoption: reddb already matched TigerStyle on the hard parts — `max_width = 100`,
+and ~15,600 release-live `assert!` (vs only ~60 `debug_assert!`). It diverged on ~4,900
+non-test `.unwrap()` calls concentrated in the storage engine, inconsistent depth-bounding of
+untrusted input, and the absence of any `[workspace.lints]`.
+
+## Adopted (see STYLE.md for the rules)
+
+1. **Two kinds of failure.** Operating errors are handled; programmer errors crash. Bare
+   `.unwrap()` is banned in favour of `.expect("invariant: …")`, enforced as a ratchet.
+2. **Assertions stay live in release** (already true) plus quality patterns: pair assertions,
+   positive + negative space, compile-time asserts. No numeric per-function count.
+3. **Function shape** — push `if`s up, `for`s down; soft `too_many_lines` ratchet (~100–120),
+   not a hard limit.
+4. **Naming (new code)** — units last by descending significance, no abbreviations,
+   helper-carries-caller's-name, nouns over participles, file order.
+5. **Off-by-one discipline** — index/count/size as distinct quantities; explicit division
+   intent; checked casts over silent `as` (cast lint ratchet).
+6. **Performance is design-time** — back-of-the-envelope sketches across network/disk/memory/CPU;
+   control vs data plane; batch the data plane; pre-size/pool buffers on hot paths. A data-plane
+   PRD/ADR must carry a one-line sketch.
+7. **Untrusted input is depth-bounded** — generalize `JSON_LITERAL_MAX_DEPTH`; recursion allowed
+   when bounded.
+
+## Rejected, and why
+
+- **"All memory statically allocated at startup; no dynamic allocation after init."** Rejected
+  wholesale. It works for a fixed-schema ledger with bounded state; reddb has arbitrary
+  collections, variable-size rows, RQL query plans, and a B-tree that grows. We adopt only its
+  *spirit* on hot paths (don't allocate per operation — pool and reuse). Adopting it broadly would
+  fight the borrow checker and the domain for no real gain.
+
+- **"Zero dependencies."** Rejected as a literal rule — we are not reimplementing tokio, axum,
+  hyper, or rustls. reddb already practices the defensible version: data-path primitives and
+  wire/file/crypto/JSON formats are homed in-house (see ADR 0046, ADR 0054) while infrastructure
+  rides vetted crates. We deliberately did **not** re-codify a dependency policy here; it is
+  governed by those ADRs.
+
+- **"Use explicitly-sized types like `u32`; avoid `usize`."** Rejected. In Rust, `usize` is the
+  correct type for indexing and lengths (`Vec::len` → `usize`; slice indexing requires it);
+  avoiding it means truncating casts everywhere for no safety gain. We keep the durable kernel —
+  the index/count/size discipline and explicit casts — which is what actually prevents on-disk
+  offset corruption.
+
+- **Hard 70-line function limit.** Rejected as a hard limit; adopted as a soft ratchet at a
+  Rust-realistic threshold (~100–120). 70 lines is calibrated for Zig; idiomatic Rust `match` and
+  builder code runs legitimately longer, so a hard 70 would rain false positives. The intent
+  ("doesn't fit on a screen") is preserved by the soft lint plus the function-shape principle.
+
+- **"No recursion."** Reframed, not adopted literally. The real safety property is *bounded depth
+  on untrusted input*, not the absence of recursion. Recursive-descent parsing is natural; we
+  require an explicit depth cap instead of converting it to explicit-stack iteration.
+
+## Enforcement
+
+CI already runs `cargo clippy --locked --all -- -D warnings`, so any `warn`-level lint becomes a
+hard global error. New lints (`unwrap_used`, `too_many_lines`, cast lints) must therefore land as
+**ratchets**: a `[workspace.lints]` deny plus crate-level `#![allow(...)]` on legacy crates,
+peeled back over time, so the gate bites on new/changed code without failing CI on the existing
+tree. The lint slices and the storage-hotspot migration are tracked under PRD #1252.
+
+## Consequences
+
+- A citable house style and decision record; reviewers and AFK agents have one reference.
+- The rejections survive — future contributors understand they were trade-offs, not oversights.
+- The mechanical gates roll out incrementally via ratchets (PRD #1252 children), so adoption does
+  not require a tree-wide rewrite up front.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Run `cargo check` after non-trivial edits. Add unit tests next to local behavior
 
 Rust uses edition 2021 and `rustfmt.toml` sets `max_width = 100`. Use `snake_case` for files, modules, and functions; `PascalCase` for types and traits; and `SCREAMING_SNAKE_CASE` for constants.
 
+See [`STYLE.md`](STYLE.md) for the house engineering style (error handling, assertions, function shape, naming, off-by-one, performance, bounded untrusted input) — a TigerStyle-derived subset. The rules we consciously rejected and why are in [ADR 0056](.red/adr/0056-tigerstyle-house-style.md).
+
 Recent commits follow Conventional Commit style such as `feat(views): ...`, `fix(timeseries): ...`, `docs: ...`, and `chore: ...`. Keep commit subjects imperative and scoped when useful. PRs should describe the behavioral change, note storage or compatibility risks, link the issue when available, and list the verification commands that were run.
 
 ## Security & Configuration

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,109 @@
+# RedDB Style
+
+House engineering style for reddb, adapted from TigerBeetle's
+[TigerStyle](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md).
+We adopt a deliberately-scoped subset — what fits a correctness-first, general-purpose
+database engine written in Rust. The rules we consciously **rejected** (and why) are
+recorded in [ADR 0056](.red/adr/0056-tigerstyle-house-style.md); read it before assuming a
+TigerBeetle rule applies here.
+
+Design goals, in order: **safety, performance, developer experience.** Good style advances
+these goals; readability is table stakes, not the end in itself.
+
+These rules apply to **new and changed code**. They are not a mandate to retroactively
+rewrite the tree — match surrounding code when editing (see CLAUDE.md §3, Surgical Changes).
+
+## 1. Errors: two kinds of failure
+
+Distinguish them at every call site:
+
+- **Operating errors** — disk, network, corrupt data, resource exhaustion. These are
+  *expected* and **must be handled** (propagate a `Result`). An analysis of production
+  failures found the majority of catastrophic outages came from mishandled non-fatal errors.
+- **Programmer errors** — broken invariants. These are *unexpected*; the only correct
+  response is to **crash**. Encode them as `assert!`/`expect`, which downgrades a silent
+  correctness bug into a loud liveness bug.
+
+A bare `.unwrap()` blurs the two. **Ban it** — write `.expect("invariant: …")` that states
+*why* the value cannot be absent, or propagate the error if it actually can. This is
+mechanically enforced as a ratchet (`clippy::unwrap_used`); `expect` with a reason is the
+sanctioned replacement.
+
+## 2. Assertions
+
+reddb already keeps assertions live in release (`assert!`, not `debug_assert!`) — that is the
+default and it stays. The expensive, valuable part (invariant checks protecting production) is
+already paid for; keep it.
+
+- `assert!` (stays in release) is the **default**. Use `debug_assert!` **only** in a
+  *measured* hot inner loop where the check is shown to cost.
+- **Pair assertions** — enforce a property on at least two code paths (e.g. validate right
+  before writing to disk *and* immediately after reading back).
+- Assert the **positive space** you expect **and** the **negative space** you don't — bugs
+  hide where data crosses the valid/invalid boundary.
+- Assert **compile-time** relationships (type sizes, layout, constant invariants) where they
+  matter — they check design integrity before the program runs.
+
+No numeric per-function assertion count is mandated; placement and quality matter, not tally.
+
+## 3. Function shape
+
+Centralize control flow: **push `if`s up, push `for`s down.** Keep all branching in the parent
+function and move non-branchy fragments to pure leaf helpers. The parent owns state; helpers
+compute what changes, they don't reach out and mutate.
+
+There is a real discontinuity between a function that fits on a screen and one you must scroll.
+A soft lint (`clippy::too_many_lines`, ratcheted) nudges new functions that run long; treat it
+as a prompt to split, not a hard wall — idiomatic `match`/builder code legitimately runs longer
+than a Zig 70-line limit would allow.
+
+## 4. Naming (new code)
+
+- `snake_case` for functions, variables, files (clippy enforces this).
+- **No abbreviations.** Long-form, descriptive names. Long-form flags in scripts (`--force`).
+- **Units/qualifiers last, by descending significance:** `latency_ms_max`, not `max_latency_ms`
+  — so `latency_ms_min` lines up beside it and related variables group and align in arithmetic.
+- A helper carries its **caller's name** to show the call history: `read_sector` →
+  `read_sector_callback`.
+- Prefer **nouns over participles**: `replica.pipeline`, not `replica.preparing` — nouns compose
+  into derived identifiers (`config.pipeline_max`) and read cleanly in prose.
+- **File order:** the important thing first (top-down read). For structs: fields, then nested
+  types, then methods.
+
+## 5. Off-by-one discipline
+
+`index` (0-based), `count` (1-based), and `size` (count × unit) are conceptually **distinct
+types**, even though they are all integers. Going index → count adds one; count → size
+multiplies by the unit. Including the unit in the name (rule 4) is what makes this checkable.
+
+- Show **division intent**: `div_ceil` / `div_floor` / `@divExact`-equivalent, not a bare `/`.
+- Prefer **checked/explicit conversions** over silent `as` truncation on lengths and on-disk
+  offsets. A cast lint (ratcheted) surfaces truncating casts.
+
+Note: we keep `usize` for indexing and lengths — it is the correct Rust type. TigerBeetle's
+"avoid `usize`" rule does **not** apply here (see ADR 0056).
+
+## 6. Performance: design-time first
+
+The biggest performance wins are won in design, before anything can be profiled. "The lack of
+back-of-the-envelope performance sketches is the root of all evil."
+
+- Sketch across the four resources — **network, disk, memory, CPU** — and their two
+  characteristics, **bandwidth** and **latency**. Optimize the slowest first, after weighting by
+  how often it runs (a frequent memory miss can cost as much as one disk fsync).
+- Separate the **control plane** from the **data plane**; **batch** the data plane so the CPU
+  gets large, predictable chunks of work instead of zig-zagging per event.
+- On hot paths, don't allocate per operation — pre-size, pool, and reuse buffers (the
+  transferable half of TigerBeetle's static-allocation rule; the wholesale rule is rejected, see
+  ADR 0056). The control plane stays idiomatic.
+
+**Requirement:** a PRD or ADR that changes the **data plane** (WAL, pager, query execution)
+must carry a one-line back-of-the-envelope sketch (e.g. "N rows × fsync latency = …"). It is
+nearly free and it is the single highest-leverage habit here.
+
+## 7. Untrusted input is bounded
+
+Every parse/expansion path over untrusted input (RQL especially) must carry an **explicit depth
+cap** — unbounded nesting is a stack-overflow DoS. Recursion is fine *when depth-bounded*; we do
+not ban it. Generalize the existing `JSON_LITERAL_MAX_DEPTH` pattern rather than inventing a new
+guard per call site.


### PR DESCRIPTION
Implements #1253 (PRD #1252, slice 1).

Adds the written foundation for reddb's TigerStyle-derived house style:

- **STYLE.md** — day-to-day rules: two-kinds-of-failure (ban bare `unwrap`), release-live assertions + quality patterns, function shape, naming (new code), off-by-one discipline, design-time performance + the data-plane back-of-envelope sketch requirement, bounded untrusted input.
- **ADR 0056** — records the adopted subset and, prominently, the four consciously-rejected rules (static allocation, zero-deps, avoid-`usize`, hard-70-line limit) with rationale. Cross-references ADRs 0046/0054 for the dependency stance.
- **AGENTS.md** — pointer to both from the Style section. (CLAUDE.md is gitignored here; AGENTS.md is the tracked agent-instruction surface.)

Docs-only — no code, no lint changes. The mechanical gates (`[workspace.lints]` ratchets) and the storage-hotspot `unwrap` migration are separate slices (#1254, #1256, #1257, #1258); the RQL depth-cap is #1255.

Closes #1253

https://claude.ai/code/session_01HYn23rqFb8amEqCCqVgkdr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784503652&installation_id=129708444&pr_number=1259&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1259&signature=fde97a277120871abe9a49dc75575e80185e2ee4c3a5c11806abf1abad0afc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established house engineering style guidelines covering error handling, assertions, function design, naming conventions, performance expectations, and security constraints for untrusted input. Documented the adoption of TigerStyle rules via a new Architecture Decision Record, including rationale for rejected rules and staged enforcement approach through CI tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->