### PR TITLE
merge: #1235 Add duplicate and concurrent cluster bootstrap drills

### DIFF
--- a/tests/cluster_bootstrap_authority.rs
+++ b/tests/cluster_bootstrap_authority.rs
@@ -10,11 +10,14 @@
 //!   * the explicit `--no-auth` / `--dev` development carveout stays
 //!     allowed and resolves to the skip-all disposition.
 
+use reddb::auth::vault::{KeyPair, Vault, VaultState};
+use reddb::auth::{Role, User};
 use reddb::cluster::{
     authorize_cluster_bootstrap, authorize_vault_bootstrap, AuthBootstrapInput,
     BootstrapDisposition, VaultBootstrapPlan,
 };
 use reddb::operational_bootstrap::{resolve_operational_bootstrap, OperationalBootstrapInput};
+use reddb::storage::engine::pager::{Pager, PagerConfig};
 use reddb::storage::{DeployProfile, StorageDeployPreset};
 
 /// Resolve the storage deploy profile a `REDDB_TOPOLOGY=cluster` boot lands
@@ -260,5 +263,367 @@ fn dev_bypass_cluster_boot_skips_the_vault() {
         let plan =
             authorize_vault_bootstrap(profile, true, AuthBootstrapInput::None, false).unwrap();
         assert_eq!(plan, VaultBootstrapPlan::SkipNoVault);
+    }
+}
+
+// ----- Issue #1235: duplicate and concurrent cluster bootstrap drills -------
+//
+// These drills exercise the supported cluster delivery shape under the two
+// adversarial first-boot conditions PRD #1227 calls out — many symmetric
+// members racing first boot, and a member re-attempting bootstrap after
+// completion — and prove the four safety properties end to end:
+//
+//   1. Concurrent first-boot attempts produce exactly one owner path and no
+//      divergent local auth/vault state on any other member.
+//   2. A restart after a completed cluster bootstrap preserves the same
+//      vault/certificate relationship, admin users, default policies, and
+//      completion marker.
+//   3. A duplicate bootstrap after completion is idempotent: it rotates no
+//      credential and overwrites no config.
+//   4. A cluster-shaped `--no-auth` boot stays anonymous: it creates no
+//      admin, vault, or policy bootstrap state.
+
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+/// How many symmetric members race a single drill. Enough threads to make a
+/// real owner-election race observable while staying cheap in CI.
+const CLUSTER_MEMBERS: usize = 16;
+
+/// Release every member thread at the same instant so the drill exercises a
+/// genuine concurrent race rather than a staggered sequence.
+fn race<T, F>(members: usize, body: F) -> Vec<T>
+where
+    T: Send + 'static,
+    F: Fn(usize) -> T + Send + Sync + 'static,
+{
+    let barrier = Arc::new(Barrier::new(members));
+    let body = Arc::new(body);
+    let handles: Vec<_> = (0..members)
+        .map(|member| {
+            let barrier = Arc::clone(&barrier);
+            let body = Arc::clone(&body);
+            thread::spawn(move || {
+                // All members line up, then boot together.
+                barrier.wait();
+                body(member)
+            })
+        })
+        .collect();
+    handles
+        .into_iter()
+        .map(|h| h.join().expect("member thread panicked"))
+        .collect()
+}
+
+/// A throwaway real (pager-backed) cluster-global auth store, isolated per
+/// drill so the certificate seal exercises the same store on restart — never
+/// an emptyDir/scratch DB, the anti-goal PRD #1227 forbids.
+fn cluster_vault_pager(label: &str) -> (Pager, std::path::PathBuf) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp_dir = std::env::temp_dir().join(format!(
+        "reddb_cluster_drill_{label}_{}_{}",
+        std::process::id(),
+        id
+    ));
+    std::fs::create_dir_all(&tmp_dir).unwrap();
+    let pager = Pager::open(&tmp_dir.join("cluster.rdb"), PagerConfig::default()).unwrap();
+    (pager, tmp_dir)
+}
+
+/// The admin/policy state a completed cluster owner seals into the real store.
+/// `kv` carries the default policy entries: the vault's encrypted key-value
+/// store is the durable home for bootstrap-installed policy material.
+fn completed_owner_state(certificate_master: &[u8]) -> VaultState {
+    let admin = User {
+        username: "admin".into(),
+        tenant_id: None,
+        password_hash: "argon2id$seal$admin".into(),
+        scram_verifier: None,
+        role: Role::Admin,
+        api_keys: vec![],
+        created_at: 1,
+        updated_at: 1,
+        enabled: true,
+    };
+    let operator = User {
+        username: "operator".into(),
+        tenant_id: None,
+        password_hash: "argon2id$seal$operator".into(),
+        scram_verifier: None,
+        role: Role::Write,
+        api_keys: vec![],
+        created_at: 2,
+        updated_at: 2,
+        enabled: true,
+    };
+    let mut kv = std::collections::HashMap::new();
+    kv.insert("red.secret.policy.default".into(), "allow-admin".into());
+    kv.insert("red.secret.policy.readonly".into(), "deny-write".into());
+    VaultState {
+        users: vec![admin, operator],
+        api_keys: vec![],
+        bootstrapped: true,
+        master_secret: Some(certificate_master.to_vec()),
+        kv,
+    }
+}
+
+#[test]
+fn concurrent_cluster_first_boot_elects_no_owner_and_writes_no_divergent_state() {
+    // Acceptance #1: many symmetric members race auth bootstrap on a
+    // cluster-shaped first boot. No owner model exists, so no member can prove
+    // it is the single writer — every concurrent attempt fails closed
+    // identically. Because zero members reach a state-creating disposition, no
+    // divergent local auth state can exist on any member.
+    let profile = cluster_topology_profile();
+    let outcomes = race(CLUSTER_MEMBERS, move |_member| {
+        authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Env, false)
+    });
+
+    let owners = outcomes.iter().filter(|o| o.is_ok()).count();
+    assert_eq!(
+        owners, 0,
+        "no symmetric member may self-elect as the bootstrap owner under a race"
+    );
+    for outcome in &outcomes {
+        let err = outcome.as_ref().unwrap_err();
+        assert!(
+            err.contains("no concrete authority owner"),
+            "every racing member must fail closed, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn concurrent_cluster_first_boot_vault_mints_no_scratch_and_consumes_no_secret() {
+    // Acceptance #1 (vault): the same race against vault first boot. Each
+    // member fails closed before any plan is produced, so no member mints a
+    // scratch or per-member vault and no secret input is consumed by a
+    // non-owner. Covers every auth bootstrap input a member might supply.
+    let profile = cluster_topology_profile();
+    for input in [
+        AuthBootstrapInput::None,
+        AuthBootstrapInput::Env,
+        AuthBootstrapInput::Manifest,
+    ] {
+        let outcomes = race(CLUSTER_MEMBERS, move |_member| {
+            authorize_vault_bootstrap(profile, false, input, false)
+        });
+        for outcome in &outcomes {
+            let err = outcome.as_ref().unwrap_err();
+            assert!(
+                err.contains("no concrete authority owner"),
+                "racing vault first boot must mint no scratch vault, got: {err}"
+            );
+        }
+    }
+}
+
+#[test]
+fn concurrent_attempts_after_completion_converge_idempotently() {
+    // Acceptance #1 + #3: once the owner has published the durable completion
+    // marker, a swarm of members (including the original owner's restart and
+    // duplicate re-attempts) race the authority path. Every member observes
+    // the one owner's completed state — `AlreadyComplete` — and the vault plan
+    // is unseal-only, so no member rotates or re-mints the shared vault.
+    let profile = cluster_topology_profile();
+    let auth = race(CLUSTER_MEMBERS, move |_member| {
+        authorize_cluster_bootstrap(profile, false, AuthBootstrapInput::Manifest, true)
+    });
+    for outcome in &auth {
+        assert_eq!(
+            outcome.as_ref().unwrap(),
+            &BootstrapDisposition::AlreadyComplete,
+            "every post-completion member must converge on the completed state"
+        );
+    }
+
+    let vault = race(CLUSTER_MEMBERS, move |_member| {
+        authorize_vault_bootstrap(profile, false, AuthBootstrapInput::Manifest, true)
+    });
+    for outcome in &vault {
+        assert_eq!(
+            outcome.as_ref().unwrap(),
+            &VaultBootstrapPlan::OpenClusterGlobalStore {
+                consume_secret_inputs: false,
+            },
+            "post-completion members unseal the shared store without rotating it"
+        );
+    }
+}
+
+#[test]
+fn restart_after_cluster_bootstrap_preserves_vault_admins_policies_and_marker() {
+    // Acceptance #2: a restart after a completed cluster bootstrap reopens the
+    // same real cluster-global store with the emitted certificate and finds
+    // the identical vault/certificate relationship, admin users, default
+    // policies, master secret, and completion marker — nothing re-minted.
+    let (pager, tmp_dir) = cluster_vault_pager("restart");
+
+    // Owner first boot: mint the certificate and seal the real store.
+    let kp = KeyPair::generate();
+    let owner_state = completed_owner_state(&kp.master_secret);
+    let vault = Vault::with_certificate_bytes(&pager, &kp.certificate).unwrap();
+    vault.save(&pager, &owner_state).unwrap();
+
+    // Restart lands on the unseal-only plan (no secret consumed → no rotation).
+    let restart_plan = authorize_vault_bootstrap(
+        cluster_topology_profile(),
+        false,
+        AuthBootstrapInput::Manifest,
+        true,
+    )
+    .unwrap();
+    assert_eq!(
+        restart_plan,
+        VaultBootstrapPlan::OpenClusterGlobalStore {
+            consume_secret_inputs: false,
+        }
+    );
+
+    // The same certificate unseals the same store; the sealed state is intact.
+    let reopened = Vault::with_certificate(&pager, &kp.certificate_hex()).unwrap();
+    let loaded = reopened.load(&pager).unwrap().unwrap();
+
+    assert!(
+        loaded.bootstrapped,
+        "completion marker must survive restart"
+    );
+    assert_eq!(
+        loaded.master_secret.as_deref(),
+        Some(kp.master_secret.as_slice()),
+        "the same certificate/master-secret relationship must survive restart"
+    );
+
+    let mut admins: Vec<_> = loaded
+        .users
+        .iter()
+        .filter(|u| matches!(u.role, Role::Admin))
+        .map(|u| u.username.clone())
+        .collect();
+    admins.sort();
+    assert_eq!(admins, vec!["admin".to_string()], "admin user must persist");
+    assert_eq!(loaded.users.len(), 2, "no bootstrap user may be dropped");
+
+    assert_eq!(
+        loaded
+            .kv
+            .get("red.secret.policy.default")
+            .map(String::as_str),
+        Some("allow-admin"),
+        "default policy material must persist unchanged"
+    );
+    assert_eq!(
+        loaded
+            .kv
+            .get("red.secret.policy.readonly")
+            .map(String::as_str),
+        Some("deny-write"),
+        "default policy material must persist unchanged"
+    );
+
+    drop(pager);
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn duplicate_bootstrap_after_completion_rotates_no_credential_and_overwrites_no_config() {
+    // Acceptance #3: a duplicate bootstrap re-attempt after completion resolves
+    // to the unseal-only plan and therefore consumes no secret input. The
+    // certificate is not rotated and the sealed config (users + policies) is
+    // not overwritten — the duplicate boot observes byte-identical state.
+    let (pager, tmp_dir) = cluster_vault_pager("duplicate");
+
+    let kp = KeyPair::generate();
+    let original = completed_owner_state(&kp.master_secret);
+    let vault = Vault::with_certificate_bytes(&pager, &kp.certificate).unwrap();
+    vault.save(&pager, &original).unwrap();
+
+    // Duplicate bootstrap attempt: operator re-supplies a manifest on a boot
+    // that already completed. The plan must not consume the re-supplied secret.
+    let dup_plan = authorize_vault_bootstrap(
+        cluster_topology_profile(),
+        false,
+        AuthBootstrapInput::Manifest,
+        true,
+    )
+    .unwrap();
+    assert_eq!(
+        dup_plan,
+        VaultBootstrapPlan::OpenClusterGlobalStore {
+            consume_secret_inputs: false,
+        },
+        "a duplicate boot must not consume secret inputs (no rotation)"
+    );
+
+    // Because no secret is consumed, the existing certificate still unseals the
+    // store and the persisted state is unchanged from first boot.
+    let reopened = Vault::with_certificate(&pager, &kp.certificate_hex()).unwrap();
+    let after = reopened.load(&pager).unwrap().unwrap();
+    assert_eq!(
+        after.master_secret.as_deref(),
+        Some(kp.master_secret.as_slice()),
+        "duplicate boot must not rotate the certificate/master secret"
+    );
+    // Compare sealed config field-by-field (the serialized form orders the KV
+    // map non-deterministically, so a byte compare would flake).
+    assert!(after.bootstrapped, "completion marker must not be cleared");
+    let user_ident = |s: &VaultState| {
+        let mut idents: Vec<_> = s
+            .users
+            .iter()
+            .map(|u| (u.username.clone(), u.role.as_str(), u.enabled))
+            .collect();
+        idents.sort();
+        idents
+    };
+    assert_eq!(
+        user_ident(&after),
+        user_ident(&original),
+        "duplicate boot must overwrite no admin/operator user"
+    );
+    assert_eq!(
+        after.kv, original.kv,
+        "duplicate boot must overwrite no default policy material"
+    );
+
+    drop(pager);
+    let _ = std::fs::remove_dir_all(&tmp_dir);
+}
+
+#[test]
+fn cluster_no_auth_boot_creates_no_admin_vault_or_policy_state() {
+    // Acceptance #4: a cluster-shaped `--no-auth` boot stays intentionally
+    // anonymous across both cluster-shaped paths and under a concurrent race.
+    // The auth disposition skips every bootstrap path and the vault plan opens
+    // no store, so no admin, vault, or policy state is ever created.
+    for profile in [
+        cluster_topology_profile(),
+        StorageDeployPreset::Cluster.selection().deploy_profile,
+    ] {
+        let auth = race(CLUSTER_MEMBERS, move |_member| {
+            authorize_cluster_bootstrap(profile, true, AuthBootstrapInput::None, false)
+        });
+        for outcome in &auth {
+            assert_eq!(
+                outcome.as_ref().unwrap(),
+                &BootstrapDisposition::SkipDevBypass,
+                "cluster --no-auth must skip every auth/bootstrap path"
+            );
+        }
+
+        let vault = race(CLUSTER_MEMBERS, move |_member| {
+            authorize_vault_bootstrap(profile, true, AuthBootstrapInput::None, false)
+        });
+        for outcome in &vault {
+            assert_eq!(
+                outcome.as_ref().unwrap(),
+                &VaultBootstrapPlan::SkipNoVault,
+                "cluster --no-auth must open no vault and mint no certificate"
+            );
+        }
     }
 }


### PR DESCRIPTION
Automated AFK landing for #1235. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1235

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784699998&installation_id=129708444&pr_number=1300&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1300&signature=0e5bf67c852351d0f4623d013850a3634c427a007e9a6133531571b72f75c013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->