### PR TITLE
merge: #1258 Migrate storage hotspots (btree/pager/wal) unwrap→expect/Result

### DIFF
--- a/crates/reddb-server/src/storage/engine/btree.rs
+++ b/crates/reddb-server/src/storage/engine/btree.rs
@@ -923,13 +923,13 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         assert!(tree.is_empty());
         assert_eq!(tree.root_page_id(), 0);
-        assert_eq!(tree.get(b"key").unwrap(), None);
-        assert_eq!(tree.count().unwrap(), 0);
+        assert_eq!(tree.get(b"key").expect("get() should succeed"), None);
+        assert_eq!(tree.count().expect("count() should succeed"), 0);
 
         cleanup(&path);
     }
@@ -939,15 +939,19 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
-        tree.insert(b"hello", b"world").unwrap();
+        tree.insert(b"hello", b"world")
+            .expect("insert() should succeed");
 
         assert!(!tree.is_empty());
-        assert_eq!(tree.get(b"hello").unwrap(), Some(b"world".to_vec()));
-        assert_eq!(tree.get(b"other").unwrap(), None);
-        assert_eq!(tree.count().unwrap(), 1);
+        assert_eq!(
+            tree.get(b"hello").expect("get() should succeed"),
+            Some(b"world".to_vec())
+        );
+        assert_eq!(tree.get(b"other").expect("get() should succeed"), None);
+        assert_eq!(tree.count().expect("count() should succeed"), 1);
 
         cleanup(&path);
     }
@@ -957,17 +961,26 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
-        tree.insert(b"c", b"3").unwrap();
-        tree.insert(b"a", b"1").unwrap();
-        tree.insert(b"b", b"2").unwrap();
+        tree.insert(b"c", b"3").expect("insert() should succeed");
+        tree.insert(b"a", b"1").expect("insert() should succeed");
+        tree.insert(b"b", b"2").expect("insert() should succeed");
 
-        assert_eq!(tree.get(b"a").unwrap(), Some(b"1".to_vec()));
-        assert_eq!(tree.get(b"b").unwrap(), Some(b"2".to_vec()));
-        assert_eq!(tree.get(b"c").unwrap(), Some(b"3".to_vec()));
-        assert_eq!(tree.count().unwrap(), 3);
+        assert_eq!(
+            tree.get(b"a").expect("get() should succeed"),
+            Some(b"1".to_vec())
+        );
+        assert_eq!(
+            tree.get(b"b").expect("get() should succeed"),
+            Some(b"2".to_vec())
+        );
+        assert_eq!(
+            tree.get(b"c").expect("get() should succeed"),
+            Some(b"3".to_vec())
+        );
+        assert_eq!(tree.count().expect("count() should succeed"), 3);
 
         cleanup(&path);
     }
@@ -977,14 +990,18 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
-        tree.insert(b"key", b"value1").unwrap();
+        tree.insert(b"key", b"value1")
+            .expect("insert() should succeed");
         let result = tree.insert(b"key", b"value2");
 
         assert!(matches!(result, Err(BTreeError::DuplicateKey)));
-        assert_eq!(tree.get(b"key").unwrap(), Some(b"value1".to_vec()));
+        assert_eq!(
+            tree.get(b"key").expect("get() should succeed"),
+            Some(b"value1".to_vec())
+        );
 
         cleanup(&path);
     }
@@ -994,20 +1011,26 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
-        tree.insert(b"a", b"1").unwrap();
-        tree.insert(b"b", b"2").unwrap();
-        tree.insert(b"c", b"3").unwrap();
+        tree.insert(b"a", b"1").expect("insert() should succeed");
+        tree.insert(b"b", b"2").expect("insert() should succeed");
+        tree.insert(b"c", b"3").expect("insert() should succeed");
 
-        assert!(tree.delete(b"b").unwrap());
-        assert!(!tree.delete(b"d").unwrap());
+        assert!(tree.delete(b"b").expect("delete() should succeed"));
+        assert!(!tree.delete(b"d").expect("delete() should succeed"));
 
-        assert_eq!(tree.get(b"a").unwrap(), Some(b"1".to_vec()));
-        assert_eq!(tree.get(b"b").unwrap(), None);
-        assert_eq!(tree.get(b"c").unwrap(), Some(b"3".to_vec()));
-        assert_eq!(tree.count().unwrap(), 2);
+        assert_eq!(
+            tree.get(b"a").expect("get() should succeed"),
+            Some(b"1".to_vec())
+        );
+        assert_eq!(tree.get(b"b").expect("get() should succeed"), None);
+        assert_eq!(
+            tree.get(b"c").expect("get() should succeed"),
+            Some(b"3".to_vec())
+        );
+        assert_eq!(tree.count().expect("count() should succeed"), 2);
 
         cleanup(&path);
     }
@@ -1017,22 +1040,27 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager.clone());
 
         let value = vec![b'v'; 200];
         for i in 0..300u32 {
             let key = format!("key{:03}", i);
-            tree.insert(key.as_bytes(), &value).unwrap();
+            tree.insert(key.as_bytes(), &value)
+                .expect("insert() should succeed");
         }
 
         let root_id = tree.root_page_id();
-        let first_leaf = tree.find_first_leaf(root_id).unwrap();
+        let first_leaf = tree
+            .find_first_leaf(root_id)
+            .expect("find_first_leaf() should succeed");
         let mut leaf_ids = Vec::new();
         let mut current = first_leaf;
         loop {
             leaf_ids.push(current);
-            let page = pager.read_page(current).unwrap();
+            let page = pager
+                .read_page(current)
+                .expect("read_page() should succeed");
             let next = read_next_leaf(&page);
             if next == 0 {
                 break;
@@ -1043,24 +1071,26 @@ mod tests {
         assert!(leaf_ids.len() >= 3);
 
         let target_leaf = leaf_ids[1];
-        let page = pager.read_page(target_leaf).unwrap();
+        let page = pager
+            .read_page(target_leaf)
+            .expect("read_page() should succeed");
         let cell_count = page.cell_count() as usize;
         let mut keys = Vec::with_capacity(cell_count);
         for i in 0..cell_count {
-            let (key, _) = read_leaf_cell(&page, i).unwrap();
+            let (key, _) = read_leaf_cell(&page, i).expect("read_leaf_cell() should succeed");
             keys.push(key);
         }
 
         for key in &keys {
-            tree.delete(key).unwrap();
+            tree.delete(key).expect("delete() should succeed");
         }
 
         let expected = 300 - keys.len();
-        assert_eq!(tree.count().unwrap(), expected);
+        assert_eq!(tree.count().expect("count() should succeed"), expected);
 
-        let mut cursor = tree.cursor_first().unwrap();
+        let mut cursor = tree.cursor_first().expect("cursor_first() should succeed");
         let mut results = Vec::new();
-        while let Some((key, _)) = cursor.next().unwrap() {
+        while let Some((key, _)) = cursor.next().expect("next() should succeed") {
             results.push(key);
         }
 
@@ -1076,17 +1106,17 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
-        tree.insert(b"c", b"3").unwrap();
-        tree.insert(b"a", b"1").unwrap();
-        tree.insert(b"b", b"2").unwrap();
+        tree.insert(b"c", b"3").expect("insert() should succeed");
+        tree.insert(b"a", b"1").expect("insert() should succeed");
+        tree.insert(b"b", b"2").expect("insert() should succeed");
 
-        let mut cursor = tree.cursor_first().unwrap();
+        let mut cursor = tree.cursor_first().expect("cursor_first() should succeed");
         let mut results: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
 
-        while let Some(entry) = cursor.next().unwrap() {
+        while let Some(entry) = cursor.next().expect("next() should succeed") {
             results.push(entry);
         }
 
@@ -1103,16 +1133,19 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         for i in 0..10u8 {
             let key = format!("key{:02}", i);
             let value = format!("val{:02}", i);
-            tree.insert(key.as_bytes(), value.as_bytes()).unwrap();
+            tree.insert(key.as_bytes(), value.as_bytes())
+                .expect("insert() should succeed");
         }
 
-        let results = tree.range(b"key03", b"key06").unwrap();
+        let results = tree
+            .range(b"key03", b"key06")
+            .expect("range() should succeed");
 
         assert_eq!(results.len(), 4);
         assert_eq!(results[0].0, b"key03".to_vec());
@@ -1126,14 +1159,14 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         let key = vec![b'x'; 500];
         let value = vec![b'y'; 500];
 
-        tree.insert(&key, &value).unwrap();
-        assert_eq!(tree.get(&key).unwrap(), Some(value));
+        tree.insert(&key, &value).expect("insert() should succeed");
+        assert_eq!(tree.get(&key).expect("get() should succeed"), Some(value));
 
         cleanup(&path);
     }
@@ -1143,7 +1176,7 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         let key = vec![b'x'; MAX_KEY_SIZE + 1];
@@ -1159,14 +1192,15 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         // Insert enough entries to force splits
         for i in 0..100u32 {
             let key = format!("key{:08}", i);
             let value = format!("value{:08}", i);
-            tree.insert(key.as_bytes(), value.as_bytes()).unwrap();
+            tree.insert(key.as_bytes(), value.as_bytes())
+                .expect("insert() should succeed");
         }
 
         // Verify all entries
@@ -1174,12 +1208,12 @@ mod tests {
             let key = format!("key{:08}", i);
             let expected = format!("value{:08}", i);
             assert_eq!(
-                tree.get(key.as_bytes()).unwrap(),
+                tree.get(key.as_bytes()).expect("get() should succeed"),
                 Some(expected.into_bytes())
             );
         }
 
-        assert_eq!(tree.count().unwrap(), 100);
+        assert_eq!(tree.count().expect("count() should succeed"), 100);
 
         cleanup(&path);
     }
@@ -1189,7 +1223,7 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         let items: Vec<(Vec<u8>, Vec<u8>)> = (0..240u32)
@@ -1201,12 +1235,16 @@ mod tests {
             })
             .collect();
 
-        tree.bulk_insert_sorted(&items).unwrap();
+        tree.bulk_insert_sorted(&items)
+            .expect("bulk_insert_sorted() should succeed");
 
-        assert_eq!(tree.count().unwrap(), items.len());
+        assert_eq!(tree.count().expect("count() should succeed"), items.len());
 
         for (key, value) in &items {
-            assert_eq!(tree.get(key).unwrap(), Some(value.clone()));
+            assert_eq!(
+                tree.get(key).expect("get() should succeed"),
+                Some(value.clone())
+            );
         }
 
         cleanup(&path);
@@ -1231,10 +1269,11 @@ mod tests {
         fn populate_tree(seed: &[(Vec<u8>, Vec<u8>)]) -> (BTree, PathBuf, Arc<Pager>) {
             let path = temp_db_path();
             cleanup(&path);
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(Arc::clone(&pager));
             for (k, v) in seed {
-                tree.upsert(k, v).unwrap();
+                tree.upsert(k, v).expect("upsert() should succeed");
             }
             (tree, path, pager)
         }
@@ -1279,7 +1318,7 @@ mod tests {
                 // Baseline: loop-of-upsert.
                 let (baseline, baseline_path, _baseline_pager) = populate_tree(&seed);
                 for (k, v) in &batch {
-                    baseline.upsert(k, v).unwrap();
+                    baseline.upsert(k, v).expect("upsert() should succeed");
                 }
 
                 // Candidate: upsert_batch_sorted after caller-side sort
@@ -1287,7 +1326,7 @@ mod tests {
                 let (candidate, candidate_path, _candidate_pager) = populate_tree(&seed);
                 let mut sorted = batch.clone();
                 sorted.sort_by(|a, b| a.0.cmp(&b.0));
-                candidate.upsert_batch_sorted(&sorted).unwrap();
+                candidate.upsert_batch_sorted(&sorted).expect("upsert_batch_sorted() should succeed");
 
                 // Compute the expected end state from BTreeMap (last
                 // write wins), independent of insertion order.
@@ -1301,8 +1340,8 @@ mod tests {
 
                 // Per-key get matches expected on both trees.
                 for (k, v) in &expected {
-                    let baseline_got = baseline.get(k).unwrap();
-                    let candidate_got = candidate.get(k).unwrap();
+                    let baseline_got = baseline.get(k).expect("get() should succeed");
+                    let candidate_got = candidate.get(k).expect("get() should succeed");
                     prop_assert_eq!(baseline_got.as_ref(), Some(v));
                     prop_assert_eq!(candidate_got.as_ref(), Some(v));
                 }
@@ -1310,8 +1349,8 @@ mod tests {
                 // Full cursor scan yields identical sorted contents.
                 let collect = |t: &BTree| -> Vec<(Vec<u8>, Vec<u8>)> {
                     let mut out = Vec::new();
-                    let mut cur = t.cursor_first().unwrap();
-                    while let Some(entry) = cur.next().unwrap() {
+                    let mut cur = t.cursor_first().expect("cursor_first() should succeed");
+                    while let Some(entry) = cur.next().expect("next() should succeed") {
                         out.push(entry);
                     }
                     out
@@ -1336,21 +1375,22 @@ mod tests {
         let path = temp_db_path();
         cleanup(&path);
 
-        let pager = Arc::new(Pager::open_default(&path).unwrap());
+        let pager = Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
         let tree = BTree::new(pager);
 
         // Insert in random order
         let keys = vec![50, 25, 75, 10, 30, 60, 80, 5, 15, 27, 35, 55, 65, 77, 90];
         for k in &keys {
             let key = format!("{:03}", k);
-            tree.insert(key.as_bytes(), key.as_bytes()).unwrap();
+            tree.insert(key.as_bytes(), key.as_bytes())
+                .expect("insert() should succeed");
         }
 
         // Should iterate in sorted order
-        let mut cursor = tree.cursor_first().unwrap();
+        let mut cursor = tree.cursor_first().expect("cursor_first() should succeed");
         let mut prev: Option<Vec<u8>> = None;
 
-        while let Some((key, _)) = cursor.next().unwrap() {
+        while let Some((key, _)) = cursor.next().expect("next() should succeed") {
             if let Some(p) = &prev {
                 assert!(p < &key, "Keys not in sorted order");
             }
@@ -1401,14 +1441,15 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("inline_no_overflow");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
-            let before = pager.page_count().unwrap();
+            let before = pager.page_count().expect("page_count() should succeed");
 
             let value = vec![0x5Au8; OVERFLOW_THRESHOLD - 1];
-            tree.insert(b"k", &value).unwrap();
+            tree.insert(b"k", &value).expect("insert() should succeed");
 
-            let after = pager.page_count().unwrap();
+            let after = pager.page_count().expect("page_count() should succeed");
             // Exactly one new page (the root leaf). An overflow path
             // would have allocated ≥ 2 pages (leaf + chain head).
             assert_eq!(
@@ -1416,7 +1457,7 @@ mod overflow_pipeline_tests {
                 1,
                 "inline value must allocate only the root leaf"
             );
-            assert_eq!(tree.get(b"k").unwrap(), Some(value));
+            assert_eq!(tree.get(b"k").expect("get() should succeed"), Some(value));
         }
         cleanup(&path);
     }
@@ -1429,7 +1470,8 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("compressible_44kb");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager);
 
             // Repeating markdown chunk — compresses far below threshold.
@@ -1440,8 +1482,9 @@ mod overflow_pipeline_tests {
             }
             assert!(value.len() > OVERFLOW_THRESHOLD);
 
-            tree.insert(b"doc", &value).unwrap();
-            assert_eq!(tree.get(b"doc").unwrap(), Some(value));
+            tree.insert(b"doc", &value)
+                .expect("insert() should succeed");
+            assert_eq!(tree.get(b"doc").expect("get() should succeed"), Some(value));
         }
         cleanup(&path);
     }
@@ -1453,7 +1496,8 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("incompressible_5mb");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             // xorshift produces incompressible bytes deterministically
@@ -1468,9 +1512,10 @@ mod overflow_pipeline_tests {
                 })
                 .collect();
 
-            let before = pager.page_count().unwrap();
-            tree.insert(b"blob", &value).unwrap();
-            let after = pager.page_count().unwrap();
+            let before = pager.page_count().expect("page_count() should succeed");
+            tree.insert(b"blob", &value)
+                .expect("insert() should succeed");
+            let after = pager.page_count().expect("page_count() should succeed");
             // 5 MB / overflow-page payload ≈ many pages — the leaf
             // alone could not absorb this.
             assert!(
@@ -1480,7 +1525,7 @@ mod overflow_pipeline_tests {
             );
 
             assert_eq!(
-                tree.get(b"blob").unwrap().as_deref(),
+                tree.get(b"blob").expect("get() should succeed").as_deref(),
                 Some(value.as_slice())
             );
         }
@@ -1495,16 +1540,17 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("ceiling_reject");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
-            let before = pager.page_count().unwrap();
+            let before = pager.page_count().expect("page_count() should succeed");
 
             let value = vec![0u8; MAX_VALUE_SIZE + 1];
             let err = tree.insert(b"too_big", &value).unwrap_err();
             assert!(matches!(err, BTreeError::ValueTooLarge(_)));
 
             assert_eq!(
-                pager.page_count().unwrap(),
+                pager.page_count().expect("page_count() should succeed"),
                 before,
                 "rejected value must not allocate pages"
             );
@@ -1523,7 +1569,8 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("bulk_mixed");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager);
 
             let mut items: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
@@ -1544,14 +1591,14 @@ mod overflow_pipeline_tests {
             // All valid rows persisted.
             for (k, v) in items.iter().filter(|(_, v)| v.len() <= MAX_VALUE_SIZE) {
                 assert_eq!(
-                    tree.get(k).unwrap().as_deref(),
+                    tree.get(k).expect("get() should succeed").as_deref(),
                     Some(v.as_slice()),
                     "valid row {:?} must land",
                     k
                 );
             }
             // The oversize row did not land.
-            assert_eq!(tree.get(b"k0005_huge").unwrap(), None);
+            assert_eq!(tree.get(b"k0005_huge").expect("get() should succeed"), None);
         }
         cleanup(&path);
     }
@@ -1564,7 +1611,8 @@ mod overflow_pipeline_tests {
         let path = temp_db_path("large_transparent");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager);
 
             // Sizes hit: just over threshold, well over threshold,
@@ -1582,9 +1630,9 @@ mod overflow_pipeline_tests {
             {
                 let value: Vec<u8> = (0..*size).map(|n| ((n + i) & 0xff) as u8).collect();
                 let key = format!("size{:08}", size).into_bytes();
-                tree.insert(&key, &value).unwrap();
+                tree.insert(&key, &value).expect("insert() should succeed");
                 assert_eq!(
-                    tree.get(&key).unwrap().as_deref(),
+                    tree.get(&key).expect("get() should succeed").as_deref(),
                     Some(value.as_slice()),
                     "size {} must round-trip",
                     size
@@ -1646,28 +1694,32 @@ mod overflow_free_tests {
         let path = temp_db_path("delete_frees");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             // First spilled insert grows the file.
             let v1 = incompressible(0xA11CE, 2 * 1024 * 1024);
-            tree.insert(b"k", &v1).unwrap();
-            let after_first = pager.page_count().unwrap();
+            tree.insert(b"k", &v1).expect("insert() should succeed");
+            let after_first = pager.page_count().expect("page_count() should succeed");
 
             // Delete: every overflow page returned to the free list.
-            assert!(tree.delete(b"k").unwrap());
+            assert!(tree.delete(b"k").expect("delete() should succeed"));
 
             // Re-insert the same size. With a working free list, the
             // pager reuses the freed pages and the file does not grow.
             let v2 = incompressible(0xB0B, 2 * 1024 * 1024);
-            tree.insert(b"k", &v2).unwrap();
-            let after_second = pager.page_count().unwrap();
+            tree.insert(b"k", &v2).expect("insert() should succeed");
+            let after_second = pager.page_count().expect("page_count() should succeed");
 
             assert_eq!(
                 after_second, after_first,
                 "second spill must reuse freed pages, not grow the file"
             );
-            assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(v2.as_slice()));
+            assert_eq!(
+                tree.get(b"k").expect("get() should succeed").as_deref(),
+                Some(v2.as_slice())
+            );
         }
         cleanup(&path);
     }
@@ -1681,29 +1733,36 @@ mod overflow_free_tests {
         let path = temp_db_path("shrink_to_inline");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             let big = incompressible(0xDEAD, 2 * 1024 * 1024);
-            tree.insert(b"k", &big).unwrap();
-            let hwm = pager.page_count().unwrap();
+            tree.insert(b"k", &big).expect("insert() should succeed");
+            let hwm = pager.page_count().expect("page_count() should succeed");
 
             // Shrink to inline raw (fits well under the threshold).
             let small = b"tiny".to_vec();
-            tree.upsert(b"k", &small).unwrap();
-            assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(small.as_slice()));
+            tree.upsert(b"k", &small).expect("upsert() should succeed");
+            assert_eq!(
+                tree.get(b"k").expect("get() should succeed").as_deref(),
+                Some(small.as_slice())
+            );
 
             // If the chain was not freed, this insert would push the
             // page count past `hwm`. If it was, the pager reuses freed
             // pages and we stay at the high-water mark.
             let big2 = incompressible(0xBEEF, 2 * 1024 * 1024);
-            tree.insert(b"k2", &big2).unwrap();
+            tree.insert(b"k2", &big2).expect("insert() should succeed");
             assert_eq!(
-                pager.page_count().unwrap(),
+                pager.page_count().expect("page_count() should succeed"),
                 hwm,
                 "shrinking update must free the chain — replacement spill should reuse"
             );
-            assert_eq!(tree.get(b"k2").unwrap().as_deref(), Some(big2.as_slice()));
+            assert_eq!(
+                tree.get(b"k2").expect("get() should succeed").as_deref(),
+                Some(big2.as_slice())
+            );
         }
         cleanup(&path);
     }
@@ -1717,15 +1776,16 @@ mod overflow_free_tests {
         let path = temp_db_path("shrink_spill_to_spill");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             // Two spilled values, the second clearly shorter than the
             // first. Both encode through the pointer path because the
             // bytes are incompressible.
             let big = incompressible(0xF00D, 3 * 1024 * 1024);
-            tree.insert(b"k", &big).unwrap();
-            let hwm_after_big = pager.page_count().unwrap();
+            tree.insert(b"k", &big).expect("insert() should succeed");
+            let hwm_after_big = pager.page_count().expect("page_count() should succeed");
 
             // Per slice F's acceptance the new chain is *independent*
             // of the old — i.e. no in-place page reuse — so the
@@ -1738,24 +1798,31 @@ mod overflow_free_tests {
             // freed, the pager reuses freed pages and we do not exceed
             // the high-water mark observed during the transient.
             let smaller = incompressible(0xCAFE, 1 * 1024 * 1024);
-            tree.upsert(b"k", &smaller).unwrap();
-            assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(smaller.as_slice()));
-            let hwm_after_upsert = pager.page_count().unwrap();
+            tree.upsert(b"k", &smaller)
+                .expect("upsert() should succeed");
+            assert_eq!(
+                tree.get(b"k").expect("get() should succeed").as_deref(),
+                Some(smaller.as_slice())
+            );
+            let hwm_after_upsert = pager.page_count().expect("page_count() should succeed");
 
-            assert!(tree.delete(b"k").unwrap());
+            assert!(tree.delete(b"k").expect("delete() should succeed"));
 
             let again = incompressible(0x1234, 3 * 1024 * 1024);
-            tree.insert(b"k", &again).unwrap();
+            tree.insert(b"k", &again).expect("insert() should succeed");
             assert!(
-                pager.page_count().unwrap() <= hwm_after_upsert,
+                pager.page_count().expect("page_count() should succeed") <= hwm_after_upsert,
                 "after delete+insert of original size, file must not grow past the upsert transient \
                  (page_count = {}, transient high-water = {}, original = {}) — the upsert must have \
                  freed the old chain so the re-insert reuses freed pages",
-                pager.page_count().unwrap(),
+                pager.page_count().expect("page_count() should succeed"),
                 hwm_after_upsert,
                 hwm_after_big,
             );
-            assert_eq!(tree.get(b"k").unwrap().as_deref(), Some(again.as_slice()));
+            assert_eq!(
+                tree.get(b"k").expect("get() should succeed").as_deref(),
+                Some(again.as_slice())
+            );
         }
         cleanup(&path);
     }
@@ -1767,24 +1834,28 @@ mod overflow_free_tests {
         let path = temp_db_path("reinsert_no_grow");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             let v1 = incompressible(0x5EED, 4 * 1024 * 1024);
-            tree.insert(b"row", &v1).unwrap();
-            let pages_after_first = pager.page_count().unwrap();
+            tree.insert(b"row", &v1).expect("insert() should succeed");
+            let pages_after_first = pager.page_count().expect("page_count() should succeed");
 
-            assert!(tree.delete(b"row").unwrap());
+            assert!(tree.delete(b"row").expect("delete() should succeed"));
 
             let v2 = incompressible(0xACE, 4 * 1024 * 1024);
-            tree.insert(b"row", &v2).unwrap();
-            let pages_after_second = pager.page_count().unwrap();
+            tree.insert(b"row", &v2).expect("insert() should succeed");
+            let pages_after_second = pager.page_count().expect("page_count() should succeed");
 
             assert_eq!(
                 pages_after_second, pages_after_first,
                 "re-inserting at the same size must reuse the freed chain"
             );
-            assert_eq!(tree.get(b"row").unwrap().as_deref(), Some(v2.as_slice()));
+            assert_eq!(
+                tree.get(b"row").expect("get() should succeed").as_deref(),
+                Some(v2.as_slice())
+            );
         }
         cleanup(&path);
     }
@@ -1798,28 +1869,30 @@ mod overflow_free_tests {
         let path = temp_db_path("batch_shrink");
         cleanup(&path);
         {
-            let pager = Arc::new(Pager::open_default(&path).unwrap());
+            let pager =
+                Arc::new(Pager::open_default(&path).expect("open_default() should succeed"));
             let tree = BTree::new(pager.clone());
 
             // Seed two spilled rows so the batch update lands in-place
             // on the same leaf.
             let big_a = incompressible(0x1111, 2 * 1024 * 1024);
             let big_b = incompressible(0x2222, 2 * 1024 * 1024);
-            tree.insert(b"a", &big_a).unwrap();
-            tree.insert(b"b", &big_b).unwrap();
-            let hwm = pager.page_count().unwrap();
+            tree.insert(b"a", &big_a).expect("insert() should succeed");
+            tree.insert(b"b", &big_b).expect("insert() should succeed");
+            let hwm = pager.page_count().expect("page_count() should succeed");
 
             let updates = vec![
                 (b"a".to_vec(), b"shrunk-a".to_vec()),
                 (b"b".to_vec(), b"shrunk-b".to_vec()),
             ];
-            tree.upsert_batch_sorted(&updates).unwrap();
+            tree.upsert_batch_sorted(&updates)
+                .expect("upsert_batch_sorted() should succeed");
             assert_eq!(
-                tree.get(b"a").unwrap().as_deref(),
+                tree.get(b"a").expect("get() should succeed").as_deref(),
                 Some(b"shrunk-a".as_slice())
             );
             assert_eq!(
-                tree.get(b"b").unwrap().as_deref(),
+                tree.get(b"b").expect("get() should succeed").as_deref(),
                 Some(b"shrunk-b".as_slice())
             );
 
@@ -1827,10 +1900,12 @@ mod overflow_free_tests {
             // inserts re-uses them instead of growing the file.
             let again_a = incompressible(0xAAAA, 2 * 1024 * 1024);
             let again_b = incompressible(0xBBBB, 2 * 1024 * 1024);
-            tree.insert(b"c", &again_a).unwrap();
-            tree.insert(b"d", &again_b).unwrap();
+            tree.insert(b"c", &again_a)
+                .expect("insert() should succeed");
+            tree.insert(b"d", &again_b)
+                .expect("insert() should succeed");
             assert!(
-                pager.page_count().unwrap() <= hwm,
+                pager.page_count().expect("page_count() should succeed") <= hwm,
                 "batch in-place shrink must free chains — replacement spills should reuse"
             );
         }

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -286,28 +286,35 @@ mod tests {
         );
 
         let dwb_path = dwb_path_for(path);
-        let mut file = fs::File::create(&dwb_path).unwrap();
-        file.write_all(&buf).unwrap();
-        file.sync_all().unwrap();
+        let mut file = fs::File::create(&dwb_path).expect("create() should succeed");
+        file.write_all(&buf).expect("write_all() should succeed");
+        file.sync_all().expect("sync_all() should succeed");
     }
 
     fn write_page_bytes(path: &Path, page_id: u32, page: &Page) {
-        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open() should succeed");
         file.seek(SeekFrom::Start(page_id as u64 * PAGE_SIZE as u64))
-            .unwrap();
-        file.write_all(page.as_bytes()).unwrap();
-        file.sync_all().unwrap();
+            .expect("value is present");
+        file.write_all(page.as_bytes())
+            .expect("write_all() should succeed");
+        file.sync_all().expect("sync_all() should succeed");
     }
 
     fn write_torn_page_bytes(path: &Path, page_id: u32, before: &Page, after: &Page) {
         let mut torn = *before.as_bytes();
         torn[..PAGE_SIZE / 2].copy_from_slice(&after.as_bytes()[..PAGE_SIZE / 2]);
 
-        let mut file = OpenOptions::new().write(true).open(path).unwrap();
+        let mut file = OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open() should succeed");
         file.seek(SeekFrom::Start(page_id as u64 * PAGE_SIZE as u64))
-            .unwrap();
-        file.write_all(&torn).unwrap();
-        file.sync_all().unwrap();
+            .expect("value is present");
+        file.write_all(&torn).expect("write_all() should succeed");
+        file.sync_all().expect("sync_all() should succeed");
     }
 
     #[test]
@@ -316,8 +323,9 @@ mod tests {
         cleanup(&path);
 
         {
-            let pager = Pager::open_default(&path).unwrap();
-            assert_eq!(pager.page_count().unwrap(), 3); // Header + reserved pages
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            assert_eq!(pager.page_count().expect("page_count() should succeed"), 3);
+            // Header + reserved pages
         }
 
         cleanup(&path);
@@ -330,19 +338,22 @@ mod tests {
 
         // Create and write
         {
-            let pager = Pager::open_default(&path).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
 
             // Allocate a page
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             assert_eq!(page.page_id(), 3);
 
-            pager.sync().unwrap();
+            pager.sync().expect("sync() should succeed");
         }
 
         // Reopen and verify
         {
-            let pager = Pager::open_default(&path).unwrap();
-            assert_eq!(pager.page_count().unwrap(), 4); // Header + reserved pages + 1 data page
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            assert_eq!(pager.page_count().expect("page_count() should succeed"), 4);
+            // Header + reserved pages + 1 data page
         }
 
         cleanup(&path);
@@ -354,18 +365,25 @@ mod tests {
         cleanup(&path);
 
         {
-            let pager = Pager::open_default(&path).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
 
             // Allocate and write
-            let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let mut page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             let page_id = page.page_id();
 
-            page.insert_cell(b"key", b"value").unwrap();
-            pager.write_page(page_id, page).unwrap();
+            page.insert_cell(b"key", b"value")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, page)
+                .expect("write_page() should succeed");
 
             // Read back
-            let read_page = pager.read_page(page_id).unwrap();
-            let (key, value) = read_page.read_cell(0).unwrap();
+            let read_page = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
+            let (key, value) = read_page.read_cell(0).expect("read_cell() should succeed");
             assert_eq!(key, b"key");
             assert_eq!(value, b"value");
         }
@@ -379,17 +397,23 @@ mod tests {
         cleanup(&path);
 
         {
-            let pager = Pager::open_default(&path).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
 
             // Allocate a page
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             let page_id = page.page_id();
 
             // First read - should be cached from allocate
-            let _ = pager.read_page(page_id).unwrap();
+            let _ = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
 
             // Second read - should hit cache
-            let _ = pager.read_page(page_id).unwrap();
+            let _ = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
 
             let stats = pager.cache_stats();
             assert!(stats.hits >= 1);
@@ -404,20 +428,26 @@ mod tests {
         cleanup(&path);
 
         {
-            let pager = Pager::open_default(&path).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
 
             // Allocate pages
-            let page1 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-            let page2 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let page1 = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
+            let page2 = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
 
             let id1 = page1.page_id();
             let id2 = page2.page_id();
 
             // Free page 1
-            pager.free_page(id1).unwrap();
+            pager.free_page(id1).expect("free_page() should succeed");
 
             // Next allocation should reuse page 1
-            let page3 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let page3 = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             assert_eq!(page3.page_id(), id1);
         }
 
@@ -431,18 +461,26 @@ mod tests {
 
         let freed_id;
         {
-            let pager = Pager::open_default(&path).unwrap();
-            let page1 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-            let _page2 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            let page1 = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
+            let _page2 = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             freed_id = page1.page_id();
 
-            pager.free_page(freed_id).unwrap();
-            pager.sync().unwrap();
+            pager
+                .free_page(freed_id)
+                .expect("free_page() should succeed");
+            pager.sync().expect("sync() should succeed");
         }
 
         {
-            let pager = Pager::open_default(&path).unwrap();
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             assert_eq!(page.page_id(), freed_id);
         }
 
@@ -456,8 +494,8 @@ mod tests {
 
         // Create database
         {
-            let pager = Pager::open_default(&path).unwrap();
-            pager.sync().unwrap();
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            pager.sync().expect("sync() should succeed");
         }
 
         // Open read-only
@@ -467,7 +505,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let pager = Pager::open(&path, config).unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
             assert!(pager.is_read_only());
 
             // Should fail to allocate
@@ -489,38 +527,63 @@ mod tests {
 
         let page_id;
         {
-            let pager = Pager::open(&path, config.clone()).unwrap();
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open(&path, config.clone()).expect("open() should succeed");
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             page_id = page.page_id();
-            pager.sync().unwrap();
+            pager.sync().expect("sync() should succeed");
         }
 
         let mut recovered_page = Page::new(PageType::BTreeLeaf, page_id);
-        recovered_page.insert_cell(b"key", b"value").unwrap();
+        recovered_page
+            .insert_cell(b"key", b"value")
+            .expect("insert_cell() should succeed");
         write_dwb_fixture(&path, &[(page_id, recovered_page.clone())]);
 
         let dwb_path = dwb_path_for(&path);
         assert!(dwb_path.exists());
-        assert!(fs::metadata(&dwb_path).unwrap().len() > 0);
+        assert!(
+            fs::metadata(&dwb_path)
+                .expect("metadata() should succeed")
+                .len()
+                > 0
+        );
 
         {
-            let pager = Pager::open(&path, config).unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
 
-            let read_page = pager.read_page(page_id).unwrap();
-            let (key, value) = read_page.read_cell(0).unwrap();
+            let read_page = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
+            let (key, value) = read_page.read_cell(0).expect("read_cell() should succeed");
             assert_eq!(key, b"key");
             assert_eq!(value, b"value");
 
             assert!(dwb_path.exists());
-            assert_eq!(fs::metadata(&dwb_path).unwrap().len(), 0);
+            assert_eq!(
+                fs::metadata(&dwb_path)
+                    .expect("metadata() should succeed")
+                    .len(),
+                0
+            );
 
             let mut updated_page = recovered_page.clone();
-            updated_page.insert_cell(b"key2", b"value2").unwrap();
-            pager.write_page(page_id, updated_page).unwrap();
-            pager.flush().unwrap();
+            updated_page
+                .insert_cell(b"key2", b"value2")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, updated_page)
+                .expect("write_page() should succeed");
+            pager.flush().expect("flush() should succeed");
 
             assert!(dwb_path.exists());
-            assert_eq!(fs::metadata(&dwb_path).unwrap().len(), 0);
+            assert_eq!(
+                fs::metadata(&dwb_path)
+                    .expect("metadata() should succeed")
+                    .len(),
+                0
+            );
         }
 
         cleanup(&path);
@@ -592,10 +655,14 @@ mod tests {
                 double_write: false,
                 ..Default::default()
             };
-            let pager = Pager::open(&path, config).unwrap();
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-            pager.write_page(page.page_id(), page).unwrap();
-            pager.flush().unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
+            pager
+                .write_page(page.page_id(), page)
+                .expect("write_page() should succeed");
+            pager.flush().expect("flush() should succeed");
         }
 
         assert!(
@@ -617,10 +684,14 @@ mod tests {
                 double_write: false,
                 ..Default::default()
             };
-            let pager = Pager::open(&path, config).unwrap();
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-            pager.write_page(page.page_id(), page).unwrap();
-            pager.flush().unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
+            pager
+                .write_page(page.page_id(), page)
+                .expect("write_page() should succeed");
+            pager.flush().expect("flush() should succeed");
         }
 
         assert!(
@@ -639,14 +710,18 @@ mod tests {
 
         let page_id;
         {
-            let pager = Pager::open(&path, PagerConfig::default()).unwrap();
-            let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open(&path, PagerConfig::default()).expect("open() should succeed");
+            let page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             page_id = page.page_id();
-            pager.sync().unwrap();
+            pager.sync().expect("sync() should succeed");
         }
 
         let mut recovered_page = Page::new(PageType::BTreeLeaf, page_id);
-        recovered_page.insert_cell(b"key", b"value").unwrap();
+        recovered_page
+            .insert_cell(b"key", b"value")
+            .expect("insert_cell() should succeed");
         write_dwb_fixture(&path, &[(page_id, recovered_page)]);
 
         {
@@ -654,9 +729,11 @@ mod tests {
                 double_write: false,
                 ..Default::default()
             };
-            let pager = Pager::open(&path, config).unwrap();
-            let read_page = pager.read_page(page_id).unwrap();
-            let (key, value) = read_page.read_cell(0).unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
+            let read_page = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
+            let (key, value) = read_page.read_cell(0).expect("read_cell() should succeed");
             assert_eq!(key, b"key");
             assert_eq!(value, b"value");
         }
@@ -684,19 +761,31 @@ mod tests {
         let before;
         let after;
         {
-            let pager = Pager::open(&path, config.clone()).unwrap();
-            let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open(&path, config.clone()).expect("open() should succeed");
+            let mut page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             page_id = page.page_id();
-            page.insert_cell(b"phase", b"before").unwrap();
-            pager.write_page(page_id, page).unwrap();
-            pager.sync().unwrap();
-            before = pager.read_page(page_id).unwrap();
+            page.insert_cell(b"phase", b"before")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, page)
+                .expect("write_page() should succeed");
+            pager.sync().expect("sync() should succeed");
+            before = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
 
             let mut page = before.clone();
-            page.insert_cell(b"phase2", b"after").unwrap();
-            pager.write_page(page_id, page).unwrap();
-            pager.flush().unwrap();
-            after = pager.read_page(page_id).unwrap();
+            page.insert_cell(b"phase2", b"after")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, page)
+                .expect("write_page() should succeed");
+            pager.flush().expect("flush() should succeed");
+            after = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
         }
 
         // CoW crash model: the interrupted write leaves either the old full
@@ -704,14 +793,16 @@ mod tests {
         for (whole_page, expected_cells) in [(&before, 1), (&after, 2)] {
             write_page_bytes(&path, page_id, whole_page);
 
-            let pager = Pager::open(&path, config.clone()).unwrap();
-            let recovered = pager.read_page(page_id).unwrap();
+            let pager = Pager::open(&path, config.clone()).expect("open() should succeed");
+            let recovered = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
             assert_eq!(recovered.cell_count(), expected_cells);
-            let (key, value) = recovered.read_cell(0).unwrap();
+            let (key, value) = recovered.read_cell(0).expect("read_cell() should succeed");
             assert_eq!(key, b"phase");
             assert_eq!(value, b"before");
             if expected_cells == 2 {
-                let (key, value) = recovered.read_cell(1).unwrap();
+                let (key, value) = recovered.read_cell(1).expect("read_cell() should succeed");
                 assert_eq!(key, b"phase2");
                 assert_eq!(value, b"after");
             }
@@ -736,39 +827,58 @@ mod tests {
         let before;
         let after;
         {
-            let pager = Pager::open(&path, config.clone()).unwrap();
-            let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+            let pager = Pager::open(&path, config.clone()).expect("open() should succeed");
+            let mut page = pager
+                .allocate_page(PageType::BTreeLeaf)
+                .expect("allocate_page() should succeed");
             page_id = page.page_id();
-            page.insert_cell(b"phase", b"before").unwrap();
-            pager.write_page(page_id, page).unwrap();
-            pager.sync().unwrap();
-            before = pager.read_page(page_id).unwrap();
+            page.insert_cell(b"phase", b"before")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, page)
+                .expect("write_page() should succeed");
+            pager.sync().expect("sync() should succeed");
+            before = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
 
             let mut page = before.clone();
-            page.insert_cell(b"phase2", b"after").unwrap();
-            pager.write_page(page_id, page).unwrap();
-            pager.flush().unwrap();
-            after = pager.read_page(page_id).unwrap();
+            page.insert_cell(b"phase2", b"after")
+                .expect("insert_cell() should succeed");
+            pager
+                .write_page(page_id, page)
+                .expect("write_page() should succeed");
+            pager.flush().expect("flush() should succeed");
+            after = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
         }
 
         write_dwb_fixture(&path, &[(page_id, after.clone())]);
         write_torn_page_bytes(&path, page_id, &before, &after);
 
         {
-            let pager = Pager::open(&path, config).unwrap();
-            let recovered = pager.read_page(page_id).unwrap();
+            let pager = Pager::open(&path, config).expect("open() should succeed");
+            let recovered = pager
+                .read_page(page_id)
+                .expect("read_page() should succeed");
             assert_eq!(recovered.cell_count(), 2);
 
-            let (key, value) = recovered.read_cell(0).unwrap();
+            let (key, value) = recovered.read_cell(0).expect("read_cell() should succeed");
             assert_eq!(key, b"phase");
             assert_eq!(value, b"before");
 
-            let (key, value) = recovered.read_cell(1).unwrap();
+            let (key, value) = recovered.read_cell(1).expect("read_cell() should succeed");
             assert_eq!(key, b"phase2");
             assert_eq!(value, b"after");
         }
 
-        assert_eq!(fs::metadata(dwb_path_for(&path)).unwrap().len(), 0);
+        assert_eq!(
+            fs::metadata(dwb_path_for(&path))
+                .expect("metadata() should succeed")
+                .len(),
+            0
+        );
         cleanup(&path);
     }
 
@@ -779,7 +889,7 @@ mod tests {
     #[test]
     fn pager_starts_without_wal_writer() {
         let path = temp_db_path();
-        let pager = Pager::open(&path, PagerConfig::default()).unwrap();
+        let pager = Pager::open(&path, PagerConfig::default()).expect("open() should succeed");
         assert!(!pager.has_wal_writer());
         drop(pager);
         cleanup(&path);
@@ -794,8 +904,10 @@ mod tests {
         let wal_path = reddb_file::layout::pager_legacy_wal_path(&db_path);
         let _ = fs::remove_file(&wal_path);
 
-        let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
-        let wal = Arc::new(Mutex::new(WalWriter::open(&wal_path).unwrap()));
+        let pager = Pager::open(&db_path, PagerConfig::default()).expect("open() should succeed");
+        let wal = Arc::new(Mutex::new(
+            WalWriter::open(&wal_path).expect("open() should succeed"),
+        ));
         pager.set_wal_writer(Arc::clone(&wal));
         assert!(pager.has_wal_writer());
 
@@ -821,25 +933,32 @@ mod tests {
         let wal_path = reddb_file::layout::pager_legacy_wal_path(&db_path);
         let _ = fs::remove_file(&wal_path);
 
-        let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
-        let wal = Arc::new(Mutex::new(WalWriter::open(&wal_path).unwrap()));
+        let pager = Pager::open(&db_path, PagerConfig::default()).expect("open() should succeed");
+        let wal = Arc::new(Mutex::new(
+            WalWriter::open(&wal_path).expect("open() should succeed"),
+        ));
         let initial_durable = {
-            let g = wal.lock().unwrap();
+            let g = wal.lock().expect("lock() should succeed");
             g.durable_lsn()
         };
         pager.set_wal_writer(Arc::clone(&wal));
 
         // Allocate and write a page with lsn = 0.
-        let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-        page.insert_cell(b"k", b"v").unwrap();
+        let mut page = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
+        page.insert_cell(b"k", b"v")
+            .expect("insert_cell() should succeed");
         // header.lsn stays at 0 — caller did not stamp.
-        pager.write_page(page.page_id(), page).unwrap();
-        pager.flush().unwrap();
+        pager
+            .write_page(page.page_id(), page)
+            .expect("write_page() should succeed");
+        pager.flush().expect("flush() should succeed");
 
         // WAL durable_lsn must be unchanged because flush_until was
         // never called (max lsn over dirty pages was 0).
         let after_flush = {
-            let g = wal.lock().unwrap();
+            let g = wal.lock().expect("lock() should succeed");
             g.durable_lsn()
         };
         assert_eq!(after_flush, initial_durable);
@@ -862,27 +981,38 @@ mod tests {
         let wal_path = reddb_file::layout::pager_legacy_wal_path(&db_path);
         let _ = fs::remove_file(&wal_path);
 
-        let pager = Pager::open(&db_path, PagerConfig::default()).unwrap();
-        let wal = Arc::new(Mutex::new(WalWriter::open(&wal_path).unwrap()));
+        let pager = Pager::open(&db_path, PagerConfig::default()).expect("open() should succeed");
+        let wal = Arc::new(Mutex::new(
+            WalWriter::open(&wal_path).expect("open() should succeed"),
+        ));
         pager.set_wal_writer(Arc::clone(&wal));
 
         // Stamp two dirty pages with a real WAL LSN.
         let stamped_lsn = {
-            let mut wal_guard = wal.lock().unwrap();
-            wal_guard.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-            wal_guard.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
+            let mut wal_guard = wal.lock().expect("lock() should succeed");
+            wal_guard
+                .append(&WalRecord::Begin { tx_id: 1 })
+                .expect("append() should succeed");
+            wal_guard
+                .append(&WalRecord::Commit { tx_id: 1 })
+                .expect("append() should succeed");
             wal_guard.current_lsn()
         };
-        let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-        page.insert_cell(b"k", b"v").unwrap();
+        let mut page = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
+        page.insert_cell(b"k", b"v")
+            .expect("insert_cell() should succeed");
         // Use the public Page API to set the LSN.
         page.set_lsn(stamped_lsn);
-        pager.write_page(page.page_id(), page).unwrap();
-        pager.flush().unwrap();
+        pager
+            .write_page(page.page_id(), page)
+            .expect("write_page() should succeed");
+        pager.flush().expect("flush() should succeed");
 
         // After flush, the WAL is durable at least up to our stamp.
         let after_flush = {
-            let g = wal.lock().unwrap();
+            let g = wal.lock().expect("lock() should succeed");
             g.durable_lsn()
         };
         assert!(

--- a/crates/reddb-server/src/storage/wal/transaction.rs
+++ b/crates/reddb-server/src/storage/wal/transaction.rs
@@ -463,7 +463,7 @@ mod tests {
     fn temp_dir() -> PathBuf {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
+            .expect("value is present")
             .as_nanos();
         std::env::temp_dir().join(format!("reddb_tx_test_{}", timestamp))
     }
@@ -484,33 +484,40 @@ mod tests {
         let wal_path = temp_wal_path(&dir, "commit");
 
         // Create pager
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
 
         // Allocate a page
-        let page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+        let page = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
         let page_id = page.page_id();
 
         // Create transaction manager
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Begin transaction
-        let mut tx = tm.begin().unwrap();
+        let mut tx = tm.begin().expect("begin() should succeed");
         assert!(tx.is_active());
 
         // Write through transaction
         let mut page = Page::new(PageType::BTreeLeaf, page_id);
         page.as_bytes_mut()[100] = 0xAB;
-        tx.write_page(page_id, page).unwrap();
+        tx.write_page(page_id, page)
+            .expect("write_page() should succeed");
 
         // Read through transaction (should see buffered write)
-        let read_page = tx.read_page(page_id).unwrap();
+        let read_page = tx.read_page(page_id).expect("read_page() should succeed");
         assert_eq!(read_page.as_bytes()[100], 0xAB);
 
         // Commit
-        tx.commit().unwrap();
+        tx.commit().expect("commit() should succeed");
 
         // Verify write is visible through pager
-        let final_page = pager.read_page(page_id).unwrap();
+        let final_page = pager
+            .read_page(page_id)
+            .expect("read_page() should succeed");
         assert_eq!(final_page.as_bytes()[100], 0xAB);
 
         cleanup(&dir);
@@ -524,34 +531,43 @@ mod tests {
         let wal_path = temp_wal_path(&dir, "rollback");
 
         // Create pager
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
 
         // Allocate a page and write initial value
-        let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+        let mut page = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
         let page_id = page.page_id();
         page.as_bytes_mut()[100] = 0x11;
-        pager.write_page(page_id, page).unwrap();
+        pager
+            .write_page(page_id, page)
+            .expect("write_page() should succeed");
 
         // Create transaction manager
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Begin transaction
-        let mut tx = tm.begin().unwrap();
+        let mut tx = tm.begin().expect("begin() should succeed");
 
         // Write through transaction
         let mut page = Page::new(PageType::BTreeLeaf, page_id);
         page.as_bytes_mut()[100] = 0xAB;
-        tx.write_page(page_id, page).unwrap();
+        tx.write_page(page_id, page)
+            .expect("write_page() should succeed");
 
         // Read through transaction (should see buffered write)
-        let read_page = tx.read_page(page_id).unwrap();
+        let read_page = tx.read_page(page_id).expect("read_page() should succeed");
         assert_eq!(read_page.as_bytes()[100], 0xAB);
 
         // Rollback
-        tx.rollback().unwrap();
+        tx.rollback().expect("rollback() should succeed");
 
         // Original value should be preserved
-        let final_page = pager.read_page(page_id).unwrap();
+        let final_page = pager
+            .read_page(page_id)
+            .expect("read_page() should succeed");
         assert_eq!(final_page.as_bytes()[100], 0x11);
 
         cleanup(&dir);
@@ -565,34 +581,46 @@ mod tests {
         let wal_path = temp_wal_path(&dir, "multiple");
 
         // Create pager
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
 
         // Allocate two pages
-        let page1 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
-        let page2 = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+        let page1 = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
+        let page2 = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
         let page1_id = page1.page_id();
         let page2_id = page2.page_id();
 
         // Create transaction manager
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Transaction 1: Write to page 1
-        let mut tx1 = tm.begin().unwrap();
+        let mut tx1 = tm.begin().expect("begin() should succeed");
         let mut page1 = Page::new(PageType::BTreeLeaf, page1_id);
         page1.as_bytes_mut()[100] = 0x11;
-        tx1.write_page(page1_id, page1).unwrap();
-        tx1.commit().unwrap();
+        tx1.write_page(page1_id, page1)
+            .expect("write_page() should succeed");
+        tx1.commit().expect("commit() should succeed");
 
         // Transaction 2: Write to page 2
-        let mut tx2 = tm.begin().unwrap();
+        let mut tx2 = tm.begin().expect("begin() should succeed");
         let mut page2 = Page::new(PageType::BTreeLeaf, page2_id);
         page2.as_bytes_mut()[100] = 0x22;
-        tx2.write_page(page2_id, page2).unwrap();
-        tx2.commit().unwrap();
+        tx2.write_page(page2_id, page2)
+            .expect("write_page() should succeed");
+        tx2.commit().expect("commit() should succeed");
 
         // Verify both writes
-        let final_page1 = pager.read_page(page1_id).unwrap();
-        let final_page2 = pager.read_page(page2_id).unwrap();
+        let final_page1 = pager
+            .read_page(page1_id)
+            .expect("read_page() should succeed");
+        let final_page2 = pager
+            .read_page(page2_id)
+            .expect("read_page() should succeed");
         assert_eq!(final_page1.as_bytes()[100], 0x11);
         assert_eq!(final_page2.as_bytes()[100], 0x22);
 
@@ -607,36 +635,47 @@ mod tests {
         let wal_path = temp_wal_path(&dir, "isolation");
 
         // Create pager
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
 
         // Allocate a page with initial value
-        let mut page = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+        let mut page = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
         let page_id = page.page_id();
         page.as_bytes_mut()[100] = 0x00;
-        pager.write_page(page_id, page).unwrap();
+        pager
+            .write_page(page_id, page)
+            .expect("write_page() should succeed");
 
         // Create transaction manager
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Transaction 1: Begin and write (but don't commit yet)
-        let mut tx1 = tm.begin().unwrap();
+        let mut tx1 = tm.begin().expect("begin() should succeed");
         let mut page1 = Page::new(PageType::BTreeLeaf, page_id);
         page1.as_bytes_mut()[100] = 0x11;
-        tx1.write_page(page_id, page1).unwrap();
+        tx1.write_page(page_id, page1)
+            .expect("write_page() should succeed");
 
         // Transaction 1 should see its own write
-        let tx1_read = tx1.read_page(page_id).unwrap();
+        let tx1_read = tx1.read_page(page_id).expect("read_page() should succeed");
         assert_eq!(tx1_read.as_bytes()[100], 0x11);
 
         // Another read from pager should not see uncommitted write
-        let pager_read = pager.read_page(page_id).unwrap();
+        let pager_read = pager
+            .read_page(page_id)
+            .expect("read_page() should succeed");
         assert_eq!(pager_read.as_bytes()[100], 0x00);
 
         // Commit tx1
-        tx1.commit().unwrap();
+        tx1.commit().expect("commit() should succeed");
 
         // Now pager should see the write
-        let final_read = pager.read_page(page_id).unwrap();
+        let final_read = pager
+            .read_page(page_id)
+            .expect("read_page() should succeed");
         assert_eq!(final_read.as_bytes()[100], 0x11);
 
         cleanup(&dir);
@@ -649,25 +688,27 @@ mod tests {
         let db_path = dir.join("test.db");
         let wal_path = temp_wal_path(&dir, "tracking");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         assert!(!tm.has_active_transactions());
 
-        let tx1 = tm.begin().unwrap();
+        let tx1 = tm.begin().expect("begin() should succeed");
         let tx1_id = tx1.id();
         assert!(tm.has_active_transactions());
         assert!(tm.active_transactions().contains(&tx1_id));
 
-        let tx2 = tm.begin().unwrap();
+        let tx2 = tm.begin().expect("begin() should succeed");
         let tx2_id = tx2.id();
         assert_eq!(tm.active_transactions().len(), 2);
 
-        tx1.commit().unwrap();
+        tx1.commit().expect("commit() should succeed");
         assert!(!tm.active_transactions().contains(&tx1_id));
         assert!(tm.active_transactions().contains(&tx2_id));
 
-        tx2.rollback().unwrap();
+        tx2.rollback().expect("rollback() should succeed");
         assert!(!tm.has_active_transactions());
 
         cleanup(&dir);
@@ -680,13 +721,15 @@ mod tests {
         let db_path = dir.join("test.db");
         let wal_path = temp_wal_path(&dir, "double-commit");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // The transaction is consumed on commit, so double commit is impossible at compile time
         // This test just verifies commit works
-        let tx = tm.begin().unwrap();
-        tx.commit().unwrap();
+        let tx = tm.begin().expect("begin() should succeed");
+        tx.commit().expect("commit() should succeed");
 
         cleanup(&dir);
     }
@@ -704,8 +747,10 @@ mod tests {
         let db_path = dir.join("test.db");
         let wal_path = temp_wal_path(&dir, "panic-lock-holder");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         let poison_target = Arc::clone(&tm);
         let _ = std::thread::spawn(move || {
@@ -734,23 +779,25 @@ mod tests {
         let db_path = dir.join("ro_durable.db");
         let wal_path = temp_wal_path(&dir, "ro-durable");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Snapshot the WAL durable_lsn BEFORE the txn.
         let before = {
-            let wal = tm.wal_writer().unwrap();
+            let wal = tm.wal_writer().expect("wal_writer() should succeed");
             wal.durable_lsn()
         };
 
-        let tx = tm.begin().unwrap();
+        let tx = tm.begin().expect("begin() should succeed");
         // Empty write_set on purpose — read-only.
-        tx.commit().unwrap();
+        tx.commit().expect("commit() should succeed");
 
         // After RO commit, the WAL durable_lsn must NOT have advanced.
         // No Begin record, no Commit record, no fsync.
         let after = {
-            let wal = tm.wal_writer().unwrap();
+            let wal = tm.wal_writer().expect("wal_writer() should succeed");
             wal.durable_lsn()
         };
         assert_eq!(
@@ -769,11 +816,15 @@ mod tests {
         let db_path = dir.join("ro_size.db");
         let wal_path = temp_wal_path(&dir, "ro-size");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // Snapshot file size after WAL header.
-        let size_before = std::fs::metadata(&wal_path).unwrap().len();
+        let size_before = std::fs::metadata(&wal_path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(
             size_before,
             reddb_file::WAL_FILE_HEADER_BYTES as u64,
@@ -782,11 +833,13 @@ mod tests {
 
         // 100 read-only commits in a loop.
         for _ in 0..100 {
-            let tx = tm.begin().unwrap();
-            tx.commit().unwrap();
+            let tx = tm.begin().expect("begin() should succeed");
+            tx.commit().expect("commit() should succeed");
         }
 
-        let size_after = std::fs::metadata(&wal_path).unwrap().len();
+        let size_after = std::fs::metadata(&wal_path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(
             size_after, size_before,
             "100 read-only commits should not have written any WAL bytes"
@@ -801,12 +854,14 @@ mod tests {
         let db_path = dir.join("ro_state.db");
         let wal_path = temp_wal_path(&dir, "ro-state");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
-        let tx = tm.begin().unwrap();
+        let tx = tm.begin().expect("begin() should succeed");
         let id = tx.id();
-        tx.commit().unwrap();
+        tx.commit().expect("commit() should succeed");
 
         // Manager must have unregistered this txn — the active list
         // no longer contains its id.
@@ -828,29 +883,38 @@ mod tests {
         let db_path = dir.join("rw_after_ro.db");
         let wal_path = temp_wal_path(&dir, "rw-after-ro");
 
-        let pager = Arc::new(Pager::open_default(&db_path).unwrap());
-        let allocated = pager.allocate_page(PageType::BTreeLeaf).unwrap();
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let allocated = pager
+            .allocate_page(PageType::BTreeLeaf)
+            .expect("allocate_page() should succeed");
         let page_id = allocated.page_id();
-        let tm = Arc::new(TransactionManager::new(Arc::clone(&pager), &wal_path).unwrap());
+        let tm = Arc::new(
+            TransactionManager::new(Arc::clone(&pager), &wal_path).expect("new() should succeed"),
+        );
 
         // First a RO commit (must take the fast path).
-        let ro = tm.begin().unwrap();
-        ro.commit().unwrap();
+        let ro = tm.begin().expect("begin() should succeed");
+        ro.commit().expect("commit() should succeed");
 
         // Then a real writing commit.
-        let mut rw = tm.begin().unwrap();
+        let mut rw = tm.begin().expect("begin() should succeed");
         let mut page = Page::new(PageType::BTreeLeaf, page_id);
         page.as_bytes_mut()[42] = 0x77;
-        rw.write_page(page_id, page).unwrap();
-        rw.commit().unwrap();
+        rw.write_page(page_id, page)
+            .expect("write_page() should succeed");
+        rw.commit().expect("commit() should succeed");
 
         // The WAL file must now contain bytes (PageWrite + Commit
         // records, and the BufWriter has been flushed by sync()).
-        let size = std::fs::metadata(&wal_path).unwrap().len();
+        let size = std::fs::metadata(&wal_path)
+            .expect("metadata() should succeed")
+            .len();
         assert!(size > 8, "writing commit should grow the WAL");
 
         // The pager cache must reflect the write.
-        let read_back = pager.read_page(page_id).unwrap();
+        let read_back = pager
+            .read_page(page_id)
+            .expect("read_page() should succeed");
         assert_eq!(read_back.as_bytes()[42], 0x77);
 
         cleanup(&dir);

--- a/crates/reddb-server/src/storage/wal/writer.rs
+++ b/crates/reddb-server/src/storage/wal/writer.rs
@@ -487,7 +487,7 @@ mod tests {
     #[test]
     fn test_create_new_wal() {
         let (_guard, path) = temp_wal("create");
-        let writer = WalWriter::open(&path).unwrap();
+        let writer = WalWriter::open(&path).expect("open() should succeed");
 
         // Should start at LSN 8 (after 8-byte header)
         assert_eq!(writer.current_lsn(), 8);
@@ -497,10 +497,10 @@ mod tests {
     #[test]
     fn test_append_record() {
         let (_guard, path) = temp_wal("append");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
         let record = WalRecord::Begin { tx_id: 42 };
-        let lsn = writer.append(&record).unwrap();
+        let lsn = writer.append(&record).expect("append() should succeed");
 
         // First record starts at LSN 8
         assert_eq!(lsn, 8);
@@ -513,11 +513,17 @@ mod tests {
     #[test]
     fn test_append_multiple_records() {
         let (_guard, path) = temp_wal("multi");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
-        let lsn1 = writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        let lsn2 = writer.append(&WalRecord::Begin { tx_id: 2 }).unwrap();
-        let lsn3 = writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
+        let lsn1 = writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        let lsn2 = writer
+            .append(&WalRecord::Begin { tx_id: 2 })
+            .expect("append() should succeed");
+        let lsn3 = writer
+            .append(&WalRecord::Commit { tx_id: 1 })
+            .expect("append() should succeed");
 
         assert_eq!(lsn1, 8);
         assert_eq!(lsn2, 8 + 21);
@@ -527,10 +533,12 @@ mod tests {
     #[test]
     fn test_page_write_lsn() {
         let (_guard, path) = temp_wal("pagewrite");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
         // First record
-        let lsn1 = writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
+        let lsn1 = writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
         assert_eq!(lsn1, 8);
 
         // PageWrite record: 1 + 8 + 4 + 4 + data_len + 4 = 21 + data_len
@@ -541,7 +549,7 @@ mod tests {
                 page_id: 100,
                 data: data.clone(),
             })
-            .unwrap();
+            .expect("value is present");
 
         assert_eq!(lsn2, 8 + 21); // after Begin
 
@@ -552,10 +560,12 @@ mod tests {
     #[test]
     fn test_sync() {
         let (_guard, path) = temp_wal("sync");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
 
         // File should be synced, just verify no error
         assert!(path.exists());
@@ -564,30 +574,36 @@ mod tests {
     #[test]
     fn test_truncate() {
         let (_guard, path) = temp_wal("truncate");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
         // Write some records
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
         writer
             .append(&WalRecord::PageWrite {
                 tx_id: 1,
                 page_id: 0,
                 data: vec![0; 100],
             })
-            .unwrap();
-        writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
+            .expect("value is present");
+        writer
+            .append(&WalRecord::Commit { tx_id: 1 })
+            .expect("append() should succeed");
 
         let lsn_before = writer.current_lsn();
         assert!(lsn_before > 8);
 
         // Truncate
-        writer.truncate().unwrap();
+        writer.truncate().expect("truncate() should succeed");
 
         // LSN should be back to 8
         assert_eq!(writer.current_lsn(), 8);
 
         // File should be 8 bytes (just header)
-        let len = std::fs::metadata(&path).unwrap().len();
+        let len = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(len, 8);
     }
 
@@ -598,15 +614,19 @@ mod tests {
         // Create and write
         let lsn_after_write;
         {
-            let mut writer = WalWriter::open(&path).unwrap();
-            writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-            writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
+            let mut writer = WalWriter::open(&path).expect("open() should succeed");
+            writer
+                .append(&WalRecord::Begin { tx_id: 1 })
+                .expect("append() should succeed");
+            writer
+                .append(&WalRecord::Commit { tx_id: 1 })
+                .expect("append() should succeed");
             lsn_after_write = writer.current_lsn();
         }
 
         // Reopen
         {
-            let writer = WalWriter::open(&path).unwrap();
+            let writer = WalWriter::open(&path).expect("open() should succeed");
             // Should continue from where we left off
             assert_eq!(writer.current_lsn(), lsn_after_write);
         }
@@ -615,12 +635,12 @@ mod tests {
     #[test]
     fn test_checkpoint_record() {
         let (_guard, path) = temp_wal("checkpoint");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
         // Checkpoint is same size as Begin (1 + 8 + 8 + 4 = 21)
         let lsn = writer
             .append(&WalRecord::Checkpoint { lsn: 12345 })
-            .unwrap();
+            .expect("value is present");
         assert_eq!(lsn, 8);
         assert_eq!(writer.current_lsn(), 8 + 21);
     }
@@ -632,7 +652,7 @@ mod tests {
     #[test]
     fn fresh_wal_has_durable_lsn_at_header_end() {
         let (_guard, path) = temp_wal("durable_init");
-        let writer = WalWriter::open(&path).unwrap();
+        let writer = WalWriter::open(&path).expect("open() should succeed");
         assert_eq!(writer.durable_lsn(), 8);
         assert_eq!(writer.current_lsn(), 8);
     }
@@ -640,63 +660,83 @@ mod tests {
     #[test]
     fn flush_until_below_durable_is_noop() {
         let (_guard, path) = temp_wal("flush_noop");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         // After open, durable_lsn == 8.
         let before = writer.durable_lsn();
-        writer.flush_until(0).unwrap();
-        writer.flush_until(8).unwrap();
+        writer.flush_until(0).expect("flush_until() should succeed");
+        writer.flush_until(8).expect("flush_until() should succeed");
         assert_eq!(writer.durable_lsn(), before);
     }
 
     #[test]
     fn flush_until_advances_durable_to_current() {
         let (_guard, path) = temp_wal("flush_advance");
-        let mut writer = WalWriter::open(&path).unwrap();
-        writer.append(&WalRecord::Begin { tx_id: 7 }).unwrap();
-        writer.append(&WalRecord::Commit { tx_id: 7 }).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
+        writer
+            .append(&WalRecord::Begin { tx_id: 7 })
+            .expect("append() should succeed");
+        writer
+            .append(&WalRecord::Commit { tx_id: 7 })
+            .expect("append() should succeed");
         let target = writer.current_lsn();
         // Before flush_until, durable still at the header.
         assert_eq!(writer.durable_lsn(), 8);
-        writer.flush_until(target).unwrap();
+        writer
+            .flush_until(target)
+            .expect("flush_until() should succeed");
         assert_eq!(writer.durable_lsn(), target);
     }
 
     #[test]
     fn flush_until_is_monotonic() {
         let (_guard, path) = temp_wal("flush_monotonic");
-        let mut writer = WalWriter::open(&path).unwrap();
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
         let lo = writer.current_lsn();
-        writer.flush_until(lo).unwrap();
+        writer
+            .flush_until(lo)
+            .expect("flush_until() should succeed");
         let durable_after_lo = writer.durable_lsn();
-        writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
+        writer
+            .append(&WalRecord::Commit { tx_id: 1 })
+            .expect("append() should succeed");
         let hi = writer.current_lsn();
-        writer.flush_until(hi).unwrap();
+        writer
+            .flush_until(hi)
+            .expect("flush_until() should succeed");
         assert!(writer.durable_lsn() >= durable_after_lo);
         // Calling flush_until(lo) after flush_until(hi) is a no-op.
-        writer.flush_until(lo).unwrap();
+        writer
+            .flush_until(lo)
+            .expect("flush_until() should succeed");
         assert_eq!(writer.durable_lsn(), hi);
     }
 
     #[test]
     fn sync_advances_durable_lsn_too() {
         let (_guard, path) = temp_wal("sync_durable");
-        let mut writer = WalWriter::open(&path).unwrap();
-        writer.append(&WalRecord::Begin { tx_id: 9 }).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
+        writer
+            .append(&WalRecord::Begin { tx_id: 9 })
+            .expect("append() should succeed");
         let before = writer.durable_lsn();
         let after_append = writer.current_lsn();
         assert!(after_append > before);
-        writer.sync().unwrap();
+        writer.sync().expect("sync() should succeed");
         assert_eq!(writer.durable_lsn(), after_append);
     }
 
     #[test]
     fn sync_all_is_used_when_wal_size_grew() {
         let (_guard, path) = temp_wal("sync_all_grew");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
 
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::All));
         assert!(writer.last_synced_size >= writer.current_lsn());
@@ -706,7 +746,7 @@ mod tests {
     #[test]
     fn sync_all_is_used_for_metadata_only_preallocation() {
         let (_guard, path) = temp_wal("sync_all_prealloc_metadata");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         if !writer.prealloc_supported {
             return;
         }
@@ -714,7 +754,7 @@ mod tests {
         assert_eq!(writer.current_lsn(), 8);
         assert!(writer.prealloc_metadata_dirty);
 
-        writer.sync().unwrap();
+        writer.sync().expect("sync() should succeed");
 
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::All));
         assert_eq!(writer.last_synced_size, writer.preallocated_to);
@@ -724,12 +764,14 @@ mod tests {
     #[test]
     fn sync_data_is_used_when_wal_size_is_unchanged() {
         let (_guard, path) = temp_wal("sync_data_unchanged");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
         let synced_size = writer.last_synced_size;
-        writer.sync().unwrap();
+        writer.sync().expect("sync() should succeed");
 
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::Data));
         assert_eq!(writer.last_synced_size, synced_size);
@@ -739,17 +781,21 @@ mod tests {
     #[test]
     fn sync_data_is_used_for_appends_within_synced_preallocation() {
         let (_guard, path) = temp_wal("sync_data_preallocated_append");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         if !writer.prealloc_supported {
             return;
         }
 
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::All));
 
-        writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Commit { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
 
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::Data));
         assert_eq!(writer.durable_lsn(), writer.current_lsn());
@@ -759,19 +805,25 @@ mod tests {
     #[test]
     fn group_sync_uses_sync_data_within_synced_preallocation() {
         let (_guard, path) = temp_wal("group_sync_data_preallocated_append");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         if !writer.prealloc_supported {
             return;
         }
 
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::All));
 
-        writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
-        let sync = writer.drain_for_group_sync().unwrap();
+        writer
+            .append(&WalRecord::Commit { tx_id: 1 })
+            .expect("append() should succeed");
+        let sync = writer
+            .drain_for_group_sync()
+            .expect("drain_for_group_sync() should succeed");
         assert_eq!(sync.method, WalSyncMethod::Data);
-        sync.sync().unwrap();
+        sync.sync().expect("sync() should succeed");
         writer.mark_durable(&sync);
 
         assert_eq!(writer.last_sync_method, Some(WalSyncMethod::Data));
@@ -781,11 +833,13 @@ mod tests {
     #[test]
     fn truncate_resets_durable_lsn() {
         let (_guard, path) = temp_wal("truncate_durable");
-        let mut writer = WalWriter::open(&path).unwrap();
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
         assert!(writer.durable_lsn() > 8);
-        writer.truncate().unwrap();
+        writer.truncate().expect("truncate() should succeed");
         assert_eq!(writer.durable_lsn(), 8);
         assert_eq!(writer.current_lsn(), 8);
     }
@@ -794,11 +848,13 @@ mod tests {
     fn reopen_initialises_durable_to_current() {
         let (_guard, path) = temp_wal("reopen_durable");
         {
-            let mut writer = WalWriter::open(&path).unwrap();
-            writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-            writer.sync().unwrap();
+            let mut writer = WalWriter::open(&path).expect("open() should succeed");
+            writer
+                .append(&WalRecord::Begin { tx_id: 1 })
+                .expect("append() should succeed");
+            writer.sync().expect("sync() should succeed");
         }
-        let writer = WalWriter::open(&path).unwrap();
+        let writer = WalWriter::open(&path).expect("open() should succeed");
         // After reopen, every byte on disk is durable by definition.
         assert_eq!(writer.durable_lsn(), writer.current_lsn());
     }
@@ -813,14 +869,18 @@ mod tests {
         // size must still equal the header (8 bytes) because the
         // bytes are sitting in the BufWriter, not in the kernel.
         let (_guard, path) = temp_wal("bufwriter_coalesce");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         for tx in 0..100u64 {
-            writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+            writer
+                .append(&WalRecord::Begin { tx_id: tx })
+                .expect("append() should succeed");
         }
         // current_lsn reflects the in-buffer position.
         assert_eq!(writer.current_lsn(), 8 + 100 * 21);
         // But the file on disk only has the header.
-        let on_disk = std::fs::metadata(&path).unwrap().len();
+        let on_disk = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(on_disk, 8, "BufWriter leaked bytes to disk before sync");
     }
 
@@ -829,12 +889,16 @@ mod tests {
         // After sync(), the file size must equal current_lsn — the
         // BufWriter has been flushed and sync_all has hit the kernel.
         let (_guard, path) = temp_wal("sync_drains");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         for tx in 0..50u64 {
-            writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+            writer
+                .append(&WalRecord::Begin { tx_id: tx })
+                .expect("append() should succeed");
         }
-        writer.sync().unwrap();
-        let on_disk = std::fs::metadata(&path).unwrap().len();
+        writer.sync().expect("sync() should succeed");
+        let on_disk = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(on_disk, writer.current_lsn());
         assert_eq!(writer.durable_lsn(), writer.current_lsn());
     }
@@ -845,13 +909,19 @@ mod tests {
         // sync_all on the underlying file — otherwise pending bytes
         // never become durable.
         let (_guard, path) = temp_wal("flush_until_drains");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         for tx in 0..30u64 {
-            writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+            writer
+                .append(&WalRecord::Begin { tx_id: tx })
+                .expect("append() should succeed");
         }
         let target = writer.current_lsn();
-        writer.flush_until(target).unwrap();
-        let on_disk = std::fs::metadata(&path).unwrap().len();
+        writer
+            .flush_until(target)
+            .expect("flush_until() should succeed");
+        let on_disk = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(on_disk, target);
         assert_eq!(writer.durable_lsn(), target);
     }
@@ -863,26 +933,42 @@ mod tests {
         // with stale records) or be lost. Verify the resulting file
         // contains only a fresh header.
         let (_guard, path) = temp_wal("truncate_drain");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         // Write enough small records to fill some of the 64 KiB buffer
         // but stay below the auto-flush threshold.
         for tx in 0..200u64 {
-            writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+            writer
+                .append(&WalRecord::Begin { tx_id: tx })
+                .expect("append() should succeed");
         }
         // Sanity: bytes are buffered.
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8);
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("metadata() should succeed")
+                .len(),
+            8
+        );
 
-        writer.truncate().unwrap();
+        writer.truncate().expect("truncate() should succeed");
         // After truncate the file is just the header again.
-        let on_disk = std::fs::metadata(&path).unwrap().len();
+        let on_disk = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(on_disk, 8);
         assert_eq!(writer.current_lsn(), 8);
         assert_eq!(writer.durable_lsn(), 8);
 
         // And we can append again successfully.
-        writer.append(&WalRecord::Begin { tx_id: 99 }).unwrap();
-        writer.sync().unwrap();
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8 + 21);
+        writer
+            .append(&WalRecord::Begin { tx_id: 99 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("metadata() should succeed")
+                .len(),
+            8 + 21
+        );
     }
 
     #[test]
@@ -898,14 +984,18 @@ mod tests {
         let (_guard, path) = temp_wal("reopen_synced_only");
         let synced_lsn;
         {
-            let mut writer = WalWriter::open(&path).unwrap();
-            writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-            writer.sync().unwrap();
+            let mut writer = WalWriter::open(&path).expect("open() should succeed");
+            writer
+                .append(&WalRecord::Begin { tx_id: 1 })
+                .expect("append() should succeed");
+            writer.sync().expect("sync() should succeed");
             synced_lsn = writer.current_lsn();
             // These records are never sync'd before drop. Drop runs
             // BufWriter::flush which DOES write them — see note below.
             for tx in 100..120u64 {
-                writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+                writer
+                    .append(&WalRecord::Begin { tx_id: tx })
+                    .expect("append() should succeed");
             }
             // Without a sync, the in-buffer bytes are still pending.
             // BufWriter's Drop impl does flush to the file but does
@@ -913,7 +1003,7 @@ mod tests {
             // bytes count regardless of fsync, so the reopened LSN
             // will reflect the dropped writes too.
         }
-        let writer = WalWriter::open(&path).unwrap();
+        let writer = WalWriter::open(&path).expect("open() should succeed");
         // The reopen LSN reflects what's physically on disk after
         // BufWriter::Drop flushes its buffer. That may or may not
         // include the unsync'd records depending on platform; the
@@ -929,8 +1019,8 @@ mod tests {
     /// allocated size (st_blocks × 512), independent of the logical length.
     fn allocated_bytes(path: &std::path::Path) -> u64 {
         use fs2::FileExt;
-        let f = std::fs::File::open(path).unwrap();
-        f.allocated_size().unwrap()
+        let f = std::fs::File::open(path).expect("open() should succeed");
+        f.allocated_size().expect("allocated_size() should succeed")
     }
 
     #[test]
@@ -965,7 +1055,7 @@ mod tests {
         // A freshly opened WAL must reserve a whole segment up front instead
         // of growing incrementally (acceptance #1).
         let (_guard, path) = temp_wal("prealloc_open");
-        let writer = WalWriter::open(&path).unwrap();
+        let writer = WalWriter::open(&path).expect("open() should succeed");
         if !writer.prealloc_supported {
             return; // filesystem without fallocate — feature is a no-op.
         }
@@ -973,7 +1063,12 @@ mod tests {
         // The reservation is real on disk, yet the logical file is still just
         // the 8-byte header.
         assert!(allocated_bytes(&path) >= reddb_file::MAIN_WAL_SEGMENT_BYTES);
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8);
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("metadata() should succeed")
+                .len(),
+            8
+        );
     }
 
     #[test]
@@ -984,12 +1079,16 @@ mod tests {
         // every filesystem (fallocate keeps i_size pinned; absent fallocate
         // there is no reservation at all).
         let (_guard, path) = temp_wal("prealloc_logical");
-        let mut writer = WalWriter::open(&path).unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
         for tx in 0..50u64 {
-            writer.append(&WalRecord::Begin { tx_id: tx }).unwrap();
+            writer
+                .append(&WalRecord::Begin { tx_id: tx })
+                .expect("append() should succeed");
         }
-        writer.sync().unwrap();
-        let logical = std::fs::metadata(&path).unwrap().len();
+        writer.sync().expect("sync() should succeed");
+        let logical = std::fs::metadata(&path)
+            .expect("metadata() should succeed")
+            .len();
         assert_eq!(logical, 8 + 50 * 21, "preallocation inflated i_size");
         assert_eq!(writer.current_lsn(), logical);
     }
@@ -999,14 +1098,21 @@ mod tests {
         // After checkpoint truncation the WAL must re-extend rather than grow
         // unbounded page-by-page (acceptance #2).
         let (_guard, path) = temp_wal("prealloc_truncate");
-        let mut writer = WalWriter::open(&path).unwrap();
-        writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
-        writer.sync().unwrap();
+        let mut writer = WalWriter::open(&path).expect("open() should succeed");
+        writer
+            .append(&WalRecord::Begin { tx_id: 1 })
+            .expect("append() should succeed");
+        writer.sync().expect("sync() should succeed");
 
-        writer.truncate().unwrap();
+        writer.truncate().expect("truncate() should succeed");
 
         assert_eq!(writer.current_lsn(), 8);
-        assert_eq!(std::fs::metadata(&path).unwrap().len(), 8);
+        assert_eq!(
+            std::fs::metadata(&path)
+                .expect("metadata() should succeed")
+                .len(),
+            8
+        );
         if writer.prealloc_supported {
             assert_eq!(writer.preallocated_to, reddb_file::MAIN_WAL_SEGMENT_BYTES);
             assert!(allocated_bytes(&path) >= reddb_file::MAIN_WAL_SEGMENT_BYTES);
@@ -1021,20 +1127,24 @@ mod tests {
         use super::super::reader::WalReader;
         let (_guard, path) = temp_wal("prealloc_recover");
         {
-            let mut writer = WalWriter::open(&path).unwrap();
-            writer.append(&WalRecord::Begin { tx_id: 1 }).unwrap();
+            let mut writer = WalWriter::open(&path).expect("open() should succeed");
+            writer
+                .append(&WalRecord::Begin { tx_id: 1 })
+                .expect("append() should succeed");
             writer
                 .append(&WalRecord::PageWrite {
                     tx_id: 1,
                     page_id: 7,
                     data: vec![1, 2, 3, 4],
                 })
-                .unwrap();
-            writer.append(&WalRecord::Commit { tx_id: 1 }).unwrap();
-            writer.sync().unwrap();
+                .expect("value is present");
+            writer
+                .append(&WalRecord::Commit { tx_id: 1 })
+                .expect("append() should succeed");
+            writer.sync().expect("sync() should succeed");
         }
         let records: Vec<_> = WalReader::open(&path)
-            .unwrap()
+            .expect("value is present")
             .iter()
             .collect::<Result<_, _>>()
             .expect("reader must stop cleanly at real EOF, not in reserved tail");


### PR DESCRIPTION
Automated AFK landing for #1258. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1258

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784555107&installation_id=129708444&pr_number=1266&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1266&signature=b204ea870ee87e43e3d8af998737a44360a0867ceef99e6266ad913292be6f00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->