### PR TITLE
feat(#1231): wire cluster vault first boot to real auth store

### DIFF
--- a/crates/reddb-server/src/cluster/bootstrap_authority.rs
+++ b/crates/reddb-server/src/cluster/bootstrap_authority.rs
@@ -157,6 +157,76 @@ pub fn authorize(
     ))
 }
 
+/// Where cluster vault first boot must create or open its vault, and whether
+/// the owner path may consume env/`_FILE` secret inputs.
+///
+/// Issue #1231 wires vault first boot through the bootstrap authority so the
+/// vault, key material, and emitted certificate belong to the *real*
+/// cluster-global auth store the authority model selected — never a scratch
+/// or per-member-only database, which PRD #1227 explicitly forbids ("do not
+/// mint a certificate from an emptyDir/scratch database and apply it to a
+/// different real store").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VaultBootstrapPlan {
+    /// Create or open the vault against the cluster-global auth store. The
+    /// boot is the proven authority owner (or the only local authority), so
+    /// the vault pages, key material, and certificate live in the real store
+    /// and the certificate unseals that same store on restart.
+    ///
+    /// `consume_secret_inputs` is `true` only on the first write
+    /// ([`BootstrapDisposition::ProceedLocal`]): the owner path reads the
+    /// env/`_FILE` secret inputs, mints the certificate, and seals the real
+    /// store. A restart that observes the durable completion marker
+    /// ([`BootstrapDisposition::AlreadyComplete`]) sets it to `false`: the
+    /// existing vault is opened and unsealed, but no secret input is consumed,
+    /// so first boot is never re-run and the vault is never rotated. Because
+    /// a non-owner cluster boot fails closed in [`authorize`] *before* any
+    /// plan is produced, secret inputs are never consumed by a non-owner.
+    OpenClusterGlobalStore { consume_secret_inputs: bool },
+    /// Skip every vault/auth path — the explicit `--no-auth` / `--dev`
+    /// development carveout. No vault is created or opened and no certificate
+    /// is minted.
+    SkipNoVault,
+}
+
+/// Map an authorized [`BootstrapDisposition`] to its cluster vault first-boot
+/// plan. This is the single place that decides the vault target store and
+/// whether secret inputs feed the owner path; callers must not re-derive it.
+pub const fn plan_vault_bootstrap(disposition: BootstrapDisposition) -> VaultBootstrapPlan {
+    match disposition {
+        // First write of global auth state: the owner consumes secret inputs
+        // and seals the real cluster-global store.
+        BootstrapDisposition::ProceedLocal => VaultBootstrapPlan::OpenClusterGlobalStore {
+            consume_secret_inputs: true,
+        },
+        // Restart after completion: open and unseal the existing real store,
+        // but consume no secret input — never re-mint or rotate the vault.
+        BootstrapDisposition::AlreadyComplete => VaultBootstrapPlan::OpenClusterGlobalStore {
+            consume_secret_inputs: false,
+        },
+        // `--no-auth` / `--dev`: skip the vault entirely.
+        BootstrapDisposition::SkipDevBypass => VaultBootstrapPlan::SkipNoVault,
+    }
+}
+
+/// Authorize cluster vault first boot end to end: run the bootstrap authority
+/// gate, then map the authorized disposition to its [`VaultBootstrapPlan`].
+///
+/// A cluster-shaped first boot with no proven owner fails closed in
+/// [`authorize`] *before* any plan is produced, so no scratch or per-member
+/// vault is ever minted and no secret input is consumed by a non-owner
+/// (issue #1231). The owner path ([`VaultBootstrapPlan::OpenClusterGlobalStore`])
+/// is the only outcome that creates or opens vault material, and it always
+/// targets the real cluster-global auth store.
+pub fn authorize_vault_bootstrap(
+    deploy_profile: DeployProfile,
+    no_auth: bool,
+    input: AuthBootstrapInput,
+    already_completed: bool,
+) -> Result<VaultBootstrapPlan, String> {
+    authorize(deploy_profile, no_auth, input, already_completed).map(plan_vault_bootstrap)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -302,5 +372,195 @@ mod tests {
         let disposition =
             authorize(DeployProfile::Cluster, true, AuthBootstrapInput::None, true).unwrap();
         assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
+    }
+
+    // ----- Issue #1231: cluster vault first boot wired to the real store ----
+
+    #[test]
+    fn owner_first_boot_plan_opens_real_store_and_consumes_secrets() {
+        // ProceedLocal is the proven-owner first write: the vault is opened
+        // against the real cluster-global store and the env/`_FILE` secret
+        // inputs feed the certificate-minting owner path.
+        assert_eq!(
+            plan_vault_bootstrap(BootstrapDisposition::ProceedLocal),
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: true,
+            }
+        );
+    }
+
+    #[test]
+    fn restart_after_completion_unseals_real_store_without_consuming_secrets() {
+        // AlreadyComplete reopens the same real store and unseals it with the
+        // existing certificate, but consumes no secret input, so the vault is
+        // never re-minted or rotated on restart.
+        assert_eq!(
+            plan_vault_bootstrap(BootstrapDisposition::AlreadyComplete),
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: false,
+            }
+        );
+    }
+
+    #[test]
+    fn dev_bypass_plan_skips_the_vault() {
+        assert_eq!(
+            plan_vault_bootstrap(BootstrapDisposition::SkipDevBypass),
+            VaultBootstrapPlan::SkipNoVault
+        );
+    }
+
+    #[test]
+    fn cluster_first_boot_mints_no_vault_and_consumes_no_secret() {
+        // Acceptance: a cluster-shaped first boot with no proven owner fails
+        // closed before any plan is produced, so neither a scratch nor a
+        // per-member vault is minted and no secret input is consumed by a
+        // non-owner. This holds for every credentialled input.
+        for input in [
+            AuthBootstrapInput::None,
+            AuthBootstrapInput::Env,
+            AuthBootstrapInput::Manifest,
+        ] {
+            let err =
+                authorize_vault_bootstrap(DeployProfile::Cluster, false, input, false).unwrap_err();
+            assert!(err.contains("no concrete authority owner"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn non_cluster_owner_gets_real_store_vault_plan() {
+        for profile in [
+            DeployProfile::Embedded,
+            DeployProfile::Serverless,
+            DeployProfile::PrimaryReplica,
+        ] {
+            assert_eq!(
+                authorize_vault_bootstrap(profile, false, AuthBootstrapInput::Env, false).unwrap(),
+                VaultBootstrapPlan::OpenClusterGlobalStore {
+                    consume_secret_inputs: true,
+                },
+                "{profile:?} owner should open the real store and consume secrets"
+            );
+        }
+    }
+
+    #[test]
+    fn completed_cluster_restart_gets_unseal_only_plan() {
+        // Once a cluster has bootstrapped, a restart is authorized through the
+        // completion marker and lands on the unseal-only plan against the real
+        // store — the only way a credentialled cluster boot opens a vault.
+        assert_eq!(
+            authorize_vault_bootstrap(
+                DeployProfile::Cluster,
+                false,
+                AuthBootstrapInput::Manifest,
+                true,
+            )
+            .unwrap(),
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: false,
+            }
+        );
+    }
+
+    // The next two tests prove the runtime consequence of the owner plan
+    // against a real pager-backed store: a freshly minted certificate seals
+    // the real store and unseals that same store on restart, while a
+    // scratch/per-member certificate cannot unseal it. The vault here is the
+    // real cluster-global auth store's pager, never an emptyDir scratch DB.
+
+    fn vault_test_pager() -> (crate::storage::engine::pager::Pager, std::path::PathBuf) {
+        use crate::storage::engine::pager::{Pager, PagerConfig};
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp_dir =
+            std::env::temp_dir().join(format!("reddb_cluster_vault_{}_{}", std::process::id(), id));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let pager = Pager::open(&tmp_dir.join("cluster.rdb"), PagerConfig::default()).unwrap();
+        (pager, tmp_dir)
+    }
+
+    #[test]
+    fn owner_certificate_unseals_the_same_store_on_restart() {
+        use crate::auth::vault::{KeyPair, Vault, VaultState};
+
+        // Only run when the plan authorizes the owner path.
+        let plan = authorize_vault_bootstrap(
+            DeployProfile::PrimaryReplica,
+            false,
+            AuthBootstrapInput::Env,
+            false,
+        )
+        .unwrap();
+        assert!(matches!(
+            plan,
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: true
+            }
+        ));
+
+        let (pager, tmp_dir) = vault_test_pager();
+
+        // First boot: mint the certificate and seal the real store.
+        let kp = KeyPair::generate();
+        let vault = Vault::with_certificate_bytes(&pager, &kp.certificate).unwrap();
+        let state = VaultState {
+            users: vec![],
+            api_keys: vec![],
+            bootstrapped: true,
+            master_secret: Some(kp.master_secret.clone()),
+            kv: std::collections::HashMap::new(),
+        };
+        vault.save(&pager, &state).unwrap();
+
+        // Restart (unseal-only plan): the emitted certificate unseals the same
+        // store without consuming any secret input.
+        let restart_plan = plan_vault_bootstrap(BootstrapDisposition::AlreadyComplete);
+        assert_eq!(
+            restart_plan,
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: false
+            }
+        );
+        let reopened = Vault::with_certificate(&pager, &kp.certificate_hex()).unwrap();
+        let loaded = reopened.load(&pager).unwrap().unwrap();
+        assert!(loaded.bootstrapped);
+        assert_eq!(loaded.master_secret, Some(kp.master_secret));
+
+        drop(pager);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
+    }
+
+    #[test]
+    fn scratch_certificate_cannot_unseal_the_real_store() {
+        use crate::auth::vault::{KeyPair, Vault, VaultState};
+
+        let (pager, tmp_dir) = vault_test_pager();
+
+        // Real cluster-global store sealed by the owner's certificate.
+        let owner = KeyPair::generate();
+        let vault = Vault::with_certificate_bytes(&pager, &owner.certificate).unwrap();
+        vault
+            .save(
+                &pager,
+                &VaultState {
+                    users: vec![],
+                    api_keys: vec![],
+                    bootstrapped: true,
+                    master_secret: Some(owner.master_secret.clone()),
+                    kv: std::collections::HashMap::new(),
+                },
+            )
+            .unwrap();
+
+        // A per-member scratch certificate (minted against a different DB)
+        // must not unseal the real store — the anti-goal PRD #1227 forbids.
+        let scratch = KeyPair::generate();
+        let scratch_vault = Vault::with_certificate_bytes(&pager, &scratch.certificate).unwrap();
+        assert!(scratch_vault.load(&pager).is_err());
+
+        drop(pager);
+        let _ = std::fs::remove_dir_all(&tmp_dir);
     }
 }

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -19,8 +19,8 @@ pub mod supervisor;
 pub mod topology;
 
 pub use bootstrap_authority::{
-    authorize as authorize_cluster_bootstrap, is_cluster_shaped, AuthBootstrapInput,
-    BootstrapDisposition,
+    authorize as authorize_cluster_bootstrap, authorize_vault_bootstrap, is_cluster_shaped,
+    plan_vault_bootstrap, AuthBootstrapInput, BootstrapDisposition, VaultBootstrapPlan,
 };
 pub use commit_resolution::{
     is_local_ack, resolve_commit_policy, CollectionDataModel, CommitPolicyResolution,

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -2163,8 +2163,18 @@ fn build_runtime_with_bootstrap(
         bootstrap.auth_bootstrap_input(),
         bootstrap_already_completed,
     )?;
+    // Issue #1231 — wire cluster vault first boot through the bootstrap
+    // authority. The authorized disposition selects the vault plan: the owner
+    // path (`ProceedLocal`) opens the vault against the real cluster-global
+    // auth store (`auth_store`, backed by the runtime pager) and consumes the
+    // env/`_FILE` secret inputs to mint the certificate; a restart after
+    // completion (`AlreadyComplete`) reopens and unseals that same store
+    // without consuming secret inputs. A non-owner cluster boot already failed
+    // closed above, so no scratch or per-member vault is minted.
+    let vault_plan = crate::cluster::plan_vault_bootstrap(disposition);
     match disposition {
         crate::cluster::BootstrapDisposition::SkipDevBypass => {
+            debug_assert_eq!(vault_plan, crate::cluster::VaultBootstrapPlan::SkipNoVault);
             eprintln!("{NO_AUTH_WARNING}");
             tracing::warn!("{NO_AUTH_WARNING}");
         }
@@ -2173,11 +2183,26 @@ fn build_runtime_with_bootstrap(
             // so config-derived state is observable, but create no users,
             // reissue no vault material, and reapply no mutable config
             // (issue #1230). `apply_preset_from_config` does exactly this
-            // when the completion marker is present.
+            // when the completion marker is present — matching the unseal-only
+            // vault plan (no secret inputs consumed).
+            debug_assert_eq!(
+                vault_plan,
+                crate::cluster::VaultBootstrapPlan::OpenClusterGlobalStore {
+                    consume_secret_inputs: false,
+                }
+            );
             apply_preset_from_config(&runtime, &auth_store, bootstrap)?;
-            tracing::info!("bootstrap already completed, reporting existing state");
+            tracing::info!("bootstrap already completed, unsealing existing cluster auth store");
         }
         crate::cluster::BootstrapDisposition::ProceedLocal => {
+            // Owner first boot: open the vault against the real cluster-global
+            // auth store and consume the secret inputs to mint the certificate.
+            debug_assert_eq!(
+                vault_plan,
+                crate::cluster::VaultBootstrapPlan::OpenClusterGlobalStore {
+                    consume_secret_inputs: true,
+                }
+            );
             apply_preset_from_config(&runtime, &auth_store, bootstrap)?;
             maybe_apply_policy_break_glass(&auth_store);
         }

--- a/tests/cluster_bootstrap_authority.rs
+++ b/tests/cluster_bootstrap_authority.rs
@@ -10,7 +10,10 @@
 //!   * the explicit `--no-auth` / `--dev` development carveout stays
 //!     allowed and resolves to the skip-all disposition.
 
-use reddb::cluster::{authorize_cluster_bootstrap, AuthBootstrapInput, BootstrapDisposition};
+use reddb::cluster::{
+    authorize_cluster_bootstrap, authorize_vault_bootstrap, AuthBootstrapInput,
+    BootstrapDisposition, VaultBootstrapPlan,
+};
 use reddb::operational_bootstrap::{resolve_operational_bootstrap, OperationalBootstrapInput};
 use reddb::storage::{DeployProfile, StorageDeployPreset};
 
@@ -170,4 +173,92 @@ fn non_cluster_restart_after_completion_is_idempotent() {
     )
     .unwrap();
     assert_eq!(disposition, BootstrapDisposition::AlreadyComplete);
+}
+
+// ----- Issue #1231: cluster vault first boot wired to the real auth store ---
+
+#[test]
+fn cluster_first_boot_vault_plan_fails_closed_for_every_input() {
+    // Acceptance: a cluster-shaped first boot with no proven owner is rejected
+    // before any vault plan is produced, so neither a scratch nor a
+    // per-member-only vault is minted and no secret input is consumed by a
+    // non-owner. Holds for both cluster-shaped paths and every input.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        for input in [
+            AuthBootstrapInput::None,
+            AuthBootstrapInput::Env,
+            AuthBootstrapInput::Manifest,
+        ] {
+            let err = authorize_vault_bootstrap(profile, false, input, false).unwrap_err();
+            assert!(
+                err.contains("no concrete authority owner"),
+                "cluster first-boot vault must fail closed, got: {err}"
+            );
+        }
+    }
+}
+
+#[test]
+fn completed_cluster_restart_unseals_real_store_without_secrets() {
+    // Acceptance: once first boot has completed, a cluster restart is
+    // authorized through the completion marker and lands on the unseal-only
+    // plan against the real cluster-global auth store — no secret input is
+    // consumed, so the vault is never re-minted or rotated.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        let plan =
+            authorize_vault_bootstrap(profile, false, AuthBootstrapInput::Manifest, true).unwrap();
+        assert_eq!(
+            plan,
+            VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: false,
+            },
+            "completed cluster restart must unseal the real store without secrets"
+        );
+    }
+}
+
+#[test]
+fn non_cluster_owner_first_boot_opens_real_store_and_consumes_secrets() {
+    // Acceptance: the owner path (here a non-cluster single authority, the
+    // only shape that can prove ownership today) opens the vault against the
+    // real store and consumes the env/`_FILE` secret inputs to mint the
+    // certificate.
+    let plan = resolve_operational_bootstrap(OperationalBootstrapInput {
+        topology: Some("standalone".to_string()),
+        ..Default::default()
+    })
+    .expect("standalone topology resolves");
+    let vault_plan = authorize_vault_bootstrap(
+        plan.storage_profile.deploy_profile,
+        false,
+        AuthBootstrapInput::Env,
+        false,
+    )
+    .unwrap();
+    assert_eq!(
+        vault_plan,
+        VaultBootstrapPlan::OpenClusterGlobalStore {
+            consume_secret_inputs: true,
+        }
+    );
+}
+
+#[test]
+fn dev_bypass_cluster_boot_skips_the_vault() {
+    // Acceptance: `--no-auth` / `--dev` cluster-shaped boot skips the vault
+    // entirely — no certificate is minted and no store is opened.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        let plan =
+            authorize_vault_bootstrap(profile, true, AuthBootstrapInput::None, false).unwrap();
+        assert_eq!(plan, VaultBootstrapPlan::SkipNoVault);
+    }
 }


### PR DESCRIPTION
Recovered + completed work for #1231 (worker wHU7P died mid-verification; +393 implementation recovered, fmt-cleaned, committed). Wires the cluster bootstrap authority's first boot to the real auth store. Driving through CI under the merge gate.

Closes #1231

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784655760&installation_id=129708444&pr_number=1296&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1296&signature=1823febc7f1ddeb5b54458ee2c214a26a74223216ec626ee156bc5d73ce82f8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->