### PR TITLE
merge: #1269 Provider capability matrix: modality dimension + MiniMax + DDL-time validation

### DIFF
--- a/crates/reddb-server/src/ai.rs
+++ b/crates/reddb-server/src/ai.rs
@@ -1549,6 +1549,7 @@ pub enum AiProvider {
     Venice,
     Ollama,
     DeepSeek,
+    MiniMax,
     HuggingFace,
     Local,
     Custom(String),
@@ -1565,6 +1566,7 @@ impl AiProvider {
             Self::Venice => "venice",
             Self::Ollama => "ollama",
             Self::DeepSeek => "deepseek",
+            Self::MiniMax => "minimax",
             Self::HuggingFace => "huggingface",
             Self::Local => "local",
             Self::Custom(name) => name.as_str(),
@@ -1581,6 +1583,7 @@ impl AiProvider {
             Self::Venice => "llama-3.3-70b",
             Self::Ollama => "llama3",
             Self::DeepSeek => "deepseek-chat",
+            Self::MiniMax => "abab6.5s-chat",
             Self::HuggingFace => "mistralai/Mistral-7B-Instruct-v0.3",
             Self::Local => "sentence-transformers/all-MiniLM-L6-v2",
             Self::Custom(_) => DEFAULT_OPENAI_PROMPT_MODEL,
@@ -1594,6 +1597,7 @@ impl AiProvider {
     pub fn default_embedding_model(&self) -> &str {
         match self {
             Self::Ollama => "nomic-embed-text",
+            Self::MiniMax => "embo-01",
             Self::HuggingFace | Self::Local => "sentence-transformers/all-MiniLM-L6-v2",
             _ => DEFAULT_OPENAI_EMBEDDING_MODEL,
         }
@@ -1609,6 +1613,7 @@ impl AiProvider {
             Self::Venice => "https://api.venice.ai/api/v1",
             Self::Ollama => "http://localhost:11434/v1",
             Self::DeepSeek => "https://api.deepseek.com/v1",
+            Self::MiniMax => "https://api.minimax.chat/v1",
             Self::HuggingFace => "https://api-inference.huggingface.co",
             Self::Local => "local",
             Self::Custom(base) => base.as_str(),
@@ -1675,6 +1680,7 @@ impl AiProvider {
                 | Self::Venice
                 | Self::Ollama
                 | Self::DeepSeek
+                | Self::MiniMax
                 | Self::Custom(_)
         )
     }
@@ -1696,6 +1702,7 @@ pub fn parse_provider(name: &str) -> crate::RedDBResult<AiProvider> {
         "venice" => Ok(AiProvider::Venice),
         "ollama" => Ok(AiProvider::Ollama),
         "deepseek" | "deep_seek" => Ok(AiProvider::DeepSeek),
+        "minimax" | "mini_max" => Ok(AiProvider::MiniMax),
         "huggingface" | "hf" => Ok(AiProvider::HuggingFace),
         "local" => Ok(AiProvider::Local),
         other => {
@@ -1705,7 +1712,7 @@ pub fn parse_provider(name: &str) -> crate::RedDBResult<AiProvider> {
             } else {
                 Err(crate::RedDBError::Query(format!(
                     "unsupported AI provider '{other}'; expected: openai, anthropic, groq, \
-                     openrouter, together, venice, ollama, deepseek, huggingface, local"
+                     openrouter, together, venice, ollama, deepseek, minimax, huggingface, local"
                 )))
             }
         }

--- a/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
+++ b/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
@@ -135,6 +135,190 @@ impl Capabilities {
     }
 }
 
+/// A service modality an AI provider+model can be asked to perform.
+///
+/// Orthogonal to the text-chat flags on [`Capabilities`] (citations /
+/// seed / streaming): a provider can be excellent at strict text chat
+/// yet have no embeddings endpoint at all (Anthropic), or be an
+/// embeddings-only backend that cannot generate (the embedded `local`
+/// model). The modality matrix records *which kinds of request* a
+/// provider+model can serve, so a policy that wires the wrong provider
+/// to a job is rejected at DDL time instead of failing at call time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Modality {
+    /// Produce embedding vectors for text (`/embeddings`).
+    Embed,
+    /// Generate free-form text from a prompt (`/chat/completions`).
+    Generate,
+    /// Accept image input alongside text (multimodal vision).
+    Vision,
+    /// Classify content against a safety taxonomy (`/moderations`).
+    Moderate,
+}
+
+impl Modality {
+    /// Canonical lower-case token, the form used in policy DDL.
+    pub fn token(self) -> &'static str {
+        match self {
+            Self::Embed => "embed",
+            Self::Generate => "generate",
+            Self::Vision => "vision",
+            Self::Moderate => "moderate",
+        }
+    }
+
+    /// Parse a policy-DDL token (case-insensitive). A couple of common
+    /// synonyms are accepted so `embedding` / `chat` don't surprise.
+    pub fn parse(token: &str) -> Option<Self> {
+        match token.trim().to_ascii_lowercase().as_str() {
+            "embed" | "embedding" | "embeddings" => Some(Self::Embed),
+            "generate" | "generation" | "chat" | "completion" => Some(Self::Generate),
+            "vision" | "image" | "multimodal" => Some(Self::Vision),
+            "moderate" | "moderation" => Some(Self::Moderate),
+            _ => None,
+        }
+    }
+
+    /// All four modalities, for exhaustive iteration in tests / catalogs.
+    pub const ALL: [Self; 4] = [Self::Embed, Self::Generate, Self::Vision, Self::Moderate];
+}
+
+/// Which modalities a provider+model can serve. Each axis is an
+/// independently testable flag, mirroring the [`Capabilities`] shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Modalities {
+    pub embed: bool,
+    pub generate: bool,
+    pub vision: bool,
+    pub moderate: bool,
+}
+
+impl Modalities {
+    /// Conservative defaults for a token the registry has no row for.
+    ///
+    /// An unknown OpenAI-compatible endpoint can plausibly serve the two
+    /// universal text modalities — embeddings and generation — but we
+    /// must *not* assume it offers vision (multimodal input) or a
+    /// moderation endpoint, since those are specialised products. So a
+    /// policy that requests `vision`/`moderate` against an undeclared
+    /// provider is rejected until the operator supplies an override.
+    /// This matches the spirit of [`Capabilities::conservative`]: deny
+    /// the capabilities you cannot verify.
+    pub const fn conservative() -> Self {
+        Self {
+            embed: true,
+            generate: true,
+            vision: false,
+            moderate: false,
+        }
+    }
+
+    /// Whether this row can serve `modality`.
+    pub fn supports(&self, modality: Modality) -> bool {
+        match modality {
+            Modality::Embed => self.embed,
+            Modality::Generate => self.generate,
+            Modality::Vision => self.vision,
+            Modality::Moderate => self.moderate,
+        }
+    }
+
+    /// Built-in modality row for a canonical provider token. Unknown
+    /// tokens get [`Modalities::conservative`].
+    ///
+    /// Defaults are rules of thumb based on each provider's public
+    /// product surface (overridable per deployment):
+    ///
+    /// - **openai**: the full matrix — embeddings, chat, gpt-4o vision,
+    ///   and a moderation endpoint.
+    /// - **anthropic**: chat + vision, but no embeddings product and no
+    ///   moderation endpoint.
+    /// - **minimax**: OpenAI-compatible chat, embeddings, and vision
+    ///   (abab multimodal models); no moderation endpoint.
+    /// - **together / ollama**: chat, embeddings, and vision-capable
+    ///   open models; no moderation.
+    /// - **groq / openrouter / venice**: chat + vision, no first-party
+    ///   embeddings, no moderation.
+    /// - **deepseek**: chat only.
+    /// - **huggingface**: raw inference for embeddings + generation; no
+    ///   uniform vision/moderation surface.
+    /// - **local**: embeddings-only backend — generation is out of
+    ///   scope (mirrors the embeddings-only HTTP reject).
+    /// - **custom / unknown**: [`Modalities::conservative`].
+    pub fn for_provider(token: &str) -> Self {
+        match token {
+            "openai" => Self {
+                embed: true,
+                generate: true,
+                vision: true,
+                moderate: true,
+            },
+            "anthropic" => Self {
+                embed: false,
+                generate: true,
+                vision: true,
+                moderate: false,
+            },
+            "minimax" | "together" | "ollama" => Self {
+                embed: true,
+                generate: true,
+                vision: true,
+                moderate: false,
+            },
+            "groq" | "openrouter" | "venice" => Self {
+                embed: false,
+                generate: true,
+                vision: true,
+                moderate: false,
+            },
+            "deepseek" => Self {
+                embed: false,
+                generate: true,
+                vision: false,
+                moderate: false,
+            },
+            "huggingface" => Self {
+                embed: true,
+                generate: true,
+                vision: false,
+                moderate: false,
+            },
+            "local" => Self {
+                embed: true,
+                generate: false,
+                vision: false,
+                moderate: false,
+            },
+            "custom" => Self::conservative(),
+            _ => Self::conservative(),
+        }
+    }
+}
+
+/// Rejection returned by the DDL-time / call-time modality gate when a
+/// policy wires a provider+model to a job it cannot serve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModalityValidationError {
+    /// Provider token as written in the policy.
+    pub provider: String,
+    /// Model name as written in the policy (informational — the gate
+    /// decides on the provider row; the model is surfaced for context
+    /// and reserved for future per-model overrides).
+    pub model: String,
+    /// The modality the policy requested.
+    pub modality: Modality,
+    /// Operator-actionable explanation.
+    pub message: String,
+}
+
+impl std::fmt::Display for ModalityValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ModalityValidationError {}
+
 /// Why the effective mode differs from the requested mode. The caller
 /// surfaces this as a structured warning entry on the ASK response.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -192,6 +376,7 @@ impl ModeOutcome {
 #[derive(Debug, Clone, Default)]
 pub struct Registry {
     overrides: HashMap<String, Capabilities>,
+    modality_overrides: HashMap<String, Modalities>,
 }
 
 impl Registry {
@@ -201,6 +386,7 @@ impl Registry {
     pub fn new() -> Self {
         Self {
             overrides: HashMap::new(),
+            modality_overrides: HashMap::new(),
         }
     }
 
@@ -219,6 +405,64 @@ impl Registry {
             return *c;
         }
         Capabilities::for_provider(&key)
+    }
+
+    /// Replace the modality row for `token` (lower-cased before
+    /// storage). Like [`Registry::with_override`], this is a complete
+    /// replacement, not a partial merge. Returns `self` for chaining.
+    pub fn with_modality_override(mut self, token: &str, modalities: Modalities) -> Self {
+        self.modality_overrides
+            .insert(token.to_ascii_lowercase(), modalities);
+        self
+    }
+
+    /// Look up the modality row for a provider token, applying any
+    /// per-deployment override on top of the built-in row.
+    pub fn modalities(&self, token: &str) -> Modalities {
+        let key = token.to_ascii_lowercase();
+        if let Some(m) = self.modality_overrides.get(&key) {
+            return *m;
+        }
+        Modalities::for_provider(&key)
+    }
+
+    /// Deterministic answer to "can provider `token` (+ `model`) serve
+    /// `modality`?". The model is accepted for signature completeness
+    /// and future per-model overrides; today the decision is driven by
+    /// the provider row.
+    pub fn can_serve(&self, token: &str, _model: &str, modality: Modality) -> bool {
+        self.modalities(token).supports(modality)
+    }
+
+    /// DDL-time (and call-time) gate: reject a policy that wires
+    /// `provider`/`model` to a `modality` it cannot serve.
+    ///
+    /// `Ok(())` means the policy is admissible. The `Err` carries an
+    /// operator-actionable message naming the provider, model, and the
+    /// unsupported modality. Use this both when a `CREATE … POLICY`
+    /// statement is parsed (fail fast, before the policy is stored) and
+    /// at call time as a defence-in-depth check.
+    pub fn validate_policy_modality(
+        &self,
+        provider: &str,
+        model: &str,
+        modality: Modality,
+    ) -> Result<(), ModalityValidationError> {
+        if self.can_serve(provider, model, modality) {
+            return Ok(());
+        }
+        Err(ModalityValidationError {
+            provider: provider.to_string(),
+            model: model.to_string(),
+            modality,
+            message: format!(
+                "AI policy is invalid: provider '{}' (model '{}') cannot serve the '{}' modality; \
+                 declare a provider that supports it or register a modality override",
+                provider.to_ascii_lowercase(),
+                model,
+                modality.token()
+            ),
+        })
     }
 
     /// Decide what mode the caller should actually run in, given the
@@ -539,5 +783,151 @@ mod tests {
             Capabilities::for_provider("custom"),
             Capabilities::conservative()
         );
+    }
+
+    // ---- modality matrix -------------------------------------------------
+
+    #[test]
+    fn modality_token_roundtrips_through_parse() {
+        for m in Modality::ALL {
+            assert_eq!(Modality::parse(m.token()), Some(m), "{m:?}");
+        }
+        // case-insensitive + common synonyms
+        assert_eq!(Modality::parse("EMBEDDING"), Some(Modality::Embed));
+        assert_eq!(Modality::parse("chat"), Some(Modality::Generate));
+        assert_eq!(Modality::parse("image"), Some(Modality::Vision));
+        assert_eq!(Modality::parse("moderation"), Some(Modality::Moderate));
+        assert_eq!(Modality::parse("nonsense"), None);
+    }
+
+    #[test]
+    fn unknown_provider_gets_conservative_modalities() {
+        // AC: unknown token → conservative defaults (the two universal
+        // text modalities allowed, specialised ones denied).
+        let c = Modalities::for_provider("totally-made-up");
+        assert_eq!(c, Modalities::conservative());
+        assert!(c.embed);
+        assert!(c.generate);
+        assert!(!c.vision);
+        assert!(!c.moderate);
+        // `custom` shares the conservative row.
+        assert_eq!(
+            Modalities::for_provider("custom"),
+            Modalities::conservative()
+        );
+    }
+
+    #[test]
+    fn openai_serves_every_modality() {
+        let c = Modalities::for_provider("openai");
+        for m in Modality::ALL {
+            assert!(c.supports(m), "openai should serve {m:?}");
+        }
+    }
+
+    #[test]
+    fn minimax_serves_embed_generate_vision_not_moderate() {
+        let c = Modalities::for_provider("minimax");
+        assert!(c.supports(Modality::Embed));
+        assert!(c.supports(Modality::Generate));
+        assert!(c.supports(Modality::Vision));
+        assert!(!c.supports(Modality::Moderate));
+    }
+
+    #[test]
+    fn anthropic_cannot_embed() {
+        // Anthropic has no embeddings product (pinned elsewhere in the
+        // multi-provider contract tests).
+        assert!(!Modalities::for_provider("anthropic").supports(Modality::Embed));
+        assert!(Modalities::for_provider("anthropic").supports(Modality::Generate));
+    }
+
+    #[test]
+    fn local_is_embeddings_only() {
+        let c = Modalities::for_provider("local");
+        assert!(c.supports(Modality::Embed));
+        assert!(!c.supports(Modality::Generate));
+        assert!(!c.supports(Modality::Vision));
+        assert!(!c.supports(Modality::Moderate));
+    }
+
+    #[test]
+    fn deepseek_is_generate_only() {
+        let c = Modalities::for_provider("deepseek");
+        assert!(c.supports(Modality::Generate));
+        assert!(!c.supports(Modality::Embed));
+        assert!(!c.supports(Modality::Vision));
+        assert!(!c.supports(Modality::Moderate));
+    }
+
+    #[test]
+    fn can_serve_is_case_insensitive_and_deterministic() {
+        let r = Registry::new();
+        for _ in 0..8 {
+            assert!(r.can_serve("OpenAI", "gpt-4o", Modality::Vision));
+            assert!(!r.can_serve("LOCAL", "all-MiniLM", Modality::Generate));
+        }
+    }
+
+    #[test]
+    fn validate_rejects_incapable_provider_modality() {
+        let r = Registry::new();
+        let err = r
+            .validate_policy_modality("local", "all-MiniLM-L6-v2", Modality::Generate)
+            .expect_err("local cannot generate");
+        assert_eq!(err.provider, "local");
+        assert_eq!(err.modality, Modality::Generate);
+        let msg = err.to_string();
+        assert!(msg.contains("local"), "{msg}");
+        assert!(msg.contains("generate"), "{msg}");
+        assert!(msg.contains("all-MiniLM-L6-v2"), "{msg}");
+    }
+
+    #[test]
+    fn validate_accepts_capable_provider_modality() {
+        let r = Registry::new();
+        assert!(r
+            .validate_policy_modality("openai", "text-embedding-3-small", Modality::Embed)
+            .is_ok());
+        assert!(r
+            .validate_policy_modality("minimax", "abab6.5s-chat", Modality::Vision)
+            .is_ok());
+    }
+
+    #[test]
+    fn modality_override_completely_replaces_builtin_row() {
+        // Operator declares that their pinned DeepSeek deployment also
+        // exposes an embeddings endpoint.
+        let upgraded = Modalities {
+            embed: true,
+            generate: true,
+            vision: false,
+            moderate: false,
+        };
+        let r = Registry::new().with_modality_override("deepseek", upgraded);
+        assert_eq!(r.modalities("deepseek"), upgraded);
+        assert!(r
+            .validate_policy_modality("deepseek", "deepseek-embed", Modality::Embed)
+            .is_ok());
+        // Unrelated providers keep their built-in rows.
+        assert_eq!(r.modalities("openai"), Modalities::for_provider("openai"));
+    }
+
+    #[test]
+    fn modality_override_can_revoke_a_builtin_capability() {
+        // A locked-down OpenAI deployment with vision disabled.
+        let restricted = Modalities {
+            embed: true,
+            generate: true,
+            vision: false,
+            moderate: false,
+        };
+        let r = Registry::new().with_modality_override("OpenAI", restricted);
+        // Stored lower-cased, so any-case lookup finds it.
+        assert_eq!(r.modalities("openai"), restricted);
+        let err = r
+            .validate_policy_modality("openai", "gpt-4o", Modality::Vision)
+            .expect_err("vision revoked by override");
+        assert_eq!(err.modality, Modality::Vision);
     }
 }

--- a/crates/reddb-server/src/server/handlers_capabilities.rs
+++ b/crates/reddb-server/src/server/handlers_capabilities.rs
@@ -68,6 +68,7 @@ impl RedDBServer {
             crate::ai::AiProvider::Venice,
             crate::ai::AiProvider::Ollama,
             crate::ai::AiProvider::DeepSeek,
+            crate::ai::AiProvider::MiniMax,
             crate::ai::AiProvider::HuggingFace,
             crate::ai::AiProvider::Local,
         ]

--- a/tests/grouped/ai_provider_contracts/integration_ai_multi_provider.rs
+++ b/tests/grouped/ai_provider_contracts/integration_ai_multi_provider.rs
@@ -14,9 +14,10 @@
 #[path = "../../support/mod.rs"]
 mod support;
 
-use reddb::ai::{grpc_embeddings, parse_provider};
+use reddb::ai::{grpc_embeddings, parse_provider, AiProvider};
 use reddb::application::{ExecuteQueryInput, QueryUseCases, SearchSimilarInput};
 use reddb::json::{Map, Value as JsonValue};
+use reddb::runtime::ai::provider_capabilities::{Modality, Registry};
 use reddb::server::RedDBServer;
 use reddb::RedDBRuntime;
 use std::io::{Read, Write};
@@ -93,12 +94,94 @@ fn parse_provider_accepts_all_readme_keywords() {
         "together",
         "venice",
         "deepseek",
+        "minimax",
         "huggingface",
         "ollama",
         "local",
     ] {
         parse_provider(name).unwrap_or_else(|e| panic!("parse_provider({name}) failed: {e}"));
     }
+}
+
+#[test]
+fn parse_provider_accepts_minimax_and_resolves_openai_compatible_base() {
+    // MiniMax is OpenAI-compatible transport: parse must succeed, the
+    // provider must report itself as compatible, and resolve a v1 base.
+    let provider = parse_provider("minimax").expect("minimax should parse");
+    assert_eq!(provider, AiProvider::MiniMax);
+    assert_eq!(provider.token(), "minimax");
+    assert!(
+        provider.is_openai_compatible(),
+        "minimax uses the OpenAI-compatible transport"
+    );
+    let base = provider.default_api_base();
+    assert!(base.starts_with("https://"), "{base}");
+    assert!(base.ends_with("/v1"), "{base}");
+    // Snake-case alias also resolves.
+    assert_eq!(
+        parse_provider("mini_max").expect("mini_max alias"),
+        AiProvider::MiniMax
+    );
+}
+
+#[test]
+fn ddl_modality_gate_rejects_incapable_and_accepts_capable() {
+    // The DDL-time validation entry point: a policy that wires an
+    // embeddings-only `local` backend to a generation job is rejected
+    // with a clear, operator-actionable message; a capable pairing is
+    // admitted. Mirrors the provider-gate style of the other contracts.
+    let registry = Registry::new();
+
+    let err = registry
+        .validate_policy_modality("local", "all-MiniLM-L6-v2", Modality::Generate)
+        .expect_err("local cannot generate");
+    let msg = err.to_string();
+    let lower = msg.to_ascii_lowercase();
+    assert!(
+        lower.contains("local"),
+        "error must name the provider: {msg}"
+    );
+    assert!(
+        lower.contains("generate"),
+        "error must name the modality: {msg}"
+    );
+    assert!(
+        lower.contains("cannot serve") || lower.contains("invalid"),
+        "error must explain the rejection: {msg}"
+    );
+
+    // MiniMax can serve embeddings, generation, and vision.
+    registry
+        .validate_policy_modality("minimax", "abab6.5s-chat", Modality::Vision)
+        .expect("minimax serves vision");
+    registry
+        .validate_policy_modality("minimax", "embo-01", Modality::Embed)
+        .expect("minimax serves embeddings");
+}
+
+#[test]
+fn ddl_modality_gate_honours_override_and_unknown_conservative_default() {
+    // Unknown provider falls back to conservative defaults: the two
+    // universal text modalities are allowed, specialised ones denied.
+    let registry = Registry::new();
+    assert!(registry.can_serve("brand-new-llm", "m", Modality::Generate));
+    assert!(registry.can_serve("brand-new-llm", "m", Modality::Embed));
+    assert!(!registry.can_serve("brand-new-llm", "m", Modality::Vision));
+
+    // A per-deployment override is honoured by the gate.
+    let upgraded = reddb::runtime::ai::provider_capabilities::Modalities {
+        embed: false,
+        generate: true,
+        vision: true,
+        moderate: false,
+    };
+    let registry = registry.with_modality_override("brand-new-llm", upgraded);
+    registry
+        .validate_policy_modality("brand-new-llm", "m", Modality::Vision)
+        .expect("override grants vision");
+    assert!(registry
+        .validate_policy_modality("brand-new-llm", "m", Modality::Embed)
+        .is_err());
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1269. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1269

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784567337&installation_id=129708444&pr_number=1277&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1277&signature=ebe3a489044b644ba668f506c143e7059653bd35dd606206cc3c2942afb22d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->