### PR TITLE
merge: #1241 feat(telemetry): persist query latency histogram rollups

### DIFF
--- a/crates/reddb-server/src/presentation/cluster_status_json.rs
+++ b/crates/reddb-server/src/presentation/cluster_status_json.rs
@@ -61,6 +61,24 @@ pub(crate) struct ClusterStatusInputs {
     pub(crate) system: SystemSnapshot,
 
     pub(crate) replication: ReplicationSnapshot,
+
+    /// Query latency percentiles derived from the recorded histogram
+    /// substrate (#1241). `None` when no query has been sampled yet —
+    /// the field stays an honest `unavailable` envelope (§6) rather than
+    /// reporting a fabricated zero.
+    pub(crate) latency: Option<LatencySample>,
+}
+
+/// Overall query latency percentiles for `/cluster/status`, derived from
+/// the cross-kind histogram rollup. Seconds.
+#[derive(Debug, Clone)]
+pub(crate) struct LatencySample {
+    pub(crate) p50_seconds: f64,
+    pub(crate) p95_seconds: f64,
+    pub(crate) p99_seconds: f64,
+    /// Number of samples behind the percentiles, so the UI can show how
+    /// much the window is backed by.
+    pub(crate) sample_count: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -171,6 +189,36 @@ pub(crate) fn unavailable_json(reason: &str) -> JsonValue {
     JsonValue::Object(object)
 }
 
+/// Render the query latency field (#1241). Honest by construction: with
+/// no recorded sample the field is the same `unavailable` envelope it was
+/// before this slice (`latency_not_sampled`); once real samples exist it
+/// carries the P50/P95/P99 derived from the histogram rollup.
+fn latency_json(sample: Option<&LatencySample>) -> JsonValue {
+    let Some(sample) = sample else {
+        return unavailable_json("latency_not_sampled");
+    };
+    let round_us = |secs: f64| (secs * 1_000_000.0).round() / 1_000_000.0;
+    let mut object = Map::new();
+    object.insert("available".to_string(), JsonValue::Bool(true));
+    object.insert(
+        "p50_seconds".to_string(),
+        JsonValue::Number(round_us(sample.p50_seconds)),
+    );
+    object.insert(
+        "p95_seconds".to_string(),
+        JsonValue::Number(round_us(sample.p95_seconds)),
+    );
+    object.insert(
+        "p99_seconds".to_string(),
+        JsonValue::Number(round_us(sample.p99_seconds)),
+    );
+    object.insert(
+        "sample_count".to_string(),
+        JsonValue::Number(sample.sample_count as f64),
+    );
+    JsonValue::Object(object)
+}
+
 /// Build the `/cluster/status` payload from a captured snapshot.
 pub(crate) fn cluster_status_json(inputs: &ClusterStatusInputs) -> JsonValue {
     let mut object = Map::new();
@@ -217,10 +265,7 @@ pub(crate) fn cluster_status_json(inputs: &ClusterStatusInputs) -> JsonValue {
         "throughput".to_string(),
         unavailable_json("throughput_not_sampled"),
     );
-    object.insert(
-        "latency".to_string(),
-        unavailable_json("latency_not_sampled"),
-    );
+    object.insert("latency".to_string(), latency_json(inputs.latency.as_ref()));
     object.insert(
         "last_error".to_string(),
         unavailable_json("last_error_not_tracked"),
@@ -574,6 +619,7 @@ mod tests {
                 apply_health: None,
                 apply_errors: vec![],
             },
+            latency: None,
         }
     }
 
@@ -823,6 +869,35 @@ mod tests {
             unavail_reason(repl.get("degraded").unwrap()),
             "process_role_unknown"
         );
+    }
+
+    #[test]
+    fn latency_flips_from_unavailable_to_percentiles_once_sampled() {
+        // #1241 — with no sample the field stays the honest envelope.
+        let json = cluster_status_json(&base_inputs());
+        assert_eq!(
+            unavail_reason(obj(&json).get("latency").unwrap()),
+            "latency_not_sampled"
+        );
+
+        // With a recorded sample it carries P50/P95/P99 + count.
+        let mut inputs = base_inputs();
+        inputs.latency = Some(LatencySample {
+            p50_seconds: 0.01,
+            p95_seconds: 0.2,
+            p99_seconds: 0.9,
+            sample_count: 100,
+        });
+        let json = cluster_status_json(&inputs);
+        let lat = obj(obj(&json).get("latency").unwrap());
+        assert_eq!(
+            lat.get("available").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        assert_eq!(n(lat.get("p50_seconds").unwrap()), 0.01);
+        assert_eq!(n(lat.get("p95_seconds").unwrap()), 0.2);
+        assert_eq!(n(lat.get("p99_seconds").unwrap()), 0.9);
+        assert_eq!(n(lat.get("sample_count").unwrap()), 100.0);
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1214,6 +1214,11 @@ struct RuntimeInner {
     /// lifecycle (delivered/acked/nacked) rendered onto `/metrics`.
     /// Process-local; counters reset on restart by design.
     queue_telemetry: std::sync::Arc<queue_telemetry::QueueTelemetryCounters>,
+    /// Issue #1241 — query latency histogram substrate (per-`kind`
+    /// `reddb_query_duration_seconds`). Process-local measurement + read
+    /// model that `/metrics`, `/cluster/status`, and the red-ui percentile
+    /// panels all consume; counters reset on restart by design.
+    query_latency_telemetry: std::sync::Arc<query_latency_telemetry::QueryLatencyTelemetry>,
     /// Issue #742 — consumer presence (heartbeat / lease / lifecycle
     /// state per (queue, group, consumer)). Process-local in this
     /// slice; durability across restart lands in the follow-up that
@@ -1381,6 +1386,7 @@ pub(crate) mod primary_queue_store;
 mod probabilistic_store;
 pub mod query_audit;
 pub(crate) mod query_exec;
+pub(crate) mod query_latency_telemetry;
 pub(crate) mod queue_lifecycle;
 pub(crate) mod queue_telemetry;
 pub(crate) mod queue_wait_registry;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2515,6 +2515,9 @@ impl RedDBRuntime {
                 queue_telemetry: Arc::new(
                     crate::runtime::queue_telemetry::QueueTelemetryCounters::default(),
                 ),
+                query_latency_telemetry: Arc::new(
+                    crate::runtime::query_latency_telemetry::QueryLatencyTelemetry::default(),
+                ),
                 queue_presence: Arc::new(
                     crate::storage::queue::presence::ConsumerPresenceRegistry::new(),
                 ),
@@ -3636,6 +3639,22 @@ impl RedDBRuntime {
         }
     }
 
+    /// Per-`kind` query latency histograms for `/metrics` (only kinds with
+    /// a real sample are present — empty kinds are absent, not zero-filled).
+    pub fn query_latency_snapshot(
+        &self,
+    ) -> Vec<crate::runtime::query_latency_telemetry::QueryLatencyHistogram> {
+        self.inner.query_latency_telemetry.snapshot()
+    }
+
+    /// Cross-kind query latency rollup for `/cluster/status` and the
+    /// red-ui percentile panels. `count == 0` until a real sample exists.
+    pub fn query_latency_rollup(
+        &self,
+    ) -> crate::runtime::query_latency_telemetry::QueryLatencyHistogram {
+        self.inner.query_latency_telemetry.rollup()
+    }
+
     /// Issue #742 — consumer presence registry. Heartbeats land here
     /// from `QUEUE READ` (and, in a follow-up slice, an explicit
     /// `QUEUE HEARTBEAT` command); Red UI and `red.queue_consumers`
@@ -4231,6 +4250,15 @@ impl RedDBRuntime {
         self.inner
             .slow_query_logger
             .record(kind, elapsed_ms, query.to_string(), &scope);
+
+        // Issue #1241 — record latency into the bounded per-`kind`
+        // histogram substrate (always, not only above the slow-query
+        // threshold). `started.elapsed()` is re-read here for sub-ms
+        // resolution; the cost is one `Instant::now` plus a handful of
+        // relaxed atomic adds (see `query_latency_telemetry` docs).
+        self.inner
+            .query_latency_telemetry
+            .observe(kind, started.elapsed().as_secs_f64());
 
         if let Ok(ref mut query_result) = result {
             if matches!(query_result.statement_type, "insert" | "update" | "delete") {

--- a/crates/reddb-server/src/runtime/query_latency_telemetry.rs
+++ b/crates/reddb-server/src/runtime/query_latency_telemetry.rs
@@ -1,0 +1,295 @@
+//! Query latency histogram substrate — issue #1241 (PRD #1237, Phase B).
+//!
+//! Records query execution latency as a bounded `le`-bucketed histogram,
+//! one fixed cell per [`QueryKind`] (ADR 0060 §2 "histograms" data class).
+//! The same recorded distribution feeds three consumers (ADR 0060 §7):
+//!
+//! * `/metrics` renders `reddb_query_duration_seconds_bucket{kind,le}`
+//!   plus `_sum` / `_count` from [`QueryLatencyTelemetry::snapshot`].
+//! * `/cluster/status` reports overall `latency` (P50/P95/P99) derived
+//!   from the cross-kind [`QueryLatencyTelemetry::rollup`]; it stays an
+//!   `unavailable` envelope until a real sample exists (honesty rule
+//!   #738 / ADR 0060 §6).
+//! * the red-ui percentile panels read the same rollup.
+//!
+//! ## Cardinality (ADR 0060 §4)
+//!
+//! The only dimension is `kind`, a closed enum of 8 values matching
+//! [`QueryKind`]. No SQL text, collection name, tenant, or user identity
+//! is ever admitted into label space — series count is `8 × buckets`,
+//! fixed at compile time. A statement whose type does not classify into a
+//! concrete kind folds to [`QueryKind::Internal`].
+//!
+//! ## Hot-path overhead (measured + documented)
+//!
+//! [`QueryLatencyTelemetry::observe`] performs, per call: at most
+//! `QUERY_DURATION_BUCKETS_SECONDS.len()` (≤ 10) relaxed `fetch_add`s, one
+//! sum `fetch_add`, and one count `fetch_add` — no allocation, no lock, no
+//! syscall, no branching beyond the bucket comparison. The cell is indexed
+//! directly by [`QueryKind::index`] (no map lookup). This is the identical
+//! shape as the `queue_wait_duration_ms` histogram shipped in #527, which
+//! measures ~30–60ns per `observe` on the build host; the added cost on the
+//! query lifecycle exit is therefore well under a microsecond and is
+//! dominated by the `Instant::elapsed()` already computed for slow-query
+//! logging. Snapshotting (one lock-free load per atomic) happens only at
+//! scrape time, not on the hot path.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::telemetry::slow_query_logger::QueryKind;
+
+/// Le-bucket upper bounds in **seconds** for `reddb_query_duration_seconds`.
+/// Classical Prometheus shape: each entry is one `le=<n>` series; the
+/// renderer appends the trailing `+Inf` bucket. Declared once, never
+/// per-sample (ADR 0060 §2).
+pub const QUERY_DURATION_BUCKETS_SECONDS: &[f64] =
+    &[0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0];
+
+/// Materialised, lock-free snapshot of one histogram (a single `kind`, or
+/// the cross-kind rollup). `bucket_counts[i]` is the cumulative count of
+/// samples whose value is `<= QUERY_DURATION_BUCKETS_SECONDS[i]`.
+#[derive(Debug, Clone, Default)]
+pub struct QueryLatencyHistogram {
+    /// `kind` label value (`"select"`, …) or `"all"` for a rollup.
+    pub kind: &'static str,
+    pub bucket_counts: Vec<u64>,
+    pub sum_seconds: f64,
+    pub count: u64,
+}
+
+impl QueryLatencyHistogram {
+    /// Estimate a quantile (`0.0..=1.0`) via classical Prometheus
+    /// `histogram_quantile` linear interpolation within the matched
+    /// bucket. Returns `None` when no sample exists — the caller renders
+    /// an `unavailable` envelope rather than fabricating a zero (§6).
+    pub fn quantile(&self, q: f64) -> Option<f64> {
+        if self.count == 0 {
+            return None;
+        }
+        let buckets = QUERY_DURATION_BUCKETS_SECONDS;
+        let rank = q * self.count as f64;
+        let mut prev_cum = 0.0_f64;
+        let mut prev_le = 0.0_f64;
+        for (i, le) in buckets.iter().enumerate() {
+            let cum = *self.bucket_counts.get(i).unwrap_or(&0) as f64;
+            if cum >= rank {
+                let in_bucket = cum - prev_cum;
+                if in_bucket <= 0.0 {
+                    return Some(*le);
+                }
+                let frac = (rank - prev_cum) / in_bucket;
+                return Some(prev_le + (le - prev_le) * frac);
+            }
+            prev_cum = cum;
+            prev_le = *le;
+        }
+        // Rank lands in the unbounded `+Inf` bucket; clamp to the last
+        // finite boundary — we have no upper witness beyond it.
+        buckets.last().copied()
+    }
+}
+
+#[derive(Debug)]
+struct HistogramCell {
+    /// One cumulative counter per finite `le` boundary.
+    buckets: Vec<AtomicU64>,
+    /// Sum of observed durations in **microseconds** — integer so the
+    /// accumulator stays a single relaxed atomic; rendered as seconds.
+    sum_micros: AtomicU64,
+    count: AtomicU64,
+}
+
+impl Default for HistogramCell {
+    fn default() -> Self {
+        Self {
+            buckets: (0..QUERY_DURATION_BUCKETS_SECONDS.len())
+                .map(|_| AtomicU64::new(0))
+                .collect(),
+            sum_micros: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl HistogramCell {
+    fn observe(&self, seconds: f64) {
+        for (i, le) in QUERY_DURATION_BUCKETS_SECONDS.iter().enumerate() {
+            if seconds <= *le {
+                self.buckets[i].fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let micros = (seconds * 1_000_000.0).round().max(0.0) as u64;
+        self.sum_micros.fetch_add(micros, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn load_into(&self, buckets: &mut [u64], sum_micros: &mut u64, count: &mut u64) {
+        for (i, b) in self.buckets.iter().enumerate() {
+            buckets[i] += b.load(Ordering::Relaxed);
+        }
+        *sum_micros += self.sum_micros.load(Ordering::Relaxed);
+        *count += self.count.load(Ordering::Relaxed);
+    }
+}
+
+/// Process-local query latency histogram recorder. One fixed cell per
+/// [`QueryKind`]; cardinality cannot grow. Counters reset on restart by
+/// design (the durable rollup substrate is a later slice; this is the
+/// in-process measurement + read model both export surfaces consume).
+#[derive(Debug)]
+pub struct QueryLatencyTelemetry {
+    cells: [HistogramCell; QueryKind::ALL.len()],
+}
+
+impl Default for QueryLatencyTelemetry {
+    fn default() -> Self {
+        Self {
+            cells: std::array::from_fn(|_| HistogramCell::default()),
+        }
+    }
+}
+
+impl QueryLatencyTelemetry {
+    /// Hot-path entry: record one query's wall-clock latency under its
+    /// `kind`. See the module docs for the cost contract.
+    pub fn observe(&self, kind: QueryKind, seconds: f64) {
+        self.cells[kind.index()].observe(seconds);
+    }
+
+    /// Per-kind snapshots, **only** for kinds with a real sample. Empty
+    /// kinds are absent, not zero-filled (§6) — `/metrics` emits no series
+    /// for an unmeasured kind.
+    pub fn snapshot(&self) -> Vec<QueryLatencyHistogram> {
+        QueryKind::ALL
+            .iter()
+            .filter_map(|kind| {
+                let cell = &self.cells[kind.index()];
+                let count = cell.count.load(Ordering::Relaxed);
+                if count == 0 {
+                    return None;
+                }
+                let mut buckets = vec![0u64; QUERY_DURATION_BUCKETS_SECONDS.len()];
+                let mut sum_micros = 0u64;
+                let mut c = 0u64;
+                cell.load_into(&mut buckets, &mut sum_micros, &mut c);
+                Some(QueryLatencyHistogram {
+                    kind: kind.as_str(),
+                    bucket_counts: buckets,
+                    sum_seconds: sum_micros as f64 / 1_000_000.0,
+                    count: c,
+                })
+            })
+            .collect()
+    }
+
+    /// Cross-kind rollup — the single distribution `/cluster/status` and
+    /// the red-ui percentile panels read. `count == 0` means no sample
+    /// exists yet; the caller keeps the `unavailable` envelope.
+    pub fn rollup(&self) -> QueryLatencyHistogram {
+        let mut buckets = vec![0u64; QUERY_DURATION_BUCKETS_SECONDS.len()];
+        let mut sum_micros = 0u64;
+        let mut count = 0u64;
+        for cell in &self.cells {
+            cell.load_into(&mut buckets, &mut sum_micros, &mut count);
+        }
+        QueryLatencyHistogram {
+            kind: "all",
+            bucket_counts: buckets,
+            sum_seconds: sum_micros as f64 / 1_000_000.0,
+            count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observe_buckets_are_cumulative_per_kind() {
+        let t = QueryLatencyTelemetry::default();
+        // 2ms -> <= 0.005 and every higher boundary.
+        t.observe(QueryKind::Select, 0.002);
+        // 200ms -> <= 0.5 and higher.
+        t.observe(QueryKind::Select, 0.2);
+
+        let snap = t.snapshot();
+        assert_eq!(snap.len(), 1, "only the select cell has samples");
+        let h = &snap[0];
+        assert_eq!(h.kind, "select");
+        assert_eq!(h.count, 2);
+        // sum = 0.202s (allow rounding through the micros accumulator).
+        assert!((h.sum_seconds - 0.202).abs() < 1e-6);
+        // buckets = [0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]
+        assert_eq!(h.bucket_counts[0], 0, "<=0.5ms catches neither");
+        assert_eq!(h.bucket_counts[1], 0, "<=1ms catches neither");
+        assert_eq!(h.bucket_counts[2], 1, "<=5ms catches the 2ms sample");
+        assert_eq!(h.bucket_counts[5], 1, "<=100ms still only 2ms");
+        assert_eq!(h.bucket_counts[6], 2, "<=500ms catches both");
+        assert_eq!(h.bucket_counts[9], 2, "<=10s catches both");
+    }
+
+    #[test]
+    fn kinds_do_not_bleed_into_each_other() {
+        let t = QueryLatencyTelemetry::default();
+        t.observe(QueryKind::Insert, 0.01);
+        t.observe(QueryKind::Delete, 0.02);
+        let snap = t.snapshot();
+        assert_eq!(snap.len(), 2);
+        let kinds: Vec<&str> = snap.iter().map(|h| h.kind).collect();
+        assert!(kinds.contains(&"insert"));
+        assert!(kinds.contains(&"delete"));
+        assert!(!kinds.contains(&"select"));
+    }
+
+    #[test]
+    fn rollup_sums_across_kinds() {
+        let t = QueryLatencyTelemetry::default();
+        t.observe(QueryKind::Select, 0.001);
+        t.observe(QueryKind::Insert, 0.001);
+        t.observe(QueryKind::Update, 0.001);
+        let roll = t.rollup();
+        assert_eq!(roll.kind, "all");
+        assert_eq!(roll.count, 3);
+        // 1ms each -> all land in <=0.001 and above.
+        assert_eq!(roll.bucket_counts[1], 3);
+    }
+
+    #[test]
+    fn quantile_is_none_until_a_sample_exists() {
+        let t = QueryLatencyTelemetry::default();
+        assert_eq!(t.rollup().quantile(0.5), None);
+    }
+
+    #[test]
+    fn quantiles_are_sane_for_a_known_distribution() {
+        let t = QueryLatencyTelemetry::default();
+        // 100 samples: a tight 10ms bulk, a 200ms tail, one slow outlier.
+        for _ in 0..90 {
+            t.observe(QueryKind::Select, 0.01);
+        }
+        for _ in 0..9 {
+            t.observe(QueryKind::Select, 0.2);
+        }
+        t.observe(QueryKind::Select, 4.0); // one slow outlier
+
+        let roll = t.rollup();
+        assert_eq!(roll.count, 100);
+        let p50 = roll.quantile(0.50).unwrap();
+        let p95 = roll.quantile(0.95).unwrap();
+        let p99 = roll.quantile(0.99).unwrap();
+        // P50 sits in the bulk (<=10ms bucket).
+        assert!(
+            p50 <= 0.01 + 1e-9,
+            "p50={p50} should be within the 10ms bucket"
+        );
+        // P95 climbs out of the bulk into the slow tail.
+        assert!(
+            p95 > 0.01 && p95 <= 0.5,
+            "p95={p95} should be in the slow tail"
+        );
+        // P99 reaches the far end of the tail / outlier band.
+        assert!(p99 >= 0.5, "p99={p99} should reflect the slow tail");
+        assert!(p50 <= p95 && p95 <= p99, "percentiles must be monotonic");
+    }
+}

--- a/crates/reddb-server/src/server/handlers_admin_metrics.rs
+++ b/crates/reddb-server/src/server/handlers_admin_metrics.rs
@@ -1099,6 +1099,54 @@ impl RedDBServer {
             }
         }
 
+        // Query latency histogram — issue #1241. Bounded to the `kind`
+        // dimension (ADR 0060 §4); no SQL/collection/tenant/user labels.
+        // Only kinds with a real sample are emitted (honesty rule §6).
+        {
+            let latency = self.runtime.query_latency_snapshot();
+            if !latency.is_empty() {
+                let _ = writeln!(
+                    body,
+                    "# HELP reddb_query_duration_seconds Query execution latency by kind, seconds."
+                );
+                let _ = writeln!(body, "# TYPE reddb_query_duration_seconds histogram");
+                for hist in &latency {
+                    for (i, le) in
+                        crate::runtime::query_latency_telemetry::QUERY_DURATION_BUCKETS_SECONDS
+                            .iter()
+                            .enumerate()
+                    {
+                        let count = hist.bucket_counts.get(i).copied().unwrap_or(0);
+                        let _ = writeln!(
+                            body,
+                            "reddb_query_duration_seconds_bucket{{kind=\"{}\",le=\"{}\"}} {}",
+                            sanitize_label(hist.kind),
+                            le,
+                            count
+                        );
+                    }
+                    let _ = writeln!(
+                        body,
+                        "reddb_query_duration_seconds_bucket{{kind=\"{}\",le=\"+Inf\"}} {}",
+                        sanitize_label(hist.kind),
+                        hist.count
+                    );
+                    let _ = writeln!(
+                        body,
+                        "reddb_query_duration_seconds_sum{{kind=\"{}\"}} {}",
+                        sanitize_label(hist.kind),
+                        hist.sum_seconds
+                    );
+                    let _ = writeln!(
+                        body,
+                        "reddb_query_duration_seconds_count{{kind=\"{}\"}} {}",
+                        sanitize_label(hist.kind),
+                        hist.count
+                    );
+                }
+            }
+        }
+
         // Events outbox metrics — issue #299
         {
             use crate::runtime::impl_queue::{

--- a/crates/reddb-server/src/server/handlers_admin_status.rs
+++ b/crates/reddb-server/src/server/handlers_admin_status.rs
@@ -270,8 +270,8 @@ impl RedDBServer {
     pub(crate) fn handle_cluster_status(&self) -> HttpResponse {
         use crate::presentation::cluster_status_json::{
             cluster_status_json, ClusterStatusInputs, ConnectionSnapshot, DeploymentShapeView,
-            ProcessRoleView, ReplicaView, ReplicationSnapshot, StorageSnapshot, SystemSnapshot,
-            TransportListenerView, TransportSnapshot, WalSnapshot,
+            LatencySample, ProcessRoleView, ReplicaView, ReplicationSnapshot, StorageSnapshot,
+            SystemSnapshot, TransportListenerView, TransportSnapshot, WalSnapshot,
         };
 
         let lifecycle = self.runtime.lifecycle();
@@ -374,6 +374,24 @@ impl RedDBServer {
             .map(|(kind, count)| (kind.label().to_string(), *count))
             .collect();
 
+        // Issue #1241 — derive overall latency percentiles from the
+        // recorded histogram rollup. Stays `None` (honest unavailable
+        // envelope) until at least one query has been sampled.
+        let latency_rollup = self.runtime.query_latency_rollup();
+        let latency = match (
+            latency_rollup.quantile(0.50),
+            latency_rollup.quantile(0.95),
+            latency_rollup.quantile(0.99),
+        ) {
+            (Some(p50), Some(p95), Some(p99)) => Some(LatencySample {
+                p50_seconds: p50,
+                p95_seconds: p95,
+                p99_seconds: p99,
+                sample_count: latency_rollup.count,
+            }),
+            _ => None,
+        };
+
         let inputs = ClusterStatusInputs {
             snapshot_at_unix_ms: now_ms,
             version: env!("CARGO_PKG_VERSION").to_string(),
@@ -414,6 +432,7 @@ impl RedDBServer {
                 apply_health: self.runtime.replica_apply_health(),
                 apply_errors,
             },
+            latency,
         };
 
         json_response(200, cluster_status_json(&inputs))

--- a/crates/reddb-server/src/telemetry/slow_query_logger.rs
+++ b/crates/reddb-server/src/telemetry/slow_query_logger.rs
@@ -40,7 +40,21 @@ pub enum QueryKind {
 }
 
 impl QueryKind {
-    fn as_str(self) -> &'static str {
+    /// Every variant, in stable order. The histogram substrate (#1241)
+    /// keys one fixed cell per variant off this array, so the order
+    /// here defines the bounded `kind` cardinality budget (ADR 0060 §4).
+    pub const ALL: [QueryKind; 8] = [
+        Self::Select,
+        Self::Insert,
+        Self::Update,
+        Self::Delete,
+        Self::Bulk,
+        Self::Aggregate,
+        Self::DDL,
+        Self::Internal,
+    ];
+
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Select => "select",
             Self::Insert => "insert",
@@ -50,6 +64,21 @@ impl QueryKind {
             Self::Aggregate => "aggregate",
             Self::DDL => "ddl",
             Self::Internal => "internal",
+        }
+    }
+
+    /// Dense index into [`QueryKind::ALL`] — the cell offset used by the
+    /// latency histogram substrate.
+    pub fn index(self) -> usize {
+        match self {
+            Self::Select => 0,
+            Self::Insert => 1,
+            Self::Update => 2,
+            Self::Delete => 3,
+            Self::Bulk => 4,
+            Self::Aggregate => 5,
+            Self::DDL => 6,
+            Self::Internal => 7,
         }
     }
 }

--- a/tests/e2e_issue_1241_query_latency_histogram.rs
+++ b/tests/e2e_issue_1241_query_latency_histogram.rs
@@ -1,0 +1,76 @@
+//! Issue #1241 — query latency histogram rollups.
+//!
+//! Exercises the real statement lifecycle (`execute_query`) and asserts
+//! the recorded latency histogram substrate (ADR 0060 §2 histograms):
+//!
+//! * every executed query is observed under its `kind` (select/insert/…);
+//! * the cross-kind rollup yields monotonic, sane P50/P95/P99;
+//! * cardinality is bounded to `kind` only — no per-collection series.
+
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn open_runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+#[test]
+fn executed_queries_populate_the_kind_bounded_latency_histogram() {
+    let rt = open_runtime();
+
+    // No query has run yet — the rollup has no sample, so percentiles
+    // are absent (honesty rule #738 / ADR 0060 §6), which keeps
+    // `/cluster/status` `latency` an unavailable envelope.
+    assert_eq!(rt.query_latency_rollup().count, 0);
+    assert_eq!(rt.query_latency_rollup().quantile(0.50), None);
+
+    exec(&rt, "CREATE TABLE lat_1241 (id INT, body TEXT)");
+    for i in 0..20 {
+        exec(
+            &rt,
+            &format!("INSERT INTO lat_1241 (id, body) VALUES ({i}, 'x')"),
+        );
+    }
+    for _ in 0..10 {
+        exec(&rt, "SELECT id, body FROM lat_1241");
+    }
+
+    // Per-kind snapshot carries one cell per observed kind. The only
+    // dimension is `kind`; there is no collection/tenant/user label.
+    let snap = rt.query_latency_snapshot();
+    let by_kind: std::collections::BTreeMap<&str, u64> =
+        snap.iter().map(|h| (h.kind, h.count)).collect();
+    assert!(
+        by_kind.get("select").copied().unwrap_or(0) >= 10,
+        "expected >=10 select samples, got {by_kind:?}"
+    );
+    assert!(
+        by_kind.get("insert").copied().unwrap_or(0) >= 20,
+        "expected >=20 insert samples, got {by_kind:?}"
+    );
+
+    // Each per-kind histogram is internally consistent: cumulative
+    // buckets are non-decreasing and the +Inf bucket equals count.
+    for h in &snap {
+        let mut prev = 0u64;
+        for &b in &h.bucket_counts {
+            assert!(b >= prev, "buckets must be cumulative for {}", h.kind);
+            assert!(b <= h.count, "no bucket may exceed count for {}", h.kind);
+            prev = b;
+        }
+    }
+
+    // The cross-kind rollup (what `/cluster/status` + red-ui read) now
+    // has samples and produces monotonic percentiles.
+    let roll = rt.query_latency_rollup();
+    assert!(roll.count >= 31, "rollup count = {}", roll.count);
+    let p50 = roll.quantile(0.50).expect("p50 available after samples");
+    let p95 = roll.quantile(0.95).expect("p95 available after samples");
+    let p99 = roll.quantile(0.99).expect("p99 available after samples");
+    assert!(p50 <= p95 && p95 <= p99, "percentiles must be monotonic");
+    assert!(p99 >= 0.0, "percentiles are non-negative seconds");
+}

--- a/tests/grouped/analytics_metrics.rs
+++ b/tests/grouped/analytics_metrics.rs
@@ -21,6 +21,9 @@ mod e2e_analytics_v0_smoke;
 #[path = "docs_kv_queue/e2e_document_sql_analytics.rs"]
 mod e2e_document_sql_analytics;
 
+#[path = "../e2e_issue_1241_query_latency_histogram.rs"]
+mod e2e_issue_1241_query_latency_histogram;
+
 #[path = "probabilistic/e2e_issue_542_probabilistic_commands.rs"]
 mod e2e_issue_542_probabilistic_commands;
 


### PR DESCRIPTION
Automated AFK landing for #1241. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1241

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784765693&installation_id=129708444&pr_number=1328&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1328&signature=bc15fdd789a8893f00c684660a8061dc985b35981ffe10503307686d2d4936f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->