### PR TITLE
merge: #1254 [workspace.lints] scaffolding + unwrap→expect ratchet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ reddb-server = { package = "reddb-io-server", version = "1.0", path = "crates/re
 reddb-types = { package = "reddb-io-types", version = "1.0", path = "crates/reddb-types" }
 reddb-wire = { package = "reddb-io-wire", version = "1.0", path = "crates/reddb-wire" }
 
+[workspace.lints.clippy]
+unwrap_used = "deny"
+expect_used = "allow"
+
 [package]
 name = "reddb-io"
 version = "1.11.0"
@@ -58,6 +62,9 @@ path = "src/bin/red.rs"
 [lib]
 name = "reddb"
 path = "src/lib.rs"
+
+[lints]
+workspace = true
 
 [dependencies]
 reddb-wire = { workspace = true }

--- a/crates/reddb-client-connector/Cargo.toml
+++ b/crates/reddb-client-connector/Cargo.toml
@@ -25,3 +25,6 @@ path = "src/lib.rs"
 reddb-grpc-proto = { workspace = true }
 reddb-wire = { workspace = true }
 tonic = { version = "0.14", default-features = false, features = ["channel", "codegen"] }
+
+[lints]
+workspace = true

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -119,3 +119,6 @@ tempfile = "3"
 [[bin]]
 name = "red_client"
 path = "src/bin/red_client.rs"
+
+[lints]
+workspace = true

--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -45,6 +45,7 @@
 //! [`RedDBClient`] and [`repl`] for back-compat with the previous
 //! `reddb-client-internal` crate.
 
+#![allow(clippy::unwrap_used)]
 #![deny(unsafe_code)]
 #![warn(missing_debug_implementations)]
 

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -17,3 +17,6 @@ path = "src/lib.rs"
 
 [dependencies]
 aes-gcm = "0.10"
+
+[lints]
+workspace = true

--- a/crates/reddb-crypto/src/lib.rs
+++ b/crates/reddb-crypto/src/lib.rs
@@ -30,6 +30,8 @@
 //! OS-CSPRNG nonce source, and key parser carried forward here. See
 //! ADR 0054 for the full rationale.
 
+#![allow(clippy::unwrap_used)]
+
 pub mod aes_gcm;
 pub mod key;
 pub mod os_random;

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -29,3 +29,6 @@ zstd = { version = "0.13", default-features = false }
 [dev-dependencies]
 toml = "1.1"
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -5,6 +5,8 @@
 //! SQL, and storage-engine payload semantics stay in `reddb-server`; this crate
 //! works with bytes, offsets, locks, checkpoints, manifests, and recovery rules.
 
+#![allow(clippy::unwrap_used)]
+
 pub mod ai_model_cache;
 pub mod audit_log;
 pub mod backup_manifest;

--- a/crates/reddb-grpc-proto/Cargo.toml
+++ b/crates/reddb-grpc-proto/Cargo.toml
@@ -30,3 +30,6 @@ reddb-wire = { workspace = true }
 [build-dependencies]
 tonic-build = "0.14"
 tonic-prost-build = "0.14"
+
+[lints]
+workspace = true

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -29,3 +29,6 @@ proptest = "1"
 # Embedded parser tests assert on parsed SECRET_REF JSON via the upstream
 # `serde_json` crate (the server carries the same dependency).
 serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -24,6 +24,7 @@
 // blanket here keeps the relocation a pure move — the parser's helper methods,
 // keyword-import lists, and parse-loop bindings stay exactly as authored
 // (matching the precedent set by `reddb-io-types`, ADR 0052).
+#![allow(clippy::unwrap_used)]
 #![allow(dead_code, unused_imports, unused_variables)]
 // The parser dispatch carries deep recursive-descent signatures the source
 // crate already opted out of linting; mirror that subset so the move stays a

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -211,3 +211,6 @@ http = "1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[lints]
+workspace = true

--- a/crates/reddb-server/build.rs
+++ b/crates/reddb-server/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unwrap_used)]
+
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 #![allow(dead_code, unused_imports, unused_variables)]
 // Structural lints we accept for API design reasons:
 #![allow(

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -20,3 +20,6 @@ zstd = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 proptest = "1"
+
+[lints]
+workspace = true

--- a/crates/reddb-types/src/lib.rs
+++ b/crates/reddb-types/src/lib.rs
@@ -19,6 +19,7 @@
 // Ipv6Addr}` in its module-level `use` even though the non-test paths
 // reference them fully-qualified and the test module re-imports them
 // locally; carrying the allow here keeps the move a pure relocation.
+#![allow(clippy::unwrap_used)]
 #![allow(unused_imports)]
 
 pub mod canonical_key;

--- a/crates/reddb-wire/Cargo.toml
+++ b/crates/reddb-wire/Cargo.toml
@@ -38,3 +38,6 @@ insta = { version = "1", features = ["filters"] }
 regex = "1"
 prost = "0.14"
 reddb-grpc-proto = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -11,6 +11,8 @@
 //! messages. Listener loops, authentication policy, SQL dispatch, and
 //! runtime integration stay in `reddb-server`.
 
+#![allow(clippy::unwrap_used)]
+
 pub mod auth;
 pub mod conn_string;
 pub mod jsonrpc;

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unwrap_used)]
 /// `red` -- RedDB unified CLI binary.
 ///
 /// Parses argv using the schema-driven CLI parser, routes to the

--- a/tests/lint-fixtures/unwrap_ratchet.rs.fixture
+++ b/tests/lint-fixtures/unwrap_ratchet.rs.fixture
@@ -1,0 +1,36 @@
+// tests/lint-fixtures/unwrap_ratchet.rs.fixture
+//
+// Demonstrates the clippy::unwrap_used ratchet established in the root
+// Cargo.toml ([workspace.lints.clippy] unwrap_used = "deny").
+//
+// This file is NOT compiled — the `.rs.fixture` extension keeps it outside
+// the cargo workspace target tree. It is a human-readable reference for the
+// ratchet behaviour; clippy is exercised by the CI gate.
+//
+// Ratchet rules (do not re-litigate):
+//   - `clippy::unwrap_used = "deny"` at workspace level (root Cargo.toml)
+//   - `clippy::expect_used = "allow"` at workspace level (expect-with-reason
+//     is the sanctioned replacement)
+//   - Legacy crates carry a crate-level `#![allow(clippy::unwrap_used)]` to
+//     keep CI green on the ~4 900 pre-existing call sites.  That allow is
+//     removed crate-by-crate as the codebase is cleaned up (#1258).
+//   - Any crate WITHOUT the legacy allow enforces the rule immediately:
+//     adding a bare `.unwrap()` fails `cargo clippy --workspace -D warnings`.
+
+// ── FAILS clippy (unwrap_used is denied at workspace level) ──────────────────
+//
+// fn bad(x: Option<i32>) -> i32 {
+//     x.unwrap()          // error: used `unwrap()` on an `Option` value
+// }
+
+// ── PASSES clippy (expect_used is allowed at workspace level) ────────────────
+//
+// fn good(x: Option<i32>) -> i32 {
+//     x.expect("caller guarantees x is Some")
+// }
+
+// ── Crates WITHOUT the legacy allow enforce the rule immediately ─────────────
+//
+// `reddb-io-client-connector` and `reddb-io-grpc-proto` carry no
+// `#![allow(clippy::unwrap_used)]`.  Any bare `.unwrap()` added to either
+// of those crates will fail CI without further configuration.


### PR DESCRIPTION
Automated AFK landing for #1254. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1254

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784549663&installation_id=129708444&pr_number=1263&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1263&signature=82fe3f7275bb49d1138c4b556e06991da4e163e7005a175aae3eaeae7a601fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->