### PR TITLE
chore: changeset for 1.12.0 (minor)

### DIFF
--- a/.changeset/minor-1-12-0.md
+++ b/.changeset/minor-1-12-0.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/cli": minor
+---
+
+Cluster bootstrap & operational telemetry groundwork.
+
+- **Cluster bootstrap authority**: fail-closed seam for cluster-shaped auth bootstrap (#1229), real auth-store wiring for cluster vault first boot (#1231), write-if-absent initial config on fenced bootstrap manifest apply (#1232), bootstrap-completion marker observed at boot through the authority seam (#1230), and cloud policy-first bootstrap manifest protections (#1233).
+- **Helm/Compose**: cluster bootstrap contract documented and render-checked; cluster members carry no bootstrap credentials, gated cluster auth/vault path with fail-closed messaging (#1234), plus duplicate/concurrent bootstrap drills (#1235).
+- **Durability**: collision-proof WAL backup temp paths so segment digests stay honest (#1294).
+- **Operational telemetry**: Phase-0 substrate contract (ADR 0060) defining the store/read-model boundary, retention/cardinality budgets, and redaction rules ahead of the metric slices (#1247).
+- **Process**: binding merge gate + green ratchet on `main` (ADR 0059, #975).


### PR DESCRIPTION
Adds the changeset that triggers the 1.11.0 → 1.12.0 minor release.

Docs/version-only PR; `ci.yml` is `paths-ignore`'d for `**.md`, so the required checks can't run (see #1307) — landed via lift-protection-per-fix.

https://claude.ai/code/session_0129P5gqSNeZz9fCxwBFvQFR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784722427&installation_id=129708444&pr_number=1308&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1308&signature=e0b8cb8cd538b09b6c2c02a60301d89d55054aacf7d1e43e421d7855bee9a441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->