### PR TITLE
merge: #1230 Persist cluster bootstrap completion marker

### DIFF
--- a/crates/reddb-server/src/cluster/bootstrap_authority.rs
+++ b/crates/reddb-server/src/cluster/bootstrap_authority.rs
@@ -8,8 +8,16 @@
 //! perform auth bootstrap, and fails closed whenever no concrete owner can
 //! be proven.
 //!
-//! Two outcomes are deliberately preserved while the owner model is absent:
+//! Three outcomes are deliberately preserved while the owner model is absent:
 //!
+//! * A boot that observes a durable, already-published bootstrap completion
+//!   marker through the authority path returns
+//!   [`BootstrapDisposition::AlreadyComplete`] *before* any other check.
+//!   First boot is over: restarts and duplicate attempts are idempotent and
+//!   must not recreate admins, reissue the vault, or reapply mutable config
+//!   over operator changes (issue #1230). This holds for every shape,
+//!   including a cluster, so a once-bootstrapped cluster observes completion
+//!   instead of failing closed.
 //! * Explicit `--no-auth` / `--dev` cluster-shaped boots remain allowed as
 //!   a development carveout and skip every auth/bootstrap path. They must
 //!   create no admin, vault, or bootstrap-complete state.
@@ -64,6 +72,13 @@ pub enum BootstrapDisposition {
     /// `--no-auth` / `--dev` boot; for a cluster shape this is the
     /// documented development carveout.
     SkipDevBypass,
+    /// First boot already completed: a durable bootstrap completion marker
+    /// is visible through the authority path. The caller must treat this as
+    /// idempotent — rehydrate read-only state, but recreate no users,
+    /// reissue no vault certificate, and reapply no mutable config over
+    /// operator changes (issue #1230). Restarts and duplicate bootstrap
+    /// attempts after completion land here, including on a cluster shape.
+    AlreadyComplete,
 }
 
 /// `true` when this boot is cluster-shaped for the purpose of auth
@@ -79,19 +94,39 @@ pub const fn is_cluster_shaped(deploy_profile: DeployProfile) -> bool {
 /// or an operator-facing error string when the cluster bootstrap authority
 /// fails closed.
 ///
+/// * When `already_completed` is `true` a durable bootstrap completion
+///   marker is visible through the authority path, so this returns
+///   [`BootstrapDisposition::AlreadyComplete`] before any other check. First
+///   boot is over: the caller must be idempotent and recreate no global auth
+///   state (issue #1230). This wins even for a cluster shape, so a restart of
+///   a once-bootstrapped cluster observes completion instead of failing
+///   closed.
 /// * Any `--no-auth` / `--dev` boot returns [`BootstrapDisposition::SkipDevBypass`]:
 ///   the caller skips all auth/bootstrap state. For cluster shapes this is
 ///   the explicit development carveout from ADR 0058.
 /// * A non-cluster boot returns [`BootstrapDisposition::ProceedLocal`]: the
 ///   local node is the only authority for its own auth state.
-/// * A cluster-shaped, non-`--no-auth` boot is rejected. There is no
-///   reserved global system range owner model yet, so no member can prove
-///   it is the single writer of global auth/vault/config/policy state.
+/// * A cluster-shaped, non-`--no-auth` boot with no completion marker is
+///   rejected. There is no reserved global system range owner model yet, so
+///   no member can prove it is the single writer of global
+///   auth/vault/config/policy state.
 pub fn authorize(
     deploy_profile: DeployProfile,
     no_auth: bool,
     input: AuthBootstrapInput,
+    already_completed: bool,
 ) -> Result<BootstrapDisposition, String> {
+    if already_completed {
+        // The durable completion marker is the authority path's record that
+        // first boot already produced global auth state. Observing it must
+        // never recreate users, reissue the vault, or reapply mutable config
+        // over operator changes — and it must short-circuit the fail-closed
+        // gate, which only guards the *first* write of that state. Duplicate
+        // bootstrap attempts after completion therefore report the existing
+        // completed state idempotently (issue #1230).
+        return Ok(BootstrapDisposition::AlreadyComplete);
+    }
+
     if no_auth {
         // `--no-auth` / `--dev` is the last word on auth for this boot
         // (issue #663). The caller skips every preset/credential path, so
@@ -135,7 +170,7 @@ mod tests {
         ] {
             assert!(!is_cluster_shaped(profile), "{profile:?} is not cluster");
             assert_eq!(
-                authorize(profile, false, AuthBootstrapInput::Env).unwrap(),
+                authorize(profile, false, AuthBootstrapInput::Env, false).unwrap(),
                 BootstrapDisposition::ProceedLocal,
                 "{profile:?} should proceed with local bootstrap"
             );
@@ -144,29 +179,50 @@ mod tests {
 
     #[test]
     fn cluster_no_auth_is_the_dev_bypass_carveout() {
-        let disposition =
-            authorize(DeployProfile::Cluster, true, AuthBootstrapInput::None).unwrap();
+        let disposition = authorize(
+            DeployProfile::Cluster,
+            true,
+            AuthBootstrapInput::None,
+            false,
+        )
+        .unwrap();
         assert_eq!(disposition, BootstrapDisposition::SkipDevBypass);
     }
 
     #[test]
     fn non_cluster_no_auth_also_skips() {
-        let disposition =
-            authorize(DeployProfile::Embedded, true, AuthBootstrapInput::Env).unwrap();
+        let disposition = authorize(
+            DeployProfile::Embedded,
+            true,
+            AuthBootstrapInput::Env,
+            false,
+        )
+        .unwrap();
         assert_eq!(disposition, BootstrapDisposition::SkipDevBypass);
     }
 
     #[test]
     fn cluster_env_bootstrap_fails_closed() {
-        let err = authorize(DeployProfile::Cluster, false, AuthBootstrapInput::Env).unwrap_err();
+        let err = authorize(
+            DeployProfile::Cluster,
+            false,
+            AuthBootstrapInput::Env,
+            false,
+        )
+        .unwrap_err();
         assert!(err.contains("no concrete authority owner"), "got: {err}");
         assert!(err.contains("env/preset"), "got: {err}");
     }
 
     #[test]
     fn cluster_manifest_bootstrap_fails_closed() {
-        let err =
-            authorize(DeployProfile::Cluster, false, AuthBootstrapInput::Manifest).unwrap_err();
+        let err = authorize(
+            DeployProfile::Cluster,
+            false,
+            AuthBootstrapInput::Manifest,
+            false,
+        )
+        .unwrap_err();
         assert!(err.contains("no concrete authority owner"), "got: {err}");
         assert!(err.contains("manifest"), "got: {err}");
     }
@@ -176,7 +232,75 @@ mod tests {
         // A `simple`-preset cluster boot writes only a per-node
         // bootstrap-complete marker, which ADR 0058 forbids without a
         // proven owner. Fail closed so no divergent marker is written.
-        let err = authorize(DeployProfile::Cluster, false, AuthBootstrapInput::None).unwrap_err();
+        let err = authorize(
+            DeployProfile::Cluster,
+            false,
+            AuthBootstrapInput::None,
+            false,
+        )
+        .unwrap_err();
         assert!(err.contains("no concrete authority owner"), "got: {err}");
+    }
+
+    #[test]
+    fn completion_marker_makes_local_restart_idempotent() {
+        // Acceptance #2: restart after a successful non-cluster bootstrap
+        // observes the durable completion marker and must not recreate
+        // global auth state.
+        for profile in [
+            DeployProfile::Embedded,
+            DeployProfile::Serverless,
+            DeployProfile::PrimaryReplica,
+        ] {
+            assert_eq!(
+                authorize(profile, false, AuthBootstrapInput::Env, true).unwrap(),
+                BootstrapDisposition::AlreadyComplete,
+                "{profile:?} restart should be idempotent once completed"
+            );
+        }
+    }
+
+    #[test]
+    fn completion_marker_short_circuits_cluster_fail_closed() {
+        // Acceptance #1/#3: once first boot has completed, a cluster restart
+        // observes completion through the authority path instead of failing
+        // closed, even though no concrete owner model exists yet. This is
+        // the only path that lets a credentialled cluster boot succeed.
+        let disposition = authorize(
+            DeployProfile::Cluster,
+            false,
+            AuthBootstrapInput::Manifest,
+            true,
+        )
+        .unwrap();
+        assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
+    }
+
+    #[test]
+    fn duplicate_bootstrap_after_completion_is_idempotent_for_every_input() {
+        // Acceptance #3: a duplicate bootstrap attempt after completion
+        // reports the existing completed state regardless of which auth
+        // bootstrap input the operator re-supplies.
+        for input in [
+            AuthBootstrapInput::None,
+            AuthBootstrapInput::Env,
+            AuthBootstrapInput::Manifest,
+        ] {
+            assert_eq!(
+                authorize(DeployProfile::Cluster, false, input, true).unwrap(),
+                BootstrapDisposition::AlreadyComplete,
+                "{input:?} duplicate after completion should be idempotent"
+            );
+        }
+    }
+
+    #[test]
+    fn completion_marker_wins_over_dev_bypass() {
+        // The durable completion marker is checked before the `--no-auth`
+        // carveout, so a once-bootstrapped node never silently downgrades
+        // into the anonymous dev path on restart.
+        let disposition =
+            authorize(DeployProfile::Cluster, true, AuthBootstrapInput::None, true).unwrap();
+        assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
     }
 }

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -2144,15 +2144,38 @@ fn build_runtime_with_bootstrap(
     // `--no-auth` is active, deliberately skip the preset machinery so a
     // stray `REDDB_USERNAME`+`REDDB_PASSWORD` pair cannot silently create an
     // admin, defeating the point of anonymous mode.
+    //
+    // Issue #1230 — the durable bootstrap completion marker
+    // (`system.bootstrap.completed`) is the authority path's record that
+    // first boot already produced global auth state. Observing it makes a
+    // restart or duplicate bootstrap attempt idempotent: the seam returns
+    // `AlreadyComplete` and the caller rehydrates read-only state only,
+    // recreating no users, reissuing no vault certificate, and reapplying no
+    // mutable config over operator changes.
+    let bootstrap_already_completed = runtime
+        .db()
+        .store()
+        .get_config(BOOTSTRAP_COMPLETED_KEY)
+        .is_some();
     let disposition = crate::cluster::authorize_cluster_bootstrap(
         db_options.storage_profile.deploy_profile,
         no_auth,
         bootstrap.auth_bootstrap_input(),
+        bootstrap_already_completed,
     )?;
     match disposition {
         crate::cluster::BootstrapDisposition::SkipDevBypass => {
             eprintln!("{NO_AUTH_WARNING}");
             tracing::warn!("{NO_AUTH_WARNING}");
+        }
+        crate::cluster::BootstrapDisposition::AlreadyComplete => {
+            // First boot is over. Rehydrate the read-only manifest registry
+            // so config-derived state is observable, but create no users,
+            // reissue no vault material, and reapply no mutable config
+            // (issue #1230). `apply_preset_from_config` does exactly this
+            // when the completion marker is present.
+            apply_preset_from_config(&runtime, &auth_store, bootstrap)?;
+            tracing::info!("bootstrap already completed, reporting existing state");
         }
         crate::cluster::BootstrapDisposition::ProceedLocal => {
             apply_preset_from_config(&runtime, &auth_store, bootstrap)?;

--- a/tests/cluster_bootstrap_authority.rs
+++ b/tests/cluster_bootstrap_authority.rs
@@ -143,8 +143,7 @@ fn duplicate_bootstrap_after_completion_is_idempotent_across_shapes() {
             AuthBootstrapInput::Env,
             AuthBootstrapInput::Manifest,
         ] {
-            let disposition =
-                authorize_cluster_bootstrap(profile, false, input, true).unwrap();
+            let disposition = authorize_cluster_bootstrap(profile, false, input, true).unwrap();
             assert_eq!(
                 disposition,
                 BootstrapDisposition::AlreadyComplete,

--- a/tests/cluster_bootstrap_authority.rs
+++ b/tests/cluster_bootstrap_authority.rs
@@ -41,9 +41,13 @@ fn cluster_storage_preset_path_is_cluster_shaped() {
 
 #[test]
 fn cluster_topology_env_bootstrap_fails_closed() {
-    let err =
-        authorize_cluster_bootstrap(cluster_topology_profile(), false, AuthBootstrapInput::Env)
-            .expect_err("cluster topology must fail closed for env auth bootstrap");
+    let err = authorize_cluster_bootstrap(
+        cluster_topology_profile(),
+        false,
+        AuthBootstrapInput::Env,
+        false,
+    )
+    .expect_err("cluster topology must fail closed for env auth bootstrap");
     assert!(err.contains("no concrete authority owner"), "got: {err}");
 }
 
@@ -53,6 +57,7 @@ fn cluster_topology_manifest_bootstrap_fails_closed() {
         cluster_topology_profile(),
         false,
         AuthBootstrapInput::Manifest,
+        false,
     )
     .expect_err("cluster topology must fail closed for manifest auth bootstrap");
     assert!(err.contains("no concrete authority owner"), "got: {err}");
@@ -61,7 +66,7 @@ fn cluster_topology_manifest_bootstrap_fails_closed() {
 #[test]
 fn cluster_storage_preset_env_bootstrap_fails_closed() {
     let profile = StorageDeployPreset::Cluster.selection().deploy_profile;
-    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Env)
+    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Env, false)
         .expect_err("cluster storage preset must fail closed for env auth bootstrap");
     assert!(err.contains("no concrete authority owner"), "got: {err}");
 }
@@ -69,7 +74,7 @@ fn cluster_storage_preset_env_bootstrap_fails_closed() {
 #[test]
 fn cluster_storage_preset_manifest_bootstrap_fails_closed() {
     let profile = StorageDeployPreset::Cluster.selection().deploy_profile;
-    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Manifest)
+    let err = authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Manifest, false)
         .expect_err("cluster storage preset must fail closed for manifest auth bootstrap");
     assert!(err.contains("no concrete authority owner"), "got: {err}");
 }
@@ -82,7 +87,7 @@ fn cluster_no_auth_dev_bypass_is_allowed_and_skips_bootstrap() {
         StorageDeployPreset::Cluster.selection().deploy_profile,
     ] {
         let disposition =
-            authorize_cluster_bootstrap(profile, true, AuthBootstrapInput::None).unwrap();
+            authorize_cluster_bootstrap(profile, true, AuthBootstrapInput::None, false).unwrap();
         assert_eq!(
             disposition,
             BootstrapDisposition::SkipDevBypass,
@@ -102,7 +107,68 @@ fn non_cluster_topology_still_bootstraps_locally() {
         plan.storage_profile.deploy_profile,
         false,
         AuthBootstrapInput::Env,
+        false,
     )
     .unwrap();
     assert_eq!(disposition, BootstrapDisposition::ProceedLocal);
+}
+
+#[test]
+fn cluster_topology_reports_completion_instead_of_failing_closed() {
+    // Issue #1230 — once a durable completion marker is visible through the
+    // authority path, a cluster restart observes it (idempotent) rather than
+    // failing closed. This is the only way a credentialled cluster boot
+    // resolves to a non-error disposition today.
+    let disposition = authorize_cluster_bootstrap(
+        cluster_topology_profile(),
+        false,
+        AuthBootstrapInput::Manifest,
+        true,
+    )
+    .expect("a completed cluster restart must not fail closed");
+    assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
+}
+
+#[test]
+fn duplicate_bootstrap_after_completion_is_idempotent_across_shapes() {
+    // Issue #1230 — a duplicate bootstrap attempt after completion reports
+    // the existing completed state for every cluster-shaped path and every
+    // auth bootstrap input the operator re-supplies.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        for input in [
+            AuthBootstrapInput::None,
+            AuthBootstrapInput::Env,
+            AuthBootstrapInput::Manifest,
+        ] {
+            let disposition =
+                authorize_cluster_bootstrap(profile, false, input, true).unwrap();
+            assert_eq!(
+                disposition,
+                BootstrapDisposition::AlreadyComplete,
+                "duplicate bootstrap after completion must be idempotent"
+            );
+        }
+    }
+}
+
+#[test]
+fn non_cluster_restart_after_completion_is_idempotent() {
+    // Issue #1230 — a standalone restart after a successful bootstrap also
+    // observes the completion marker and recreates no global auth state.
+    let plan = resolve_operational_bootstrap(OperationalBootstrapInput {
+        topology: Some("standalone".to_string()),
+        ..Default::default()
+    })
+    .expect("standalone topology resolves");
+    let disposition = authorize_cluster_bootstrap(
+        plan.storage_profile.deploy_profile,
+        false,
+        AuthBootstrapInput::Env,
+        true,
+    )
+    .unwrap();
+    assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
 }


### PR DESCRIPTION
Automated AFK landing for #1230. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1230

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784650656&installation_id=129708444&pr_number=1295&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1295&signature=d47d73c1d05f58a5369bd16abb3c6636e40d136576b4be7079ec1fcce75413dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster bootstrap authorization now supports persistent completion markers to enable idempotent restarts and duplicate bootstrap attempts without authorization failures. Completion marker precedence in the authorization flow improves reliability during cluster initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->