### PR TITLE
docs: 3-week refresh — AI multimodality, crate split, TigerStyle, clustering design

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -16,6 +16,7 @@
   - [Local HuggingFace Embeddings](/guides/local-embeddings.md)
   - [Multi-Model Queries](/guides/multi-model-queries.md)
   - [AI Provider Modes](/api/ai-provider-modes.md)
+  - [AI Policy (per-collection)](/query/ai-policy.md)
 
 - **Query Language (RQL)**
   - [SELECT](/query/select.md)
@@ -90,6 +91,7 @@
   - [Bloom Filter](/engine/bloom-filter.md)
   - [Memtable & Skip List](/engine/memtable.md)
   - [File Format Anatomy](/engine/file-format.md)
+  - [Operational Storage Profiles](/engine/operational-storage-profiles.md)
   - [WAL & Recovery](/engine/wal.md)
   - [SIEVE Cache](/engine/cache.md)
   - [Columnar Batch Execution](/engine/columnar-execution.md)
@@ -198,6 +200,7 @@
 
 - **Guides**
   - [Monorepo Structure](/dev/monorepo-structure.md)
+  - [House Style (TigerStyle)](/dev/house-style.md)
   - [Permission Recipes](/guides/permissions-cookbook.md)
   - [Builds, Targets, and CI Speed](/guides/builds-and-ci-speed.md)
   - [JavaScript and TypeScript Driver](/guides/javascript-typescript-driver.md)
@@ -229,6 +232,7 @@
   - [Limitations](/reference/limitations.md)
 
 - **Release Notes**
+  - [2026-06-20 (AI Multimodality + TigerStyle + Crate Split)](/release-notes-2026-06-20.md)
   - [2026-04-26 (RedWire + Auth)](/release-notes-2026-04-26.md)
   - [2026-04-17 (Multi-tenancy + Perf)](/release-notes-2026-04-17.md)
   - [v1.0 Migration Guide](/release/v1.0-migration.md)

--- a/docs/api/ai-provider-modes.md
+++ b/docs/api/ai-provider-modes.md
@@ -64,6 +64,45 @@ Non-2xx responses are surfaced as `RedDBError::Query` carrying the
 status code and the provider's parsed `error.message` (or the raw
 body when the provider doesn't return JSON).
 
+## Modality matrix
+
+Separately from the *wire-protocol* mode above, every provider carries a
+**modality capability** — which AI jobs it can serve. The four modalities are:
+
+| Modality | Token | What it does |
+|:---------|:------|:-------------|
+| Embed | `embed` (`embedding`, `embeddings`) | Produce embedding vectors for text |
+| Generate | `generate` (`generation`, `chat`, `completion`) | Generate free-form text from a prompt |
+| Vision | `vision` (`image`, `multimodal`) | Accept image input alongside text |
+| Moderate | `moderate` (`moderation`) | Classify content against a safety taxonomy |
+
+The built-in provider × modality matrix:
+
+| Provider | `embed` | `generate` | `vision` | `moderate` |
+|:---------|:-------:|:----------:|:--------:|:----------:|
+| `openai` | ✅ | ✅ | ✅ | ✅ |
+| `anthropic` | — | ✅ | ✅ | — |
+| `minimax` | ✅ | ✅ | ✅ | — |
+| `together` | ✅ | ✅ | ✅ | — |
+| `ollama` | ✅ | ✅ | ✅ | — |
+| `groq` | — | ✅ | ✅ | — |
+| `openrouter` | — | ✅ | ✅ | — |
+| `venice` | — | ✅ | ✅ | — |
+| `deepseek` | — | ✅ | — | — |
+| `huggingface` | ✅ | ✅ | — | — |
+| `local` | ✅ | — | — | — |
+| unknown / `custom` | ✅ | ✅ | — | — |
+
+An **unknown** provider token is treated conservatively: only the universal
+text modalities (`embed`, `generate`) are assumed, and `vision`/`moderate`
+requests against it are rejected rather than guessed.
+
+The matrix gates a [per-collection AI policy](../query/ai-policy.md) at
+**`CREATE TABLE` time**: a policy that wires a provider to a modality it cannot
+serve is rejected immediately, not on the first write. Per-deployment overrides
+can layer onto the built-in rows when a deployment runs a provider with a
+different capability set.
+
 ## Relationship to `red.config.ai.default.provider`
 
 * `red.config.ai.default.provider` → names a vendor (`openai`,

--- a/docs/architecture/cluster-sharding.md
+++ b/docs/architecture/cluster-sharding.md
@@ -10,6 +10,8 @@ The implementation lives under `crates/reddb-server/src/cluster/`, especially:
 
 - `ownership.rs` for collection range ownership, epochs, catalog versions, and
   the per-range public write gate.
+- `slot.rs` for the hash-slot primitive: the fixed slot count, the
+  `shard_key -> hash -> slot` function, and the slot-to-range-key encoding.
 - `routing.rs` for any-node routing, forwarding, and redirect hints.
 - `cross_range.rs` for first-cut cross-range transaction and read behavior.
 - `placement.rs` and `move_range.rs` for planning rebalancing, hotspot relief,
@@ -21,6 +23,7 @@ The implementation lives under `crates/reddb-server/src/cluster/`, especially:
 |---|---|
 | Range ownership catalog | Landed as a pure control-plane model |
 | Hash and ordered collection sharding modes | Landed in the catalog model |
+| Fixed hash-slot primitive (16,384 slots) | Landed in `slot.rs` |
 | Any-node routing decisions | Landed as pure routing decisions |
 | Public write fencing by owner epoch | Landed in the catalog model |
 | Cross-range write transaction guardrails | Landed as pure planning decisions |
@@ -88,6 +91,39 @@ A collection cannot mix the two modes. The first range, or an explicit
 collection declaration, fixes the collection's `ShardKeyMode`. Later catalog
 updates that try to add a range of the other mode are rejected with
 `ShardKeyModeMismatch`.
+
+### Hash Slots
+
+In `Hash` mode the indirection above is concrete: a shard key is first mapped to
+a fixed *hash slot*, and slots are what the catalog ranges actually cover.
+
+- The slot count is a cluster-format constant — `PRODUCTION_HASH_SLOT_COUNT =
+  16_384` — not `node_count`. Adding or removing members does not remap the
+  keyspace; it only moves which member owns a slot span.
+- `hash_shard_key_to_slot` hashes the shard-key bytes with BLAKE3, takes the
+  first 8 bytes big-endian, and reduces modulo the slot count. The mapping is
+  stable and deterministic for a given key.
+- Each slot encodes a big-endian `range_key`, so a contiguous slot span folds
+  directly into the catalog's existing half-open `[lower, upper)` `RangeBounds`.
+  A `RangeOwnership` entry in hash mode therefore represents a contiguous span
+  of slots, and the catalog records which owner holds that span.
+
+So a slot is the *logical* hash bucket and a range is still the *cataloged*
+ownership unit. Point routing is formulaic — `shard key -> hash -> slot -> range
+-> owner` — while ownership remains versioned catalog state that the supervisor
+splits and moves. The user-facing routing example reads, in full hash mode:
+
+```text
+tenant_id='acme' -> hash -> slot 9381 -> range [8192, 12288) -> shard group -> owner
+```
+
+This slot layer is shipped as a pure primitive in `slot.rs` and consumed by the
+ownership and topology models. It is not yet wired into a finished cluster
+serving path, and there is still no public `SHARD BY` DDL that lets a user
+declare the shard key — see [Not Yet Promised](#not-yet-promised). The full
+slot-map and cross-shard contract is specified in
+[ADR 0055](../../.red/adr/0055-cluster-slot-map-and-cross-shard-operations.md)
+(status: proposed).
 
 ## Who Chooses The Mode
 
@@ -239,6 +275,8 @@ The cluster sharding model is designed around these properties:
 
 Do not claim these as production behavior until the runtime work lands:
 
+- A public `SHARD BY` DDL surface for declaring the shard key. The hash-slot and
+  ownership primitives exist, but parsing/wiring `SHARD BY` is not implemented.
 - Full multi-writer serving in the container/Helm `cluster` profile.
 - Distributed SQL planning with shard-local subplans and coordinator merge.
 - Automatic cluster-wide result cache invalidation.

--- a/docs/architecture/distributed-roadmap.md
+++ b/docs/architecture/distributed-roadmap.md
@@ -19,12 +19,21 @@ is documented in
   collection sharding modes, owner epochs, stale-version rejection, any-node
   routing decisions, and cross-range guardrails. See
   [Cluster Sharding](./cluster-sharding.md).
+* **Fixed hash-slot primitive** — `slot.rs` ships the production 16,384-slot
+  map and the stable `shard_key -> hash -> slot -> range-key` function, so
+  hash-mode ranges are slot spans rather than `hash(key) % node_count`. The
+  primitive is consumed by the ownership/topology models but not yet wired into
+  a serving path, and there is no public `SHARD BY` DDL yet.
 * **Serialisable batches** — the `ColumnBatch` format introduced in
   B1 is explicitly laid out so a future network layer can ship
   batches between nodes without re-serialising.
 * **Cluster control-plane model** — ADR 0037 defines versioned
   shard/range ownership, ADR 0045 defines range-oriented cluster file
-  layout, and ADR 0052 defines control-plane consensus boundaries.
+  layout, and ADR 0052 (accepted) fixes the control-plane consensus
+  boundaries: a Raft-equivalent log governs membership, leader election,
+  and ownership-catalog transitions *only*, while user-data writes stay
+  out of that log. The decision is accepted; the durable replicated
+  control-plane log itself is a named follow-up slice, not yet built.
 * **Range-authority substrate** — logical replication records can
   carry range identity and ownership epoch, and the control-plane
   seam accepts membership changes and ownership transitions without
@@ -118,7 +127,7 @@ Write flow:
 | D2 | Wire cluster routing/fencing into the serving request paths | In progress |
 | D3 | Distributed scan: ship sub-plan, collect batches, local merge | Roadmap |
 | D4 | Distributed aggregate: ship partial state, merge at coordinator | Roadmap |
-| D5 | Raft catalog for globally consistent schema/control-plane changes | Roadmap |
+| D5 | Raft catalog for globally consistent schema/control-plane changes | Boundary accepted (ADR 0052); replicated log slice roadmap |
 | D6 | Auto-failover runtime wiring: leader lease + replica promotion | In progress |
 
 Total: ~1 trimester of focused work **after** the TS/CH parity

--- a/docs/data-models/vectors.md
+++ b/docs/data-models/vectors.md
@@ -262,6 +262,42 @@ WITH AUTO EMBED (title, body) USING openai MODEL 'text-embedding-3-small'
 
 For bulk inserts, RedDB batches all non-empty embedding texts through `AiBatchClient`, applies provider retry/timeout handling, and then stores one vector per embedded row. The SQL and HTTP request shape did not change; batching is transparent to clients.
 
+## Auto-embed over CDC
+
+Instead of repeating `WITH AUTO EMBED` on every insert, a collection can declare
+an `EMBED` policy once in its DDL. Then **every** write to that collection is
+embedded automatically, asynchronously, off the write path:
+
+```sql
+CREATE TABLE articles (id INT, title TEXT, body TEXT)
+WITH (
+  EMBED (fields = ('title', 'body'), provider = 'openai', model = 'text-embedding-3-small')
+)
+```
+
+With an `EMBED` policy in place:
+
+- An `INSERT`/`UPDATE` commits and returns immediately — it emits its usual CDC
+  change event and does **no** provider work, so write latency stays independent
+  of the embedding provider.
+- A CDC enrichment consumer later drains the change stream, embeds the declared
+  fields, and attaches the vector — exactly as a manual `WITH AUTO EMBED` insert
+  would have.
+- Until the vector is attached, the row is **`pending`** and is naturally
+  excluded from `VECTOR SEARCH` (it has no vector yet), so a search never returns
+  a half-enriched set. Failed enrichment retries with backoff and then
+  dead-letters, with an operator re-drive path.
+
+> [!TIP]
+> Inline `WITH AUTO EMBED` (above) and the declarative `EMBED` policy attach
+> vectors the same way and are searchable identically. Use inline `AUTO EMBED`
+> for one-off control per insert; use the `EMBED` policy when you want every
+> write to a collection embedded without restating it.
+
+See [Per-collection AI policy](../query/ai-policy.md) for the full `EMBED`
+grammar, the retry/dead-letter/re-drive states, and DDL-time provider
+validation.
+
 ## Distance Metrics
 
 | Metric | Description |

--- a/docs/deployment/embedded.md
+++ b/docs/deployment/embedded.md
@@ -60,3 +60,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 For the full API surface, see [Embedded (Rust)](/api/embedded.md).
+
+## Storage profile
+
+Embedded mode today opens a single `.rdb` file plus the sidecar shadows
+documented in [`.rdb` File Format](/engine/file-format.md). The target embedded
+profile keeps the one-file ergonomics but moves that state into a single
+internally *zoned* `.rdb` with an in-file manifest, WAL region, and ping-pong
+superblocks, so no sidecars are required for normal operation. That design is
+proposed, not shipped — see
+[Operational Storage Profiles](/engine/operational-storage-profiles.md) for the
+full profile matrix and how embedded relates to serverless, primary-replica, and
+cluster packaging.

--- a/docs/deployment/first-boot.md
+++ b/docs/deployment/first-boot.md
@@ -14,14 +14,44 @@ Every `red server` boot follows this order:
 3. Build the auth store. If `--vault` is active, open the encrypted vault from
    `REDDB_CERTIFICATE` or `REDDB_VAULT_KEY` and their `_FILE` companions.
 4. If `--no-auth` or `--dev` is active, skip every auth bootstrap path.
-5. Otherwise apply `REDDB_BOOTSTRAP_MANIFEST` when set, or `REDDB_PRESET`
-   (`simple`, `production`, `regulated`).
+5. Otherwise apply `REDDB_BOOTSTRAP_MANIFEST` when set, or the configured
+   bootstrap preset.
 
-`REDDB_PRESET=production` creates the first platform admin, installs an
-allow-all policy, attaches it to that admin, and persists
-`system.bootstrap.completed`. When vault-backed, the preset prints the newly
-issued certificate to stderr; save it and update the runtime secret before any
-restart.
+The bootstrap preset is selected by `--bootstrap-preset` /
+`REDDB_BOOTSTRAP_PRESET` (with `REDDB_PRESET` accepted as a legacy alias). The
+accepted values are `simple`, `production`, `regulated`, and `cloud`; the
+default is `simple`. The `production` and `cloud` presets auto-enable `--auth`,
+`--require-auth`, and `--vault` unless `--no-auth` wins.
+
+`--bootstrap-preset production` creates the first platform admin, installs an
+allow-all policy, attaches it to that admin, and persists the bootstrap-complete
+marker. When vault-backed, the preset prints the newly issued certificate to
+stderr; save it and update the runtime secret before any restart.
+
+## Bootstrap Presets
+
+Presets are policy-first: every user a preset creates is an ordinary,
+policy-governed platform user. There is no `system_owned` shortcut — protection
+comes from explicit allow/deny statements (see [policy-first bootstrap](#policy-first-bootstrap)).
+
+| Preset | Users created at first boot | Allow-all policy | Auth/vault auto-enabled | Managed guardrails installed |
+|---|---|---|---|---|
+| `simple` (default) | None | — | No (auth knobs stay as configured) | None |
+| `production` | One first admin from `--bootstrap-admin` / `REDDB_USERNAME` (+ password) | Yes, attached to the admin | Yes | `system.bootstrap.first-admin-allow-all` |
+| `cloud` | Two: a head/platform admin (`--cloud-head-admin`) and a customer admin (`--customer-admin`) | Yes, attached to both | Yes | `system.cloud.protect-managed`; `red.config.cloud.*` registered managed |
+| `regulated` | None | — | Yes | `system.regulated.protect-managed`; audit / evidence / query-audit config registered managed; query-audit infrastructure enabled |
+
+Admin credentials are supplied per preset:
+
+- `production` reads `--bootstrap-admin` / `REDDB_USERNAME` and
+  `--bootstrap-admin-password` / `REDDB_PASSWORD` (or the `*-password-file`
+  variant).
+- `cloud` reads `--cloud-head-admin` / `REDDB_CLOUD_HEAD_ADMIN` and
+  `--customer-admin` / `REDDB_CUSTOMER_ADMIN` (each with matching password and
+  `-password-file` flags). The two usernames must differ.
+
+The bootstrap-complete marker makes presets idempotent: a preset applies once
+and is skipped on every later boot of the same database.
 
 For the standalone `red bootstrap` command, always run it against the same
 database file/volume that will be served. A certificate minted from a scratch
@@ -31,8 +61,8 @@ database does not unseal another database.
 
 | Delivery shape | No-auth first boot | Auth/vault first boot | Current status |
 |---|---|---|---|
-| Standalone / embedded file | Supported with `--no-auth` or `--dev`; this disables vault and skips presets. | Supported through `red bootstrap --vault` on the real file/volume, or `red server --vault` plus `REDDB_PRESET=production` and admin env. | Supported. |
-| Serverless writer | Same as standalone; serverless is a standalone process role with serverless storage/remote backend contract. | Supported on the single writer. Bootstrap the local writer volume before remote backup/restore, or use first-start `REDDB_PRESET=production` and capture the emitted certificate. | Supported for one writer. |
+| Standalone / embedded file | Supported with `--no-auth` or `--dev`; this disables vault and skips presets. | Supported through `red bootstrap --vault` on the real file/volume, or `red server --vault` plus `REDDB_BOOTSTRAP_PRESET=production` and admin env. | Supported. |
+| Serverless writer | Same as standalone; serverless is a standalone process role with serverless storage/remote backend contract. | Supported on the single writer. Bootstrap the local writer volume before remote backup/restore, or use first-start `REDDB_BOOTSTRAP_PRESET=production` and capture the emitted certificate. | Supported for one writer. |
 | Primary-replica | Supported on the primary; replicas should not create local admins. | Supported on the primary only. Replicas must receive replicated auth state from the primary and must not receive bootstrap env. | Supported for the primary-replica writer path. |
 | Cluster | Supported only as today's cluster-shaped storage/discovery contract with standalone process roles. | Not supported yet. Symmetric members cannot safely pick a first writer, so `mode=cluster` rejects `auth.enabled=true`, and `red server` rejects bootstrap env when the resolved shape is cluster. | Incomplete until cluster writer election/range ownership defines a single auth bootstrap owner; tracked by [PRD #1227](https://github.com/reddb-io/reddb/issues/1227). |
 
@@ -47,6 +77,24 @@ Initial config comes from three layers:
 
 This means an operator can ship initial config with the container without
 overwriting later `SET CONFIG` changes.
+
+## Policy-First Bootstrap
+
+Bootstrap and manifest users are ordinary policy-governed principals. There is
+no special operator-owned class:
+
+- The engine rejects `users[].system_owned` in bootstrap manifests and rejects
+  `condition.system_owned` in policies. Ownership must be modeled as explicit
+  `user:*` / `policy:*` allow and deny statements.
+- User-lifecycle mutations authorize against `user:*` actions
+  (`user:create`, `user:update`, `user:disable`, `user:delete`,
+  `user:password:change`, `user:role:update`) on `user:<username>` resources.
+  Public HTTP and gRPC user-delete / password-change paths call that gate.
+- Managed policies are protected by policy, not by a structural flag: once IAM
+  is active, `policy:put` / `policy:drop` / `policy:attach` / `policy:detach`
+  on a managed policy resource must be explicitly allowed, and an explicit Deny
+  always wins. The `production`, `cloud`, and `regulated` presets install their
+  guardrails as managed policies governed this way.
 
 ## RedDB Cloud Admin Model
 
@@ -124,14 +172,17 @@ user and policy resources.
 
 - `service_cli::to_db_options` makes `--no-auth` the final word and disables
   vault/presets for that boot.
-- `service_cli::apply_preset` applies manifests or presets idempotently via
-  `system.bootstrap.completed`.
+- `service_cli` resolves the bootstrap preset from `--bootstrap-preset`,
+  `REDDB_BOOTSTRAP_PRESET`, then the legacy `REDDB_PRESET`, defaulting to
+  `simple`, and applies manifests or presets idempotently via the
+  bootstrap-complete marker.
 - `AuthStore::bootstrap` creates the first admin, API key, vault keypair, and
   certificate when a pager-backed vault exists.
 - Helm renders auth bootstrap env only into the writer StatefulSet and rejects
   `mode=cluster` with `auth.enabled=true`. The `red server` CLI also rejects
-  `REDDB_PRESET`, `REDDB_BOOTSTRAP_MANIFEST`, and admin username/password env
-  in cluster-shaped boots unless `--no-auth` or `--dev` is explicit.
+  `REDDB_BOOTSTRAP_PRESET` / `REDDB_PRESET`, `REDDB_BOOTSTRAP_MANIFEST`, and
+  admin username/password env in cluster-shaped boots unless `--no-auth` or
+  `--dev` is explicit.
 - User lifecycle policy gates cover `user:create`, `user:delete`,
   `user:disable`, `user:password:change`, and `user:role:update`; public HTTP
   and gRPC user-delete/password-change paths call that gate.

--- a/docs/deployment/serverless.md
+++ b/docs/deployment/serverless.md
@@ -185,9 +185,19 @@ deployments use S3-compatible storage so the writer lease has a
 home. See [Remote Backends](backends.md) for the full matrix and
 the conditional-write contract.
 
+## Storage profile
+
+The serverless artifact remains a single canonical `.rdb`. The target serverless
+profile additionally lets a runtime export and hydrate a derived *segment pack* —
+a manifest plus immutable parts and delta WAL segments — to support object-storage
+caching, multipart copy, and faster cold boot, while round-tripping back to the
+same `.rdb` logical state. That packaging is proposed, not shipped; see
+[Operational Storage Profiles](/engine/operational-storage-profiles.md).
+
 ## See also
 
 - [Backends](backends.md) — `RED_BACKEND` matrix, CAS contract
+- [Operational Storage Profiles](/engine/operational-storage-profiles.md) — target storage layouts
 - [Replication](replication.md) — commit policy, writer lease
 - [Operator Runbook](../operations/runbook.md) — full deploy / DR playbook
 - [Metrics Spec](../spec/metrics.md) — every gauge / counter named above

--- a/docs/dev/house-style.md
+++ b/docs/dev/house-style.md
@@ -1,0 +1,83 @@
+# House Style (TigerStyle-derived)
+
+RedDB follows a deliberately-scoped, correctness-first house style adapted from
+TigerBeetle's [TigerStyle](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md).
+This page is a **summary and index** — the source of truth is
+[`STYLE.md`](https://github.com/reddb-io/reddb/blob/main/STYLE.md) at the repo
+root, and the rationale (including the rules we consciously rejected) is in
+**ADR 0056 — Adopt a TigerStyle-derived house style**. Read those before
+assuming a TigerBeetle rule applies here.
+
+Design goals, in order: **safety, performance, developer experience.** These
+rules apply to **new and changed code**; match surrounding code when editing
+existing files (CLAUDE.md §3, Surgical Changes).
+
+## The rules at a glance
+
+- **Two kinds of failure.** *Operating* errors (disk, network, corrupt data,
+  exhaustion) are expected and must be handled by propagating a `Result`.
+  *Programmer* errors (broken invariants) are unexpected and must crash. A bare
+  `.unwrap()` blurs the two and is banned — write `.expect("invariant: …")`
+  stating why the value cannot be absent, or propagate the error.
+- **Assertions stay live in release.** `assert!` (not `debug_assert!`) is the
+  default; use `debug_assert!` only in a *measured* hot loop. Pair assertions
+  across at least two code paths, assert both the positive and negative space,
+  and use compile-time asserts for type-size / layout invariants.
+- **Function shape.** Push `if`s up and `for`s down — keep branching in the
+  parent and move non-branchy fragments to pure leaf helpers. A soft
+  `too_many_lines` lint nudges long new functions to split; it is a prompt, not
+  a hard wall.
+- **Naming (new code).** `snake_case`; no abbreviations; units/qualifiers last
+  by descending significance (`latency_ms_max`, not `max_latency_ms`); helpers
+  carry the caller's name; nouns over participles.
+- **Off-by-one discipline.** Treat `index` (0-based), `count` (1-based), and
+  `size` (count × unit) as distinct quantities. Show division intent
+  (`div_ceil` / `div_floor`) and prefer checked conversions over silent `as`
+  truncation on lengths and on-disk offsets.
+- **Performance is design-time first.** A PRD or ADR that changes the **data
+  plane** (WAL, pager, query execution) must carry a one-line
+  back-of-the-envelope sketch across network / disk / memory / CPU. Separate
+  control plane from data plane, batch the data plane, and pool/reuse buffers
+  on hot paths instead of allocating per operation.
+- **Untrusted input is depth-bounded.** Every parse/expansion path over
+  untrusted input (RQL especially) carries an explicit depth cap — recursion is
+  fine when bounded. Generalize the existing `JSON_LITERAL_MAX_DEPTH` pattern
+  rather than inventing a new guard per call site.
+
+## Consciously rejected
+
+ADR 0056 records four TigerBeetle rules RedDB declined, with rationale, so a
+future contributor does not reintroduce them:
+
+- **Static allocation / no dynamic allocation after init** — rejected wholesale
+  (RedDB has arbitrary collections, variable-size rows, growing B-trees); only
+  the hot-path spirit ("don't allocate per operation") is adopted.
+- **Zero dependencies** — rejected as a literal rule; the defensible version
+  (data-path primitives and wire/file/crypto/JSON formats homed in-house) is
+  governed by ADR 0046 / ADR 0054, not re-codified here.
+- **Avoid `usize`** — rejected; `usize` is the correct Rust type for indexing
+  and lengths, and avoiding it would force truncating casts everywhere.
+- **Hard 70-line function limit** — rejected as a hard limit; adopted as a soft
+  ratchet (~100–120 lines), since idiomatic Rust `match` / builder code
+  legitimately runs longer than a Zig 70-line cap.
+
+## Mechanical enforcement (lint ratchets)
+
+The taste calls are written guidance; the rules with mechanical backing are
+enforced as **ratchets** — clean on existing code, enforced on new/changed code
+— via `[workspace.lints]` / clippy / CI (`cargo clippy --locked --all -- -D
+warnings`):
+
+| Rule | Lint / mechanism |
+|---|---|
+| Ban bare `.unwrap()` → `.expect("invariant: …")` | `clippy::unwrap_used`; storage-hotspot migration landed separately |
+| Long new functions | `clippy::too_many_lines` (soft ratchet) |
+| Truncating `as` casts on lengths / offsets | cast lint ratchet |
+| Depth-bounded untrusted input | generalized depth cap (RQL parse paths) |
+
+## See also
+
+- `STYLE.md` (repo root) — the day-to-day rules, in full.
+- ADR 0056 — adopted subset, rejected rules, and enforcement.
+- ADR 0046 / ADR 0054 — the in-house data-path / format dependency stance.
+- `AGENTS.md` — points agents at both `STYLE.md` and ADR 0056.

--- a/docs/dev/monorepo-structure.md
+++ b/docs/dev/monorepo-structure.md
@@ -40,23 +40,51 @@ Do not introduce public Rust packages named `reddb-*` or short package names
 such as `red-rql`; they break the registry naming pattern and make the crate
 graph harder to scan.
 
-## Contract Modules
+## Authority Crates
 
-Contract modules are the authority for formats shared across runtimes or
-languages:
+Authority crates are the single home for formats, vocabularies, and contracts
+shared across runtimes or languages. Each owns a correctness-critical surface so
+that surface is declared once, never redeclared opportunistically inside
+`reddb-server`. They form an acyclic layer *below* the server: every authority
+crate may depend on the keystone, but nothing depends back on `reddb-server`.
 
-- `crates/reddb-wire` owns communication contracts: RedWire frames, payloads,
-  topology advertisements, connection strings, sanitizers, and replication wire
-  messages.
-- `crates/reddb-file` owns persistence contracts: file names, layouts,
-  manifests, WAL envelopes, snapshots, checkpoints, and recovery metadata.
-- `crates/reddb-rql` owns the RQL front-end and conformance corpus.
-- `crates/reddb-types` owns neutral logical values and type vocabulary.
-- `crates/reddb-grpc-proto` owns generated gRPC stubs while reusing canonical
-  wire/topology types where applicable.
+- `crates/reddb-types` (`reddb-io-types`) is the **neutral keystone** at the
+  bottom of the graph. It owns the logical type vocabulary — `Value`,
+  `DataType`, `SqlTypeName`, `TypeModifier`, `TypeCategory`, `ValueError`, `Row`
+  — plus the `value_codec` serialization those types delegate to. It depends on
+  no other workspace crate; every other authority crate depends on it. See
+  ADR 0052.
+- `crates/reddb-rql` (`reddb-io-rql`) owns the **RQL language front-end** and the
+  **conformance corpus**: lexer, parser, AST, the mode translators (SQL,
+  Gremlin, Cypher, SPARQL, Path, Natural, vector extensions), analyzer,
+  expression typing, and the storage-agnostic optimizer — text in, typed logical
+  plan out. The physical executors stay in `reddb-server`; this crate does not
+  execute queries. Its sqllogictest-format conformance suite (truth from the
+  public SQLite corpus plus RedDB-authored goldens) is the correctness
+  specification CI runs against the server engine. Depends only on
+  `reddb-io-types`. See ADR 0053.
+- `crates/reddb-crypto` (`reddb-io-crypto`) owns the **per-page
+  encryption-at-rest envelope**: the canonical `encrypt_page` / `decrypt_page`
+  byte-format (AES-256-GCM), the fixed `params` (key/nonce/tag sizes, overhead,
+  AEAD name), and key parsing (`parse_key`, hex or base64). The page-0
+  "is-this-database-encrypted" header (`RDBE` marker, salt, key-check) stays in
+  `reddb-file`. See ADR 0054.
+- `crates/reddb-wire` (`reddb-io-wire`) owns **communication contracts**: RedWire
+  frames, payloads, topology advertisements, connection strings, sanitizers, and
+  replication wire messages.
+- `crates/reddb-file` (`reddb-io-file`) owns **persistence contracts**: file
+  names, layouts, manifests, WAL envelopes, snapshots, checkpoints, the page-0
+  paged-encryption header, and recovery metadata.
+- `crates/reddb-grpc-proto` (`reddb-io-grpc-proto`) owns the **generated gRPC
+  stubs** (tonic server + client), reusing canonical wire/topology types where
+  applicable.
 
-Runtime code may adapt these contracts, but should not redeclare protocol or
-file shapes locally. See ADR 0046 for the wire/file authority rule.
+Runtime code may adapt these contracts, but should not redeclare protocol, file,
+type, query, or crypto shapes locally. `reddb-server` keeps thin delegating
+facades over each authority crate (for example `crypto::page_encryption`, which
+re-exports the envelope and adds the server-only `key_from_env`); per ADR 0046 a
+facade carries no second format. See ADR 0046 for the umbrella authority rule and
+ADRs 0052–0054 for the type, query, and crypto crates respectively.
 
 ## Adapters
 

--- a/docs/engine/architecture.md
+++ b/docs/engine/architecture.md
@@ -63,7 +63,10 @@ The physical layer manages durable file I/O:
 - **WAL**: Write-ahead log for crash recovery
 - **SIEVE Cache**: Adaptive page cache (SIEVE eviction algorithm)
 - **Memory Map**: Optional mmap for read-heavy workloads
-- **Encryption**: AES-256-GCM encryption at the page level
+- **Encryption**: AES-256-GCM per-page envelope (foundation code; not yet
+  written by the live pager — see [Storage Engine Encryption](encryption.md)).
+  The canonical envelope is owned by the `reddb-io-crypto` authority crate
+  (ADR 0054); the page-0 encrypted-database header lives in `reddb-io-file`.
 
 ## Logical Catalog
 

--- a/docs/engine/columnar-chunk-format.md
+++ b/docs/engine/columnar-chunk-format.md
@@ -207,7 +207,12 @@ the columns it reads. The whole-block CRC is still verified regardless.
 The chunk-level reader transposes the two column streams back into
 `(timestamp_ns, value)` rows:
 
-- `points_from_column_block(bytes)` — full decode, every row.
+- `points_from_column_block(bytes)` — full row decode, every row.
+- `column_batch_from_block(bytes, projection)` — typed zero-copy batch decode
+  into a [`ColumnBatch`](columnar-execution.md#columnar-read-decode). Numeric
+  columns decode straight into an aligned word buffer that is reinterpreted in
+  place as `i64` / `f64` without a copy (committed in #962). This is the path a
+  vectorized scan consumes.
 - `query_column_block_range(bytes, start_ns, end_ns)` — range scan that
   prunes via the timestamp column's granule index.
 - `query_column_block_value_eq(bytes, target)` — point query that prunes via
@@ -216,6 +221,11 @@ The chunk-level reader transposes the two column streams back into
 The range and value-eq scans return a `PrunedColumnScan` carrying
 `granules_total` and `granules_scanned`, which is how pruning is made
 measurable end to end.
+
+Activation note: this read path is live for the time-series / hypertable read
+bridge on `COLUMNAR` collections. Routing general `SELECT` execution through the
+batch decode is not wired yet — see
+[Columnar Batch Execution](columnar-execution.md#columnar-read-decode).
 
 ## See also
 

--- a/docs/engine/columnar-execution.md
+++ b/docs/engine/columnar-execution.md
@@ -104,15 +104,40 @@ The picker, planned for the B5/B6 sprint:
 | Aggregate that can read from a matching projection    | Projection → Batch |
 | Hypertable scan filtered by time column               | Pruned Batch |
 
+## Columnar read decode
+
+Reading a sealed columnar (RDCC) chunk back is now done through a typed,
+zero-copy batch decode (committed in #962, lineage PRD #850). The decoder
+(`column_batch_from_block`) decodes each numeric column straight into an
+aligned `Vec<u64>` in one pass, then reinterprets that allocation in place as
+`Vec<i64>` / `Vec<f64>` without copying. A row-shaped decode
+(`points_from_column_block`) is also available for callers that want
+`TimeSeriesPoint`s rather than a `ColumnBatch`.
+
+Inside the runtime, the time-series read bridge dispatches on chunk format:
+columnar-sealed chunks decode through the column-block range scan (granule
+pruned), and row-sealed chunks fall back to the row materializer, so a
+collection can mix both chunk formats and still read back correctly.
+
+> **Activation status.** The typed columnar read-back is live for the
+> time-series / hypertable read path on collections sealed with `COLUMNAR`. The
+> general SQL planner does **not** yet route arbitrary `SELECT` execution
+> through the batch path — the batch-vs-row picker (table below) is still
+> planned. Columnar storage is opt-in per collection and off by default; see
+> [When to use columnar vs row](../data-models/timeseries.md#when-to-use-columnar-vs-row).
+
 ## Benchmarks
 
-Published in [`docs/perf/olap-benchmarks.md`](../perf/olap-benchmarks.md)
-as each sprint lands. Rough current state (micro-benchmarks on
-synthetic data):
+The committed columnar-vs-row read benchmark lives in
+[`docs/perf/2026-06-03-columnar-read.md`](../perf/2026-06-03-columnar-read.md)
+(harness: `crates/reddb-server/benches/columnar_read_bench.rs`). After the #962
+optimization the batch decode path matches or beats the row path at every
+measured chunk size (1 K / 10 K / 50 K rows): batch p50 and p99 are both ≤ the
+row path, with the batch path ~2–3% faster at 10 K and 50 K rows.
 
-* `sum_f64` — SIMD/scalar ratio ~4× on AVX2 hardware for 10k f64s.
-* `batch_aggregate` on 1M rows grouped by a single TEXT column:
-  150ms single-thread, 45ms with 4 rayon workers.
+> The absolute timings in that doc are only comparable **within a single bench
+> run** — the batch/row *ratio* is the load-invariant signal, not the raw µs.
 
-Keep in mind these are unit-level measurements; end-to-end figures
-require the planner to choose the batch path — tracked in B5 + B6.
+Other figures on this page (`sum_f64` SIMD ratios, `batch_aggregate`
+throughput) are unit-level micro-benchmarks on synthetic data; treat them as
+illustrative until end-to-end SQL routes through the batch path.

--- a/docs/engine/encryption.md
+++ b/docs/engine/encryption.md
@@ -10,6 +10,62 @@ The storage engine has cryptographic building blocks for an encrypted pager, but
 - The main pager does not yet encrypt every page before writing.
 - Archived WAL segments and snapshots rely on backend-side encryption if the operator needs at-rest protection.
 
+## The Page Envelope (`reddb-io-crypto`)
+
+The per-page encryption-at-rest envelope is owned by the `reddb-io-crypto`
+authority crate (lib `reddb_crypto`, ADR 0054), paralleling `reddb-io-wire`
+(protocol contracts) and `reddb-io-file` (on-disk artifacts) under ADR 0046. The
+crate owns three things and nothing else:
+
+- the canonical envelope byte-format — `encrypt_page` / `decrypt_page`,
+  AES-256-GCM;
+- the fixed crypto `params` (key/nonce/tag sizes, overhead, AEAD name) as
+  constants, not configuration;
+- key parsing (`parse_key`, hex or base64).
+
+### Envelope layout
+
+The envelope is a **magic-less frame**: a `12`-byte AES-GCM nonce, the
+ciphertext, and a `16`-byte GCM tag, for a fixed **`28`-byte overhead** per page
+(`NONCE_SIZE + TAG_SIZE`). The AEAD additional-authenticated-data binds the page
+identifier as a `u32` little-endian value — the pager's native page-address
+width, with `u32::MAX` reserved for the page-0 key-check slot.
+
+| Field | Size | Notes |
+|:------|:-----|:------|
+| Nonce (IV) | 12 bytes | OS CSPRNG per page |
+| Ciphertext | plaintext length | AES-256-GCM |
+| Tag | 16 bytes | GCM authentication tag |
+| **Overhead** | **28 bytes** | `NONCE_SIZE + TAG_SIZE` |
+
+There is deliberately **no per-page magic or version**. The page-0
+encrypted-database header is the self-describing authority for *whether* a
+database is encrypted and under which salt — it lives in `reddb-io-file`
+(`PAGED_ENCRYPTION_MARKER` = `b"RDBE"`, `PagedEncryptionHeader`), and the
+fixed-size `60`-byte key-check slot (32-byte plaintext + 28 overhead) already
+embeds this exact frame. A per-page magic would duplicate authority the page-0
+header already holds, which ADR 0046 forbids. Future envelope changes (a new
+AEAD or nonce scheme) version through that page-0 header, never through a silent
+edit to `params`.
+
+### How this differs from vault encryption
+
+The page envelope is **not** the same surface as the configuration/secrets
+vault. The vault protects secret *values* (users, API keys, config secrets) with
+AES-256-GCM authenticated encryption and Argon2id key derivation, and is active
+today — see [Encryption at Rest](../security/encryption.md) and the
+[Vault](../security/vault.md) page. The page envelope is a *storage-engine*
+contract for whole-page data and remains dormant in the live pager (the path
+hardcodes `encryption: None`), so nothing is byte-persisted through it yet.
+
+### Server facade
+
+`reddb-server` keeps a thin delegating facade (`crypto::page_encryption`) that
+re-exports the envelope and adds the server-specific `key_from_env`
+(`RED_ENCRYPTION_KEY` / `RED_ENCRYPTION_KEY_FILE`) plus a `PageEncryptor`
+convenience wrapper that binds a zeroizing `SecureKey` to the canonical free
+functions. Per ADR 0046 the facade carries no second envelope.
+
 ## Why Pager Encryption Is Post-v1.0
 
 Wiring encryption into the pager is a format change, not a toggle. It needs:

--- a/docs/engine/file-format.md
+++ b/docs/engine/file-format.md
@@ -630,6 +630,17 @@ A RedDB database may have these companion files:
 | `.rdb-dwb` | Double-write buffer (empty when idle) |
 | `.wal` | Write-ahead log |
 
+> [!NOTE]
+> **Target evolution.** The companion-file model above is the current shipped
+> format. The proposed embedded profile (ADR 0038) folds the WAL, manifest, and
+> page-0/page-1 shadows into a single internally *zoned* `.rdb` with ping-pong
+> superblocks, so those sidecars are no longer required for normal operation. The
+> serverless profile (ADR 0039) adds a derived *segment pack* — manifest plus
+> immutable parts and delta WAL segments — that round-trips back to `.rdb`.
+> Primary-replica production and cluster deployments move to an operational
+> directory layout instead of a single file. None of these layouts ship yet; see
+> [Operational Storage Profiles](operational-storage-profiles.md).
+
 ### Durability Summary
 
 1. **WAL-first**: All changes written to WAL before modifying database pages

--- a/docs/engine/operational-storage-profiles.md
+++ b/docs/engine/operational-storage-profiles.md
@@ -1,0 +1,164 @@
+# Operational Storage Profiles
+
+> [!NOTE]
+> This page describes a **target storage design**, not the current shipped
+> on-disk format. The decisions below come from ADRs 0038–0045, all of which are
+> currently **proposed**. What ships today is the single-file `.rdb` page format
+> with sidecar shadows documented in
+> [`.rdb` File Format](file-format.md); the zoned, directory, and segment-pack
+> layouts here are the planned evolution, surfaced so deployment docs and
+> operators can reason about where each profile is headed.
+
+RedDB does not assume one physical packaging for every deployment. The target
+model separates a small set of **storage profiles** so embedded portability,
+serverless cold-boot, primary-replica backup, and cluster range movement can each
+optimize for their own constraints, while sharing the same *logical* concepts —
+collection identity, range identity, LSN/term, ownership epoch, checksums, and
+manifest/checkpoint boundaries.
+
+## Profile matrix
+
+The profile distinction is the core decision in
+[ADR 0040 — Operational Storage Profiles](../../.red/adr/0040-operational-storage-profiles.md).
+
+| Profile | Packaging | Notes |
+|---|---|---|
+| Embedded | Single zoned `.rdb` file | SQLite-like one-file artifact; self-contained, no mandatory sidecars (target). ADR 0038. |
+| Serverless | `.rdb` plus a derived segment pack | `.rdb` stays canonical; a manifest + immutable parts + delta WAL segments support object storage, multipart copy, and hot boot. ADR 0039. |
+| Primary-replica | Single-file for dev/small; **operational directory** for production | Operational layout becomes required once replicas, managed backup, or WAL retention are enabled. ADR 0040/0044. |
+| Cluster | **Operational directory**, range-oriented | Always directory layout; physical files are organized by shard/range. ADR 0040/0045. |
+
+Two product rules follow from this matrix:
+
+- **Preset selection is guided, not automatic migration.** RedDB does not
+  silently promote a running single-file deployment into an operational directory
+  layout. Dev/small presets default to single-file; production presets make the
+  operational layout required once HA or backup intent is declared.
+- **Cluster nodes never use embedded single-file packaging**, because range
+  movement, snapshots, repair, WAL retention, and range-indexed recovery need
+  explicit local structure.
+
+## Embedded: single-file zoned `.rdb`
+
+[ADR 0038](../../.red/adr/0038-embedded-single-file-zoned-rdb.md) targets a single
+`.rdb` file that carries all required durable state, internally zoned for
+superblock copies, manifest/catalog state, a circular WAL region, page/grid
+storage, free-space metadata, and checksums. The design borrows TigerBeetle-style
+discipline (ping-pong superblocks, checksummed block references, replayable
+state) while keeping a SQLite-like single-file user experience.
+
+Sidecars such as the double-write buffer, header/metadata shadows, and external
+WAL remain transitional implementation details while the zoned format is
+introduced; the promoted embedded profile must not require them. The sidecars
+that ship today are documented in [`.rdb` File Format](file-format.md#companion-files).
+
+## Serverless: derived segment pack
+
+[ADR 0039](../../.red/adr/0039-serverless-rdb-segment-pack.md) keeps `.rdb` as the
+one canonical database artifact and lets a runtime export it to — and hydrate it
+from — a derived *segment pack*: a manifest plus immutable parts and delta WAL
+segments. The pack exists to support object-storage caching, multipart copy, and
+fast cold boot. It must round-trip: exporting `.rdb` to a pack and hydrating it
+back must preserve the same logical state, checksums, and recovery boundary. It is
+a serverless packaging optimization, never a second database format users have to
+reason about separately, and it does not weaken embedded single-file semantics.
+
+## Operational directory layout
+
+Primary-replica production and all cluster deployments use an operational
+directory rather than a single file. The directory model is split across several
+ADRs:
+
+### Collection layouts (ADR 0041)
+
+[ADR 0041](../../.red/adr/0041-operational-collection-layouts.md) gives mutable and
+append-only collections different physical shapes:
+
+- **Mutable collections** use stable object files such as `collection_id.rdb` and
+  `collection_index_id.rdb` (WiredTiger/Postgres-style file separation).
+- **Append-only collections** (timeseries, events, logs) use immutable closed
+  segments plus compaction and retention rather than in-place pages. The first
+  contract is strict: no logical `UPDATE`/`DELETE`; retirement happens through
+  retention, TTL, or compaction. Closed segments are immutable.
+- **Segment chunks are 512 KiB**, each with an expected checksum recorded in the
+  segment index/manifest, supporting predictable prefetch, validation, multipart
+  copy, and future fine-grained repair.
+- **Compression starts at append-only segment granularity** — default `zstd`,
+  with `none` available. Mutable collection files do not use page/block
+  compression in the first design.
+- **One physical WAL per node/store.** WAL records carry collection, index,
+  range, transaction, and LSN identity; replicas and range movement consume a
+  *derived logical stream*, not the physical WAL.
+
+### Manifest and DDL recovery (ADR 0042)
+
+[ADR 0042](../../.red/adr/0042-operational-manifest-and-ddl-recovery.md) makes
+`red.manifest` the authoritative map from logical objects (collection, index,
+range, segment) to physical files, plus the checkpoint boundary. Key rules:
+
+- Physical files are identified by stable internal IDs (globally unique
+  `file_id`s), not human names, so renames do not move files.
+- Manifest updates are copy-on-write atomic replace: write the next generation
+  with a checksum, fsync, atomically rename, fsync the directory.
+- **Create publishes after durability** (file created and fsynced, then
+  published); **drop is two-phase** through a `drop_pending` manifest state.
+- **Orphan recovery quarantines by default**: files present on disk but absent
+  from the manifest move to `lost+found/` with recovery metadata, never auto-
+  deleted or auto-attached.
+
+### Backup and restore boundary (ADR 0043)
+
+[ADR 0043](../../.red/adr/0043-operational-backup-restore-boundary.md) defines a
+local/primary-replica backup contract: a backup starts from a consistent
+checkpoint, copies the manifest plus covered data/index/segment files, and retains
+WAL from the checkpoint boundary forward. Restore loads the checkpoint, validates
+the manifest and file checksums, then replays WAL to a target LSN before opening
+the store. WAL pruning is bounded by the stricter of PITR retention and the
+slowest replica's durable restart LSN. **Coordinated cluster-wide backup is
+explicitly out of scope** for this first contract and needs a separate distributed
+protocol.
+
+## Cluster: range file layout
+
+[ADR 0045](../../.red/adr/0045-cluster-range-file-layout.md) organizes cluster
+local storage by shard/range so ownership, repair, movement, and recovery share
+one operational unit:
+
+- **Each range is a directory** containing separate data, index, and append-only
+  segment files as needed.
+- The node still keeps **one physical WAL per store**; WAL records carry range,
+  collection, index, transaction, term/epoch, and LSN identity rather than being
+  split per range.
+- **Move-range copies a physical snapshot first, then catches up** through the
+  logical range-indexed stream; only after catch-up does the ownership catalog
+  advance the epoch and move write authority.
+- **Initial range repair uses full rebootstrap** — a corrupt or too-stale range
+  replica is quarantined locally and rebootstrapped from a healthy owner. Finer
+  block/segment-level repair by checksum is deferred.
+
+The cluster routing, ownership-catalog, and cross-range model that sits above this
+layout is documented in [Cluster Sharding](../architecture/cluster-sharding.md).
+
+## Shared logical concepts
+
+Whatever the physical packaging, profiles share core logical identity so backup,
+replication, and recovery tooling can reason across them:
+
+- collection / range / index identity;
+- LSN and term;
+- ownership epoch (cluster);
+- page and segment-block checksums;
+- manifest / checkpoint boundaries (operational and embedded-internal).
+
+This is why a logical replication stream — not the physical WAL — is the
+replication and range-movement contract across primary-replica and cluster
+profiles (ADR 0041/0044).
+
+## See also
+
+- [`.rdb` File Format](file-format.md) — the shipped single-file page format.
+- [Cluster Sharding](../architecture/cluster-sharding.md) — range ownership,
+  hash slots, and cross-range operations.
+- [Distributed Roadmap](../architecture/distributed-roadmap.md) — what is landed
+  versus planned across the distributed stack.
+- [Replication](../deployment/replication.md) — primary-replica runtime today.

--- a/docs/guides/ai-providers.md
+++ b/docs/guides/ai-providers.md
@@ -1,10 +1,10 @@
 # AI providers — what works where
 
-RedDB speaks to 11 AI providers for the `ASK`, `WITH AUTO EMBED`, and
-`SEARCH SIMILAR ... USING` flows. This page documents which provider
-supports which capability, the wire shape RedDB uses for each, and
-how RedDB behaves when a provider does not offer a capability the
-operator asked for.
+RedDB speaks to a roster of AI providers for the `ASK`, `WITH AUTO EMBED`, and
+`SEARCH SIMILAR ... USING` flows, plus the per-collection
+[AI policy](../query/ai-policy.md). This page documents which provider supports
+which capability, the wire shape RedDB uses for each, and how RedDB behaves when
+a provider does not offer a capability the operator asked for.
 
 If you came here because `ASK 'something' USING anthropic` for an
 embeddings step failed unexpectedly — read the [Anthropic
@@ -14,19 +14,34 @@ embeddings](#anthropic-embeddings-policy) section first.
 
 ## Capability matrix
 
-| Provider    | Token         | API key | Prompt / `ASK` | Embeddings           | Wire shape            |
-|:------------|:--------------|:-------:|:--------------:|:---------------------|:----------------------|
-| OpenAI      | `openai`      | yes     | ✅            | ✅                  | OpenAI-compat         |
-| Anthropic   | `anthropic`   | yes     | ✅            | **rejected** (see below) | Anthropic Messages    |
-| Groq        | `groq`        | yes     | ✅            | ✅                  | OpenAI-compat         |
-| OpenRouter  | `openrouter`  | yes     | ✅            | ✅                  | OpenAI-compat         |
-| Together    | `together`    | yes     | ✅            | ✅                  | OpenAI-compat         |
-| Venice      | `venice`      | yes     | ✅            | ✅                  | OpenAI-compat         |
-| DeepSeek    | `deepseek`    | yes     | ✅            | ✅                  | OpenAI-compat         |
-| HuggingFace | `huggingface` | yes     | ✅            | ✅                  | HF feature-extraction |
-| Ollama      | `ollama`      | no      | ✅            | ✅                  | OpenAI-compat         |
-| Local       | `local`       | no      | feature-gated  | feature-gated        | candle in-process     |
-| Custom URL  | `https://...` | depends | ✅            | ✅                  | OpenAI-compat         |
+| Provider    | Token         | API key | Generate / `ASK` | Embed                    | Vision | Moderate | Wire shape            |
+|:------------|:--------------|:-------:|:----------------:|:-------------------------|:------:|:--------:|:----------------------|
+| OpenAI      | `openai`      | yes     | ✅              | ✅                      | ✅    | ✅      | OpenAI-compat         |
+| Anthropic   | `anthropic`   | yes     | ✅              | **rejected** (see below) | ✅    | —       | Anthropic Messages    |
+| MiniMax     | `minimax`     | yes     | ✅              | ✅                      | ✅    | —       | OpenAI-compat         |
+| Groq        | `groq`        | yes     | ✅              | —                       | ✅    | —       | OpenAI-compat         |
+| OpenRouter  | `openrouter`  | yes     | ✅              | —                       | ✅    | —       | OpenAI-compat         |
+| Together    | `together`    | yes     | ✅              | ✅                      | ✅    | —       | OpenAI-compat         |
+| Venice      | `venice`      | yes     | ✅              | —                       | ✅    | —       | OpenAI-compat         |
+| DeepSeek    | `deepseek`    | yes     | ✅              | —                       | —     | —       | OpenAI-compat         |
+| HuggingFace | `huggingface` | yes     | ✅              | ✅                      | —     | —       | HF feature-extraction |
+| Ollama      | `ollama`      | no      | ✅              | ✅                      | ✅    | —       | OpenAI-compat         |
+| Local       | `local`       | no      | —               | feature-gated            | —     | —       | in-process backend    |
+| Custom URL  | `https://...` | depends | ✅              | ✅                      | —     | —       | OpenAI-compat         |
+
+The **Generate / Embed / Vision / Moderate** columns are the provider's
+[modality capabilities](../api/ai-provider-modes.md#modality-matrix). They gate a
+per-collection [AI policy](../query/ai-policy.md) at `CREATE TABLE` time — a
+policy that asks a provider for a modality it does not serve is rejected up
+front. A `—` in the **Embed** column means RedDB does not route embeddings to
+that provider; name an embed-capable provider for the embedding step instead.
+
+> [!NOTE]
+> The **Vision** and **Moderate** columns describe declared provider capability.
+> The collection-level `VISION` and `MODERATE` policy clauses that consume them
+> are still in progress — see [AI policy](../query/ai-policy.md). The `embed`
+> and `generate` modalities are live today via `AUTO EMBED`, `ASK`, and the
+> `EMBED` policy clause.
 
 `OpenAI-compat` means the provider exposes `POST {base}/embeddings`
 and `POST {base}/chat/completions` with the OpenAI shape, so RedDB
@@ -130,8 +145,12 @@ Default provider can be overridden per-call with `USING <provider>`.
 
 Every provider in the matrix above (except `local` and `ollama`, which
 do not require an API key) resolves its key through the same lookup
-chain. Storing the key in the vault is the production path; env vars
-are useful for dev.
+chain. As of issue #1270, resolution **prefers the encrypted vault over
+environment variables**: the env vars are a zero-config bootstrap fallback so a
+fresh deployment can talk to a provider before any key is written to the vault.
+Vault-stored keys are encrypted at rest and rotatable through the vault KV path;
+env vars carry no such guarantees, which is why they are the fallback rather than
+the primary source.
 
 **Canonical vault path:**
 
@@ -155,12 +174,17 @@ reddb-cli vault set red.secret.ai.openai.prod.api_key "sk-prod-..."
 
 Vault setup itself is covered in [Security → Vault](/security/vault.md).
 
-**Resolution order** (first non-empty wins, per request):
+**Resolution order** (first non-empty wins, per request — vault first, env as a
+bootstrap fallback):
 
-1. Env var `REDDB_<PROVIDER>_API_KEY_<ALIAS>` (or `REDDB_<PROVIDER>_API_KEY` for the default alias)
-2. Vault: `red.secret.ai.<provider>.<alias>.api_key`
-3. Config indirection: `red.config.ai.<provider>.<alias>.secret_ref` points at another KV/vault path
+1. Vault secret: `red.secret.ai.<provider>.<alias>.api_key`
+2. Vault indirection: `red.config.ai.<provider>.<alias>.secret_ref` points at another vault path
+3. Env var `REDDB_<PROVIDER>_API_KEY_<ALIAS>` (or `REDDB_<PROVIDER>_API_KEY` for the default alias)
 4. Legacy plaintext config: `red.config.ai.<provider>.<alias>.key` (deprecated — do not use for new deployments)
+
+For the **default** alias (no `"credential"` in the request), the vault path is
+`red.secret.ai.<provider>.default.api_key` and the env fallback is
+`REDDB_<PROVIDER>_API_KEY`.
 
 A missing key surfaces as a `400` with the exact path the operator
 should populate. There is no silent fallback to a different alias or

--- a/docs/guides/ask-your-database.md
+++ b/docs/guides/ask-your-database.md
@@ -73,6 +73,11 @@ curl -X POST http://127.0.0.1:8080/ai/credentials \
 
 The `"default": true` flag tells RedDB to use Groq whenever you omit `USING` from a query.
 
+> [!NOTE]
+> When both are set, the **vault wins**: key resolution prefers the encrypted
+> vault and treats the `REDDB_{PROVIDER}_API_KEY` env vars as a bootstrap
+> fallback. See [AI providers → Vault credentials](ai-providers.md#vault-credentials).
+
 ### Verify configuration
 
 ```bash
@@ -235,6 +240,12 @@ This single command does three things:
 3. Stores the resulting vector in the `incidents` vector index
 
 > **Tip**: You can use `WITH AUTO EMBED` on every insert. For bulk historical data, the `/ai/embeddings` endpoint with `source_query` mode is more efficient. See the [HTTP API docs](/api/http.md#embeddings).
+
+> [!TIP]
+> To embed **every** write to a collection without restating `WITH AUTO EMBED`,
+> declare an [`EMBED` policy](../query/ai-policy.md) on the collection. Writes
+> then commit immediately and are embedded asynchronously over CDC; rows are
+> `pending` (excluded from vector search) until their vector is attached.
 
 ---
 
@@ -589,9 +600,31 @@ explicitly:
 ASK 'host 10.0.0.5' AS RQL
 ```
 
-The `AS RQL` path does not call the LLM. It uses schema vocabulary and literal
-extraction, validates the generated read-only query through the parser, and
-returns the candidate in the `rql` column for the caller to execute or approve.
+`AS RQL` returns a candidate query in the `rql` column instead of synthesizing a
+natural-language answer. It has two backends, selected by the
+`ai.ask_rql.backend` config key:
+
+- **`deterministic` (default)** — no AI call. Schema vocabulary + literal
+  extraction build the candidate.
+- **`llm`** — the configured `generate` provider translates the question into
+  RQL (parser-validated inference). Falls back to the deterministic planner when
+  no provider/API key is available.
+
+Either way the candidate is **always re-validated through the production parser**
+before it is returned, and it is **not executed** by default. Add `EXECUTE` to
+auto-run a candidate — but only **read-only** candidates run; a mutating
+candidate (`INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`/DDL) is refused even with
+`EXECUTE`:
+
+```sql
+-- returns the candidate only
+ASK 'host 10.0.0.5' AS RQL
+
+-- opts in to running a read-only candidate
+ASK 'host 10.0.0.5' AS RQL EXECUTE
+```
+
+See [Search commands → `AS RQL` and `EXECUTE`](../query/search-commands.md#ask--as-rql-and-execute).
 
 ### SEARCH CONTEXT = 3-Tier Strategy
 
@@ -629,7 +662,7 @@ paths. The provider boundary is enforced as follows:
 | `SELECT … COUNT/SUM/AVG/MIN/MAX(…)` | SQL planner + executor | Exact, reproducible, no network call. |
 | `SEARCH CONTEXT 'term'` | Multi-tier index (field → token → scan) | Returns table rows, documents, KV entries, graph nodes/edges, and vectors when each backing collection exists. Empty result set when nothing matches &mdash; the contract is "ground or fall silent". |
 | `ASK '…'` | `AskPipeline` funnel + LLM synthesis | Pipeline grounds first (Stage 4 literal filter / Stage 3 BM25 + vector / Stage 3c graph), then the LLM rewrites the grounded rows into a citation-bearing sentence. |
-| `ASK '…' AS RQL` | Deterministic RQL planner | Uses schema vocabulary + literal extraction to return a parser-validated read-only query candidate. It does not call the LLM and does not execute the generated RQL. |
+| `ASK '…' AS RQL` | RQL planner (`deterministic`) or inference (`llm`), per `ai.ask_rql.backend` | Returns a parser-validated query candidate. The candidate is re-validated through the parser regardless of backend, and is not executed unless `EXECUTE` is given — and then only when read-only. |
 | Missing or unsupported analytics inside an `ASK` question | Pipeline short-circuits with a structured error OR returns an answer that openly cites "no matching sources" | The LLM never invents a number; it can only quote what `sources_flat` contains. |
 
 A practical rule: if the question is a calculation (`how many incidents are

--- a/docs/guides/local-embeddings.md
+++ b/docs/guides/local-embeddings.md
@@ -375,6 +375,12 @@ untouched** — no partial rows, no rollback dance. The integration
 suite in `tests/integration_auto_embed_local.rs` pins each of these
 behaviours.
 
+> [!TIP]
+> A collection can also declare an [`EMBED` policy](../query/ai-policy.md) so
+> that **every** write is embedded automatically, asynchronously over CDC,
+> without restating `WITH AUTO EMBED`. The end-to-end enrichment path currently
+> drives this `local` embedding backend.
+
 ---
 
 ## No silent fallback

--- a/docs/query/ai-policy.md
+++ b/docs/query/ai-policy.md
@@ -1,0 +1,205 @@
+# Per-collection AI policy
+
+A collection can declare an **AI policy** in its DDL. The policy makes AI a
+declarative property of the data: configured once on the collection, persisted
+in the catalog, and read by the runtime — rather than something every write has
+to re-specify.
+
+The policy is split into one clause per modality, all inside the `CREATE TABLE
+... WITH (...)` option list, next to the existing `tenant_by` / `append_only`
+options:
+
+| Clause | Modality | Status |
+|:-------|:---------|:-------|
+| `EMBED (...)` | Auto-embed declared fields over CDC | **Available** |
+| `MODERATE (...)` | Pre-commit content moderation gate | Parses today; enforcement **planned** |
+| `VISION (...)` | Image understanding from a reference field | Parses today; enforcement **planned** |
+
+The architectural rationale (hybrid write-path coupling, moderation quarantine,
+the provider modality matrix) is recorded in **ADR 0057**.
+
+> [!IMPORTANT]
+> Only the `EMBED` clause is wired end-to-end today (auto-embed over CDC). The
+> `MODERATE` and `VISION` clauses **parse, validate, and persist** in the
+> collection contract, but the moderation gate (content-moderation, in progress)
+> and vision detections (computer vision, in progress) are not yet enforced.
+> Declaring them is forward-compatible, not active.
+
+---
+
+## EMBED — auto-embed over CDC
+
+`EMBED` declares which text fields are automatically vectorised after every
+write. The write path itself does no provider work: an `INSERT`/`UPDATE` commits
+and returns immediately, and a [CDC enrichment consumer](#how-auto-embed-works)
+computes and attaches the vector asynchronously.
+
+```sql
+CREATE TABLE articles (id INT, title TEXT, body TEXT)
+WITH (
+  EMBED (fields = ('title', 'body'), provider = 'openai', model = 'text-embedding-3-small')
+)
+```
+
+### Options
+
+| Option | Required | Description |
+|:-------|:---------|:------------|
+| `fields` | Yes | One or more source columns whose text is embedded, e.g. `('title', 'body')` |
+| `provider` | Yes | Provider token (`openai`, `minimax`, `local`, …) — must support the `embed` modality |
+| `model` | Yes | Embedding model name as the provider expects it |
+
+All three options are required; omitting any of them is a DDL error.
+
+### How auto-embed works
+
+1. An `INSERT`/`UPDATE` on an `EMBED` collection commits normally and emits its
+   usual CDC change event. **Write latency stays independent of the AI
+   provider.**
+2. A CDC enrichment consumer drains the LSN-ordered change stream, joins the
+   declared `fields` into one text value, embeds it through the policy's
+   provider, and attaches the result as a vector in the same collection —
+   exactly as a manual `INSERT ... WITH AUTO EMBED` would.
+3. Until the vector is attached, the row is **`pending`**: it is naturally
+   excluded from `VECTOR SEARCH` (no vector exists yet), so a vector search
+   never returns a half-enriched set.
+
+Inserts always enrich. An update re-enriches only when it touched one of the
+declared `fields`. Deletes do not enrich.
+
+### Retry, dead-letter, and re-drive
+
+| State | Meaning |
+|:------|:--------|
+| `pending` | Enrichment queued or in progress; row not yet vector-searchable |
+| retry | A provider failure re-schedules the row with exponential backoff |
+| dead-letter | After the attempt budget is exhausted, the row is parked for operators |
+
+The consumer retries a failed embedding with exponential backoff (base × 2^n).
+After the configured number of attempts (default 3) the work item is
+**dead-lettered** and surfaced to operators with its last error. Operators can
+**re-drive** dead-letters back into the pending set with a fresh attempt budget
+— for example after fixing a provider credential or outage.
+
+> [!NOTE]
+> The end-to-end enrichment path currently drives the in-process `local`
+> embedding backend. A collection whose `EMBED` policy names another provider
+> parses and persists, and the enrichment consumer treats an unsupported
+> provider as a retryable failure (it will retry then dead-letter).
+
+---
+
+## MODERATE — content moderation gate (planned)
+
+> [!WARNING]
+> The `MODERATE` clause parses, validates against the provider matrix, and
+> persists in the collection contract today, but the moderation enforcement
+> pipeline is **in progress and not yet active**. Declaring it does not yet
+> screen, quarantine, or reject writes. The grammar below is stable; treat the
+> behaviour as a preview.
+
+```sql
+CREATE TABLE comments (id INT, body TEXT)
+WITH (
+  MODERATE (
+    fields  = ('body'),
+    provider = 'openai',
+    model    = 'omni-moderation-latest',
+    sync     = true,
+    degraded = closed,
+    on_reject = flag
+  )
+)
+```
+
+### Options
+
+| Option | Required | Values | Default | Description |
+|:-------|:---------|:-------|:--------|:------------|
+| `fields` | Yes | column list | — | Source fields screened by the moderation provider |
+| `provider` | Yes | provider token | — | Must support the `moderate` modality |
+| `model` | Yes | model name | — | Moderation model |
+| `sync` | No | `true` / `false` | `false` | When `true`, moderation is a synchronous pre-commit gate |
+| `degraded` | No | `open` / `closed` | `open` | Behaviour when the provider is unavailable — `open` lets the write through, `closed` rejects it |
+| `on_reject` | No | `reject` / `flag` / `redact` | `reject` | What happens to content that fails moderation |
+
+The intended design (per ADR 0057) couples moderation **synchronously** to the
+write — rejecting content after it has persisted is pointless. The architectural
+record also describes a fail-open + quarantine degraded posture and a
+tombstone-on-reject visibility rule; those are decided in the ADR and land with
+the moderation pipeline, not with this DDL surface.
+
+---
+
+## VISION — image understanding (planned)
+
+> [!WARNING]
+> The `VISION` clause parses, validates against the provider matrix, and
+> persists today, but vision detections are **in progress and not yet active**.
+> No vision output is attached to rows yet, and there is **no query predicate
+> for filtering on vision output**. Declaring `VISION` is forward-compatible
+> only.
+
+```sql
+CREATE TABLE photos (id INT, image_url TEXT)
+WITH (
+  VISION (
+    image_field = 'image_url',
+    outputs     = ('caption', 'tags'),
+    provider    = 'openai',
+    model       = 'gpt-4o'
+  )
+)
+```
+
+### Options
+
+| Option | Required | Description |
+|:-------|:---------|:------------|
+| `image_field` | Yes | Column holding the image **reference** (a URL/URI — reddb stores the reference, not the image bytes) |
+| `outputs` | Yes | Output kinds to request, e.g. `('caption', 'tags', 'objects')` |
+| `provider` | Yes | Must support the `vision` modality |
+| `model` | Yes | Vision-capable model name |
+
+Like embedding, vision is designed as an **asynchronous enrichment** over CDC.
+The image is referenced by URL; reddb does not introduce a binary/blob type for
+image bytes.
+
+---
+
+## DDL-time validation
+
+Every AI clause is validated **at `CREATE TABLE` time** against the
+[provider modality matrix](../api/ai-provider-modes.md#modality-matrix): a policy
+that wires a provider to a modality it cannot serve is rejected immediately, not
+on the first insert. For example, the `local` backend supports `embed` but not
+`generate`/`vision`/`moderate`, so:
+
+```sql
+-- rejected at DDL time: 'local' cannot serve the moderate modality
+CREATE TABLE t (id INT, body TEXT)
+WITH (MODERATE (fields = ('body'), provider = 'local', model = 'x'));
+```
+
+A policy that references an **unknown provider token** is treated
+conservatively: the matrix assumes only `embed`/`generate` for unknown tokens
+and rejects `vision`/`moderate` requests against them.
+
+---
+
+## Introspection
+
+The persisted AI policy travels with the collection contract and survives
+restarts. Introspecting the collection shows the declared policy as part of its
+schema, so the catalog is the single source of truth for "what AI runs on this
+collection".
+
+---
+
+## See also
+
+- [CREATE TABLE](create-table.md) — full table DDL and `WITH (...)` options
+- [Vectors & embeddings](../data-models/vectors.md#auto-embed-over-cdc) — `AUTO EMBED` and the async enrichment model
+- [AI providers](../guides/ai-providers.md) — provider tokens, the modality matrix, and vault credentials
+- [AI provider modes](../api/ai-provider-modes.md#modality-matrix) — the modality dimension
+- ADR 0057 — AI multi-modality architectural spine

--- a/docs/query/ai-policy.md
+++ b/docs/query/ai-policy.md
@@ -13,17 +13,19 @@ options:
 |:-------|:---------|:-------|
 | `EMBED (...)` | Auto-embed declared fields over CDC | **Available** |
 | `MODERATE (...)` | Pre-commit content moderation gate | Parses today; enforcement **planned** |
-| `VISION (...)` | Image understanding from a reference field | Parses today; enforcement **planned** |
+| `VISION (...)` | Image detections from a reference field | **Pipeline shipped** (local backend; remote providers pending) |
 
 The architectural rationale (hybrid write-path coupling, moderation quarantine,
 the provider modality matrix) is recorded in **ADR 0057**.
 
 > [!IMPORTANT]
-> Only the `EMBED` clause is wired end-to-end today (auto-embed over CDC). The
-> `MODERATE` and `VISION` clauses **parse, validate, and persist** in the
-> collection contract, but the moderation gate (content-moderation, in progress)
-> and vision detections (computer vision, in progress) are not yet enforced.
-> Declaring them is forward-compatible, not active.
+> `EMBED` and `VISION` run over CDC today. `EMBED` is wired end-to-end;
+> `VISION` ships its full pipeline but only against the in-process `local`
+> backend (remote vision providers validate at DDL time but are rejected at
+> enrichment time — see below). The `MODERATE` clause **parses, validates, and
+> persists** in the collection contract, but the moderation gate is **in
+> progress and not yet enforced** — declaring it is forward-compatible, not
+> active.
 
 ---
 
@@ -131,14 +133,20 @@ the moderation pipeline, not with this DDL surface.
 
 ---
 
-## VISION — image understanding (planned)
+## VISION — image understanding
 
-> [!WARNING]
-> The `VISION` clause parses, validates against the provider matrix, and
-> persists today, but vision detections are **in progress and not yet active**.
-> No vision output is attached to rows yet, and there is **no query predicate
-> for filtering on vision output**. Declaring `VISION` is forward-compatible
-> only.
+> [!NOTE]
+> The vision **pipeline shipped** in #1275: with a `VISION` policy, the CDC
+> enrichment consumer fetches the referenced image (`http(s)://`, `file://`,
+> or a bare path), analyzes it, and attaches a structured detections array to
+> the derived `vision_detections` field — which is filterable from RQL with
+> `CONTAINS` (see below). Retry / dead-letter behaves like the `EMBED` path.
+>
+> **Caveat — local backend only.** The analysis currently runs an in-process
+> deterministic backend (the `local` provider). A remote `provider` such as
+> `openai` **validates at `CREATE TABLE` time** (it supports the `vision`
+> modality) but is **rejected at enrichment time** — only `local` actually
+> runs today. End-to-end vision against a hosted model is not yet wired.
 
 ```sql
 CREATE TABLE photos (id INT, image_url TEXT)
@@ -158,12 +166,23 @@ WITH (
 |:-------|:---------|:------------|
 | `image_field` | Yes | Column holding the image **reference** (a URL/URI — reddb stores the reference, not the image bytes) |
 | `outputs` | Yes | Output kinds to request, e.g. `('caption', 'tags', 'objects')` |
-| `provider` | Yes | Must support the `vision` modality |
+| `provider` | Yes | Must support the `vision` modality (validated at DDL time; only `local` runs at enrichment time today) |
 | `model` | Yes | Vision-capable model name |
 
-Like embedding, vision is designed as an **asynchronous enrichment** over CDC.
-The image is referenced by URL; reddb does not introduce a binary/blob type for
-image bytes.
+Like embedding, vision is an **asynchronous enrichment** over CDC. The image is
+referenced by URL/URI; reddb does not introduce a binary/blob type for image
+bytes. Detections land in the `vision_detections` field as
+`[{label, confidence, bbox:[x,y,w,h]}]`; an optional image-embedding output
+reuses the vector pipeline for image similarity.
+
+### Filtering on detections
+
+`CONTAINS` descends into JSON object/array values in the live query path
+(#1275), so you can filter rows by detected label:
+
+```sql
+SELECT * FROM photos WHERE CONTAINS(vision_detections, 'person')
+```
 
 ---
 

--- a/docs/query/create-table.md
+++ b/docs/query/create-table.md
@@ -84,6 +84,25 @@ CREATE TABLE sessions (
 > [!NOTE]
 > Context-indexed fields are not unique constraints. They tell RedDB which fields carry identifying information so that `SEARCH CONTEXT` can link entities across different tables automatically.
 
+## AI policy
+
+The `WITH (...)` option list also accepts per-collection AI policy clauses,
+alongside `tenant_by` and `append_only`. The `EMBED` clause auto-embeds the
+declared text fields on every write, asynchronously over CDC:
+
+```sql
+CREATE TABLE articles (id INT, title TEXT, body TEXT)
+WITH (
+  EMBED (fields = ('title', 'body'), provider = 'openai', model = 'text-embedding-3-small')
+)
+```
+
+`MODERATE (...)` and `VISION (...)` clauses parse and persist today but are not
+yet enforced (in progress). Each clause is validated against the
+[provider modality matrix](../api/ai-provider-modes.md#modality-matrix) at
+`CREATE TABLE` time. See [Per-collection AI policy](ai-policy.md) for the full
+grammar and behaviour.
+
 ## DROP TABLE
 
 Remove a table and all its data:

--- a/docs/query/ddl.md
+++ b/docs/query/ddl.md
@@ -74,6 +74,29 @@ TRUNCATE COLLECTION IF EXISTS embeddings
 Use polymorphic DDL for admin tools, migrations, and cleanup jobs that operate
 over catalog rows rather than hard-coded models.
 
+## AI policy options
+
+`CREATE TABLE ... WITH (...)` accepts per-collection AI policy clauses next to
+`tenant_by` and `append_only`:
+
+```sql
+CREATE TABLE articles (id INT, title TEXT, body TEXT)
+WITH (
+  EMBED (fields = ('title', 'body'), provider = 'openai', model = 'text-embedding-3-small')
+)
+```
+
+| Clause | Purpose | Status |
+|---|---|---|
+| `EMBED (...)` | Auto-embed declared fields over CDC | Available |
+| `MODERATE (...)` | Content-moderation gate | Parses + persists; enforcement planned |
+| `VISION (...)` | Image understanding from a reference field | Parses + persists; enforcement planned |
+
+Each clause is validated against the provider modality matrix at `CREATE TABLE`
+time, so a provider that cannot serve the requested modality is rejected up
+front. See [Per-collection AI policy](ai-policy.md) for full grammar and
+semantics.
+
 ## DROP Forms
 
 ```sql

--- a/docs/query/search-commands.md
+++ b/docs/query/search-commands.md
@@ -236,9 +236,11 @@ stable URNs for UI deep-links. See
 
 > [!IMPORTANT]
 > Plain `ASK` is retrieval-grounded answer synthesis. It does not convert the
-> question into a `SELECT`, and LLM output is never parsed or executed as RQL.
-> Use `ASK ... AS RQL` when you want RedDB to return a validated read-only RQL
-> candidate for caller approval/execution.
+> question into a `SELECT`, and its LLM answer is never parsed or executed as
+> RQL. Use `ASK ... AS RQL` when you want RedDB to return a parser-validated RQL
+> candidate for caller approval; add `EXECUTE` to auto-run a read-only
+> candidate. Even on the inference backend, a candidate is always re-validated
+> through the parser and a mutating candidate is never auto-executed.
 
 ```sql
 ASK 'what happened on host 10.0.0.1?' USING groq
@@ -261,7 +263,8 @@ ASK 'list all users with admin access' USING ollama MODEL 'llama3'
 | `STREAM` | No | HTTP/SSE token stream; transports without SSE return non-streaming rows |
 | `CACHE TTL '5m'` | No | Cache this answer for the supplied TTL |
 | `NOCACHE` | No | Bypass the global ASK cache default |
-| `AS RQL` | No | Return a deterministic, parser-validated RQL candidate instead of calling an AI provider |
+| `AS RQL` | No | Return a parser-validated RQL candidate instead of synthesizing a natural-language answer |
+| `EXECUTE` | No | Auto-run the candidate produced by `AS RQL` — read-only candidates only (see [`AS RQL` and `EXECUTE`](#ask--as-rql-and-execute)) |
 
 ### Examples
 
@@ -312,12 +315,45 @@ candidate explicitly:
 ASK 'passport FDD-12313' AS RQL
 ```
 
-`ASK ... AS RQL` uses schema vocabulary and literal extraction to produce a
-read-only `SELECT`, validates the generated text through the parser, and
-returns it in the `rql` column. Missing `FROM` means the universal source
+`ASK ... AS RQL` returns a candidate RQL statement in the `rql` column. The
+candidate is **always re-validated through the production parser** before it is
+returned, and it is **not executed** unless you add `EXECUTE` (see below).
+
+### `ASK ... AS RQL` and `EXECUTE`
+
+`AS RQL` has two backends, selected by the `ai.ask_rql.backend` config key:
+
+| Backend | `ai.ask_rql.backend` | How the candidate is built |
+|:--------|:---------------------|:---------------------------|
+| Deterministic | `deterministic` (default) | Schema vocabulary + literal extraction — **no AI provider call** |
+| Inference | `llm` | The configured `generate` provider translates the question into RQL |
+
+Both backends produce a candidate and then **re-validate it through the same
+parser seam**, so a model is never trusted to emit safe RQL — the parser is the
+gate. When `ai.ask_rql.backend = "llm"` but no generate provider/API key is
+available, RedDB falls back to the deterministic planner.
+
+With the deterministic backend, a missing `FROM` means the universal source
 `any`, so the eventual query searches eligible collections and applies the
-`WHERE` filter itself. This path does not call an AI provider and does not
-execute the generated RQL for you.
+`WHERE` filter itself.
+
+**`EXECUTE` is an explicit opt-in to run the candidate.** By default `AS RQL`
+returns the candidate only:
+
+```sql
+-- default: returns the candidate, does NOT run it
+ASK 'who owns passport FDD-12313?' AS RQL
+
+-- opt in to auto-run the candidate
+ASK 'who owns passport FDD-12313?' AS RQL EXECUTE
+```
+
+`EXECUTE` auto-runs **read-only** candidates only (`SELECT`, `MATCH`/graph,
+vector, search, …). A candidate the parser classifies as **mutating** (`INSERT`,
+`UPDATE`, `DELETE`, `TRUNCATE`, DDL, …) is **refused** for auto-execution — even
+with `EXECUTE` — and returns an error rather than running. Without `EXECUTE`, the
+result includes a warning telling you to add `EXECUTE` to run a read-only
+candidate.
 
 If no provider is configured, ASK returns an error. Configure one with:
 

--- a/docs/reference/health.md
+++ b/docs/reference/health.md
@@ -79,6 +79,21 @@ Response:
 }
 ```
 
+`/stats` reports instance-wide totals. For **per-collection** storage telemetry
+— including `on_disk_bytes` (reachable primary B-tree bytes) alongside
+`in_memory_bytes`, `entities`, and `segments` — query the `red.collections`
+virtual table:
+
+```sql
+SELECT name, model, entities, in_memory_bytes, on_disk_bytes FROM red.collections;
+```
+
+`on_disk_bytes` is a conservative estimate (reachable B-tree pages × the 4 KiB
+page size); it is `NULL` when the local page store cannot expose a root page,
+and excludes shared header/freelist/WAL bytes and unreachable artifacts. See
+[`red.collections`](red-schema.md#redcollections) for the full column set and
+caveats.
+
 ## Catalog Readiness
 
 Get a comprehensive readiness view:

--- a/docs/release-notes-2026-06-20.md
+++ b/docs/release-notes-2026-06-20.md
@@ -1,0 +1,149 @@
+# Release Notes — 2026-05-30 → 2026-06-20
+
+Window: roughly three weeks of work on `main`. Grouped by subsystem,
+ordered by user visibility. Two large initiatives landed in this
+window — the **AI multi-modality spine** (PRD #1267, ADR 0057) and the
+**TigerStyle house style + workspace crate split** (PRD #1252, ADRs
+0052–0056) — alongside operational-storage and clustering design work
+that is mostly captured as accepted/proposed ADRs rather than shipped
+runtime behaviour.
+
+> Where a feature is partly landed, this note says so explicitly.
+> "Shipped" means it is live on `main`; "planned" / "proposed" means the
+> contract or scaffolding exists but the runtime behaviour is not yet
+> wired.
+
+## AI & multi-modality
+
+The AI subsystem moved from "embeddings + one-shot prompts" toward a
+configurable, per-collection, multi-modal model surface (ADR 0057).
+
+- **`ASK … AS RQL` with an inference backend (shipped).** `ASK` can now
+  translate a natural-language question into RQL through the configured
+  model. Two backends: `deterministic` (the default, template-based) and
+  `llm` (inference). Either way the produced query is **always parsed and
+  validated** before it is returned. The default is *candidate-only* — it
+  hands back the RQL without running it.
+- **`EXECUTE` opt-in (shipped).** Append `EXECUTE` to run the validated
+  candidate. Execution is **read-only**: a candidate that parses to a
+  mutating statement is refused, not run. MCP- and gRPC-built `ASK`
+  queries default to `execute=false`.
+- **Per-collection AI policy via DDL `WITH (…)` (shipped for `EMBED`).**
+  `CREATE TABLE … WITH (EMBED …)` attaches an embedding policy to a
+  collection. The policy is validated at DDL time against the provider
+  modality matrix and persisted in the catalog (introspectable). See the
+  new [AI Policy (per-collection)](/query/ai-policy.md) page.
+- **Auto-embed over CDC (shipped).** With an `EMBED` policy, inserts and
+  updates are embedded **asynchronously after commit** by the CDC
+  enrichment consumer. Rows are **excluded from `VECTOR SEARCH` until the
+  embedding is attached** (`pending`); enrichment failures retry, then
+  move to a dead-letter state with re-drive. The enrichment path
+  currently drives the `local` embedding backend.
+- **Provider modality matrix + MiniMax (shipped).** Providers now carry a
+  modality dimension — `embed`, `generate`, `vision`, `moderate` — and a
+  built-in capability table gates which provider can serve which
+  modality, with DDL-time validation. **MiniMax** was added as a
+  provider. See [AI Providers](/guides/ai-providers.md) and
+  [AI Provider Modes](/api/ai-provider-modes.md).
+- **Vault-backed provider credentials (shipped).** Provider API keys
+  resolve from the encrypted vault first, falling back to environment
+  variables.
+- **Content moderation and computer-vision detections (planned).** The
+  `MODERATE` and `VISION` policy clauses **parse, validate, and persist**,
+  but enforcement (the moderation write-path gate; vision detection
+  ingestion + filtering) is still in progress and is **not active**. Do
+  not rely on them yet.
+
+## House style & correctness (TigerStyle)
+
+Adapted from TigerBeetle's TIGER_STYLE, codified in `STYLE.md` and ADR
+0056 (PRD #1252). Developer-facing; see the new
+[House Style](/dev/house-style.md) page.
+
+- **`[workspace.lints]` scaffolding** with an `unwrap → expect` ratchet,
+  so new `unwrap()`s in production paths are caught.
+- **`clippy::too_many_lines`** as a warn-as-ratchet function-length nudge.
+- **Truncating-cast lints** (`cast_possible_truncation`,
+  `as_conversions`).
+- **Storage hotspots migrated** (`btree`/`pager`/`wal`) from `unwrap` to
+  `expect`/`Result`.
+- **RQL depth-cap generalised** (`JSON_LITERAL_MAX_DEPTH`) across
+  expression and subquery nesting, with a bounded parser-fuzz target in
+  CI.
+
+## Workspace & crate authority
+
+The workspace was split into authority crates with explicit boundaries
+(ADRs 0046, 0052, 0053, 0054). See
+[Monorepo Structure](/dev/monorepo-structure.md).
+
+- **`reddb-io-types`** — the keystone vocabulary crate, below the server.
+- **`reddb-io-rql`** — the SQL/RQL front end (lexer, AST, parser,
+  planner, optimizer); executors stay in the server.
+- **`reddb-io-crypto`** — the page-envelope crypto authority (ADR 0054):
+  a magic-less AES-256-GCM envelope, **28 bytes of overhead** (12-byte
+  nonce + 16-byte tag), page-id as AAD. This is **dormant** at runtime —
+  it is distinct from the active vault encryption used for secrets. See
+  [Encryption at Rest](/engine/encryption.md).
+- **`reddb-io-wire` / `reddb-io-file`** — the wire-vs-file codec
+  authority boundary (ADR 0046).
+
+> ADR numbering note: there are two ADRs numbered 0052
+> (`reddb-io-types-keystone` and `cluster-supervisor-control-plane-consensus`).
+> A renumber is pending; both are referenced by name in the docs.
+
+## Clustering & operational storage (mostly design)
+
+Most of this window's clustering and operational-storage work landed as
+**accepted or proposed ADRs**, not as runtime behaviour. Treat it as
+design intent.
+
+- **Fixed hash-slot primitive (shipped, inert).** A 16,384-slot hash-slot
+  layer (`cluster/slot.rs`, BLAKE3 → slot, slots folded into the range
+  catalog) landed (#1218). It is consumed by the control-plane topology
+  models but is **not wired into request serving**, and there is **no
+  `SHARD BY` DDL**.
+- **Supervisor control-plane consensus boundary accepted (ADR 0052).**
+  The boundary is decided; the durable replicated control-plane log
+  itself is a named follow-up slice, not built.
+- **Operational storage profiles / collection layouts / manifest &
+  DDL recovery / backup-restore boundary / cluster range file layout
+  (ADRs 0038–0045, 0055 — proposed).** Captured on the new
+  [Operational Storage Profiles](/engine/operational-storage-profiles.md)
+  reference page as a target design.
+- **Container topology helm modes (shipped, #1204).**
+  `standalone` / `serverless` / `primary-replica` / `cluster` modes in
+  the Helm chart. See [Kubernetes and Helm](/deployment/kubernetes.md).
+
+## Auth, bootstrap & operations
+
+- **First-boot auth presets (shipped, #1236).** `REDDB_BOOTSTRAP_PRESET`
+  selects a first-boot posture — `simple` (default), `production`,
+  `regulated`, `cloud` — each with its own users/policy/auth defaults.
+  See [First Boot](/deployment/first-boot.md).
+- **Policy-first bootstrap guardrails (shipped, #1224).** Bootstrap is
+  now policy-first: `system_owned` mutations are rejected, managed
+  policies gate `user:*` actions.
+- **Per-collection `on_disk_bytes` telemetry (shipped, #1240).** Surfaced
+  via the `red.collections` virtual table (queried with SQL), not via
+  `/stats` or Prometheus. See [Health & Observability](/reference/health.md).
+- **Discovered HTTP route catalog (shipped, #1251).**
+
+## Storage engine
+
+- **Columnar read decode (shipped, #962).** Typed zero-copy column-batch
+  and row decode for the columnar (RDCC) format. It is used by the
+  time-series / hypertable read bridge; it is **not yet wired into
+  general `SELECT` execution**, which still uses the row engine. Bench
+  detail in [the columnar-read note](/perf/2026-06-03-columnar-read.md).
+- **Embedded snapshot fix (shipped, #1186).** Avoid an embedded snapshot
+  on paged reopen.
+
+## CI & dependencies
+
+- Hardened chaos backends (minio/s3 via floci), restored the nightly DR
+  drill target, grouped runtime/persistence/AI integration test targets,
+  installed `protoc` for the parser-fuzz nightly, and wired coverage
+  gates and changeset checks.
+- Routine dependency bumps (prost, http, regex, insta, webpki-roots,
+  alpine, GitHub Actions group).

--- a/docs/release-notes-2026-06-20.md
+++ b/docs/release-notes-2026-06-20.md
@@ -48,11 +48,20 @@ configurable, per-collection, multi-modal model surface (ADR 0057).
 - **Vault-backed provider credentials (shipped).** Provider API keys
   resolve from the encrypted vault first, falling back to environment
   variables.
-- **Content moderation and computer-vision detections (planned).** The
-  `MODERATE` and `VISION` policy clauses **parse, validate, and persist**,
-  but enforcement (the moderation write-path gate; vision detection
-  ingestion + filtering) is still in progress and is **not active**. Do
-  not rely on them yet.
+- **Computer-vision detections over CDC (shipped — local backend, #1275).**
+  A `VISION` policy fetches the referenced image (`http(s)`/`file`/bare
+  path), analyzes it, and attaches a structured detections array to the
+  derived `vision_detections` field, with the same retry/dead-letter
+  behaviour as `EMBED`. **Caveat:** analysis runs the in-process `local`
+  backend only — a remote `provider` (e.g. `openai`) validates at DDL time
+  but is rejected at enrichment time, so end-to-end against a hosted vision
+  model is not yet wired.
+- **`CONTAINS` descends into JSON objects/arrays (shipped, #1275).** The
+  live query path now supports `WHERE CONTAINS(vision_detections, 'person')`
+  and JSON-object containment generally.
+- **Content moderation gate (planned, #1274).** The `MODERATE` policy clause
+  **parses, validates, and persists**, but the write-path moderation gate
+  is still in progress and **not active**. Do not rely on it yet.
 
 ## House style & correctness (TigerStyle)
 

--- a/docs/security/overview.md
+++ b/docs/security/overview.md
@@ -42,6 +42,14 @@ which enables them unless `--no-auth` is set.
 red server --http --path ./data/reddb.rdb --auth --require-auth --vault --bind 0.0.0.0:8080
 ```
 
+The first-boot presets are `simple` (default, creates nothing), `production`
+(one policy-governed admin with an allow-all policy), `cloud` (a head admin
+plus a customer admin), and `regulated` (no admin; installs audit/evidence
+guardrails and enables query-audit infrastructure). `production` and `cloud`
+auto-enable auth and the vault. Every preset is policy-first — see
+[First Boot Contract](../deployment/first-boot.md#bootstrap-presets) for the
+per-preset behavior and credential flags.
+
 ## Bootstrap
 
 When no users exist, bootstrap the first admin:


### PR DESCRIPTION
## What

Refreshes the docsify site (`./docs`) to reflect ~3 weeks of work on `main` (2026-05-30 → 2026-06-20). 26 files, +1176/−79, plus 3 new pages and a release-notes entry.

Researched and written by area, then reconciled for consistency. Every claim was grounded in the actual ADRs / PR diffs / crate code — **features still in flight are labelled planned, not shipped.**

## Highlights

- **AI multi-modality** (PRD #1267, ADR 0057): `ASK … AS RQL` inference + `EXECUTE` opt-in (read-only), per-collection AI policy via DDL `WITH(…)` + auto-embed over CDC (async attach, `pending` exclusion, retry→dead-letter), provider modality matrix + **MiniMax**, vault-backed credentials. **Moderation (#1274) and vision (#1275) are documented as _planned_** — the clauses parse/persist but enforcement is not active. New page: `query/ai-policy.md`.
- **Crate authority split** (ADRs 0046/0052/0053/0054): `reddb-io-types` keystone, `reddb-io-rql` front end, `reddb-io-crypto` page envelope (28B overhead, dormant — distinct from active vault encryption), wire/file boundary.
- **TigerStyle house style** (ADR 0056, PRD #1252): new `dev/house-style.md` summarising the adopted rules + lint ratchets; points at `STYLE.md` as source of truth.
- **Clustering / operational storage**: framed honestly as accepted/proposed ADRs. The 16,384-slot hash-slot primitive shipped (#1218) **but is inert in the serving path; `SHARD BY` is not implemented.** New reference page `engine/operational-storage-profiles.md` (target design).
- **Auth & ops**: first-boot presets (`simple`/`production`/`regulated`/`cloud`), policy-first bootstrap, per-collection `on_disk_bytes` via `red.collections`, columnar read decode (used by the time-series read bridge, **not** general `SELECT`).
- New `release-notes-2026-06-20.md` + sidebar wiring for all 3 new pages.

## Notes / flags

- **ADR 0052 numbering collision** surfaced during research: two ADRs share `0052` (`reddb-io-types-keystone` and `cluster-supervisor-control-plane-consensus`). Documented by name; renumber is a separate task.
- The 3 pre-existing `/adr/*` sidebar links point at a `docs/adr/` directory that doesn't exist — left as-is (pre-existing, out of scope).
- Docs-only change; no code touched.

https://claude.ai/code/session_01HYn23rqFb8amEqCCqVgkdr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784593088&installation_id=129708444&pr_number=1282&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1282&signature=1bbad1216676cab3175f29b8f9f470f61214f3680e33a5e2d7c1911ad026ccdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Per-collection EMBED policy for automatic write embedding via CDC (asynchronous, rows marked pending until complete)
  * ASK...AS RQL with EXECUTE for deterministic or LLM-based query candidates (read-only execution enforced)
  * First-boot auth preset configuration with production and cloud modes

* **Documentation**
  * Added house style guide, operational storage profiles, columnar execution details, cluster sharding primitives, and encryption envelope documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->