### PR TITLE
merge: #1257 Truncating-cast lint ratchet (cast_possible_truncation / as_conversions)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,13 @@ expect_used = "allow"
 # new/changed code, not the pre-existing oversized functions (incl. the
 # generated gRPC stubs in reddb-grpc-proto).
 too_many_lines = "warn"
+# Truncating-cast nudge (PRD #1252). The mechanical half of the
+# index/count/size discipline in STYLE.md: silent `as` truncations on lengths
+# and on-disk offsets get surfaced so they become checked/explicit casts.
+# Wired as a warn-level ratchet — legacy crates carry
+# `#![allow(clippy::cast_possible_truncation)]` so the gate bites on
+# new/changed code, not the pre-existing truncating casts.
+cast_possible_truncation = "warn"
 
 [package]
 name = "reddb-io"

--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -46,6 +46,10 @@
 //! `reddb-client-internal` crate.
 
 #![allow(clippy::unwrap_used)]
+// Legacy allow for the cast_possible_truncation ratchet (PRD #1252):
+// pre-existing truncating `as` casts (e.g. f64→u64 narrowing). The lint bites
+// on new/changed code; remove once those casts become checked conversions.
+#![allow(clippy::cast_possible_truncation)]
 #![deny(unsafe_code)]
 #![warn(missing_debug_implementations)]
 

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -10,6 +10,11 @@
 // pre-existing functions over the 120-line threshold. The lint bites on
 // new/changed code; remove this once the existing functions are split up.
 #![allow(clippy::too_many_lines)]
+// Legacy allow for the cast_possible_truncation ratchet (PRD #1252): this
+// crate has pre-existing truncating `as` casts on lengths/offsets. The lint
+// bites on new/changed code; remove this once those casts become explicit
+// checked conversions.
+#![allow(clippy::cast_possible_truncation)]
 
 pub mod ai_model_cache;
 pub mod audit_log;

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -37,7 +37,11 @@
     // Legacy allow for the too_many_lines ratchet (PRD #1252): pre-existing
     // parser/lexer functions exceed the 120-line threshold. The lint bites on
     // new/changed code; remove once these functions are split up.
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    // Legacy allow for the cast_possible_truncation ratchet (PRD #1252):
+    // pre-existing truncating `as` casts on lengths/offsets. The lint bites on
+    // new/changed code; remove once those casts become checked conversions.
+    clippy::cast_possible_truncation
 )]
 
 pub mod analyzer;

--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -13,7 +13,12 @@
     // Legacy allow for the too_many_lines ratchet (PRD #1252): this crate has
     // many pre-existing functions over the 120-line threshold. The lint bites
     // on new/changed code; remove once those functions are split up.
-    clippy::too_many_lines
+    clippy::too_many_lines,
+    // Legacy allow for the cast_possible_truncation ratchet (PRD #1252): this
+    // crate has many pre-existing truncating `as` casts on lengths/offsets and
+    // numeric narrowing. The lint bites on new/changed code; remove once those
+    // casts become explicit checked conversions.
+    clippy::cast_possible_truncation
 )]
 
 pub mod ai;

--- a/crates/reddb-types/src/lib.rs
+++ b/crates/reddb-types/src/lib.rs
@@ -25,6 +25,11 @@
 // codec/type functions exceed the 120-line threshold. The lint bites on
 // new/changed code; remove once those functions are split up.
 #![allow(clippy::too_many_lines)]
+// Legacy allow for the cast_possible_truncation ratchet (PRD #1252):
+// pre-existing codec/coercion functions truncate via `as` on lengths and
+// numeric narrowing. The lint bites on new/changed code; remove once those
+// casts become explicit checked conversions.
+#![allow(clippy::cast_possible_truncation)]
 
 pub mod canonical_key;
 pub mod cast_catalog;

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -12,6 +12,10 @@
 //! runtime integration stay in `reddb-server`.
 
 #![allow(clippy::unwrap_used)]
+// Legacy allow for the cast_possible_truncation ratchet (PRD #1252):
+// pre-existing truncating `as` casts on frame lengths/offsets. The lint bites
+// on new/changed code; remove once those casts become checked conversions.
+#![allow(clippy::cast_possible_truncation)]
 
 pub mod auth;
 pub mod conn_string;

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -3,6 +3,11 @@
 // dispatchers in this binary exceed the 120-line threshold. The lint bites on
 // new/changed code; remove once those functions are split up.
 #![allow(clippy::too_many_lines)]
+// Legacy allow for the cast_possible_truncation ratchet (PRD #1252): the CLI
+// has pre-existing truncating `as` casts (e.g. f64→u64 narrowing). The lint
+// bites on new/changed code; remove once those casts become checked
+// conversions.
+#![allow(clippy::cast_possible_truncation)]
 /// `red` -- RedDB unified CLI binary.
 ///
 /// Parses argv using the schema-driven CLI parser, routes to the

--- a/tests/lint-fixtures/cast_possible_truncation_ratchet.rs.fixture
+++ b/tests/lint-fixtures/cast_possible_truncation_ratchet.rs.fixture
@@ -1,0 +1,54 @@
+// tests/lint-fixtures/cast_possible_truncation_ratchet.rs.fixture
+//
+// Demonstrates the clippy::cast_possible_truncation ratchet established for the
+// TigerStyle-derived house style (PRD #1252). This is the mechanical half of
+// the off-by-one / index-count-size discipline documented in STYLE.md: silent
+// `as` truncations on lengths and on-disk offsets get surfaced so they become
+// checked/explicit casts.
+//
+//   - Lint level: `clippy::cast_possible_truncation = "warn"` in
+//     [workspace.lints.clippy] (root Cargo.toml). CI runs
+//     `cargo clippy --workspace -D warnings`, so a warn-level hit fails the
+//     gate exactly like a deny.
+//   - The lint fires when an `as` cast narrows an integer/float to a type that
+//     cannot represent every value of the source (e.g. `u64 as u8`,
+//     `usize as u32`, `i64 as i32`, `f64 as u64`). Widening casts and casts the
+//     compiler can prove are lossless do NOT fire.
+//
+// This file is NOT compiled — the `.rs.fixture` extension keeps it outside the
+// cargo workspace target tree. It is a human-readable reference for the ratchet
+// behaviour; clippy is exercised by the CI gate.
+//
+// Ratchet rules (do not re-litigate):
+//   - Legacy crates whose pre-existing tree already truncates carry a
+//     crate-level `#![allow(clippy::cast_possible_truncation)]`:
+//       reddb-io-file, reddb-io-rql, reddb-io-server, reddb-io-types,
+//       reddb-io-wire, reddb-io-client, and the root `reddb-io` binary
+//       (src/bin/red.rs). These allows keep CI green on the existing tree; they
+//       are removed crate-by-crate as the casts are made explicit/checked.
+//   - Note: `#![allow(clippy::all)]` does NOT cover `cast_possible_truncation` —
+//     it lives in the pedantic group — so a crate that only allows
+//     `clippy::all` still enforces this lint (e.g. reddb-io-grpc-proto, which
+//     happens to have no truncating casts and therefore needs no allow).
+//   - Crates WITHOUT the legacy allow enforce the rule immediately:
+//     reddb-io-client-connector, reddb-io-crypto, and reddb-io-grpc-proto. A
+//     new truncating `as` cast added to any of those fails
+//     `cargo clippy --workspace -D warnings` without further config.
+
+// ── FAILS clippy (truncating `as` cast, in a crate without the allow) ────────
+//
+// fn encode_len(buf: &[u8]) -> u32 {
+//     buf.len() as u32
+//     // error: casting `usize` to `u32` may truncate the value
+//     //   = help: if this is intentional allow the lint with
+//     //           `#[allow(clippy::cast_possible_truncation)]`
+//     //           ... or use `u32::try_from(buf.len())` instead
+// }
+
+// ── PASSES clippy (explicit checked conversion) ──────────────────────────────
+//
+// fn encode_len(buf: &[u8]) -> Result<u32, std::num::TryFromIntError> {
+//     // A length that does not fit a u32 frame header is a real error, not a
+//     // value to silently wrap — surface it with a checked conversion.
+//     u32::try_from(buf.len())
+// }


### PR DESCRIPTION
Automated AFK landing for #1257. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1257

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784553374&installation_id=129708444&pr_number=1265&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1265&signature=f8329fa8502cbb0990d4c1766c7e214a85fa1b62048af766df647faccc178376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->