### PR TITLE
merge: #1255 RQL: generalize depth-cap (JSON_LITERAL_MAX_DEPTH) + audit expr/subquery + tests

### DIFF
--- a/crates/reddb-rql/src/limits.rs
+++ b/crates/reddb-rql/src/limits.rs
@@ -67,3 +67,15 @@ impl ParserLimits {
         }
     }
 }
+
+/// Maximum nesting depth for JSON object literals, validated after
+/// parsing by [`crate::parser::dml::json_literal_depth_check`] using
+/// an iterative stack walk.
+///
+/// Defined here — alongside [`ParserLimits`] and [`DepthCounter`] —
+/// so every depth-cap constant is co-located in one module. Expression
+/// and subquery nesting are guarded inline by
+/// [`crate::parser::Parser::enter_depth`] /
+/// [`crate::parser::Parser::exit_depth`] against
+/// [`ParserLimits::max_depth`].
+pub const JSON_LITERAL_MAX_DEPTH: u32 = 128;

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -10,10 +10,10 @@ use crate::lexer::Token;
 use crate::sql_lowering::{filter_to_expr, fold_expr_to_value};
 use reddb_types::types::Value;
 
-/// DoS guard: maximum JSON nesting depth accepted by the parser.
-/// Mirrors typical web-server JSON limits and bails out before stack
-/// usage gets dangerous in downstream traversals.
-pub(crate) const JSON_LITERAL_MAX_DEPTH: u32 = 128;
+/// Maximum nesting depth for JSON object literals — shared constant
+/// that now lives in the crate-level [`crate::limits`] module so every
+/// depth cap is co-located with [`crate::limits::ParserLimits`].
+pub(crate) use crate::limits::JSON_LITERAL_MAX_DEPTH;
 
 /// Walk a parsed `JsonValue` tree and bail out if nesting exceeds
 /// `JSON_LITERAL_MAX_DEPTH`. Iterative to avoid the very stack

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -7399,3 +7399,85 @@ fn test_parse_vault_list_and_watch() {
         }) if collection == "secrets" && key == "api"
     ));
 }
+
+// ============================================================================
+// Depth-cap conformance — issue #1255
+//
+// Expression and subquery nesting paths are depth-bounded through the
+// shared `Parser::enter_depth` / `Parser::exit_depth` mechanism and
+// `ParserLimits::max_depth` (default 32).  Feeding input nested past
+// that cap must return a bounded `ParseError` mentioning "max_depth" —
+// never a panic or stack overflow.  Mirrors the `json_literal_table`
+// DoS tests as prior art.
+// ============================================================================
+
+#[test]
+fn dos_expr_paren_nesting_depth_exceeded() {
+    // 200 layers of parentheses — exceeds the default max_depth (32).
+    let open: String = "(".repeat(200);
+    let close: String = ")".repeat(200);
+    let sql = format!("SELECT * FROM t WHERE x = {}1{}", open, close);
+    let err = parse(&sql).expect_err("expected depth-limit error for expression nesting");
+    assert!(
+        err.to_string().contains("max_depth"),
+        "expected depth error mentioning 'max_depth', got: {}",
+        err
+    );
+}
+
+#[test]
+fn dos_expr_paren_nesting_at_cap_passes() {
+    // 10 layers — well under the default max_depth cap of 32.
+    let open: String = "(".repeat(10);
+    let close: String = ")".repeat(10);
+    let sql = format!("SELECT * FROM t WHERE x = {}1{}", open, close);
+    parse(&sql).expect("10 levels of paren nesting must parse");
+}
+
+#[test]
+fn dos_filter_not_nesting_depth_exceeded() {
+    // 200 chained NOTs — each recurse through `parse_not_expr` which
+    // calls `enter_depth`, so this hits the default max_depth (32) cap.
+    let nots: String = "NOT ".repeat(200);
+    let sql = format!("SELECT * FROM t WHERE {}x = 1", nots);
+    let err = parse(&sql).expect_err("expected depth-limit error for NOT nesting");
+    assert!(
+        err.to_string().contains("max_depth"),
+        "expected depth error mentioning 'max_depth', got: {}",
+        err
+    );
+}
+
+#[test]
+fn dos_filter_not_nesting_at_cap_passes() {
+    // 5 levels of NOT — well under the default max_depth cap of 32.
+    let nots: String = "NOT ".repeat(5);
+    let sql = format!("SELECT * FROM t WHERE {}x = 1", nots);
+    parse(&sql).expect("5 levels of NOT nesting must parse");
+}
+
+#[test]
+fn dos_subquery_nesting_depth_exceeded() {
+    // Build `SELECT (SELECT (SELECT … FROM t) FROM t) FROM t` × 200.
+    // Each SELECT level enters `parse_select_query` (→ enter_depth)
+    // and the wrapping expression enters `parse_expr_prec`
+    // (→ enter_depth again), so depth accumulates quickly.
+    let mut inner = "SELECT 1 FROM t".to_string();
+    for _ in 0..200 {
+        inner = format!("SELECT ({}) FROM t", inner);
+    }
+    let sql = format!("SELECT ({}) FROM t", inner);
+    let err = parse(&sql).expect_err("expected depth-limit error for subquery nesting");
+    assert!(
+        err.to_string().contains("max_depth"),
+        "expected depth error mentioning 'max_depth', got: {}",
+        err
+    );
+}
+
+#[test]
+fn dos_subquery_nesting_at_cap_passes() {
+    // 3 levels — well under the default max_depth cap.
+    let sql = "SELECT (SELECT (SELECT 1 FROM t) FROM t) FROM t";
+    parse(sql).expect("3 levels of subquery nesting must parse");
+}


### PR DESCRIPTION
Automated AFK landing for #1255. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1255

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784547674&installation_id=129708444&pr_number=1262&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1262&signature=f679db86279f7d96a3776238e6cf6ac63da0f2206a472b2d9d1f4bc08780437c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->