### PR TITLE
feat(telemetry): record HTTP request counters in operational telemetry (#1239)

### DIFF
--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -162,6 +162,7 @@ pub mod http_connection_limiter;
 pub mod http_handler_metrics;
 pub mod http_limits;
 pub mod http_principal_limiter;
+pub mod http_request_metrics;
 pub mod ingest_pipeline;
 pub mod output_stream;
 mod patch_support;
@@ -189,6 +190,7 @@ pub use self::http_limits::{
     HttpLimitsCliInput, HttpLimitsResolved, DEFAULT_HANDLER_TIMEOUT_MS, DEFAULT_RETRY_AFTER_SECS,
 };
 use self::http_principal_limiter::PrincipalConnectionLimiter;
+use self::http_request_metrics::HttpRequestMetrics;
 use self::patch_support::*;
 use self::request_body::*;
 use self::routing::*;
@@ -306,6 +308,12 @@ pub struct RedDBServer {
     /// with the server via `Arc` so every serve loop on the same
     /// `RedDBServer` writes to one set of counters.
     http_metrics: HttpHandlerMetrics,
+    /// Issue #1239 / PRD #1237 — `reddb_http_requests_total` counters by
+    /// `method`, matched route template, and status class. Recorded once
+    /// per handled request in `route()`; read by `/metrics` and the
+    /// operational telemetry read model. Cloned with the server via `Arc`
+    /// so every serve loop on the same `RedDBServer` shares one counter set.
+    http_request_metrics: HttpRequestMetrics,
     /// `Retry-After` value (seconds) emitted in the async edge's
     /// capacity-reject 503 path (issue #574 slice 5). Read on the reject
     /// path in `axum_edge`.
@@ -440,6 +448,7 @@ impl RedDBServer {
             handler_clock: Arc::new(SystemMonotonicClock::new()),
             slow_inject_ms: Arc::new(AtomicU64::new(0)),
             http_metrics: HttpHandlerMetrics::new(),
+            http_request_metrics: HttpRequestMetrics::new(),
             retry_after_secs: DEFAULT_RETRY_AFTER_SECS,
             principal_limiter: PrincipalConnectionLimiter::new(
                 http_limits::DEFAULT_MAX_INFLIGHT_PER_PRINCIPAL,
@@ -468,6 +477,13 @@ impl RedDBServer {
     #[doc(hidden)]
     pub fn http_metrics(&self) -> &HttpHandlerMetrics {
         &self.http_metrics
+    }
+
+    /// HTTP request/error volume counters (`reddb_http_requests_total`).
+    /// Read by `/metrics` and the operational telemetry read model.
+    #[doc(hidden)]
+    pub fn http_request_metrics(&self) -> &HttpRequestMetrics {
+        &self.http_request_metrics
     }
 
     /// Visible for tests. Lets the integration test in

--- a/crates/reddb-server/src/server/handlers_admin_metrics.rs
+++ b/crates/reddb-server/src/server/handlers_admin_metrics.rs
@@ -1167,6 +1167,11 @@ impl RedDBServer {
         // saturation against the bounded handler-thread cap.
         self.http_metrics().render(&mut body, self.http_limiter());
 
+        // Issue #1239 — HTTP request/error volume by method, matched route
+        // template, and status class. Read from the operational telemetry
+        // substrate; this surface only shapes it (ADR 0017 boundary).
+        self.http_request_metrics().render(&mut body);
+
         HttpResponse {
             status: 200,
             content_type: "text/plain; version=0.0.4",

--- a/crates/reddb-server/src/server/http_request_metrics.rs
+++ b/crates/reddb-server/src/server/http_request_metrics.rs
@@ -120,7 +120,7 @@ impl HttpRequestMetrics {
     pub fn snapshot(&self) -> Vec<(HttpRequestLabels, u64)> {
         let guard = self.counters.lock().unwrap_or_else(|e| e.into_inner());
         let mut rows: Vec<(HttpRequestLabels, u64)> = guard.iter().map(|(k, v)| (*k, *v)).collect();
-        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows.sort_by_key(|a| a.0);
         rows
     }
 

--- a/crates/reddb-server/src/server/http_request_metrics.rs
+++ b/crates/reddb-server/src/server/http_request_metrics.rs
@@ -1,0 +1,245 @@
+//! HTTP request/error volume counters for operational telemetry.
+//!
+//! Issue #1239 / PRD #1237 Phase A, against the Phase-0 substrate
+//! contract (ADR 0060). Every handled HTTP request increments a single
+//! counter keyed by three **bounded** dimensions:
+//!
+//! - `method` — the request method, folded to the closed HTTP verb set
+//!   (`GET`/`POST`/…); anything outside it collapses to `OTHER`.
+//! - `route`  — the matched route *template* (`/catalog/collections/:name`),
+//!   never the raw path. Requests that match no catalog route collapse to
+//!   the reserved `__unmatched__` bucket. The normalization is the caller's
+//!   job (it needs the route catalog); this module only stores the label.
+//! - `status` — the HTTP status *class* (`2xx`/`4xx`/`5xx`/…) per ADR 0060
+//!   §4, which keeps the status dimension at ≤6 values instead of the full
+//!   code space.
+//!
+//! Because all three label components are `&'static str` (verb labels,
+//! catalog route templates, and status-class strings are all static), the
+//! key set is bounded by construction: the product of the closed verb set,
+//! the static route table, and the six status classes. No raw path, id,
+//! query string, tenant value, or authorization material is ever admitted
+//! as a label — the caller passes pre-normalized static strings.
+//!
+//! The counter is a plain `Mutex<HashMap>`; HTTP request dispatch is not a
+//! lock-contention-sensitive hot path at this granularity, and the bounded
+//! key set keeps the map small. The substrate read model and the `/metrics`
+//! exporter both read [`HttpRequestMetrics::snapshot`].
+
+use std::collections::HashMap;
+use std::fmt::Write;
+use std::sync::{Arc, Mutex};
+
+use super::handlers_admin::sanitize_label;
+
+/// One bounded label set for a recorded HTTP request. Every component is
+/// `&'static str` so the cardinality of the key space is fixed at compile
+/// time (closed verb set × static route table × status classes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct HttpRequestLabels {
+    pub method: &'static str,
+    pub route: &'static str,
+    pub status: &'static str,
+}
+
+/// Reserved route label for any request that matched no catalog route.
+/// Folding to a single bucket is what keeps raw 404 paths from blowing up
+/// the `route` dimension (ADR 0060 §4 overflow rule).
+pub const UNMATCHED_ROUTE: &str = "__unmatched__";
+
+/// Reserved method label for any verb outside the closed HTTP set.
+pub const OTHER_METHOD: &str = "OTHER";
+
+/// Fold a request method to its bounded static label. The closed HTTP verb
+/// set maps to its canonical upper-case label; anything else collapses to
+/// [`OTHER_METHOD`] so a hostile/unknown verb cannot open a new series.
+pub fn method_label(method: &str) -> &'static str {
+    match method {
+        "GET" => "GET",
+        "POST" => "POST",
+        "PUT" => "PUT",
+        "PATCH" => "PATCH",
+        "DELETE" => "DELETE",
+        "OPTIONS" => "OPTIONS",
+        "HEAD" => "HEAD",
+        _ => OTHER_METHOD,
+    }
+}
+
+/// Map an HTTP status code to its bounded status *class*. Per ADR 0060 §4
+/// the class (`2xx`/`4xx`/`5xx`/…) is preferred over the exact code so the
+/// `status` dimension stays at ≤6 values.
+pub fn status_class(status: u16) -> &'static str {
+    match status {
+        100..=199 => "1xx",
+        200..=299 => "2xx",
+        300..=399 => "3xx",
+        400..=499 => "4xx",
+        500..=599 => "5xx",
+        _ => "other",
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HttpRequestMetrics {
+    counters: Arc<Mutex<HashMap<HttpRequestLabels, u64>>>,
+}
+
+impl HttpRequestMetrics {
+    pub fn new() -> Self {
+        Self {
+            counters: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Record one handled HTTP request. `method` and `route` must already
+    /// be normalized to bounded static labels by the caller (the verb set
+    /// and the route catalog are the authorities); `status` is the raw
+    /// response code, folded to its class here.
+    pub fn record(&self, method: &'static str, route: &'static str, status: u16) {
+        let key = HttpRequestLabels {
+            method,
+            route,
+            status: status_class(status),
+        };
+        let mut guard = self.counters.lock().unwrap_or_else(|e| e.into_inner());
+        *guard.entry(key).or_insert(0) += 1;
+    }
+
+    /// Current value of one series, or 0 if never incremented. Visible for
+    /// tests and the read model.
+    pub fn count(&self, labels: HttpRequestLabels) -> u64 {
+        let guard = self.counters.lock().unwrap_or_else(|e| e.into_inner());
+        guard.get(&labels).copied().unwrap_or(0)
+    }
+
+    /// Deterministically-ordered snapshot of every recorded series. This is
+    /// the substrate read surface: `/metrics` renders it and the
+    /// operational read model (red-ui / `/cluster/status` summaries) derives
+    /// request throughput from the same measured facts.
+    pub fn snapshot(&self) -> Vec<(HttpRequestLabels, u64)> {
+        let guard = self.counters.lock().unwrap_or_else(|e| e.into_inner());
+        let mut rows: Vec<(HttpRequestLabels, u64)> = guard.iter().map(|(k, v)| (*k, *v)).collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        rows
+    }
+
+    /// Render `reddb_http_requests_total{method,route,status}` in Prometheus
+    /// text exposition format, appending to `body`. Per ADR 0017 this is a
+    /// boundary adapter: it reads the substrate snapshot and shapes it, it
+    /// owns no storage. An empty substrate emits only HELP/TYPE (Prometheus
+    /// has no envelope concept; absent series read as "nothing happened").
+    pub fn render(&self, body: &mut String) {
+        let _ = writeln!(
+            body,
+            "# HELP reddb_http_requests_total HTTP requests handled since process start, by method, route template, and status class."
+        );
+        let _ = writeln!(body, "# TYPE reddb_http_requests_total counter");
+        for (labels, count) in self.snapshot() {
+            let _ = writeln!(
+                body,
+                "reddb_http_requests_total{{method=\"{}\",route=\"{}\",status=\"{}\"}} {}",
+                sanitize_label(labels.method),
+                sanitize_label(labels.route),
+                sanitize_label(labels.status),
+                count
+            );
+        }
+    }
+}
+
+impl Default for HttpRequestMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labels(
+        method: &'static str,
+        route: &'static str,
+        status: &'static str,
+    ) -> HttpRequestLabels {
+        HttpRequestLabels {
+            method,
+            route,
+            status,
+        }
+    }
+
+    #[test]
+    fn status_codes_fold_to_classes() {
+        assert_eq!(status_class(200), "2xx");
+        assert_eq!(status_class(204), "2xx");
+        assert_eq!(status_class(301), "3xx");
+        assert_eq!(status_class(404), "4xx");
+        assert_eq!(status_class(503), "5xx");
+        assert_eq!(status_class(700), "other");
+    }
+
+    #[test]
+    fn record_increments_per_labelset() {
+        let m = HttpRequestMetrics::new();
+        m.record("GET", "/catalog/collections/:name", 200);
+        m.record("GET", "/catalog/collections/:name", 200);
+        m.record("GET", "/catalog/collections/:name", 404);
+        assert_eq!(
+            m.count(labels("GET", "/catalog/collections/:name", "2xx")),
+            2
+        );
+        assert_eq!(
+            m.count(labels("GET", "/catalog/collections/:name", "4xx")),
+            1
+        );
+        assert_eq!(
+            m.count(labels("POST", "/catalog/collections/:name", "2xx")),
+            0
+        );
+    }
+
+    #[test]
+    fn high_cardinality_status_codes_collapse_to_one_class_series() {
+        let m = HttpRequestMetrics::new();
+        // Distinct 2xx codes must not each open a new series — they fold to
+        // the single `2xx` class bucket.
+        for status in [200u16, 201, 202, 204, 206] {
+            m.record("POST", "/query", status);
+        }
+        let snapshot = m.snapshot();
+        let query_2xx: Vec<_> = snapshot
+            .iter()
+            .filter(|(l, _)| l.route == "/query" && l.status == "2xx")
+            .collect();
+        assert_eq!(query_2xx.len(), 1, "all 2xx codes must share one series");
+        assert_eq!(query_2xx[0].1, 5);
+    }
+
+    #[test]
+    fn render_emits_prometheus_counter() {
+        let m = HttpRequestMetrics::new();
+        m.record("GET", "/health", 200);
+        let mut body = String::new();
+        m.render(&mut body);
+        assert!(body.contains("# TYPE reddb_http_requests_total counter"));
+        assert!(body.contains(
+            "reddb_http_requests_total{method=\"GET\",route=\"/health\",status=\"2xx\"} 1"
+        ));
+    }
+
+    #[test]
+    fn snapshot_is_deterministically_ordered() {
+        let m = HttpRequestMetrics::new();
+        m.record("POST", "/query", 500);
+        m.record("GET", "/health", 200);
+        m.record("GET", "/health", 200);
+        let snap = m.snapshot();
+        // Sorted by (method, route, status) — GET sorts before POST.
+        assert_eq!(snap[0].0.method, "GET");
+        assert_eq!(snap[0].0.route, "/health");
+        assert_eq!(snap[0].1, 2);
+        assert_eq!(snap[1].0.method, "POST");
+    }
+}

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -294,7 +294,42 @@ impl RedDBServer {
             .and_then(|(id, _role)| id.tenant)
     }
 
+    /// Dispatch one HTTP request and record its method/route/status into
+    /// the operational telemetry counter (`reddb_http_requests_total`,
+    /// issue #1239). The label normalization folds the raw path to its
+    /// matched route *template* (or `__unmatched__`) so high-cardinality
+    /// paths/ids/query strings never become labels; the status is folded to
+    /// its class. Recording wraps the full dispatch so gate rejections
+    /// (401/404/405/429) are counted too — every handled request increments.
     pub(crate) fn route(&self, request: HttpRequest) -> HttpResponse {
+        let method_label = http_request_metrics::method_label(&request.method);
+        let route_label = self.http_metric_route_label(&request.method, &request.path);
+        let response = self.dispatch_route(request);
+        self.http_request_metrics()
+            .record(method_label, route_label, response.status);
+        response
+    }
+
+    /// Normalize `(method, path)` to a bounded static route label: the
+    /// matched catalog route *template* (e.g. `/catalog/collections/:name`),
+    /// or the reserved `__unmatched__` bucket. Alias paths are resolved to
+    /// their canonical template first so an alias and its canonical share
+    /// one label. This is the only place raw paths are inspected, and the
+    /// output is always one of the static route patterns — never the path.
+    fn http_metric_route_label(&self, method: &str, path: &str) -> &'static str {
+        let Some(method) = route_catalog::RouteMethod::from_http_method(method) else {
+            return http_request_metrics::UNMATCHED_ROUTE;
+        };
+        let catalog = routes::discovered_route_catalog();
+        let canonical = catalog.resolve_alias(method, path);
+        let lookup = canonical.as_deref().unwrap_or(path);
+        match catalog.find(method, lookup) {
+            Some(matched) => matched.spec.pattern,
+            None => http_request_metrics::UNMATCHED_ROUTE,
+        }
+    }
+
+    fn dispatch_route(&self, request: HttpRequest) -> HttpResponse {
         let request = Self::rewrite_route_alias(request);
         let HttpRequest {
             method,
@@ -3286,6 +3321,65 @@ mod tests {
             .headers
             .insert("authorization".to_string(), format!("Bearer {token}"));
         request
+    }
+
+    #[test]
+    fn http_request_counter_collapses_raw_paths_to_route_template() {
+        let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        let server = RedDBServer::new(runtime);
+
+        // Two distinct high-cardinality paths under the same dynamic route
+        // must both fold to the single `/catalog/collections/:name` label —
+        // the raw collection names never appear as labels. Status class is
+        // left unasserted (the collections may not exist); the point is the
+        // route dimension collapses regardless of outcome.
+        let _ = server.route(request("/catalog/collections/users"));
+        let _ = server.route(request("/catalog/collections/orders"));
+
+        let snapshot = server.http_request_metrics().snapshot();
+        let collapsed: u64 = snapshot
+            .iter()
+            .filter(|(labels, _)| {
+                labels.method == "GET" && labels.route == "/catalog/collections/:name"
+            })
+            .map(|(_, count)| *count)
+            .sum();
+        assert_eq!(
+            collapsed, 2,
+            "both raw collection paths must collapse to one route-template series: {snapshot:?}"
+        );
+
+        // The raw paths must not have leaked into the snapshot as labels.
+        assert!(
+            snapshot
+                .iter()
+                .all(|(labels, _)| !labels.route.contains("users")
+                    && !labels.route.contains("orders")),
+            "raw collection names must never become route labels: {snapshot:?}"
+        );
+    }
+
+    #[test]
+    fn http_request_counter_records_unmatched_paths_in_reserved_bucket() {
+        use crate::server::http_request_metrics::{HttpRequestLabels, UNMATCHED_ROUTE};
+
+        let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        let server = RedDBServer::new(runtime);
+
+        // Unknown high-cardinality paths must fold to the reserved bucket so
+        // a 404 scan cannot blow up the `route` dimension.
+        let _ = server.route(request("/no/such/path/aaaa"));
+        let _ = server.route(request("/no/such/path/bbbb"));
+
+        let unmatched = server.http_request_metrics().count(HttpRequestLabels {
+            method: "GET",
+            route: UNMATCHED_ROUTE,
+            status: "4xx",
+        });
+        assert_eq!(
+            unmatched, 2,
+            "unmatched paths collapse to one bounded bucket"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Lands the recovered work for #1239 — HTTP request counters in operational telemetry.

Adds a bounded HTTP request counter substrate, wires it onto `RedDBServer`, records method/route/status on every handled request, and exports `reddb_http_requests_total` via `/metrics`.

Recovered from AFK attempt branch; the only delta over the agent attempt is the clippy fix `unnecessary_sort_by` → `sort_by_key` (hidden from the agent by the rtk wrapper).

Closes #1239

https://claude.ai/code/session_01UAa2a34cjzaHhyUTMFv1wS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784805665&installation_id=129708444&pr_number=1335&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1335&signature=7abb5bbc19817b9aee436f55f3319d2f08d2e3ac53cf6fed6dfd1a4ae1d88e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->