### PR TITLE
merge: #1256 clippy::too_many_lines ratchet (~100–120, warn-as-ratchet)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,12 @@ reddb-wire = { package = "reddb-io-wire", version = "1.0", path = "crates/reddb-
 [workspace.lints.clippy]
 unwrap_used = "deny"
 expect_used = "allow"
+# Function-length nudge (PRD #1252). Threshold lives in clippy.toml
+# (too-many-lines-threshold = 120). Wired as a warn-level ratchet: legacy
+# crates carry `#![allow(clippy::too_many_lines)]` so the gate bites on
+# new/changed code, not the pre-existing oversized functions (incl. the
+# generated gRPC stubs in reddb-grpc-proto).
+too_many_lines = "warn"
 
 [package]
 name = "reddb-io"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,13 @@
+# Function-length nudge for the TigerStyle-derived house style (PRD #1252).
+#
+# `clippy::too_many_lines` fires when a function's *code* lines (blank and
+# comment-only lines excluded) exceed this threshold. We pick 120 — the
+# lenient end of the ~100–120 window — so the lint captures TigerStyle's
+# "doesn't fit on a screen" discontinuity without raining false positives on
+# idiomatic `match`/builder code (a hard 70-line TigerStyle limit would).
+#
+# The lint is wired as a warn-level ratchet in [workspace.lints.clippy].
+# Legacy crates whose existing tree (incl. generated gRPC stubs) already
+# exceeds the threshold carry a crate-level `#![allow(clippy::too_many_lines)]`
+# so the gate bites on new/changed code rather than the pre-existing tree.
+too-many-lines-threshold = 120

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -6,6 +6,10 @@
 //! works with bytes, offsets, locks, checkpoints, manifests, and recovery rules.
 
 #![allow(clippy::unwrap_used)]
+// Legacy allow for the too_many_lines ratchet (PRD #1252): this crate has
+// pre-existing functions over the 120-line threshold. The lint bites on
+// new/changed code; remove this once the existing functions are split up.
+#![allow(clippy::too_many_lines)]
 
 pub mod ai_model_cache;
 pub mod audit_log;

--- a/crates/reddb-grpc-proto/src/lib.rs
+++ b/crates/reddb-grpc-proto/src/lib.rs
@@ -9,6 +9,11 @@
 //! `tonic_prost_build` at compile time.
 
 #![allow(clippy::all)]
+// `clippy::all` does NOT include the pedantic `too_many_lines` lint, and the
+// tonic-generated service stubs contain functions far over the 120-line
+// threshold (PRD #1252 ratchet). This crate is entirely generated, so the
+// allow is permanent rather than a clean-up TODO.
+#![allow(clippy::too_many_lines)]
 
 tonic::include_proto!("reddb.v1");
 

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -33,7 +33,11 @@
     clippy::too_many_arguments,
     clippy::type_complexity,
     clippy::should_implement_trait,
-    clippy::new_without_default
+    clippy::new_without_default,
+    // Legacy allow for the too_many_lines ratchet (PRD #1252): pre-existing
+    // parser/lexer functions exceed the 120-line threshold. The lint bites on
+    // new/changed code; remove once these functions are split up.
+    clippy::too_many_lines
 )]
 
 pub mod analyzer;

--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -9,7 +9,11 @@
     clippy::new_without_default,  // some constructors have side effects
     clippy::enum_variant_names,   // JoinPhase variants all end in Start by design
     clippy::wrong_self_convention, // to_bytes on Copy types in our serialization
-    clippy::len_without_is_empty  // segment structs don't need is_empty
+    clippy::len_without_is_empty, // segment structs don't need is_empty
+    // Legacy allow for the too_many_lines ratchet (PRD #1252): this crate has
+    // many pre-existing functions over the 120-line threshold. The lint bites
+    // on new/changed code; remove once those functions are split up.
+    clippy::too_many_lines
 )]
 
 pub mod ai;

--- a/crates/reddb-types/src/lib.rs
+++ b/crates/reddb-types/src/lib.rs
@@ -21,6 +21,10 @@
 // locally; carrying the allow here keeps the move a pure relocation.
 #![allow(clippy::unwrap_used)]
 #![allow(unused_imports)]
+// Legacy allow for the too_many_lines ratchet (PRD #1252): pre-existing
+// codec/type functions exceed the 120-line threshold. The lint bites on
+// new/changed code; remove once those functions are split up.
+#![allow(clippy::too_many_lines)]
 
 pub mod canonical_key;
 pub mod cast_catalog;

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1,4 +1,8 @@
 #![allow(clippy::unwrap_used)]
+// Legacy allow for the too_many_lines ratchet (PRD #1252): the CLI command
+// dispatchers in this binary exceed the 120-line threshold. The lint bites on
+// new/changed code; remove once those functions are split up.
+#![allow(clippy::too_many_lines)]
 /// `red` -- RedDB unified CLI binary.
 ///
 /// Parses argv using the schema-driven CLI parser, routes to the

--- a/tests/lint-fixtures/too_many_lines_ratchet.rs.fixture
+++ b/tests/lint-fixtures/too_many_lines_ratchet.rs.fixture
@@ -1,0 +1,57 @@
+// tests/lint-fixtures/too_many_lines_ratchet.rs.fixture
+//
+// Demonstrates the clippy::too_many_lines ratchet established for the
+// TigerStyle-derived house style (PRD #1252).
+//
+//   - Lint level: `clippy::too_many_lines = "warn"` in [workspace.lints.clippy]
+//     (root Cargo.toml). CI runs `cargo clippy --workspace -D warnings`, so a
+//     warn-level hit fails the gate exactly like a deny.
+//   - Threshold: `too-many-lines-threshold = 120` in `clippy.toml` (workspace
+//     root). 120 is the lenient end of the ~100–120 window: it captures
+//     TigerStyle's "doesn't fit on a screen" discontinuity without a hard
+//     70-line limit that would rain false positives on idiomatic
+//     `match`/builder code. (The function-shape *principle* — "push ifs up,
+//     fors down" — is documented in STYLE.md, not enforced here.)
+//   - clippy counts *code* lines: blank lines and comment-only lines do NOT
+//     count toward the 120.
+//
+// This file is NOT compiled — the `.rs.fixture` extension keeps it outside the
+// cargo workspace target tree. It is a human-readable reference for the ratchet
+// behaviour; clippy is exercised by the CI gate.
+//
+// Ratchet rules (do not re-litigate):
+//   - Legacy crates whose pre-existing tree already exceeds the threshold carry
+//     a crate-level `#![allow(clippy::too_many_lines)]`:
+//       reddb-io-file, reddb-io-rql, reddb-io-server, reddb-io-types,
+//       reddb-io-grpc-proto (generated tonic stubs — permanent), and the root
+//       `reddb-io` binary (src/bin/red.rs). These allows keep CI green on the
+//       existing tree; they are removed crate-by-crate as functions are split.
+//   - Note: `#![allow(clippy::all)]` does NOT cover `too_many_lines` — it lives
+//     in the pedantic group — so reddb-io-grpc-proto needs its own explicit
+//     allow despite already allowing `clippy::all`.
+//   - Crates WITHOUT the legacy allow enforce the rule immediately:
+//     reddb-io-client, reddb-io-client-connector, reddb-io-crypto, and
+//     reddb-io-wire. A new function over 120 code lines added to any of those
+//     fails `cargo clippy --workspace -D warnings` without further config.
+
+// ── FAILS clippy (over the 120-line threshold, in a crate without the allow) ──
+//
+// fn process_everything(input: &[u32]) -> u64 {
+//     let mut acc: u64 = 0;
+//     acc = acc.wrapping_add(input[0] as u64);   // line 1 of body
+//     acc = acc.wrapping_add(input[1] as u64);   // line 2 of body
+//     // ... 120+ more straight-line statements ...
+//     acc = acc.wrapping_add(input[121] as u64); // line 121 of body
+//     acc
+//     // error: this function has too many lines (122/120)
+// }
+
+// ── PASSES clippy (under the threshold) ──────────────────────────────────────
+//
+// fn process_some(input: &[u32]) -> u64 {
+//     let mut acc: u64 = 0;
+//     for &x in input {
+//         acc = acc.wrapping_add(x as u64);
+//     }
+//     acc                       // a handful of code lines — well under 120
+// }


### PR DESCRIPTION
Automated AFK landing for #1256. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1256

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784551881&installation_id=129708444&pr_number=1264&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1264&signature=73a8b60abe8795a0a12b35b0f54367d8bd6d3fd2fc13d0d320f5adb37c98fa89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality linting configuration to enforce consistency across the codebase. Existing legacy code subject to granular exemptions to prevent disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->