### PR TITLE
fix(wal): unique backup staging temp paths to fix PITR segment sha mismatch

### DIFF
--- a/crates/reddb-file/src/backup_temp.rs
+++ b/crates/reddb-file/src/backup_temp.rs
@@ -1,8 +1,17 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::{layout, RdbFileResult};
+
+/// Process-global monotonic counter that makes every temp-file name unique
+/// even when `now_nanos()` collides (coarse clock resolution) or when
+/// concurrent archives stage the same LSN range. Without it, two threads in
+/// the same process could write distinct payloads to the same staging path,
+/// uploading one body under the other's manifest digest and failing the WAL
+/// segment integrity check on restore.
+static BACKUP_TEMP_JSON_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 pub const BACKUP_JSON_OBJECT_TEMP_PREFIX: &str = "reddb-json-object";
 pub const BACKUP_JSON_OBJECT_READ_TEMP_PREFIX: &str = "reddb-json-object-read";
@@ -26,6 +35,7 @@ impl BackupTempJsonFile {
             prefix,
             std::process::id(),
             now_nanos(),
+            BACKUP_TEMP_JSON_COUNTER.fetch_add(1, Ordering::Relaxed),
             start_lsn,
             end_lsn,
         )
@@ -51,17 +61,19 @@ impl BackupTempJsonFile {
         Self::new(ARCHIVED_CHANGE_RECORDS_READ_TEMP_PREFIX, None, None)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_clock(
         temp_dir: &Path,
         prefix: &str,
         process_id: u32,
         nanos: u128,
+        unique: u64,
         start_lsn: Option<u64>,
         end_lsn: Option<u64>,
     ) -> Self {
         Self {
             path: layout::backup_temp_json_path(
-                temp_dir, prefix, process_id, nanos, start_lsn, end_lsn,
+                temp_dir, prefix, process_id, nanos, unique, start_lsn, end_lsn,
             ),
         }
     }
@@ -117,13 +129,14 @@ mod tests {
             BACKUP_JSON_OBJECT_TEMP_PREFIX,
             7,
             99,
+            3,
             Some(10),
             Some(20),
         );
 
         assert_eq!(
             temp.path(),
-            root.join("reddb-json-object-7-10-20-99.json").as_path()
+            root.join("reddb-json-object-7-10-20-99-3.json").as_path()
         );
         assert_eq!(temp.write_bytes(b"{\"ok\":true}").expect("write"), 11);
         assert_eq!(temp.read_bytes().expect("read"), b"{\"ok\":true}");
@@ -147,6 +160,7 @@ mod tests {
             BACKUP_JSON_OBJECT_TEMP_PREFIX,
             7,
             99,
+            3,
             None,
             None,
         );
@@ -193,5 +207,15 @@ mod tests {
         let path = object.path().to_path_buf();
         drop(object);
         assert!(!path.exists());
+    }
+
+    #[test]
+    fn same_lsn_range_stagings_get_distinct_paths() {
+        // Two stagings of the identical LSN range within one process must
+        // never share a path, otherwise concurrent archives could overwrite
+        // each other's payload and break WAL segment integrity on restore.
+        let a = BackupTempJsonFile::archived_change_records(1, 5);
+        let b = BackupTempJsonFile::archived_change_records(1, 5);
+        assert_ne!(a.path(), b.path());
     }
 }

--- a/crates/reddb-file/src/layout.rs
+++ b/crates/reddb-file/src/layout.rs
@@ -466,11 +466,12 @@ pub fn backup_temp_json_path(
     prefix: &str,
     process_id: u32,
     nanos: u128,
+    unique: u64,
     start_lsn: Option<u64>,
     end_lsn: Option<u64>,
 ) -> PathBuf {
     temp_dir.join(backup_temp_json_file_name(
-        prefix, process_id, nanos, start_lsn, end_lsn,
+        prefix, process_id, nanos, unique, start_lsn, end_lsn,
     ))
 }
 
@@ -478,14 +479,18 @@ pub fn backup_temp_json_file_name(
     prefix: &str,
     process_id: u32,
     nanos: u128,
+    unique: u64,
     start_lsn: Option<u64>,
     end_lsn: Option<u64>,
 ) -> String {
+    // `unique` is a process-global monotonic counter so two stagings can
+    // never share a path even when `nanos` collides under coarse clock
+    // resolution or when concurrent archives stage the same LSN range.
     match (start_lsn, end_lsn) {
         (Some(start_lsn), Some(end_lsn)) => {
-            format!("{prefix}-{process_id}-{start_lsn}-{end_lsn}-{nanos}.json")
+            format!("{prefix}-{process_id}-{start_lsn}-{end_lsn}-{nanos}-{unique}.json")
         }
-        _ => format!("{prefix}-{process_id}-{nanos}.json"),
+        _ => format!("{prefix}-{process_id}-{nanos}-{unique}.json"),
     }
 }
 
@@ -820,14 +825,15 @@ mod tests {
                 "reddb-archived-change-records",
                 7,
                 99,
+                3,
                 Some(10),
                 Some(20)
             ),
-            PathBuf::from("/tmp/reddb-archived-change-records-7-10-20-99.json")
+            PathBuf::from("/tmp/reddb-archived-change-records-7-10-20-99-3.json")
         );
         assert_eq!(
-            backup_temp_json_path(Path::new("/tmp"), "reddb-json-object", 7, 99, None, None),
-            PathBuf::from("/tmp/reddb-json-object-7-99.json")
+            backup_temp_json_path(Path::new("/tmp"), "reddb-json-object", 7, 99, 3, None, None),
+            PathBuf::from("/tmp/reddb-json-object-7-99-3.json")
         );
         assert_eq!(
             logical_wal_path(path),


### PR DESCRIPTION
## Problem
`Test Suite` is red on `main` (the one failing required check after the merge gate / ADR 0059 went live), failing `drill_pitr_target_time::restore_to_target_time_skips_records_after_t` with a WAL segment integrity error (manifest sha256 != computed sha256). Red on CI, green locally.

## Root cause
Backup staging temp files (`BackupTempJsonFile`) were named only by `pid + SystemTime nanos (+ LSN range)`. CI runs the 4 PITR drills **in parallel**, each archiving a segment starting at **lsn 1**; on a coarse-clock runner two concurrent same-LSN archives collide on the staging path. Thread B overwrites thread A's staged bytes before A's `upload()`, so A ships B's bytes under A's key → restore recomputes a digest != A's stored manifest sha → the integrity check correctly fails closed. The encode/decode round-trip and the integrity check itself were both fine; the defect was a write-path overwrite upstream of the check.

## Fix
Process-global monotonic `AtomicU64` threaded into the staging filename (`backup_temp.rs` + `layout.rs`), so every staging path is unique regardless of clock resolution or concurrent same-LSN archives. Mirrors the existing `ServerlessWriterLeaseTempFile` precedent. Closes the same collision class for `json_object`/snapshot-manifest stagings too. Does NOT weaken the integrity check or touch the test.

## Verification
`cargo test --test grouped_pitr_drills` → 4 passed; reddb-io-file backup_temp + layout unit tests green; `cargo fmt --all -- --check` clean; `cargo clippy --workspace --locked -- -D warnings` clean. The collision is timing-dependent (didn't reproduce locally), so **this PR's CI is the real proof** — it must turn `Test Suite` green.

Unblocks the AFK merge-gate freeze (PRD #964 / ADR 0059).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784646659&installation_id=129708444&pr_number=1294&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1294&signature=6f80b132b280987453f6538d552116445b8bf1fde1e55ed18ba5f8c37614e1a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed temporary backup staging file naming collisions that could occur during concurrent backup operations within the same process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->