### PR TITLE
feat(install): detect-and-warn for optional CA-certificates dep

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -243,6 +243,30 @@ install_file() {
   echo "Installed: ${binary_path}"
 }
 
+# The static `red` has no hard runtime deps. The one optional dep is a CA-cert
+# bundle, needed ONLY for outbound TLS to remote storage backends (S3 / Turso /
+# D1). Detect its absence and guide — never auto-install (that would need sudo
+# and can't be done safely from a piped installer).
+check_optional_runtime_deps() {
+  [[ "$OS" != "linux" ]] && return 0   # macOS/Windows ship a system trust store
+  local ca
+  for ca in /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt \
+            /etc/ssl/cert.pem /etc/ssl/ca-bundle.pem; do
+    [[ -f "$ca" ]] && return 0
+  done
+  echo ""
+  echo "Note: no CA-certificate bundle found. The local database works without it,"
+  echo "but outbound TLS (S3 / Turso / D1 remote backends) needs one:"
+  if   command -v apt-get >/dev/null 2>&1; then echo "  sudo apt-get install -y ca-certificates"
+  elif command -v dnf     >/dev/null 2>&1; then echo "  sudo dnf install -y ca-certificates"
+  elif command -v yum     >/dev/null 2>&1; then echo "  sudo yum install -y ca-certificates"
+  elif command -v apk     >/dev/null 2>&1; then echo "  sudo apk add ca-certificates"
+  elif command -v pacman  >/dev/null 2>&1; then echo "  sudo pacman -S --noconfirm ca-certificates"
+  elif command -v zypper  >/dev/null 2>&1; then echo "  sudo zypper install -y ca-certificates"
+  else echo "  install your distro's 'ca-certificates' package"
+  fi
+}
+
 main() {
   detect_platform
   fetch_release_info
@@ -259,6 +283,7 @@ main() {
   done
 
   echo "✅ RedDB installed."
+  check_optional_runtime_deps
   echo ""
   echo "Quick start:"
   echo "  red --help"


### PR DESCRIPTION
Follow-up to #1380. The static `red` has no hard runtime deps; the only optional one is a CA-cert bundle for outbound TLS to remote backends (S3/Turso/D1). The installer now detects its absence and prints the exact per-distro install command — guidance only, never auto-`sudo`. Bash-syntax validated. Merged via lift-protection (main red on PRD #1362 repair).

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784901668&installation_id=129708444&pr_number=1381&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1381&signature=d972507c7d33d3cf91dad27aaff362509b3db7a76c2f989959d2655c300cef42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->