### PR TITLE
merge: #1229 Add ClusterBootstrapAuthority fail-closed seam

### DIFF
--- a/crates/reddb-server/src/cluster/bootstrap_authority.rs
+++ b/crates/reddb-server/src/cluster/bootstrap_authority.rs
@@ -1,0 +1,182 @@
+//! Cluster bootstrap authority — fail-closed seam (ADR 0058).
+//!
+//! Cluster first boot needs a single authority for global auth, vault,
+//! config, and policy. ADR 0058 makes that authority the reserved global
+//! system range owner, fenced by lease/term and ownership epoch. No
+//! concrete owner model is implemented yet, so this module is only the
+//! runtime *seam*: it decides whether a cluster-shaped boot is allowed to
+//! perform auth bootstrap, and fails closed whenever no concrete owner can
+//! be proven.
+//!
+//! Two outcomes are deliberately preserved while the owner model is absent:
+//!
+//! * Explicit `--no-auth` / `--dev` cluster-shaped boots remain allowed as
+//!   a development carveout and skip every auth/bootstrap path. They must
+//!   create no admin, vault, or bootstrap-complete state.
+//! * Every other cluster-shaped boot that would create auth/bootstrap state
+//!   (preset env, credentials, or a manifest) is rejected, because a
+//!   symmetric member cannot prove that it — and not a peer — is the single
+//!   writer of global auth state.
+//!
+//! Both the cluster *topology* default and an explicit cluster *storage
+//! preset* resolve to [`DeployProfile::Cluster`], so the deploy profile is
+//! the single signal this seam reads for "cluster-shaped".
+
+use crate::storage::DeployProfile;
+
+/// The kind of auth bootstrap a boot is requesting, as classified from the
+/// CLI/env contract. Used only to render a precise denial message; the
+/// fail-closed decision does not depend on which variant is present.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthBootstrapInput {
+    /// No auth bootstrap requested (e.g. the `simple` preset with no
+    /// credentials and no manifest). A non-owner still must not write a
+    /// per-node bootstrap-complete marker, so this is fail-closed too on a
+    /// cluster-shaped boot.
+    None,
+    /// Auth bootstrap requested through the environment/preset surface:
+    /// the `production`/`cloud`/`regulated` presets, or
+    /// `REDDB_USERNAME` + `REDDB_PASSWORD`.
+    Env,
+    /// Auth bootstrap requested through `REDDB_BOOTSTRAP_MANIFEST`.
+    Manifest,
+}
+
+impl AuthBootstrapInput {
+    const fn describe(self) -> &'static str {
+        match self {
+            Self::None => "no explicit auth bootstrap input",
+            Self::Env => "auth bootstrap env/preset input",
+            Self::Manifest => "auth bootstrap manifest input",
+        }
+    }
+}
+
+/// What the boot path should do with auth bootstrap, once the authority
+/// seam has authorized it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapDisposition {
+    /// Proceed with ordinary local single-owner bootstrap. The local node
+    /// is the sole authority for its own auth state (standalone,
+    /// serverless, or primary-replica).
+    ProceedLocal,
+    /// Skip every auth/bootstrap path. Reached only by an explicit
+    /// `--no-auth` / `--dev` boot; for a cluster shape this is the
+    /// documented development carveout.
+    SkipDevBypass,
+}
+
+/// `true` when this boot is cluster-shaped for the purpose of auth
+/// bootstrap authority. Both the cluster topology default and an explicit
+/// cluster storage preset land on [`DeployProfile::Cluster`].
+pub const fn is_cluster_shaped(deploy_profile: DeployProfile) -> bool {
+    matches!(deploy_profile, DeployProfile::Cluster)
+}
+
+/// Decide whether a boot may perform auth bootstrap.
+///
+/// Returns [`BootstrapDisposition`] when the boot is allowed to continue,
+/// or an operator-facing error string when the cluster bootstrap authority
+/// fails closed.
+///
+/// * Any `--no-auth` / `--dev` boot returns [`BootstrapDisposition::SkipDevBypass`]:
+///   the caller skips all auth/bootstrap state. For cluster shapes this is
+///   the explicit development carveout from ADR 0058.
+/// * A non-cluster boot returns [`BootstrapDisposition::ProceedLocal`]: the
+///   local node is the only authority for its own auth state.
+/// * A cluster-shaped, non-`--no-auth` boot is rejected. There is no
+///   reserved global system range owner model yet, so no member can prove
+///   it is the single writer of global auth/vault/config/policy state.
+pub fn authorize(
+    deploy_profile: DeployProfile,
+    no_auth: bool,
+    input: AuthBootstrapInput,
+) -> Result<BootstrapDisposition, String> {
+    if no_auth {
+        // `--no-auth` / `--dev` is the last word on auth for this boot
+        // (issue #663). The caller skips every preset/credential path, so
+        // no admin, vault, or bootstrap marker is created — exactly the
+        // cluster development carveout ADR 0058 keeps open.
+        return Ok(BootstrapDisposition::SkipDevBypass);
+    }
+
+    if !is_cluster_shaped(deploy_profile) {
+        return Ok(BootstrapDisposition::ProceedLocal);
+    }
+
+    // Cluster-shaped, credentialled boot. ADR 0058 requires the reserved
+    // global system range owner — fenced by lease/term + ownership epoch —
+    // before any member may create admins, initialize vault material,
+    // install policy, apply a manifest, or publish the bootstrap-complete
+    // marker. No owner model is implemented, so no member can prove
+    // ownership: fail closed instead of letting a symmetric member create
+    // divergent global auth state.
+    Err(format!(
+        "cluster bootstrap authority: refusing to run auth bootstrap on a \
+         cluster-shaped boot ({}) — no concrete authority owner is available. \
+         The reserved global system range owner (ADR 0058) is not yet \
+         implemented, so no member can prove it is the single writer of \
+         global auth/vault/config/policy state. Use --no-auth / --dev for a \
+         development cluster, or run auth bootstrap on a non-cluster topology.",
+        input.describe(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_cluster_profiles_proceed_locally() {
+        for profile in [
+            DeployProfile::Embedded,
+            DeployProfile::Serverless,
+            DeployProfile::PrimaryReplica,
+        ] {
+            assert!(!is_cluster_shaped(profile), "{profile:?} is not cluster");
+            assert_eq!(
+                authorize(profile, false, AuthBootstrapInput::Env).unwrap(),
+                BootstrapDisposition::ProceedLocal,
+                "{profile:?} should proceed with local bootstrap"
+            );
+        }
+    }
+
+    #[test]
+    fn cluster_no_auth_is_the_dev_bypass_carveout() {
+        let disposition =
+            authorize(DeployProfile::Cluster, true, AuthBootstrapInput::None).unwrap();
+        assert_eq!(disposition, BootstrapDisposition::SkipDevBypass);
+    }
+
+    #[test]
+    fn non_cluster_no_auth_also_skips() {
+        let disposition =
+            authorize(DeployProfile::Embedded, true, AuthBootstrapInput::Env).unwrap();
+        assert_eq!(disposition, BootstrapDisposition::SkipDevBypass);
+    }
+
+    #[test]
+    fn cluster_env_bootstrap_fails_closed() {
+        let err = authorize(DeployProfile::Cluster, false, AuthBootstrapInput::Env).unwrap_err();
+        assert!(err.contains("no concrete authority owner"), "got: {err}");
+        assert!(err.contains("env/preset"), "got: {err}");
+    }
+
+    #[test]
+    fn cluster_manifest_bootstrap_fails_closed() {
+        let err =
+            authorize(DeployProfile::Cluster, false, AuthBootstrapInput::Manifest).unwrap_err();
+        assert!(err.contains("no concrete authority owner"), "got: {err}");
+        assert!(err.contains("manifest"), "got: {err}");
+    }
+
+    #[test]
+    fn cluster_without_explicit_input_still_fails_closed() {
+        // A `simple`-preset cluster boot writes only a per-node
+        // bootstrap-complete marker, which ADR 0058 forbids without a
+        // proven owner. Fail closed so no divergent marker is written.
+        let err = authorize(DeployProfile::Cluster, false, AuthBootstrapInput::None).unwrap_err();
+        assert!(err.contains("no concrete authority owner"), "got: {err}");
+    }
+}

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -1,5 +1,6 @@
 //! Shared cluster identity and membership model.
 
+pub mod bootstrap_authority;
 pub mod commit_resolution;
 pub mod cross_range;
 pub mod drain;
@@ -17,6 +18,10 @@ pub mod slot;
 pub mod supervisor;
 pub mod topology;
 
+pub use bootstrap_authority::{
+    authorize as authorize_cluster_bootstrap, is_cluster_shaped, AuthBootstrapInput,
+    BootstrapDisposition,
+};
 pub use commit_resolution::{
     is_local_ack, resolve_commit_policy, CollectionDataModel, CommitPolicyResolution,
     CommitPolicyViolation, FailoverEligibility, GuardrailDisposition, HaIntent, ResolutionSource,

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -485,6 +485,32 @@ impl BootstrapConfig {
         })
     }
 
+    /// Classify the auth bootstrap this config would perform, for the
+    /// cluster bootstrap authority seam (ADR 0058). A manifest wins over
+    /// preset/credential env because it is the broadest authority input.
+    fn auth_bootstrap_input(&self) -> crate::cluster::AuthBootstrapInput {
+        use crate::cluster::AuthBootstrapInput;
+        if self.selected_manifest().is_some() {
+            return AuthBootstrapInput::Manifest;
+        }
+        let preset = self.resolved_preset();
+        let preset_creates_auth = matches!(
+            preset.as_str(),
+            PRESET_PRODUCTION | PRESET_CLOUD | PRESET_REGULATED
+        );
+        // Even the `simple` preset auto-creates an admin when
+        // `REDDB_USERNAME` + `REDDB_PASSWORD` are present (see
+        // `AuthStore::bootstrap_from_env`), so treat credential env as
+        // auth bootstrap input too.
+        let credentials_present =
+            self.production_username().is_some() && self.production_password().is_some();
+        if preset_creates_auth || credentials_present {
+            AuthBootstrapInput::Env
+        } else {
+            AuthBootstrapInput::None
+        }
+    }
+
     fn explicit_value(value: &Option<String>) -> Option<String> {
         value
             .as_deref()
@@ -2110,16 +2136,28 @@ fn build_runtime_with_bootstrap(
         runtime.control_event_ledger(),
         runtime.control_event_config(),
     );
-    // Issue #663 — when `--no-auth` is active, deliberately skip the
-    // preset machinery. Otherwise a stray `REDDB_USERNAME`+`REDDB_PASSWORD`
-    // pair in the operator's environment would silently create an admin
-    // user, defeating the whole point of opting into anonymous mode.
-    if no_auth {
-        eprintln!("{NO_AUTH_WARNING}");
-        tracing::warn!("{NO_AUTH_WARNING}");
-    } else {
-        apply_preset_from_config(&runtime, &auth_store, bootstrap)?;
-        maybe_apply_policy_break_glass(&auth_store);
+    // ADR 0058 — cluster bootstrap authority fail-closed seam. A
+    // cluster-shaped boot may only run auth bootstrap when a concrete
+    // reserved-range owner can be proven; none is implemented yet, so the
+    // seam rejects credentialled cluster boots and allows only the explicit
+    // `--no-auth` / `--dev` development carveout. Issue #663 — when
+    // `--no-auth` is active, deliberately skip the preset machinery so a
+    // stray `REDDB_USERNAME`+`REDDB_PASSWORD` pair cannot silently create an
+    // admin, defeating the point of anonymous mode.
+    let disposition = crate::cluster::authorize_cluster_bootstrap(
+        db_options.storage_profile.deploy_profile,
+        no_auth,
+        bootstrap.auth_bootstrap_input(),
+    )?;
+    match disposition {
+        crate::cluster::BootstrapDisposition::SkipDevBypass => {
+            eprintln!("{NO_AUTH_WARNING}");
+            tracing::warn!("{NO_AUTH_WARNING}");
+        }
+        crate::cluster::BootstrapDisposition::ProceedLocal => {
+            apply_preset_from_config(&runtime, &auth_store, bootstrap)?;
+            maybe_apply_policy_break_glass(&auth_store);
+        }
     }
 
     // Background session purge (every 5 minutes)

--- a/tests/cluster_bootstrap_authority.rs
+++ b/tests/cluster_bootstrap_authority.rs
@@ -1,0 +1,108 @@
+//! Cluster bootstrap authority fail-closed seam (issue #1229, ADR 0058).
+//!
+//! These tests exercise the public seam through the two ways a boot becomes
+//! cluster-shaped — the cluster *topology* (which defaults storage to the
+//! cluster profile) and an explicit cluster *storage preset* — and prove
+//! that:
+//!
+//!   * a credentialled cluster boot fails closed (no concrete authority
+//!     owner can be proven), and
+//!   * the explicit `--no-auth` / `--dev` development carveout stays
+//!     allowed and resolves to the skip-all disposition.
+
+use reddb::cluster::{authorize_cluster_bootstrap, AuthBootstrapInput, BootstrapDisposition};
+use reddb::operational_bootstrap::{resolve_operational_bootstrap, OperationalBootstrapInput};
+use reddb::storage::{DeployProfile, StorageDeployPreset};
+
+/// Resolve the storage deploy profile a `REDDB_TOPOLOGY=cluster` boot lands
+/// on, so the seam test mirrors the real boot path rather than hard-coding
+/// the enum.
+fn cluster_topology_profile() -> DeployProfile {
+    let plan = resolve_operational_bootstrap(OperationalBootstrapInput {
+        topology: Some("cluster".to_string()),
+        ..Default::default()
+    })
+    .expect("cluster topology resolves");
+    plan.storage_profile.deploy_profile
+}
+
+#[test]
+fn cluster_topology_path_is_cluster_shaped() {
+    assert_eq!(cluster_topology_profile(), DeployProfile::Cluster);
+}
+
+#[test]
+fn cluster_storage_preset_path_is_cluster_shaped() {
+    assert_eq!(
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+        DeployProfile::Cluster
+    );
+}
+
+#[test]
+fn cluster_topology_env_bootstrap_fails_closed() {
+    let err =
+        authorize_cluster_bootstrap(cluster_topology_profile(), false, AuthBootstrapInput::Env)
+            .expect_err("cluster topology must fail closed for env auth bootstrap");
+    assert!(err.contains("no concrete authority owner"), "got: {err}");
+}
+
+#[test]
+fn cluster_topology_manifest_bootstrap_fails_closed() {
+    let err = authorize_cluster_bootstrap(
+        cluster_topology_profile(),
+        false,
+        AuthBootstrapInput::Manifest,
+    )
+    .expect_err("cluster topology must fail closed for manifest auth bootstrap");
+    assert!(err.contains("no concrete authority owner"), "got: {err}");
+}
+
+#[test]
+fn cluster_storage_preset_env_bootstrap_fails_closed() {
+    let profile = StorageDeployPreset::Cluster.selection().deploy_profile;
+    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Env)
+        .expect_err("cluster storage preset must fail closed for env auth bootstrap");
+    assert!(err.contains("no concrete authority owner"), "got: {err}");
+}
+
+#[test]
+fn cluster_storage_preset_manifest_bootstrap_fails_closed() {
+    let profile = StorageDeployPreset::Cluster.selection().deploy_profile;
+    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Manifest)
+        .expect_err("cluster storage preset must fail closed for manifest auth bootstrap");
+    assert!(err.contains("no concrete authority owner"), "got: {err}");
+}
+
+#[test]
+fn cluster_no_auth_dev_bypass_is_allowed_and_skips_bootstrap() {
+    // Both cluster-shaped paths keep the `--no-auth` / `--dev` carveout.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        let disposition =
+            authorize_cluster_bootstrap(profile, true, AuthBootstrapInput::None).unwrap();
+        assert_eq!(
+            disposition,
+            BootstrapDisposition::SkipDevBypass,
+            "cluster --no-auth must skip every auth/bootstrap path"
+        );
+    }
+}
+
+#[test]
+fn non_cluster_topology_still_bootstraps_locally() {
+    let plan = resolve_operational_bootstrap(OperationalBootstrapInput {
+        topology: Some("standalone".to_string()),
+        ..Default::default()
+    })
+    .expect("standalone topology resolves");
+    let disposition = authorize_cluster_bootstrap(
+        plan.storage_profile.deploy_profile,
+        false,
+        AuthBootstrapInput::Env,
+    )
+    .unwrap();
+    assert_eq!(disposition, BootstrapDisposition::ProceedLocal);
+}


### PR DESCRIPTION
Automated AFK landing for #1229. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1229

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784615635&installation_id=129708444&pr_number=1289&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1289&signature=f9484f815eb3a6e553dd550cd57de1e289ed9f44165354721fc26bd81b95190a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster bootstrap authorization requiring explicit development mode (`--no-auth`/`--dev`) for multi-node deployments; single-node deployments remain unaffected.

* **Tests**
  * Added comprehensive tests validating authorization behavior across cluster and non-cluster deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->