### PR TITLE
merge: #1232 Apply cluster bootstrap manifest on fenced owner only

### DIFF
--- a/crates/reddb-server/src/cli/bootstrap_manifest.rs
+++ b/crates/reddb-server/src/cli/bootstrap_manifest.rs
@@ -276,7 +276,7 @@ impl BootstrapManifest {
         }
 
         for config in &self.config {
-            insert_config_value(runtime, &config.key, config.value.clone())?;
+            insert_config_value_if_absent(runtime, &config.key, config.value.clone())?;
         }
         if !registered.is_empty() {
             persist_registry_state(runtime, &registered)?;
@@ -704,6 +704,28 @@ fn registry_entry_from_json(value: &JsonValue, idx: usize) -> Result<ConfigRegis
     })
 }
 
+/// Write an initial config value only when the key is absent (issue #1232,
+/// acceptance #3). The fenced bootstrap owner applies the manifest exactly
+/// once, but initial config must use first-boot/write-if-absent semantics so
+/// a value an operator has already set for the same key is never overwritten.
+/// Internal bootstrap bookkeeping (e.g. the registry snapshot) keeps using
+/// [`insert_config_value`] directly, because that state is owned by the
+/// bootstrap path itself, not by the operator.
+fn insert_config_value_if_absent(
+    runtime: &RedDBRuntime,
+    key: &str,
+    value: Value,
+) -> Result<(), String> {
+    if runtime.db().store().get_config(key).is_some() {
+        tracing::info!(
+            key,
+            "bootstrap manifest config key already present; preserving operator value"
+        );
+        return Ok(());
+    }
+    insert_config_value(runtime, key, value)
+}
+
 fn insert_config_value(runtime: &RedDBRuntime, key: &str, value: Value) -> Result<(), String> {
     let store = runtime.db().store();
     let _ = store.get_or_create_collection("red_config");
@@ -910,7 +932,109 @@ fn secret_ref_storage_value(value: &JsonValue, idx: usize) -> Result<Value, Stri
 
 #[cfg(test)]
 mod tests {
-    use super::BootstrapManifest;
+    use super::{apply_manifest_file, BootstrapManifest};
+    use crate::auth::store::AuthStore;
+    use crate::auth::AuthConfig;
+    use crate::storage::schema::Value;
+    use crate::RedDBRuntime;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    fn manifest_test_env() -> (RedDBRuntime, Arc<AuthStore>, std::path::PathBuf) {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let runtime =
+            RedDBRuntime::with_options(crate::api::RedDBOptions::in_memory()).expect("runtime");
+        let auth = Arc::new(AuthStore::new(AuthConfig::default()));
+        let tmp =
+            std::env::temp_dir().join(format!("reddb_manifest_{}_{}.json", std::process::id(), id));
+        (runtime, auth, tmp)
+    }
+
+    fn write_manifest(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).expect("write manifest");
+    }
+
+    #[test]
+    fn owner_apply_creates_user_and_initial_config() {
+        // Acceptance #1/#4: the fenced owner applies the manifest, creating the
+        // initial admin and writing initial config.
+        let (runtime, auth, path) = manifest_test_env();
+        write_manifest(
+            &path,
+            r#"{
+                "users": [{"username":"ops","password":"hunter2","role":"admin"}],
+                "config": [{"key":"app.feature.x","value":"on"}]
+            }"#,
+        );
+
+        let actor =
+            apply_manifest_file(&runtime, &auth, &runtime.config_registry(), &path).expect("apply");
+        assert_eq!(actor, "ops");
+        assert!(
+            auth.get_user(None, "ops").is_some(),
+            "admin must be created"
+        );
+        assert_eq!(
+            runtime.db().store().get_config("app.feature.x"),
+            Some(Value::text("on".to_string())),
+            "initial config must be written on owner apply"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn initial_config_is_write_if_absent_and_keeps_operator_value() {
+        // Acceptance #3: initial config uses write-if-absent semantics — a value
+        // an operator has already set for the same key survives manifest apply.
+        let (runtime, auth, path) = manifest_test_env();
+        super::insert_config_value(
+            &runtime,
+            "app.feature.x",
+            Value::text("operator".to_string()),
+        )
+        .expect("seed operator config");
+
+        write_manifest(
+            &path,
+            r#"{
+                "users": [{"username":"ops","password":"hunter2","role":"admin"}],
+                "config": [{"key":"app.feature.x","value":"manifest"}]
+            }"#,
+        );
+        apply_manifest_file(&runtime, &auth, &runtime.config_registry(), &path).expect("apply");
+
+        assert_eq!(
+            runtime.db().store().get_config("app.feature.x"),
+            Some(Value::text("operator".to_string())),
+            "manifest must not overwrite a later operator change"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn duplicate_manifest_apply_is_rejected_idempotently() {
+        // Acceptance #4: a duplicate apply (e.g. a restart that re-runs the
+        // manifest) refuses to recreate existing global auth state instead of
+        // silently mutating it.
+        let (runtime, auth, path) = manifest_test_env();
+        write_manifest(
+            &path,
+            r#"{
+                "users": [{"username":"ops","password":"hunter2","role":"admin"}],
+                "config": [{"key":"app.feature.x","value":"on"}]
+            }"#,
+        );
+        apply_manifest_file(&runtime, &auth, &runtime.config_registry(), &path).expect("first");
+
+        let err = apply_manifest_file(&runtime, &auth, &runtime.config_registry(), &path)
+            .expect_err("duplicate apply must be rejected");
+        assert!(err.contains("already exists"), "got: {err}");
+
+        let _ = std::fs::remove_file(&path);
+    }
 
     #[test]
     fn rejects_system_owned_user_field() {


### PR DESCRIPTION
Automated AFK landing for #1232. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1232

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784659262&installation_id=129708444&pr_number=1297&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1297&signature=26dc851e391683389aea3aa54f8e75a22765607fb29a9ff20bf6bb4f8a581e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Bootstrap manifest now preserves existing config values instead of overwriting them during application.
  * Duplicate manifest applications are now prevented to avoid unintended state mutations.

* **Tests**
  * Expanded test coverage for config preservation and manifest idempotency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->