### PR TITLE
merge: #1272 Auto-embed per collection over CDC (births the enrichment consumer: pending/retry/dead-letter/exclusion)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -90,6 +90,19 @@ fn ensure_collection_model_contract(
         if collection_model_allows(contract.declared_model, requested_model) {
             return Ok(());
         }
+        // A collection that declares an EMBED policy (#1271/#1272) holds its
+        // rows' enrichment vectors in place: the CDC enrichment consumer
+        // attaches vectors into the same collection so `VECTOR SEARCH` over
+        // it surfaces the embedded rows. Permit vector writes on such a
+        // collection even when it is otherwise a strict table.
+        if requested_model == crate::catalog::CollectionModel::Vector
+            && contract
+                .ai_policy
+                .as_ref()
+                .is_some_and(|policy| policy.embed.is_some())
+        {
+            return Ok(());
+        }
         return Err(crate::RedDBError::InvalidOperation(format!(
             "collection '{}' is declared as '{}' and does not allow '{}' writes",
             collection,

--- a/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
+++ b/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
@@ -1,0 +1,360 @@
+//! CDC enrichment consumer (#1272, PRD #1267) — the first end-to-end AI
+//! modality wired over the existing change stream.
+//!
+//! A collection that declares an `EMBED (...)` policy (issue #1271) gets
+//! its declared fields auto-vectorised *asynchronously* after commit. The
+//! write path itself does no provider work: an INSERT/UPDATE simply emits
+//! its usual CDC event and returns. This consumer is the thing that, on a
+//! later pass, drains the LSN-ordered change stream, recomputes embeddings
+//! for committed rows via the policy's provider, and attaches the vectors
+//! into the collection (reusing the existing `create_vector` +
+//! local-embedding machinery).
+//!
+//! Because a row is only searchable once its vector exists, "pending"
+//! enrichment is naturally excluded from `VECTOR SEARCH` until the consumer
+//! attaches the vector — at which point the row is included like any other.
+//! The consumer additionally owns:
+//!   - a `pending` work set (rows whose enrichment hasn't completed),
+//!   - retry-with-backoff on provider failure,
+//!   - a dead-letter list after a bounded number of failures, and
+//!   - an ops re-drive path that moves dead-letters back to pending.
+//!
+//! The consumer is driven explicitly via [`CdcEnrichmentConsumer::tick`],
+//! which takes the current time so retry backoff is deterministic in tests
+//! and a production scheduler can drive it from a background thread without
+//! changing the semantics.
+
+use crate::application::entity::CreateVectorInput;
+use crate::application::ports::RuntimeEntityPort;
+use crate::catalog::EmbedPolicy;
+use crate::replication::cdc::ChangeOperation;
+use crate::storage::schema::Value;
+use crate::storage::{EntityData, EntityId};
+use crate::{RedDBError, RedDBResult, RedDBRuntime};
+
+/// Tunables for the enrichment consumer.
+#[derive(Debug, Clone)]
+pub struct EnrichmentConfig {
+    /// Number of provider attempts before a work item is dead-lettered.
+    /// Must be `>= 1`.
+    pub max_attempts: u32,
+    /// Base backoff applied after the first failure; subsequent failures
+    /// back off exponentially (`base * 2^(attempts-1)`).
+    pub base_backoff_ms: u64,
+    /// Maximum number of CDC events ingested per `tick`.
+    pub poll_max: usize,
+}
+
+impl Default for EnrichmentConfig {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            base_backoff_ms: 100,
+            poll_max: 1024,
+        }
+    }
+}
+
+/// A row awaiting enrichment.
+#[derive(Debug, Clone)]
+struct PendingWork {
+    collection: String,
+    entity_id: u64,
+    attempts: u32,
+    /// Earliest wall-clock (unix ms) at which the next attempt may run.
+    not_before_ms: u64,
+}
+
+/// A work item that exhausted its retry budget. Surfaced to operators and
+/// re-drivable via [`CdcEnrichmentConsumer::redrive`].
+#[derive(Debug, Clone)]
+pub struct DeadLetter {
+    pub collection: String,
+    pub entity_id: u64,
+    pub attempts: u32,
+    pub last_error: String,
+}
+
+/// Per-`tick` outcome counters.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TickStats {
+    /// CDC events accepted into the pending set this tick.
+    pub ingested: usize,
+    /// Rows whose vectors were attached this tick.
+    pub attached: usize,
+    /// Failed attempts re-scheduled with backoff this tick.
+    pub retried: usize,
+    /// Work items dead-lettered this tick.
+    pub dead_lettered: usize,
+}
+
+/// Drains the CDC stream and enriches embed-policy collections.
+///
+/// Holds its own cursor, pending set, and dead-letter list — one consumer
+/// instance owns the enrichment state for a runtime.
+pub struct CdcEnrichmentConsumer {
+    cursor: u64,
+    config: EnrichmentConfig,
+    pending: Vec<PendingWork>,
+    dead_letters: Vec<DeadLetter>,
+}
+
+impl CdcEnrichmentConsumer {
+    /// New consumer starting from the stream origin (LSN 0) with the given
+    /// config.
+    pub fn new(config: EnrichmentConfig) -> Self {
+        Self {
+            cursor: 0,
+            config,
+            pending: Vec::new(),
+            dead_letters: Vec::new(),
+        }
+    }
+
+    /// New consumer with default tunables.
+    pub fn with_defaults() -> Self {
+        Self::new(EnrichmentConfig::default())
+    }
+
+    /// Last CDC LSN this consumer has ingested.
+    pub fn cursor(&self) -> u64 {
+        self.cursor
+    }
+
+    /// Rows currently awaiting enrichment.
+    pub fn pending_len(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// True while `(collection, entity_id)` is still awaiting enrichment.
+    pub fn is_pending(&self, collection: &str, entity_id: u64) -> bool {
+        self.pending
+            .iter()
+            .any(|w| w.collection == collection && w.entity_id == entity_id)
+    }
+
+    /// Dead-lettered work items (enrichment failed past the retry budget).
+    pub fn dead_letters(&self) -> &[DeadLetter] {
+        &self.dead_letters
+    }
+
+    /// Ops re-drive: move every dead-letter back into the pending set with a
+    /// fresh retry budget. Returns the number of items re-driven.
+    pub fn redrive(&mut self) -> usize {
+        let drained: Vec<DeadLetter> = self.dead_letters.drain(..).collect();
+        let count = drained.len();
+        for dl in drained {
+            self.enqueue(dl.collection, dl.entity_id);
+        }
+        count
+    }
+
+    /// Ingest newly committed CDC events and then attempt every pending item
+    /// whose backoff has elapsed. Embedding work happens here, never on the
+    /// write path — so write latency is independent of provider latency.
+    pub fn tick(&mut self, rt: &RedDBRuntime, now_ms: u64) -> RedDBResult<TickStats> {
+        let mut stats = TickStats::default();
+
+        // 1. Ingest committed change events for embed-policy collections.
+        let events = rt.cdc_poll(self.cursor, self.config.poll_max);
+        for event in &events {
+            if event.lsn > self.cursor {
+                self.cursor = event.lsn;
+            }
+            let Some(policy) = rt.collection_embed_policy(&event.collection) else {
+                continue;
+            };
+            if !change_touches_embed_fields(event, &policy) {
+                continue;
+            }
+            if self.enqueue(event.collection.clone(), event.entity_id) {
+                stats.ingested += 1;
+            }
+        }
+
+        // 2. Attempt every ready pending item.
+        let drained: Vec<PendingWork> = std::mem::take(&mut self.pending);
+        let mut still_pending = Vec::with_capacity(drained.len());
+        for mut work in drained {
+            if work.not_before_ms > now_ms {
+                still_pending.push(work);
+                continue;
+            }
+            // The policy can disappear if the collection was dropped/altered
+            // between enqueue and drain — quietly forget such work.
+            let Some(policy) = rt.collection_embed_policy(&work.collection) else {
+                continue;
+            };
+            match rt.enrich_row_embedding(&work.collection, work.entity_id, &policy) {
+                Ok(()) => stats.attached += 1,
+                Err(err) => {
+                    work.attempts += 1;
+                    if work.attempts >= self.config.max_attempts {
+                        self.dead_letters.push(DeadLetter {
+                            collection: work.collection,
+                            entity_id: work.entity_id,
+                            attempts: work.attempts,
+                            last_error: format!("{err:?}"),
+                        });
+                        stats.dead_lettered += 1;
+                    } else {
+                        let shift = work.attempts - 1;
+                        let backoff = self
+                            .config
+                            .base_backoff_ms
+                            .saturating_mul(1u64.checked_shl(shift).unwrap_or(u64::MAX));
+                        work.not_before_ms = now_ms.saturating_add(backoff);
+                        still_pending.push(work);
+                        stats.retried += 1;
+                    }
+                }
+            }
+        }
+        self.pending = still_pending;
+
+        Ok(stats)
+    }
+
+    /// Add a row to the pending set unless it is already queued. Returns
+    /// true when a new item was enqueued.
+    fn enqueue(&mut self, collection: String, entity_id: u64) -> bool {
+        if self
+            .pending
+            .iter()
+            .any(|w| w.entity_id == entity_id && w.collection == collection)
+        {
+            return false;
+        }
+        self.pending.push(PendingWork {
+            collection,
+            entity_id,
+            attempts: 0,
+            not_before_ms: 0,
+        });
+        true
+    }
+}
+
+/// Whether a change event should (re)enrich the row under `policy`.
+///
+/// Inserts always enrich. Updates enrich when the damage vector intersects
+/// the declared embed fields, or when no damage vector is available (the
+/// emitter didn't compute one — enrich conservatively). Deletes/refreshes
+/// never enrich.
+fn change_touches_embed_fields(
+    event: &crate::replication::cdc::ChangeEvent,
+    policy: &EmbedPolicy,
+) -> bool {
+    match event.operation {
+        ChangeOperation::Insert => true,
+        ChangeOperation::Update => match &event.changed_columns {
+            Some(columns) => columns
+                .iter()
+                .any(|column| policy.fields.iter().any(|field| field == column)),
+            None => true,
+        },
+        ChangeOperation::Delete | ChangeOperation::Refresh => false,
+    }
+}
+
+impl RedDBRuntime {
+    /// The declared embed policy for `collection`, if any.
+    pub fn collection_embed_policy(&self, collection: &str) -> Option<EmbedPolicy> {
+        self.db()
+            .collection_contract_arc(collection)
+            .and_then(|contract| contract.ai_policy.as_ref().and_then(|p| p.embed.clone()))
+    }
+
+    /// Compute the embedding for one committed row and attach it as a vector
+    /// in the same collection. Reuses the existing embedding + vector
+    /// storage path so `VECTOR SEARCH` surfaces the row exactly as a manual
+    /// `WITH AUTO EMBED` insert would.
+    ///
+    /// A row whose declared fields are all empty is treated as complete (no
+    /// vector attached) rather than failed — there is nothing to embed.
+    pub(crate) fn enrich_row_embedding(
+        &self,
+        collection: &str,
+        entity_id: u64,
+        policy: &EmbedPolicy,
+    ) -> RedDBResult<()> {
+        let db = self.db();
+        // The CDC event carries the row's stable *logical* id; resolve the
+        // live version through it so an update re-embeds the new field values
+        // rather than a superseded MVCC version. A `None` here means the
+        // event was not a live table row (e.g. the enrichment vector's own
+        // insert event, or a deleted row) — nothing to enrich.
+        let Some(entity) = db
+            .store()
+            .get_table_row_by_logical_id(collection, EntityId::new(entity_id))
+        else {
+            return Ok(());
+        };
+
+        let Some(text) = combine_embed_text(&entity.data, &policy.fields) else {
+            return Ok(());
+        };
+
+        let dense = embed_one(self, policy, &text)?;
+        if dense.is_empty() {
+            return Ok(());
+        }
+
+        self.create_vector(CreateVectorInput {
+            collection: collection.to_string(),
+            dense,
+            content: Some(text),
+            metadata: Vec::new(),
+            link_row: None,
+            link_node: None,
+        })?;
+        Ok(())
+    }
+}
+
+/// Join the declared embed fields' text values, mirroring the manual
+/// `WITH AUTO EMBED` collector. Returns `None` when no non-empty text field
+/// is present (e.g. the entity is a vector/non-row, or all fields are empty).
+fn combine_embed_text(data: &EntityData, fields: &[String]) -> Option<String> {
+    let EntityData::Row(row) = data else {
+        return None;
+    };
+    let named = row.named.as_ref()?;
+    let texts: Vec<String> = fields
+        .iter()
+        .filter_map(|field| match named.get(field) {
+            Some(Value::Text(t)) if !t.is_empty() => Some(t.to_string()),
+            _ => None,
+        })
+        .collect();
+    if texts.is_empty() {
+        None
+    } else {
+        Some(texts.join(" "))
+    }
+}
+
+/// Dispatch a single embedding through the policy's provider. This slice
+/// drives the in-process `local` backend (the path the issue's mock
+/// provider exercises); other providers are rejected with a deterministic
+/// error that the retry/dead-letter machinery handles like any failure.
+fn embed_one(rt: &RedDBRuntime, policy: &EmbedPolicy, text: &str) -> RedDBResult<Vec<f32>> {
+    let provider = crate::ai::parse_provider(&policy.provider)?;
+    match provider {
+        crate::ai::AiProvider::Local => {
+            let db = rt.db();
+            let response = crate::runtime::ai::local_embedding::embed_local_with_db(
+                &db,
+                &policy.model,
+                vec![text.to_string()],
+            )?;
+            response.embeddings.into_iter().next().ok_or_else(|| {
+                RedDBError::Query("local embedding backend returned no vector".to_string())
+            })
+        }
+        other => Err(RedDBError::Query(format!(
+            "CDC enrichment currently drives the 'local' provider; \
+             collection policy declares '{other:?}'"
+        ))),
+    }
+}

--- a/crates/reddb-server/src/runtime/ai/mod.rs
+++ b/crates/reddb-server/src/runtime/ai/mod.rs
@@ -17,6 +17,7 @@ pub mod ask_response_envelope;
 pub mod ask_rql_planner;
 pub mod audit_record_builder;
 pub mod batch_client;
+pub mod cdc_enrichment;
 pub mod citation_parser;
 pub mod cost_guard;
 pub mod dedup_cache;

--- a/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
+++ b/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
@@ -20,6 +20,7 @@
 use std::sync::{Arc, Mutex};
 
 use reddb::application::{CreateKvInput, EntityUseCases, ExecuteQueryInput, QueryUseCases};
+use reddb::runtime::ai::cdc_enrichment::{CdcEnrichmentConsumer, EnrichmentConfig};
 use reddb::runtime::ai::local_embedding::{
     clear_local_embedding_backend_for_tests, install_local_embedding_backend,
     LocalEmbeddingBackend, LocalEmbeddingRequest,
@@ -78,6 +79,50 @@ impl LocalEmbeddingBackend for FixedBackend {
         self.calls.lock().unwrap().push(request.inputs.clone());
         Ok(request.inputs.iter().map(|_| self.vector.clone()).collect())
     }
+}
+
+/// Backend that fails its first `fail_remaining` calls before producing a
+/// fixed vector. Drives the consumer's retry → dead-letter path with a
+/// controllable provider outage.
+struct FailingBackend {
+    fail_remaining: Arc<Mutex<u32>>,
+    vector: Vec<f32>,
+}
+
+impl LocalEmbeddingBackend for FailingBackend {
+    fn embed(&self, request: &LocalEmbeddingRequest) -> RedDBResult<Vec<Vec<f32>>> {
+        let mut remaining = self.fail_remaining.lock().unwrap();
+        if *remaining > 0 {
+            *remaining -= 1;
+            return Err(RedDBError::Query(
+                "mock embedding provider is down".to_string(),
+            ));
+        }
+        Ok(request.inputs.iter().map(|_| self.vector.clone()).collect())
+    }
+}
+
+/// Run a query and report how many records it surfaced, treating any error
+/// (e.g. a collection with no attached vectors yet) as zero hits — a
+/// pending row is simply not returned by `VECTOR SEARCH`.
+fn search_hits(rt: &RedDBRuntime, sql: &str) -> usize {
+    QueryUseCases::new(rt)
+        .execute(ExecuteQueryInput {
+            query: sql.to_string(),
+        })
+        .map(|result| result.result.records.len())
+        .unwrap_or(0)
+}
+
+/// `CREATE TABLE docs ... WITH (EMBED (...))` declaring a per-collection
+/// embed policy over the local provider (issue #1271 DDL, #1272 enrichment).
+fn create_docs_with_embed_policy(rt: &RedDBRuntime) {
+    exec(
+        rt,
+        "CREATE TABLE docs (id INT, body TEXT) WITH ( \
+           EMBED (fields = ('body'), provider = 'local', model = 'mini') \
+         )",
+    );
 }
 
 #[test]
@@ -220,6 +265,172 @@ fn auto_embed_insert_with_local_provider_requires_model_clause() {
     assert!(
         matches!(select_err, RedDBError::NotFound(_)),
         "no rows must be written when MODEL clause is missing: {select_err:?}"
+    );
+
+    clear_local_embedding_backend_for_tests();
+}
+
+/// Issue #1272: a collection with an embed policy auto-vectorises the
+/// declared fields *asynchronously* over CDC — the INSERT itself carries no
+/// `WITH AUTO EMBED` clause and does not block on the provider. The row is
+/// excluded from `VECTOR SEARCH` until the enrichment consumer attaches the
+/// vector, then included once attached.
+#[test]
+fn auto_embed_over_cdc_attaches_after_commit_and_excludes_pending() {
+    let _bg = backend_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_local_embedding_backend(Arc::new(FixedBackend {
+        vector: vec![1.0, 0.0],
+        calls: Arc::new(Mutex::new(Vec::new())),
+    }));
+
+    let rt = rt();
+    register_installed_local_model(&rt, "mini", 2);
+    create_docs_with_embed_policy(&rt);
+
+    // Plain INSERT — the policy drives enrichment; no per-request clause.
+    exec(&rt, "INSERT INTO docs (id, body) VALUES (1, 'alpha')");
+
+    // Before the consumer runs, the row has no vector and is therefore
+    // excluded from vector search (it is pending).
+    assert_eq!(
+        search_hits(&rt, "VECTOR SEARCH docs SIMILAR TO [1.0, 0.0] LIMIT 5"),
+        0,
+        "row must be excluded from vector search while enrichment is pending"
+    );
+
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 0).expect("enrichment tick");
+    assert!(stats.ingested >= 1, "insert event should be ingested");
+    assert_eq!(stats.attached, 1, "one vector should be attached");
+
+    // Once attached, the row is searchable.
+    let result = exec(&rt, "VECTOR SEARCH docs SIMILAR TO [1.0, 0.0] LIMIT 5");
+    assert_eq!(
+        result.result.records.len(),
+        1,
+        "row must be included in vector search once enrichment attaches"
+    );
+
+    clear_local_embedding_backend_for_tests();
+}
+
+/// Issue #1272: an update to an embedded field re-vectorises over CDC.
+#[test]
+fn auto_embed_over_cdc_revectorizes_on_update() {
+    let _bg = backend_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    install_local_embedding_backend(Arc::new(FixedBackend {
+        vector: vec![1.0, 0.0],
+        calls: Arc::clone(&calls),
+    }));
+
+    let rt = rt();
+    register_installed_local_model(&rt, "mini", 2);
+    create_docs_with_embed_policy(&rt);
+
+    exec(&rt, "INSERT INTO docs (id, body) VALUES (1, 'alpha')");
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    consumer.tick(&rt, 0).expect("initial enrichment tick");
+    let calls_after_insert = calls.lock().unwrap().len();
+    assert!(calls_after_insert >= 1, "insert should embed the row");
+
+    // Mutate the embedded field — the consumer must re-embed it.
+    exec(&rt, "UPDATE docs SET body = 'beta' WHERE id = 1");
+    let stats = consumer.tick(&rt, 1).expect("update enrichment tick");
+    assert!(
+        stats.attached >= 1,
+        "update to an embedded field should re-vectorise: {stats:?}"
+    );
+    let observed: Vec<Vec<String>> = calls.lock().unwrap().clone();
+    assert!(
+        observed
+            .iter()
+            .any(|inputs| inputs == &vec!["beta".to_string()]),
+        "the updated field text must be re-embedded: {observed:?}"
+    );
+
+    clear_local_embedding_backend_for_tests();
+}
+
+/// Issue #1272: provider failure retries with backoff and dead-letters
+/// after a bounded number of attempts; the re-drive path then re-enqueues
+/// the work and a healthy provider completes it.
+#[test]
+fn auto_embed_over_cdc_retries_then_dead_letters_then_redrives() {
+    let _bg = backend_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_local_embedding_backend(Arc::new(FailingBackend {
+        // Always fail through the dead-letter phase.
+        fail_remaining: Arc::new(Mutex::new(1_000)),
+        vector: vec![1.0, 0.0],
+    }));
+
+    let rt = rt();
+    register_installed_local_model(&rt, "mini", 2);
+    create_docs_with_embed_policy(&rt);
+
+    exec(&rt, "INSERT INTO docs (id, body) VALUES (1, 'alpha')");
+
+    let mut consumer = CdcEnrichmentConsumer::new(EnrichmentConfig {
+        max_attempts: 3,
+        base_backoff_ms: 10,
+        poll_max: 1024,
+    });
+
+    // Attempt 1 fails → scheduled with backoff (not_before = 10).
+    let s1 = consumer.tick(&rt, 0).expect("tick 1");
+    assert_eq!(s1.retried, 1, "first failure retries: {s1:?}");
+    assert_eq!(consumer.pending_len(), 1, "row stays pending after retry");
+    assert!(consumer.dead_letters().is_empty());
+
+    // Backoff is honoured: a tick before `not_before` does nothing.
+    let s_early = consumer.tick(&rt, 5).expect("early tick");
+    assert_eq!(
+        s_early,
+        Default::default(),
+        "backoff must defer the retry: {s_early:?}"
+    );
+    assert_eq!(consumer.pending_len(), 1);
+
+    // Attempt 2 fails → backoff grows (not_before = 30).
+    let s2 = consumer.tick(&rt, 10).expect("tick 2");
+    assert_eq!(s2.retried, 1, "second failure retries: {s2:?}");
+
+    // Attempt 3 exhausts the budget → dead-lettered.
+    let s3 = consumer.tick(&rt, 30).expect("tick 3");
+    assert_eq!(s3.dead_lettered, 1, "third failure dead-letters: {s3:?}");
+    assert_eq!(
+        consumer.pending_len(),
+        0,
+        "dead-lettered work leaves pending"
+    );
+    assert_eq!(consumer.dead_letters().len(), 1);
+    assert_eq!(consumer.dead_letters()[0].collection, "docs");
+    assert_eq!(consumer.dead_letters()[0].attempts, 3);
+    assert_eq!(
+        search_hits(&rt, "VECTOR SEARCH docs SIMILAR TO [1.0, 0.0] LIMIT 5"),
+        0,
+        "a dead-lettered row never enters vector search"
+    );
+
+    // Provider recovers; ops re-drive re-enqueues the dead-letter.
+    install_local_embedding_backend(Arc::new(FixedBackend {
+        vector: vec![1.0, 0.0],
+        calls: Arc::new(Mutex::new(Vec::new())),
+    }));
+    let redriven = consumer.redrive();
+    assert_eq!(redriven, 1, "re-drive returns the dead-letter to pending");
+    assert!(consumer.dead_letters().is_empty());
+    assert_eq!(consumer.pending_len(), 1);
+
+    let s4 = consumer.tick(&rt, 40).expect("tick after redrive");
+    assert_eq!(
+        s4.attached, 1,
+        "healthy provider completes the work: {s4:?}"
+    );
+    assert_eq!(
+        search_hits(&rt, "VECTOR SEARCH docs SIMILAR TO [1.0, 0.0] LIMIT 5"),
+        1,
+        "re-driven row is searchable once enriched"
     );
 
     clear_local_embedding_backend_for_tests();

--- a/tests/grouped/ai_local_vector/integration_vector_query_text.rs
+++ b/tests/grouped/ai_local_vector/integration_vector_query_text.rs
@@ -1,13 +1,19 @@
 use reddb::application::{CreateVectorInput, EntityUseCases, ExecuteQueryInput, QueryUseCases};
+use reddb::runtime::ai::cdc_enrichment::CdcEnrichmentConsumer;
+use reddb::runtime::ai::local_embedding::{
+    clear_local_embedding_backend_for_tests, install_local_embedding_backend,
+    LocalEmbeddingBackend, LocalEmbeddingRequest,
+};
 use reddb::storage::query::UnifiedRecord;
 use reddb::storage::schema::Value;
-use reddb::RedDBRuntime;
+use reddb::{RedDBResult, RedDBRuntime};
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
 use std::net::TcpListener;
+use std::sync::Arc;
 use std::thread;
 
-use super::support::env_lock;
+use super::support::{backend_lock, env_lock};
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("failed to create in-memory runtime")
@@ -173,6 +179,79 @@ fn test_vector_search_with_reference_source_uses_stored_vector() {
     assert_eq!(result.result.records.len(), 1);
     assert_eq!(text(&result.result.records[0], "content"), "anchor");
     assert_eq!(text(&result.result.records[0], "red_entity_type"), "vector");
+}
+
+/// Backend returning a fixed vector for every input — the mock provider for
+/// the CDC enrichment path.
+struct FixedBackend {
+    vector: Vec<f32>,
+}
+
+impl LocalEmbeddingBackend for FixedBackend {
+    fn embed(&self, request: &LocalEmbeddingRequest) -> RedDBResult<Vec<Vec<f32>>> {
+        Ok(request.inputs.iter().map(|_| self.vector.clone()).collect())
+    }
+}
+
+fn register_installed_local_model(rt: &RedDBRuntime, name: &str, dimensions: u32) {
+    let payload = format!(
+        r#"{{"name":"{name}","provider":"local","source":"sentence-transformers/all-MiniLM-L6-v2","task":"embedding","revision":"main","engine":"candle","dimensions":{dimensions},"status":"installed","pull_policy":"if_missing"}}"#
+    );
+    EntityUseCases::new(rt)
+        .create_kv(reddb::application::CreateKvInput {
+            collection: "red_config".to_string(),
+            key: format!("red.config.ai.models.{name}"),
+            value: Value::text(payload),
+            metadata: Vec::new(),
+        })
+        .expect("register model entry");
+}
+
+/// Issue #1272: a row whose embed-policy enrichment is still pending is
+/// absent from `VECTOR SEARCH`, and appears once the CDC enrichment consumer
+/// attaches its vector.
+#[test]
+fn vector_search_excludes_pending_until_cdc_enrichment_attaches() {
+    let _bg = backend_lock().lock().unwrap_or_else(|p| p.into_inner());
+    install_local_embedding_backend(Arc::new(FixedBackend {
+        vector: vec![1.0, 0.0],
+    }));
+
+    let rt = rt();
+    register_installed_local_model(&rt, "mini", 2);
+    exec(
+        &rt,
+        "CREATE TABLE notes (id INT, body TEXT) WITH ( \
+           EMBED (fields = ('body'), provider = 'local', model = 'mini') \
+         )",
+    );
+    exec(&rt, "INSERT INTO notes (id, body) VALUES (1, 'alpha')");
+
+    // Pending: no vector yet, so the row is not surfaced.
+    let pending = QueryUseCases::new(&rt)
+        .execute(ExecuteQueryInput {
+            query: "VECTOR SEARCH notes SIMILAR TO [1.0, 0.0] LIMIT 5".to_string(),
+        })
+        .map(|r| r.result.records.len())
+        .unwrap_or(0);
+    assert_eq!(
+        pending, 0,
+        "pending row must be excluded from vector search"
+    );
+
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 0).expect("enrichment tick");
+    assert_eq!(stats.attached, 1, "consumer attaches the pending vector");
+
+    let result = exec(&rt, "VECTOR SEARCH notes SIMILAR TO [1.0, 0.0] LIMIT 5");
+    assert_eq!(
+        result.result.records.len(),
+        1,
+        "row is included once the enrichment consumer attaches the vector"
+    );
+    assert_eq!(text(&result.result.records[0], "content"), "alpha");
+
+    clear_local_embedding_backend_for_tests();
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1272. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1272

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784578572&installation_id=129708444&pr_number=1280&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1280&signature=48961b445a88e6d796f62e8b0f0d6654b6e4ccd2fdc327da085b994f9b673dc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->