### PR TITLE
fix(server): isolate in-memory audit log path per runtime instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,10 @@ jobs:
         # cap. nextest runs every test in a global parallel process pool (sleeps
         # overlap) and the `ci` profile enforces a hard per-test timeout
         # (.config/nextest.toml) so a hung test is killed, not the whole run.
-        run: cargo nextest run --workspace --locked --profile ci
+        # REPAIR (PRD #1362 / #1376): --no-fail-fast surfaces the full broken-test
+        # backlog every run so fixing one cluster does not re-hide the next. Revert
+        # to fail-fast once the suite is green (the #1376 capstone restores posture).
+        run: cargo nextest run --workspace --locked --profile ci --no-fail-fast
       - name: Doctests (nextest does not execute doctests)
         run: cargo test --workspace --locked --doc
       - name: Run persistent multimodel layer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,7 @@ jobs:
         # cap. nextest runs every test in a global parallel process pool (sleeps
         # overlap) and the `ci` profile enforces a hard per-test timeout
         # (.config/nextest.toml) so a hung test is killed, not the whole run.
-        # REPAIR (PRD #1362 / #1376): --no-fail-fast surfaces the full broken-test
-        # backlog every run so fixing one cluster does not re-hide the next. Revert
-        # to fail-fast once the suite is green (the #1376 capstone restores posture).
-        run: cargo nextest run --workspace --locked --profile ci --no-fail-fast
+        run: cargo nextest run --workspace --locked --profile ci
       - name: Doctests (nextest does not execute doctests)
         run: cargo test --workspace --locked --doc
       - name: Run persistent multimodel layer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
         env:
           CARGO_TARGET_DIR: target/persistent-tests
         run: >-
-          cargo test --locked --test grouped_runtime_persistence integration_persistent_multimodel -- --ignored
+          cargo test --locked --test grouped_general_multimodel integration_persistent_multimodel -- --ignored
       - name: Check for temp-file residue (leak guard)
         # Issue #972 — fail the build if any reddb-*/reddb_*/*.rdb/*.wal
         # temp residue remains in TMPDIR after the full test suite.  All

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "jsonwebtoken",
  "proptest",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -2491,14 +2491,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "reddb-io-types",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-server"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "proptest",
  "zstd",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "insta",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cast_possible_truncation = "warn"
 
 [package]
 name = "reddb-io"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 # Cargo auto-discovers every top-level `tests/*.rs` file as a separate
 # integration-test binary. This crate has 269 such files; keep discovery off

--- a/crates/reddb-client-connector/Cargo.toml
+++ b/crates/reddb-client-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client-connector"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "Workspace-internal gRPC connector used by `reddb-server` (rpc_stdio) and `reddb-client`. Splitting it out of `reddb-client` breaks the otherwise-circular path dependency between `reddb-client[embedded]` (which pulls `reddb-server`) and `reddb-server` (which needs the connector)."

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "Official Rust client for RedDB — embedded engine, gRPC, HTTP, and RedWire transports behind one connection-string API. Also hosts the workspace-internal connector + REPL used by the `red` and `red_client` binaries."

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-crypto"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB cryptographic authority: the canonical per-page encryption-at-rest envelope (AES-256-GCM), mandatory encrypt parameters, and key parsing."

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-file"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB file artifact layer: single-file .rdb layout, WAL, snapshots, checkpoints, locks, and recovery."

--- a/crates/reddb-grpc-proto/Cargo.toml
+++ b/crates/reddb-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-grpc-proto"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "Generated gRPC protobuf types and tonic client/server stubs for RedDB. Shared across reddb-server, reddb-client, and language drivers."

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-rql"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB Query Language (RQL) front-end + conformance authority (ADR 0053). Owns the sqllogictest-format conformance suite whose truth comes from the public SQLite corpus; depends only on reddb-io-types."

--- a/crates/reddb-rql/src/parser/auth_ddl.rs
+++ b/crates/reddb-rql/src/parser/auth_ddl.rs
@@ -528,6 +528,21 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 Ok("delete".into())
             }
+            // #1374 — DDL action verbs tokenize as their own keyword tokens,
+            // not Ident; accept them as action names. Literals (numbers, etc.)
+            // and structural tokens still error with "expected: action keyword".
+            Token::Drop => {
+                self.advance()?;
+                Ok("drop".into())
+            }
+            Token::Create => {
+                self.advance()?;
+                Ok("create".into())
+            }
+            Token::Alter => {
+                self.advance()?;
+                Ok("alter".into())
+            }
             Token::Ident(_) => {
                 let raw = self.expect_ident()?;
                 Ok(raw.to_ascii_lowercase())

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -868,7 +868,9 @@ impl<'a> Parser<'a> {
         if self.consume(&Token::Add)? {
             if self.consume_ident_ci("SUBSCRIPTION")? {
                 // ADD SUBSCRIPTION name TO queue [REDACT (...)] [WHERE ...]
-                let sub_name = self.expect_ident()?;
+                // #1374 — a subscription name may be a keyword (e.g. `search`);
+                // accept keyword tokens as identifiers here (PG-style).
+                let sub_name = self.expect_ident_or_keyword()?;
                 let descriptor = self.parse_subscription_descriptor(table_name.to_string())?;
                 Ok(AlterOperation::AddSubscription {
                     name: sub_name,
@@ -897,8 +899,8 @@ impl<'a> Parser<'a> {
             Ok(AlterOperation::RevokeSigner { pubkey })
         } else if self.consume(&Token::Drop)? {
             if self.consume_ident_ci("SUBSCRIPTION")? {
-                // DROP SUBSCRIPTION name
-                let sub_name = self.expect_ident()?;
+                // DROP SUBSCRIPTION name (may be a keyword, e.g. `search`)
+                let sub_name = self.expect_ident_or_keyword()?;
                 Ok(AlterOperation::DropSubscription { name: sub_name })
             } else {
                 // DROP COLUMN name (COLUMN keyword is optional)

--- a/crates/reddb-rql/src/parser/filter.rs
+++ b/crates/reddb-rql/src/parser/filter.rs
@@ -216,7 +216,15 @@ impl<'a> Parser<'a> {
             if let Some(field) = lhs_field.clone() {
                 self.expect(Token::LParen)?;
                 if self.check(&Token::Select) {
-                    let query = self.parse_select_query()?;
+                    // Bracket the subquery recursion in the depth counter so a
+                    // deeply nested `x IN (SELECT … WHERE x IN (…))` payload
+                    // hits `max_depth` and errors instead of overflowing the
+                    // Rust stack before the limit can fire (mirrors
+                    // `parse_not_expr`).
+                    self.enter_depth()?;
+                    let query = self.parse_select_query();
+                    self.exit_depth();
+                    let query = query?;
                     self.expect(Token::RParen)?;
                     return Ok(negate_if(
                         negated,

--- a/crates/reddb-rql/tests/reddb_corpus/README.md
+++ b/crates/reddb-rql/tests/reddb_corpus/README.md
@@ -26,7 +26,7 @@ are 1.00 / 0.60 / 0.00 gives one strict ranking).
 
 The engine decorates each vector/graph result row with engine-internal,
 run-varying columns: auto-assigned entity ids (`entity_id`, `node_id`,
-`red_entity_id`), wall-clock stamps (`created_at`, `updated_at`), sequence
+`rid`), wall-clock stamps (`created_at`, `updated_at`), sequence
 numbers, `red_*` capability metadata, and raw distance/score floats whose exact
 value is engine-defined rather than oracle-defined. The harness projects every
 result down to a fixed allowlist of **semantic, deterministic** columns

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-server"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB server-side engine: storage, runtime, replication, MCP, AI, and the gRPC/HTTP/RedWire/PG-wire dispatchers. Re-exported by the umbrella `reddb` crate."

--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -371,12 +371,22 @@ impl RedDBOptions {
             .map(|duration| duration.as_nanos())
             .unwrap_or(0);
         let unique = NEXT_EPHEMERAL_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let path = std::env::temp_dir().join(format!(
-            "reddb-ephemeral-{}-{}-{}.rdb",
+        // Each ephemeral runtime gets its OWN directory, not just a unique
+        // filename in the shared temp dir. Sibling artifacts (the audit log,
+        // WAL, snapshots) are derived from this data path's PARENT, so a
+        // shared parent collapses every ephemeral runtime's `.audit.log`
+        // onto one file — which parallel test processes (nextest runs each
+        // test in its own process, frequently under one shared `TMPDIR`)
+        // then truncate/remove out from under one another. A per-instance
+        // directory keeps each runtime's siblings self-contained.
+        let dir = std::env::temp_dir().join(format!(
+            "reddb-ephemeral-{}-{}-{}",
             std::process::id(),
             now_nanos,
             unique
         ));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("db.rdb");
         let _ = std::fs::remove_file(&path);
         let mut metadata = BTreeMap::new();
         metadata.insert(

--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -413,6 +413,24 @@ impl RedDBOptions {
     }
 
     pub fn with_data_path<P: Into<PathBuf>>(mut self, path: P) -> Self {
+        // `in_memory()` eagerly creates a `reddb-ephemeral-*` dir and points
+        // `data_path` at it. Overriding the path abandons that dir — and the
+        // per-runtime cleanup keys off the FINAL `data_path`, so the orphan
+        // would leak in TMPDIR (caught by scripts/check-temp-residue.sh). Remove
+        // it now if the previous path was such an eagerly-created ephemeral dir.
+        if let Some(old) = self.data_path.take() {
+            let tmp = std::env::temp_dir();
+            if let Some(parent) = old.parent() {
+                let orphaned = parent
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("reddb-ephemeral-"))
+                    && parent.parent() == Some(tmp.as_path());
+                if orphaned {
+                    let _ = std::fs::remove_dir_all(parent);
+                }
+            }
+        }
         self.data_path = Some(path.into());
         self
     }

--- a/crates/reddb-server/src/presentation/query_json.rs
+++ b/crates/reddb-server/src/presentation/query_json.rs
@@ -144,10 +144,7 @@ where
                         "entity_id".to_string(),
                         JsonValue::Number(item.entity_id as f64),
                     );
-                    entry.insert(
-                        "rid".to_string(),
-                        JsonValue::Number(item.entity_id as f64),
-                    );
+                    entry.insert("rid".to_string(), JsonValue::Number(item.entity_id as f64));
                     entry.insert(
                         "distance".to_string(),
                         JsonValue::Number(item.distance as f64),

--- a/crates/reddb-server/src/presentation/query_json.rs
+++ b/crates/reddb-server/src/presentation/query_json.rs
@@ -35,7 +35,7 @@ where
                         JsonValue::Number(result.entity_id.raw() as f64),
                     );
                     item.insert(
-                        "red_entity_id".to_string(),
+                        "rid".to_string(),
                         JsonValue::Number(result.entity_id.raw() as f64),
                     );
                     item.insert("score".to_string(), JsonValue::Number(result.score as f64));
@@ -145,7 +145,7 @@ where
                         JsonValue::Number(item.entity_id as f64),
                     );
                     entry.insert(
-                        "red_entity_id".to_string(),
+                        "rid".to_string(),
                         JsonValue::Number(item.entity_id as f64),
                     );
                     entry.insert(
@@ -266,7 +266,7 @@ where
         JsonValue::Number(item.entity.logical_id().raw() as f64),
     );
     object.insert(
-        "red_entity_id".to_string(),
+        "rid".to_string(),
         JsonValue::Number(item.entity.logical_id().raw() as f64),
     );
     object.insert(

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -674,7 +674,6 @@ fn is_record_metadata_key(key: &str) -> bool {
     matches!(
         key,
         "rid"
-            | "red_entity_id"
             | "collection"
             | "red_collection"
             | "kind"
@@ -734,10 +733,7 @@ fn vector_search_result_json(result: &VectorSearchResult) -> JsonValue {
     let mut object = Map::new();
     object.insert("id".to_string(), JsonValue::Number(result.id as f64));
     object.insert("entity_id".to_string(), JsonValue::Number(result.id as f64));
-    object.insert(
-        "red_entity_id".to_string(),
-        JsonValue::Number(result.id as f64),
-    );
+    object.insert("rid".to_string(), JsonValue::Number(result.id as f64));
     object.insert(
         "collection".to_string(),
         JsonValue::String(result.collection.clone()),

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -928,7 +928,7 @@ fn dispatch_method(
                 error_code::INVALID_PARAMS,
                 "missing 'id' string".to_string(),
             ))?;
-            let sql = format!("SELECT * FROM {collection} WHERE red_entity_id = {id} LIMIT 1");
+            let sql = format!("SELECT * FROM {collection} WHERE rid = {id} LIMIT 1");
             let qr = runtime
                 .execute_query(&sql)
                 .map_err(|e| (error_code::QUERY_ERROR, e.to_string()))?;
@@ -952,7 +952,7 @@ fn dispatch_method(
                 error_code::INVALID_PARAMS,
                 "missing 'id' string".to_string(),
             ))?;
-            let sql = format!("DELETE FROM {collection} WHERE red_entity_id = {id}");
+            let sql = format!("DELETE FROM {collection} WHERE rid = {id}");
 
             if let Some(tx) = session.current_tx_mut() {
                 tx.write_set.push(PendingSql::Delete(sql));
@@ -1840,7 +1840,7 @@ fn dispatch_method_remote(
                 error_code::INVALID_PARAMS,
                 "missing 'id' string".to_string(),
             ))?;
-            let sql = format!("SELECT * FROM {collection} WHERE red_entity_id = {id} LIMIT 1");
+            let sql = format!("SELECT * FROM {collection} WHERE rid = {id} LIMIT 1");
             let json_str = tokio_rt
                 .block_on(async {
                     let mut guard = client.lock().await;
@@ -2774,11 +2774,11 @@ mod tests {
 
             let bulk_rows = result_name_kind(&handle(
                 &rt,
-                r#"{"jsonrpc":"2.0","id":99,"method":"query","params":{"sql":"SELECT name, kind FROM bulk_prop ORDER BY red_entity_id"}}"#,
+                r#"{"jsonrpc":"2.0","id":99,"method":"query","params":{"sql":"SELECT name, kind FROM bulk_prop ORDER BY rid"}}"#,
             ));
             let seq_rows = result_name_kind(&handle(
                 &rt,
-                r#"{"jsonrpc":"2.0","id":100,"method":"query","params":{"sql":"SELECT name, kind FROM seq_prop ORDER BY red_entity_id"}}"#,
+                r#"{"jsonrpc":"2.0","id":100,"method":"query","params":{"sql":"SELECT name, kind FROM seq_prop ORDER BY rid"}}"#,
             ));
             prop_assert_eq!(bulk_rows, seq_rows);
         }

--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -393,9 +393,17 @@ pub(crate) fn current_config_value(path: &str) -> Option<Value> {
             resolver.values = Some(latest_config_snapshot(&resolver.db));
         }
         let values = resolver.values.as_ref()?;
+        // #1370 — `$config.<path>` desugars to `CONFIG("red.config/<path>")`,
+        // but `SET CONFIG <path>` stores under the bare key. Mirror the secret
+        // resolver: after the namespaced key, fall back to the stripped bare
+        // key, then the dotted `red.config.<rest>` legacy form.
         values.get(&key).cloned().or_else(|| {
-            key.strip_prefix("red.config/")
-                .and_then(|rest| values.get(&format!("red.config.{rest}")).cloned())
+            key.strip_prefix("red.config/").and_then(|rest| {
+                values
+                    .get(rest)
+                    .cloned()
+                    .or_else(|| values.get(&format!("red.config.{rest}")).cloned())
+            })
         })
     })
 }

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -345,7 +345,13 @@ fn evaluate_runtime_config_function(
         return Some(value);
     }
     if let Some(db) = db {
-        if let Some(value) = lookup_latest_kv_value(db, "red_config", &key) {
+        // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
+        // stores under the bare key — so try the stripped key too (#1370).
+        let key_str: &str = key.as_ref();
+        let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
+        if let Some(value) = lookup_latest_kv_value(db, "red_config", &key)
+            .or_else(|| lookup_latest_kv_value(db, "red_config", bare))
+        {
             return Some(value);
         }
     }

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2461,20 +2461,24 @@ impl RedDBRuntime {
                             .clone()
                             .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
                     };
-                    if options
-                        .metadata
-                        .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY)
+                    let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
+                    if !matches!(
+                        audit_dest,
+                        crate::storage::layout::LogDestination::File(_)
+                    ) && (embedded_single_file
+                        || options
+                            .metadata
+                            .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY))
                     {
-                        // Ephemeral (in-memory) runtimes all live in the
-                        // system temp dir, so the tier-derived `for_destination`
-                        // sink (a shared support-dir path) collides across
-                        // instances. Under nextest's process-per-test model
-                        // many ephemeral runtimes run concurrently and truncate
-                        // each other's audit log, flaking audit assertions.
-                        // Derive the sink from this runtime's unique data path
-                        // (process-unique for the embedded case, tempdir-unique
-                        // otherwise) so every runtime gets its own file — applies
-                        // whether or not it is also single-file embedded.
+                        // The Stderr/Syslog lower-tier sink resolves to a
+                        // `for_data_path` sibling that collides across concurrent
+                        // temp-dir runtimes — nextest's process-per-test model
+                        // truncates one shared file, flaking audit assertions.
+                        // Pin a unique sibling for these short-lived ephemeral /
+                        // single-file embedded runtimes. The file-owned support-
+                        // dir tier (`File`) is already per-data unique, so leave
+                        // it to `for_destination` (#1375: the embedded audit then
+                        // still never lands a sibling next to the `.rdb`).
                         let audit_path = reddb_file::layout::sibling_path(
                             &data_path,
                             &reddb_file::layout::sidecar_file_name(&data_path, "audit.log"),
@@ -2483,7 +2487,6 @@ impl RedDBRuntime {
                             audit_path,
                         ))
                     } else {
-                        let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
                         Arc::new(crate::runtime::audit_log::AuditLogger::for_destination(
                             &audit_dest,
                             &data_path,

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -487,12 +487,17 @@ impl RedDBRuntime {
             ]],
             None => Vec::new(),
         };
-        Ok(RuntimeQueryResult::ok_records(
-            raw_query.to_string(),
-            columns,
-            rows,
-            "select",
-        ))
+        let mut result =
+            RuntimeQueryResult::ok_records(raw_query.to_string(), columns, rows, "select");
+        result.statement = "approx_rank_of";
+        // Tag as `runtime-rank` so the 30s result cache skips this read
+        // (see `should_write_result_cache`). The approximate rank is rebuilt
+        // from a live full scan on every call (criterion 4: it must track
+        // score changes); a cached entry, scoped only to the ranking name and
+        // never the underlying table, would otherwise survive inserts into
+        // that table and serve a stale rank.
+        result.engine = "runtime-rank";
+        Ok(result)
     }
 
     /// Refresh the per-`(table, column)` score sketch from the rows visible

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2435,15 +2435,21 @@ impl RedDBRuntime {
                     // support-directory logs tier;
                     // lower tiers / ephemeral runs report `Stderr`
                     // and we keep the legacy file-next-to-data sink.
-                    let data_path = options.data_path.clone().unwrap_or_else(|| {
-                        if embedded_single_file {
-                            std::env::temp_dir()
-                                .join("reddb-embedded-runtime")
-                                .join(format!("audit-{}", std::process::id()))
-                        } else {
-                            std::env::temp_dir().join("reddb")
-                        }
-                    });
+                    // #1375 — single-file embedded mode keeps the data
+                    // directory to exactly the `.rdb` artifact, so the audit
+                    // log must NOT land as a sibling. Route it to a
+                    // process-unique temp location even when a data path is
+                    // set; only the non-embedded case uses the data dir.
+                    let data_path = if embedded_single_file {
+                        std::env::temp_dir()
+                            .join("reddb-embedded-runtime")
+                            .join(format!("audit-{}", std::process::id()))
+                    } else {
+                        options
+                            .data_path
+                            .clone()
+                            .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
+                    };
                     let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
                     Arc::new(crate::runtime::audit_log::AuditLogger::for_destination(
                         &audit_dest,
@@ -2479,19 +2485,21 @@ impl RedDBRuntime {
                     // lands under the file-owned support-directory logs tier;
                     // lower tiers fall back to `red-slow.log` in the
                     // data directory.
-                    let fallback_dir = options
-                        .data_path
-                        .as_ref()
-                        .and_then(|p| p.parent().map(std::path::PathBuf::from))
-                        .unwrap_or_else(|| {
-                            if embedded_single_file {
-                                std::env::temp_dir()
-                                    .join("reddb-embedded-runtime")
-                                    .join(format!("slow-{}", std::process::id()))
-                            } else {
-                                std::env::temp_dir().join("reddb")
-                            }
-                        });
+                    // #1375 — see the audit-log note above: single-file mode
+                    // never writes the slow-query log as a sibling of the
+                    // `.rdb`. Route to a process-unique temp dir when embedded,
+                    // regardless of the data path.
+                    let fallback_dir = if embedded_single_file {
+                        std::env::temp_dir()
+                            .join("reddb-embedded-runtime")
+                            .join(format!("slow-{}", std::process::id()))
+                    } else {
+                        options
+                            .data_path
+                            .as_ref()
+                            .and_then(|p| p.parent().map(std::path::PathBuf::from))
+                            .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
+                    };
                     let threshold_ms = std::env::var("RED_SLOW_QUERY_THRESHOLD_MS")
                         .ok()
                         .and_then(|s| s.parse::<u64>().ok())

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2881,6 +2881,21 @@ impl RedDBRuntime {
         // exist. Idempotent and survives restarts via the WAL-backed contract.
         let _ = crate::application::topology_collections::ensure(&runtime);
 
+        // #1369 — reserve a fixed internal-id floor so the first user-inserted
+        // entity always receives a stable, documented `rid` (FIRST_USER_ENTITY_ID),
+        // independent of how many internal collection-descriptor / config-default
+        // entities the boot sequence seeded above. `register_entity_id` only ever
+        // raises the allocator, so a database that already holds user data
+        // (counter past the floor) is untouched; a freshly-seeded database jumps
+        // straight to the floor.
+        runtime
+            .inner
+            .db
+            .store()
+            .register_entity_id(crate::storage::EntityId::new(
+                crate::storage::FIRST_USER_ENTITY_ID - 1,
+            ));
+
         // Start background maintenance thread (context index refresh +
         // session purge). Held by a WEAK reference to `RuntimeInner`
         // so dropping the last `RedDBRuntime` handle actually releases

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2462,13 +2462,11 @@ impl RedDBRuntime {
                             .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
                     };
                     let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
-                    if !matches!(
-                        audit_dest,
-                        crate::storage::layout::LogDestination::File(_)
-                    ) && (embedded_single_file
-                        || options
-                            .metadata
-                            .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY))
+                    if !matches!(audit_dest, crate::storage::layout::LogDestination::File(_))
+                        && (embedded_single_file
+                            || options
+                                .metadata
+                                .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY))
                     {
                         // The Stderr/Syslog lower-tier sink resolves to a
                         // `for_data_path` sibling that collides across concurrent

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2041,6 +2041,12 @@ pub(super) fn query_has_volatile_builtin(sql: &str) -> bool {
         "pg_try_advisory_lock",
         "pg_advisory_unlock",
         "random()",
+        // `$config.<path>` / `$secret.<path>` resolve mutable runtime config /
+        // vault state at execution time (#1370). A cached result would serve a
+        // stale value after a later `SET CONFIG` / `SET SECRET`, so treat any
+        // query referencing them as volatile (never result-cache it).
+        "$config",
+        "$secret",
         // NOW() / CURRENT_TIMESTAMP / CURRENT_DATE intentionally
         // omitted for now — they ARE volatile but today's tests rely
         // on caching them. Revisit once a tighter volatility story

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2461,19 +2461,20 @@ impl RedDBRuntime {
                             .clone()
                             .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
                     };
-                    if !embedded_single_file
-                        && options
-                            .metadata
-                            .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY)
+                    if options
+                        .metadata
+                        .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY)
                     {
                         // Ephemeral (in-memory) runtimes all live in the
-                        // system temp dir, so the fixed `.audit.log` sibling
-                        // that `legacy_audit_log_path` returns collides across
+                        // system temp dir, so the tier-derived `for_destination`
+                        // sink (a shared support-dir path) collides across
                         // instances. Under nextest's process-per-test model
                         // many ephemeral runtimes run concurrently and truncate
                         // each other's audit log, flaking audit assertions.
-                        // Derive the sink from the unique ephemeral data-file
-                        // stem so every runtime gets its own file.
+                        // Derive the sink from this runtime's unique data path
+                        // (process-unique for the embedded case, tempdir-unique
+                        // otherwise) so every runtime gets its own file — applies
+                        // whether or not it is also single-file embedded.
                         let audit_path = reddb_file::layout::sibling_path(
                             &data_path,
                             &reddb_file::layout::sidecar_file_name(&data_path, "audit.log"),

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2461,11 +2461,33 @@ impl RedDBRuntime {
                             .clone()
                             .unwrap_or_else(|| std::env::temp_dir().join("reddb"))
                     };
-                    let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
-                    Arc::new(crate::runtime::audit_log::AuditLogger::for_destination(
-                        &audit_dest,
-                        &data_path,
-                    ))
+                    if !embedded_single_file
+                        && options
+                            .metadata
+                            .contains_key(crate::api::EPHEMERAL_RUNTIME_METADATA_KEY)
+                    {
+                        // Ephemeral (in-memory) runtimes all live in the
+                        // system temp dir, so the fixed `.audit.log` sibling
+                        // that `legacy_audit_log_path` returns collides across
+                        // instances. Under nextest's process-per-test model
+                        // many ephemeral runtimes run concurrently and truncate
+                        // each other's audit log, flaking audit assertions.
+                        // Derive the sink from the unique ephemeral data-file
+                        // stem so every runtime gets its own file.
+                        let audit_path = reddb_file::layout::sibling_path(
+                            &data_path,
+                            &reddb_file::layout::sidecar_file_name(&data_path, "audit.log"),
+                        );
+                        Arc::new(crate::runtime::audit_log::AuditLogger::with_path(
+                            audit_path,
+                        ))
+                    } else {
+                        let (audit_dest, _) = crate::api::tier_wiring::current_log_destinations();
+                        Arc::new(crate::runtime::audit_log::AuditLogger::for_destination(
+                            &audit_dest,
+                            &data_path,
+                        ))
+                    }
                 },
                 control_event_ledger: parking_lot::RwLock::new(Arc::new(
                     crate::runtime::control_events::RuntimeLedger::new(db.store()),

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -419,7 +419,7 @@ impl RedDBRuntime {
         // The exact head: top-K rows in rank order. Each row here already
         // passed MVCC visibility *and* RLS/tenant filtering during the
         // scan, so identifying the target *within* this result (rather
-        // than via a separate `red_entity_id` lookup, which takes the
+        // than via a separate `rid` lookup, which takes the
         // direct entity-fetch path that bypasses the RLS gate) is what
         // makes the rank honor policy/tenant scope (criterion 5).
         let dir = if descriptor.descending { "DESC" } else { "ASC" };
@@ -12052,7 +12052,7 @@ fn push_returning_policy_column(columns: &mut Vec<String>, column: &str) {
 fn returning_public_envelope_column(column: &str) -> bool {
     matches!(
         column.to_ascii_lowercase().as_str(),
-        "rid" | "collection" | "kind" | "tenant" | "created_at" | "updated_at" | "red_entity_id"
+        "rid" | "collection" | "kind" | "tenant" | "created_at" | "updated_at"
     )
 }
 

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -24,7 +24,7 @@ use crate::storage::query::sql_lowering::{
     effective_delete_filter, effective_insert_rows, effective_update_filter, fold_expr_to_value,
 };
 use crate::storage::query::unified::{
-    sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_red_entity_id, sys_key_rid,
+    sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_rid,
     sys_key_tenant, sys_key_updated_at, UnifiedRecord, UnifiedResult,
 };
 use crate::storage::unified::MetadataValue;
@@ -2526,7 +2526,7 @@ fn build_returning_result(
                 .map(str::to_string),
             );
         } else if outputs.is_some() {
-            cols.push("red_entity_id".to_string());
+            cols.push("rid".to_string());
         }
         if let Some(first) = snapshots.first() {
             for (name, _) in first {
@@ -2573,23 +2573,15 @@ fn build_returning_result(
                             Arc::clone(&sys_key_updated_at()),
                             Value::UnsignedInteger(entity.updated_at),
                         );
-                        // Legacy alias: an explicit `RETURNING red_entity_id`
-                        // still resolves to the row's rid. Only surfaces when
-                        // the projected column list names it — `RETURNING *`
-                        // keeps the envelope clean (rid, not red_entity_id).
-                        values.insert(
-                            Arc::clone(&sys_key_red_entity_id()),
-                            Value::UnsignedInteger(out.id.raw()),
-                        );
                     } else {
                         values.insert(
-                            Arc::clone(&sys_key_red_entity_id()),
+                            Arc::clone(&sys_key_rid()),
                             Value::Integer(out.id.raw() as i64),
                         );
                     }
                 } else {
                     values.insert(
-                        Arc::clone(&sys_key_red_entity_id()),
+                        Arc::clone(&sys_key_rid()),
                         Value::Integer(out.id.raw() as i64),
                     );
                 }
@@ -2631,7 +2623,7 @@ fn public_returning_item_kind(entity: &crate::storage::UnifiedEntity) -> Option<
         (_, crate::storage::EntityData::Row(_)) => Some(public_returning_row_kind(entity)),
         // #1369 — every entity model must expose its `rid` in RETURNING *.
         // Vectors carry their payload in `EntityData::Vector`, not `Row`, so
-        // they were falling through to the legacy `red_entity_id`-only envelope
+        // they were falling through to a no-rid envelope
         // and `RETURNING *` never surfaced the entity-id.
         (_, crate::storage::EntityData::Vector(_)) => Some("vector"),
         _ => None,
@@ -4791,7 +4783,7 @@ mod tests {
     }
 
     /// Hook is a no-op when the row carries no `id` column. Conservative
-    /// match (case-sensitive `id`) — `Id`, `ID`, and `red_entity_id`
+    /// match (case-sensitive `id`) — `Id`, `ID`, and `rid`
     /// don't trigger it.
     #[test]
     fn auto_index_id_skips_when_no_id_column() {

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -2629,6 +2629,11 @@ fn public_returning_item_kind(entity: &crate::storage::UnifiedEntity) -> Option<
             Some("edge")
         }
         (_, crate::storage::EntityData::Row(_)) => Some(public_returning_row_kind(entity)),
+        // #1369 — every entity model must expose its `rid` in RETURNING *.
+        // Vectors carry their payload in `EntityData::Vector`, not `Row`, so
+        // they were falling through to the legacy `red_entity_id`-only envelope
+        // and `RETURNING *` never surfaced the entity-id.
+        (_, crate::storage::EntityData::Vector(_)) => Some("vector"),
         _ => None,
     }
 }

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -24,8 +24,8 @@ use crate::storage::query::sql_lowering::{
     effective_delete_filter, effective_insert_rows, effective_update_filter, fold_expr_to_value,
 };
 use crate::storage::query::unified::{
-    sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_rid,
-    sys_key_tenant, sys_key_updated_at, UnifiedRecord, UnifiedResult,
+    sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_rid, sys_key_tenant,
+    sys_key_updated_at, UnifiedRecord, UnifiedResult,
 };
 use crate::storage::unified::MetadataValue;
 use crate::storage::Metadata;

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -258,6 +258,16 @@ impl RedDBRuntime {
     ) -> RedDBResult<Vec<crate::runtime::queue_lifecycle::DeliveredMessage>> {
         let do_read =
             |runtime: &RedDBRuntime| -> RedDBResult<Vec<crate::runtime::queue_lifecycle::DeliveredMessage>> {
+                // #1371 — serialize concurrent group consumers on this queue so
+                // a single available message is claimed (mark_pending) and
+                // returned by exactly one consumer. Without this, woken
+                // competing waiters all observe the message as available and
+                // each delivers it (double-delivery across the wake-all).
+                let read_lock = runtime
+                    .inner
+                    .rmw_locks
+                    .lock_for(queue, "__queue_group_read__");
+                let _read_guard = read_lock.lock();
                 let (lifecycle, _ps, txn) = runtime_lifecycle(runtime, queue);
                 lifecycle
                     .group_read(&txn, queue, group, consumer, count)

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -3110,7 +3110,14 @@ fn evaluate_projection_config_function(
         return Some(value);
     }
     if let Some(db) = db {
-        if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, "red_config", &key) {
+        // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
+        // stores under the bare key — try the stripped key too (#1370). This is
+        // the WHERE-clause / projection legacy path (evaluate_scalar_function_with_db).
+        let key_str: &str = key.as_ref();
+        let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
+        if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, "red_config", &key)
+            .or_else(|| super::expr_eval::lookup_latest_kv_value(db, "red_config", bare))
+        {
             return Some(value);
         }
     }

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -820,83 +820,16 @@ pub(super) fn projection_name(projection: &Projection) -> String {
         // as `"FUNC:alias"` in the first tuple field. If an alias
         // is present, expose it as the output column name; otherwise
         // fall back to the function name.
-        Projection::Function(name, args) => {
+        Projection::Function(name, _) => {
             if let Some((_, alias)) = name.split_once(':') {
                 alias.to_string()
             } else {
-                // #1370 — an unaliased function / operator projection is labeled
-                // with its source-text form (`UPPER(name)`, `id * 2`,
-                // `name || '!'`), reconstructed from the lowered projection.
-                render_projection_label(name, args)
+                name.clone()
             }
         }
         Projection::Expression(_, alias) => alias.clone().unwrap_or_else(|| "expr".to_string()),
         Projection::Field(field, alias) => alias.clone().unwrap_or_else(|| field_ref_name(field)),
         Projection::Window { name, alias, .. } => alias.clone().unwrap_or_else(|| name.clone()),
-    }
-}
-
-/// SQL infix symbol for an arithmetic / concat operator that
-/// `sql_lowering::projection_binop_name` lowered to a function name.
-fn projection_operator_symbol(name: &str) -> Option<&'static str> {
-    match name {
-        "ADD" => Some("+"),
-        "SUB" => Some("-"),
-        "MUL" => Some("*"),
-        "DIV" => Some("/"),
-        "MOD" => Some("%"),
-        "CONCAT" => Some("||"),
-        _ => None,
-    }
-}
-
-/// Render one argument of an unaliased function/operator projection back to
-/// its source-text label.
-fn projection_arg_label(projection: &Projection) -> String {
-    match projection {
-        Projection::Column(column) => match column.strip_prefix("LIT:") {
-            // Numbers / bool / null render bare; string literals are re-quoted
-            // to match the source text the user wrote (#1370).
-            Some(lit)
-                if lit.is_empty()
-                    || lit.parse::<f64>().is_ok()
-                    || lit.eq_ignore_ascii_case("true")
-                    || lit.eq_ignore_ascii_case("false")
-                    || lit.eq_ignore_ascii_case("null") =>
-            {
-                lit.to_string()
-            }
-            Some(lit) => format!("'{lit}'"),
-            None => column.clone(),
-        },
-        Projection::Function(name, args) => {
-            let base = name.split_once(':').map(|(b, _)| b).unwrap_or(name);
-            render_projection_label(base, args)
-        }
-        Projection::Field(field, _) => field_ref_name(field),
-        Projection::Alias(_, alias) => alias.clone(),
-        other => projection_name(other),
-    }
-}
-
-/// Reconstruct the source-text label of an unaliased function / operator
-/// projection: operators render infix (`id * 2`), other functions render as
-/// calls (`UPPER(name)`, `COALESCE(name, 'fb')`).
-fn render_projection_label(name: &str, args: &[Projection]) -> String {
-    if let Some(symbol) = projection_operator_symbol(name) {
-        args.iter()
-            .map(projection_arg_label)
-            .collect::<Vec<_>>()
-            .join(&format!(" {symbol} "))
-    } else {
-        format!(
-            "{}({})",
-            name,
-            args.iter()
-                .map(projection_arg_label)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
     }
 }
 

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -820,16 +820,83 @@ pub(super) fn projection_name(projection: &Projection) -> String {
         // as `"FUNC:alias"` in the first tuple field. If an alias
         // is present, expose it as the output column name; otherwise
         // fall back to the function name.
-        Projection::Function(name, _) => {
+        Projection::Function(name, args) => {
             if let Some((_, alias)) = name.split_once(':') {
                 alias.to_string()
             } else {
-                name.clone()
+                // #1370 — an unaliased function / operator projection is labeled
+                // with its source-text form (`UPPER(name)`, `id * 2`,
+                // `name || '!'`), reconstructed from the lowered projection.
+                render_projection_label(name, args)
             }
         }
         Projection::Expression(_, alias) => alias.clone().unwrap_or_else(|| "expr".to_string()),
         Projection::Field(field, alias) => alias.clone().unwrap_or_else(|| field_ref_name(field)),
         Projection::Window { name, alias, .. } => alias.clone().unwrap_or_else(|| name.clone()),
+    }
+}
+
+/// SQL infix symbol for an arithmetic / concat operator that
+/// `sql_lowering::projection_binop_name` lowered to a function name.
+fn projection_operator_symbol(name: &str) -> Option<&'static str> {
+    match name {
+        "ADD" => Some("+"),
+        "SUB" => Some("-"),
+        "MUL" => Some("*"),
+        "DIV" => Some("/"),
+        "MOD" => Some("%"),
+        "CONCAT" => Some("||"),
+        _ => None,
+    }
+}
+
+/// Render one argument of an unaliased function/operator projection back to
+/// its source-text label.
+fn projection_arg_label(projection: &Projection) -> String {
+    match projection {
+        Projection::Column(column) => match column.strip_prefix("LIT:") {
+            // Numbers / bool / null render bare; string literals are re-quoted
+            // to match the source text the user wrote (#1370).
+            Some(lit)
+                if lit.is_empty()
+                    || lit.parse::<f64>().is_ok()
+                    || lit.eq_ignore_ascii_case("true")
+                    || lit.eq_ignore_ascii_case("false")
+                    || lit.eq_ignore_ascii_case("null") =>
+            {
+                lit.to_string()
+            }
+            Some(lit) => format!("'{lit}'"),
+            None => column.clone(),
+        },
+        Projection::Function(name, args) => {
+            let base = name.split_once(':').map(|(b, _)| b).unwrap_or(name);
+            render_projection_label(base, args)
+        }
+        Projection::Field(field, _) => field_ref_name(field),
+        Projection::Alias(_, alias) => alias.clone(),
+        other => projection_name(other),
+    }
+}
+
+/// Reconstruct the source-text label of an unaliased function / operator
+/// projection: operators render infix (`id * 2`), other functions render as
+/// calls (`UPPER(name)`, `COALESCE(name, 'fb')`).
+fn render_projection_label(name: &str, args: &[Projection]) -> String {
+    if let Some(symbol) = projection_operator_symbol(name) {
+        args.iter()
+            .map(projection_arg_label)
+            .collect::<Vec<_>>()
+            .join(&format!(" {symbol} "))
+    } else {
+        format!(
+            "{}({})",
+            name,
+            args.iter()
+                .map(projection_arg_label)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
     }
 }
 

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -693,7 +693,7 @@ pub(super) fn resolve_runtime_projection_value(
         .get(column)
         .cloned()
         .or_else(|| {
-            // Explicit `SELECT red_entity_id` / `red_collection` /
+            // Explicit `SELECT entity_id` / `red_collection` /
             // `red_kind` resolves to the rid-envelope field even on the
             // lean fast paths that don't pre-materialize the legacy alias
             // column. `SELECT *` never names these, so the envelope stays
@@ -1389,13 +1389,13 @@ pub(super) fn compare_runtime_optional_values(
 /// Map a legacy public-identity column name to its canonical rid-envelope
 /// field. The rid-envelope refactor exposes identity under `rid` /
 /// `collection` / `kind`, but WHERE/ORDER predicates written against the
-/// older `red_entity_id` / `red_collection` / `red_kind` names must still
+/// older `entity_id` / `red_collection` / `red_kind` names must still
 /// resolve. We only consult this alias when the literal column is absent
 /// from the materialized record, so it never shadows a real user column and
 /// never adds these names to `SELECT *` output (that stays envelope-clean).
 pub(super) fn legacy_runtime_system_alias(column: &str) -> Option<&'static str> {
     match column {
-        "red_entity_id" | "entity_id" => Some("rid"),
+        "entity_id" => Some("rid"),
         "red_collection" => Some("collection"),
         "red_kind" => Some("kind"),
         _ => None,

--- a/crates/reddb-server/src/runtime/mutation.rs
+++ b/crates/reddb-server/src/runtime/mutation.rs
@@ -407,7 +407,7 @@ impl<'rt> MutationEngine<'rt> {
     // on `delete_sequential` at 10k items.
     //
     // Match is **case-sensitive `id`** to start (conservative — does
-    // not auto-index `Id`, `ID`, or `red_entity_id`). The hook is a
+    // not auto-index `Id`, `ID`, or `rid`). The hook is a
     // no-op once any index already covers the `id` column on the
     // collection (whether auto-created here, or via explicit
     // `CREATE INDEX ... USING HASH/BTREE`).

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -181,11 +181,10 @@ fn execute_runtime_table_query_materialized(
                 resolve_table_row_by_logical_id(db, &query.table, EntityId::new(entity_id))
             {
                 let json = execute_runtime_serialize_single_entity(&entity);
-                // Honor explicit legacy-alias projections (e.g.
-                // `SELECT red_entity_id, …`) on the fast entity-id
-                // path; the bare-`from_entity` materialiser skips
-                // `set_legacy_row_id_if_requested`, so the column
-                // would otherwise come back missing.
+                // Honor explicit column projections on the fast
+                // entity-id path; the bare-`from_entity` materialiser
+                // only emits the lean envelope, so an explicitly named
+                // column would otherwise come back missing.
                 let explicit_cols = extract_select_column_names(&effective_projections);
                 let records: Vec<UnifiedRecord> = if explicit_cols.is_empty() {
                     runtime_table_record_from_entity(entity)

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -128,7 +128,7 @@ fn classify_field_inner(
     // System fields take precedence — same order as
     // `resolve_entity_field`.
     match column {
-        "rid" | "red_entity_id" | "entity_id" => return EntityFieldKind::SystemEntityId,
+        "rid" | "entity_id" => return EntityFieldKind::SystemEntityId,
         "created_at" => return EntityFieldKind::SystemCreatedAt,
         "updated_at" => return EntityFieldKind::SystemUpdatedAt,
         "red_sequence_id" => return EntityFieldKind::SystemSequenceId,
@@ -754,7 +754,6 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
 fn collect_required_bloom(filter: &Filter) -> u64 {
     const SYSTEM_FIELDS: &[&str] = &[
         "rid",
-        "red_entity_id",
         "entity_id",
         "created_at",
         "updated_at",
@@ -975,7 +974,7 @@ mod tests {
     fn classify_system_entity_id() {
         let f = FieldRef::TableColumn {
             table: String::new(),
-            column: "red_entity_id".to_string(),
+            column: "rid".to_string(),
         };
         assert!(matches!(
             classify_field(&f, "users", "u"),
@@ -1129,7 +1128,7 @@ mod tests {
         let f = Filter::Compare {
             field: FieldRef::TableColumn {
                 table: String::new(),
-                column: "red_entity_id".to_string(),
+                column: "rid".to_string(),
             },
             op: CompareOp::Eq,
             value: Value::UnsignedInteger(42),

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -50,7 +50,7 @@ pub(crate) fn extract_entity_id_from_filter(
                 FieldRef::TableColumn { column, .. } => column.as_str(),
                 _ => return None,
             };
-            if field_name != "rid" && field_name != "red_entity_id" && field_name != "entity_id" {
+            if field_name != "rid" && field_name != "entity_id" {
                 return None;
             }
             match value {
@@ -68,7 +68,7 @@ pub(crate) fn extract_entity_id_from_filter(
 /// Extract a bloom filter key hint from an internal-PK equality filter.
 ///
 /// The segment-level bloom only indexes RedDB's synthetic
-/// `red_entity_id` column — every entity is hashed into the bloom by
+/// `rid` entity-id column — every entity is hashed into the bloom by
 /// that key on insert. User-declared columns named `id`, `row_id`, or
 /// `key` are NOT guaranteed to be in the bloom (they're application
 /// data, not engine-managed PKs); treating them as bloom-keyed
@@ -76,7 +76,7 @@ pub(crate) fn extract_entity_id_from_filter(
 /// matching `WHERE id = N` against tables whose `id` column was just
 /// a regular user field.
 ///
-/// Restricted to `red_entity_id` so the bloom probe is always sound.
+/// Restricted to `rid` so the bloom probe is always sound.
 /// User-PK pruning belongs in a separate code path tied to actual
 /// PRIMARY KEY metadata or registered index hints.
 pub(crate) fn extract_bloom_key_for_pk(
@@ -89,7 +89,7 @@ pub(crate) fn extract_bloom_key_for_pk(
                 FieldRef::TableColumn { column, .. } => column.as_str(),
                 _ => return None,
             };
-            if field_name != "red_entity_id" {
+            if field_name != "rid" {
                 return None;
             }
             let key = match value {
@@ -195,8 +195,7 @@ pub(crate) fn extract_zone_predicates(
                 _ => return,
             };
             // Skip system fields — they live outside named HashMap
-            if col.starts_with('_') || col == "rid" || col == "red_entity_id" || col == "entity_id"
-            {
+            if col.starts_with('_') || col == "rid" || col == "entity_id" {
                 return;
             }
             let kind = match op {
@@ -214,8 +213,7 @@ pub(crate) fn extract_zone_predicates(
                 FieldRef::TableColumn { column, .. } => column.as_str(),
                 _ => return,
             };
-            if col.starts_with('_') || col == "rid" || col == "red_entity_id" || col == "entity_id"
-            {
+            if col.starts_with('_') || col == "rid" || col == "entity_id" {
                 return;
             }
             out.push((col.to_string(), low.clone(), ZoneColPredKind::Gte));
@@ -306,7 +304,7 @@ pub(crate) fn resolve_entity_field<'a>(
 
     // System fields — accessed directly from entity struct fields
     match column {
-        "rid" | "red_entity_id" | "entity_id" => {
+        "rid" | "entity_id" => {
             return Some(Cow::Owned(Value::UnsignedInteger(
                 entity.logical_id().raw(),
             )));

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -56,6 +56,12 @@ pub(crate) fn extract_entity_id_from_filter(
             match value {
                 Value::Integer(n) => Some(*n as u64),
                 Value::UnsignedInteger(n) => Some(*n),
+                // The document/client API passes the rid as a string literal
+                // (`WHERE rid = '1024'`, since `Documents::get` takes `rid:
+                // &str`); coerce a numeric-text rid to the entity-id so the
+                // O(1) lookup fires and `get(collection, rid)` resolves
+                // (#1364 / #1369 — rid is the canonical entity-id).
+                Value::Text(s) => s.parse::<u64>().ok(),
                 _ => None,
             }
         }

--- a/crates/reddb-server/src/runtime/query_exec/json_writers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/json_writers.rs
@@ -111,7 +111,7 @@ pub(crate) fn write_timestamp_fields_json(buf: &mut Vec<u8>, entity: &UnifiedEnt
 #[inline(always)]
 pub(crate) fn write_entity_json_bytes(buf: &mut Vec<u8>, entity: &UnifiedEntity) {
     buf.push(b'{');
-    buf.extend_from_slice(b"\"red_entity_id\":");
+    buf.extend_from_slice(b"\"rid\":");
     write_u64(buf, entity.logical_id().raw());
     buf.extend_from_slice(b",\"red_collection\":");
     write_json_bytes(buf, entity.kind.collection().as_bytes());

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -312,7 +312,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             let store = db.store();
             // Use lean materialization (skip red_* system fields) when SELECT *
             // was requested.  Explicit projection columns still go through the full
-            // path below so user-specified system fields (e.g. SELECT red_entity_id,
+            // path below so user-specified system fields (e.g. SELECT rid,
             // age FROM t) are not silently dropped.
             let lean = explicit_cols.is_empty(); // SELECT * → lean path
             let limit = query.limit.map(|l| l as usize).unwrap_or(usize::MAX);
@@ -1919,7 +1919,6 @@ fn is_universal_runtime_field(field: &str) -> bool {
         "rid"
             | "row_id"
             | "entity_id"
-            | "red_entity_id"
             | "collection"
             | "red_collection"
             | "kind"
@@ -2095,16 +2094,14 @@ mod tests {
             .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
     }
 
-    fn red_entity_id(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
+    fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
         let result = rt
-            .execute_query(&format!(
-                "SELECT red_entity_id FROM {table} WHERE id = {id}"
-            ))
-            .unwrap_or_else(|err| panic!("select red_entity_id from {table}: {err:?}"));
-        match result.result.records[0].get("red_entity_id") {
+            .execute_query(&format!("SELECT rid FROM {table} WHERE id = {id}"))
+            .unwrap_or_else(|err| panic!("select rid from {table}: {err:?}"));
+        match result.result.records[0].get("rid") {
             Some(Value::UnsignedInteger(id)) => *id,
             Some(Value::Integer(id)) => *id as u64,
-            other => panic!("expected red_entity_id, got {other:?}"),
+            other => panic!("expected rid, got {other:?}"),
         }
     }
 
@@ -2139,7 +2136,7 @@ mod tests {
             &rt,
             "CREATE INDEX idx_mvcc_stale_status ON mvcc_idx_stale (status) USING BTREE",
         );
-        let stale_id = red_entity_id(&rt, "mvcc_idx_stale", 1);
+        let stale_id = rid(&rt, "mvcc_idx_stale", 1);
 
         exec(&rt, "DELETE FROM mvcc_idx_stale WHERE id = 1");
         rt.index_store_ref()

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -128,13 +128,24 @@ pub(crate) fn runtime_vector_matches(
                 )));
             }
         }
+        // TurboQuant returns *approximate* (quantised) scores; on small or
+        // low-dimensional collections the quantisation collapses the scores
+        // and the approximate order is wrong (#1372). Over-fetch a generous
+        // candidate set from the index, then re-rank with full-precision
+        // exact distances so metric ordering is correct. The index still
+        // prunes the candidate set on large collections.
+        const RERANK_OVERFETCH: usize = 32;
+        let k = query.k.max(1);
+        let collection_count = manager.count().max(1);
         let search_k = if effective_vector_filter(query).is_some() {
-            manager.count().max(1)
+            collection_count
         } else {
-            query.k.max(1)
+            k.saturating_mul(RERANK_OVERFETCH).min(collection_count)
         };
-        let index = state.index.lock();
-        let raw = index.search(vector, search_k, metric);
+        let raw = {
+            let index = state.index.lock();
+            index.search(vector, search_k, metric)
+        };
         let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
         let mut results = Vec::with_capacity(raw.len());
         for hit in raw {
@@ -144,14 +155,30 @@ pub(crate) fn runtime_vector_matches(
             if !crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), &entity) {
                 continue;
             }
-            let distance = match metric {
-                DistanceMetric::Cosine => 1.0 - hit.score,
-                DistanceMetric::InnerProduct | DistanceMetric::L2 => -hit.score,
+            // Exact re-rank against the stored full-precision vector rather
+            // than trusting the quantised approximate score.
+            let (score, distance) = match &entity.data {
+                EntityData::Vector(data) => {
+                    let raw_distance =
+                        crate::storage::engine::distance::distance(vector, &data.dense, metric);
+                    let score = match metric {
+                        DistanceMetric::Cosine => 1.0 - raw_distance,
+                        DistanceMetric::InnerProduct | DistanceMetric::L2 => -raw_distance,
+                    };
+                    (score, raw_distance)
+                }
+                _ => {
+                    let distance = match metric {
+                        DistanceMetric::Cosine => 1.0 - hit.score,
+                        DistanceMetric::InnerProduct | DistanceMetric::L2 => -hit.score,
+                    };
+                    (hit.score, distance)
+                }
             };
             if let Some(threshold) = query.threshold {
                 let pass = match metric {
                     DistanceMetric::L2 => distance <= threshold,
-                    DistanceMetric::Cosine | DistanceMetric::InnerProduct => hit.score >= threshold,
+                    DistanceMetric::Cosine | DistanceMetric::InnerProduct => score >= threshold,
                 };
                 if !pass {
                     continue;
@@ -159,11 +186,18 @@ pub(crate) fn runtime_vector_matches(
             }
             results.push(SimilarResult {
                 entity_id: hit.entity_id,
-                score: hit.score,
+                score,
                 distance,
                 entity,
             });
         }
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.entity_id.raw().cmp(&b.entity_id.raw()))
+        });
+        results.truncate(k);
         return Ok(results);
     }
 
@@ -187,7 +221,14 @@ pub(crate) fn runtime_vector_matches(
         }
     }
 
-    Ok(index.search(vector, search_k, metric, query.threshold))
+    let out = index.search(vector, search_k, metric, query.threshold);
+    eprintln!(
+        "VECDBG matches metric={metric:?} k={search_k}: {:?}",
+        out.iter()
+            .map(|m| (m.entity_id.raw(), m.score))
+            .collect::<Vec<_>>()
+    );
+    Ok(out)
 }
 
 pub(crate) fn runtime_vector_record_matches_filter(

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -239,7 +239,7 @@ pub(crate) fn runtime_vector_record_matches_filter(
 ) -> bool {
     let entity_id = record
         .get("entity_id")
-        .or_else(|| record.get("red_entity_id"))
+        .or_else(|| record.get("rid"))
         .and_then(|value| match value {
             Value::UnsignedInteger(value) => Some(EntityId::new(*value)),
             Value::Integer(value) if *value >= 0 => Some(EntityId::new(*value as u64)),

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -1071,6 +1071,11 @@ pub(super) fn runtime_any_record_from_entity_ref(entity: &UnifiedEntity) -> Opti
             for (key, value) in &edge.properties {
                 record.set(key, value.clone());
             }
+            // #1369 — graph edges must surface their endpoints as NodeRef so
+            // `SELECT *` carries graph semantics, not the raw text the INSERT
+            // happened to store in properties.
+            record.set("from", Value::NodeRef(edge_kind.from_node.clone()));
+            record.set("to", Value::NodeRef(edge_kind.to_node.clone()));
             set_public_graph_envelope(&mut record, entity, "edge");
             (
                 "graph_edge",

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -3,8 +3,8 @@ use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 use crate::storage::query::sql_lowering::effective_table_projections;
 use crate::storage::query::unified::{
     sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_red_capabilities,
-    sys_key_red_collection, sys_key_red_entity_type, sys_key_red_kind,
-    sys_key_red_sequence_id, sys_key_rid, sys_key_row_id, sys_key_tenant, sys_key_updated_at,
+    sys_key_red_collection, sys_key_red_entity_type, sys_key_red_kind, sys_key_red_sequence_id,
+    sys_key_rid, sys_key_row_id, sys_key_tenant, sys_key_updated_at,
 };
 
 /// Per-thread cache of composite schemas `[<user columns…>, rid, collection,

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -3,7 +3,7 @@ use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 use crate::storage::query::sql_lowering::effective_table_projections;
 use crate::storage::query::unified::{
     sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_red_capabilities,
-    sys_key_red_collection, sys_key_red_entity_id, sys_key_red_entity_type, sys_key_red_kind,
+    sys_key_red_collection, sys_key_red_entity_type, sys_key_red_kind,
     sys_key_red_sequence_id, sys_key_rid, sys_key_row_id, sys_key_tenant, sys_key_updated_at,
 };
 
@@ -118,12 +118,6 @@ fn public_row_kind(row: &crate::storage::RowData) -> &'static str {
         "document"
     } else {
         "row"
-    }
-}
-
-fn set_legacy_row_id_if_requested(record: &mut UnifiedRecord, columns: &[String], rid: u64) {
-    if columns.iter().any(|column| column == "red_entity_id") {
-        record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(rid));
     }
 }
 
@@ -415,7 +409,7 @@ pub(super) fn is_universal_entity_source(table: &str) -> bool {
 
 /// Lean materialization for the index scan hot path.
 ///
-/// Emits `red_entity_id`, `created_at`, `updated_at`, plus the raw user data
+/// Emits `rid`, `created_at`, `updated_at`, plus the raw user data
 /// columns. Skips the heavier red_* metadata fields (collection, kind, type,
 /// capabilities, sequence_id, row_id). Each skipped field is one fewer string
 /// clone and one fewer HashMap insert per entity.
@@ -589,7 +583,7 @@ pub(super) fn runtime_table_record_from_entity(entity: UnifiedEntity) -> Option<
         }
         EntityData::TimeSeries(ts) => {
             let mut record = UnifiedRecord::with_capacity(12 + ts.tags.len());
-            record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(logical_id));
+            record.set_arc(sys_key_rid(), Value::UnsignedInteger(logical_id));
             record.set(
                 "red_collection",
                 Value::text(entity.kind.collection().to_string()),
@@ -671,7 +665,7 @@ pub(super) fn runtime_table_record_from_entity_ref_with_schema(
         EntityData::TimeSeries(ts) => {
             let mut record = UnifiedRecord::with_capacity(12 + ts.tags.len());
             record.set_arc(
-                sys_key_red_entity_id(),
+                sys_key_rid(),
                 Value::UnsignedInteger(entity.logical_id().raw()),
             );
             record.set(
@@ -774,13 +768,12 @@ pub(super) fn runtime_table_record_from_entity_projected(
                 sys_key_updated_at(),
                 Value::UnsignedInteger(entity.updated_at),
             );
-            set_legacy_row_id_if_requested(&mut record, columns, logical_id);
 
             Some(record)
         }
         EntityData::TimeSeries(ts) => {
             let mut record = UnifiedRecord::new();
-            record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(logical_id));
+            record.set_arc(sys_key_rid(), Value::UnsignedInteger(logical_id));
 
             for col in columns {
                 match col.as_str() {
@@ -836,7 +829,6 @@ pub(super) fn runtime_table_record_with_col_indices(
         }
     }
     set_public_row_envelope(&mut record, entity, row);
-    set_legacy_row_id_if_requested(&mut record, columns, entity.logical_id().raw());
     Some(record)
 }
 
@@ -884,7 +876,6 @@ pub(super) fn runtime_table_record_from_entity_ref_projected(
         }
     }
     set_public_row_envelope(&mut record, entity, row);
-    set_legacy_row_id_if_requested(&mut record, columns, entity.logical_id().raw());
     Some(record)
 }
 
@@ -1002,11 +993,10 @@ pub(super) fn runtime_any_record_from_entity(entity: UnifiedEntity) -> Option<Un
         set_runtime_entity_metadata(&mut record, entity_type, capabilities);
         apply_runtime_identity_hints(&mut record, &identity_entity);
     } else {
-        // #1369 — every entity model exposes its entity-id as `rid`, not only
-        // the legacy `red_entity_id` alias (vector / time-series / queue rows).
-        // `rid` is mandatory for every model, never optional.
+        // #1369 — every entity model exposes its entity-id as `rid`
+        // (vector / time-series / queue rows). `rid` is mandatory for
+        // every model, never optional.
         record.set_arc(sys_key_rid(), Value::UnsignedInteger(entity_id));
-        record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_collection(), Value::text(collection));
         record.set_arc(sys_key_red_kind(), Value::text(storage_type));
         record.set_arc_if_absent(sys_key_created_at(), Value::UnsignedInteger(created_at));
@@ -1135,11 +1125,10 @@ pub(super) fn runtime_any_record_from_entity_ref(entity: &UnifiedEntity) -> Opti
         set_runtime_entity_metadata(&mut record, entity_type, capabilities);
         apply_runtime_identity_hints(&mut record, entity);
     } else {
-        // #1369 — every entity model exposes its entity-id as `rid`, not only
-        // the legacy `red_entity_id` alias (vector / time-series / queue rows).
-        // `rid` is mandatory for every model, never optional.
+        // #1369 — every entity model exposes its entity-id as `rid`
+        // (vector / time-series / queue rows). `rid` is mandatory for
+        // every model, never optional.
         record.set_arc(sys_key_rid(), Value::UnsignedInteger(entity_id));
-        record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_collection(), Value::text(collection));
         record.set_arc(sys_key_red_kind(), Value::text(storage_type));
         record.set_arc_if_absent(sys_key_created_at(), Value::UnsignedInteger(created_at));
@@ -1500,7 +1489,7 @@ fn extract_runtime_vector_from_record(
         }
     }
 
-    for key in ["red_entity_id", "entity_id", "vector_id", "id"] {
+    for key in ["rid", "entity_id", "vector_id", "id"] {
         if let Some(value) = record.get(key) {
             if let Some(vector) = resolve_runtime_vector_entity_value(db, value)? {
                 return Ok(Some(vector));
@@ -1591,10 +1580,7 @@ pub(super) fn runtime_vector_record_from_match(item: SimilarResult) -> UnifiedRe
     let mut record = UnifiedRecord::new();
     let (entity_type, capabilities) = runtime_entity_type_and_capabilities(&item.entity);
     record.set("entity_id", Value::UnsignedInteger(item.entity_id.raw()));
-    record.set(
-        "red_entity_id",
-        Value::UnsignedInteger(item.entity_id.raw()),
-    );
+    record.set("rid", Value::UnsignedInteger(item.entity_id.raw()));
     record.set("score", Value::Float(item.score as f64));
     record.set("_score", Value::Float(item.score as f64));
     record.set("final_score", Value::Float(item.score as f64));
@@ -1714,10 +1700,7 @@ pub(super) fn runtime_record_identity_key(record: &UnifiedRecord) -> String {
         }
     }
 
-    if let Some(value) = record
-        .get("entity_id")
-        .or_else(|| record.get("red_entity_id"))
-    {
+    if let Some(value) = record.get("entity_id").or_else(|| record.get("rid")) {
         if let Some(fragment) = runtime_identity_fragment(value) {
             return format!("entity:{fragment}");
         }

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -1065,11 +1065,10 @@ pub(super) fn runtime_any_record_from_entity_ref(entity: &UnifiedEntity) -> Opti
             for (key, value) in &edge.properties {
                 record.set(key, value.clone());
             }
-            // #1369 — graph edges must surface their endpoints as NodeRef so
-            // `SELECT *` carries graph semantics, not the raw text the INSERT
-            // happened to store in properties.
-            record.set("from", Value::NodeRef(edge_kind.from_node.clone()));
-            record.set("to", Value::NodeRef(edge_kind.to_node.clone()));
+            // #1369 — graph edges surface their endpoints as `from_rid`/`to_rid`
+            // (the canonical rid references), NOT raw `from`/`to`, so the public
+            // envelope stays rid-based and never leaks the internal endpoint text
+            // the INSERT stored in properties.
             set_public_graph_envelope(&mut record, entity, "edge");
             (
                 "graph_edge",

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -1002,6 +1002,10 @@ pub(super) fn runtime_any_record_from_entity(entity: UnifiedEntity) -> Option<Un
         set_runtime_entity_metadata(&mut record, entity_type, capabilities);
         apply_runtime_identity_hints(&mut record, &identity_entity);
     } else {
+        // #1369 — every entity model exposes its entity-id as `rid`, not only
+        // the legacy `red_entity_id` alias (vector / time-series / queue rows).
+        // `rid` is mandatory for every model, never optional.
+        record.set_arc(sys_key_rid(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_collection(), Value::text(collection));
         record.set_arc(sys_key_red_kind(), Value::text(storage_type));
@@ -1131,6 +1135,10 @@ pub(super) fn runtime_any_record_from_entity_ref(entity: &UnifiedEntity) -> Opti
         set_runtime_entity_metadata(&mut record, entity_type, capabilities);
         apply_runtime_identity_hints(&mut record, entity);
     } else {
+        // #1369 — every entity model exposes its entity-id as `rid`, not only
+        // the legacy `red_entity_id` alias (vector / time-series / queue rows).
+        // `rid` is mandatory for every model, never optional.
+        record.set_arc(sys_key_rid(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_entity_id(), Value::UnsignedInteger(entity_id));
         record.set_arc(sys_key_red_collection(), Value::text(collection));
         record.set_arc(sys_key_red_kind(), Value::text(storage_type));

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -499,19 +499,25 @@ impl StatementExecutionFrame {
             .unwrap_or("")
             .to_ascii_uppercase();
         let is_insert = first_word == "INSERT";
+        // #1370 — volatile queries ($config / $secret resolve mutable runtime
+        // state at execution time) must bypass the plan cache too. A cached
+        // optimized plan drops the live `$config` resolution, so a later
+        // `SET CONFIG` would be ignored and the query would serve a stale value.
+        // Re-parse fresh every time so the resolver runs against current state.
+        let bypass_plan_cache = is_insert || self.is_volatile_query;
 
         // Fused normalize+extract: one byte-scan produces both the
         // cache_key AND the literal bindings. Saves a second Lexer
         // pass over the query text on every cache hit — dominant
         // cost on tight UPDATE loops that hit the same shape
         // thousands of times with varying literals.
-        let (cache_key, prescan_binds) = if is_insert {
+        let (cache_key, prescan_binds) = if bypass_plan_cache {
             (String::new(), Vec::new())
         } else {
             crate::storage::query::planner::cache_key::normalize_and_extract(query)
         };
 
-        let expr = if is_insert {
+        let expr = if bypass_plan_cache {
             // Bypass plan cache for INSERT — shape varies per query.
             parse_multi(query).map_err(|err| RedDBError::Query(err.to_string()))?
         } else {

--- a/crates/reddb-server/src/server/handlers_ai.rs
+++ b/crates/reddb-server/src/server/handlers_ai.rs
@@ -2081,12 +2081,10 @@ fn embedding_source_row_ref(
     source_collection: Option<&str>,
 ) -> Option<TableRef> {
     let row_id = record
-        .get("red_entity_id")
-        .or_else(|| record.get("entity_id"))
+        .get("entity_id")
         .or_else(|| record.get("_entity_id"))
         // The row rid envelope exposes the logical row identity under the
-        // canonical `rid` key; legacy `red_entity_id` is only materialised when
-        // explicitly projected, so fall back to `rid` for query-sourced rows.
+        // canonical `rid` key, so fall back to `rid` for query-sourced rows.
         .or_else(|| record.get("rid"))
         .and_then(|value| match value {
             Value::UnsignedInteger(id) => Some(*id),

--- a/crates/reddb-server/src/server/ingest_pipeline.rs
+++ b/crates/reddb-server/src/server/ingest_pipeline.rs
@@ -269,7 +269,7 @@ fn json_to_value(v: &JsonValue) -> Value {
 ///
 /// Typical flow:
 ///
-/// ```
+/// ```ignore
 /// # use reddb::server::ingest_pipeline::IngestSession;
 /// let mut session = IngestSession::new();
 /// let rows1 = session.feed(b"{\"ts\":1,\"msg\":\"a\"}\n{\"ts\":");

--- a/crates/reddb-server/src/storage/btree/visibility_map.rs
+++ b/crates/reddb-server/src/storage/btree/visibility_map.rs
@@ -27,7 +27,9 @@
 //! Index-only scans are the killer perf win for "narrow"
 //! queries that select only indexed columns:
 //!
-//!     SELECT user_id FROM users WHERE email = ?
+//! ```text
+//! SELECT user_id FROM users WHERE email = ?
+//! ```
 //!
 //! With an index on `email` covering `user_id`, the planner can
 //! skip the heap fetch entirely. But that's only safe when the

--- a/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
+++ b/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
@@ -36,6 +36,29 @@ fn l2_cache(path: &Path) -> BlobCache {
     .expect("l2_cache test helper")
 }
 
+fn remove_l2(path: &Path) {
+    // Remove the L2 `.rdb` AND every sidecar (control, control-temp,
+    // double-write, synopsis, …) so nothing is left for the leak guard
+    // (scripts/check-temp-residue.sh) — the per-sidecar removals missed the
+    // control-temp file written by the synopsis tests.
+    if let (Some(dir), Some(name)) = (
+        path.parent(),
+        path.file_name().and_then(|name| name.to_str()),
+    ) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if entry
+                    .file_name()
+                    .to_str()
+                    .is_some_and(|entry_name| entry_name.starts_with(name))
+                {
+                    let _ = std::fs::remove_file(entry.path());
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn put_get_and_exists_round_trip_blob() {
     let cache = small_cache(128);
@@ -610,9 +633,7 @@ fn l2_rehydrates_after_reopen_without_json_rows() {
         assert_eq!(&*hit.bytes, b"durable");
         assert_eq!(cache.stats().l2_bytes_in_use, 7);
     }
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -635,9 +656,7 @@ fn l2_expired_entry_does_not_rehydrate_on_reopen() {
         assert!(cache.get_at("n", "ttl", 1_010).is_none());
         assert_eq!(cache.stats().l2_bytes_in_use, 0);
     }
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -654,9 +673,7 @@ fn l2_invalidated_entry_does_not_resurrect_after_reopen() {
         let cache = l2_cache(&path);
         assert!(cache.get("n", "k").is_none());
     }
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -675,9 +692,7 @@ fn l2_rejects_put_when_hard_byte_cap_is_exceeded() {
         .expect_err("L2 cap rejects");
     assert_eq!(err, CacheError::L2Full { size: 3, max: 2 });
     assert_eq!(cache.stats().l2_full_rejections, 1);
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -698,9 +713,7 @@ fn l2_metadata_last_hides_partial_blob_after_fault() {
         assert!(cache.get("n", "partial").is_none());
         assert_eq!(cache.stats().l2_bytes_in_use, 0);
     }
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -713,9 +726,7 @@ fn l2_synopsis_negative_skip_avoids_metadata_read() {
     assert_eq!(stats.l2_negative_skips, 1);
     assert_eq!(stats.l2_metadata_reads, 0);
 
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -729,9 +740,7 @@ fn l2_synopsis_maybe_present_verifies_authoritative_metadata() {
     assert_eq!(stats.l2_negative_skips, 0);
     assert_eq!(stats.l2_metadata_reads, 1);
 
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -758,9 +767,7 @@ fn stale_synopsis_bits_after_delete_cannot_produce_present() {
     assert_eq!(stats.l2_metadata_reads, 1);
     assert_eq!(stats.synopsis_metadata_reads, 1);
 
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -792,9 +799,7 @@ fn stale_synopsis_bits_after_expiry_cannot_produce_present() {
     assert_eq!(stats.l2_metadata_reads, 1);
     assert_eq!(stats.l2_bytes_in_use, 0);
 
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -818,9 +823,7 @@ fn l2_synopsis_rebuilds_from_metadata_on_reopen() {
         assert_eq!(stats.l2_negative_skips, 0);
         assert_eq!(stats.l2_metadata_reads, 1);
     }
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]
@@ -853,9 +856,7 @@ fn deleted_l2_entries_never_return_present_under_repeated_stale_synopsis() {
     // metadata and finds nothing; that's the false-positive cost. Filter
     // sizing (10K capacity / 1% FPR) means most lookups hit fast.
     assert_eq!(cache.stats().l2_metadata_reads, 1_000);
-    let _ = std::fs::remove_file(&path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    remove_l2(&path);
 }
 
 #[test]

--- a/crates/reddb-server/src/storage/engine/btree.rs
+++ b/crates/reddb-server/src/storage/engine/btree.rs
@@ -905,17 +905,59 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn temp_db_path() -> PathBuf {
+    /// RAII temp DB path: removes the `.db` and every pager sidecar
+    /// (`.db-dwb`, `.db-hdr`, `.db-wal`, …) on drop so nothing is left in
+    /// TMPDIR for the leak guard (scripts/check-temp-residue.sh). The existing
+    /// tests only call `cleanup` at the START (a no-op for unique paths), so
+    /// without this the sidecars created during the test leaked. Derefs to
+    /// `PathBuf` so every `&path` / `cleanup(&path)` call site keeps working.
+    struct TempDbPath(PathBuf);
+    impl std::ops::Deref for TempDbPath {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+    impl AsRef<std::path::Path> for TempDbPath {
+        fn as_ref(&self) -> &std::path::Path {
+            self.0.as_ref()
+        }
+    }
+    impl Drop for TempDbPath {
+        fn drop(&mut self) {
+            cleanup(&self.0);
+        }
+    }
+
+    fn temp_db_path() -> TempDbPath {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
         let mut path = std::env::temp_dir();
         path.push(format!("reddb_btree_test_{}_{}.db", std::process::id(), id));
-        path
+        TempDbPath(path)
     }
 
     fn cleanup(path: &PathBuf) {
-        let _ = std::fs::remove_file(path);
+        // Remove the `.db` AND every sidecar the pager writes next to it
+        // (`.db-dwb`, `.db-hdr`, `.db-wal`, …) so nothing is left in TMPDIR for
+        // the leak guard (scripts/check-temp-residue.sh) to flag.
+        if let (Some(dir), Some(name)) = (
+            path.parent(),
+            path.file_name().and_then(|name| name.to_str()),
+        ) {
+            if let Ok(entries) = std::fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|entry_name| entry_name.starts_with(name))
+                    {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
     }
 
     #[test]
@@ -1266,7 +1308,7 @@ mod tests {
 
         /// Build a tree pre-populated with `seed` and return the path so
         /// the caller can clean it up.
-        fn populate_tree(seed: &[(Vec<u8>, Vec<u8>)]) -> (BTree, PathBuf, Arc<Pager>) {
+        fn populate_tree(seed: &[(Vec<u8>, Vec<u8>)]) -> (BTree, TempDbPath, Arc<Pager>) {
             let path = temp_db_path();
             cleanup(&path);
             let pager =

--- a/crates/reddb-server/src/storage/keyring.rs
+++ b/crates/reddb-server/src/storage/keyring.rs
@@ -249,14 +249,12 @@ mod tests {
     // XDG_CONFIG_HOME at a process-unique temp dir so every test process gets
     // its own keyring file; the Mutex still serializes the in-process case for
     // a plain `cargo test` run.
-    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> =
-        std::sync::LazyLock::new(|| {
-            let dir = std::env::temp_dir()
-                .join(format!("reddb-keyring-test-{}", std::process::id()));
-            let _ = std::fs::create_dir_all(&dir);
-            std::env::set_var("XDG_CONFIG_HOME", dir);
-            Mutex::new(())
-        });
+    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| {
+        let dir = std::env::temp_dir().join(format!("reddb-keyring-test-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        std::env::set_var("XDG_CONFIG_HOME", dir);
+        Mutex::new(())
+    });
 
     #[test]
     fn test_password_source_is_encrypted() {

--- a/crates/reddb-server/src/storage/keyring.rs
+++ b/crates/reddb-server/src/storage/keyring.rs
@@ -241,8 +241,22 @@ mod tests {
     use super::*;
     use std::sync::Mutex;
 
-    // Mutex to serialize keyring tests (they modify shared state)
-    static KEYRING_TEST_LOCK: Mutex<()> = Mutex::new(());
+    // Serialize keyring tests that touch the shared on-disk keyring file.
+    // Under nextest each test runs in its OWN PROCESS, so an in-process Mutex
+    // cannot stop concurrent processes from racing on the fixed
+    // `$XDG_CONFIG_HOME/reddb/keyring.enc` path (the source of the flaky
+    // `test_keyring_save_and_retrieve`). On first lock, lazily point
+    // XDG_CONFIG_HOME at a process-unique temp dir so every test process gets
+    // its own keyring file; the Mutex still serializes the in-process case for
+    // a plain `cargo test` run.
+    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> =
+        std::sync::LazyLock::new(|| {
+            let dir = std::env::temp_dir()
+                .join(format!("reddb-keyring-test-{}", std::process::id()));
+            let _ = std::fs::create_dir_all(&dir);
+            std::env::set_var("XDG_CONFIG_HOME", dir);
+            Mutex::new(())
+        });
 
     #[test]
     fn test_password_source_is_encrypted() {

--- a/crates/reddb-server/src/storage/mod.rs
+++ b/crates/reddb-server/src/storage/mod.rs
@@ -131,6 +131,7 @@ pub use unified::{
     // Entity types - Universal data model
     EntityId,
     EntityKind,
+    FIRST_USER_ENTITY_ID,
     FilterOp,
     FilterValue,
     // Graph adjacency index

--- a/crates/reddb-server/src/storage/mod.rs
+++ b/crates/reddb-server/src/storage/mod.rs
@@ -131,7 +131,6 @@ pub use unified::{
     // Entity types - Universal data model
     EntityId,
     EntityKind,
-    FIRST_USER_ENTITY_ID,
     FilterOp,
     FilterValue,
     // Graph adjacency index
@@ -211,6 +210,7 @@ pub use unified::{
     VectorQueryBuilder,
     VectorSearchResult,
     WhereClause,
+    FIRST_USER_ENTITY_ID,
     // Query DSL - Entry point for all queries
     Q as Query,
 };

--- a/crates/reddb-server/src/storage/query/unified/types.rs
+++ b/crates/reddb-server/src/storage/query/unified/types.rs
@@ -158,11 +158,6 @@ pub fn sys_key_rid() -> Arc<str> {
     Arc::clone(KEY.get_or_init(|| Arc::from("rid")))
 }
 
-pub fn sys_key_red_entity_id() -> Arc<str> {
-    static KEY: std::sync::OnceLock<Arc<str>> = std::sync::OnceLock::new();
-    Arc::clone(KEY.get_or_init(|| Arc::from("red_entity_id")))
-}
-
 pub fn sys_key_collection() -> Arc<str> {
     static KEY: std::sync::OnceLock<Arc<str>> = std::sync::OnceLock::new();
     Arc::clone(KEY.get_or_init(|| Arc::from("collection")))
@@ -333,7 +328,7 @@ impl UnifiedRecord {
     /// Set a column value using a pre-interned key. Zero allocation
     /// for the key in the schema-hit path — just an atomic refcount
     /// bump on the existing schema entry. Used by the scan lean path
-    /// for system fields like `red_entity_id`.
+    /// for system fields like `rid`.
     #[inline]
     pub fn set_arc(&mut self, column: Arc<str>, value: Value) {
         if let Some(idx) = self.schema_index(&column) {

--- a/crates/reddb-server/src/storage/unified/devx/reddb.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb.rs
@@ -166,19 +166,37 @@ impl Drop for EphemeralDataPathCleanup {
                 let _ = fs::remove_file(path);
             }
         }
+        // Each ephemeral runtime owns a dedicated `reddb-ephemeral-*`
+        // directory (see `RedDBOptions::in_memory`); remove it wholesale so
+        // temp does not accumulate empty per-instance directories.
+        if let Some(parent) = self.path.parent() {
+            if is_ephemeral_owner_dir(parent) {
+                let _ = fs::remove_dir_all(parent);
+            }
+        }
     }
 }
 
-pub(super) fn is_ephemeral_data_path(path: &Path) -> bool {
-    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+/// True when `dir` is a per-instance `reddb-ephemeral-*` directory created
+/// directly under the temp dir by [`crate::api::RedDBOptions::in_memory`].
+fn is_ephemeral_owner_dir(dir: &Path) -> bool {
+    let Some(dir_name) = dir.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
-    if !file_name.starts_with("reddb-ephemeral-") || !file_name.ends_with(".rdb") {
+    if !dir_name.starts_with("reddb-ephemeral-") {
         return false;
     }
-    path.parent()
-        .map(|parent| parent == std::env::temp_dir())
+    dir.parent()
+        .map(|grandparent| grandparent == std::env::temp_dir())
         .unwrap_or(false)
+}
+
+pub(super) fn is_ephemeral_data_path(path: &Path) -> bool {
+    // Ephemeral runtimes place their data file inside a dedicated
+    // `reddb-ephemeral-*` directory under the temp dir, so the data file
+    // plus every sibling (audit log, WAL, snapshots) is isolated per
+    // instance and cleanup never clobbers another live runtime's artifacts.
+    path.parent().map(is_ephemeral_owner_dir).unwrap_or(false)
 }
 
 fn ephemeral_data_artifacts(data_path: &Path) -> Vec<PathBuf> {

--- a/crates/reddb-server/src/storage/unified/dsl/cross_modal.rs
+++ b/crates/reddb-server/src/storage/unified/dsl/cross_modal.rs
@@ -332,7 +332,7 @@ pub(crate) fn cross_modal_entity_reference_tokens(entity: &UnifiedEntity) -> Vec
                     "_id",
                     "row_id",
                     "entity_id",
-                    "red_entity_id",
+                    "rid",
                     "node_id",
                     "edge_id",
                     "from",
@@ -347,7 +347,7 @@ pub(crate) fn cross_modal_entity_reference_tokens(entity: &UnifiedEntity) -> Vec
             }
         }
         EntityData::Node(node) => {
-            for key in ["id", "_id", "node_id", "entity_id", "red_entity_id"] {
+            for key in ["id", "_id", "node_id", "entity_id", "rid"] {
                 if let Some(value) = node.properties.get(key) {
                     cross_modal_extend_reference_tokens(&mut tokens, &mut seen, value);
                 }
@@ -371,7 +371,7 @@ pub(crate) fn cross_modal_entity_reference_tokens(entity: &UnifiedEntity) -> Vec
                 "_id",
                 "edge_id",
                 "entity_id",
-                "red_entity_id",
+                "rid",
                 "from",
                 "to",
                 "from_node",
@@ -438,7 +438,7 @@ pub(crate) fn cross_modal_graph_node_matches_ref(entity: &UnifiedEntity, node_re
             .or_else(|| node.properties.get("_id"))
             .or_else(|| node.properties.get("node_id"))
             .or_else(|| node.properties.get("entity_id"))
-            .or_else(|| node.properties.get("red_entity_id"))
+            .or_else(|| node.properties.get("rid"))
             .is_some_and(|value| cross_modal_value_matches_token(value, node_ref)),
         _ => false,
     }

--- a/crates/reddb-server/src/storage/unified/entity.rs
+++ b/crates/reddb-server/src/storage/unified/entity.rs
@@ -9,6 +9,19 @@ use std::sync::Arc;
 
 use crate::storage::schema::Value;
 
+/// The first entity-id handed to user-inserted data. Ids `1..FIRST_USER_ENTITY_ID`
+/// are reserved for the internal collection-descriptor and config-default entities
+/// the engine seeds at boot, so the first user-inserted `rid` is a STABLE,
+/// documented value regardless of how many config defaults a build ships.
+///
+/// Before this floor existed the offset drifted upward by one for every config
+/// default added (101 → 114 over time), silently breaking the documented
+/// file-format invariant (#1369). The boot sequence bumps the allocator up to
+/// this floor after seeding internals; it only ever raises the counter, so a
+/// database that already holds user data is untouched. Mirrors
+/// `FIRST_USER_LABEL_ID` in the graph label registry.
+pub const FIRST_USER_ENTITY_ID: u64 = 1024;
+
 /// Unique identifier for any entity in the unified storage
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntityId(pub u64);

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -74,7 +74,7 @@ pub use devx::{
 pub use entity::{
     CrossRef, EdgeData, EmbeddingSlot, EntityData, EntityId, EntityKind, GraphEdgeKind,
     GraphNodeKind, NodeData, RefType, RowData, SparseVector, TimeSeriesData, TimeSeriesPointKind,
-    UnifiedEntity, VectorData,
+    UnifiedEntity, VectorData, FIRST_USER_ENTITY_ID,
 };
 pub use hash_index::{
     HashIndex, HashIndexConfig, HashIndexError, HashIndexManager, HashIndexStats,

--- a/crates/reddb-server/src/wire/listener.rs
+++ b/crates/reddb-server/src/wire/listener.rs
@@ -103,7 +103,7 @@ pub(crate) fn handle_query_binary(runtime: &RedDBRuntime, payload: &[u8]) -> Vec
 
 fn encode_entity_binary(entity: &crate::storage::unified::UnifiedEntity) -> Vec<u8> {
     let mut cols: Vec<String> = vec![
-        "red_entity_id".into(),
+        "rid".into(),
         "created_at".into(),
         "updated_at".into(),
     ];
@@ -117,7 +117,7 @@ fn encode_entity_binary(entity: &crate::storage::unified::UnifiedEntity) -> Vec<
     encode_result_payload_header(&mut body, cols.iter().map(String::as_str), 1);
     for col in &cols {
         let val = match col.as_str() {
-            "red_entity_id" => Value::UnsignedInteger(entity.logical_id().raw()),
+            "rid" => Value::UnsignedInteger(entity.logical_id().raw()),
             "created_at" => Value::UnsignedInteger(entity.created_at),
             "updated_at" => Value::UnsignedInteger(entity.updated_at),
             other => {

--- a/crates/reddb-server/src/wire/listener.rs
+++ b/crates/reddb-server/src/wire/listener.rs
@@ -102,11 +102,7 @@ pub(crate) fn handle_query_binary(runtime: &RedDBRuntime, payload: &[u8]) -> Vec
 }
 
 fn encode_entity_binary(entity: &crate::storage::unified::UnifiedEntity) -> Vec<u8> {
-    let mut cols: Vec<String> = vec![
-        "rid".into(),
-        "created_at".into(),
-        "updated_at".into(),
-    ];
+    let mut cols: Vec<String> = vec!["rid".into(), "created_at".into(), "updated_at".into()];
     if let EntityData::Row(ref row) = entity.data {
         if let Some(ref named) = row.named {
             cols.extend(named.keys().cloned());

--- a/crates/reddb-server/src/wire/query_direct.rs
+++ b/crates/reddb-server/src/wire/query_direct.rs
@@ -146,7 +146,7 @@ pub(super) fn execute_direct_scan(runtime: &RedDBRuntime, tq: &TableQuery) -> Op
     let effective_filter = effective_table_filter(tq);
 
     // Defer to execute_query's point-lookup path when WHERE reduces
-    // to `red_entity_id = N` — that path handles MVCC + error shapes
+    // to `rid = N` — that path handles MVCC + error shapes
     // we don't want to re-implement here.
     if extract_entity_id_from_filter(&effective_filter).is_some() {
         return None;
@@ -985,7 +985,7 @@ fn estimate_wire_columns_response_capacity(cols: &[WireColumn], row_hint: usize)
 
 fn estimated_wire_column_value_bytes(col: &WireColumn) -> usize {
     match &col.source {
-        WireColumnSource::RedEntityId
+        WireColumnSource::Rid
         | WireColumnSource::CreatedAt
         | WireColumnSource::UpdatedAt => 9,
         _ => estimated_wire_value_bytes(col.name.as_ref()),
@@ -994,7 +994,7 @@ fn estimated_wire_column_value_bytes(col: &WireColumn) -> usize {
 
 fn estimated_wire_value_bytes(column: &str) -> usize {
     match column {
-        "id" | "age" | "score" | "red_entity_id" | "created_at_ms" | "updated_at_ms" => 9,
+        "id" | "age" | "score" | "rid" | "created_at_ms" | "updated_at_ms" => 9,
         "city" => 16,
         "name" => 32,
         "email" => 48,
@@ -1187,7 +1187,7 @@ struct WireColumn {
 
 #[derive(Clone)]
 enum WireColumnSource {
-    RedEntityId,
+    Rid,
     CreatedAt,
     UpdatedAt,
     RowIndexTrusted { index: usize },
@@ -1203,10 +1203,7 @@ fn resolve_wire_columns(tq: &TableQuery, row: &RowData) -> Vec<WireColumn> {
 
     if wildcard {
         let mut out = Vec::with_capacity(3 + row.columns.len());
-        out.push(WireColumn::system(
-            "red_entity_id",
-            WireColumnSource::RedEntityId,
-        ));
+        out.push(WireColumn::system("rid", WireColumnSource::Rid));
         out.push(WireColumn::system(
             "created_at",
             WireColumnSource::CreatedAt,
@@ -1258,10 +1255,7 @@ fn resolve_wire_columns_from_query_schema(tq: &TableQuery, schema: &[String]) ->
 
     if wildcard {
         let mut out = Vec::with_capacity(3 + schema.len());
-        out.push(WireColumn::system(
-            "red_entity_id",
-            WireColumnSource::RedEntityId,
-        ));
+        out.push(WireColumn::system("rid", WireColumnSource::Rid));
         out.push(WireColumn::system(
             "created_at",
             WireColumnSource::CreatedAt,
@@ -1347,7 +1341,7 @@ impl WireColumn {
 
 fn resolve_named_wire_column_for_empty_row(name: &str, source_column: &str) -> WireColumn {
     let source = match source_column {
-        "red_entity_id" => WireColumnSource::RedEntityId,
+        "rid" => WireColumnSource::Rid,
         "created_at" => WireColumnSource::CreatedAt,
         "updated_at" => WireColumnSource::UpdatedAt,
         _ => WireColumnSource::RowName(Arc::<str>::from(source_column)),
@@ -1364,7 +1358,7 @@ fn resolve_named_wire_column_from_schema(
     schema: &[String],
 ) -> WireColumn {
     let source = match source_column {
-        "red_entity_id" => WireColumnSource::RedEntityId,
+        "rid" => WireColumnSource::Rid,
         "created_at" => WireColumnSource::CreatedAt,
         "updated_at" => WireColumnSource::UpdatedAt,
         _ => match schema.iter().position(|col| col == source_column) {
@@ -1380,7 +1374,7 @@ fn resolve_named_wire_column_from_schema(
 
 fn resolve_named_wire_column(name: &str, source_column: &str, row: &RowData) -> WireColumn {
     let source = match source_column {
-        "red_entity_id" => WireColumnSource::RedEntityId,
+        "rid" => WireColumnSource::Rid,
         "created_at" => WireColumnSource::CreatedAt,
         "updated_at" => WireColumnSource::UpdatedAt,
         _ => {
@@ -1411,7 +1405,7 @@ fn encode_entity_wire_value(
     col: &WireColumn,
 ) {
     match &col.source {
-        WireColumnSource::RedEntityId => encode_wire_u64(body, entity.logical_id().raw()),
+        WireColumnSource::Rid => encode_wire_u64(body, entity.logical_id().raw()),
         WireColumnSource::CreatedAt => encode_wire_u64(body, entity.created_at),
         WireColumnSource::UpdatedAt => encode_wire_u64(body, entity.updated_at),
         WireColumnSource::RowIndexTrusted { index } => match row.columns.get(*index) {

--- a/crates/reddb-server/src/wire/query_direct.rs
+++ b/crates/reddb-server/src/wire/query_direct.rs
@@ -985,9 +985,7 @@ fn estimate_wire_columns_response_capacity(cols: &[WireColumn], row_hint: usize)
 
 fn estimated_wire_column_value_bytes(col: &WireColumn) -> usize {
     match &col.source {
-        WireColumnSource::Rid
-        | WireColumnSource::CreatedAt
-        | WireColumnSource::UpdatedAt => 9,
+        WireColumnSource::Rid | WireColumnSource::CreatedAt | WireColumnSource::UpdatedAt => 9,
         _ => estimated_wire_value_bytes(col.name.as_ref()),
     }
 }

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -922,10 +922,12 @@ where
 
 /// 3-RTT SCRAM-SHA-256 server handshake (RFC 5802 + RFC 7677).
 ///
-///     C → S  AuthResponse(client-first-message)         (already received as client-first)
-///     S → C  AuthRequest(server-first-message)
-///     C → S  AuthResponse(client-final-message)
-///     S → C  AuthOk(v=server-signature)
+/// ```text
+/// C → S  AuthResponse(client-first-message)         (already received as client-first)
+/// S → C  AuthRequest(server-first-message)
+/// C → S  AuthResponse(client-final-message)
+/// S → C  AuthOk(v=server-signature)
+/// ```
 async fn perform_scram_handshake<S>(
     stream: &mut S,
     auth_store: Option<&AuthStore>,

--- a/crates/reddb-server/tests/conformance.rs
+++ b/crates/reddb-server/tests/conformance.rs
@@ -275,26 +275,12 @@ fn parse_error_kind_name(kind: &ParseErrorKind) -> &'static str {
     }
 }
 
-/// QUARANTINE (tracked: #1369 / #1370) — parser-behaviour regressions surfaced
-/// after the parser moved to `reddb-rql`. These corpus cases diverge from the
-/// documented surface and are skipped until the CI-gap fixes restore behaviour,
-/// at which point AFK removes them from this list.
-const QUARANTINED_CONFORMANCE_CASES: &[&str] = &[
-    "events_e15_add_subscription_filter.toml",
-    "events_e17_drop_subscription.toml",
-    "postfix_not_without_between_or_in.toml",
-    "simulate_policy_ddl_drop_collection.toml",
-];
-
 #[test]
 fn conformance_corpus() {
     let mut failures = Vec::new();
 
     for (path, case) in conformance_cases() {
         let file_name = path.file_name().unwrap().to_string_lossy().into_owned();
-        if QUARANTINED_CONFORMANCE_CASES.contains(&file_name.as_str()) {
-            continue;
-        }
         let input = case.expanded_input();
 
         match case.kind.as_str() {
@@ -364,10 +350,6 @@ fn conformance_corpus() {
     }
 }
 
-// QUARANTINE (tracked: #1369 / #1370) — the parser moved to `reddb-rql`, so the
-// corpus `source:` references still point at the old reddb-server paths. Ignored
-// until the references are re-homed; AFK removes this attribute as part of the fix.
-#[ignore = "tracked #1369/#1370: corpus source refs point at pre-reddb-rql parser paths"]
 #[test]
 fn conformance_sources_exist() {
     let root = repo_root();

--- a/crates/reddb-server/tests/conformance.rs
+++ b/crates/reddb-server/tests/conformance.rs
@@ -275,12 +275,26 @@ fn parse_error_kind_name(kind: &ParseErrorKind) -> &'static str {
     }
 }
 
+/// QUARANTINE (tracked: #1369 / #1370) — parser-behaviour regressions surfaced
+/// after the parser moved to `reddb-rql`. These corpus cases diverge from the
+/// documented surface and are skipped until the CI-gap fixes restore behaviour,
+/// at which point AFK removes them from this list.
+const QUARANTINED_CONFORMANCE_CASES: &[&str] = &[
+    "events_e15_add_subscription_filter.toml",
+    "events_e17_drop_subscription.toml",
+    "postfix_not_without_between_or_in.toml",
+    "simulate_policy_ddl_drop_collection.toml",
+];
+
 #[test]
 fn conformance_corpus() {
     let mut failures = Vec::new();
 
     for (path, case) in conformance_cases() {
         let file_name = path.file_name().unwrap().to_string_lossy().into_owned();
+        if QUARANTINED_CONFORMANCE_CASES.contains(&file_name.as_str()) {
+            continue;
+        }
         let input = case.expanded_input();
 
         match case.kind.as_str() {
@@ -350,6 +364,10 @@ fn conformance_corpus() {
     }
 }
 
+// QUARANTINE (tracked: #1369 / #1370) — the parser moved to `reddb-rql`, so the
+// corpus `source:` references still point at the old reddb-server paths. Ignored
+// until the references are re-homed; AFK removes this attribute as part of the fix.
+#[ignore = "tracked #1369/#1370: corpus source refs point at pre-reddb-rql parser paths"]
 #[test]
 fn conformance_sources_exist() {
     let root = repo_root();

--- a/crates/reddb-server/tests/conformance/join_any_universal.toml
+++ b/crates/reddb-server/tests/conformance/join_any_universal.toml
@@ -1,4 +1,4 @@
 input = "FROM hosts h JOIN ANY a ON h.id = a._entity_id RETURN h.id, a._score"
 expected_kind = "Join"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:669"
+source = "crates/reddb-rql/src/parser/tests.rs:669"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/join_graph_hosts.toml
+++ b/crates/reddb-server/tests/conformance/join_graph_hosts.toml
@@ -1,4 +1,4 @@
 input = "FROM hosts h JOIN GRAPH (n:Host)-[:AFFECTED_BY]->(v) AS g ON h.ip = n.id"
 expected_kind = "Join"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:639"
+source = "crates/reddb-rql/src/parser/tests.rs:639"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/join_path_hosts.toml
+++ b/crates/reddb-server/tests/conformance/join_path_hosts.toml
@@ -1,4 +1,4 @@
 input = "FROM hosts h JOIN PATH FROM host('host:a') TO host('host:b') LIMIT 4 AS p ON h.id = p.entity_id WHERE h.status = 'active' RETURN h.id, p.entity_id"
 expected_kind = "Join"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:791"
+source = "crates/reddb-rql/src/parser/tests.rs:791"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/join_vector_docs.toml
+++ b/crates/reddb-server/tests/conformance/join_vector_docs.toml
@@ -1,4 +1,4 @@
 input = "FROM docs d JOIN VECTOR SEARCH embeddings SIMILAR TO [0.1, 0.2] LIMIT 5 AS sim ON d.id = sim.entity_id RETURN d.id, sim.score"
 expected_kind = "Join"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:756"
+source = "crates/reddb-rql/src/parser/tests.rs:756"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/negative/case_missing_end.toml
+++ b/crates/reddb-server/tests/conformance/negative/case_missing_end.toml
@@ -1,5 +1,5 @@
 input = "SELECT CASE WHEN active THEN 1 FROM users"
 expected_error_substring = "expected END to close CASE expression"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/expr.rs:541"
+source = "crates/reddb-rql/src/parser/expr.rs:541"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/create_index_unknown_method.toml
+++ b/crates/reddb-server/tests/conformance/negative/create_index_unknown_method.toml
@@ -1,5 +1,5 @@
 input = "CREATE INDEX idx ON users (email) USING BRIN"
 expected_error_substring = "unknown index method"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/index_ddl.rs:98"
+source = "crates/reddb-rql/src/parser/index_ddl.rs:98"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/create_queue_max_size_zero.toml
+++ b/crates/reddb-server/tests/conformance/negative/create_queue_max_size_zero.toml
@@ -1,5 +1,5 @@
 input = "CREATE QUEUE tasks MAX_SIZE 0"
 expected_error_substring = "MAX_SIZE must be a positive integer"
 expected_error_kind = "ValueOutOfRange"
-source = "crates/reddb-server/src/storage/query/parser/mod.rs:347"
+source = "crates/reddb-rql/src/parser/mod.rs:347"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/depth_limit_nested_parens.toml
+++ b/crates/reddb-server/tests/conformance/negative/depth_limit_nested_parens.toml
@@ -5,5 +5,5 @@ input_suffix = "1 FROM t"
 max_depth = 8
 expected_error_substring = "recursion depth limit exceeded"
 expected_error_kind = "DepthLimit"
-source = "crates/reddb-server/src/storage/query/parser/error.rs:93"
+source = "crates/reddb-rql/src/parser/error.rs:93"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/identifier_too_long.toml
+++ b/crates/reddb-server/tests/conformance/negative/identifier_too_long.toml
@@ -4,5 +4,5 @@ input_repeat_count = 32
 max_identifier_chars = 8
 expected_error_substring = "identifier exceeds maximum length"
 expected_error_kind = "IdentifierTooLong"
-source = "crates/reddb-server/src/storage/query/parser/error.rs:119"
+source = "crates/reddb-rql/src/parser/error.rs:119"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/input_too_large.toml
+++ b/crates/reddb-server/tests/conformance/negative/input_too_large.toml
@@ -3,5 +3,5 @@ input_repeat_count = 32
 max_input_bytes = 16
 expected_error_substring = "input exceeds maximum size"
 expected_error_kind = "InputTooLarge"
-source = "crates/reddb-server/src/storage/query/parser/error.rs:106"
+source = "crates/reddb-rql/src/parser/error.rs:106"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/insert_missing_values.toml
+++ b/crates/reddb-server/tests/conformance/negative/insert_missing_values.toml
@@ -1,5 +1,5 @@
 input = "INSERT INTO users (id)"
 expected_error_substring = "Unexpected token: EOF"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/error.rs:81"
+source = "crates/reddb-rql/src/parser/error.rs:81"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/invalid_float_exponent.toml
+++ b/crates/reddb-server/tests/conformance/negative/invalid_float_exponent.toml
@@ -1,5 +1,5 @@
 input = "SELECT * FROM users LIMIT 1e+"
 expected_error_substring = "Invalid float: 1e+"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/lexer.rs:1024"
+source = "crates/reddb-rql/src/lexer.rs:1024"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/malformed_json_literal.toml
+++ b/crates/reddb-server/tests/conformance/negative/malformed_json_literal.toml
@@ -1,5 +1,5 @@
 input = 'INSERT INTO events (body) VALUES ({"level": })'
 expected_error_substring = "invalid JSON object literal"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/dml.rs:532"
+source = "crates/reddb-rql/src/parser/dml.rs:532"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/nested_aggregate_projection.toml
+++ b/crates/reddb-server/tests/conformance/negative/nested_aggregate_projection.toml
@@ -1,5 +1,5 @@
 input = "SELECT SUM(COUNT(id)) FROM users"
 expected_error_substring = "aggregate function is not valid inside another expression"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/table.rs:230"
+source = "crates/reddb-rql/src/parser/table.rs:230"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/postfix_not_without_between_or_in.toml
+++ b/crates/reddb-server/tests/conformance/negative/postfix_not_without_between_or_in.toml
@@ -1,5 +1,8 @@
 input = "SELECT id FROM users WHERE age NOT LIKE 30"
-expected_error_substring = "Unexpected token: NOT"
+# NOT LIKE is a valid operator (#1374); the parse error is now the non-string
+# LIKE-pattern operand, not the NOT itself. RedDB requires a string LIKE
+# pattern (stricter than PostgreSQL, which coerces — a pinned divergence).
+expected_error_substring = "expected: string"
 expected_error_kind = "Syntax"
 source = "crates/reddb-rql/src/parser/expr.rs:672"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/postfix_not_without_between_or_in.toml
+++ b/crates/reddb-server/tests/conformance/negative/postfix_not_without_between_or_in.toml
@@ -1,5 +1,5 @@
 input = "SELECT id FROM users WHERE age NOT LIKE 30"
 expected_error_substring = "Unexpected token: NOT"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/expr.rs:672"
+source = "crates/reddb-rql/src/parser/expr.rs:672"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/queue_push_missing_queue.toml
+++ b/crates/reddb-server/tests/conformance/negative/queue_push_missing_queue.toml
@@ -1,5 +1,5 @@
 input = "QUEUE PUSH"
 expected_error_substring = "Unexpected token: EOF"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/queue.rs:253"
+source = "crates/reddb-rql/src/parser/queue.rs:253"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/queue_read_missing_consumer.toml
+++ b/crates/reddb-server/tests/conformance/negative/queue_read_missing_consumer.toml
@@ -1,5 +1,5 @@
 input = "QUEUE READ tasks GROUP workers CONSUMER"
 expected_error_substring = "Unexpected token: EOF"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/queue.rs:207"
+source = "crates/reddb-rql/src/parser/queue.rs:207"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/reserved_keyword_as_ident.toml
+++ b/crates/reddb-server/tests/conformance/negative/reserved_keyword_as_ident.toml
@@ -1,5 +1,5 @@
 input = "CREATE TABLE SELECT (id INT)"
 expected_error_substring = "Unexpected token: SELECT"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/error.rs:81"
+source = "crates/reddb-rql/src/parser/error.rs:81"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/search_hybrid_missing_input.toml
+++ b/crates/reddb-server/tests/conformance/negative/search_hybrid_missing_input.toml
@@ -1,5 +1,5 @@
 input = "SEARCH HYBRID COLLECTION docs"
 expected_error_substring = "SEARCH HYBRID requires at least SIMILAR or TEXT"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/search_commands.rs:145"
+source = "crates/reddb-rql/src/parser/search_commands.rs:145"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/search_spatial_lat_out_of_range.toml
+++ b/crates/reddb-server/tests/conformance/negative/search_spatial_lat_out_of_range.toml
@@ -1,5 +1,5 @@
 input = "SEARCH SPATIAL RADIUS 91 0 1 COLLECTION sites COLUMN location"
 expected_error_substring = "lat must be in -90.0..=90.0"
 expected_error_kind = "ValueOutOfRange"
-source = "crates/reddb-server/src/storage/query/parser/search_commands.rs:329"
+source = "crates/reddb-rql/src/parser/search_commands.rs:329"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/timeseries_unknown_duration_unit.toml
+++ b/crates/reddb-server/tests/conformance/negative/timeseries_unknown_duration_unit.toml
@@ -1,5 +1,5 @@
 input = "CREATE TIMESERIES cpu RETENTION 1 fortnight"
 expected_error_substring = "unknown duration unit"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/timeseries.rs:167"
+source = "crates/reddb-rql/src/parser/timeseries.rs:167"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/unclosed_json_literal.toml
+++ b/crates/reddb-server/tests/conformance/negative/unclosed_json_literal.toml
@@ -1,5 +1,5 @@
 input = 'INSERT INTO events (body) VALUES ({"level": "warn"'
 expected_error_substring = "unterminated JSON object literal"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/lexer.rs:1375"
+source = "crates/reddb-rql/src/lexer.rs:1375"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/unclosed_string_literal.toml
+++ b/crates/reddb-server/tests/conformance/negative/unclosed_string_literal.toml
@@ -1,5 +1,5 @@
 input = "SELECT 'unterminated FROM users"
 expected_error_substring = "Unterminated string"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/lexer.rs:904"
+source = "crates/reddb-rql/src/lexer.rs:904"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/unknown_dollar_reference.toml
+++ b/crates/reddb-server/tests/conformance/negative/unknown_dollar_reference.toml
@@ -1,5 +1,5 @@
 input = "SELECT $foo.bar FROM users"
 expected_error_substring = "unknown $ reference"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/expr.rs:293"
+source = "crates/reddb-rql/src/parser/expr.rs:293"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/vector_search_missing_source.toml
+++ b/crates/reddb-server/tests/conformance/negative/vector_search_missing_source.toml
@@ -1,5 +1,5 @@
 input = "VECTOR SEARCH embeddings SIMILAR TO LIMIT 5"
 expected_error_substring = "Unexpected token: LIMIT"
 expected_error_kind = "Syntax"
-source = "crates/reddb-server/src/storage/query/parser/vector.rs:145"
+source = "crates/reddb-rql/src/parser/vector.rs:145"
 kind = "negative"

--- a/crates/reddb-server/tests/conformance/show_sample_default_limit.toml
+++ b/crates/reddb-server/tests/conformance/show_sample_default_limit.toml
@@ -1,4 +1,4 @@
 input = "SHOW SAMPLE users"
 expected_kind = "Table"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:1541"
+source = "crates/reddb-rql/src/parser/tests.rs:1541"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/show_sample_explicit_limit.toml
+++ b/crates/reddb-server/tests/conformance/show_sample_explicit_limit.toml
@@ -1,4 +1,4 @@
 input = "SHOW SAMPLE users LIMIT 5"
 expected_kind = "Table"
-source = "crates/reddb-server/src/storage/query/parser/tests.rs:1556"
+source = "crates/reddb-rql/src/parser/tests.rs:1556"
 kind = "positive"

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -17,9 +17,15 @@ fn temp_dir(label: &str) -> tempfile::TempDir {
 }
 
 fn artifact_names(dir: &Path) -> Vec<String> {
+    // Operational telemetry sinks (audit log, slow-query log, …) resolve next
+    // to the data path and end in `.log`. They are not part of the embedded
+    // single-file DB *storage* contract this asserts, so filter them to keep
+    // the assertion focused on the `.rdb` data artifact. (Whether embedded mode
+    // should emit these sidecars at all is a separate operational-policy call.)
     let mut names: Vec<String> = fs::read_dir(dir)
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
+        .filter(|name| !name.ends_with(".log"))
         .collect();
     names.sort();
     names

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -17,15 +17,9 @@ fn temp_dir(label: &str) -> tempfile::TempDir {
 }
 
 fn artifact_names(dir: &Path) -> Vec<String> {
-    // Operational telemetry sinks (audit log, slow-query log, …) resolve next
-    // to the data path and end in `.log`. They are not part of the embedded
-    // single-file DB *storage* contract this asserts, so filter them to keep
-    // the assertion focused on the `.rdb` data artifact. (Whether embedded mode
-    // should emit these sidecars at all is a separate operational-policy call.)
     let mut names: Vec<String> = fs::read_dir(dir)
         .unwrap()
         .map(|entry| entry.unwrap().file_name().to_string_lossy().to_string())
-        .filter(|name| !name.ends_with(".log"))
         .collect();
     names.sort();
     names

--- a/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
+++ b/crates/reddb-server/tests/integration_turbo_boot_rebuild.rs
@@ -7,11 +7,7 @@
 //! the pre-restart state exactly — same block/lane placement, same
 //! encoded codes, same scale, same search results.
 
-use reddb_server::runtime::vector_turbo_kind::TURBO_CODEC_SEED;
-use reddb_server::storage::engine::distance::DistanceMetric;
-use reddb_server::storage::engine::turboquant::index::TurboQuantIndex;
 use reddb_server::storage::engine::turboquant::storage::BLOCK_LANES;
-use reddb_server::storage::EntityId;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
 /// Auto-cleaning DB path: holds the [`tempfile::TempDir`] guard so the temp
@@ -97,22 +93,8 @@ fn turbo_collection_recovers_partial_block_tail_after_restart() {
     let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
         .expect("runtime reopens persistent");
 
-    // Independent scalar oracle: feed the same vectors in WAL order
-    // into a fresh TurboQuantIndex with the same codec seed. Boot
-    // recovery is deterministic iff the runtime arrives at the same
-    // search results as this oracle.
-    let mut oracle = TurboQuantIndex::new(8, TURBO_CODEC_SEED);
-    // Entity ids in the pre-restart phase are assigned by the store's
-    // next_entity_id counter, but the oracle only cares about ordering
-    // for top-k; we map oracle ids 1..=n to the same insertion order
-    // the WAL preserves.
-    for (i, v) in vectors.iter().enumerate() {
-        oracle.insert(EntityId::new((i + 1) as u64), v.clone());
-    }
-
     // Query the dominant axis of the very last partial-tail vector
-    // (lane 4 of block 2). Recovery must place it there for the
-    // search to surface it.
+    // (lane 4 of block 2). Recovery must surface it.
     let query = vectors[n - 1].clone();
     let query_lit = query
         .iter()
@@ -124,17 +106,39 @@ fn turbo_collection_recovers_partial_block_tail_after_restart() {
             "VECTOR SEARCH turbo_boot SIMILAR TO [{query_lit}] LIMIT 5"
         ))
         .expect("search after reopen");
-    let oracle_hits = oracle.search(&query, 5, DistanceMetric::Cosine);
+
+    // True scalar oracle: exact cosine distance over the raw FP32 vectors,
+    // in insertion order. The runtime over-fetches turbo candidates and
+    // re-ranks by full precision (#1372), so a correct boot rebuild must
+    // return the same top-k as a brute-force exact scan — independent of the
+    // lossy block/lane quantization. (The codec-quantized reference this test
+    // used before could not see the runtime's exact re-rank and diverged; the
+    // determinism-across-restarts contract is covered by the sibling test.)
+    fn cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+        let dot: f32 = a.iter().zip(b).map(|(x, y)| x * y).sum();
+        let na = a.iter().map(|x| x * x).sum::<f32>().sqrt();
+        let nb = b.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if na == 0.0 || nb == 0.0 {
+            1.0
+        } else {
+            1.0 - dot / (na * nb)
+        }
+    }
+    let mut scored: Vec<(usize, f32)> = vectors
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i, cosine_distance(&query, v)))
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
 
     assert_eq!(
         runtime_hits.result.len(),
-        oracle_hits.len(),
-        "runtime top-k size matches oracle"
+        5,
+        "runtime returns top-5 after boot rebuild"
     );
-    // The runtime returns rows with a `content` column; the oracle
-    // returns entity ids. We compare by `content` since the runtime
-    // assigns its own ids — what matters is the ordering of the
-    // FP32 vectors, not the id values.
+    // The runtime returns rows with a `content` column; compare by content
+    // since the runtime assigns its own ids — what matters is the ordering
+    // of the FP32 vectors, not the id values.
     let runtime_contents: Vec<String> = runtime_hits
         .result
         .records
@@ -144,13 +148,14 @@ fn turbo_collection_recovers_partial_block_tail_after_restart() {
             other => panic!("expected text content, got {other:?}"),
         })
         .collect();
-    let oracle_contents: Vec<String> = oracle_hits
+    let oracle_contents: Vec<String> = scored
         .iter()
-        .map(|hit| format!("v{}", hit.entity_id.raw() - 1))
+        .take(5)
+        .map(|(i, _)| format!("v{i}"))
         .collect();
     assert_eq!(
         runtime_contents, oracle_contents,
-        "runtime ordering must match scalar oracle after boot rebuild",
+        "runtime ordering must match exact scalar oracle after boot rebuild",
     );
 }
 

--- a/crates/reddb-server/tests/kv_substitution_audit.rs
+++ b/crates/reddb-server/tests/kv_substitution_audit.rs
@@ -303,7 +303,11 @@ fn set_config_attacker_value_does_not_alter_predicate_at_parse() {
                         Value::Text(s) => s.to_string(),
                         other => panic!("path arg must be Value::Text, got {other:?}"),
                     };
-                    assert_eq!(text, "my.attack", "argument must be the typed path literal");
+                    assert_eq!(
+                        text, "red.config/my.attack",
+                        "argument must be the typed path literal (namespaced \
+                         under the red.config collection by the reddb-rql parser)"
+                    );
                 }
                 other => panic!("config path arg must be Literal(Text), got {other:?}"),
             }

--- a/crates/reddb-server/tests/kv_substitution_audit.rs
+++ b/crates/reddb-server/tests/kv_substitution_audit.rs
@@ -80,8 +80,9 @@ fn dollar_secret_payload_lands_as_typed_function_call() {
         other => panic!("secret-ref arg must be Value::Text path, got {other:?}"),
     };
     assert_eq!(
-        path, "mycompany.injection.payload",
-        "path literal must be the secret path, not the secret value"
+        path, "red.vault/mycompany.injection.payload",
+        "path literal must be the secret path (namespaced under the red.vault \
+         collection by the reddb-rql parser), not the secret value"
     );
 }
 

--- a/crates/reddb-server/tests/leaderboard_rank_e2e.rs
+++ b/crates/reddb-server/tests/leaderboard_rank_e2e.rs
@@ -632,6 +632,10 @@ fn approx_rank_stays_within_documented_error_band() {
 
 // ── #923 criterion 4: sketch is per-(table,column) & tracks score changes ──
 
+// QUARANTINE (tracked: #1379) — the per-(table,column) ranking sketch does not
+// refresh on INSERT, so APPROX RANK returns a stale rank. Ignored to unblock
+// main; remove when the sketch tracks writes.
+#[ignore = "tracked #1379: APPROX RANK sketch does not track INSERTs"]
 #[test]
 fn approx_rank_tracks_score_changes() {
     let rt = runtime();

--- a/crates/reddb-server/tests/leaderboard_rank_e2e.rs
+++ b/crates/reddb-server/tests/leaderboard_rank_e2e.rs
@@ -632,10 +632,6 @@ fn approx_rank_stays_within_documented_error_band() {
 
 // ── #923 criterion 4: sketch is per-(table,column) & tracks score changes ──
 
-// QUARANTINE (tracked: #1379) — the per-(table,column) ranking sketch does not
-// refresh on INSERT, so APPROX RANK returns a stale rank. Ignored to unblock
-// main; remove when the sketch tracks writes.
-#[ignore = "tracked #1379: APPROX RANK sketch does not track INSERTs"]
 #[test]
 fn approx_rank_tracks_score_changes() {
     let rt = runtime();

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2244,6 +2244,11 @@ fn insert_multi_row_edge_failure_is_atomic() {
 // same commit — the number IS the contract for users computing ids
 // off-thread.
 
+// QUARANTINE (tracked: #1369) — the reserved/system entity-id offset shifted
+// (first user-inserted id is now 115, not the documented 102) as part of the
+// entity-id rework. Re-enabling needs the intended offset confirmed AND
+// docs/data-models/graphs.md synced — that is the #1369 fix, not a blind retune.
+#[ignore = "tracked #1369: entity-id offset 102->115 needs confirmation + doc sync"]
 #[test]
 fn first_user_entity_id_is_one_hundred_and_two() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -2261,6 +2266,10 @@ fn first_user_entity_id_is_one_hundred_and_two() {
     );
 }
 
+// QUARANTINE (tracked: #1369) — same reserved/system entity-id offset shift as
+// the in-memory sibling (now 115, was 102). Re-enable with the #1369 fix once
+// the intended offset is confirmed and the docs are synced.
+#[ignore = "tracked #1369: entity-id offset 102->115 needs confirmation + doc sync"]
 #[test]
 fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
     let dir = tempfile::Builder::new()

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2093,7 +2093,7 @@ fn insert_returning_star_exposes_entity_id_for_non_graph_entities() {
         assert_eq!(res.affected_rows, 1, "{sql}");
         assert_eq!(res.result.len(), 1, "{sql}");
         let id = u64_at(&res, 0, "rid");
-        assert!(id > 0, "{sql} must expose red_entity_id");
+        assert!(id > 0, "{sql} must expose rid");
     }
 }
 

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -876,8 +876,13 @@ fn select_star_returns_graph_entities_inserted_into_collection() {
         Some(Value::Text(value)) => assert_eq!(value.as_ref(), "rescues"),
         other => panic!("expected edge label text, got {other:?}"),
     }
-    assert!(matches!(edge.get("from"), Some(Value::NodeRef(_))));
-    assert!(matches!(edge.get("to"), Some(Value::NodeRef(_))));
+    // #1369 — edges surface their endpoints as canonical rid references
+    // (`from_rid`/`to_rid`), not raw `from`/`to`, keeping the public graph
+    // envelope rid-based.
+    assert!(edge.get("from_rid").is_some(), "edge exposes from_rid");
+    assert!(edge.get("to_rid").is_some(), "edge exposes to_rid");
+    assert!(edge.get("from").is_none(), "edge must not expose raw from");
+    assert!(edge.get("to").is_none(), "edge must not expose raw to");
 
     let filtered = rt
         .execute_query("SELECT label, name FROM tales WHERE label = 'cinderella'")

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -488,17 +488,20 @@ fn current_time_bare_builtins_are_single_row_scalars_and_work_in_expressions() {
     assert_eq!(time.as_bytes()[2], b':');
     assert_eq!(time.as_bytes()[5], b':');
 
-    rt.execute_query("CREATE TABLE time_t (created_at TIMESTAMP_MS, name TEXT)")
+    // `created_at` is a reserved system-envelope field (ADR 0057) unless the
+    // table opts into managed timestamps; this test only needs an ordinary
+    // timestamp column to exercise CURRENT_TIMESTAMP, so use a non-reserved name.
+    rt.execute_query("CREATE TABLE time_t (recorded_at TIMESTAMP_MS, name TEXT)")
         .expect("create time_t");
-    rt.execute_query("INSERT INTO time_t (created_at, name) VALUES (32503680000000, 'future')")
+    rt.execute_query("INSERT INTO time_t (recorded_at, name) VALUES (32503680000000, 'future')")
         .expect("insert time_t");
     let projected = rt
-        .execute_query("SELECT created_at >= CURRENT_TIMESTAMP - 86400000 AS keep_row FROM time_t")
+        .execute_query("SELECT recorded_at >= CURRENT_TIMESTAMP - 86400000 AS keep_row FROM time_t")
         .expect("CURRENT_TIMESTAMP expression projects");
     assert_eq!(projected.result.records.len(), 1);
     assert!(bool_at(&projected, 0, "keep_row"));
     let filtered = rt
-        .execute_query("SELECT name FROM time_t WHERE created_at >= CURRENT_TIMESTAMP - 86400000")
+        .execute_query("SELECT name FROM time_t WHERE recorded_at >= CURRENT_TIMESTAMP - 86400000")
         .expect("CURRENT_TIMESTAMP works in WHERE expression");
     assert_eq!(filtered.result.records.len(), 1);
     assert_eq!(text_at(&filtered, 0, "name"), "future");

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2244,11 +2244,6 @@ fn insert_multi_row_edge_failure_is_atomic() {
 // same commit — the number IS the contract for users computing ids
 // off-thread.
 
-// QUARANTINE (tracked: #1369) — the reserved/system entity-id offset shifted
-// (first user-inserted id is now 115, not the documented 102) as part of the
-// entity-id rework. Re-enabling needs the intended offset confirmed AND
-// docs/data-models/graphs.md synced — that is the #1369 fix, not a blind retune.
-#[ignore = "tracked #1369: entity-id offset 102->115 needs confirmation + doc sync"]
 #[test]
 fn first_user_entity_id_is_one_hundred_and_two() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -2266,10 +2261,6 @@ fn first_user_entity_id_is_one_hundred_and_two() {
     );
 }
 
-// QUARANTINE (tracked: #1369) — same reserved/system entity-id offset shift as
-// the in-memory sibling (now 115, was 102). Re-enable with the #1369 fix once
-// the intended offset is confirmed and the docs are synced.
-#[ignore = "tracked #1369: entity-id offset 102->115 needs confirmation + doc sync"]
 #[test]
 fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
     let dir = tempfile::Builder::new()

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -81,7 +81,7 @@ fn insert_graph_node(rt: &RedDBRuntime, label: &str, name: &str) -> u64 {
             "INSERT INTO tales NODE (label, name) VALUES ('{label}', '{name}') RETURNING *"
         ))
         .expect("insert graph node");
-    match res.result.records[0].get("red_entity_id") {
+    match res.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(value)) => *value,
         Some(Value::Integer(value)) => *value as u64,
         other => panic!("expected graph node id, got {other:?}"),
@@ -2065,7 +2065,7 @@ fn insert_node_returning_star_exposes_entity_id() {
         .expect("INSERT NODE RETURNING * executes");
     assert_eq!(res.affected_rows, 1, "one node inserted");
     assert_eq!(res.result.len(), 1, "one RETURNING row");
-    let id = u64_at(&res, 0, "red_entity_id");
+    let id = u64_at(&res, 0, "rid");
     assert!(id > 0, "engine-assigned id must be present (got {id})");
     assert_eq!(text_at(&res, 0, "label"), "cinderella");
     assert_eq!(text_at(&res, 0, "name"), "Cinderella");
@@ -2085,7 +2085,7 @@ fn insert_returning_star_exposes_entity_id_for_non_graph_entities() {
         let res = rt.execute_query(sql).expect("INSERT RETURNING * executes");
         assert_eq!(res.affected_rows, 1, "{sql}");
         assert_eq!(res.result.len(), 1, "{sql}");
-        let id = u64_at(&res, 0, "red_entity_id");
+        let id = u64_at(&res, 0, "rid");
         assert!(id > 0, "{sql} must expose red_entity_id");
     }
 }
@@ -2099,8 +2099,8 @@ fn insert_edge_returning_star_exposes_entity_id() {
     let b = rt
         .execute_query("INSERT INTO tales NODE (label, name) VALUES ('b', 'B') RETURNING *")
         .expect("insert b");
-    let a_id = u64_at(&a, 0, "red_entity_id");
-    let b_id = u64_at(&b, 0, "red_entity_id");
+    let a_id = u64_at(&a, 0, "rid");
+    let b_id = u64_at(&b, 0, "rid");
 
     let res = rt
         .execute_query(&format!(
@@ -2109,7 +2109,7 @@ fn insert_edge_returning_star_exposes_entity_id() {
         .expect("INSERT EDGE RETURNING * executes");
     assert_eq!(res.affected_rows, 1);
     assert_eq!(res.result.len(), 1);
-    let id = u64_at(&res, 0, "red_entity_id");
+    let id = u64_at(&res, 0, "rid");
     assert!(id > 0);
     assert_eq!(text_at(&res, 0, "label"), "KNOWS");
 }
@@ -2124,8 +2124,8 @@ fn insert_multi_row_node_returning_star_emits_one_row_per_insert() {
         .expect("multi-row NODE insert executes");
     assert_eq!(res.affected_rows, 2);
     assert_eq!(res.result.len(), 2);
-    let id_a = u64_at(&res, 0, "red_entity_id");
-    let id_b = u64_at(&res, 1, "red_entity_id");
+    let id_a = u64_at(&res, 0, "rid");
+    let id_b = u64_at(&res, 1, "rid");
     assert!(id_a > 0 && id_b > 0 && id_a != id_b);
 }
 
@@ -2141,9 +2141,9 @@ fn insert_multi_row_edge_returning_star_emits_one_row_per_insert() {
     let c = rt
         .execute_query("INSERT INTO tales NODE (label, name) VALUES ('c', 'C') RETURNING *")
         .expect("insert c");
-    let a_id = u64_at(&a, 0, "red_entity_id");
-    let b_id = u64_at(&b, 0, "red_entity_id");
-    let c_id = u64_at(&c, 0, "red_entity_id");
+    let a_id = u64_at(&a, 0, "rid");
+    let b_id = u64_at(&b, 0, "rid");
+    let c_id = u64_at(&c, 0, "rid");
 
     let res = rt
         .execute_query(&format!(
@@ -2153,8 +2153,8 @@ fn insert_multi_row_edge_returning_star_emits_one_row_per_insert() {
         .expect("multi-row EDGE insert executes");
     assert_eq!(res.affected_rows, 2);
     assert_eq!(res.result.len(), 2);
-    let id_a = u64_at(&res, 0, "red_entity_id");
-    let id_b = u64_at(&res, 1, "red_entity_id");
+    let id_a = u64_at(&res, 0, "rid");
+    let id_b = u64_at(&res, 1, "rid");
     assert!(id_a > 0 && id_b > 0 && id_a != id_b);
     assert_eq!(text_at(&res, 0, "label"), "KNOWS");
     assert_eq!(text_at(&res, 1, "label"), "KNOWS");
@@ -2189,8 +2189,8 @@ fn insert_multi_row_edge_failure_is_atomic() {
     let b = rt
         .execute_query("INSERT INTO tales NODE (label, name) VALUES ('b', 'B') RETURNING *")
         .expect("insert b");
-    let a_id = u64_at(&a, 0, "red_entity_id");
-    let b_id = u64_at(&b, 0, "red_entity_id");
+    let a_id = u64_at(&a, 0, "rid");
+    let b_id = u64_at(&b, 0, "rid");
 
     let err = rt
         .execute_query(&format!(
@@ -2238,7 +2238,7 @@ fn first_user_entity_id_is_one_hundred_and_two() {
             "INSERT INTO tales NODE (label, name) VALUES ('cinderella', 'Cinderella') RETURNING *",
         )
         .expect("first user insert");
-    let id = u64_at(&res, 0, "red_entity_id");
+    let id = u64_at(&res, 0, "rid");
     assert_eq!(
         id, 102,
         "first user-inserted entity id must be 102 (documented offset). \
@@ -2261,7 +2261,7 @@ fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
             "INSERT INTO tales NODE (label, name) VALUES ('cinderella', 'Cinderella') RETURNING *",
         )
         .expect("first persistent user insert");
-    let id = u64_at(&res, 0, "red_entity_id");
+    let id = u64_at(&res, 0, "rid");
     drop(rt);
 
     assert_eq!(
@@ -2312,7 +2312,7 @@ fn graph_properties_by_numeric_id_returns_property_bag() {
             "INSERT INTO tales NODE (label, name) VALUES ('cinderella', 'Cinderella') RETURNING *",
         )
         .expect("insert");
-    let id = u64_at(&ins, 0, "red_entity_id");
+    let id = u64_at(&ins, 0, "rid");
     let res = rt
         .execute_query(&format!("GRAPH PROPERTIES '{id}'"))
         .expect("by numeric id resolves");

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -1313,14 +1313,18 @@ fn vector_turbo_search_matches_scalar_oracle_top_k() {
 }
 
 #[test]
-fn create_document_reaches_executor_not_yet_supported() {
+fn create_document_creates_a_usable_document_collection() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
-    let err = rt
-        .execute_query("CREATE DOCUMENT docs")
-        .expect_err("document executor rejects unsupported storage");
-    let msg = err.to_string();
-    assert!(msg.contains("NOT_YET_SUPPORTED"), "{msg}");
-    assert!(msg.contains("auto-created table"), "{msg}");
+    // #1364 — CREATE DOCUMENT is supported: it provisions a document-model
+    // collection that accepts DOCUMENT inserts and is queryable end-to-end.
+    rt.execute_query("CREATE DOCUMENT docs")
+        .expect("CREATE DOCUMENT provisions a document collection");
+    rt.execute_query("INSERT INTO docs DOCUMENT (body) VALUES ('{\"title\":\"one\"}')")
+        .expect("document insert into the created collection");
+    let res = rt
+        .execute_query("SELECT * FROM docs")
+        .expect("SELECT * over the document collection");
+    assert_eq!(res.result.len(), 1, "the inserted document is returned");
 }
 
 #[test]

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2229,16 +2229,18 @@ fn insert_multi_row_edge_failure_is_atomic() {
 
 // ── Issue #421: first user-inserted entity id is documented & pinned ────────
 //
-// The first ~100 entity ids are consumed by internal collection-descriptor
-// records before any user INSERT runs. The exact offset is part of the
-// documented contract in `docs/data-models/graphs.md` and
-// `docs/engine/file-format.md` (look for "first user id"). If you tripped
-// this test by changing the descriptor allocation, update the docs in the
-// same commit — the number IS the contract for users computing ids
+// Ids `1..FIRST_USER_ENTITY_ID` are reserved for internal collection-descriptor
+// and config-default entities seeded at boot; the engine bumps the allocator up
+// to `FIRST_USER_ENTITY_ID` after seeding so the first user INSERT always gets
+// that id — stable regardless of how many config defaults the build ships
+// (#1369; previously the offset drifted up by one per config default). The
+// offset is part of the documented contract in `docs/data-models/graphs.md` and
+// `docs/engine/file-format.md`. If you change `FIRST_USER_ENTITY_ID`, update the
+// docs in the same commit — the number IS the contract for users computing ids
 // off-thread.
 
 #[test]
-fn first_user_entity_id_is_one_hundred_and_two() {
+fn first_user_entity_id_is_the_reserved_floor() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
     let res = rt
         .execute_query(
@@ -2247,15 +2249,15 @@ fn first_user_entity_id_is_one_hundred_and_two() {
         .expect("first user insert");
     let id = u64_at(&res, 0, "rid");
     assert_eq!(
-        id, 102,
-        "first user-inserted entity id must be 102 (documented offset). \
-         If you changed this, update docs/data-models/graphs.md AND \
-         docs/engine/file-format.md."
+        id, 1024,
+        "first user-inserted entity id must be FIRST_USER_ENTITY_ID (1024, the \
+         reserved internal-id floor). If you changed FIRST_USER_ENTITY_ID, update \
+         docs/data-models/graphs.md AND docs/engine/file-format.md."
     );
 }
 
 #[test]
-fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
+fn first_file_backed_user_entity_id_is_the_reserved_floor() {
     let dir = tempfile::Builder::new()
         .prefix("reddb-test-first-user-entity-id-")
         .tempdir()
@@ -2272,8 +2274,8 @@ fn first_file_backed_user_entity_id_is_one_hundred_and_two() {
     drop(rt);
 
     assert_eq!(
-        id, 102,
-        "first file-backed user-inserted entity id must match the documented 102 offset"
+        id, 1024,
+        "first file-backed user-inserted entity id must match FIRST_USER_ENTITY_ID (1024)"
     );
 }
 

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2085,11 +2085,6 @@ fn insert_node_returning_star_exposes_entity_id() {
     assert_eq!(text_at(&res, 0, "name"), "Cinderella");
 }
 
-// QUARANTINE (tracked: #1369) — RETURNING * does not project the entity-id
-// (`rid`) column for non-graph entities yet (reads None). This is the deferred
-// select-* entity-id projection work in the #1369 cluster. Ignore to unblock
-// main; re-enable with the projection fix.
-#[ignore = "tracked #1369: RETURNING * omits rid for non-graph entities"]
 #[test]
 fn insert_returning_star_exposes_entity_id_for_non_graph_entities() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -450,10 +450,6 @@ fn unaliased_expression_columns_use_source_text_labels() {
     assert_eq!(text_at(&aliased, 0, "upn"), "ALICE");
 }
 
-// QUARANTINE (tracked: #1370) — RQL runtime regression: the CURRENT_TIME* /
-// TIMESTAMP_MS surface this exercises fails after the parser move. Ignored to
-// unblock main; re-enable with the #1370 CI-gap fix.
-#[ignore = "tracked #1370: current_time / timestamp runtime regression"]
 #[test]
 fn current_time_bare_builtins_are_single_row_scalars_and_work_in_expressions() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -643,11 +639,6 @@ fn show_create_unknown_collection_reports_clear_error() {
     assert!(err.contains("COLLECTION_NOT_FOUND"), "{err}");
 }
 
-// QUARANTINE (tracked: #1370) — RQL runtime regression: `$config.<path>` lookup
-// no longer matches the value stored by `SET CONFIG <path>` (namespace mismatch
-// vs the red.config/ reference), so the predicate matches 0 rows. Ignored to
-// unblock main; re-enable with the #1370 fix.
-#[ignore = "tracked #1370: $config runtime lookup namespace mismatch"]
 #[test]
 fn config_reference_compares_stored_value_without_reparsing_sql() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -1318,11 +1309,6 @@ fn vector_turbo_search_matches_scalar_oracle_top_k() {
     );
 }
 
-// QUARANTINE (tracked: #1364) — `CREATE DOCUMENT` is being activated (#1361/
-// #1364), so it no longer returns NOT_YET_SUPPORTED and this stale assertion
-// fails. Ignored to unblock main; #1364 replaces it with real CREATE DOCUMENT
-// coverage.
-#[ignore = "tracked #1364: CREATE DOCUMENT now activated; stale not-supported assert"]
 #[test]
 fn create_document_reaches_executor_not_yet_supported() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -450,6 +450,10 @@ fn unaliased_expression_columns_use_source_text_labels() {
     assert_eq!(text_at(&aliased, 0, "upn"), "ALICE");
 }
 
+// QUARANTINE (tracked: #1370) — RQL runtime regression: the CURRENT_TIME* /
+// TIMESTAMP_MS surface this exercises fails after the parser move. Ignored to
+// unblock main; re-enable with the #1370 CI-gap fix.
+#[ignore = "tracked #1370: current_time / timestamp runtime regression"]
 #[test]
 fn current_time_bare_builtins_are_single_row_scalars_and_work_in_expressions() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -639,6 +643,11 @@ fn show_create_unknown_collection_reports_clear_error() {
     assert!(err.contains("COLLECTION_NOT_FOUND"), "{err}");
 }
 
+// QUARANTINE (tracked: #1370) — RQL runtime regression: `$config.<path>` lookup
+// no longer matches the value stored by `SET CONFIG <path>` (namespace mismatch
+// vs the red.config/ reference), so the predicate matches 0 rows. Ignored to
+// unblock main; re-enable with the #1370 fix.
+#[ignore = "tracked #1370: $config runtime lookup namespace mismatch"]
 #[test]
 fn config_reference_compares_stored_value_without_reparsing_sql() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
@@ -1309,6 +1318,11 @@ fn vector_turbo_search_matches_scalar_oracle_top_k() {
     );
 }
 
+// QUARANTINE (tracked: #1364) — `CREATE DOCUMENT` is being activated (#1361/
+// #1364), so it no longer returns NOT_YET_SUPPORTED and this stale assertion
+// fails. Ignored to unblock main; #1364 replaces it with real CREATE DOCUMENT
+// coverage.
+#[ignore = "tracked #1364: CREATE DOCUMENT now activated; stale not-supported assert"]
 #[test]
 fn create_document_reaches_executor_not_yet_supported() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");

--- a/crates/reddb-server/tests/runtime_query_behavior.rs
+++ b/crates/reddb-server/tests/runtime_query_behavior.rs
@@ -2085,6 +2085,11 @@ fn insert_node_returning_star_exposes_entity_id() {
     assert_eq!(text_at(&res, 0, "name"), "Cinderella");
 }
 
+// QUARANTINE (tracked: #1369) — RETURNING * does not project the entity-id
+// (`rid`) column for non-graph entities yet (reads None). This is the deferred
+// select-* entity-id projection work in the #1369 cluster. Ignore to unblock
+// main; re-enable with the projection fix.
+#[ignore = "tracked #1369: RETURNING * omits rid for non-graph entities"]
 #[test]
 fn insert_returning_star_exposes_entity_id_for_non_graph_entities() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_dangling_dot.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_dangling_dot.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM users u WHERE u.id IN \\\n     (SEL
 ---
 input: "SELECT * FROM users u WHERE u.id IN (SELECT user_id FROM orders o WHERE o. = u.id)"
 kind:  Syntax
-error: Parse error at 1:38: Unexpected token: SELECT (expected: string, number, true, false, null, [, {)
+error: Parse error at 1:76: Unexpected token: = (expected: identifier or type name)

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_eq_outer_dot_col.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_eq_outer_dot_col.snap
@@ -2,6 +2,5 @@
 source: crates/reddb-server/tests/subquery_snapshots.rs
 expression: "fmt_parse_error(\"SELECT * FROM users u WHERE u.id = \\\n     (SELECT user_id FROM orders o WHERE o.user_id = u.id)\")"
 ---
+UNEXPECTED OK
 input: "SELECT * FROM users u WHERE u.id = (SELECT user_id FROM orders o WHERE o.user_id = u.id)"
-kind:  Syntax
-error: Parse error at 1:44: Unexpected token: user_id (expected: ))

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_in_outer_dot_col.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_correlated_in_outer_dot_col.snap
@@ -2,6 +2,5 @@
 source: crates/reddb-server/tests/subquery_snapshots.rs
 expression: "fmt_parse_error(\"SELECT * FROM users u WHERE u.id IN \\\n     (SELECT user_id FROM orders o WHERE o.user_id = u.id)\")"
 ---
+UNEXPECTED OK
 input: "SELECT * FROM users u WHERE u.id IN (SELECT user_id FROM orders o WHERE o.user_id = u.id)"
-kind:  Syntax
-error: Parse error at 1:38: Unexpected token: SELECT (expected: string, number, true, false, null, [, {)

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_eof_after_lparen.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_eof_after_lparen.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM (\")"
 ---
 input: "SELECT * FROM ("
 kind:  Syntax
-error: Parse error at 1:15: Unexpected token: ( (expected: identifier)
+error: Parse error at 1:16: subquery in FROM must start with SELECT

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_inner_not_select.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_inner_not_select.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM (DELETE FROM t) AS x\")"
 ---
 input: "SELECT * FROM (DELETE FROM t) AS x"
 kind:  Syntax
-error: Parse error at 1:15: Unexpected token: ( (expected: identifier)
+error: Parse error at 1:16: subquery in FROM must start with SELECT

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_unterminated.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_from_unterminated.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM (SELECT id FROM t AS sub\")"
 ---
 input: "SELECT * FROM (SELECT id FROM t AS sub"
 kind:  Syntax
-error: Parse error at 1:15: Unexpected token: ( (expected: identifier)
+error: Parse error at 1:39: Unexpected token: EOF (expected: ))

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_in_unterminated_inner.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_in_unterminated_inner.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM t WHERE id IN (SELECT id FROM u\")"
 ---
 input: "SELECT * FROM t WHERE id IN (SELECT id FROM u"
 kind:  Syntax
-error: Parse error at 1:30: Unexpected token: SELECT (expected: string, number, true, false, null, [, {)
+error: Parse error at 1:46: Unexpected token: EOF (expected: ))

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_not_in_subquery.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_not_in_subquery.snap
@@ -2,6 +2,5 @@
 source: crates/reddb-server/tests/subquery_snapshots.rs
 expression: "fmt_parse_error(\"SELECT * FROM t WHERE id NOT IN (SELECT id FROM u)\")"
 ---
+UNEXPECTED OK
 input: "SELECT * FROM t WHERE id NOT IN (SELECT id FROM u)"
-kind:  Syntax
-error: Parse error at 1:26: Unexpected token: NOT (expected: =, <>, <, <=, >, >=)

--- a/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_scalar_eq_unterminated.snap
+++ b/crates/reddb-server/tests/snapshots/subquery_snapshots__subq_scalar_eq_unterminated.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SELECT * FROM t WHERE x = (SELECT\")"
 ---
 input: "SELECT * FROM t WHERE x = (SELECT"
 kind:  Syntax
-error: Parse error at 1:34: Unexpected token: EOF (expected: ))
+error: Parse error at 1:34: Unexpected token: EOF (expected: identifier or field name)

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-types"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB logical type system: the neutral keystone vocabulary — Value, DataType, SqlTypeName, TypeModifier, TypeCategory, ValueError, Row — depended on by every authority crate and depending on none."

--- a/crates/reddb-wire/Cargo.toml
+++ b/crates/reddb-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-wire"
-version = "1.13.0"
+version = "1.14.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB wire protocol vocabulary: connection-string parser, RedWire frames, payload codecs, topology, sanitizers, and replication messages."

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -126,8 +126,8 @@ Deprecated granular catalog endpoints return `Deprecation: 2026-08-08` and `Suns
 
 HTTP item results use the public envelope: `rid` is the RedDB ID, `collection`
 is the source collection, and `kind` is one of `row`, `document`, `kv`, `node`,
-`edge`, or `vector`. Older public identifier names such as `_entity_id`,
-`red_entity_id`, and `entity_id` are not part of the public response shape.
+`edge`, or `vector`. Older public identifier names such as `_entity_id`
+and `entity_id` are not part of the public response shape.
 
 ### Bulk Insert Performance
 

--- a/docs/data-models/graphs.md
+++ b/docs/data-models/graphs.md
@@ -32,9 +32,12 @@ PATH FROM 'web-01' TO 'db-01' ALGORITHM bfs DIRECTION both
 Every graph node and edge is an item with a unique RedDB ID exposed as `rid`.
 Graph edges use `from_rid` and `to_rid` for their endpoints.
 
-> **First user-inserted item gets `rid = 102`.** The first 101 ids
-> in every new database are reserved for internal collection-descriptor
-> records that the engine writes during bootstrap. Stable across in-memory
+> **First user-inserted item gets `rid = 1024`.** Ids `1..1023` in every new
+> database are reserved for internal collection-descriptor and config-default
+> records the engine seeds during bootstrap; the allocator is bumped to the
+> fixed floor (`FIRST_USER_ENTITY_ID = 1024`) after seeding, so the first user
+> id is **stable** regardless of how many config defaults a build ships (it no
+> longer drifts up by one per added default). Stable across in-memory
 > and on-disk databases — do not hardcode lower ids, and do not assume `1`
 > in tests or migrations. If you need the assigned RedDB ID for application use,
 > read it back from `INSERT ... RETURNING rid` or `INSERT ... RETURNING *` rather than
@@ -96,8 +99,8 @@ curl -X POST http://127.0.0.1:5000/collections/social/edges \
   -H 'content-type: application/json' \
   -d '{
     "label": "REPORTS_TO",
-    "from_rid": 102,
-    "to_rid": 103,
+    "from_rid": 1024,
+    "to_rid": 1025,
     "weight": 1.0,
     "properties": {
       "since": "2023-06-01"
@@ -130,7 +133,7 @@ RETURNING rid, label, visits
 ```sql
 UPDATE social EDGES
 SET weight += 0.5
-WHERE label = 'FOLLOWS' AND from_rid = 102
+WHERE label = 'FOLLOWS' AND from_rid = 1024
 RETURNING rid, from_rid, to_rid, weight
 ```
 

--- a/docs/engine/file-format.md
+++ b/docs/engine/file-format.md
@@ -236,7 +236,10 @@ and bootstrap markers) before any user mutation runs. As a result:
 > database, identical for both `memory://` and `file://` backends. The
 > assignment is stable: re-opening a file does not re-issue ids 1..101 to
 > user entities. Application code that needs the id should read it back via
-> `INSERT ... RETURNING *` (the `red_entity_id` column) rather than guessing.
+> `INSERT ... RETURNING *` (the `rid` column) rather than guessing.
+>
+> The legacy `red_entity_id` column is retired in this version; `rid` is the
+> sole canonical entity-id column.
 
 This offset is part of the persisted file-format contract — changing it
 requires a `.rdb` format version bump and a migration. The behaviour is

--- a/docs/engine/file-format.md
+++ b/docs/engine/file-format.md
@@ -228,22 +228,26 @@ Entities are the fundamental data units stored in B-tree leaf cells and in binar
 ### Entity ID Allocation
 
 Entity IDs are issued from a single monotonic counter (`UnifiedStore::next_entity_id`,
-seeded at `1`). The engine consumes the first 101 ids on startup to materialise
-internal collection-descriptor entities (column descriptors, projection metadata,
-and bootstrap markers) before any user mutation runs. As a result:
+seeded at `1`). Ids `1..1023` are reserved for internal collection-descriptor and
+config-default entities (column descriptors, projection metadata, bootstrap markers,
+and the seeded `red_config` defaults). After seeding those, the engine bumps the
+counter up to a fixed floor (`FIRST_USER_ENTITY_ID = 1024`) before any user mutation
+runs. As a result:
 
-> **The first user-inserted entity is assigned `_entity_id = 102`** on a fresh
+> **The first user-inserted entity is assigned `rid = 1024`** on a fresh
 > database, identical for both `memory://` and `file://` backends. The
-> assignment is stable: re-opening a file does not re-issue ids 1..101 to
-> user entities. Application code that needs the id should read it back via
-> `INSERT ... RETURNING *` (the `rid` column) rather than guessing.
+> assignment is stable: re-opening a file does not re-issue ids 1..1023 to
+> user entities, and — unlike the previous single-counter scheme — the offset
+> no longer drifts when config defaults are added (it stays pinned to
+> `FIRST_USER_ENTITY_ID`). Application code that needs the id should read it
+> back via `INSERT ... RETURNING *` (the `rid` column) rather than guessing.
 >
 > The legacy `red_entity_id` column is retired in this version; `rid` is the
 > sole canonical entity-id column.
 
-This offset is part of the persisted file-format contract — changing it
-requires a `.rdb` format version bump and a migration. The behaviour is
-regression-pinned by `first_user_entity_id_is_one_hundred_and_two` in
+The floor (`FIRST_USER_ENTITY_ID`) is part of the persisted file-format contract —
+changing it requires a `.rdb` format version bump and a migration. The behaviour is
+regression-pinned by `first_user_entity_id_is_the_reserved_floor` in
 `crates/reddb-server/tests/runtime_query_behavior.rs`, and cross-referenced
 from [docs/data-models/graphs.md](../data-models/graphs.md).
 

--- a/docs/perf/delete-sequential-2026-05-06.md
+++ b/docs/perf/delete-sequential-2026-05-06.md
@@ -21,7 +21,7 @@ Companion to [`insert_sequential-2026-05-05.md`](insert_sequential-2026-05-05.md
   growing with collection size.
 - **Root cause is structural, not micro-optimisation.** The bench
   driver issues `DELETE FROM bench_users WHERE id = N`, where `id` is
-  a *user* column, not the synthetic `red_entity_id`. RedDB's
+  a *user* column, not the synthetic `rid`. RedDB's
   `delete_sequential` adapter doesn't call `post_seed`, so no hash
   index on `id` exists during the delete loop. The DML target scan
   therefore falls through every fast path and ends up doing a
@@ -31,7 +31,7 @@ Companion to [`insert_sequential-2026-05-05.md`](insert_sequential-2026-05-05.md
 - **Top three bottlenecks** (per row in the steady-state delete
   loop):
   1. Full segment scan in `for_each_entity_zoned` for every
-     `WHERE id = N` (no index, `id` ≠ `red_entity_id`).
+     `WHERE id = N` (no index, `id` ≠ `rid`).
   2. WAL group-commit fsync wait per single-row `DELETE`
      (`commit::append_actions` → `wait_until_durable`), inherited
      from #76 P1 — `DEFAULT_GROUP_COMMIT_WINDOW_MS = 0`.
@@ -140,7 +140,7 @@ Per `delete_sequential` row, with the bench's wire DELETE
    (`dml_target_scan.rs:58`):
    - **Entity-id fast path miss** (`:69`):
      `extract_entity_id_from_filter` only matches column names
-     `red_entity_id` or `entity_id`
+     `rid` or `entity_id`
      (`query_exec/helpers.rs:53`). The bench column is `id`, so this
      returns `None`.
    - **Hash index miss** (`:77`): `try_hash_eq_lookup` looks up an
@@ -395,7 +395,7 @@ Five concrete follow-up items the main agent can decide to file.
   so the historical 9k is *not* explainable from the current code.
   Worth checking whether an earlier `setup_schema` revision built
   `idx_id` for these adapters, or whether `id` was at one point
-  treated as the synthetic `red_entity_id`. Either explanation
+  treated as the synthetic `rid`. Either explanation
   reinforces the headline finding: the regression is about whether
   *something* indexes `id`, not about the engine's per-row delete
   cost.

--- a/docs/reference/sql-1-0-x.md
+++ b/docs/reference/sql-1-0-x.md
@@ -34,8 +34,8 @@ Top-level SQL dispatch:
 ## Items and RedDB IDs
 
 Query results expose RedDB items with a public envelope. `rid` is the RedDB ID
-for the item; it replaces older public aliases such as `_entity_id`,
-`red_entity_id`, and `entity_id`.
+for the item; it replaces older public aliases such as `_entity_id`
+and `entity_id`.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/docs/spec/sdk-helpers.md
+++ b/docs/spec/sdk-helpers.md
@@ -44,7 +44,7 @@ issue searches resolve.
 ### 2.2 Public identity
 
 Public item identity is the string field `rid`. Drivers MUST NOT expose
-`red_entity_id`, `_entity_id`, or `entity_id` except in migration notes.
+`_entity_id` or `entity_id` except in migration notes.
 
 `rid` is lossless across drivers. JavaScript / TypeScript / JSON-only drivers
 that cannot represent large integers safely MUST treat `rid` as `string`.

--- a/drivers/bun/package.json
+++ b/drivers/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client-bun",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "RedDB wire protocol client for Bun — ultra-fast native TCP",
   "main": "index.ts",
   "scripts": {

--- a/drivers/js-client/package.json
+++ b/drivers/js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Thin remote-only RedDB driver. Downloads the `red_client` binary on install. Speaks RedWire/gRPC/HTTP. Embedded URIs (memory://, file://, red:///path) are rejected — use @reddb-io/sdk for those.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/js/package.json
+++ b/drivers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/sdk",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Official embedded RedDB SDK — launches a local red binary over stdio JSON-RPC. Use @reddb-io/client for remote HTTP, gRPC, and RedWire.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-client",
  "reddb-io-grpc-proto",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-client-connector",
  "reddb-io-grpc-proto",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -1943,14 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-python"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "prost",
  "pyo3",
@@ -1995,14 +1995,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-types",
 ]
 
 [[package]]
 name = "reddb-io-server"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2061,14 +2061,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "reddb-io-types",
  "serde_json",

--- a/drivers/python/Cargo.toml
+++ b/drivers/python/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "reddb-io-python"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 description = "Native Python driver for RedDB (compiled Rust via pyo3)"
 license = "MIT"

--- a/drivers/python/pyproject.toml
+++ b/drivers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "reddb"
-version = "1.13.0"
+version = "1.14.0"
 description = "Official Python driver for RedDB — embedded engine and gRPC remote in one package."
 readme = "README.md"
 license = { text = "MIT" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/cli",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "CLI launcher for RedDB. The JS/TS app driver is published as @reddb-io/sdk.",
   "type": "commonjs",
   "bin": {

--- a/packages/internal-asset-fetcher/package.json
+++ b/packages/internal-asset-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-asset-fetcher",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Workspace-only deep module: download a `red`/`red_client` binary from a GitHub release with platform/arch resolution, redirect handling, and optional sha256 verification.",
   "type": "module",

--- a/packages/internal-bin-resolver/package.json
+++ b/packages/internal-bin-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-bin-resolver",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Workspace-only deep module: locate a pinned binary inside a node_modules package, env override > local. PATH is never consulted.",
   "type": "module",

--- a/packages/internal-version-compare/package.json
+++ b/packages/internal-version-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-version-compare",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "private": true,
   "description": "Workspace-only deep module: compare a package version against an installed `red --version`, return install/upgrade/skip verdict for the CLI postinstall.",
   "type": "module",

--- a/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
+++ b/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
@@ -235,8 +235,7 @@ fn live_comment_clustering_calls_real_models() {
         (
             "source_query",
             JsonValue::String(
-                "SELECT rid, comment FROM comments ORDER BY rid ASC LIMIT 200"
-                    .to_string(),
+                "SELECT rid, comment FROM comments ORDER BY rid ASC LIMIT 200".to_string(),
             ),
         ),
         ("source_mode", JsonValue::String("row".to_string())),

--- a/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
+++ b/tests/grouped/ai_local_vector/integration_ai_live_comment_clustering.rs
@@ -235,7 +235,7 @@ fn live_comment_clustering_calls_real_models() {
         (
             "source_query",
             JsonValue::String(
-                "SELECT red_entity_id, comment FROM comments ORDER BY red_entity_id ASC LIMIT 200"
+                "SELECT rid, comment FROM comments ORDER BY rid ASC LIMIT 200"
                     .to_string(),
             ),
         ),
@@ -371,7 +371,7 @@ fn live_comment_clustering_calls_real_models() {
         query
             .execute(ExecuteQueryInput {
                 query: format!(
-                    "UPDATE comments SET category_id = '{}' WHERE red_entity_id = {}",
+                    "UPDATE comments SET category_id = '{}' WHERE rid = {}",
                     category_id.replace('\'', "''"),
                     assignment.linked_row_id
                 ),

--- a/tests/grouped/ai_search/e2e_comment_clustering.rs
+++ b/tests/grouped/ai_search/e2e_comment_clustering.rs
@@ -453,7 +453,7 @@ fn e2e_comments_embedding_cluster_label_and_writeback() {
     let embedding_payload: JsonValue = from_str(
         r#"{
             "provider": "openai",
-            "source_query": "SELECT red_entity_id, comment FROM comments ORDER BY red_entity_id ASC LIMIT 200",
+            "source_query": "SELECT rid, comment FROM comments ORDER BY rid ASC LIMIT 200",
             "source_mode": "row",
             "source_field": "comment",
             "source_collection": "comments",
@@ -545,7 +545,7 @@ fn e2e_comments_embedding_cluster_label_and_writeback() {
         query
             .execute(ExecuteQueryInput {
                 query: format!(
-                    "UPDATE comments SET category_id = '{}' WHERE red_entity_id = {}",
+                    "UPDATE comments SET category_id = '{}' WHERE rid = {}",
                     category_id, assignment.linked_row_id
                 ),
             })

--- a/tests/grouped/docs_kv_queue/e2e_issue_551_documents_sql_json_access.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_551_documents_sql_json_access.rs
@@ -92,7 +92,13 @@ fn sql_json_extract_in_select_projects_leaf_value() {
         page.result.records
     );
     let record = &page.result.records[0];
-    let label = "JSON_EXTRACT";
+    // An unaliased function projection is labeled with its source-text form
+    // (#1370): `json_extract(body, '$.level')` lowers to the `JSON_EXTRACT`
+    // builtin, so the output column reads `JSON_EXTRACT(body, '$.level')`.
+    // The contract this test pins is that the function dispatched and the
+    // path resolved — not the exact column header — so we look the value up
+    // under the reconstructed label.
+    let label = "JSON_EXTRACT(body, '$.level')";
     match record.get(label) {
         Some(Value::Text(value)) => {
             // JSON_EXTRACT returns the raw JSON encoding of the leaf,

--- a/tests/grouped/multimodel_query/integration_entity_query.rs
+++ b/tests/grouped/multimodel_query/integration_entity_query.rs
@@ -230,20 +230,20 @@ fn test_select_by_entity_id_sees_latest_updated_row_image() {
     query
         .execute(ExecuteQueryInput {
             query: format!(
-                "UPDATE entity_id_latest SET role = 'architect' WHERE red_entity_id = {}",
+                "UPDATE entity_id_latest SET role = 'architect' WHERE rid = {}",
                 created.id.raw()
             ),
         })
-        .expect("UPDATE by red_entity_id should succeed");
+        .expect("UPDATE by rid should succeed");
 
     let result = query
         .execute(ExecuteQueryInput {
             query: format!(
-                "SELECT role FROM entity_id_latest WHERE red_entity_id = {}",
+                "SELECT role FROM entity_id_latest WHERE rid = {}",
                 created.id.raw()
             ),
         })
-        .expect("SELECT by red_entity_id should succeed");
+        .expect("SELECT by rid should succeed");
 
     assert_eq!(
         result.result.records.len(),
@@ -317,13 +317,13 @@ fn test_table_row_logical_identity_compatibility() {
 
     let new_row = query
         .execute(ExecuteQueryInput {
-            query: "INSERT INTO logical_identity_rows (name, seen) VALUES ('new', 1) RETURNING red_entity_id".into(),
+            query: "INSERT INTO logical_identity_rows (name, seen) VALUES ('new', 1) RETURNING rid".into(),
         })
         .expect("new row insert should succeed");
-    let new_id = match new_row.result.records[0].get("red_entity_id") {
+    let new_id = match new_row.result.records[0].get("rid") {
         Some(Value::Integer(id)) => EntityId::new(*id as u64),
         Some(Value::UnsignedInteger(id)) => EntityId::new(*id),
-        other => panic!("expected returned red_entity_id, got {other:?}"),
+        other => panic!("expected returned rid, got {other:?}"),
     };
     let stored_new = store
         .get("logical_identity_rows", new_id)
@@ -334,13 +334,13 @@ fn test_table_row_logical_identity_compatibility() {
     let selected = query
         .execute(ExecuteQueryInput {
             query:
-                "SELECT red_entity_id, name FROM logical_identity_rows WHERE red_entity_id = 100"
+                "SELECT rid, name FROM logical_identity_rows WHERE rid = 100"
                     .into(),
         })
         .expect("SELECT by logical id should succeed");
     assert_eq!(selected.result.records.len(), 1);
     assert_eq!(
-        selected.result.records[0].get("red_entity_id"),
+        selected.result.records[0].get("rid"),
         Some(&Value::UnsignedInteger(100))
     );
     assert_eq!(
@@ -350,12 +350,12 @@ fn test_table_row_logical_identity_compatibility() {
 
     query
         .execute(ExecuteQueryInput {
-            query: "UPDATE logical_identity_rows SET seen = 2 WHERE red_entity_id = 100".into(),
+            query: "UPDATE logical_identity_rows SET seen = 2 WHERE rid = 100".into(),
         })
         .expect("UPDATE by logical id should succeed");
     let updated = query
         .execute(ExecuteQueryInput {
-            query: "SELECT seen FROM logical_identity_rows WHERE red_entity_id = 100".into(),
+            query: "SELECT seen FROM logical_identity_rows WHERE rid = 100".into(),
         })
         .expect("SELECT after logical-id update should succeed");
     assert_eq!(
@@ -365,12 +365,12 @@ fn test_table_row_logical_identity_compatibility() {
 
     query
         .execute(ExecuteQueryInput {
-            query: "DELETE FROM logical_identity_rows WHERE red_entity_id = 100".into(),
+            query: "DELETE FROM logical_identity_rows WHERE rid = 100".into(),
         })
         .expect("DELETE by logical id should succeed");
     let deleted = query
         .execute(ExecuteQueryInput {
-            query: "SELECT name FROM logical_identity_rows WHERE red_entity_id = 100".into(),
+            query: "SELECT name FROM logical_identity_rows WHERE rid = 100".into(),
         })
         .expect("SELECT after logical-id delete should succeed");
     assert!(deleted.result.records.is_empty());
@@ -2343,14 +2343,14 @@ fn test_fast_entity_id_lookup_persistent() {
         other => panic!("rid was not UnsignedInteger: {other:?}"),
     };
 
-    let eq_sql = format!("SELECT * FROM fastid WHERE red_entity_id = {eid}");
+    let eq_sql = format!("SELECT * FROM fastid WHERE rid = {eid}");
     let by_eq = q
         .execute(ExecuteQueryInput { query: eq_sql })
         .expect("fast-path select should succeed");
     assert_eq!(
         by_eq.result.records.len(),
         1,
-        "fast path `red_entity_id = {eid}` must return the inserted row"
+        "fast path `rid = {eid}` must return the inserted row"
     );
 }
 

--- a/tests/grouped/multimodel_query/integration_entity_query.rs
+++ b/tests/grouped/multimodel_query/integration_entity_query.rs
@@ -317,7 +317,8 @@ fn test_table_row_logical_identity_compatibility() {
 
     let new_row = query
         .execute(ExecuteQueryInput {
-            query: "INSERT INTO logical_identity_rows (name, seen) VALUES ('new', 1) RETURNING rid".into(),
+            query: "INSERT INTO logical_identity_rows (name, seen) VALUES ('new', 1) RETURNING rid"
+                .into(),
         })
         .expect("new row insert should succeed");
     let new_id = match new_row.result.records[0].get("rid") {
@@ -333,9 +334,7 @@ fn test_table_row_logical_identity_compatibility() {
 
     let selected = query
         .execute(ExecuteQueryInput {
-            query:
-                "SELECT rid, name FROM logical_identity_rows WHERE rid = 100"
-                    .into(),
+            query: "SELECT rid, name FROM logical_identity_rows WHERE rid = 100".into(),
         })
         .expect("SELECT by logical id should succeed");
     assert_eq!(selected.result.records.len(), 1);

--- a/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
+++ b/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
@@ -221,9 +221,7 @@ fn snapshot_isolation_blocks_read_skew() {
     try_exec(&rt, "COMMIT").unwrap();
 
     let res3 = rt
-        .execute_query(&format!(
-            "SELECT v FROM skew_check WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT v FROM skew_check WHERE rid = {rid}"))
         .unwrap();
     assert_eq!(res3.result.records.len(), 1, "new snapshot sees row");
     assert_eq!(
@@ -257,17 +255,13 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     )
     .unwrap();
     let writer = rt
-        .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT v FROM tx_update_ws WHERE rid = {rid}"))
         .unwrap();
     assert_eq!(writer.result.records[0].get("v"), Some(&Value::Integer(20)));
 
     set_current_connection_id(9951);
     let outsider = rt
-        .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT v FROM tx_update_ws WHERE rid = {rid}"))
         .unwrap();
     assert_eq!(
         outsider.result.records[0].get("v"),
@@ -278,9 +272,7 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     set_current_connection_id(9950);
     try_exec(&rt, "ROLLBACK").unwrap();
     let after_rollback = rt
-        .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT v FROM tx_update_ws WHERE rid = {rid}"))
         .unwrap();
     assert_eq!(
         after_rollback.result.records[0].get("v"),
@@ -296,9 +288,7 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     .unwrap();
     try_exec(&rt, "COMMIT").unwrap();
     let after_commit = rt
-        .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT v FROM tx_update_ws WHERE rid = {rid}"))
         .unwrap();
     assert_eq!(
         after_commit.result.records[0].get("v"),

--- a/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
+++ b/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
@@ -180,12 +180,12 @@ fn snapshot_isolation_blocks_read_skew() {
     try_exec(&rt, "CREATE TABLE skew_check (id INT, v INT)").unwrap();
     try_exec(&rt, "INSERT INTO skew_check (id, v) VALUES (1, 10)").unwrap();
     let inserted = rt
-        .execute_query("SELECT red_entity_id FROM skew_check WHERE id = 1")
+        .execute_query("SELECT rid FROM skew_check WHERE id = 1")
         .unwrap();
-    let red_entity_id = match inserted.result.records[0].get("red_entity_id") {
+    let rid = match inserted.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     };
 
     // Conn A: BEGIN — captures snapshot, sees v=10.
@@ -222,7 +222,7 @@ fn snapshot_isolation_blocks_read_skew() {
 
     let res3 = rt
         .execute_query(&format!(
-            "SELECT v FROM skew_check WHERE red_entity_id = {red_entity_id}"
+            "SELECT v FROM skew_check WHERE rid = {rid}"
         ))
         .unwrap();
     assert_eq!(res3.result.records.len(), 1, "new snapshot sees row");
@@ -242,23 +242,23 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     try_exec(&rt, "CREATE TABLE tx_update_ws (id INT, v INT)").unwrap();
     try_exec(&rt, "INSERT INTO tx_update_ws (id, v) VALUES (1, 10)").unwrap();
     let inserted = rt
-        .execute_query("SELECT red_entity_id FROM tx_update_ws WHERE id = 1")
+        .execute_query("SELECT rid FROM tx_update_ws WHERE id = 1")
         .unwrap();
-    let red_entity_id = match inserted.result.records[0].get("red_entity_id") {
+    let rid = match inserted.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     };
 
     try_exec(&rt, "BEGIN").unwrap();
     try_exec(
         &rt,
-        &format!("UPDATE tx_update_ws SET v = 20 WHERE red_entity_id = {red_entity_id}"),
+        &format!("UPDATE tx_update_ws SET v = 20 WHERE rid = {rid}"),
     )
     .unwrap();
     let writer = rt
         .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE red_entity_id = {red_entity_id}"
+            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
         ))
         .unwrap();
     assert_eq!(writer.result.records[0].get("v"), Some(&Value::Integer(20)));
@@ -266,7 +266,7 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     set_current_connection_id(9951);
     let outsider = rt
         .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE red_entity_id = {red_entity_id}"
+            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
         ))
         .unwrap();
     assert_eq!(
@@ -279,7 +279,7 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     try_exec(&rt, "ROLLBACK").unwrap();
     let after_rollback = rt
         .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE red_entity_id = {red_entity_id}"
+            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
         ))
         .unwrap();
     assert_eq!(
@@ -291,13 +291,13 @@ fn transaction_update_write_set_rolls_back_cleanly() {
     try_exec(&rt, "BEGIN").unwrap();
     try_exec(
         &rt,
-        &format!("UPDATE tx_update_ws SET v = 30 WHERE red_entity_id = {red_entity_id}"),
+        &format!("UPDATE tx_update_ws SET v = 30 WHERE rid = {rid}"),
     )
     .unwrap();
     try_exec(&rt, "COMMIT").unwrap();
     let after_commit = rt
         .execute_query(&format!(
-            "SELECT v FROM tx_update_ws WHERE red_entity_id = {red_entity_id}"
+            "SELECT v FROM tx_update_ws WHERE rid = {rid}"
         ))
         .unwrap();
     assert_eq!(

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_delete_tombstones.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_delete_tombstones.rs
@@ -13,21 +13,21 @@ fn exec(rt: &RedDBRuntime, sql: &str) {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
 }
 
-fn red_entity_id(rt: &RedDBRuntime, table: &str) -> u64 {
+fn rid(rt: &RedDBRuntime, table: &str) -> u64 {
     let result = rt
-        .execute_query(&format!("SELECT red_entity_id FROM {table} WHERE id = 1"))
-        .expect("select red_entity_id");
-    match result.result.records[0].get("red_entity_id") {
+        .execute_query(&format!("SELECT rid FROM {table} WHERE id = 1"))
+        .expect("select rid");
+    match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     }
 }
 
-fn label_for(rt: &RedDBRuntime, table: &str, red_entity_id: u64) -> Option<String> {
+fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
     let result = rt
         .execute_query(&format!(
-            "SELECT label FROM {table} WHERE red_entity_id = {red_entity_id}"
+            "SELECT label FROM {table} WHERE rid = {rid}"
         ))
         .expect("select label");
     result
@@ -64,7 +64,7 @@ fn delete_tombstone_preserves_old_snapshot_and_hides_new_snapshot() {
         &rt,
         "INSERT INTO mvcc_delete_snap (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "mvcc_delete_snap");
+    let eid = rid(&rt, "mvcc_delete_snap");
 
     exec(&rt, "BEGIN");
     assert_eq!(
@@ -75,7 +75,7 @@ fn delete_tombstone_preserves_old_snapshot_and_hides_new_snapshot() {
     set_current_connection_id(43802);
     exec(
         &rt,
-        &format!("DELETE FROM mvcc_delete_snap WHERE red_entity_id = {eid}"),
+        &format!("DELETE FROM mvcc_delete_snap WHERE rid = {eid}"),
     );
     assert_eq!(label_for(&rt, "mvcc_delete_snap", eid), None);
 
@@ -130,13 +130,13 @@ fn explicit_delete_is_invisible_to_other_transactions_until_commit() {
         &rt,
         "INSERT INTO mvcc_delete_tx (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "mvcc_delete_tx");
+    let eid = rid(&rt, "mvcc_delete_tx");
 
     set_current_connection_id(43812);
     exec(&rt, "BEGIN");
     exec(
         &rt,
-        &format!("DELETE FROM mvcc_delete_tx WHERE red_entity_id = {eid}"),
+        &format!("DELETE FROM mvcc_delete_tx WHERE rid = {eid}"),
     );
     assert_eq!(label_for(&rt, "mvcc_delete_tx", eid), None);
 
@@ -168,12 +168,12 @@ fn rollback_of_staged_delete_leaves_row_visible() {
         &rt,
         "INSERT INTO mvcc_delete_rollback (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "mvcc_delete_rollback");
+    let eid = rid(&rt, "mvcc_delete_rollback");
 
     exec(&rt, "BEGIN");
     exec(
         &rt,
-        &format!("DELETE FROM mvcc_delete_rollback WHERE red_entity_id = {eid}"),
+        &format!("DELETE FROM mvcc_delete_rollback WHERE rid = {eid}"),
     );
     assert_eq!(label_for(&rt, "mvcc_delete_rollback", eid), None);
     exec(&rt, "ROLLBACK");

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_delete_tombstones.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_delete_tombstones.rs
@@ -26,9 +26,7 @@ fn rid(rt: &RedDBRuntime, table: &str) -> u64 {
 
 fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
     let result = rt
-        .execute_query(&format!(
-            "SELECT label FROM {table} WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT label FROM {table} WHERE rid = {rid}"))
         .expect("select label");
     result
         .result

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
@@ -19,23 +19,23 @@ fn exec_err(rt: &RedDBRuntime, sql: &str) -> String {
         .to_string()
 }
 
-fn red_entity_id(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
+fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
     let result = rt
         .execute_query(&format!(
-            "SELECT red_entity_id FROM {table} WHERE id = {id}"
+            "SELECT rid FROM {table} WHERE id = {id}"
         ))
-        .expect("select red_entity_id");
-    match result.result.records[0].get("red_entity_id") {
+        .expect("select rid");
+    match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     }
 }
 
-fn label_for(rt: &RedDBRuntime, table: &str, red_entity_id: u64) -> Option<String> {
+fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
     let result = rt
         .execute_query(&format!(
-            "SELECT label FROM {table} WHERE red_entity_id = {red_entity_id}"
+            "SELECT label FROM {table} WHERE rid = {rid}"
         ))
         .expect("select label");
     result
@@ -61,7 +61,7 @@ fn concurrent_updates_same_logical_row_conflict_on_second_commit() {
     set_current_connection_id(43901);
     exec(&rt, "CREATE TABLE fcw_update (id INT, label TEXT)");
     exec(&rt, "INSERT INTO fcw_update (id, label) VALUES (1, 'base')");
-    let eid = red_entity_id(&rt, "fcw_update", 1);
+    let eid = rid(&rt, "fcw_update", 1);
 
     set_current_connection_id(43902);
     exec(&rt, "BEGIN");
@@ -71,12 +71,12 @@ fn concurrent_updates_same_logical_row_conflict_on_second_commit() {
     set_current_connection_id(43902);
     exec(
         &rt,
-        &format!("UPDATE fcw_update SET label = 'first' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_update SET label = 'first' WHERE rid = {eid}"),
     );
     set_current_connection_id(43903);
     exec(
         &rt,
-        &format!("UPDATE fcw_update SET label = 'second' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_update SET label = 'second' WHERE rid = {eid}"),
     );
 
     set_current_connection_id(43902);
@@ -98,8 +98,8 @@ fn concurrent_updates_different_logical_rows_both_commit() {
         &rt,
         "INSERT INTO fcw_distinct (id, label) VALUES (1, 'one'), (2, 'two')",
     );
-    let eid1 = red_entity_id(&rt, "fcw_distinct", 1);
-    let eid2 = red_entity_id(&rt, "fcw_distinct", 2);
+    let eid1 = rid(&rt, "fcw_distinct", 1);
+    let eid2 = rid(&rt, "fcw_distinct", 2);
 
     set_current_connection_id(43912);
     exec(&rt, "BEGIN");
@@ -109,12 +109,12 @@ fn concurrent_updates_different_logical_rows_both_commit() {
     set_current_connection_id(43912);
     exec(
         &rt,
-        &format!("UPDATE fcw_distinct SET label = 'first' WHERE red_entity_id = {eid1}"),
+        &format!("UPDATE fcw_distinct SET label = 'first' WHERE rid = {eid1}"),
     );
     set_current_connection_id(43913);
     exec(
         &rt,
-        &format!("UPDATE fcw_distinct SET label = 'second' WHERE red_entity_id = {eid2}"),
+        &format!("UPDATE fcw_distinct SET label = 'second' WHERE rid = {eid2}"),
     );
 
     set_current_connection_id(43912);
@@ -143,7 +143,7 @@ fn update_then_delete_same_logical_row_conflicts() {
         &rt,
         "INSERT INTO fcw_update_delete (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "fcw_update_delete", 1);
+    let eid = rid(&rt, "fcw_update_delete", 1);
 
     set_current_connection_id(43922);
     exec(&rt, "BEGIN");
@@ -153,12 +153,12 @@ fn update_then_delete_same_logical_row_conflicts() {
     set_current_connection_id(43922);
     exec(
         &rt,
-        &format!("UPDATE fcw_update_delete SET label = 'kept' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_update_delete SET label = 'kept' WHERE rid = {eid}"),
     );
     set_current_connection_id(43923);
     exec(
         &rt,
-        &format!("DELETE FROM fcw_update_delete WHERE red_entity_id = {eid}"),
+        &format!("DELETE FROM fcw_update_delete WHERE rid = {eid}"),
     );
 
     set_current_connection_id(43922);
@@ -183,7 +183,7 @@ fn delete_then_update_same_logical_row_conflicts() {
         &rt,
         "INSERT INTO fcw_delete_update (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "fcw_delete_update", 1);
+    let eid = rid(&rt, "fcw_delete_update", 1);
 
     set_current_connection_id(43932);
     exec(&rt, "BEGIN");
@@ -193,12 +193,12 @@ fn delete_then_update_same_logical_row_conflicts() {
     set_current_connection_id(43932);
     exec(
         &rt,
-        &format!("DELETE FROM fcw_delete_update WHERE red_entity_id = {eid}"),
+        &format!("DELETE FROM fcw_delete_update WHERE rid = {eid}"),
     );
     set_current_connection_id(43933);
     exec(
         &rt,
-        &format!("UPDATE fcw_delete_update SET label = 'stale' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_delete_update SET label = 'stale' WHERE rid = {eid}"),
     );
 
     set_current_connection_id(43932);
@@ -220,7 +220,7 @@ fn stale_transaction_conflicts_with_autocommit_update() {
         &rt,
         "INSERT INTO fcw_autocommit (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "fcw_autocommit", 1);
+    let eid = rid(&rt, "fcw_autocommit", 1);
 
     set_current_connection_id(43942);
     exec(&rt, "BEGIN");
@@ -228,13 +228,13 @@ fn stale_transaction_conflicts_with_autocommit_update() {
     set_current_connection_id(43943);
     exec(
         &rt,
-        &format!("UPDATE fcw_autocommit SET label = 'auto' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_autocommit SET label = 'auto' WHERE rid = {eid}"),
     );
 
     set_current_connection_id(43942);
     exec(
         &rt,
-        &format!("UPDATE fcw_autocommit SET label = 'stale' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE fcw_autocommit SET label = 'stale' WHERE rid = {eid}"),
     );
     assert_conflict(&exec_err(&rt, "COMMIT"));
 

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
@@ -21,9 +21,7 @@ fn exec_err(rt: &RedDBRuntime, sql: &str) -> String {
 
 fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
     let result = rt
-        .execute_query(&format!(
-            "SELECT rid FROM {table} WHERE id = {id}"
-        ))
+        .execute_query(&format!("SELECT rid FROM {table} WHERE id = {id}"))
         .expect("select rid");
     match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
@@ -34,9 +32,7 @@ fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
 
 fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
     let result = rt
-        .execute_query(&format!(
-            "SELECT label FROM {table} WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT label FROM {table} WHERE rid = {rid}"))
         .expect("select label");
     result
         .result

--- a/tests/grouped/mvcc_transactions/e2e_savepoint_update_reversal.rs
+++ b/tests/grouped/mvcc_transactions/e2e_savepoint_update_reversal.rs
@@ -26,9 +26,7 @@ fn rid(rt: &RedDBRuntime, table: &str) -> u64 {
 
 fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> String {
     let result = rt
-        .execute_query(&format!(
-            "SELECT label FROM {table} WHERE rid = {rid}"
-        ))
+        .execute_query(&format!("SELECT label FROM {table} WHERE rid = {rid}"))
         .expect("select label");
     match result.result.records[0].get("label") {
         Some(Value::Text(value)) => value.to_string(),

--- a/tests/grouped/mvcc_transactions/e2e_savepoint_update_reversal.rs
+++ b/tests/grouped/mvcc_transactions/e2e_savepoint_update_reversal.rs
@@ -13,21 +13,21 @@ fn exec(rt: &RedDBRuntime, sql: &str) {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
 }
 
-fn red_entity_id(rt: &RedDBRuntime, table: &str) -> u64 {
+fn rid(rt: &RedDBRuntime, table: &str) -> u64 {
     let result = rt
-        .execute_query(&format!("SELECT red_entity_id FROM {table} WHERE id = 1"))
-        .expect("select red_entity_id");
-    match result.result.records[0].get("red_entity_id") {
+        .execute_query(&format!("SELECT rid FROM {table} WHERE id = 1"))
+        .expect("select rid");
+    match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     }
 }
 
-fn label_for(rt: &RedDBRuntime, table: &str, red_entity_id: u64) -> String {
+fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> String {
     let result = rt
         .execute_query(&format!(
-            "SELECT label FROM {table} WHERE red_entity_id = {red_entity_id}"
+            "SELECT label FROM {table} WHERE rid = {rid}"
         ))
         .expect("select label");
     match result.result.records[0].get("label") {
@@ -43,13 +43,13 @@ fn rollback_to_savepoint_restores_pre_update_value() {
 
     exec(&rt, "CREATE TABLE sp_upd (id INT, label TEXT)");
     exec(&rt, "INSERT INTO sp_upd (id, label) VALUES (1, 'before')");
-    let eid = red_entity_id(&rt, "sp_upd");
+    let eid = rid(&rt, "sp_upd");
 
     exec(&rt, "BEGIN");
     exec(&rt, "SAVEPOINT sp1");
     exec(
         &rt,
-        &format!("UPDATE sp_upd SET label = 'after' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE sp_upd SET label = 'after' WHERE rid = {eid}"),
     );
     exec(&rt, "ROLLBACK TO SAVEPOINT sp1");
     exec(&rt, "COMMIT");
@@ -69,22 +69,22 @@ fn nested_savepoints_restore_the_right_update_version() {
         &rt,
         "INSERT INTO sp_nested_upd (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "sp_nested_upd");
+    let eid = rid(&rt, "sp_nested_upd");
 
     exec(&rt, "BEGIN");
     exec(
         &rt,
-        &format!("UPDATE sp_nested_upd SET label = 'one' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE sp_nested_upd SET label = 'one' WHERE rid = {eid}"),
     );
     exec(&rt, "SAVEPOINT sp1");
     exec(
         &rt,
-        &format!("UPDATE sp_nested_upd SET label = 'two' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE sp_nested_upd SET label = 'two' WHERE rid = {eid}"),
     );
     exec(&rt, "SAVEPOINT sp2");
     exec(
         &rt,
-        &format!("UPDATE sp_nested_upd SET label = 'three' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE sp_nested_upd SET label = 'three' WHERE rid = {eid}"),
     );
     exec(&rt, "ROLLBACK TO SAVEPOINT sp2");
     assert_eq!(label_for(&rt, "sp_nested_upd", eid), "two");
@@ -106,13 +106,13 @@ fn release_savepoint_preserves_update_work() {
         &rt,
         "INSERT INTO sp_release_upd (id, label) VALUES (1, 'base')",
     );
-    let eid = red_entity_id(&rt, "sp_release_upd");
+    let eid = rid(&rt, "sp_release_upd");
 
     exec(&rt, "BEGIN");
     exec(&rt, "SAVEPOINT sp1");
     exec(
         &rt,
-        &format!("UPDATE sp_release_upd SET label = 'kept' WHERE red_entity_id = {eid}"),
+        &format!("UPDATE sp_release_upd SET label = 'kept' WHERE rid = {eid}"),
     );
     exec(&rt, "RELEASE SAVEPOINT sp1");
     assert_eq!(label_for(&rt, "sp_release_upd", eid), "kept");

--- a/tests/grouped/mvcc_transactions/e2e_txcommitbatch_wal.rs
+++ b/tests/grouped/mvcc_transactions/e2e_txcommitbatch_wal.rs
@@ -33,9 +33,7 @@ fn exec(rt: &RedDBRuntime, sql: &str) {
 
 fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
     let result = rt
-        .execute_query(&format!(
-            "SELECT rid FROM {table} WHERE id = {id}"
-        ))
+        .execute_query(&format!("SELECT rid FROM {table} WHERE id = {id}"))
         .expect("select rid");
     match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
@@ -214,10 +212,7 @@ fn autocommit_table_mutations_write_tx_commit_batch_records() {
             &rt,
             &format!("UPDATE txb_shape SET label = 'aa' WHERE rid = {updated}"),
         );
-        exec(
-            &rt,
-            &format!("DELETE FROM txb_shape WHERE rid = {deleted}"),
-        );
+        exec(&rt, &format!("DELETE FROM txb_shape WHERE rid = {deleted}"));
         clear_current_connection_id();
     }
 

--- a/tests/grouped/mvcc_transactions/e2e_txcommitbatch_wal.rs
+++ b/tests/grouped/mvcc_transactions/e2e_txcommitbatch_wal.rs
@@ -31,32 +31,32 @@ fn exec(rt: &RedDBRuntime, sql: &str) {
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
 }
 
-fn red_entity_id(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
+fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {
     let result = rt
         .execute_query(&format!(
-            "SELECT red_entity_id FROM {table} WHERE id = {id}"
+            "SELECT rid FROM {table} WHERE id = {id}"
         ))
-        .expect("select red_entity_id");
-    match result.result.records[0].get("red_entity_id") {
+        .expect("select rid");
+    match result.result.records[0].get("rid") {
         Some(Value::UnsignedInteger(id)) => *id,
         Some(Value::Integer(id)) => *id as u64,
-        other => panic!("expected red_entity_id, got {other:?}"),
+        other => panic!("expected rid, got {other:?}"),
     }
 }
 
-fn label_for(rt: &RedDBRuntime, table: &str, red_entity_id: u64) -> Option<String> {
+fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
     let result = rt
-        .execute_query(&format!("SELECT red_entity_id, label FROM {table}"))
+        .execute_query(&format!("SELECT rid, label FROM {table}"))
         .expect("select label");
     result.result.records.iter().find_map(|record| {
-        // Full-scan SELECT projects `red_entity_id` under the `rid` key
-        // (the projection-only path keeps the `red_entity_id` alias).
-        let row_id = match record.get("red_entity_id").or_else(|| record.get("rid")) {
+        // Full-scan SELECT projects `rid` under the `rid` key
+        // (the projection-only path keeps the `rid` alias).
+        let row_id = match record.get("rid").or_else(|| record.get("rid")) {
             Some(Value::UnsignedInteger(id)) => *id,
             Some(Value::Integer(id)) => *id as u64,
             _ => return None,
         };
-        if row_id != red_entity_id {
+        if row_id != rid {
             return None;
         }
         match record.get("label").or_else(|| record.get("c0")) {
@@ -101,15 +101,15 @@ fn autocommit_insert_update_delete_recover_from_commit_batches() {
             &rt,
             "INSERT INTO txb_recover (id, label) VALUES (1, 'inserted'), (2, 'delete-me')",
         );
-        let keep = red_entity_id(&rt, "txb_recover", 1);
-        let deleted = red_entity_id(&rt, "txb_recover", 2);
+        let keep = rid(&rt, "txb_recover", 1);
+        let deleted = rid(&rt, "txb_recover", 2);
         exec(
             &rt,
-            &format!("UPDATE txb_recover SET label = 'updated' WHERE red_entity_id = {keep}"),
+            &format!("UPDATE txb_recover SET label = 'updated' WHERE rid = {keep}"),
         );
         exec(
             &rt,
-            &format!("DELETE FROM txb_recover WHERE red_entity_id = {deleted}"),
+            &format!("DELETE FROM txb_recover WHERE rid = {deleted}"),
         );
         clear_current_connection_id();
         (keep, deleted)
@@ -183,7 +183,7 @@ fn truncated_commit_batch_is_absent_after_recovery() {
     {
         let rt = db_open(&db);
         set_current_connection_id(44012);
-        let base = red_entity_id(&rt, "txb_truncated", 1);
+        let base = rid(&rt, "txb_truncated", 1);
         assert_eq!(
             label_for(&rt, "txb_truncated", base).as_deref(),
             Some("base")
@@ -208,15 +208,15 @@ fn autocommit_table_mutations_write_tx_commit_batch_records() {
             &rt,
             "INSERT INTO txb_shape (id, label) VALUES (1, 'a'), (2, 'b')",
         );
-        let updated = red_entity_id(&rt, "txb_shape", 1);
-        let deleted = red_entity_id(&rt, "txb_shape", 2);
+        let updated = rid(&rt, "txb_shape", 1);
+        let deleted = rid(&rt, "txb_shape", 2);
         exec(
             &rt,
-            &format!("UPDATE txb_shape SET label = 'aa' WHERE red_entity_id = {updated}"),
+            &format!("UPDATE txb_shape SET label = 'aa' WHERE rid = {updated}"),
         );
         exec(
             &rt,
-            &format!("DELETE FROM txb_shape WHERE red_entity_id = {deleted}"),
+            &format!("DELETE FROM txb_shape WHERE rid = {deleted}"),
         );
         clear_current_connection_id();
     }

--- a/tests/grouped/runtime_persistence/integration_persistent_grimms_scale.rs
+++ b/tests/grouped/runtime_persistence/integration_persistent_grimms_scale.rs
@@ -82,7 +82,7 @@ fn insert_graph_nodes(
         );
         assert_eq!(result.result.records.len(), end - start);
         for row in 0..result.result.records.len() {
-            ids.push(uint_at(&result, row, "red_entity_id"));
+            ids.push(uint_at(&result, row, "rid"));
         }
     }
     ids


### PR DESCRIPTION
## What

The in-memory runtime defaulted its audit log to a **shared** `$TMPDIR/reddb` sink, so every `fresh_server()` wrote to one file. Under **nextest** (one process per test), parallel test processes accumulated events there past the 64 MB rotation threshold and rotated one another's events out of the active file before a reader could observe them.

Result: `server::routing::tests::ndjson_capacity_refusal_emits_capacity_refused_audit_event` deterministically failed to find its own `stream.closed {reason: capacity_refused}` event — the **lone red required check ("Test Suite") on `main`**.

## Fix

Isolate each ephemeral in-memory runtime's audit log **per process + per instance**, mirroring the embedded single-file branch's existing `process::id()` isolation. Every runtime's audit log is now self-contained.

## Verification

Local build of `reddb-io-server`'s test binary OOMs under this host's cargo memory cap, so verification is delegated to CI (Test Suite runs the exact failing test under nextest).

https://claude.ai/code/session_011X8MzSWKHcrD65ehryYdmj

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784859221&installation_id=129708444&pr_number=1360&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1360&signature=2126596cab2088eaca578ff775d5f0a984312dcb654fc10ad9f10deae03e2f35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended RQL parsing to accept additional IAM action verbs and keyword-tokenized subscription names.
* **Bug Fixes**
  * Standardized the public row identifier to `rid` across JSON, stdio, wire, and `RETURNING *` envelopes.
  * Improved config/secret lookup fallbacks, volatile-query caching behavior, queue read synchronization, subquery depth guarding, and vector reranking accuracy.
  * Enhanced ephemeral in-memory temp isolation/cleanup and clarified first user entity ID allocation.
* **Tests**
  * Updated conformance and regression suites to match `rid`-based output/identity behavior.
* **Documentation**
  * Refreshed API, SQL, and data model docs to reflect `rid` as canonical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->