### PR TITLE
fix(release-candidate): pin workspace dep versions to exact RC semver

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -83,6 +83,13 @@ jobs:
           node scripts/sync-version.js
           bash scripts/check-versions.sh
 
+      - name: Patch workspace dep version requirements for RC
+        # Cargo does not match pre-release versions against range requirements like "^1.0".
+        # Pin every internal workspace dep to the exact RC version so generate-lockfile resolves.
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          sed -i -E "s/(package = \"reddb-io-[^\"]+\", version = \")[^\"]+(\")/\1=${RC_VERSION}\2/" Cargo.toml
+
       - name: Regenerate lockfile after version sync
         run: cargo generate-lockfile
 
@@ -216,6 +223,11 @@ jobs:
           node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='${RC_VERSION}';fs.writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
           node scripts/sync-version.js
           bash scripts/check-versions.sh
+
+      - name: Patch workspace dep version requirements for RC
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          sed -i -E "s/(package = \"reddb-io-[^\"]+\", version = \")[^\"]+(\")/\1=${RC_VERSION}\2/" Cargo.toml
 
       - name: Regenerate lockfile after version sync
         run: cargo generate-lockfile


### PR DESCRIPTION
cargo rejects pre-release versions against range requirements like \`^1.0\`.

After \`sync-version.js\` bumps all crate versions to e.g. \`1.13.0-rc.7\`, the workspace \`[dependencies]\` entries still declare \`version = \"1.0\"\` — cargo's resolver excludes pre-release from that range and fails at \`generate-lockfile\`.

Fix: add a \`sed\` step after version sync that patches every internal workspace dep to the exact RC version (\`=RC_VERSION\`), making the resolver happy before \`generate-lockfile\` runs.

Same fix applied to both \`build-linux\` and \`publish-cargo\` jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784836393&installation_id=129708444&pr_number=1349&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1349&signature=06bba155677e07d05a22588097a457d43316443c6169b74096bdc266e0b6c9e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->