### PR TITLE
ci: nextest test suite + release-candidate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,9 @@ jobs:
           workspaces: |
             . -> target
             . -> target/persistent-tests
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Prepare isolated temp dir
         run: |
           mkdir -p "$RUNNER_TEMP/reddb-test-suite-tmp"
@@ -367,8 +370,15 @@ jobs:
         run: cargo build --locked --bin red_client -p reddb-io-client --no-default-features
       - name: red_client size budget
         run: ./scripts/check-red-client-size.sh
-      - name: Run default test layer
-        run: cargo test --locked --verbose
+      - name: Run default test layer (nextest — parallel across test binaries)
+        # cargo test runs the grouped integration binaries sequentially, so the
+        # per-test sleeps (replication/timing tests) sum and blew past the 20m
+        # cap. nextest runs every test in a global parallel process pool (sleeps
+        # overlap) and the `ci` profile enforces a hard per-test timeout
+        # (.config/nextest.toml) so a hung test is killed, not the whole run.
+        run: cargo nextest run --workspace --locked --profile ci
+      - name: Doctests (nextest does not execute doctests)
+        run: cargo test --workspace --locked --doc
       - name: Run persistent multimodel layer
         env:
           CARGO_TARGET_DIR: target/persistent-tests

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,0 +1,178 @@
+name: Release Candidate
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG**'
+      - 'LICENSE**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+# New pushes to main cancel the in-flight RC — only the latest commit matters.
+concurrency:
+  group: release-candidate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  plan:
+    name: Plan
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: github.actor != 'dependabot[bot]'
+    outputs:
+      should_skip: ${{ steps.plan.outputs.should_skip }}
+      rc_version: ${{ steps.plan.outputs.rc_version }}
+      rc_tag: ${{ steps.plan.outputs.rc_tag }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compute release candidate version
+        id: plan
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          COMMIT_MSG="${HEAD_COMMIT_MESSAGE:-}"
+          SHOULD_SKIP=false
+
+          # Skip release-bot commits and explicit [skip rc] marker.
+          if [[ "$COMMIT_MSG" =~ ^chore:\ release ]] \
+            || [[ "$COMMIT_MSG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || [[ "$COMMIT_MSG" == *"[skip rc]"* ]]; then
+            SHOULD_SKIP=true
+          fi
+
+          BASE_VERSION=$(awk -F'"' '/^version = / {print $2; exit}' Cargo.toml)
+          RC_VERSION="${BASE_VERSION}-rc.${GITHUB_RUN_NUMBER}"
+          RC_TAG="v${RC_VERSION}"
+
+          echo "should_skip=${SHOULD_SKIP}" >> "$GITHUB_OUTPUT"
+          echo "rc_version=${RC_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "rc_tag=${RC_TAG}" >> "$GITHUB_OUTPUT"
+
+  build-linux:
+    name: Build Linux x86_64
+    needs: [plan]
+    if: needs.plan.outputs.should_skip != 'true'
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rc-linux-x86_64
+          cache-on-failure: "true"
+
+      - name: Build (release-fast)
+        env:
+          SCCACHE_GHA_ENABLED: "true"
+          RUSTC_WRAPPER: sccache
+        run: |
+          cargo build --locked --profile release-fast --bin red
+          cargo build --locked --profile release-fast --bin red_client -p reddb-io-client --no-default-features
+
+      - name: Strip
+        run: |
+          strip target/release-fast/red
+          strip target/release-fast/red_client
+
+      - name: Package
+        run: |
+          cp target/release-fast/red red-linux-x86_64
+          cp target/release-fast/red_client red_client-linux-x86_64
+          shasum -a 256 red-linux-x86_64 > red-linux-x86_64.sha256
+          shasum -a 256 red_client-linux-x86_64 > red_client-linux-x86_64.sha256
+
+      - name: Smoke test
+        run: |
+          ./red-linux-x86_64 version
+          set +e; ./red_client-linux-x86_64; rc=$?; set -e
+          [[ "$rc" == "1" ]] || { echo "red_client smoke: expected exit 1, got $rc"; exit 1; }
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux-x86_64
+          path: |
+            red-linux-x86_64
+            red-linux-x86_64.sha256
+            red_client-linux-x86_64
+            red_client-linux-x86_64.sha256
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  publish-github:
+    name: GitHub Pre-release
+    needs: [plan, build-linux]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          path: release
+          merge-multiple: true
+
+      - name: Create pre-release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.plan.outputs.rc_tag }}
+          name: RedDB ${{ needs.plan.outputs.rc_tag }}
+          prerelease: true
+          body: |
+            Release candidate built from `${{ github.sha }}` with `--profile release-fast`.
+
+            **Not for production use.** Linux x86_64 binary only.
+
+            ```bash
+            # Server + embedded engine
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red-linux-x86_64 -o red && chmod +x red
+
+            # Thin remote-only client
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red_client-linux-x86_64 -o red_client && chmod +x red_client
+            ```
+          files: release/*
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-npm:
+    name: Publish npm @rc
+    needs: [plan, publish-github]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Set RC version in package.json
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${RC_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::warning::NPM_TOKEN not set — skipping npm @rc publish."
+            exit 0
+          fi
+          pnpm publish --tag rc --access public --no-git-checks

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -72,6 +72,20 @@ jobs:
           version: '28.3'
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: rui314/setup-mold@v1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Sync RC version across all manifests
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${RC_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          node scripts/sync-version.js
+          bash scripts/check-versions.sh
+
+      - name: Regenerate lockfile after version sync
+        run: cargo generate-lockfile
+
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rc-linux-x86_64
@@ -82,8 +96,8 @@ jobs:
           SCCACHE_GHA_ENABLED: "true"
           RUSTC_WRAPPER: sccache
         run: |
-          cargo build --locked --profile release-fast --bin red
-          cargo build --locked --profile release-fast --bin red_client -p reddb-io-client --no-default-features
+          cargo build --profile release-fast --bin red
+          cargo build --profile release-fast --bin red_client -p reddb-io-client --no-default-features
 
       - name: Strip
         run: |
@@ -150,7 +164,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
   publish-npm:
-    name: Publish npm @rc
+    name: Publish npm packages @rc
     needs: [plan, publish-github]
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
@@ -162,12 +176,14 @@ jobs:
       - name: Enable pnpm
         run: corepack enable
 
-      - name: Set RC version in package.json
+      - name: Sync RC version across all manifests
         run: |
           RC_VERSION="${{ needs.plan.outputs.rc_version }}"
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${RC_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          node scripts/sync-version.js
+          bash scripts/check-versions.sh
 
-      - name: Publish
+      - name: Publish all public packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
@@ -175,4 +191,65 @@ jobs:
             echo "::warning::NPM_TOKEN not set — skipping npm @rc publish."
             exit 0
           fi
-          pnpm publish --tag rc --access public --no-git-checks
+          for PKG_DIR in . drivers/js drivers/js-client drivers/bun; do
+            echo "==> publishing ${PKG_DIR}"
+            pnpm publish --filter "./${PKG_DIR}" --tag rc --access public --no-git-checks
+          done
+
+  publish-cargo:
+    name: Publish crates @rc
+    needs: [plan, build-linux]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Sync RC version across all manifests
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${RC_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+          node scripts/sync-version.js
+          bash scripts/check-versions.sh
+
+      - name: Regenerate lockfile after version sync
+        run: cargo generate-lockfile
+
+      - name: Publish workspace crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "::warning::CARGO_REGISTRY_TOKEN not set — skipping crates.io @rc publish."
+            exit 0
+          fi
+
+          publish_one() {
+            local crate="$1"
+            echo "==> publish ${crate}@${{ needs.plan.outputs.rc_version }}"
+            local out
+            out=$(cargo publish --allow-dirty --no-verify -p "$crate" 2>&1) && { echo "$out"; return 0; }
+            if echo "$out" | grep -qE "already uploaded|already exists"; then
+              echo "  ${crate} already on crates.io — skipping"
+            else
+              echo "$out" >&2
+              return 1
+            fi
+          }
+
+          publish_one reddb-io-types
+          publish_one reddb-io-crypto
+          publish_one reddb-io-file
+          publish_one reddb-io-rql
+          publish_one reddb-io-wire
+          publish_one reddb-io-grpc-proto
+          publish_one reddb-io-client-connector
+          publish_one reddb-io-server
+          publish_one reddb-io-client
+          publish_one reddb-io


### PR DESCRIPTION
## Problem

The `Test Suite` job times out at the 20-minute cap (run [27983689966](https://github.com/reddb-io/reddb/actions/runs/27983689966)). Diagnosis from the log:

- **Build:** ~1 min (sccache cache hit) — never the bottleneck.
- **Execution:** ~19 min and killed mid-run. `cargo test` runs the **12 grouped integration binaries sequentially**, so the per-test sleeps (81× `from_secs(5)`, 19× `from_secs(10)`, 6× `from_secs(15)` across 1440 tests) **sum** instead of overlapping.

## Fix

The repo already ships full nextest support (issue #973): `.config/nextest.toml` (hard per-test timeout + `ci` profile with retries/JUnit), Makefile lanes, and a shard script — but **CI never used it**. This PR points the Test Suite step at `cargo nextest run --workspace --locked --profile ci`:

- Runs every test in a **global parallel process pool** → sleeps overlap → wall-clock drops sharply.
- **Per-test timeout** kills a hung test instead of stalling (and failing) the whole job.
- Adds a `cargo test --doc` step since nextest does not execute doctests.

## Verify

This PR's own `Test Suite` run is the measurement — compare its wall-clock against the 20m timeout. Follow-up (not in this PR): shard the e2e lane across a matrix via the existing `scripts/nextest-e2e-shard.sh` for further speedup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784763663&installation_id=129708444&pr_number=1327&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1327&signature=84eacef22ad5fed648a870729d9df76790c67eadf3e3c0fbd187eb2a8f37c2f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline efficiency through parallel test execution
  * Updated test workflow to execute documentation tests separately from unit tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->