### PR TITLE
feat(ai): synchronous moderation gate + quarantine + tombstone (#1274) — HELD for review

### DIFF
--- a/crates/reddb-file/src/physical_metadata.rs
+++ b/crates/reddb-file/src/physical_metadata.rs
@@ -971,6 +971,10 @@ fn ai_moderate_policy_json_value(policy: &PhysicalAiModeratePolicy) -> serde_jso
         "reject_action".to_string(),
         serde_json::Value::String(policy.reject_action.clone()),
     );
+    object.insert(
+        "hard_delete_on_reject".to_string(),
+        serde_json::Value::Bool(policy.hard_delete_on_reject),
+    );
     serde_json::Value::Object(object)
 }
 
@@ -1046,6 +1050,10 @@ fn ai_moderate_policy_from_json_value(
             .and_then(serde_json::Value::as_str)
             .unwrap_or("reject")
             .to_string(),
+        hard_delete_on_reject: object
+            .get("hard_delete_on_reject")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
     })
 }
 

--- a/crates/reddb-file/src/physical_metadata.rs
+++ b/crates/reddb-file/src/physical_metadata.rs
@@ -9,9 +9,11 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+mod ai_policy_codec;
 mod json_helpers;
 mod types;
 
+use ai_policy_codec::*;
 use json_helpers::*;
 pub use types::*;
 
@@ -902,170 +904,6 @@ fn analytical_storage_from_json_value(
             .get("order_by_key")
             .and_then(serde_json::Value::as_str)
             .map(ToString::to_string),
-    })
-}
-
-fn ai_policy_json_value(policy: &PhysicalAiPolicy) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    object.insert(
-        "embed".to_string(),
-        policy
-            .embed
-            .as_ref()
-            .map(ai_embed_policy_json_value)
-            .unwrap_or(serde_json::Value::Null),
-    );
-    object.insert(
-        "moderate".to_string(),
-        policy
-            .moderate
-            .as_ref()
-            .map(ai_moderate_policy_json_value)
-            .unwrap_or(serde_json::Value::Null),
-    );
-    object.insert(
-        "vision".to_string(),
-        policy
-            .vision
-            .as_ref()
-            .map(ai_vision_policy_json_value)
-            .unwrap_or(serde_json::Value::Null),
-    );
-    serde_json::Value::Object(object)
-}
-
-fn ai_embed_policy_json_value(policy: &PhysicalAiEmbedPolicy) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    object.insert("fields".to_string(), string_array_json(&policy.fields));
-    object.insert(
-        "provider".to_string(),
-        serde_json::Value::String(policy.provider.clone()),
-    );
-    object.insert(
-        "model".to_string(),
-        serde_json::Value::String(policy.model.clone()),
-    );
-    serde_json::Value::Object(object)
-}
-
-fn ai_moderate_policy_json_value(policy: &PhysicalAiModeratePolicy) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    object.insert("fields".to_string(), string_array_json(&policy.fields));
-    object.insert(
-        "provider".to_string(),
-        serde_json::Value::String(policy.provider.clone()),
-    );
-    object.insert(
-        "model".to_string(),
-        serde_json::Value::String(policy.model.clone()),
-    );
-    object.insert(
-        "sync_gate".to_string(),
-        serde_json::Value::Bool(policy.sync_gate),
-    );
-    object.insert(
-        "degraded_mode".to_string(),
-        serde_json::Value::String(policy.degraded_mode.clone()),
-    );
-    object.insert(
-        "reject_action".to_string(),
-        serde_json::Value::String(policy.reject_action.clone()),
-    );
-    object.insert(
-        "hard_delete_on_reject".to_string(),
-        serde_json::Value::Bool(policy.hard_delete_on_reject),
-    );
-    serde_json::Value::Object(object)
-}
-
-fn ai_vision_policy_json_value(policy: &PhysicalAiVisionPolicy) -> serde_json::Value {
-    let mut object = serde_json::Map::new();
-    object.insert(
-        "image_field".to_string(),
-        serde_json::Value::String(policy.image_field.clone()),
-    );
-    object.insert(
-        "output_kinds".to_string(),
-        string_array_json(&policy.output_kinds),
-    );
-    object.insert(
-        "provider".to_string(),
-        serde_json::Value::String(policy.provider.clone()),
-    );
-    object.insert(
-        "model".to_string(),
-        serde_json::Value::String(policy.model.clone()),
-    );
-    serde_json::Value::Object(object)
-}
-
-fn ai_policy_from_json_value(value: &serde_json::Value) -> RdbFileResult<PhysicalAiPolicy> {
-    let object = expect_object(value, "physical ai policy")?;
-    Ok(PhysicalAiPolicy {
-        embed: match object.get("embed") {
-            Some(serde_json::Value::Null) | None => None,
-            Some(value) => Some(ai_embed_policy_from_json_value(value)?),
-        },
-        moderate: match object.get("moderate") {
-            Some(serde_json::Value::Null) | None => None,
-            Some(value) => Some(ai_moderate_policy_from_json_value(value)?),
-        },
-        vision: match object.get("vision") {
-            Some(serde_json::Value::Null) | None => None,
-            Some(value) => Some(ai_vision_policy_from_json_value(value)?),
-        },
-    })
-}
-
-fn ai_embed_policy_from_json_value(
-    value: &serde_json::Value,
-) -> RdbFileResult<PhysicalAiEmbedPolicy> {
-    let object = expect_object(value, "physical ai embed policy")?;
-    Ok(PhysicalAiEmbedPolicy {
-        fields: string_array_from_json(object.get("fields")).unwrap_or_default(),
-        provider: json_string_required(object, "provider")?,
-        model: json_string_required(object, "model")?,
-    })
-}
-
-fn ai_moderate_policy_from_json_value(
-    value: &serde_json::Value,
-) -> RdbFileResult<PhysicalAiModeratePolicy> {
-    let object = expect_object(value, "physical ai moderate policy")?;
-    Ok(PhysicalAiModeratePolicy {
-        fields: string_array_from_json(object.get("fields")).unwrap_or_default(),
-        provider: json_string_required(object, "provider")?,
-        model: json_string_required(object, "model")?,
-        sync_gate: object
-            .get("sync_gate")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false),
-        degraded_mode: object
-            .get("degraded_mode")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("open")
-            .to_string(),
-        reject_action: object
-            .get("reject_action")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("reject")
-            .to_string(),
-        hard_delete_on_reject: object
-            .get("hard_delete_on_reject")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false),
-    })
-}
-
-fn ai_vision_policy_from_json_value(
-    value: &serde_json::Value,
-) -> RdbFileResult<PhysicalAiVisionPolicy> {
-    let object = expect_object(value, "physical ai vision policy")?;
-    Ok(PhysicalAiVisionPolicy {
-        image_field: json_string_required(object, "image_field")?,
-        output_kinds: string_array_from_json(object.get("output_kinds")).unwrap_or_default(),
-        provider: json_string_required(object, "provider")?,
-        model: json_string_required(object, "model")?,
     })
 }
 

--- a/crates/reddb-file/src/physical_metadata/ai_policy_codec.rs
+++ b/crates/reddb-file/src/physical_metadata/ai_policy_codec.rs
@@ -1,0 +1,178 @@
+//! AI-policy JSON codecs for the physical metadata document contract.
+//!
+//! Split out of the parent `physical_metadata` module to keep that file under
+//! the 2000-line file-contract budget enforced by
+//! `tests/layout_authority/storage.rs`. Behaviour is unchanged — these are the
+//! same `*_json_value` / `*_from_json_value` helpers, moved verbatim. Only the
+//! two entry points the parent calls (`ai_policy_json_value` /
+//! `ai_policy_from_json_value`) are re-exposed to it via `pub(super)`.
+
+use super::json_helpers::*;
+use super::types::*;
+use crate::RdbFileResult;
+
+pub(super) fn ai_policy_json_value(policy: &PhysicalAiPolicy) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    object.insert(
+        "embed".to_string(),
+        policy
+            .embed
+            .as_ref()
+            .map(ai_embed_policy_json_value)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    object.insert(
+        "moderate".to_string(),
+        policy
+            .moderate
+            .as_ref()
+            .map(ai_moderate_policy_json_value)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    object.insert(
+        "vision".to_string(),
+        policy
+            .vision
+            .as_ref()
+            .map(ai_vision_policy_json_value)
+            .unwrap_or(serde_json::Value::Null),
+    );
+    serde_json::Value::Object(object)
+}
+
+fn ai_embed_policy_json_value(policy: &PhysicalAiEmbedPolicy) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    object.insert("fields".to_string(), string_array_json(&policy.fields));
+    object.insert(
+        "provider".to_string(),
+        serde_json::Value::String(policy.provider.clone()),
+    );
+    object.insert(
+        "model".to_string(),
+        serde_json::Value::String(policy.model.clone()),
+    );
+    serde_json::Value::Object(object)
+}
+
+fn ai_moderate_policy_json_value(policy: &PhysicalAiModeratePolicy) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    object.insert("fields".to_string(), string_array_json(&policy.fields));
+    object.insert(
+        "provider".to_string(),
+        serde_json::Value::String(policy.provider.clone()),
+    );
+    object.insert(
+        "model".to_string(),
+        serde_json::Value::String(policy.model.clone()),
+    );
+    object.insert(
+        "sync_gate".to_string(),
+        serde_json::Value::Bool(policy.sync_gate),
+    );
+    object.insert(
+        "degraded_mode".to_string(),
+        serde_json::Value::String(policy.degraded_mode.clone()),
+    );
+    object.insert(
+        "reject_action".to_string(),
+        serde_json::Value::String(policy.reject_action.clone()),
+    );
+    object.insert(
+        "hard_delete_on_reject".to_string(),
+        serde_json::Value::Bool(policy.hard_delete_on_reject),
+    );
+    serde_json::Value::Object(object)
+}
+
+fn ai_vision_policy_json_value(policy: &PhysicalAiVisionPolicy) -> serde_json::Value {
+    let mut object = serde_json::Map::new();
+    object.insert(
+        "image_field".to_string(),
+        serde_json::Value::String(policy.image_field.clone()),
+    );
+    object.insert(
+        "output_kinds".to_string(),
+        string_array_json(&policy.output_kinds),
+    );
+    object.insert(
+        "provider".to_string(),
+        serde_json::Value::String(policy.provider.clone()),
+    );
+    object.insert(
+        "model".to_string(),
+        serde_json::Value::String(policy.model.clone()),
+    );
+    serde_json::Value::Object(object)
+}
+
+pub(super) fn ai_policy_from_json_value(
+    value: &serde_json::Value,
+) -> RdbFileResult<PhysicalAiPolicy> {
+    let object = expect_object(value, "physical ai policy")?;
+    Ok(PhysicalAiPolicy {
+        embed: match object.get("embed") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(value) => Some(ai_embed_policy_from_json_value(value)?),
+        },
+        moderate: match object.get("moderate") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(value) => Some(ai_moderate_policy_from_json_value(value)?),
+        },
+        vision: match object.get("vision") {
+            Some(serde_json::Value::Null) | None => None,
+            Some(value) => Some(ai_vision_policy_from_json_value(value)?),
+        },
+    })
+}
+
+fn ai_embed_policy_from_json_value(
+    value: &serde_json::Value,
+) -> RdbFileResult<PhysicalAiEmbedPolicy> {
+    let object = expect_object(value, "physical ai embed policy")?;
+    Ok(PhysicalAiEmbedPolicy {
+        fields: string_array_from_json(object.get("fields")).unwrap_or_default(),
+        provider: json_string_required(object, "provider")?,
+        model: json_string_required(object, "model")?,
+    })
+}
+
+fn ai_moderate_policy_from_json_value(
+    value: &serde_json::Value,
+) -> RdbFileResult<PhysicalAiModeratePolicy> {
+    let object = expect_object(value, "physical ai moderate policy")?;
+    Ok(PhysicalAiModeratePolicy {
+        fields: string_array_from_json(object.get("fields")).unwrap_or_default(),
+        provider: json_string_required(object, "provider")?,
+        model: json_string_required(object, "model")?,
+        sync_gate: object
+            .get("sync_gate")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+        degraded_mode: object
+            .get("degraded_mode")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("open")
+            .to_string(),
+        reject_action: object
+            .get("reject_action")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("reject")
+            .to_string(),
+        hard_delete_on_reject: object
+            .get("hard_delete_on_reject")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false),
+    })
+}
+
+fn ai_vision_policy_from_json_value(
+    value: &serde_json::Value,
+) -> RdbFileResult<PhysicalAiVisionPolicy> {
+    let object = expect_object(value, "physical ai vision policy")?;
+    Ok(PhysicalAiVisionPolicy {
+        image_field: json_string_required(object, "image_field")?,
+        output_kinds: string_array_from_json(object.get("output_kinds")).unwrap_or_default(),
+        provider: json_string_required(object, "provider")?,
+        model: json_string_required(object, "model")?,
+    })
+}

--- a/crates/reddb-file/src/physical_metadata/tests.rs
+++ b/crates/reddb-file/src/physical_metadata/tests.rs
@@ -306,6 +306,7 @@ fn physical_collection_contract_round_trips() {
             time_key: "ts".to_string(),
             order_by_key: Some("id".to_string()),
         }),
+        ai_policy: None,
     };
 
     let json = encode_physical_collection_contract_json(&contract).unwrap();

--- a/crates/reddb-file/src/physical_metadata/tests.rs
+++ b/crates/reddb-file/src/physical_metadata/tests.rs
@@ -318,6 +318,82 @@ fn physical_collection_contract_round_trips() {
 }
 
 #[test]
+fn physical_collection_contract_with_ai_policy_round_trips() {
+    let contract = PhysicalCollectionContract {
+        name: "posts".to_string(),
+        declared_model: "table".to_string(),
+        schema_mode: "strict".to_string(),
+        origin: "explicit".to_string(),
+        version: 1,
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        default_ttl_ms: None,
+        vector_dimension: None,
+        vector_metric: None,
+        context_index_fields: Vec::new(),
+        declared_columns: Vec::new(),
+        table_def_hex: None,
+        timestamps_enabled: false,
+        context_index_enabled: false,
+        metrics_raw_retention_ms: None,
+        metrics_rollup_policies: Vec::new(),
+        metrics_tenant_identity: None,
+        metrics_namespace: None,
+        append_only: false,
+        subscriptions: Vec::new(),
+        analytics_config: Vec::new(),
+        session_key: None,
+        session_gap_ms: None,
+        retention_duration_ms: None,
+        analytical_storage: None,
+        ai_policy: Some(PhysicalAiPolicy {
+            embed: Some(PhysicalAiEmbedPolicy {
+                fields: vec!["title".to_string(), "body".to_string()],
+                provider: "openai".to_string(),
+                model: "text-embedding-3-small".to_string(),
+            }),
+            moderate: Some(PhysicalAiModeratePolicy {
+                fields: vec!["body".to_string()],
+                provider: "openai".to_string(),
+                model: "omni-moderation-latest".to_string(),
+                sync_gate: true,
+                degraded_mode: "closed".to_string(),
+                reject_action: "flag".to_string(),
+                hard_delete_on_reject: true,
+            }),
+            vision: Some(PhysicalAiVisionPolicy {
+                image_field: "photo".to_string(),
+                output_kinds: vec!["caption".to_string(), "tags".to_string()],
+                provider: "openai".to_string(),
+                model: "gpt-4o".to_string(),
+            }),
+        }),
+    };
+
+    let json = encode_physical_collection_contract_json(&contract).expect("encode ai policy");
+    assert!(json.contains("\"hard_delete_on_reject\""));
+    assert_eq!(
+        decode_physical_collection_contract_json(&json).expect("decode ai policy"),
+        contract
+    );
+
+    // A present-but-empty policy round-trips through the Null modality arms.
+    let bare = PhysicalCollectionContract {
+        ai_policy: Some(PhysicalAiPolicy {
+            embed: None,
+            moderate: None,
+            vision: None,
+        }),
+        ..contract
+    };
+    let json = encode_physical_collection_contract_json(&bare).expect("encode bare policy");
+    assert_eq!(
+        decode_physical_collection_contract_json(&json).expect("decode bare policy"),
+        bare
+    );
+}
+
+#[test]
 fn physical_metadata_core_contracts_round_trip() {
     let mut roots = BTreeMap::new();
     roots.insert("docs".to_string(), 42);

--- a/crates/reddb-file/src/physical_metadata/types.rs
+++ b/crates/reddb-file/src/physical_metadata/types.rs
@@ -311,6 +311,11 @@ pub struct PhysicalAiModeratePolicy {
     pub sync_gate: bool,
     pub degraded_mode: String,
     pub reject_action: String,
+    /// When true, a quarantined row that re-moderates to a reject is
+    /// hard-deleted rather than tombstoned-and-retained. Defaults to
+    /// false (audit-retaining tombstone) on sidecars written before this
+    /// field existed.
+    pub hard_delete_on_reject: bool,
 }
 
 /// Persisted form of a `VISION (...)` AI-policy block (issue #1271).

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -1837,6 +1837,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_embed_and_vision_policy_error_branches() {
+        // EMBED + VISION unknown-option and missing-required-field arms each
+        // surface a descriptive parse error.
+        for (sql, needle) in [
+            (
+                "t (id INT, body TEXT) WITH (EMBED (fields = ('body'), provider = 'o', model = 'm', bogus = 1))",
+                "unsupported EMBED policy option",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (EMBED (provider = 'o', model = 'm'))",
+                "EMBED policy requires fields",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (EMBED (fields = ('body'), model = 'm'))",
+                "EMBED policy requires provider",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (EMBED (fields = ('body'), provider = 'o'))",
+                "EMBED policy requires model",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (image_field = 'photo', provider = 'o', model = 'm', bogus = 1))",
+                "unsupported VISION policy option",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (provider = 'o', model = 'm'))",
+                "VISION policy requires image_field",
+            ),
+        ] {
+            let err = parser(sql)
+                .parse_create_table_body()
+                .expect_err("ai policy error");
+            assert!(format!("{err}").contains(needle), "got: {err}");
+        }
+
+        // The `output_kinds` alias for VISION parses like `outputs`.
+        let QueryExpr::CreateTable(table) = parser(
+            "t (id INT, photo TEXT) WITH (VISION (image_field = 'photo', \
+               output_kinds = ('caption'), provider = 'o', model = 'm'))",
+        )
+        .parse_create_table_body()
+        .expect("vision output_kinds alias") else {
+            panic!("Expected CreateTableQuery");
+        };
+        let vision = table
+            .ai_policy
+            .expect("policy")
+            .vision
+            .expect("vision block");
+        assert_eq!(vision.output_kinds, vec!["caption".to_string()]);
+    }
+
+    #[test]
     fn parse_create_table_ai_policy_defaults_and_no_clause() {
         use reddb_types::catalog::{ModerateDegradedMode, ModerateRejectAction};
         // MODERATE with no sync/degraded/on_reject falls back to defaults.

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -1400,6 +1400,7 @@ impl<'a> Parser<'a> {
         let mut sync_gate = false;
         let mut degraded_mode = ModerateDegradedMode::default();
         let mut reject_action = ModerateRejectAction::default();
+        let mut hard_delete_on_reject = false;
         loop {
             let key = self.expect_ident_or_keyword()?.to_ascii_lowercase();
             self.expect(Token::Eq)?;
@@ -1408,6 +1409,9 @@ impl<'a> Parser<'a> {
                 "provider" => provider = Some(self.parse_string()?),
                 "model" => model = Some(self.parse_string()?),
                 "sync" | "sync_gate" => sync_gate = self.parse_ai_bool()?,
+                "hard_delete" | "hard_delete_on_reject" => {
+                    hard_delete_on_reject = self.parse_ai_bool()?
+                }
                 "degraded" | "degraded_mode" => {
                     let word = self.parse_ai_word()?;
                     degraded_mode = ModerateDegradedMode::from_str(&word).ok_or_else(|| {
@@ -1433,7 +1437,7 @@ impl<'a> Parser<'a> {
                 other => {
                     return Err(ParseError::new(
                         format!(
-                            "unsupported MODERATE policy option {other:?}; supported: fields, provider, model, sync, degraded, on_reject"
+                            "unsupported MODERATE policy option {other:?}; supported: fields, provider, model, sync, degraded, on_reject, hard_delete"
                         ),
                         self.position(),
                     ));
@@ -1469,6 +1473,7 @@ impl<'a> Parser<'a> {
             sync_gate,
             degraded_mode,
             reject_action,
+            hard_delete_on_reject,
         })
     }
 
@@ -1748,7 +1753,7 @@ mod tests {
         let QueryExpr::CreateTable(table) = parser(
             "posts (id INT, title TEXT, body TEXT, photo TEXT) WITH ( \
                EMBED (fields = ('title', 'body'), provider = 'openai', model = 'text-embedding-3-small'), \
-               MODERATE (fields = ('body'), provider = 'openai', model = 'omni-moderation-latest', sync = true, degraded = closed, on_reject = flag), \
+               MODERATE (fields = ('body'), provider = 'openai', model = 'omni-moderation-latest', sync = true, degraded = closed, on_reject = flag, hard_delete = true), \
                VISION (image_field = 'photo', outputs = ('caption', 'tags'), provider = 'openai', model = 'gpt-4o') \
              )",
         )
@@ -1769,6 +1774,7 @@ mod tests {
         assert!(moderate.sync_gate);
         assert_eq!(moderate.degraded_mode, ModerateDegradedMode::Closed);
         assert_eq!(moderate.reject_action, ModerateRejectAction::Flag);
+        assert!(moderate.hard_delete_on_reject);
 
         let vision = policy.vision.expect("vision block");
         assert_eq!(vision.image_field, "photo");
@@ -1800,6 +1806,7 @@ mod tests {
         assert!(!moderate.sync_gate);
         assert_eq!(moderate.degraded_mode, ModerateDegradedMode::Open);
         assert_eq!(moderate.reject_action, ModerateRejectAction::Reject);
+        assert!(!moderate.hard_delete_on_reject);
 
         // No AI clause leaves the policy entirely absent.
         let QueryExpr::CreateTable(plain) = parser("plain (id INT)")

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -1786,6 +1786,57 @@ mod tests {
     }
 
     #[test]
+    fn parse_moderate_policy_aliases_and_error_branches() {
+        use reddb_types::catalog::{ModerateDegradedMode, ModerateRejectAction};
+        // Alias spellings hit the same match arms as the short forms.
+        let QueryExpr::CreateTable(table) = parser(
+            "t (id INT, body TEXT) WITH ( \
+               MODERATE (fields = ('body'), provider = 'openai', model = 'm', \
+                 sync_gate = true, degraded_mode = open, reject_action = redact, \
+                 hard_delete_on_reject = true) \
+             )",
+        )
+        .parse_create_table_body()
+        .expect("alias spellings parse") else {
+            panic!("Expected CreateTableQuery");
+        };
+        let moderate = table
+            .ai_policy
+            .expect("policy")
+            .moderate
+            .expect("moderate block");
+        assert!(moderate.sync_gate);
+        assert_eq!(moderate.degraded_mode, ModerateDegradedMode::Open);
+        assert_eq!(moderate.reject_action, ModerateRejectAction::Redact);
+        assert!(moderate.hard_delete_on_reject);
+
+        // Each invalid MODERATE option surfaces a descriptive parse error.
+        for (sql, needle) in [
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (fields = ('body'), provider = 'o', model = 'm', bogus = 1))",
+                "unsupported MODERATE policy option",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (fields = ('body'), provider = 'o', model = 'm', degraded = sideways))",
+                "unsupported MODERATE degraded mode",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (fields = ('body'), provider = 'o', model = 'm', on_reject = explode))",
+                "unsupported MODERATE reject action",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (provider = 'o', model = 'm'))",
+                "MODERATE policy requires fields",
+            ),
+        ] {
+            let err = parser(sql)
+                .parse_create_table_body()
+                .expect_err("moderate policy error");
+            assert!(format!("{err}").contains(needle), "got: {err}");
+        }
+    }
+
+    #[test]
     fn parse_create_table_ai_policy_defaults_and_no_clause() {
         use reddb_types::catalog::{ModerateDegradedMode, ModerateRejectAction};
         // MODERATE with no sync/degraded/on_reject falls back to defaults.

--- a/crates/reddb-server/src/physical/json_codec.rs
+++ b/crates/reddb-server/src/physical/json_codec.rs
@@ -381,6 +381,7 @@ fn ai_policy_to_persisted(policy: &crate::catalog::AiPolicy) -> reddb_file::Phys
                 sync_gate: moderate.sync_gate,
                 degraded_mode: moderate.degraded_mode.as_str().to_string(),
                 reject_action: moderate.reject_action.as_str().to_string(),
+                hard_delete_on_reject: moderate.hard_delete_on_reject,
             }),
         vision: policy
             .vision
@@ -413,6 +414,7 @@ fn ai_policy_from_persisted(policy: reddb_file::PhysicalAiPolicy) -> crate::cata
                     .unwrap_or_default(),
                 reject_action: ModerateRejectAction::from_str(&moderate.reject_action)
                     .unwrap_or_default(),
+                hard_delete_on_reject: moderate.hard_delete_on_reject,
             }),
         vision: policy.vision.map(|vision| crate::catalog::VisionPolicy {
             image_field: vision.image_field,
@@ -1189,6 +1191,7 @@ mod tests {
                 sync_gate: true,
                 degraded_mode: crate::catalog::ModerateDegradedMode::Closed,
                 reject_action: crate::catalog::ModerateRejectAction::Redact,
+                hard_delete_on_reject: true,
             }),
             vision: Some(crate::catalog::VisionPolicy {
                 image_field: "photo".to_string(),

--- a/crates/reddb-server/src/reserved_fields.rs
+++ b/crates/reddb-server/src/reserved_fields.rs
@@ -5,6 +5,11 @@ pub(crate) const RESERVED_PUBLIC_ITEM_FIELDS: &[&str] = &[
     "tenant",
     "created_at",
     "updated_at",
+    // Moderation visibility marker (#1274, ADR 0057). The moderation gate
+    // and re-moderation lane set this to hide quarantine-pending and
+    // rejected-tombstone rows from normal reads; users cannot declare or
+    // set it as a top-level field.
+    crate::runtime::ai::moderation::MODERATION_STATUS_FIELD,
 ];
 
 pub(crate) fn is_reserved_public_item_field(field: &str) -> bool {

--- a/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
+++ b/crates/reddb-server/src/runtime/ai/cdc_enrichment.rs
@@ -24,10 +24,15 @@
 //! and a production scheduler can drive it from a background thread without
 //! changing the semantics.
 
-use crate::application::entity::{CreateVectorInput, PatchEntityInput};
+use crate::application::entity::{CreateVectorInput, DeleteEntityInput, PatchEntityInput};
 use crate::application::ports::RuntimeEntityPort;
-use crate::catalog::{EmbedPolicy, VisionPolicy};
+use crate::catalog::{EmbedPolicy, ModerateDegradedMode, ModeratePolicy, VisionPolicy};
 use crate::replication::cdc::ChangeOperation;
+use crate::runtime::ai::moderation::{
+    ModerationOutcome, MODERATION_STATUS_FIELD, MODERATION_STATUS_PENDING,
+    MODERATION_STATUS_REJECTED,
+};
+use crate::runtime::mutation::MutationRow;
 use crate::storage::schema::Value;
 use crate::storage::{EntityData, EntityId};
 use crate::{RedDBError, RedDBResult, RedDBRuntime};
@@ -47,6 +52,10 @@ pub enum EnrichmentKind {
     Embed,
     /// Run computer vision over the declared image-reference field (#1275).
     Vision,
+    /// Re-moderate a quarantine-pending row's declared text fields (#1274).
+    /// A pass clears the row's quarantine (it becomes visible); a reject
+    /// tombstones it (hidden, retained for audit) or hard-deletes it.
+    Moderate,
 }
 
 /// Tunables for the enrichment consumer.
@@ -213,6 +222,23 @@ impl CdcEnrichmentConsumer {
                     stats.ingested += 1;
                 }
             }
+            // Re-moderation rides the same lane, but only quarantine-pending
+            // rows are eligible: the synchronous gate already screened
+            // everything that committed clean, so a normal insert/update
+            // must NOT be re-screened here. We gate on the row actually
+            // carrying the pending marker (see `row_is_moderation_pending`).
+            if let Some(policy) = rt.collection_moderate_policy(&event.collection) {
+                if change_touches_moderate_fields(event, &policy)
+                    && rt.row_is_moderation_pending(&event.collection, event.entity_id)
+                    && self.enqueue(
+                        event.collection.clone(),
+                        event.entity_id,
+                        EnrichmentKind::Moderate,
+                    )
+                {
+                    stats.ingested += 1;
+                }
+            }
         }
 
         // 2. Attempt every ready pending item.
@@ -234,6 +260,12 @@ impl CdcEnrichmentConsumer {
                 },
                 EnrichmentKind::Vision => match rt.collection_vision_policy(&work.collection) {
                     Some(policy) => rt.enrich_row_vision(&work.collection, work.entity_id, &policy),
+                    None => continue,
+                },
+                EnrichmentKind::Moderate => match rt.collection_moderate_policy(&work.collection) {
+                    Some(policy) => {
+                        rt.remoderate_pending_row(&work.collection, work.entity_id, &policy)
+                    }
                     None => continue,
                 },
             };
@@ -332,6 +364,30 @@ fn change_touches_vision_field(
     }
 }
 
+/// Whether a change event should (re)moderate the row under `policy`.
+///
+/// Inserts always qualify; updates qualify when a declared moderated field
+/// changed (or no damage vector is available, so we screen conservatively).
+/// Crucially the consumer's own write-backs — clearing the pending marker
+/// or stamping a reject — touch only [`MODERATION_STATUS_FIELD`], never a
+/// declared field, so re-moderation never re-triggers itself into a loop.
+/// Deletes/refreshes never qualify.
+fn change_touches_moderate_fields(
+    event: &crate::replication::cdc::ChangeEvent,
+    policy: &ModeratePolicy,
+) -> bool {
+    match event.operation {
+        ChangeOperation::Insert => true,
+        ChangeOperation::Update => match &event.changed_columns {
+            Some(columns) => columns
+                .iter()
+                .any(|column| policy.fields.iter().any(|field| field == column)),
+            None => true,
+        },
+        ChangeOperation::Delete | ChangeOperation::Refresh => false,
+    }
+}
+
 /// Whether the policy's output kinds request structured component
 /// detections. Several spellings are accepted so DDL authors are not
 /// boxed into one keyword.
@@ -367,6 +423,187 @@ impl RedDBRuntime {
         self.db()
             .collection_contract_arc(collection)
             .and_then(|contract| contract.ai_policy.as_ref().and_then(|p| p.vision.clone()))
+    }
+
+    /// The declared moderation policy for `collection`, if any.
+    pub fn collection_moderate_policy(&self, collection: &str) -> Option<ModeratePolicy> {
+        self.db()
+            .collection_contract_arc(collection)
+            .and_then(|contract| contract.ai_policy.as_ref().and_then(|p| p.moderate.clone()))
+    }
+
+    /// True when the live row carries the quarantine-pending moderation
+    /// marker. Resolves the row through its stable logical id (the same
+    /// path the enrichment methods use), so a superseded MVCC version
+    /// never reports a stale state.
+    pub(crate) fn row_is_moderation_pending(&self, collection: &str, entity_id: u64) -> bool {
+        self.db()
+            .store()
+            .get_table_row_by_logical_id(collection, EntityId::new(entity_id))
+            .map(|entity| {
+                matches!(
+                    row_text_field(&entity.data, MODERATION_STATUS_FIELD).as_deref(),
+                    Some(MODERATION_STATUS_PENDING)
+                )
+            })
+            .unwrap_or(false)
+    }
+
+    /// Synchronous pre-commit moderation gate (#1274, ADR 0057).
+    ///
+    /// Runs only when `collection` declares a `MODERATE (... sync = true)`
+    /// policy. For every queued row it screens the concatenated text of the
+    /// declared moderated fields BEFORE the durable commit:
+    ///   * **Allow** — the row commits unchanged.
+    ///   * **Reject** — the whole write is refused (`Err`); no row persists.
+    ///   * **ProviderDown** + degraded `Open` (default) — the row is
+    ///     quarantined: the reserved [`MODERATION_STATUS_FIELD`] is set to
+    ///     `pending`, so it commits but is hidden from normal reads and is
+    ///     re-moderated asynchronously by the CDC consumer.
+    ///   * **ProviderDown** + degraded `Closed` — the write is refused.
+    ///
+    /// A row whose declared fields are all empty has nothing to screen and
+    /// is allowed unchanged.
+    pub(crate) fn apply_sync_moderation_gate(
+        &self,
+        collection: &str,
+        rows: &mut [MutationRow],
+    ) -> RedDBResult<()> {
+        let Some(policy) = self.collection_moderate_policy(collection) else {
+            return Ok(());
+        };
+        if !policy.sync_gate || rows.is_empty() {
+            return Ok(());
+        }
+
+        for row in rows.iter_mut() {
+            let text = combine_moderate_text(&row.fields, &policy.fields);
+            if text.is_empty() {
+                continue;
+            }
+            let outcome =
+                crate::runtime::ai::moderation::moderate_local(&policy.model, text.clone())?;
+            match outcome {
+                ModerationOutcome::Allow => {}
+                ModerationOutcome::Reject { categories } => {
+                    // Reject fails the write — the row never persists.
+                    return Err(RedDBError::Query(format!(
+                        "write rejected by moderation gate on collection '{collection}': \
+                         flagged categories [{}]",
+                        categories.join(", ")
+                    )));
+                }
+                ModerationOutcome::ProviderDown { reason } => match policy.degraded_mode {
+                    // Fail-closed: provider-down blocks the write.
+                    ModerateDegradedMode::Closed => {
+                        return Err(RedDBError::Query(format!(
+                            "write blocked: moderation provider unavailable for collection \
+                             '{collection}' (degraded = closed): {reason}"
+                        )));
+                    }
+                    // Fail-open default: quarantine the row. It commits but
+                    // is hidden from normal reads and re-moderated async.
+                    ModerateDegradedMode::Open => {
+                        set_row_moderation_marker(row, MODERATION_STATUS_PENDING);
+                    }
+                },
+            }
+        }
+        Ok(())
+    }
+
+    /// Re-moderate one quarantine-pending row (CDC lane). A pass clears the
+    /// pending marker (the row becomes visible); a reject either tombstones
+    /// the row (default — hidden, retained for audit/appeal) or hard-deletes
+    /// it when the policy opts in via `hard_delete`. Provider-down here is a
+    /// retryable failure: the row stays pending and the consumer's
+    /// retry/dead-letter machinery handles it like any other failure.
+    pub(crate) fn remoderate_pending_row(
+        &self,
+        collection: &str,
+        entity_id: u64,
+        policy: &ModeratePolicy,
+    ) -> RedDBResult<()> {
+        let db = self.db();
+        let Some(entity) = db
+            .store()
+            .get_table_row_by_logical_id(collection, EntityId::new(entity_id))
+        else {
+            return Ok(());
+        };
+
+        // Only act on rows still in the pending state. A row that was
+        // already cleared or tombstoned between enqueue and drain needs no
+        // further work.
+        if !matches!(
+            row_text_field(&entity.data, MODERATION_STATUS_FIELD).as_deref(),
+            Some(MODERATION_STATUS_PENDING)
+        ) {
+            return Ok(());
+        }
+
+        let text = combine_moderate_text_named(&entity.data, &policy.fields);
+        if text.is_empty() {
+            // Nothing to screen — clear the quarantine so the row surfaces.
+            return self.clear_row_moderation_marker(collection, entity.id);
+        }
+
+        let outcome = crate::runtime::ai::moderation::moderate_local(&policy.model, text)?;
+        match outcome {
+            ModerationOutcome::Allow => self.clear_row_moderation_marker(collection, entity.id),
+            ModerationOutcome::Reject { .. } => {
+                if policy.hard_delete_on_reject {
+                    self.delete_entity(DeleteEntityInput {
+                        collection: collection.to_string(),
+                        id: entity.id,
+                    })?;
+                    Ok(())
+                } else {
+                    self.set_row_moderation_status(
+                        collection,
+                        entity.id,
+                        MODERATION_STATUS_REJECTED,
+                    )
+                }
+            }
+            // Provider still down — surface as a retryable error so the
+            // row stays pending and is retried/dead-lettered.
+            ModerationOutcome::ProviderDown { reason } => Err(RedDBError::Query(format!(
+                "re-moderation provider unavailable for collection '{collection}': {reason}"
+            ))),
+        }
+    }
+
+    /// Clear the moderation marker so a previously-quarantined row becomes
+    /// visible to normal reads. Patches the field to an empty string and
+    /// relies on the visibility helper treating only a present text marker
+    /// as hidden — so an empty marker is, by design, still hidden. To make
+    /// the row visible we instead remove the field via a `fields` patch
+    /// that sets it to JSON null, which the storage merge drops.
+    fn clear_row_moderation_marker(&self, collection: &str, id: EntityId) -> RedDBResult<()> {
+        self.patch_entity(PatchEntityInput {
+            collection: collection.to_string(),
+            id,
+            payload: moderation_marker_clear_payload(),
+            operations: Vec::new(),
+        })?;
+        Ok(())
+    }
+
+    /// Stamp the row with a moderation status (`pending`/`rejected`).
+    fn set_row_moderation_status(
+        &self,
+        collection: &str,
+        id: EntityId,
+        status: &str,
+    ) -> RedDBResult<()> {
+        self.patch_entity(PatchEntityInput {
+            collection: collection.to_string(),
+            id,
+            payload: moderation_marker_set_payload(status),
+            operations: Vec::new(),
+        })?;
+        Ok(())
     }
 
     /// Compute the embedding for one committed row and attach it as a vector
@@ -555,6 +792,77 @@ fn vision_detections_payload(
     let mut root = Map::new();
     root.insert("fields".to_string(), Sj::Object(fields));
     Sj::Object(root)
+}
+
+/// Concatenate the declared moderated fields' text from a pre-commit
+/// `MutationRow`'s field list. Only text-valued declared fields contribute;
+/// the result is empty when there is nothing to screen.
+fn combine_moderate_text(fields: &[(String, Value)], declared: &[String]) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for field in declared {
+        for (name, value) in fields {
+            if name == field {
+                if let Value::Text(text) = value {
+                    if !text.is_empty() {
+                        parts.push(text);
+                    }
+                }
+            }
+        }
+    }
+    parts.join(" ")
+}
+
+/// Concatenate the declared moderated fields' text from a committed row's
+/// `EntityData`. Empty when the entity is not a row or no declared field
+/// holds non-empty text.
+fn combine_moderate_text_named(data: &EntityData, declared: &[String]) -> String {
+    let EntityData::Row(row) = data else {
+        return String::new();
+    };
+    let Some(named) = row.named.as_ref() else {
+        return String::new();
+    };
+    let parts: Vec<String> = declared
+        .iter()
+        .filter_map(|field| match named.get(field) {
+            Some(Value::Text(t)) if !t.is_empty() => Some(t.to_string()),
+            _ => None,
+        })
+        .collect();
+    parts.join(" ")
+}
+
+/// Stamp the reserved moderation marker onto a pre-commit row's field list,
+/// replacing any prior value for the field.
+fn set_row_moderation_marker(row: &mut MutationRow, status: &str) {
+    row.fields
+        .retain(|(name, _)| name != MODERATION_STATUS_FIELD);
+    row.fields.push((
+        MODERATION_STATUS_FIELD.to_string(),
+        Value::Text(std::sync::Arc::from(status)),
+    ));
+}
+
+/// `fields`-merge patch payload that sets the moderation marker to `status`.
+fn moderation_marker_set_payload(status: &str) -> crate::serde_json::Value {
+    use crate::serde_json::{Map, Value as Sj};
+    let mut fields = Map::new();
+    fields.insert(
+        MODERATION_STATUS_FIELD.to_string(),
+        Sj::String(status.to_string()),
+    );
+    let mut root = Map::new();
+    root.insert("fields".to_string(), Sj::Object(fields));
+    Sj::Object(root)
+}
+
+/// `fields`-merge patch payload that clears the moderation marker (sets it
+/// to the empty string). The storage merge has no field-removal form, so
+/// the cleared row keeps an empty marker — which the visibility helper
+/// treats as visible, exactly like an absent marker.
+fn moderation_marker_clear_payload() -> crate::serde_json::Value {
+    moderation_marker_set_payload("")
 }
 
 /// Join the declared embed fields' text values, mirroring the manual

--- a/crates/reddb-server/src/runtime/ai/mod.rs
+++ b/crates/reddb-server/src/runtime/ai/mod.rs
@@ -27,6 +27,7 @@ pub mod grpc_ask_message;
 pub mod local_embedding;
 pub mod mcp_ask_tool;
 pub mod metrics;
+pub mod moderation;
 pub mod ner;
 pub mod pg_wire_ask_row_encoder;
 pub mod prompt_assembler;

--- a/crates/reddb-server/src/runtime/ai/moderation.rs
+++ b/crates/reddb-server/src/runtime/ai/moderation.rs
@@ -1,0 +1,206 @@
+//! Local content-moderation backend (#1274, PRD #1267, ADR 0057).
+//!
+//! Moderation is the third AI modality on the write/CDC lane (after
+//! embeddings #1272 and vision #1275). A collection that declares a
+//! `MODERATE (...)` policy names text/image-reference fields that are
+//! screened by a moderation provider. Unlike embed/vision, moderation has
+//! a **synchronous pre-commit gate**: when `sync = true`, the write path
+//! screens the declared fields *before the durable commit* and refuses the
+//! write on a reject (ADR 0057). Provider-down behaviour and re-moderation
+//! of quarantined rows ride the existing CDC enrichment lane.
+//!
+//! Mirroring [`super::vision`] and [`super::local_embedding`], the engine
+//! is a swappable, process-global [`LocalModerationBackend`]. There is no
+//! built-in default — a real engine or a mock is installed via
+//! [`install_local_moderation_backend`]. A backend may also report itself
+//! *down* (returning [`ModerationOutcome::ProviderDown`]) so tests can
+//! exercise the fail-open-quarantine and fail-closed paths deterministically.
+
+use std::sync::{Arc, OnceLock, RwLock};
+
+use crate::storage::schema::Value;
+use crate::storage::unified::entity::{EntityData, UnifiedEntity};
+use crate::{RedDBError, RedDBResult};
+
+/// Reserved row field that carries a row's moderation visibility state.
+///
+/// A row that committed but is hidden from normal reads carries this
+/// field; a fully-cleared (allowed) row does not. Two values are used:
+///   * [`MODERATION_STATUS_PENDING`] — quarantine-pending (provider was
+///     down at write time under fail-open; awaiting async re-moderation),
+///   * [`MODERATION_STATUS_REJECTED`] — re-moderated to a reject; the row
+///     is tombstoned-and-retained for audit/appeal.
+///
+/// It is a reserved system field (see `crate::reserved_fields`) so users
+/// cannot declare or set it, and the read-path visibility helpers hide any
+/// row that carries it from normal SELECT/scan reads (ADR 0057).
+pub const MODERATION_STATUS_FIELD: &str = "__moderation_status";
+
+/// Value of [`MODERATION_STATUS_FIELD`] for a quarantine-pending row.
+pub const MODERATION_STATUS_PENDING: &str = "pending";
+
+/// Value of [`MODERATION_STATUS_FIELD`] for a rejected-tombstone row.
+pub const MODERATION_STATUS_REJECTED: &str = "rejected";
+
+/// Whether `entity` carries a moderation status that must hide it from
+/// normal reads (quarantine-pending or rejected-tombstone).
+///
+/// This is consulted on the hot read path for *every* table-row candidate,
+/// so it is a single, allocation-free field probe. Non-row entities and
+/// rows without the marker are never hidden by moderation.
+#[inline]
+pub fn entity_moderation_hidden(entity: &UnifiedEntity) -> bool {
+    let EntityData::Row(row) = &entity.data else {
+        return false;
+    };
+    // Hidden only for the two active hidden states. A cleared (allowed)
+    // row carries an empty/absent marker and stays visible; this keeps the
+    // clear path a simple field overwrite (the storage merge has no
+    // field-removal form) without leaking a stale "hidden" decision.
+    matches!(
+        row.get_field(MODERATION_STATUS_FIELD),
+        Some(Value::Text(status))
+            if status.as_ref() == MODERATION_STATUS_PENDING
+                || status.as_ref() == MODERATION_STATUS_REJECTED
+    )
+}
+
+/// Verdict for one moderation pass over a row's declared fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModerationOutcome {
+    /// Content passed — the write/row is allowed to be visible.
+    Allow,
+    /// Content failed moderation — the write is rejected. `categories`
+    /// carries the flagged reasons for audit/appeal.
+    Reject { categories: Vec<String> },
+    /// The provider could not be reached. The caller applies the policy's
+    /// degraded-mode behaviour (fail-open + quarantine, or fail-closed).
+    ProviderDown { reason: String },
+}
+
+impl ModerationOutcome {
+    /// True when the content was rejected by moderation.
+    pub fn is_reject(&self) -> bool {
+        matches!(self, Self::Reject { .. })
+    }
+
+    /// True when the provider was unreachable.
+    pub fn is_provider_down(&self) -> bool {
+        matches!(self, Self::ProviderDown { .. })
+    }
+}
+
+/// A materialised moderation request handed to a backend. The declared
+/// text fields are concatenated by the caller into `text`; an empty
+/// `text` means there was nothing to screen.
+#[derive(Debug, Clone)]
+pub struct ModerationRequest {
+    /// Model name as written in the collection's MODERATE policy.
+    pub model: String,
+    /// The concatenated text of the row's declared moderated fields.
+    pub text: String,
+}
+
+/// Backend abstraction so the gate/enrichment lanes do not depend on a
+/// specific moderation engine. Tests install a mock; production installs a
+/// real engine via [`install_local_moderation_backend`].
+pub trait LocalModerationBackend: Send + Sync {
+    fn moderate(&self, request: &ModerationRequest) -> RedDBResult<ModerationOutcome>;
+}
+
+const LOCAL_MODERATION_DISABLED_MESSAGE: &str =
+    "local moderation requires a backend installed via \
+     runtime::ai::moderation::install_local_moderation_backend. Alternatively, \
+     declare a moderation-capable remote provider in the collection's MODERATE \
+     policy.";
+
+type BackendSlot = Arc<dyn LocalModerationBackend>;
+
+fn backend_slot() -> &'static RwLock<Option<BackendSlot>> {
+    static SLOT: OnceLock<RwLock<Option<BackendSlot>>> = OnceLock::new();
+    SLOT.get_or_init(|| RwLock::new(None))
+}
+
+/// Install (or replace) the process-global local moderation backend.
+///
+/// Production servers call this once at boot with their real engine. Tests
+/// use it to swap in a mock moderation provider. Safe to call from any
+/// thread; the most recent install wins.
+pub fn install_local_moderation_backend(backend: Arc<dyn LocalModerationBackend>) {
+    let mut guard = backend_slot()
+        .write()
+        .expect("moderation backend slot poisoned");
+    *guard = Some(backend);
+}
+
+/// Test-only: clear the installed backend so a subsequent call exercises
+/// the feature-disabled path again.
+#[doc(hidden)]
+pub fn clear_local_moderation_backend_for_tests() {
+    let mut guard = backend_slot()
+        .write()
+        .expect("moderation backend slot poisoned");
+    *guard = None;
+}
+
+fn current_backend() -> Option<BackendSlot> {
+    backend_slot()
+        .read()
+        .expect("moderation backend slot poisoned")
+        .as_ref()
+        .map(Arc::clone)
+}
+
+/// Resolve and run a local moderation request end-to-end. Errors with a
+/// clear message when no backend is installed; a *down provider* is NOT an
+/// error — the backend signals it via [`ModerationOutcome::ProviderDown`]
+/// so the caller can apply the policy's degraded-mode behaviour.
+pub fn moderate_local(model: &str, text: String) -> RedDBResult<ModerationOutcome> {
+    let backend = current_backend().ok_or_else(|| {
+        RedDBError::FeatureNotEnabled(LOCAL_MODERATION_DISABLED_MESSAGE.to_string())
+    })?;
+    backend.moderate(&ModerationRequest {
+        model: model.to_string(),
+        text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct AllowAll;
+    impl LocalModerationBackend for AllowAll {
+        fn moderate(&self, _request: &ModerationRequest) -> RedDBResult<ModerationOutcome> {
+            Ok(ModerationOutcome::Allow)
+        }
+    }
+
+    #[test]
+    fn missing_backend_is_feature_disabled_error() {
+        clear_local_moderation_backend_for_tests();
+        let err = moderate_local("m", "hello".to_string()).expect_err("no backend");
+        assert!(matches!(err, RedDBError::FeatureNotEnabled(_)));
+    }
+
+    #[test]
+    fn installed_backend_drives_outcome() {
+        install_local_moderation_backend(Arc::new(AllowAll));
+        let outcome = moderate_local("m", "hello".to_string()).expect("allowed");
+        assert_eq!(outcome, ModerationOutcome::Allow);
+        clear_local_moderation_backend_for_tests();
+    }
+
+    #[test]
+    fn outcome_predicates() {
+        assert!(ModerationOutcome::Reject {
+            categories: vec!["hate".to_string()],
+        }
+        .is_reject());
+        assert!(ModerationOutcome::ProviderDown {
+            reason: "timeout".to_string(),
+        }
+        .is_provider_down());
+        assert!(!ModerationOutcome::Allow.is_reject());
+    }
+}

--- a/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
+++ b/crates/reddb-server/src/runtime/ai/provider_capabilities.rs
@@ -290,9 +290,13 @@ impl Modalities {
                 // (#1275) alongside embeddings: an installed
                 // `LocalVisionBackend` runs detection/image-embedding over
                 // a collection's declared image-reference field via the CDC
-                // enrichment lane. Generation/moderation stay out of scope.
+                // enrichment lane. It also serves content moderation
+                // (#1274): an installed `LocalModerationBackend` screens a
+                // collection's declared text fields via the synchronous
+                // pre-commit gate and the async re-moderation lane.
+                // Generation stays out of scope.
                 vision: true,
-                moderate: false,
+                moderate: true,
             },
             "custom" => Self::conservative(),
             _ => Self::conservative(),
@@ -848,13 +852,15 @@ mod tests {
     }
 
     #[test]
-    fn local_serves_embed_and_vision() {
+    fn local_serves_embed_vision_and_moderate() {
         let c = Modalities::for_provider("local");
         assert!(c.supports(Modality::Embed));
         assert!(c.supports(Modality::Vision));
-        // Generation and moderation stay out of scope for the local backend.
+        // Content moderation (#1274) rides the in-process local backend
+        // alongside vision (#1275).
+        assert!(c.supports(Modality::Moderate));
+        // Generation stays out of scope for the local backend.
         assert!(!c.supports(Modality::Generate));
-        assert!(!c.supports(Modality::Moderate));
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -279,6 +279,16 @@ impl<'a> DmlTargetScan<'a> {
     }
 
     fn visible_candidate(&self, entity: &crate::storage::UnifiedEntity) -> bool {
+        // Moderation visibility gate (#1274): quarantine-pending and
+        // rejected-tombstone rows are excluded from DML targeting too, so
+        // an UPDATE/DELETE without an explicit moderation override never
+        // re-touches a hidden row. The resolver path below routes through
+        // `entity_visible_under_current_snapshot`, which already applies
+        // the same check; the `live_table_rows` fast path bypasses that
+        // helper, so it must apply the marker check here.
+        if crate::runtime::ai::moderation::entity_moderation_hidden(entity) {
+            return false;
+        }
         if matches!(entity.kind, EntityKind::TableRow { .. }) {
             if self.live_table_rows {
                 return entity.xmax == 0;

--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -574,6 +574,15 @@ impl Drop for CurrentSnapshotGuard {
 pub fn entity_visible_under_current_snapshot(
     entity: &crate::storage::unified::entity::UnifiedEntity,
 ) -> bool {
+    // Moderation visibility gate (#1274, ADR 0057). A row carrying the
+    // moderation status marker — quarantine-pending or rejected-tombstone
+    // — is hidden from every normal read, on top of MVCC visibility. The
+    // marker lives on the row itself, so the check is a single field probe
+    // and rides the existing per-row visibility chokepoint rather than
+    // adding a separate filter pass to each scan call-site.
+    if crate::runtime::ai::moderation::entity_moderation_hidden(entity) {
+        return false;
+    }
     // Fast path — one `Cell<bool>` read, no RefCell borrow. Autocommit
     // reads (no active MVCC transaction) still hide superseded physical
     // versions while avoiding a full snapshot-context lookup.
@@ -715,6 +724,12 @@ pub fn entity_visible_with_context(
     ctx: Option<&SnapshotContext>,
     entity: &crate::storage::unified::entity::UnifiedEntity,
 ) -> bool {
+    // Same moderation visibility gate as the thread-local path (#1274):
+    // parallel scan workers capture the snapshot context but must apply
+    // the moderation marker check identically.
+    if crate::runtime::ai::moderation::entity_moderation_hidden(entity) {
+        return false;
+    }
     match ctx {
         Some(ctx) => visibility_check(ctx, entity.xmin, entity.xmax),
         None => true,

--- a/crates/reddb-server/src/runtime/mutation.rs
+++ b/crates/reddb-server/src/runtime/mutation.rs
@@ -89,6 +89,19 @@ impl<'rt> MutationEngine<'rt> {
         // method, so legitimate replica catch-up is unaffected.
         self.runtime
             .check_write(crate::runtime::write_gate::WriteKind::Dml)?;
+
+        // Synchronous content-moderation gate (#1274, ADR 0057). For a
+        // collection that declares a `MODERATE (... sync = true)` policy,
+        // every declared text field of every row is screened BEFORE the
+        // durable commit below. A reject refuses the whole write (no row
+        // persists); a provider-down outcome either quarantines the row
+        // (fail-open default — commit hidden, re-moderate async) or blocks
+        // the write (fail-closed opt-in). The gate may inject the reserved
+        // moderation marker field into a row's `fields`, so it runs before
+        // the entity build in the kernels.
+        self.runtime
+            .apply_sync_moderation_gate(&collection, &mut rows)?;
+
         match rows.len() {
             0 => Ok(MutationResult::empty()),
             1 => self.append_one(collection, rows.remove(0)),

--- a/crates/reddb-server/tests/moderation_gate.rs
+++ b/crates/reddb-server/tests/moderation_gate.rs
@@ -1,0 +1,282 @@
+//! #1274 — synchronous moderation gate + quarantine + tombstone, end-to-end
+//! (PRD #1267, ADR 0057).
+//!
+//! A collection that declares a `MODERATE (... sync = true)` policy over
+//! declared text fields gets:
+//!   * a **synchronous pre-commit gate**: a reject fails the write (no row
+//!     persists); a provider-down outcome either quarantines the row
+//!     (fail-open default) or blocks the write (fail-closed opt-in);
+//!   * **read-path hiding**: quarantine-pending and rejected-tombstone rows
+//!     are excluded from normal SELECT/scan reads;
+//!   * **async re-moderation** over the CDC enrichment lane: a quarantined
+//!     row that re-moderates clean becomes visible, and one that
+//!     re-moderates to a reject is tombstoned (hidden, retained for audit)
+//!     or hard-deleted when the policy opts in.
+//!
+//! These tests install a deterministic mock moderation provider (no model
+//! download, no network) whose verdict is a pure function of the screened
+//! text plus a process-global "provider down" switch the test flips.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use reddb_server::runtime::ai::cdc_enrichment::{CdcEnrichmentConsumer, EnrichmentKind};
+use reddb_server::runtime::ai::moderation::{
+    install_local_moderation_backend, LocalModerationBackend, ModerationOutcome, ModerationRequest,
+};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+/// Sentinel substring: any screened text containing it is rejected by the
+/// mock provider. Lets a single backend cover allow and reject in one test.
+const TOXIC_MARKER: &str = "TOXIC";
+
+/// Process-global switch: while true the mock reports the provider as down
+/// so the degraded-mode (quarantine / fail-closed) paths are exercised.
+static PROVIDER_DOWN: AtomicBool = AtomicBool::new(false);
+
+/// Deterministic mock moderation provider. Rejects text containing
+/// [`TOXIC_MARKER`], reports the provider down while [`PROVIDER_DOWN`] is
+/// set, and otherwise allows.
+struct MockModerationProvider;
+
+impl LocalModerationBackend for MockModerationProvider {
+    fn moderate(
+        &self,
+        request: &ModerationRequest,
+    ) -> reddb_server::RedDBResult<ModerationOutcome> {
+        if PROVIDER_DOWN.load(Ordering::SeqCst) {
+            return Ok(ModerationOutcome::ProviderDown {
+                reason: "mock provider down".to_string(),
+            });
+        }
+        if request.text.contains(TOXIC_MARKER) {
+            return Ok(ModerationOutcome::Reject {
+                categories: vec!["harassment".to_string()],
+            });
+        }
+        Ok(ModerationOutcome::Allow)
+    }
+}
+
+/// The mock backend and [`PROVIDER_DOWN`] are process-global, so the tests
+/// in this file (run in parallel threads of one binary) must not interleave
+/// their provider-down toggling. Each test holds this guard for its whole
+/// body, serialising them.
+fn test_guard() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Acquire the serialising guard, reset the provider-down switch, and
+/// install the mock backend. The returned guard must be held for the whole
+/// test body.
+#[must_use]
+fn install_mock() -> MutexGuard<'static, ()> {
+    let guard = test_guard();
+    PROVIDER_DOWN.store(false, Ordering::SeqCst);
+    install_local_moderation_backend(Arc::new(MockModerationProvider));
+    guard
+}
+
+fn row_count(rt: &RedDBRuntime, sql: &str) -> usize {
+    rt.execute_query(sql)
+        .unwrap_or_else(|e| panic!("query failed: {sql}\n  err: {e}"))
+        .result
+        .records
+        .len()
+}
+
+fn create_moderated_table(rt: &RedDBRuntime, name: &str, extra: &str) {
+    rt.execute_query(&format!(
+        "CREATE TABLE {name} (id INT, body TEXT) \
+         WITH (MODERATE (fields = ('body'), provider = 'local', \
+         model = 'mock-moderation', sync = true{extra}))"
+    ))
+    .unwrap_or_else(|e| panic!("create {name}: {e}"));
+}
+
+/// Acceptance: a reject fails the write — the row never persists (normal
+/// path, provider up).
+#[test]
+fn reject_blocks_write() {
+    let _guard = install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    create_moderated_table(&rt, "posts", "");
+
+    // Clean content commits and is visible.
+    rt.execute_query("INSERT INTO posts (id, body) VALUES (1, 'a friendly hello')")
+        .expect("clean insert commits");
+    assert_eq!(row_count(&rt, "SELECT * FROM posts"), 1);
+
+    // Toxic content is rejected at the synchronous gate: the write errors
+    // and the row never persists.
+    let err = rt
+        .execute_query(&format!(
+            "INSERT INTO posts (id, body) VALUES (2, 'this is {TOXIC_MARKER} content')"
+        ))
+        .expect_err("toxic insert must be rejected");
+    assert!(
+        err.to_string().to_lowercase().contains("moderation"),
+        "reject error should mention moderation: {err}"
+    );
+
+    // Still exactly one row — the rejected write left nothing behind.
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM posts"),
+        1,
+        "rejected row must not persist"
+    );
+}
+
+/// Acceptance: provider-down default = fail-open + quarantine. The row
+/// commits but is excluded from all normal reads, then is re-moderated
+/// asynchronously via the CDC enrichment consumer; a clean re-moderation
+/// makes it visible.
+#[test]
+fn provider_down_quarantine_then_clear_on_remoderation() {
+    let _guard = install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    create_moderated_table(&rt, "msgs", ""); // degraded defaults to open
+
+    // Provider is down at write time → fail-open quarantine.
+    PROVIDER_DOWN.store(true, Ordering::SeqCst);
+    rt.execute_query("INSERT INTO msgs (id, body) VALUES (1, 'benign while provider down')")
+        .expect("quarantined insert still commits");
+
+    // Excluded from all normal reads while quarantine-pending.
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM msgs"),
+        0,
+        "quarantine-pending row must be hidden from normal reads"
+    );
+
+    // Provider recovers; CDC re-moderation runs and clears the quarantine.
+    PROVIDER_DOWN.store(false, Ordering::SeqCst);
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert!(stats.ingested >= 1, "the quarantined row must be ingested");
+    assert!(stats.attached >= 1, "re-moderation must complete");
+    assert_eq!(consumer.pending_len(), 0);
+
+    // Re-moderated clean → now visible.
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM msgs"),
+        1,
+        "cleared row must surface after a clean re-moderation"
+    );
+
+    // Re-ticking must not re-enqueue the now-cleared row (the clear write-
+    // back touches only the reserved marker, never a declared field).
+    let again = consumer.tick(&rt, 2_000).expect("second tick");
+    assert_eq!(again.ingested, 0, "cleared row must not re-enqueue");
+}
+
+/// Acceptance: a quarantined row that re-moderates to reject is tombstoned
+/// + hidden by default (retained for audit/appeal).
+#[test]
+fn quarantine_then_remoderation_reject_tombstones() {
+    let _guard = install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    create_moderated_table(&rt, "notes", ""); // degraded=open, hard_delete=false
+
+    // Toxic content, but provider is down → fail-open quarantine (the gate
+    // could not screen it yet).
+    PROVIDER_DOWN.store(true, Ordering::SeqCst);
+    rt.execute_query(&format!(
+        "INSERT INTO notes (id, body) VALUES (1, 'sneaky {TOXIC_MARKER} note')"
+    ))
+    .expect("quarantined insert commits");
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM notes"),
+        0,
+        "quarantine-pending row hidden"
+    );
+
+    // Provider recovers; re-moderation now sees the toxic content and
+    // rejects → the row is tombstoned (hidden, retained).
+    PROVIDER_DOWN.store(false, Ordering::SeqCst);
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert!(stats.ingested >= 1);
+    assert!(stats.attached >= 1, "re-moderation must complete");
+
+    // Rejected-tombstone row stays hidden from normal reads.
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM notes"),
+        0,
+        "rejected-tombstone row must remain hidden"
+    );
+    // Re-ticking must not re-enqueue the tombstoned row.
+    let again = consumer.tick(&rt, 2_000).expect("second tick");
+    assert_eq!(again.ingested, 0, "tombstoned row must not re-enqueue");
+}
+
+/// Acceptance: per-collection opt-in hard-delete. A quarantined row that
+/// re-moderates to reject under `hard_delete = true` is removed entirely.
+#[test]
+fn quarantine_reject_hard_delete_removes_row() {
+    let _guard = install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    create_moderated_table(&rt, "ephemeral", ", hard_delete = true");
+
+    PROVIDER_DOWN.store(true, Ordering::SeqCst);
+    rt.execute_query(&format!(
+        "INSERT INTO ephemeral (id, body) VALUES (1, 'bad {TOXIC_MARKER} stuff')"
+    ))
+    .expect("quarantined insert commits");
+
+    PROVIDER_DOWN.store(false, Ordering::SeqCst);
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert!(stats.attached >= 1, "re-moderation must complete");
+
+    // Hard-deleted → hidden, and a second tick finds nothing to do.
+    assert_eq!(row_count(&rt, "SELECT * FROM ephemeral"), 0);
+    let again = consumer.tick(&rt, 2_000).expect("second tick");
+    assert_eq!(again.ingested, 0);
+}
+
+/// Acceptance: per-collection opt-in fail-closed. Provider-down blocks the
+/// write instead of quarantining it.
+#[test]
+fn fail_closed_blocks_write_when_provider_down() {
+    let _guard = install_mock();
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    create_moderated_table(&rt, "strict", ", degraded = closed");
+
+    PROVIDER_DOWN.store(true, Ordering::SeqCst);
+    let err = rt
+        .execute_query("INSERT INTO strict (id, body) VALUES (1, 'anything at all')")
+        .expect_err("fail-closed must block the write when provider is down");
+    assert!(
+        err.to_string().to_lowercase().contains("moderation")
+            || err.to_string().to_lowercase().contains("blocked"),
+        "fail-closed error should explain the block: {err}"
+    );
+
+    // Nothing persisted, and nothing to re-moderate.
+    PROVIDER_DOWN.store(false, Ordering::SeqCst);
+    assert_eq!(
+        row_count(&rt, "SELECT * FROM strict"),
+        0,
+        "fail-closed write must not persist"
+    );
+    let mut consumer = CdcEnrichmentConsumer::with_defaults();
+    let stats = consumer.tick(&rt, 1_000).expect("tick");
+    assert_eq!(stats.ingested, 0, "no quarantined row exists to ingest");
+
+    // Sanity: with the provider up, the same write commits and is visible.
+    rt.execute_query("INSERT INTO strict (id, body) VALUES (2, 'now it is fine')")
+        .expect("provider-up write commits");
+    assert_eq!(row_count(&rt, "SELECT * FROM strict"), 1);
+}
+
+/// The EnrichmentKind::Moderate variant is what the CDC lane queues for
+/// quarantined rows; guard that the public surface exposes it.
+#[test]
+fn moderate_enrichment_kind_is_public() {
+    let kind = EnrichmentKind::Moderate;
+    assert_eq!(kind, EnrichmentKind::Moderate);
+}

--- a/crates/reddb-types/src/catalog.rs
+++ b/crates/reddb-types/src/catalog.rs
@@ -180,7 +180,8 @@ pub struct EmbedPolicy {
     pub model: String,
 }
 
-/// `MODERATE (fields = (...), provider, model, sync, degraded, on_reject)`.
+/// `MODERATE (fields = (...), provider, model, sync, degraded, on_reject,
+/// hard_delete)`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModeratePolicy {
     /// Source fields screened by the moderation provider.
@@ -194,6 +195,11 @@ pub struct ModeratePolicy {
     pub degraded_mode: ModerateDegradedMode,
     /// What happens to content that fails moderation.
     pub reject_action: ModerateRejectAction,
+    /// When true (`hard_delete = true`), a quarantined row that
+    /// re-moderates to a reject is hard-deleted instead of being
+    /// tombstoned-and-retained for audit/appeal (the default). Opt-in
+    /// per-collection because hard-delete forfeits the audit trail.
+    pub hard_delete_on_reject: bool,
 }
 
 /// Behaviour when the moderation provider can't be reached.


### PR DESCRIPTION
## ⚠️ HELD PR — do NOT admin-merge. Review carefully first.

Implements **#1274** (last slice of PRD #1267 / ADR 0057). This **changes write-path transactional semantics** — a write can now be rejected/quarantined by an external moderation verdict, and quarantine/tombstone rows are hidden from reads. Please review before merging; this was deliberately produced as a reviewable PR rather than auto-merged.

## What it does (7/7 acceptance criteria)

- **Synchronous pre-commit gate** at `MutationEngine::apply` (the single chokepoint for SQL/gRPC/HTTP/native-wire writes): declared `MODERATE (... sync = true)` fields are screened **before** the durable append.
- **Reject → write fails** (`RedDBError::Query`); the row never persists.
- **Provider-down, default `degraded = open`** → row commits but is **quarantined** (`__moderation_status = pending`), hidden from normal reads, and **re-moderated async** via the new `EnrichmentKind::Moderate` over CDC.
- **Per-collection opt-in `degraded = closed`** → provider-down **blocks** the write.
- **Re-moderation → reject** → **tombstoned** (`__moderation_status = rejected`, hidden, retained for audit) or **hard-deleted** when the new `hard_delete = true` policy key is set.
- **Read-path hides** quarantine-pending + rejected-tombstone rows via `entity_moderation_hidden` wired into all three table-row visibility chokepoints.
- **Integration test** `tests/moderation_gate.rs`: 6 cases (reject-blocks-write, provider-down-quarantine + clear-on-remoderation, re-moderation-tombstone, hard-delete, fail-closed) with a deterministic mock backend.

## Validation
- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --locked -- -D warnings` → No issues found
- `cargo test -p reddb-io-server --test moderation_gate` → **6 passed**
- relevant unit tests (ddl parser, provider_capabilities, json_codec round-trip, moderation module) → pass

## Reviewer attention (design decisions / risks)
1. **Marker lives on the row** (`__moderation_status` reserved field), not in a side metadata store — the read-path chokepoints only receive `&UnifiedEntity`, and per-row metadata fetches on the hot path would be a perf disaster. Trade-off: the field is visible in a raw `SELECT *` admin read that bypasses the filter (mirrors vision's `vision_detections`). Rows that never hit provider-down carry no marker.
2. **Replica catch-up bypasses the gate** — `LogicalChangeApplier` replays the leader's already-gated rows rather than re-moderating. Intended (leader is the authority), but worth confirming.
3. **Clear-marker overwrites with `""`** (the storage `fields` merge can't drop a key); `entity_moderation_hidden` treats only exact `pending`/`rejected` as hidden. An `Unset` patch op could truly remove it — left as a follow-up to keep the change minimal.
4. **No self-trigger loop** — re-moderation write-backs touch only the reserved marker, never a declared field, so they don't re-enqueue.
5. **`local.moderate = true`** — mirrors how #1275 enabled `local.vision`: lets `provider = 'local'` drive the in-process mock at gate/enrichment time; real remote providers still validate against the modality matrix at DDL time.

## Pre-existing issue (NOT from this PR)
`crates/reddb-file/src/physical_metadata/tests.rs:248` fails to compile on the **clean base branch** (`missing field ai_policy` in `PhysicalCollectionContract`, leftover from #1271) — confirmed via `git stash`. Out of scope. This PR's reddb-file changes are validated end-to-end through the passing `json_codec` round-trip test.

Closes-after-review: #1274

https://claude.ai/code/session_01HYn23rqFb8amEqCCqVgkdr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784598625&installation_id=129708444&pr_number=1284&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1284&signature=3e113f68f6f7c6a9a4c6f6c23ed6ed6540ac20f4991551cd02600e83c9d050e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI content moderation with configurable `hard_delete_on_reject` option for controlling quarantine behavior.
  * Synchronous moderation gates validate writes with provider degradation handling.
  * Asynchronous re-moderation of quarantined rows when connectivity is restored.

* **Tests**
  * Added moderation test suite covering synchronous/asynchronous operations and degradation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->