### PR TITLE
merge: #1275 Computer vision: URL fetch + structured component detections + optional image-embedding (over CDC)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -90,16 +90,17 @@ fn ensure_collection_model_contract(
         if collection_model_allows(contract.declared_model, requested_model) {
             return Ok(());
         }
-        // A collection that declares an EMBED policy (#1271/#1272) holds its
+        // A collection that declares an EMBED policy (#1271/#1272) — or a
+        // VISION policy with an image-embedding output (#1275) — holds its
         // rows' enrichment vectors in place: the CDC enrichment consumer
         // attaches vectors into the same collection so `VECTOR SEARCH` over
-        // it surfaces the embedded rows. Permit vector writes on such a
+        // it surfaces the enriched rows. Permit vector writes on such a
         // collection even when it is otherwise a strict table.
         if requested_model == crate::catalog::CollectionModel::Vector
             && contract
                 .ai_policy
                 .as_ref()
-                .is_some_and(|policy| policy.embed.is_some())
+                .is_some_and(|policy| policy.embed.is_some() || policy.vision.is_some())
         {
             return Ok(());
         }

--- a/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
+++ b/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
@@ -24,13 +24,30 @@
 //! and a production scheduler can drive it from a background thread without
 //! changing the semantics.
 
-use crate::application::entity::CreateVectorInput;
+use crate::application::entity::{CreateVectorInput, PatchEntityInput};
 use crate::application::ports::RuntimeEntityPort;
-use crate::catalog::EmbedPolicy;
+use crate::catalog::{EmbedPolicy, VisionPolicy};
 use crate::replication::cdc::ChangeOperation;
 use crate::storage::schema::Value;
 use crate::storage::{EntityData, EntityId};
 use crate::{RedDBError, RedDBResult, RedDBRuntime};
+
+/// Derived field that receives the structured component-detections array
+/// (`[{label, confidence, bbox:[x,y,w,h]}]`). It is a normal row field, so
+/// RQL filters (e.g. `CONTAINS(vision_detections, 'person')`) work over it
+/// once the consumer attaches it.
+pub const VISION_DETECTIONS_FIELD: &str = "vision_detections";
+
+/// Which async enrichment a pending work item carries. A single committed
+/// row can require both (a collection may declare EMBED and VISION); each
+/// is tracked and retried independently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentKind {
+    /// Auto-embed the declared text fields (#1272).
+    Embed,
+    /// Run computer vision over the declared image-reference field (#1275).
+    Vision,
+}
 
 /// Tunables for the enrichment consumer.
 #[derive(Debug, Clone)]
@@ -60,6 +77,7 @@ impl Default for EnrichmentConfig {
 struct PendingWork {
     collection: String,
     entity_id: u64,
+    kind: EnrichmentKind,
     attempts: u32,
     /// Earliest wall-clock (unix ms) at which the next attempt may run.
     not_before_ms: u64,
@@ -71,6 +89,7 @@ struct PendingWork {
 pub struct DeadLetter {
     pub collection: String,
     pub entity_id: u64,
+    pub kind: EnrichmentKind,
     pub attempts: u32,
     pub last_error: String,
 }
@@ -126,11 +145,20 @@ impl CdcEnrichmentConsumer {
         self.pending.len()
     }
 
-    /// True while `(collection, entity_id)` is still awaiting enrichment.
+    /// True while `(collection, entity_id)` is still awaiting any kind of
+    /// enrichment.
     pub fn is_pending(&self, collection: &str, entity_id: u64) -> bool {
         self.pending
             .iter()
             .any(|w| w.collection == collection && w.entity_id == entity_id)
+    }
+
+    /// True while `(collection, entity_id)` is awaiting the given kind of
+    /// enrichment specifically.
+    pub fn is_pending_kind(&self, collection: &str, entity_id: u64, kind: EnrichmentKind) -> bool {
+        self.pending
+            .iter()
+            .any(|w| w.collection == collection && w.entity_id == entity_id && w.kind == kind)
     }
 
     /// Dead-lettered work items (enrichment failed past the retry budget).
@@ -144,7 +172,7 @@ impl CdcEnrichmentConsumer {
         let drained: Vec<DeadLetter> = self.dead_letters.drain(..).collect();
         let count = drained.len();
         for dl in drained {
-            self.enqueue(dl.collection, dl.entity_id);
+            self.enqueue(dl.collection, dl.entity_id, dl.kind);
         }
         count
     }
@@ -155,20 +183,35 @@ impl CdcEnrichmentConsumer {
     pub fn tick(&mut self, rt: &RedDBRuntime, now_ms: u64) -> RedDBResult<TickStats> {
         let mut stats = TickStats::default();
 
-        // 1. Ingest committed change events for embed-policy collections.
+        // 1. Ingest committed change events for embed- and vision-policy
+        //    collections. A row can require both; each modality is queued
+        //    and retried independently.
         let events = rt.cdc_poll(self.cursor, self.config.poll_max);
         for event in &events {
             if event.lsn > self.cursor {
                 self.cursor = event.lsn;
             }
-            let Some(policy) = rt.collection_embed_policy(&event.collection) else {
-                continue;
-            };
-            if !change_touches_embed_fields(event, &policy) {
-                continue;
+            if let Some(policy) = rt.collection_embed_policy(&event.collection) {
+                if change_touches_embed_fields(event, &policy)
+                    && self.enqueue(
+                        event.collection.clone(),
+                        event.entity_id,
+                        EnrichmentKind::Embed,
+                    )
+                {
+                    stats.ingested += 1;
+                }
             }
-            if self.enqueue(event.collection.clone(), event.entity_id) {
-                stats.ingested += 1;
+            if let Some(policy) = rt.collection_vision_policy(&event.collection) {
+                if change_touches_vision_field(event, &policy)
+                    && self.enqueue(
+                        event.collection.clone(),
+                        event.entity_id,
+                        EnrichmentKind::Vision,
+                    )
+                {
+                    stats.ingested += 1;
+                }
             }
         }
 
@@ -182,10 +225,19 @@ impl CdcEnrichmentConsumer {
             }
             // The policy can disappear if the collection was dropped/altered
             // between enqueue and drain — quietly forget such work.
-            let Some(policy) = rt.collection_embed_policy(&work.collection) else {
-                continue;
+            let attempt = match work.kind {
+                EnrichmentKind::Embed => match rt.collection_embed_policy(&work.collection) {
+                    Some(policy) => {
+                        rt.enrich_row_embedding(&work.collection, work.entity_id, &policy)
+                    }
+                    None => continue,
+                },
+                EnrichmentKind::Vision => match rt.collection_vision_policy(&work.collection) {
+                    Some(policy) => rt.enrich_row_vision(&work.collection, work.entity_id, &policy),
+                    None => continue,
+                },
             };
-            match rt.enrich_row_embedding(&work.collection, work.entity_id, &policy) {
+            match attempt {
                 Ok(()) => stats.attached += 1,
                 Err(err) => {
                     work.attempts += 1;
@@ -193,6 +245,7 @@ impl CdcEnrichmentConsumer {
                         self.dead_letters.push(DeadLetter {
                             collection: work.collection,
                             entity_id: work.entity_id,
+                            kind: work.kind,
                             attempts: work.attempts,
                             last_error: format!("{err:?}"),
                         });
@@ -215,19 +268,20 @@ impl CdcEnrichmentConsumer {
         Ok(stats)
     }
 
-    /// Add a row to the pending set unless it is already queued. Returns
-    /// true when a new item was enqueued.
-    fn enqueue(&mut self, collection: String, entity_id: u64) -> bool {
+    /// Add a row to the pending set unless this `(collection, entity, kind)`
+    /// is already queued. Returns true when a new item was enqueued.
+    fn enqueue(&mut self, collection: String, entity_id: u64, kind: EnrichmentKind) -> bool {
         if self
             .pending
             .iter()
-            .any(|w| w.entity_id == entity_id && w.collection == collection)
+            .any(|w| w.entity_id == entity_id && w.kind == kind && w.collection == collection)
         {
             return false;
         }
         self.pending.push(PendingWork {
             collection,
             entity_id,
+            kind,
             attempts: 0,
             not_before_ms: 0,
         });
@@ -257,12 +311,62 @@ fn change_touches_embed_fields(
     }
 }
 
+/// Whether a change event should (re)run vision over the row under
+/// `policy`. Inserts always run. Updates run only when the declared
+/// image-reference field changed (or no damage vector is available, so we
+/// run conservatively). Crucially, an update that only touched the derived
+/// detections field — the consumer's own write-back — does NOT match,
+/// because that field is not the image-reference field, so vision never
+/// re-triggers itself into a loop. Deletes/refreshes never run.
+fn change_touches_vision_field(
+    event: &crate::replication::cdc::ChangeEvent,
+    policy: &VisionPolicy,
+) -> bool {
+    match event.operation {
+        ChangeOperation::Insert => true,
+        ChangeOperation::Update => match &event.changed_columns {
+            Some(columns) => columns.iter().any(|column| column == &policy.image_field),
+            None => true,
+        },
+        ChangeOperation::Delete | ChangeOperation::Refresh => false,
+    }
+}
+
+/// Whether the policy's output kinds request structured component
+/// detections. Several spellings are accepted so DDL authors are not
+/// boxed into one keyword.
+fn vision_wants_detections(policy: &VisionPolicy) -> bool {
+    policy.output_kinds.iter().any(|kind| {
+        matches!(
+            kind.trim().to_ascii_lowercase().as_str(),
+            "detections" | "objects" | "components" | "detection"
+        )
+    })
+}
+
+/// Whether the policy's output kinds request an image-embedding output.
+fn vision_wants_embedding(policy: &VisionPolicy) -> bool {
+    policy.output_kinds.iter().any(|kind| {
+        matches!(
+            kind.trim().to_ascii_lowercase().as_str(),
+            "embedding" | "image_embedding" | "image-embedding"
+        )
+    })
+}
+
 impl RedDBRuntime {
     /// The declared embed policy for `collection`, if any.
     pub fn collection_embed_policy(&self, collection: &str) -> Option<EmbedPolicy> {
         self.db()
             .collection_contract_arc(collection)
             .and_then(|contract| contract.ai_policy.as_ref().and_then(|p| p.embed.clone()))
+    }
+
+    /// The declared vision policy for `collection`, if any.
+    pub fn collection_vision_policy(&self, collection: &str) -> Option<VisionPolicy> {
+        self.db()
+            .collection_contract_arc(collection)
+            .and_then(|contract| contract.ai_policy.as_ref().and_then(|p| p.vision.clone()))
     }
 
     /// Compute the embedding for one committed row and attach it as a vector
@@ -310,6 +414,147 @@ impl RedDBRuntime {
         })?;
         Ok(())
     }
+
+    /// Run computer vision over one committed row: fetch the image
+    /// referenced by the policy's `image_field`, call the vision provider,
+    /// write the structured component-detections to the derived
+    /// [`VISION_DETECTIONS_FIELD`] (RQL-filterable), and — when the policy
+    /// requests it — attach an image-embedding vector reusing the existing
+    /// vector pipeline.
+    ///
+    /// A row whose image reference is absent/empty is treated as complete
+    /// (nothing to analyze) rather than failed.
+    pub(crate) fn enrich_row_vision(
+        &self,
+        collection: &str,
+        entity_id: u64,
+        policy: &VisionPolicy,
+    ) -> RedDBResult<()> {
+        // This slice drives the in-process `local` provider (the path the
+        // mock vision backend exercises); other providers are rejected with
+        // a deterministic error that the retry/dead-letter machinery
+        // handles like any failure.
+        match crate::ai::parse_provider(&policy.provider)? {
+            crate::ai::AiProvider::Local => {}
+            other => {
+                return Err(RedDBError::Query(format!(
+                    "CDC vision enrichment currently drives the 'local' provider; \
+                     collection policy declares '{other:?}'"
+                )));
+            }
+        }
+
+        let db = self.db();
+        // Resolve the live row through its stable logical id (see
+        // `enrich_row_embedding`). `None` means the event was not a live
+        // table row — nothing to enrich.
+        let Some(entity) = db
+            .store()
+            .get_table_row_by_logical_id(collection, EntityId::new(entity_id))
+        else {
+            return Ok(());
+        };
+
+        let Some(reference) = row_text_field(&entity.data, &policy.image_field) else {
+            return Ok(());
+        };
+        if reference.is_empty() {
+            return Ok(());
+        }
+
+        let want_detections = vision_wants_detections(policy);
+        let want_embedding = vision_wants_embedding(policy);
+        if !want_detections && !want_embedding {
+            return Ok(());
+        }
+
+        let image_bytes = crate::runtime::ai::vision::fetch_image_bytes(&reference)?;
+        let result = crate::runtime::ai::vision::analyze_local(
+            &policy.model,
+            image_bytes,
+            want_detections,
+            want_embedding,
+        )?;
+
+        if want_detections {
+            // Write the canonical detections array as a JSON row field. The
+            // damage vector for this update covers only the derived field,
+            // never `image_field`, so it cannot re-trigger vision.
+            let detections_json = detections_to_json(&result.detections);
+            self.patch_entity(PatchEntityInput {
+                collection: collection.to_string(),
+                id: entity.id,
+                payload: vision_detections_payload(detections_json),
+                operations: Vec::new(),
+            })?;
+        }
+
+        if want_embedding {
+            if let Some(embedding) = result.embedding {
+                if !embedding.is_empty() {
+                    self.create_vector(CreateVectorInput {
+                        collection: collection.to_string(),
+                        dense: embedding,
+                        content: Some(reference),
+                        metadata: Vec::new(),
+                        link_row: None,
+                        link_node: None,
+                    })?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Read a row's text-valued field as an owned string. Returns `None` when
+/// the entity is not a row, the field is absent, or it is not text.
+fn row_text_field(data: &EntityData, field: &str) -> Option<String> {
+    let EntityData::Row(row) = data else {
+        return None;
+    };
+    let named = row.named.as_ref()?;
+    match named.get(field) {
+        Some(Value::Text(text)) => Some(text.to_string()),
+        Some(Value::Url(url)) => Some(url.clone()),
+        _ => None,
+    }
+}
+
+/// Encode the detections as a JSON array value
+/// (`[{label, confidence, bbox:[x,y,w,h]}]`).
+fn detections_to_json(
+    detections: &[crate::runtime::ai::vision::VisionDetection],
+) -> crate::serde_json::Value {
+    use crate::serde_json::{Map, Value as Sj};
+    let items = detections
+        .iter()
+        .map(|d| {
+            let mut obj = Map::new();
+            obj.insert("label".to_string(), Sj::String(d.label.clone()));
+            obj.insert("confidence".to_string(), Sj::Number(d.confidence as f64));
+            obj.insert(
+                "bbox".to_string(),
+                Sj::Array(d.bbox.iter().map(|v| Sj::Number(*v as f64)).collect()),
+            );
+            Sj::Object(obj)
+        })
+        .collect();
+    Sj::Array(items)
+}
+
+/// Build the JSON-patch payload that sets the derived detections field via
+/// `patch_entity`'s `fields` merge form.
+fn vision_detections_payload(
+    detections_json: crate::serde_json::Value,
+) -> crate::serde_json::Value {
+    use crate::serde_json::{Map, Value as Sj};
+    let mut fields = Map::new();
+    fields.insert(VISION_DETECTIONS_FIELD.to_string(), detections_json);
+    let mut root = Map::new();
+    root.insert("fields".to_string(), Sj::Object(fields));
+    Sj::Object(root)
 }
 
 /// Join the declared embed fields' text values, mirroring the manual

--- a/crates/reddb-server/src/runtime/ai/mod.rs
+++ b/crates/reddb-server/src/runtime/ai/mod.rs
@@ -41,6 +41,7 @@ pub mod strict_validator;
 pub mod text_chunker;
 pub mod transport;
 pub mod urn_codec;
+pub mod vision;
 
 pub(crate) fn block_on_ai<F, T>(future: F) -> crate::RedDBResult<T>
 where

--- a/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
+++ b/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
@@ -286,7 +286,12 @@ impl Modalities {
             "local" => Self {
                 embed: true,
                 generate: false,
-                vision: false,
+                // The in-process local backend now serves computer vision
+                // (#1275) alongside embeddings: an installed
+                // `LocalVisionBackend` runs detection/image-embedding over
+                // a collection's declared image-reference field via the CDC
+                // enrichment lane. Generation/moderation stay out of scope.
+                vision: true,
                 moderate: false,
             },
             "custom" => Self::conservative(),
@@ -843,11 +848,12 @@ mod tests {
     }
 
     #[test]
-    fn local_is_embeddings_only() {
+    fn local_serves_embed_and_vision() {
         let c = Modalities::for_provider("local");
         assert!(c.supports(Modality::Embed));
+        assert!(c.supports(Modality::Vision));
+        // Generation and moderation stay out of scope for the local backend.
         assert!(!c.supports(Modality::Generate));
-        assert!(!c.supports(Modality::Vision));
         assert!(!c.supports(Modality::Moderate));
     }
 

--- a/crates/reddb-server/src/runtime/ai/vision.rs
+++ b/crates/reddb-server/src/runtime/ai/vision.rs
@@ -1,0 +1,352 @@
+//! Local computer-vision backend + image fetch (#1275, PRD #1267).
+//!
+//! Vision is the second async AI modality wired over the CDC enrichment
+//! lane (the first being embeddings, #1272). A collection that declares a
+//! `VISION (...)` policy names an *image-reference field* whose value is a
+//! URL/URI. After commit, the CDC enrichment consumer fetches the
+//! referenced image and runs the policy's vision provider, producing:
+//!
+//!   * a structured **component-detections** array
+//!     (`[{label, confidence, bbox:[x,y,w,h]}]`) written to a derived
+//!     field that RQL can filter, and
+//!   * an optional **image-embedding** vector reusing the existing vector
+//!     pipeline for image similarity search.
+//!
+//! Mirroring [`super::local_embedding`], the engine is a swappable,
+//! process-global [`LocalVisionBackend`]. The default
+//! [`DeterministicFakeVisionBackend`] derives stable detections from
+//! `SHA-256(model || image-bytes)` so the end-to-end contract (fetch →
+//! analyze → attach) can be exercised without a real model. Tests install
+//! their own mock provider via [`install_local_vision_backend`]; a real
+//! candle/onnx engine slots in the same way at server boot.
+
+use std::sync::{Arc, OnceLock, RwLock};
+use std::time::Duration;
+
+use crate::crypto::sha256::Sha256;
+use crate::{RedDBError, RedDBResult};
+
+/// One structured component detection: a labelled, scored bounding box.
+/// `bbox` is `[x, y, w, h]` in image-relative units, matching the
+/// canonical output shape recorded in the issue.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VisionDetection {
+    pub label: String,
+    pub confidence: f32,
+    pub bbox: [f32; 4],
+}
+
+/// Output of a single vision analysis pass.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct VisionResult {
+    /// Structured component detections (present when detections were
+    /// requested by the policy).
+    pub detections: Vec<VisionDetection>,
+    /// Image embedding (present only when the policy requested an
+    /// image-embedding output kind).
+    pub embedding: Option<Vec<f32>>,
+}
+
+/// A materialised vision request handed to a backend.
+#[derive(Debug, Clone)]
+pub struct VisionRequest {
+    /// Model name as written in the collection's VISION policy.
+    pub model: String,
+    /// Fetched image bytes (already resolved from the row's reference).
+    pub image_bytes: Vec<u8>,
+    /// Whether the policy asked for structured detections.
+    pub want_detections: bool,
+    /// Whether the policy asked for an image-embedding output.
+    pub want_embedding: bool,
+}
+
+/// Backend abstraction so the enrichment lane does not depend on a
+/// specific vision engine. Tests install a mock; production installs a
+/// real engine via [`install_local_vision_backend`].
+pub trait LocalVisionBackend: Send + Sync {
+    fn analyze(&self, request: &VisionRequest) -> RedDBResult<VisionResult>;
+}
+
+const LOCAL_VISION_DISABLED_MESSAGE: &str =
+    "local vision requires the `local-models` feature flag at engine build time, \
+     or a backend installed via \
+     runtime::ai::vision::install_local_vision_backend. Alternatively, declare a \
+     vision-capable remote provider in the collection's VISION policy.";
+
+/// Width (in f32 lanes) of the deterministic fake image embedding.
+const FAKE_EMBEDDING_DIM: usize = 16;
+
+/// Deterministic, dependency-free vision backend used to prove the
+/// fetch → analyze → attach contract end-to-end. Output is a pure
+/// function of `(model, image-bytes)` — no I/O, no clocks, no RNGs — so
+/// tests get byte-identical results across runs.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DeterministicFakeVisionBackend;
+
+impl LocalVisionBackend for DeterministicFakeVisionBackend {
+    fn analyze(&self, request: &VisionRequest) -> RedDBResult<VisionResult> {
+        let digest = {
+            let mut hasher = Sha256::new();
+            hasher.update(request.model.as_bytes());
+            hasher.update(&[0u8]);
+            hasher.update(&request.image_bytes);
+            hasher.finalize()
+        };
+
+        let detections = if request.want_detections {
+            // One detection per non-overlapping label, chosen
+            // deterministically from a small fixed vocabulary by the
+            // digest. Two distinct, stable detections so containment
+            // filters have something to match.
+            const VOCAB: [&str; 4] = ["person", "car", "dog", "bicycle"];
+            let pick = |byte: u8| VOCAB[(byte as usize) % VOCAB.len()].to_string();
+            let conf = |byte: u8| (byte as f32) / 255.0;
+            let coord = |byte: u8| (byte as f32) / 255.0;
+            vec![
+                VisionDetection {
+                    label: pick(digest[0]),
+                    confidence: conf(digest[1]),
+                    bbox: [
+                        coord(digest[2]),
+                        coord(digest[3]),
+                        coord(digest[4]),
+                        coord(digest[5]),
+                    ],
+                },
+                VisionDetection {
+                    label: pick(digest[6]),
+                    confidence: conf(digest[7]),
+                    bbox: [
+                        coord(digest[8]),
+                        coord(digest[9]),
+                        coord(digest[10]),
+                        coord(digest[11]),
+                    ],
+                },
+            ]
+        } else {
+            Vec::new()
+        };
+
+        let embedding = if request.want_embedding {
+            let mut out = Vec::with_capacity(FAKE_EMBEDDING_DIM);
+            let mut counter: u32 = 0;
+            while out.len() < FAKE_EMBEDDING_DIM {
+                let mut hasher = Sha256::new();
+                hasher.update(&digest);
+                hasher.update(&counter.to_le_bytes());
+                let chunk_digest = hasher.finalize();
+                for chunk in chunk_digest.chunks(4) {
+                    if out.len() >= FAKE_EMBEDDING_DIM {
+                        break;
+                    }
+                    let mut bytes = [0u8; 4];
+                    bytes.copy_from_slice(chunk);
+                    let raw = u32::from_le_bytes(bytes) as f32 / u32::MAX as f32;
+                    out.push(raw * 2.0 - 1.0);
+                }
+                counter = counter.wrapping_add(1);
+            }
+            Some(out)
+        } else {
+            None
+        };
+
+        Ok(VisionResult {
+            detections,
+            embedding,
+        })
+    }
+}
+
+type BackendSlot = Arc<dyn LocalVisionBackend>;
+
+fn backend_slot() -> &'static RwLock<Option<BackendSlot>> {
+    static SLOT: OnceLock<RwLock<Option<BackendSlot>>> = OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+/// Install (or replace) the process-global local vision backend.
+///
+/// Production servers built with `--features local-models` call this once
+/// at boot with their real engine. Tests use it to swap in a mock vision
+/// provider. Safe to call from any thread; the most recent install wins.
+pub fn install_local_vision_backend(backend: Arc<dyn LocalVisionBackend>) {
+    let mut guard = backend_slot()
+        .write()
+        .expect("vision backend slot poisoned");
+    *guard = Some(backend);
+}
+
+/// Test-only: clear the installed backend so a subsequent call exercises
+/// the feature-disabled path again.
+#[doc(hidden)]
+pub fn clear_local_vision_backend_for_tests() {
+    let mut guard = backend_slot()
+        .write()
+        .expect("vision backend slot poisoned");
+    *guard = None;
+}
+
+fn current_backend() -> Option<BackendSlot> {
+    backend_slot()
+        .read()
+        .expect("vision backend slot poisoned")
+        .as_ref()
+        .map(Arc::clone)
+}
+
+/// Resolve and run a local vision request end-to-end. Falls back to the
+/// deterministic fake when the `local-models` feature is on but no engine
+/// was installed; errors with a clear message when neither is available.
+pub fn analyze_local(
+    model: &str,
+    image_bytes: Vec<u8>,
+    want_detections: bool,
+    want_embedding: bool,
+) -> RedDBResult<VisionResult> {
+    let backend = match current_backend() {
+        Some(b) => b,
+        None => {
+            if cfg!(feature = "local-models") {
+                let fake: Arc<dyn LocalVisionBackend> = Arc::new(DeterministicFakeVisionBackend);
+                install_local_vision_backend(Arc::clone(&fake));
+                fake
+            } else {
+                return Err(RedDBError::FeatureNotEnabled(
+                    LOCAL_VISION_DISABLED_MESSAGE.to_string(),
+                ));
+            }
+        }
+    };
+
+    backend.analyze(&VisionRequest {
+        model: model.to_string(),
+        image_bytes,
+        want_detections,
+        want_embedding,
+    })
+}
+
+/// Fetch the bytes of an image referenced by a row field.
+///
+/// The reference is a URL/URI (ADR 0057 stores the reference, never the
+/// bytes). Supported schemes:
+///   * `file://<path>` and bare filesystem paths — read from disk;
+///   * `http://` / `https://` — fetched via `ureq` (rustls).
+///
+/// Network/IO failures surface as [`RedDBError`] so the enrichment lane's
+/// retry-with-backoff and dead-letter machinery handles them like any
+/// other provider failure.
+pub fn fetch_image_bytes(reference: &str) -> RedDBResult<Vec<u8>> {
+    let reference = reference.trim();
+    if reference.is_empty() {
+        return Err(RedDBError::Query(
+            "vision image reference is empty".to_string(),
+        ));
+    }
+
+    if let Some(rest) = reference.strip_prefix("file://") {
+        // Tolerate the `file://localhost/path` authority form.
+        let path = rest.strip_prefix("localhost").unwrap_or(rest);
+        return std::fs::read(path)
+            .map_err(|err| RedDBError::Internal(format!("read image '{path}': {err}")));
+    }
+
+    if reference.starts_with("http://") || reference.starts_with("https://") {
+        return fetch_http_image(reference);
+    }
+
+    // Bare filesystem path.
+    std::fs::read(reference)
+        .map_err(|err| RedDBError::Internal(format!("read image '{reference}': {err}")))
+}
+
+fn fetch_http_image(url: &str) -> RedDBResult<Vec<u8>> {
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(15)))
+        .timeout_send_request(Some(Duration::from_secs(30)))
+        .timeout_recv_response(Some(Duration::from_secs(30)))
+        .timeout_recv_body(Some(Duration::from_secs(120)))
+        .build()
+        .into();
+
+    let mut resp = agent
+        .get(url)
+        .call()
+        .map_err(|err| RedDBError::Internal(format!("HTTP GET image '{url}': {err}")))?;
+
+    let status = resp.status().as_u16();
+    if status != 200 {
+        return Err(RedDBError::Internal(format!(
+            "HTTP GET image '{url}': status {status}"
+        )));
+    }
+
+    resp.body_mut()
+        .read_to_vec()
+        .map_err(|err| RedDBError::Internal(format!("read image body from '{url}': {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_fake_is_pure() {
+        let req = VisionRequest {
+            model: "fake-vision".to_string(),
+            image_bytes: b"some image bytes".to_vec(),
+            want_detections: true,
+            want_embedding: true,
+        };
+        let a = DeterministicFakeVisionBackend.analyze(&req).expect("a");
+        let b = DeterministicFakeVisionBackend.analyze(&req).expect("b");
+        assert_eq!(a, b, "fake vision backend must be pure");
+        assert_eq!(a.detections.len(), 2);
+        assert_eq!(a.embedding.as_ref().map(Vec::len), Some(FAKE_EMBEDDING_DIM));
+    }
+
+    #[test]
+    fn detections_and_embedding_are_gated_by_request() {
+        let base = VisionRequest {
+            model: "m".to_string(),
+            image_bytes: b"img".to_vec(),
+            want_detections: false,
+            want_embedding: false,
+        };
+        let none = DeterministicFakeVisionBackend.analyze(&base).expect("none");
+        assert!(none.detections.is_empty());
+        assert!(none.embedding.is_none());
+
+        let detect_only = DeterministicFakeVisionBackend
+            .analyze(&VisionRequest {
+                want_detections: true,
+                ..base.clone()
+            })
+            .expect("detect");
+        assert!(!detect_only.detections.is_empty());
+        assert!(detect_only.embedding.is_none());
+    }
+
+    #[test]
+    fn fetch_reads_file_uri_and_bare_path() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("reddb_vision_fetch_fixture.bin");
+        std::fs::write(&path, b"\x89PNG fixture").expect("write fixture");
+
+        let via_bare = fetch_image_bytes(path.to_str().expect("utf8 path")).expect("bare");
+        assert_eq!(via_bare, b"\x89PNG fixture");
+
+        let uri = format!("file://{}", path.to_str().expect("utf8 path"));
+        let via_uri = fetch_image_bytes(&uri).expect("file uri");
+        assert_eq!(via_uri, b"\x89PNG fixture");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn fetch_rejects_empty_reference() {
+        assert!(fetch_image_bytes("   ").is_err());
+    }
+}

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1656,10 +1656,18 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::Array(values) => values
             .iter()
             .any(|value| json_value_contains(value, needle)),
+        // Recurse into object *values* so a needle nested inside a JSON
+        // object matches — e.g. `CONTAINS(vision_detections, 'person')`
+        // over a derived `[{"label":"person",...}]` array (#1275). Keys
+        // are deliberately not matched: containment is about the data, not
+        // the field names. Mirrors the same rule in the scalar evaluator.
+        crate::serde_json::Value::Object(map) => {
+            map.values().any(|value| json_value_contains(value, needle))
+        }
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
-        crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,
+        crate::serde_json::Value::Null => false,
     }
 }
 

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -936,10 +936,18 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::Array(values) => values
             .iter()
             .any(|value| json_value_contains(value, needle)),
+        // Recurse into object *values* so a needle nested inside a JSON
+        // object matches — e.g. `CONTAINS(vision_detections, 'person')`
+        // over a derived `[{"label":"person",...}]` array (#1275). Keys
+        // are deliberately not matched: containment is about the data, not
+        // the field names.
+        crate::serde_json::Value::Object(map) => {
+            map.values().any(|value| json_value_contains(value, needle))
+        }
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
-        crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,
+        crate::serde_json::Value::Null => false,
     }
 }
 
@@ -1119,6 +1127,21 @@ mod tests {
 
     fn empty_row() -> impl Row {
         |_field: &FieldRef| -> Option<Value> { None }
+    }
+
+    #[test]
+    fn contains_descends_into_json_object_values() {
+        // A derived component-detections array (#1275): CONTAINS must find
+        // a label nested inside the object elements, not just top-level
+        // array strings.
+        let detections = br#"[{"label":"person","confidence":0.9,"bbox":[0,0,1,1]},
+                              {"label":"car","confidence":0.7,"bbox":[1,1,2,2]}]"#;
+        let json = Value::Json(detections.to_vec());
+        assert!(value_contains(&json, "person"));
+        assert!(value_contains(&json, "car"));
+        assert!(!value_contains(&json, "bicycle"));
+        // Keys are not matched — only the data.
+        assert!(!value_contains(&json, "label"));
     }
 
     #[test]

--- a/crates/reddb-server/tests/vision_enrichment.rs
+++ b/crates/reddb-server/tests/vision_enrichment.rs
@@ -1,0 +1,256 @@
+//! #1275 — computer-vision enrichment over the CDC lane, end-to-end.
+//!
+//! A collection that declares a `VISION (...)` policy over an
+//! image-reference field gets, asynchronously after commit:
+//!   * structured component detections (`[{label, confidence, bbox}]`)
+//!     written to a derived field that RQL can filter, and
+//!   * an optional image-embedding vector queryable via `VECTOR SEARCH`.
+//!
+//! The pipeline rides the shared CDC enrichment consumer (#1272): rows are
+//! excluded from vision queries until ready, and fetch/provider failures
+//! retry with backoff and then dead-letter.
+//!
+//! These tests install a mock vision provider (no model download, no
+//! network) and use a local image fixture referenced by a `file://` URI.
+
+use std::sync::Arc;
+
+use reddb_server::runtime::ai::cdc_enrichment::{CdcEnrichmentConsumer, EnrichmentKind};
+use reddb_server::runtime::ai::vision::{
+    install_local_vision_backend, LocalVisionBackend, VisionDetection, VisionRequest, VisionResult,
+};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+/// Deterministic mock vision provider. Returns fixed detections so the
+/// RQL-filter assertions are stable, and a fixed-width embedding when the
+/// policy requests one.
+struct MockVisionProvider;
+
+impl LocalVisionBackend for MockVisionProvider {
+    fn analyze(&self, request: &VisionRequest) -> reddb_server::RedDBResult<VisionResult> {
+        let detections = if request.want_detections {
+            vec![
+                VisionDetection {
+                    label: "person".to_string(),
+                    confidence: 0.91,
+                    bbox: [0.10, 0.20, 0.30, 0.40],
+                },
+                VisionDetection {
+                    label: "car".to_string(),
+                    confidence: 0.72,
+                    bbox: [0.50, 0.55, 0.20, 0.25],
+                },
+            ]
+        } else {
+            Vec::new()
+        };
+        let embedding = request.want_embedding.then(|| vec![0.25_f32; 8]);
+        Ok(VisionResult {
+            detections,
+            embedding,
+        })
+    }
+}
+
+fn install_mock() {
+    install_local_vision_backend(Arc::new(MockVisionProvider));
+}
+
+/// Write a tiny image fixture to a unique temp path and return a
+/// `file://` URI referencing it.
+fn write_fixture(tag: &str) -> (std::path::PathBuf, String) {
+    let path = std::env::temp_dir().join(format!("reddb_vision_{tag}.png"));
+    std::fs::write(&path, b"\x89PNG\r\n\x1a\n mock image fixture").expect("write fixture");
+    let uri = format!("file://{}", path.to_str().expect("utf8 path"));
+    (path, uri)
+}
+
+fn row_count(rt: &RedDBRuntime, sql: &str) -> usize {
+    rt.execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  err: {e}"))
+        .result
+        .records
+        .len()
+}
+
+#[test]
+fn vision_detections_are_written_filterable_and_pending_excluded() {
+    install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+
+    rt.execute_query(
+        "CREATE TABLE photos (id INT, photo TEXT, vision_detections JSON) \
+         WITH (VISION (image_field = 'photo', outputs = ('detections'), \
+         provider = 'local', model = 'mock-vision'))",
+    )
+    .expect("create photos with vision policy");
+
+    let (fixture, uri) = write_fixture("primary");
+    rt.execute_query(&format!(
+        "INSERT INTO photos (id, photo) VALUES (1, '{uri}')"
+    ))
+    .expect("insert row");
+
+    // Pending exclusion: before the consumer runs, a vision-component
+    // filter must not surface the row — its detections are not ready.
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT * FROM photos WHERE CONTAINS(vision_detections, 'person') = true"
+        ),
+        0,
+        "row must be excluded from vision queries while pending"
+    );
+
+    // Drain the CDC stream: fetch image, run vision, attach detections.
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert!(stats.ingested >= 1, "the committed row must be ingested");
+    assert!(stats.attached >= 1, "vision enrichment must attach");
+    assert_eq!(
+        consumer.pending_len(),
+        0,
+        "vision work must complete after the tick"
+    );
+
+    // Detections written + RQL-filterable: the row now matches a
+    // component filter, and only for components actually detected.
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT * FROM photos WHERE CONTAINS(vision_detections, 'person') = true"
+        ),
+        1,
+        "row must surface once its 'person' detection is attached"
+    );
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT * FROM photos WHERE CONTAINS(vision_detections, 'car') = true"
+        ),
+        1,
+        "row must surface for its 'car' detection too"
+    );
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT * FROM photos WHERE CONTAINS(vision_detections, 'bicycle') = true"
+        ),
+        0,
+        "row must NOT match a component that was not detected"
+    );
+
+    // No self-trigger loop: the consumer's own detections write-back is an
+    // UPDATE on the derived field (not the image_field), so re-ticking must
+    // not re-enqueue the row, and the detections stay stable.
+    let again = consumer.tick(&rt, 2_000).expect("second tick");
+    assert_eq!(
+        again.ingested, 0,
+        "derived-field write-back must not re-enqueue vision"
+    );
+    assert_eq!(
+        row_count(
+            &rt,
+            "SELECT * FROM photos WHERE CONTAINS(vision_detections, 'person') = true"
+        ),
+        1,
+        "re-ticking must not duplicate or drop detections"
+    );
+
+    let _ = std::fs::remove_file(&fixture);
+}
+
+#[test]
+fn vision_image_embedding_is_queryable_via_vector_search() {
+    install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+
+    rt.execute_query(
+        "CREATE TABLE frames (id INT, photo TEXT, vision_detections JSON) \
+         WITH (VISION (image_field = 'photo', outputs = ('detections', 'embedding'), \
+         provider = 'local', model = 'mock-vision'))",
+    )
+    .expect("create frames with vision policy");
+
+    let (fixture, uri) = write_fixture("embedding");
+    rt.execute_query(&format!(
+        "INSERT INTO frames (id, photo) VALUES (1, '{uri}')"
+    ))
+    .expect("insert row");
+
+    // Before enrichment the vector does not exist — vector search is empty.
+    assert_eq!(
+        row_count(
+            &rt,
+            "VECTOR SEARCH frames SIMILAR TO [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25] LIMIT 5",
+        ),
+        0,
+        "no image embedding exists while the row is pending"
+    );
+
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert!(stats.attached >= 1, "vision enrichment must attach");
+
+    // Optional image-embedding output: queryable via the existing vector
+    // search once the policy requested it.
+    let hits = row_count(
+        &rt,
+        "VECTOR SEARCH frames SIMILAR TO [0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25, 0.25] LIMIT 5",
+    );
+    assert!(
+        hits >= 1,
+        "image embedding must be queryable via VECTOR SEARCH"
+    );
+
+    let _ = std::fs::remove_file(&fixture);
+}
+
+#[test]
+fn vision_fetch_failure_retries_then_dead_letters() {
+    install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+
+    rt.execute_query(
+        "CREATE TABLE shots (id INT, photo TEXT, vision_detections JSON) \
+         WITH (VISION (image_field = 'photo', outputs = ('detections'), \
+         provider = 'local', model = 'mock-vision'))",
+    )
+    .expect("create shots with vision policy");
+
+    // A reference that cannot be fetched — the image does not exist.
+    rt.execute_query(
+        "INSERT INTO shots (id, photo) VALUES (1, 'file:///nonexistent/reddb-vision-missing.png')",
+    )
+    .expect("insert row");
+
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+
+    // First tick: ingest + first attempt fails → re-queued with backoff.
+    let s0 = consumer.tick(&rt, 0).expect("tick 0");
+    assert_eq!(s0.ingested, 1);
+    assert_eq!(s0.attached, 0, "fetch must fail, nothing attached");
+    assert_eq!(s0.retried, 1, "first failure retries");
+    assert_eq!(
+        consumer.pending_len(),
+        1,
+        "failed work stays pending across the retry budget"
+    );
+    assert!(consumer.dead_letters().is_empty());
+
+    // Advance past the backoff windows; default budget is 3 attempts.
+    let _ = consumer.tick(&rt, 1_000).expect("tick 1");
+    let s2 = consumer.tick(&rt, 10_000).expect("tick 2");
+    assert_eq!(s2.dead_lettered, 1, "exhausting retries dead-letters");
+    assert_eq!(consumer.pending_len(), 0);
+
+    let dead = consumer.dead_letters();
+    assert_eq!(dead.len(), 1);
+    assert_eq!(dead[0].collection, "shots");
+    assert_eq!(dead[0].kind, EnrichmentKind::Vision);
+
+    // Ops re-drive moves it back to pending with a fresh budget.
+    assert_eq!(consumer.redrive(), 1);
+    assert_eq!(consumer.pending_len(), 1);
+    assert!(consumer.dead_letters().is_empty());
+}


### PR DESCRIPTION
Automated AFK landing for #1275. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1275

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784593451&installation_id=129708444&pr_number=1283&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1283&signature=73dad46a3f3d27572dfbed33d1488c9a1e57104b15b7c041483a86a9d8788865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->