### PR TITLE
merge: #1234 Enable and document cluster auth in Helm and Compose

### DIFF
--- a/charts/reddb/README.md
+++ b/charts/reddb/README.md
@@ -150,6 +150,44 @@ pods run `red server --role standalone` with `REDDB_STORAGE_PRESET=cluster` and
 `RED_CLUSTER_HA_INTENT=declared`. Treat this as the Kubernetes contract for the
 cluster supervisor and range ownership runtime as those pieces mature.
 
+### Cluster bootstrap contract
+
+Cluster members are symmetric and *non-owner*: no member can prove it — and not
+a peer — is the single writer of global auth/vault/config/policy state. The
+chart and the runtime therefore share one fail-closed contract (ADR 0058,
+[`docs/deployment/first-boot.md`](../../docs/deployment/first-boot.md)):
+
+- **Cluster no-auth (supported today).** The default cluster values render no
+  bootstrap credentials at all. Members boot anonymously and create no admin,
+  vault, or `system.bootstrap.completed` marker. This is the documented
+  development/no-auth carveout, not a credentialled production bootstrap.
+- **Cluster auth/vault (gated).** `auth.enabled=true` is rejected fail-closed in
+  `mode=cluster`: `helm template`/`helm install` fail with a message that points
+  here. The gate stays closed in lockstep with the runtime, which rejects a
+  cluster-shaped credentialled boot until the reserved global system range owner
+  path lands (PRD #1227). When that owner path ships, only the proven reserved
+  range owner runs the first preset, mints the vault, applies the first policy
+  manifest, and publishes the completion marker.
+- **Certificate handling.** A cluster member may still receive the vault
+  certificate (`auth.vault.certificate.value` / `existingSecret`, or the
+  `fileMount` path) so it can *unseal* an already-bootstrapped store. Receiving a
+  certificate never bootstraps auth — it only opens an existing vault. Capture
+  the certificate the owner mints once and preserve it offline; losing it means
+  the encrypted store cannot be unsealed.
+- **Restart idempotency.** Once `system.bootstrap.completed` is durable, a
+  restart observes the marker and rehydrates read-only state: it recreates no
+  admin, reissues no certificate, and reapplies no mutable config over operator
+  changes. Re-running `helm upgrade` is safe for the same reason.
+- **Non-owner behavior.** Because members never receive bootstrap credentials,
+  the bootstrap env (`REDDB_PRESET`, `REDDB_USERNAME`, `REDDB_PASSWORD`,
+  `REDDB_BOOTSTRAP_MANIFEST`) is never rendered into a cluster pod. A non-owner
+  that did observe credentials must wait for / redirect to the owner rather than
+  mutate global auth state.
+
+`scripts/verify-helm-chart.sh` asserts this contract on every render: cluster
+pods carry no bootstrap credentials, `auth.enabled=true` fails closed, and a
+vault certificate is still injectable for unseal.
+
 ## Security
 
 - Non-root UID/GID `10001` by chart default.
@@ -159,7 +197,8 @@ cluster supervisor and range ownership runtime as those pieces mature.
   `auth.enabled=true`, `REDDB_PRESET=production`, `REDDB_USERNAME`, and
   `REDDB_PASSWORD` are rendered only into the writer pod: serverless or primary.
   Replica pods never receive bootstrap credentials, and `mode=cluster` rejects
-  chart-managed auth bootstrap until a concrete writer bootstrap path exists.
+  chart-managed auth bootstrap fail-closed until the reserved global system
+  range owner path lands (see [Cluster bootstrap contract](#cluster-bootstrap-contract)).
 - Vault certificates can be injected through env or mounted file using the
   existing `auth.vault.certificate.fileMount` path.
 - `auth.vault.bootstrapJob.enabled` is disabled fail-closed. The legacy hook

--- a/charts/reddb/templates/_helpers.tpl
+++ b/charts/reddb/templates/_helpers.tpl
@@ -164,7 +164,7 @@ Validate the deployment mode.
 {{- fail "config.file.enabled=true requires config.file.existingConfigMap or non-empty config.file.inline" -}}
 {{- end -}}
 {{- if and (eq .Values.mode "cluster") .Values.auth.enabled -}}
-{{- fail "auth.enabled bootstrap env is not supported in mode=cluster; bootstrap cluster admins only after a concrete writer/volume bootstrap path exists" -}}
+{{- fail "auth.enabled chart-managed bootstrap is not supported in mode=cluster: a symmetric member cannot prove it is the reserved global system range owner (ADR 0058), so the runtime fails closed on a cluster-shaped credentialled boot. This gate keeps the chart fail-closed in lockstep with the runtime until the reserved-range owner path lands (PRD #1227). Run a no-auth/dev cluster, or bootstrap auth on a non-cluster topology. See charts/reddb/README.md (Cluster) and docs/deployment/first-boot.md (Cluster Bootstrap Authority)." -}}
 {{- end -}}
 {{- if .Values.auth.vault.bootstrapJob.enabled -}}
 {{- fail "auth.vault.bootstrapJob.enabled is disabled: the legacy hook bootstraps an emptyDir DB, not the StatefulSet PVC. Run red bootstrap against the real volume or use HTTP bootstrap after the writer starts." -}}

--- a/charts/reddb/values.yaml
+++ b/charts/reddb/values.yaml
@@ -108,8 +108,10 @@ replication:
 # When enabled, the writer pod receives REDDB_PRESET=production plus
 # REDDB_USERNAME / REDDB_PASSWORD so first boot creates the initial admin
 # through the policy-first bootstrap preset. Replica pods never receive
-# these bootstrap env vars. Cluster mode rejects auth.enabled because the
-# current chart renders symmetric members and cannot safely pick one writer.
+# these bootstrap env vars. Cluster mode rejects auth.enabled fail-closed: a
+# symmetric member cannot prove it is the reserved global system range owner
+# (ADR 0058), so the gate stays closed in lockstep with the runtime until the
+# owner path lands (PRD #1227). See README.md "Cluster bootstrap contract".
 auth:
   enabled: false
   username: admin

--- a/docs/deployment/first-boot.md
+++ b/docs/deployment/first-boot.md
@@ -81,6 +81,34 @@ Non-owner members must not run presets, create initial admins, or initialize vau
 
 Anonymous `--no-auth` / `--dev` cluster-shaped boot remains an explicit development carveout, not a production bootstrap path. RedDB Cloud keeps the policy-first manifest model: the reserved range owner applies the cloud/operator manifest as the initial global policy source.
 
+### Helm and Compose Cluster Delivery
+
+The Helm chart (`charts/reddb`) and the Compose example
+(`examples/docker-compose.cluster.yml`) render this contract directly, and
+`scripts/verify-helm-chart.sh` asserts it on every render:
+
+- **No-auth cluster (supported today).** Both deliveries render cluster members
+  as symmetric non-owners with *no* bootstrap credentials
+  (`REDDB_PRESET` / `REDDB_USERNAME` / `REDDB_PASSWORD` /
+  `REDDB_BOOTSTRAP_MANIFEST` are never emitted into a cluster pod). Members boot
+  anonymously and write no admin, vault, or completion marker.
+- **Auth/vault cluster (gated).** `auth.enabled=true` is rejected fail-closed in
+  `mode=cluster` (`helm template` fails with an authority-aware message), in
+  lockstep with the runtime seam, until the reserved-range owner path lands
+  (PRD #1227). For a credentialled deploy today, bootstrap auth on a single-owner
+  topology (standalone/serverless/primary) — e.g. `red bootstrap --vault`
+  against the real volume as in `examples/docker-compose.vault.yml`.
+- **Certificate handling.** A cluster member may still receive the vault
+  certificate (env or `fileMount`) to *unseal* an already-bootstrapped store on
+  restart; receiving a certificate never bootstraps auth. Operators capture the
+  certificate the owner mints once and preserve it offline.
+- **Restart idempotency.** A restart that observes `system.bootstrap.completed`
+  rehydrates read-only state only, so re-running `helm upgrade` or
+  `docker compose up` recreates no admin and reissues no certificate.
+- **Non-owner behavior.** Because members never receive credentials, no member
+  can mutate global auth state; the owner is the only writer once the runtime
+  owner path exists.
+
 ## Config First Boot
 
 Initial config comes from three layers:

--- a/examples/docker-compose.cluster.yml
+++ b/examples/docker-compose.cluster.yml
@@ -2,6 +2,26 @@
 # `red server --role standalone` plus the cluster storage preset; the
 # cluster supervisor consumes the stable identity/discovery contract as it
 # matures.
+#
+# Cluster bootstrap contract (issue #1234, ADR 0058, docs/deployment/first-boot.md):
+#   * No-auth (this file): members are symmetric NON-OWNERS, so they carry NO
+#     bootstrap credentials (no REDDB_USERNAME / REDDB_PASSWORD / REDDB_PRESET /
+#     REDDB_BOOTSTRAP_MANIFEST). They boot anonymously and create no admin,
+#     vault, or `system.bootstrap.completed` marker. This is the documented
+#     development/no-auth carveout, not a credentialled production bootstrap.
+#   * Auth/vault (gated): compose/chart-managed cluster auth bootstrap stays
+#     fail-closed until the reserved global system range owner path lands
+#     (PRD #1227) — a symmetric member cannot prove it is the single writer of
+#     global auth state, and the runtime rejects a cluster-shaped credentialled
+#     boot. For a credentialled deploy today, bootstrap auth on a single-owner
+#     topology (see docker-compose.vault.yml) instead of these members.
+#   * Certificate handling: when the owner path ships, only the proven owner
+#     mints the vault certificate. Capture it once and preserve it offline; a
+#     member may then mount it (REDDB_CERTIFICATE / _FILE) to UNSEAL the existing
+#     store on restart — mounting a certificate never bootstraps auth.
+#   * Restart idempotency: once `system.bootstrap.completed` is durable, restarts
+#     observe the marker and recreate no admin, reissue no certificate, and
+#     reapply no mutable config.
 
 x-reddb-cluster-env: &reddb-cluster-env
   RUST_LOG: info

--- a/scripts/verify-helm-chart.sh
+++ b/scripts/verify-helm-chart.sh
@@ -31,6 +31,24 @@ assert_not_grep() {
   fi
 }
 
+# Render must fail (helm template returns non-zero) AND the captured stderr must
+# contain the expected operator-facing pattern. Used to prove a fail-closed gate
+# rejects an unsupported value combination with a precise message.
+assert_template_fails() {
+  local pattern="$1"
+  shift
+  local err
+  if err="$(helm template smoke "${CHART}" --namespace reddb-test "$@" 2>&1 1>/dev/null)"; then
+    echo "expected 'helm template $*' to fail, but it succeeded" >&2
+    exit 1
+  fi
+  if ! printf '%s' "${err}" | grep -qE "$pattern"; then
+    echo "expected failure message to match: ${pattern}" >&2
+    echo "got: ${err}" >&2
+    exit 1
+  fi
+}
+
 require helm
 
 helm lint "${CHART}"
@@ -65,5 +83,48 @@ assert_grep 'name: smoke-reddb-cluster' "${TMP}/cluster.yaml"
 assert_grep 'name: REDDB_CLUSTER_PEERS' "${TMP}/cluster.yaml"
 assert_grep 'value: "cluster"' "${TMP}/cluster.yaml"
 assert_grep 'name: RED_CLUSTER_HA_INTENT' "${TMP}/cluster.yaml"
+
+# --- Cluster bootstrap contract (issue #1234) ---------------------------------
+# Symmetric cluster members are non-owners: they must never receive auth
+# bootstrap credentials, because a member that is not the reserved global system
+# range owner must not mutate global auth state (ADR 0058 / first-boot.md).
+assert_grep 'value: "cluster-member"' "${TMP}/cluster.yaml"
+assert_not_grep 'name: REDDB_PRESET' "${TMP}/cluster.yaml"
+assert_not_grep 'name: REDDB_USERNAME' "${TMP}/cluster.yaml"
+assert_not_grep 'name: REDDB_PASSWORD' "${TMP}/cluster.yaml"
+assert_not_grep 'name: REDDB_BOOTSTRAP_MANIFEST' "${TMP}/cluster.yaml"
+
+# Chart-managed auth bootstrap stays fail-closed in cluster mode until the
+# runtime reserved-range owner path lands (PRD #1227): rendering must fail with
+# the authority-aware message rather than emit a member that boots into a
+# CrashLoopBackOff on the runtime fail-closed seam.
+assert_template_fails 'reserved global system range owner' \
+  -f "${CHART}/ci/cluster-values.yaml" --set auth.enabled=true
+
+# Certificate handling: a cluster member may still receive the vault certificate
+# (to unseal an already-bootstrapped store), even though it never bootstraps.
+helm template smoke "${CHART}" --namespace reddb-test \
+  -f "${CHART}/ci/cluster-values.yaml" \
+  --set auth.vault.enabled=true \
+  --set auth.vault.certificate.existingSecret=reddb-cluster-cert \
+  >"${TMP}/cluster-vault.yaml"
+assert_grep 'name: REDDB_CERTIFICATE' "${TMP}/cluster-vault.yaml"
+assert_not_grep 'name: REDDB_PASSWORD' "${TMP}/cluster-vault.yaml"
+
+# --- Compose cluster bootstrap contract (issue #1234) -------------------------
+# The Compose cluster example mirrors the Helm contract: symmetric members carry
+# no bootstrap credentials, and the vault example documents the supported
+# single-owner bootstrap path (`red bootstrap` against the real volume).
+COMPOSE_CLUSTER="${ROOT}/examples/docker-compose.cluster.yml"
+COMPOSE_VAULT="${ROOT}/examples/docker-compose.vault.yml"
+# Match the Compose env-assignment form (`KEY:`) so the contract check ignores
+# the explanatory header comment, which names these vars in prose.
+assert_grep 'REDDB_NODE_ROLE: cluster-member' "${COMPOSE_CLUSTER}"
+assert_not_grep 'REDDB_USERNAME:' "${COMPOSE_CLUSTER}"
+assert_not_grep 'REDDB_PASSWORD:' "${COMPOSE_CLUSTER}"
+assert_not_grep 'REDDB_PRESET:' "${COMPOSE_CLUSTER}"
+assert_not_grep 'REDDB_BOOTSTRAP_MANIFEST:' "${COMPOSE_CLUSTER}"
+assert_grep 'print-certificate' "${COMPOSE_VAULT}"
+assert_grep 'Bootstrap the same Docker volume the server will use' "${COMPOSE_VAULT}"
 
 echo "helm chart topology verification passed"


### PR DESCRIPTION
Automated AFK landing for #1234. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1234

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784694532&installation_id=129708444&pr_number=1299&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1299&signature=d713897afb5cd96d842b1385d0ef48b48e8d15a5dadee6f182a0d63fe1567e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->