### PR TITLE
merge: #1273 ASK→RQL via inference (parser-validated candidate default + EXECUTE opt-in)

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -876,6 +876,10 @@ pub struct AskQuery {
     /// `ASK '...' AS RQL` returns a validated RQL candidate instead of
     /// calling an AI provider. The runtime owns translation and validation.
     pub as_rql: bool,
+    /// `ASK '...' EXECUTE` opts in to auto-running a generated RQL
+    /// candidate when (and only when) it is read-only. A mutating
+    /// candidate is refused for auto-execution regardless of this flag.
+    pub execute: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -591,10 +591,11 @@ impl<'a> Parser<'a> {
         let mut stream = false;
         let mut cache = AskCacheClause::Default;
         let mut as_rql = false;
+        let mut execute = false;
 
         // Parse optional clauses in any order. Loop bound = number of
         // clause kinds, so each can appear at most once.
-        for _ in 0..13 {
+        for _ in 0..14 {
             if self.consume(&Token::Using)? {
                 provider = Some(match &self.current.token {
                     Token::String(_) => self.parse_string()?,
@@ -663,6 +664,14 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 as_rql = true;
+            } else if self.consume_ident_ci("EXECUTE")? {
+                if execute {
+                    return Err(ParseError::new(
+                        "ASK EXECUTE specified more than once",
+                        self.position(),
+                    ));
+                }
+                execute = true;
             } else {
                 break;
             }
@@ -684,6 +693,7 @@ impl<'a> Parser<'a> {
             stream,
             cache,
             as_rql,
+            execute,
         }))
     }
 

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -220,6 +220,7 @@ fn ask_query_from_request(
         stream,
         cache: crate::storage::query::ast::AskCacheClause::Default,
         as_rql: false,
+        execute: false,
     })
 }
 

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -344,6 +344,7 @@ impl McpServer {
                 crate::storage::query::ast::AskCacheClause::Default
             },
             as_rql: false,
+            execute: false,
         };
         let result = self
             .runtime

--- a/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
@@ -184,6 +184,230 @@ fn validate_read_only_table_query(rql: &str) -> RedDBResult<()> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Inference path (#1273): augment — not replace — the deterministic planner.
+//
+// `ASK '<natural language>'` can be translated to an RQL candidate by the
+// configured text2text (generate) provider. The model output is *never*
+// trusted: it is always re-validated through the production parser via the
+// same read-only-candidate seam used by the deterministic planner, and a
+// mutating candidate is never auto-executed regardless of `EXECUTE`.
+// ---------------------------------------------------------------------------
+
+/// Read-only vs mutating classification of a parser-validated candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CandidateDisposition {
+    /// The candidate only reads (SELECT / MATCH / vector / search / …) and
+    /// may be auto-executed when `EXECUTE` is requested.
+    ReadOnly,
+    /// The candidate writes, drops, alters, or otherwise mutates state and
+    /// is refused for auto-execution regardless of `EXECUTE`.
+    Mutating,
+}
+
+/// A model-generated RQL candidate that has passed the production parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedCandidate {
+    /// The candidate RQL, trimmed, exactly as it parsed.
+    pub rql: String,
+    /// Whether the candidate is read-only or mutating.
+    pub disposition: CandidateDisposition,
+    /// Canonical statement-type label for the candidate.
+    pub statement_type: &'static str,
+}
+
+impl ValidatedCandidate {
+    /// True when the candidate is safe to auto-execute.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self.disposition, CandidateDisposition::ReadOnly)
+    }
+}
+
+/// Result of an inference translation pass.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskRqlInference {
+    /// The parser-validated candidate.
+    pub candidate: ValidatedCandidate,
+    /// The prompt that was sent to the model (for explain/audit).
+    pub prompt: String,
+    /// Whether the candidate should be auto-executed by the caller. True
+    /// only when `EXECUTE` was requested *and* the candidate is read-only.
+    pub execute: bool,
+    /// Non-fatal advisories surfaced to the caller.
+    pub warnings: Vec<String>,
+}
+
+/// A model that turns an inference prompt into a single RQL candidate.
+///
+/// The blanket impl over `Fn(&str) -> RedDBResult<String>` lets callers
+/// pass a closure wrapping the configured provider (production) or a canned
+/// string (tests / mock model) without a bespoke type.
+pub trait RqlModel {
+    fn generate_rql(&self, prompt: &str) -> RedDBResult<String>;
+}
+
+impl<F> RqlModel for F
+where
+    F: Fn(&str) -> RedDBResult<String>,
+{
+    fn generate_rql(&self, prompt: &str) -> RedDBResult<String> {
+        self(prompt)
+    }
+}
+
+/// Re-validate a model-generated RQL candidate through the production
+/// parser and classify it read-only vs mutating. An invalid candidate
+/// surfaces an error and is never returned for execution.
+pub fn validate_candidate(rql: &str) -> RedDBResult<ValidatedCandidate> {
+    let trimmed = rql.trim();
+    if trimmed.is_empty() {
+        return Err(RedDBError::Query(
+            "ASK inference produced an empty RQL candidate".to_string(),
+        ));
+    }
+    let parsed = crate::storage::query::parser::parse(trimmed).map_err(|err| {
+        RedDBError::Query(format!(
+            "ASK inference produced an invalid RQL candidate: {err}"
+        ))
+    })?;
+    let (disposition, statement_type) = classify(&parsed.query);
+    Ok(ValidatedCandidate {
+        rql: trimmed.to_string(),
+        disposition,
+        statement_type,
+    })
+}
+
+/// Classify a parsed query as read-only or mutating. The read-only set is
+/// an explicit allowlist; anything not on it (writes, DDL, migrations,
+/// maintenance, unknown future variants) is treated as mutating so it is
+/// never auto-executed.
+fn classify(query: &QueryExpr) -> (CandidateDisposition, &'static str) {
+    use CandidateDisposition::{Mutating, ReadOnly};
+    match query {
+        QueryExpr::Table(_) => (ReadOnly, "select"),
+        QueryExpr::Graph(_) => (ReadOnly, "graph"),
+        QueryExpr::Join(_) => (ReadOnly, "join"),
+        QueryExpr::Path(_) => (ReadOnly, "path"),
+        QueryExpr::Vector(_) => (ReadOnly, "vector"),
+        QueryExpr::Hybrid(_) => (ReadOnly, "hybrid"),
+        QueryExpr::GraphCommand(_) => (ReadOnly, "graph_command"),
+        QueryExpr::SearchCommand(_) => (ReadOnly, "search"),
+        QueryExpr::RankOf(_) => (ReadOnly, "rank_of"),
+        QueryExpr::ApproxRankOf(_) => (ReadOnly, "approx_rank_of"),
+        QueryExpr::RankRange(_) => (ReadOnly, "rank_range"),
+        QueryExpr::Insert(_) => (Mutating, "insert"),
+        QueryExpr::Update(_) => (Mutating, "update"),
+        QueryExpr::Delete(_) => (Mutating, "delete"),
+        QueryExpr::Truncate(_) => (Mutating, "truncate"),
+        _ => (Mutating, "mutating"),
+    }
+}
+
+/// Translate a natural-language question into a parser-validated RQL
+/// candidate via the supplied model, then apply the read-only-candidate /
+/// `EXECUTE` policy.
+///
+/// - The candidate is *always* re-validated through the parser.
+/// - Default (`execute = false`) returns the candidate without executing.
+/// - `execute = true` marks read-only candidates for auto-execution.
+/// - A mutating candidate is refused for auto-execution when `execute`
+///   is requested, and is never marked executable.
+pub fn infer<M: RqlModel>(
+    question: &str,
+    candidates: &CandidateCollections,
+    requested_collection: Option<&str>,
+    execute: bool,
+    model: &M,
+) -> RedDBResult<AskRqlInference> {
+    let prompt = build_inference_prompt(question, candidates, requested_collection);
+    let raw = model.generate_rql(&prompt)?;
+    let candidate = validate_candidate(&raw)?;
+
+    let mut warnings = Vec::new();
+    let execute = if execute {
+        match candidate.disposition {
+            CandidateDisposition::ReadOnly => true,
+            CandidateDisposition::Mutating => {
+                return Err(RedDBError::Query(format!(
+                    "ASK ... EXECUTE refused: generated `{}` candidate is mutating and is \
+                     never auto-executed",
+                    candidate.statement_type
+                )));
+            }
+        }
+    } else {
+        if candidate.is_read_only() {
+            warnings.push(
+                "candidate not executed; add EXECUTE to auto-run read-only candidates".to_string(),
+            );
+        } else {
+            warnings.push(format!(
+                "candidate is a mutating `{}` statement and is never auto-executed",
+                candidate.statement_type
+            ));
+        }
+        false
+    };
+
+    if requested_collection.is_none() {
+        warnings.push(
+            "no COLLECTION was specified; candidate validated against the full schema vocabulary"
+                .to_string(),
+        );
+    }
+
+    Ok(AskRqlInference {
+        candidate,
+        prompt,
+        execute,
+        warnings,
+    })
+}
+
+/// Assemble the inference prompt: the question plus the schema vocabulary
+/// (collections + columns) the model may reference, with an explicit
+/// instruction to emit a single read-only RQL statement.
+pub fn build_inference_prompt(
+    question: &str,
+    candidates: &CandidateCollections,
+    requested_collection: Option<&str>,
+) -> String {
+    let mut prompt = String::new();
+    prompt.push_str(
+        "Translate the user's question into a single read-only RQL SELECT statement. \
+         Return only the RQL, with no commentary, code fences, or trailing semicolon.\n\n",
+    );
+
+    if let Some(collection) = requested_collection {
+        prompt.push_str("Target collection: ");
+        prompt.push_str(collection);
+        prompt.push('\n');
+    }
+
+    if !candidates.collections.is_empty() {
+        prompt.push_str("Available collections: ");
+        prompt.push_str(&candidates.collections.join(", "));
+        prompt.push('\n');
+    }
+
+    let mut columns: BTreeSet<String> = BTreeSet::new();
+    for cols in candidates.columns_by_collection.values() {
+        for col in cols {
+            columns.insert(col.clone());
+        }
+    }
+    if !columns.is_empty() {
+        prompt.push_str("Available columns: ");
+        prompt.push_str(&columns.into_iter().collect::<Vec<_>>().join(", "));
+        prompt.push('\n');
+    }
+
+    prompt.push_str("\nQuestion: ");
+    prompt.push_str(question);
+    prompt
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -236,5 +460,97 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.to_string().contains("could not infer a WHERE field"));
+    }
+
+    // ---- inference path (#1273) ------------------------------------
+
+    /// A mock model that returns a fixed candidate string regardless of
+    /// the prompt — stands in for the configured generate provider.
+    fn mock_model(candidate: &'static str) -> impl RqlModel {
+        move |_prompt: &str| Ok(candidate.to_string())
+    }
+
+    #[test]
+    fn infer_validates_candidate_through_parser() {
+        let err = infer(
+            "anything",
+            &candidates(),
+            None,
+            false,
+            &mock_model("this is not valid rql"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid RQL candidate"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn infer_default_returns_candidate_without_executing() {
+        let out = infer(
+            "who owns passport FDD-12313?",
+            &candidates(),
+            Some("travelers"),
+            false,
+            &mock_model("SELECT * FROM travelers WHERE passport = 'FDD-12313'"),
+        )
+        .unwrap();
+        assert!(!out.execute, "default must not execute");
+        assert!(out.candidate.is_read_only());
+        assert_eq!(out.candidate.statement_type, "select");
+        assert_eq!(
+            out.candidate.rql,
+            "SELECT * FROM travelers WHERE passport = 'FDD-12313'"
+        );
+    }
+
+    #[test]
+    fn infer_execute_marks_read_only_candidate_for_run() {
+        let out = infer(
+            "list travelers",
+            &candidates(),
+            Some("travelers"),
+            true,
+            &mock_model("SELECT * FROM travelers WHERE passport = 'FDD-12313'"),
+        )
+        .unwrap();
+        assert!(out.execute, "EXECUTE on read-only candidate must run");
+        assert!(out.candidate.is_read_only());
+    }
+
+    #[test]
+    fn infer_refuses_mutating_candidate_for_execute() {
+        let err = infer(
+            "delete everything",
+            &candidates(),
+            Some("travelers"),
+            true,
+            &mock_model("DELETE FROM travelers WHERE passport = 'FDD-12313'"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("refused"), "got: {err}");
+        assert!(err.to_string().contains("mutating"), "got: {err}");
+    }
+
+    #[test]
+    fn infer_mutating_candidate_never_executes_without_execute() {
+        let out = infer(
+            "delete everything",
+            &candidates(),
+            Some("travelers"),
+            false,
+            &mock_model("DELETE FROM travelers WHERE passport = 'FDD-12313'"),
+        )
+        .unwrap();
+        assert!(!out.execute);
+        assert_eq!(out.candidate.disposition, CandidateDisposition::Mutating);
+        assert_eq!(out.candidate.statement_type, "delete");
+    }
+
+    #[test]
+    fn validate_candidate_rejects_empty() {
+        let err = validate_candidate("   ").unwrap_err();
+        assert!(err.to_string().contains("empty RQL candidate"));
     }
 }

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1706,12 +1706,80 @@ impl RedDBRuntime {
             ));
         }
         let candidates = crate::runtime::ask_pipeline::match_schema(self, &scope, &tokens)?;
-        let plan = crate::runtime::ai::ask_rql_planner::plan(
-            &ask.question,
-            &tokens,
-            &candidates,
-            ask.collection.as_deref(),
-        )?;
+
+        // Inference path (#1273): when `ai.ask_rql.backend = "llm"` and a
+        // generate provider is available, the model proposes the RQL
+        // candidate; otherwise fall back to the deterministic planner. Both
+        // candidates are re-validated through the parser via the same seam.
+        let candidate;
+        let engine;
+        let field;
+        let value;
+        let candidate_fields;
+        let candidate_collections;
+        let mut warnings;
+        let used_inference;
+        match self.ask_rql_inference(ask, &candidates)? {
+            Some(inference) => {
+                candidate = inference.candidate;
+                engine = "runtime-ai-rql-inference";
+                field = None;
+                value = None;
+                candidate_fields = Vec::new();
+                candidate_collections = candidates.collections.clone();
+                warnings = inference.warnings;
+                used_inference = true;
+            }
+            None => {
+                let plan = crate::runtime::ai::ask_rql_planner::plan(
+                    &ask.question,
+                    &tokens,
+                    &candidates,
+                    ask.collection.as_deref(),
+                )?;
+                // Re-validate the deterministic candidate through the same
+                // parser seam so the disposition / EXECUTE gating is shared.
+                candidate = crate::runtime::ai::ask_rql_planner::validate_candidate(&plan.rql)?;
+                engine = "runtime-ai-rql-planner";
+                field = Some(plan.field);
+                value = Some(plan.value);
+                candidate_fields = plan.candidate_fields;
+                candidate_collections = plan.candidate_collections;
+                warnings = plan.warnings;
+                used_inference = false;
+            }
+        }
+
+        // EXECUTE policy: auto-run read-only candidates only; a mutating
+        // candidate is refused for auto-execution regardless of EXECUTE.
+        if ask.execute {
+            if candidate.is_read_only() {
+                let mut executed = self.execute_query(&candidate.rql)?;
+                executed.query = raw_query.to_string();
+                return Ok(executed);
+            }
+            return Err(RedDBError::Query(format!(
+                "ASK ... EXECUTE refused: generated `{}` candidate is mutating and is never \
+                 auto-executed",
+                candidate.statement_type
+            )));
+        }
+
+        // The inference path already records the not-executed / mutating
+        // advisory inside `infer`; only the deterministic path needs it here.
+        if !used_inference {
+            if candidate.is_read_only() {
+                warnings.push(
+                    "candidate not executed; add EXECUTE to auto-run read-only candidates"
+                        .to_string(),
+                );
+            } else {
+                warnings.push(format!(
+                    "candidate is a mutating `{}` statement and is never auto-executed",
+                    candidate.statement_type
+                ));
+            }
+        }
 
         let mut result = UnifiedResult::with_columns(vec![
             "rql".into(),
@@ -1724,39 +1792,98 @@ impl RedDBRuntime {
             "warnings".into(),
         ]);
         let mut record = UnifiedRecord::new();
-        record.set("rql", Value::text(plan.rql));
-        record.set("statement_type", Value::text("select"));
-        record.set("field", Value::text(plan.field));
-        record.set("value", Value::text(plan.value));
-        if let Some(collection) = plan.collection {
-            record.set("collection", Value::text(collection));
-        } else {
-            record.set("collection", Value::Null);
+        record.set("rql", Value::text(candidate.rql));
+        record.set("statement_type", Value::text(candidate.statement_type));
+        match field {
+            Some(field) => record.set("field", Value::text(field)),
+            None => record.set("field", Value::Null),
+        }
+        match value {
+            Some(value) => record.set("value", Value::text(value)),
+            None => record.set("value", Value::Null),
+        }
+        match ask.collection.clone() {
+            Some(collection) => record.set("collection", Value::text(collection)),
+            None => record.set("collection", Value::Null),
         }
         record.set(
             "candidate_fields",
-            Value::Json(json_string_array_bytes(&plan.candidate_fields)),
+            Value::Json(json_string_array_bytes(&candidate_fields)),
         );
         record.set(
             "candidate_collections",
-            Value::Json(json_string_array_bytes(&plan.candidate_collections)),
+            Value::Json(json_string_array_bytes(&candidate_collections)),
         );
-        record.set(
-            "warnings",
-            Value::Json(json_string_array_bytes(&plan.warnings)),
-        );
+        record.set("warnings", Value::Json(json_string_array_bytes(&warnings)));
         result.push(record);
 
         Ok(RuntimeQueryResult {
             query: raw_query.to_string(),
             mode: QueryMode::Sql,
             statement: "ask_as_rql",
-            engine: "runtime-ai-rql-planner",
+            engine,
             result,
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
         })
+    }
+
+    /// Inference backend (#1273): when `ai.ask_rql.backend = "llm"`,
+    /// translate the question into an RQL candidate via the configured
+    /// generate provider. Returns `None` when the backend is disabled or no
+    /// provider / API key is available, so the caller falls back to the
+    /// deterministic planner. The model output is always re-validated
+    /// through the parser inside `ask_rql_planner::infer`.
+    fn ask_rql_inference(
+        &self,
+        ask: &crate::storage::query::ast::AskQuery,
+        candidates: &crate::runtime::ask_pipeline::CandidateCollections,
+    ) -> RedDBResult<Option<crate::runtime::ai::ask_rql_planner::AskRqlInference>> {
+        if self.config_string("ai.ask_rql.backend", "deterministic") != "llm" {
+            return Ok(None);
+        }
+
+        let (default_provider, default_model) = crate::ai::resolve_defaults_from_runtime(self);
+        let provider = match ask.provider.as_deref() {
+            Some(name) => crate::ai::parse_provider(name)?,
+            None => default_provider,
+        };
+        crate::runtime::ai::provider_gate::enforce(self, &provider)?;
+        let api_key = match crate::ai::resolve_api_key_from_runtime(&provider, None, self) {
+            Ok(key) => key,
+            Err(_) => return Ok(None),
+        };
+        let api_base = provider.resolve_api_base();
+        let model = ask.model.clone().unwrap_or(default_model);
+        let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
+        let max_tokens = self.config_f64("ai.ask_rql.max_tokens", 256.0).max(1.0) as usize;
+
+        let generate = move |prompt: &str| -> RedDBResult<String> {
+            let response = call_ask_llm(
+                &provider,
+                transport.clone(),
+                api_key.clone(),
+                model.clone(),
+                prompt.to_string(),
+                api_base.clone(),
+                max_tokens,
+                Some(0.0),
+                None,
+                false,
+                None,
+            )?;
+            Ok(response.output_text)
+        };
+
+        let inference = crate::runtime::ai::ask_rql_planner::infer(
+            &ask.question,
+            candidates,
+            ask.collection.as_deref(),
+            ask.execute,
+            &generate,
+        )?;
+        Ok(Some(inference))
     }
 
     fn execute_explain_ask(
@@ -4181,6 +4308,32 @@ mod citation_wedge_tests {
         assert_eq!(selected.result.records.len(), 1);
         assert_eq!(
             selected.result.records[0].get("name"),
+            Some(&Value::text("Ada".to_string()))
+        );
+    }
+
+    #[test]
+    fn ask_as_rql_execute_runs_read_only_candidate_and_returns_rows() {
+        let rt = crate::runtime::RedDBRuntime::in_memory().expect("runtime");
+        rt.execute_query("CREATE TABLE travelers (passport TEXT, name TEXT)")
+            .expect("create table");
+        rt.execute_query("INSERT INTO travelers (passport, name) VALUES ('FDD-12313', 'Ada')")
+            .expect("insert row");
+
+        // Default (no EXECUTE) returns the validated candidate, no rows.
+        let planned = rt
+            .execute_query("ASK 'who owns passport FDD-12313?' AS RQL")
+            .expect("ASK AS RQL candidate");
+        assert_eq!(planned.engine, "runtime-ai-rql-planner");
+
+        // EXECUTE auto-runs the read-only candidate and returns the rows.
+        let executed = rt
+            .execute_query("ASK 'who owns passport FDD-12313?' AS RQL EXECUTE")
+            .expect("ASK AS RQL EXECUTE should run the read-only candidate");
+        assert_eq!(executed.engine, "runtime-table");
+        assert_eq!(executed.result.records.len(), 1);
+        assert_eq!(
+            executed.result.records[0].get("name"),
             Some(&Value::text("Ada".to_string()))
         );
     }

--- a/crates/reddb-server/tests/ask_parser.rs
+++ b/crates/reddb-server/tests/ask_parser.rs
@@ -309,6 +309,105 @@ fn search_context_full_clause_chain_parses() {
 }
 
 #[test]
+fn ask_as_rql_clause_parses() {
+    let q = parse_query("ASK 'who owns passport FDD-12313?' AS RQL");
+    match q {
+        QueryExpr::Ask(ask) => {
+            assert!(ask.as_rql, "AS RQL should set as_rql");
+            assert!(!ask.execute, "AS RQL without EXECUTE must not set execute");
+        }
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+#[test]
+fn ask_as_rql_execute_clause_parses() {
+    // `EXECUTE` is the opt-in that auto-runs a read-only candidate; it
+    // can appear with `AS RQL` in any order.
+    let q = parse_query("ASK 'who owns passport FDD-12313?' AS RQL EXECUTE");
+    match q {
+        QueryExpr::Ask(ask) => {
+            assert!(ask.as_rql);
+            assert!(ask.execute, "EXECUTE should set execute");
+        }
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+#[test]
+fn ask_execute_before_as_rql_parses() {
+    let q = parse_query("ASK 'q' EXECUTE AS RQL");
+    match q {
+        QueryExpr::Ask(ask) => {
+            assert!(ask.as_rql);
+            assert!(ask.execute);
+        }
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+#[test]
+fn ask_execute_specified_twice_errors() {
+    let err = parser::parse("ASK 'q' EXECUTE EXECUTE").expect_err("double EXECUTE must error");
+    assert!(
+        err.to_string().contains("EXECUTE specified more than once"),
+        "got: {err}"
+    );
+}
+
+// ---- inference seam with a mock model (#1273) --------------------
+//
+// There is no stubbable LLM transport on the SQL ASK path, so the
+// generate-provider seam is exercised here through a mock `RqlModel`
+// closure that stands in for the configured text2text provider.
+
+mod ask_rql_inference {
+    use reddb_server::runtime::ai::ask_rql_planner::{infer, CandidateDisposition};
+    use reddb_server::runtime::ask_pipeline::CandidateCollections;
+
+    fn candidates() -> CandidateCollections {
+        CandidateCollections {
+            collections: vec!["travelers".to_string()],
+            columns_by_collection: std::collections::HashMap::from([(
+                "travelers".to_string(),
+                vec!["passport".to_string(), "name".to_string()],
+            )]),
+        }
+    }
+
+    #[test]
+    fn invalid_candidate_is_rejected_by_parser() {
+        let model = |_p: &str| Ok("not valid rql at all".to_string());
+        let err = infer("q", &candidates(), Some("travelers"), false, &model).unwrap_err();
+        assert!(err.to_string().contains("invalid RQL candidate"), "{err}");
+    }
+
+    #[test]
+    fn default_returns_validated_candidate_without_executing() {
+        let model =
+            |_p: &str| Ok("SELECT * FROM travelers WHERE passport = 'FDD-12313'".to_string());
+        let out = infer("q", &candidates(), Some("travelers"), false, &model).unwrap();
+        assert!(!out.execute);
+        assert_eq!(out.candidate.disposition, CandidateDisposition::ReadOnly);
+    }
+
+    #[test]
+    fn execute_runs_read_only_candidate() {
+        let model =
+            |_p: &str| Ok("SELECT * FROM travelers WHERE passport = 'FDD-12313'".to_string());
+        let out = infer("q", &candidates(), Some("travelers"), true, &model).unwrap();
+        assert!(out.execute, "read-only candidate with EXECUTE must run");
+    }
+
+    #[test]
+    fn mutating_candidate_refused_for_execute() {
+        let model = |_p: &str| Ok("DELETE FROM travelers WHERE passport = 'FDD-12313'".to_string());
+        let err = infer("q", &candidates(), Some("travelers"), true, &model).unwrap_err();
+        assert!(err.to_string().contains("refused"), "{err}");
+    }
+}
+
+#[test]
 fn ask_lowercase_keyword_parses() {
     // The dispatch path uses `eq_ignore_ascii_case("ASK")`, so the
     // lowercase form must round-trip. Pinning prevents a future


### PR DESCRIPTION
Automated AFK landing for #1273. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1273

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784580080&installation_id=129708444&pr_number=1281&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1281&signature=4c7342766f5447b9c8698cefd7a5c8b3cb130d1934ec105eeeb1a5318a73ebe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->