### PR TITLE
feat: multi-model MVCC history — versioned KV/document/graph/vector (un-defer ADR 0014)

### DIFF
--- a/.red/adr/0014-mvcc-history-store-and-transaction-recovery.md
+++ b/.red/adr/0014-mvcc-history-store-and-transaction-recovery.md
@@ -371,3 +371,63 @@ events unavoidable.
 - Old-snapshot index performance: v1.0 table-row correctness requires MVCC
   recheck plus fallback scan/history lookup. Historical secondary indexes are
   explicitly deferred as a performance feature.
+
+## Amendment — 2026-06-25: multi-model history adoption (lifting the non-table deferral)
+
+**Status:** Accepted — extends the Decision above.
+
+The original rollout contract deferred non-table models: *"non-table models must
+not claim the new guarantee until their read and write paths explicitly adopt the
+resolver"* and *"Full multi-model adoption is deferred behind table-row
+correctness."* Table-row correctness is now shipped and stable (released in
+v1.14.0), so that deferral is lifted by product decision: **non-table collections
+explicitly marked `versioned` adopt the MVCC history-store resolver**, so
+AS OF / time-travel / VCS merge work across models, not only tables. This is what
+makes the VCS ("Git for Data") premise hold for every model.
+
+### Gating principle
+
+History retention for non-table models is **opt-in per collection via the
+`versioned` flag** (`runtime.vcs_is_versioned()`). Non-versioned collections —
+including the `red_config` KV and the secrets vault — keep last-writer-wins and
+the zero-scan fast path unchanged. Table rows remain unconditionally versioned
+(the original baseline). The xmin/xmax stamping, `logical_id` version-selection
+(`resolve_read_candidate`), commit-time first-committer-wins
+(`check_table_row_write_conflicts`), tombstone-on-delete, and VACUUM reclamation
+are reused unchanged — every model travels the same machinery rather than
+duplicating rules.
+
+### Adopted (branch `feat/versioned-kv-mvcc-history`)
+
+- **KV** — full: tombstone-on-PUT/DELETE, snapshot version-selection (keyed on the
+  `key` field), first-committer-wins. Caught a real bug along the way: the
+  autocommit-pool xmin is non-monotonic vs commit xids, so the new version's xmin
+  is restamped via `begin()/commit()`.
+- **Document** — full: stored as `EntityKind::TableRow` with `logical_id`, so reads
+  and SQL `UPDATE` already versioned; the only gap was PATCH (mutated in place) —
+  now emits a versioned post-image.
+- **Graph** (nodes/edges) — full: own `EntityKind` but the machinery is
+  kind-agnostic; stamp `logical_id`, open the PATCH/UPDATE and DELETE gates; the
+  read path was already snapshot-correct.
+- **Vector** — live-read correct + write-side history: the TurboQuant index is
+  append-only (no removal), so search post-filters every candidate by
+  snapshot/xmax visibility. This also fixed a pre-existing bug where
+  `DELETE FROM <vector> WHERE rid=N` matched zero rows (vector deletes never took
+  effect) and deleted vectors lingered in search results. Versioned vector deletes
+  tombstone with first-committer-wins.
+
+### Still deferred (scoped follow-ups; `#[ignore]`d specs left in `tests/grouped/vcs/`)
+
+- **Vector AS OF read surface** — `VECTOR SEARCH` has no `AS OF` grammar and vectors
+  are not row-scannable, so reading a historical vector version back needs
+  grammar + planner + a historical-version resolver. Write-side history is retained
+  physically, so this lands later without a data-model change.
+- **CDC/watch-event transactionality** — KV (`record_kv_watch_event`) and document
+  CDC emit eagerly during the write rather than at commit, so a rolled-back or
+  conflicted versioned write still emits its event. The table path defers CDC to
+  `finalize_pending_*`; the non-table paths should follow (consistent with the CDC
+  idempotence deferral above).
+- **PATCH vs SQL-UPDATE gating** — SQL `UPDATE` versions table rows unconditionally
+  (the baseline); the new non-table PATCH path is flag-gated. For a non-versioned
+  document the two verbs therefore differ in history accrual (invisible without
+  AS OF, which is rejected for non-versioned). Align if uniform behavior is wanted.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "jsonwebtoken",
  "proptest",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2482,7 +2482,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -2491,14 +2491,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "proptest",
  "reddb-io-types",
@@ -2536,7 +2536,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-server"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "proptest",
  "zstd",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "insta",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cast_possible_truncation = "warn"
 
 [package]
 name = "reddb-io"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 # Cargo auto-discovers every top-level `tests/*.rs` file as a separate
 # integration-test binary. This crate has 269 such files; keep discovery off

--- a/crates/reddb-client-connector/Cargo.toml
+++ b/crates/reddb-client-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client-connector"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "Workspace-internal gRPC connector used by `reddb-server` (rpc_stdio) and `reddb-client`. Splitting it out of `reddb-client` breaks the otherwise-circular path dependency between `reddb-client[embedded]` (which pulls `reddb-server`) and `reddb-server` (which needs the connector)."

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "Official Rust client for RedDB — embedded engine, gRPC, HTTP, and RedWire transports behind one connection-string API. Also hosts the workspace-internal connector + REPL used by the `red` and `red_client` binaries."

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-crypto"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB cryptographic authority: the canonical per-page encryption-at-rest envelope (AES-256-GCM), mandatory encrypt parameters, and key parsing."

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-file"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB file artifact layer: single-file .rdb layout, WAL, snapshots, checkpoints, locks, and recovery."

--- a/crates/reddb-grpc-proto/Cargo.toml
+++ b/crates/reddb-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-grpc-proto"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "Generated gRPC protobuf types and tonic client/server stubs for RedDB. Shared across reddb-server, reddb-client, and language drivers."

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-rql"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB Query Language (RQL) front-end + conformance authority (ADR 0053). Owns the sqllogictest-format conformance suite whose truth comes from the public SQLite corpus; depends only on reddb-io-types."

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-server"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB server-side engine: storage, runtime, replication, MCP, AI, and the gRPC/HTTP/RedWire/PG-wire dispatchers. Re-exported by the umbrella `reddb` crate."

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1289,15 +1289,23 @@ impl RedDBRuntime {
         // empty for non-row entities, which is the desired no-op.
         let pre_mutation_fields = entity_row_fields_snapshot(&entity);
 
-        // Versioned collections retain MVCC history: a PATCH must produce
-        // a NEW full version (the merged document/row) with the prior
-        // version tombstoned, mirroring the SQL UPDATE row path. Gated
-        // STRICTLY on the collection `versioned` flag — non-versioned
-        // collections keep last-writer-wins in-place mutation. Only Row
-        // entities (documents / table rows / KV) carry logical-id MVCC
-        // history; graph/vector/etc. stay in-place.
-        let patch_versions = matches!(entity.data, crate::storage::EntityData::Row(_))
-            && self.vcs_is_versioned(&collection).unwrap_or(false);
+        // Versioned collections retain MVCC history: a PATCH/UPDATE must
+        // produce a NEW full version (the merged document/row/node) with
+        // the prior version tombstoned, mirroring the SQL UPDATE row
+        // path. Gated STRICTLY on the collection `versioned` flag —
+        // non-versioned collections keep last-writer-wins in-place
+        // mutation. Row entities (documents / table rows / KV) carry
+        // logical-id MVCC history (Phase 1/2); graph nodes & edges join
+        // in Phase 3. The post-image re-stamp (new physical id, same
+        // logical_id, fresh xmin) at the tail of this function is fully
+        // kind-agnostic, so the same machinery installs a versioned
+        // graph-node update.
+        let patch_versions = matches!(
+            entity.data,
+            crate::storage::EntityData::Row(_)
+                | crate::storage::EntityData::Node(_)
+                | crate::storage::EntityData::Edge(_)
+        ) && self.vcs_is_versioned(&collection).unwrap_or(false);
         let versioned_update_xid = if patch_versions {
             match self.current_xid() {
                 Some(xid) => Some(xid),

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1283,10 +1283,39 @@ impl RedDBRuntime {
         operations: Vec<PatchEntityOperation>,
     ) -> RedDBResult<AppliedEntityMutation> {
         let id = entity.id;
+        let previous_xmax = entity.xmax;
         let operations = normalize_ttl_patch_operations(operations)?;
         // Snapshot pre-patch row fields for the secondary-index hook —
         // empty for non-row entities, which is the desired no-op.
         let pre_mutation_fields = entity_row_fields_snapshot(&entity);
+
+        // Versioned collections retain MVCC history: a PATCH must produce
+        // a NEW full version (the merged document/row) with the prior
+        // version tombstoned, mirroring the SQL UPDATE row path. Gated
+        // STRICTLY on the collection `versioned` flag — non-versioned
+        // collections keep last-writer-wins in-place mutation. Only Row
+        // entities (documents / table rows / KV) carry logical-id MVCC
+        // history; graph/vector/etc. stay in-place.
+        let patch_versions = matches!(entity.data, crate::storage::EntityData::Row(_))
+            && self.vcs_is_versioned(&collection).unwrap_or(false);
+        let versioned_update_xid = if patch_versions {
+            match self.current_xid() {
+                Some(xid) => Some(xid),
+                None => {
+                    let snapshot_manager = self.snapshot_manager();
+                    let xid = snapshot_manager.begin();
+                    snapshot_manager.commit(xid);
+                    Some(xid)
+                }
+            }
+        } else {
+            None
+        };
+        let mut replaced_entity = versioned_update_xid.map(|xid| {
+            let mut old = entity.clone();
+            old.set_xmax(xid);
+            old
+        });
 
         let db = self.db();
         let store = db.store();
@@ -1806,18 +1835,34 @@ impl RedDBRuntime {
             .unwrap_or_default()
             .as_secs();
 
+        // Versioned PATCH: re-stamp the merged post-image as a fresh
+        // physical version keyed on the same logical_id, and close the
+        // prior version's xmax at the same xid. `install_versioned_*`
+        // in persist installs the new row and tombstones the old one;
+        // `record_pending_versioned_update` arms first-committer-wins.
+        if let Some(xid) = versioned_update_xid {
+            let logical_id = entity.logical_id();
+            entity.id = store.next_entity_id();
+            entity.set_logical_id(logical_id);
+            entity.set_xmin(xid);
+            entity.set_xmax(0);
+            if let Some(old) = replaced_entity.as_mut() {
+                old.set_xmax(xid);
+            }
+        }
+
         modified_columns = dedupe_modified_columns(modified_columns);
 
         Ok(AppliedEntityMutation {
-            id,
+            id: entity.id,
             collection,
             entity,
             metadata: patch_metadata,
             modified_columns,
             persist_metadata: metadata_changed,
             context_index_dirty,
-            replaced_entity: None,
-            replaced_entity_previous_xmax: 0,
+            replaced_entity,
+            replaced_entity_previous_xmax: previous_xmax,
             pre_mutation_fields,
         })
     }

--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -106,6 +106,17 @@ impl<'a> DmlTargetScan<'a> {
                 if let Some(entity) = entity {
                     return Ok(self.target_ids_from_entities([entity]));
                 }
+                // Non-table-row entities (e.g. vectors) carry their
+                // physical id as their identity and are invisible to the
+                // table-row logical-id resolver above. Fall back to a
+                // direct physical-id lookup so `DELETE FROM <vector>
+                // WHERE rid = N` actually targets the vector instead of
+                // silently matching nothing.
+                if let Some(entity) = store.get(self.table, logical_id) {
+                    if !matches!(entity.kind, EntityKind::TableRow { .. }) {
+                        return Ok(self.target_ids_from_entities([entity]));
+                    }
+                }
                 return Ok(Vec::new());
             }
         }

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -411,6 +411,12 @@ impl RedDBRuntime {
         // Non-versioned graph collections keep the legacy physical
         // delete (no history). Row entities (Phase 1/2) always tombstone
         // under universal MVCC and are unaffected by this flag.
+        //
+        // Vectors are intentionally NOT included: their only read surface
+        // is `VECTOR SEARCH`, which reads without a snapshot context in
+        // autocommit (so a tombstone would stay searchable) and the
+        // TurboQuant index is not pruned on delete. Vector versioning is
+        // scoped as a follow-up; see e2e_vcs_vector_mvcc_history.rs.
         let versioned_collection = self.vcs_is_versioned(collection).unwrap_or(false);
 
         for &id in ids {

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -412,11 +412,13 @@ impl RedDBRuntime {
         // delete (no history). Row entities (Phase 1/2) always tombstone
         // under universal MVCC and are unaffected by this flag.
         //
-        // Vectors are intentionally NOT included: their only read surface
-        // is `VECTOR SEARCH`, which reads without a snapshot context in
-        // autocommit (so a tombstone would stay searchable) and the
-        // TurboQuant index is not pruned on delete. Vector versioning is
-        // scoped as a follow-up; see e2e_vcs_vector_mvcc_history.rs.
+        // Vectors (Phase 3b): versioned vector deletes tombstone (xmax
+        // stamp) instead of physically dropping, so history is retained.
+        // The `VECTOR SEARCH` read path post-filters every candidate
+        // through the current-snapshot visibility gate (which hides
+        // `xmax != 0` even in autocommit), so a tombstoned versioned
+        // vector never reaches live search. Non-versioned vectors keep
+        // the legacy physical delete.
         let versioned_collection = self.vcs_is_versioned(collection).unwrap_or(false);
 
         for &id in ids {
@@ -425,10 +427,25 @@ impl RedDBRuntime {
             };
             let is_versioned_graph = versioned_collection
                 && matches!(entity.data, EntityData::Node(_) | EntityData::Edge(_));
-            if matches!(entity.data, EntityData::Row(_)) || is_versioned_graph {
+            let is_versioned_vector =
+                versioned_collection && matches!(entity.data, EntityData::Vector(_));
+            if matches!(entity.data, EntityData::Row(_))
+                || is_versioned_graph
+                || is_versioned_vector
+            {
                 let previous_xmax = entity.xmax;
                 if matches!(entity.kind, crate::storage::EntityKind::TableRow { .. }) {
                     if table_row_resolver.resolve_candidate(&entity).is_none() {
+                        continue;
+                    }
+                } else if is_versioned_vector {
+                    // Versioned vectors gate the delete on the statement
+                    // snapshot (not a crude `xmax != 0`) so a concurrent
+                    // delete whose snapshot predates a still-uncommitted
+                    // tombstone still targets the row, records its own
+                    // pending tombstone, and conflicts at commit
+                    // (first-committer-wins).
+                    if table_row_resolver.resolve_read_candidate(&entity).is_none() {
                         continue;
                     }
                 } else if entity.xmax != 0 {

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -405,12 +405,21 @@ impl RedDBRuntime {
         let mut physical_delete_ids = Vec::new();
         let table_row_resolver =
             crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
+        // Phase 3: versioned graph collections tombstone node/edge
+        // deletes (xmax stamp) instead of physically removing them, so
+        // `AS OF` time-travel can still resolve the pre-delete version.
+        // Non-versioned graph collections keep the legacy physical
+        // delete (no history). Row entities (Phase 1/2) always tombstone
+        // under universal MVCC and are unaffected by this flag.
+        let versioned_collection = self.vcs_is_versioned(collection).unwrap_or(false);
 
         for &id in ids {
             let Some(mut entity) = manager.get(id) else {
                 continue;
             };
-            if matches!(entity.data, EntityData::Row(_)) {
+            let is_versioned_graph = versioned_collection
+                && matches!(entity.data, EntityData::Node(_) | EntityData::Edge(_));
+            if matches!(entity.data, EntityData::Row(_)) || is_versioned_graph {
                 let previous_xmax = entity.xmax;
                 if matches!(entity.kind, crate::storage::EntityKind::TableRow { .. }) {
                     if table_row_resolver.resolve_candidate(&entity).is_none() {

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -220,8 +220,22 @@ impl<'a> KvAtomicOps<'a> {
             &value,
         ));
 
-        // Delete old entry so we can create fresh (handles TTL refresh).
-        if was_present {
+        // Versioned KV retains MVCC history: the prior visible version is
+        // tombstoned (set_xmax) *after* the new version is created, so both
+        // coexist physically — exactly like a table-row update. Non-versioned
+        // KV keeps last-writer-wins: pre-delete the old row before creating
+        // fresh (also handles TTL refresh).
+        let versioned = self.is_versioned_collection(model, collection);
+        // Capture the prior *visible* version (if any) before the write so we
+        // can tombstone it. On a re-PUT after a delete (`was_present` false)
+        // there is no visible prior, but earlier versions still exist
+        // physically — see the xmin restamp below.
+        let prior_versioned_entity = if versioned && was_present {
+            self.get_entity(model, collection, key)?
+        } else {
+            None
+        };
+        if was_present && !versioned {
             self.delete(model, collection, key)?;
         }
 
@@ -240,6 +254,34 @@ impl<'a> KvAtomicOps<'a> {
                 value,
                 metadata,
             })?;
+
+        // Every versioned PUT stamps the new version's xmin from ONE monotonic
+        // xid (begin()/commit() or the active tx xid) — NOT the autocommit
+        // pool, whose batched reservation is not monotonic against commit
+        // root_xids and would let AS OF resolve the wrong version. The prior
+        // visible version (if any) is tombstoned with that SAME xid, so
+        // old.xmax == new.xmin and exactly one version is visible to any
+        // snapshot (mirrors `apply_loaded_sql_update_row_core`). Restamping
+        // unconditionally also fixes the re-PUT-after-delete case, where no
+        // visible prior exists but the pool xmin would still scramble ordering
+        // against existing tombstoned versions.
+        if versioned {
+            let version_xid = match self.runtime.current_xid() {
+                Some(xid) => xid,
+                None => {
+                    let mgr = self.runtime.snapshot_manager();
+                    let xid = mgr.begin();
+                    mgr.commit(xid);
+                    xid
+                }
+            };
+            if let Some(new_entity) = output.entity.clone() {
+                self.restamp_xmin(collection, new_entity, version_xid)?;
+            }
+            if let Some(prior) = prior_versioned_entity {
+                self.tombstone_version(collection, prior, version_xid)?;
+            }
+        }
         if model == crate::catalog::CollectionModel::Kv {
             self.runtime
                 .inner
@@ -280,6 +322,38 @@ impl<'a> KvAtomicOps<'a> {
         key: &str,
     ) -> RedDBResult<bool> {
         self.ensure_declared_model(model, collection)?;
+
+        // Versioned KV deletes tombstone the prior visible version
+        // (set_xmax) instead of reclaiming it physically, so history and
+        // time-travel reads survive — VACUUM reclaims the version later.
+        if self.is_versioned_collection(model, collection) {
+            let Some(entity) = self.get_entity(model, collection, key)? else {
+                return Ok(false);
+            };
+            let id = entity.id;
+            let value = kv_value_from_entity(&entity);
+            let xid = self.runtime.current_xid().unwrap_or_else(|| {
+                let mgr = self.runtime.snapshot_manager();
+                let xid = mgr.begin();
+                mgr.commit(xid);
+                xid
+            });
+            self.tombstone_version(collection, entity, xid)?;
+            self.runtime.inner.kv_tag_index.remove(collection, key);
+            self.runtime.record_kv_watch_event(
+                crate::replication::cdc::ChangeOperation::Delete,
+                collection,
+                key,
+                id.raw(),
+                value
+                    .as_ref()
+                    .map(crate::presentation::entity_json::storage_value_to_json),
+                None,
+            );
+            self.runtime.inner.kv_stats.incr_deletes();
+            return Ok(true);
+        }
+
         let found = self.get_entry(model, collection, key)?;
         if let Some((value, id)) = found {
             let store = self.runtime.inner.db.store();
@@ -307,6 +381,60 @@ impl<'a> KvAtomicOps<'a> {
         } else {
             Ok(false)
         }
+    }
+
+    /// Tombstone a KV version by stamping `xmax = xid` and persisting it.
+    ///
+    /// The physical row stays alive (history); VACUUM reclaims it once no
+    /// snapshot can see it. Used by versioned PUT (old version) and
+    /// versioned DELETE.
+    fn tombstone_version(
+        &self,
+        collection: &str,
+        mut entity: crate::storage::UnifiedEntity,
+        xid: crate::storage::transaction::snapshot::Xid,
+    ) -> RedDBResult<()> {
+        let store = self.runtime.inner.db.store();
+        let Some(manager) = store.get_collection(collection) else {
+            return Ok(());
+        };
+        let id = entity.id;
+        entity.set_xmax(xid);
+        manager
+            .update(entity.clone())
+            .map_err(|err| RedDBError::Internal(format!("{err:?}")))?;
+        store
+            .persist_entities_to_pager(collection, std::slice::from_ref(&entity))
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+        // The tombstoned version drops out of the live context index but
+        // stays physically resident for AS OF reads until VACUUM.
+        store.context_index().remove_entity(id);
+        Ok(())
+    }
+
+    /// Restamp a freshly-created KV version's `xmin` to a monotonic version
+    /// xid and persist it. `create_kv` stamps a (non-monotonic) autocommit
+    /// pool xid; the versioned write path overrides it so the new version's
+    /// xmin equals the old version's xmax, preserving AS OF ordering against
+    /// commit root_xids.
+    fn restamp_xmin(
+        &self,
+        collection: &str,
+        mut entity: crate::storage::UnifiedEntity,
+        xid: crate::storage::transaction::snapshot::Xid,
+    ) -> RedDBResult<()> {
+        let store = self.runtime.inner.db.store();
+        let Some(manager) = store.get_collection(collection) else {
+            return Ok(());
+        };
+        entity.set_xmin(xid);
+        manager
+            .update(entity.clone())
+            .map_err(|err| RedDBError::Internal(format!("{err:?}")))?;
+        store
+            .persist_entities_to_pager(collection, std::slice::from_ref(&entity))
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+        Ok(())
     }
 
     /// Atomically increment (or decrement) a counter key. Returns the new value.
@@ -574,6 +702,25 @@ impl<'a> KvAtomicOps<'a> {
         Ok(kv_value_from_entity(&entity).map(|value| (value, entity.id)))
     }
 
+    /// Whether `collection` retains MVCC history (opted into versioning).
+    ///
+    /// Versioned KV reads must do MVCC version-selection; non-versioned
+    /// collections (config `red_config`, the secrets vault) keep the
+    /// last-writer-wins fast path. Internal `red_*` collections are
+    /// never versioned, so this stays cheap for them.
+    fn is_versioned_collection(
+        &self,
+        model: crate::catalog::CollectionModel,
+        collection: &str,
+    ) -> bool {
+        // Only plain KV ever opts into versioning; the vault and config
+        // tiers are non-versioned by construction.
+        if model != crate::catalog::CollectionModel::Kv {
+            return false;
+        }
+        self.runtime.vcs_is_versioned(collection).unwrap_or(false)
+    }
+
     fn get_entity(
         &self,
         model: crate::catalog::CollectionModel,
@@ -585,16 +732,37 @@ impl<'a> KvAtomicOps<'a> {
         let Some(manager) = store.get_collection(collection) else {
             return Ok(None);
         };
+
+        // Versioned KV: multiple physical versions per logical key can
+        // coexist (tombstoned + live). Select the snapshot-visible
+        // version with the greatest xmin — mirroring the table-row
+        // resolver's per-logical-id rule, keyed on the KV `key` field.
+        if self.is_versioned_collection(model, collection) {
+            let resolver =
+                crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
+            let mut best: Option<crate::storage::UnifiedEntity> = None;
+            for entity in manager.query_all(|_| true) {
+                if !kv_entity_has_key(&entity, key) {
+                    continue;
+                }
+                if resolver.resolve_read_candidate(&entity).is_none() {
+                    continue;
+                }
+                let better = match &best {
+                    Some(current) => entity.xmin >= current.xmin,
+                    None => true,
+                };
+                if better {
+                    best = Some(entity);
+                }
+            }
+            return Ok(best);
+        }
+
         let entities = manager.query_all(|_| true);
         for entity in entities {
-            if let crate::storage::EntityData::Row(ref row) = entity.data {
-                if let Some(ref named) = row.named {
-                    if let Some(crate::storage::schema::Value::Text(ref k)) = named.get("key") {
-                        if &**k == key {
-                            return Ok(Some(entity));
-                        }
-                    }
-                }
+            if kv_entity_has_key(&entity, key) {
+                return Ok(Some(entity));
             }
         }
         Ok(None)
@@ -610,6 +778,16 @@ impl<'a> KvAtomicOps<'a> {
         let Some(manager) = store.get_collection(collection) else {
             return Ok(Vec::new());
         };
+        // Versioned KV: per logical key, keep the snapshot-visible
+        // version with the greatest xmin; keys whose every version is
+        // tombstoned (no visible version) drop out entirely. Mirrors
+        // the per-key version-selection used by `get_entity`.
+        let versioned =
+            self.is_versioned_collection(crate::catalog::CollectionModel::Kv, collection);
+        let resolver = versioned.then(|| {
+            crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement()
+        });
+
         let mut entries: std::collections::BTreeMap<String, crate::storage::UnifiedEntity> =
             std::collections::BTreeMap::new();
         for entity in manager.query_all(|_| true) {
@@ -630,7 +808,15 @@ impl<'a> KvAtomicOps<'a> {
             if prefix.is_some_and(|prefix| !key.starts_with(prefix)) {
                 continue;
             }
+            if let Some(resolver) = resolver.as_ref() {
+                // Skip versions not visible to the current snapshot
+                // (tombstoned by a visible deleter, or not yet created).
+                if resolver.resolve_read_candidate(&entity).is_none() {
+                    continue;
+                }
+            }
             let should_replace = match entries.get(&key) {
+                Some(existing) if versioned => entity.xmin >= existing.xmin,
                 Some(existing) => entity.id.raw() >= existing.id.raw(),
                 None => true,
             };
@@ -2623,6 +2809,18 @@ fn kv_value_from_entity(entity: &crate::storage::UnifiedEntity) -> Option<Value>
         }
     }
     None
+}
+
+/// Whether a KV row entity carries the logical `key`.
+fn kv_entity_has_key(entity: &crate::storage::UnifiedEntity, key: &str) -> bool {
+    if let crate::storage::EntityData::Row(ref row) = entity.data {
+        if let Some(ref named) = row.named {
+            if let Some(crate::storage::schema::Value::Text(ref k)) = named.get("key") {
+                return &**k == key;
+            }
+        }
+    }
+    false
 }
 
 fn insert_kv_json_path(root: &mut crate::json::Value, path: &str, value: crate::json::Value) {

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -279,7 +279,28 @@ impl<'a> KvAtomicOps<'a> {
                 self.restamp_xmin(collection, new_entity, version_xid)?;
             }
             if let Some(prior) = prior_versioned_entity {
+                // First-committer-wins (ADR 0014): inside an explicit
+                // transaction, defer the prior version's tombstone to the
+                // commit-time conflict check by recording it as a pending
+                // versioned update — exactly like a table-row versioned
+                // UPDATE (`persist_applied_entity_mutations`). The check
+                // rejects this txn's COMMIT if the prior version was
+                // already tombstoned by a concurrent committed writer.
+                // Autocommit (`current_xid()` is None) commits eagerly and
+                // records nothing, matching the table path.
+                let previous_xmax = prior.xmax;
+                let old_id = prior.id;
                 self.tombstone_version(collection, prior, version_xid)?;
+                if self.runtime.current_xid().is_some() {
+                    self.runtime.record_pending_versioned_update(
+                        crate::runtime::impl_core::current_connection_id(),
+                        collection,
+                        old_id,
+                        output.id,
+                        version_xid,
+                        previous_xmax,
+                    );
+                }
             }
         }
         if model == crate::catalog::CollectionModel::Kv {
@@ -338,7 +359,25 @@ impl<'a> KvAtomicOps<'a> {
                 mgr.commit(xid);
                 xid
             });
+            // First-committer-wins (ADR 0014): inside an explicit
+            // transaction, defer this tombstone to the commit-time
+            // conflict check by recording it as a pending tombstone —
+            // exactly like a table-row DELETE (`delete_entities_batch`).
+            // The check rejects this txn's COMMIT if the version was
+            // already tombstoned by a concurrent committed writer.
+            // Autocommit (`current_xid()` is None) commits eagerly and
+            // records nothing, matching the table path.
+            let previous_xmax = entity.xmax;
             self.tombstone_version(collection, entity, xid)?;
+            if self.runtime.current_xid().is_some() {
+                self.runtime.record_pending_tombstone(
+                    crate::runtime::impl_core::current_connection_id(),
+                    collection,
+                    id,
+                    xid,
+                    previous_xmax,
+                );
+            }
             self.runtime.inner.kv_tag_index.remove(collection, key);
             self.runtime.record_kv_watch_event(
                 crate::replication::cdc::ChangeOperation::Delete,

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -146,13 +146,19 @@ pub(crate) fn runtime_vector_matches(
             let index = state.index.lock();
             index.search(vector, search_k, metric)
         };
-        let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
         let mut results = Vec::with_capacity(raw.len());
         for hit in raw {
             let Some(entity) = db.store().get(&query.collection, hit.entity_id) else {
                 continue;
             };
-            if !crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), &entity) {
+            // The TurboQuant index is append-only and never prunes
+            // deleted/superseded vectors (#673/#688 own removal). Post-
+            // filter every candidate through the current-snapshot
+            // visibility gate — which hides any tombstoned/superseded
+            // physical version (`xmax != 0`) even in autocommit (where
+            // there is no captured snapshot context) — so a deleted or
+            // version-superseded vector never reaches the results.
+            if !crate::runtime::impl_core::entity_visible_under_current_snapshot(&entity) {
                 continue;
             }
             // Exact re-rank against the stored full-precision vector rather
@@ -210,6 +216,17 @@ pub(crate) fn runtime_vector_matches(
     };
 
     for entity in manager.query_all(|entity| {
+        // `query_all` may fan out across worker threads that do not
+        // inherit the dispatch thread's snapshot thread-local, so we
+        // pass the captured snapshot context explicitly. In autocommit
+        // there is no captured context (`None`); the table-scan paths
+        // would treat that as "always visible", but a deleted/superseded
+        // vector carries `xmax != 0` and must be hidden — mirror the
+        // autocommit rule of `entity_visible_under_current_snapshot`.
+        if snap_ctx.is_none() {
+            return entity.xmax == 0
+                && !crate::runtime::ai::moderation::entity_moderation_hidden(entity);
+        }
         crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity)
     }) {
         if let EntityData::Vector(data) = &entity.data {

--- a/crates/reddb-server/src/storage/unified/entity.rs
+++ b/crates/reddb-server/src/storage/unified/entity.rs
@@ -725,12 +725,26 @@ impl UnifiedEntity {
         self.logical_id = Some(logical_id);
     }
 
-    /// Ensure table rows written by the current engine carry explicit
-    /// logical identity. Other models retain the legacy implicit mapping
-    /// until their MVCC rollout adopts the resolver.
+    /// Ensure entities written by the current engine carry explicit
+    /// logical identity. Table rows + documents (Phase 1/2) and graph
+    /// nodes/edges + vectors (Phase 3) all participate in the multi-model
+    /// MVCC versioning rollout and so need a stable logical id for
+    /// version-chain selection. Stamping the logical id is inert for
+    /// non-versioned collections: history only accrues through
+    /// `install_versioned_table_row_update`, which is gated on the
+    /// collection `versioned` flag, so a stamped-but-never-superseded
+    /// entity keeps `logical_id == id` and behaves exactly as before.
     #[inline]
     pub(crate) fn ensure_table_logical_id(&mut self) {
-        if matches!(self.kind, EntityKind::TableRow { .. }) && self.logical_id.is_none() {
+        if self.logical_id.is_none()
+            && matches!(
+                self.kind,
+                EntityKind::TableRow { .. }
+                    | EntityKind::GraphNode(_)
+                    | EntityKind::GraphEdge(_)
+                    | EntityKind::Vector { .. }
+            )
+        {
             self.logical_id = Some(self.id);
         }
     }

--- a/crates/reddb-server/src/storage/unified/entity.rs
+++ b/crates/reddb-server/src/storage/unified/entity.rs
@@ -727,22 +727,21 @@ impl UnifiedEntity {
 
     /// Ensure entities written by the current engine carry explicit
     /// logical identity. Table rows + documents (Phase 1/2) and graph
-    /// nodes/edges + vectors (Phase 3) all participate in the multi-model
-    /// MVCC versioning rollout and so need a stable logical id for
+    /// nodes/edges (Phase 3) participate in the multi-model MVCC
+    /// versioning rollout and so need a stable logical id for
     /// version-chain selection. Stamping the logical id is inert for
     /// non-versioned collections: history only accrues through
     /// `install_versioned_table_row_update`, which is gated on the
     /// collection `versioned` flag, so a stamped-but-never-superseded
     /// entity keeps `logical_id == id` and behaves exactly as before.
+    /// Vectors are intentionally excluded pending their read-path follow
+    /// up (no snapshot-honoring `VECTOR SEARCH`).
     #[inline]
     pub(crate) fn ensure_table_logical_id(&mut self) {
         if self.logical_id.is_none()
             && matches!(
                 self.kind,
-                EntityKind::TableRow { .. }
-                    | EntityKind::GraphNode(_)
-                    | EntityKind::GraphEdge(_)
-                    | EntityKind::Vector { .. }
+                EntityKind::TableRow { .. } | EntityKind::GraphNode(_) | EntityKind::GraphEdge(_)
             )
         {
             self.logical_id = Some(self.id);

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-types"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB logical type system: the neutral keystone vocabulary — Value, DataType, SqlTypeName, TypeModifier, TypeCategory, ValueError, Row — depended on by every authority crate and depending on none."

--- a/crates/reddb-wire/Cargo.toml
+++ b/crates/reddb-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-wire"
-version = "1.14.0"
+version = "1.15.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB wire protocol vocabulary: connection-string parser, RedWire frames, payload codecs, topology, sanitizers, and replication messages."

--- a/drivers/bun/package.json
+++ b/drivers/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client-bun",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "RedDB wire protocol client for Bun — ultra-fast native TCP",
   "main": "index.ts",
   "scripts": {

--- a/drivers/js-client/package.json
+++ b/drivers/js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Thin remote-only RedDB driver. Downloads the `red_client` binary on install. Speaks RedWire/gRPC/HTTP. Embedded URIs (memory://, file://, red:///path) are rejected — use @reddb-io/sdk for those.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/js/package.json
+++ b/drivers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/sdk",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "Official embedded RedDB SDK — launches a local red binary over stdio JSON-RPC. Use @reddb-io/client for remote HTTP, gRPC, and RedWire.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-client",
  "reddb-io-grpc-proto",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-client-connector",
  "reddb-io-grpc-proto",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -1943,14 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-python"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "prost",
  "pyo3",
@@ -1995,14 +1995,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-types",
 ]
 
 [[package]]
 name = "reddb-io-server"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2061,14 +2061,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "reddb-io-types",
  "serde_json",

--- a/drivers/python/Cargo.toml
+++ b/drivers/python/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "reddb-io-python"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2021"
 description = "Native Python driver for RedDB (compiled Rust via pyo3)"
 license = "MIT"

--- a/drivers/python/pyproject.toml
+++ b/drivers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "reddb"
-version = "1.14.0"
+version = "1.15.0"
 description = "Official Python driver for RedDB — embedded engine and gRPC remote in one package."
 readme = "README.md"
 license = { text = "MIT" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/cli",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "CLI launcher for RedDB. The JS/TS app driver is published as @reddb-io/sdk.",
   "type": "commonjs",
   "bin": {

--- a/packages/internal-asset-fetcher/package.json
+++ b/packages/internal-asset-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-asset-fetcher",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "description": "Workspace-only deep module: download a `red`/`red_client` binary from a GitHub release with platform/arch resolution, redirect handling, and optional sha256 verification.",
   "type": "module",

--- a/packages/internal-bin-resolver/package.json
+++ b/packages/internal-bin-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-bin-resolver",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "description": "Workspace-only deep module: locate a pinned binary inside a node_modules package, env override > local. PATH is never consulted.",
   "type": "module",

--- a/packages/internal-version-compare/package.json
+++ b/packages/internal-version-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-version-compare",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "description": "Workspace-only deep module: compare a package version against an installed `red --version`, return install/upgrade/skip verdict for the CLI postinstall.",
   "type": "module",

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -72,6 +72,9 @@ mod e2e_vcs_kv_write_conflict;
 #[path = "vcs/e2e_vcs_document_mvcc_history.rs"]
 mod e2e_vcs_document_mvcc_history;
 
+#[path = "vcs/e2e_vcs_graph_mvcc_history.rs"]
+mod e2e_vcs_graph_mvcc_history;
+
 #[path = "vcs/e2e_vcs_opt_in.rs"]
 mod e2e_vcs_opt_in;
 

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -75,6 +75,9 @@ mod e2e_vcs_document_mvcc_history;
 #[path = "vcs/e2e_vcs_graph_mvcc_history.rs"]
 mod e2e_vcs_graph_mvcc_history;
 
+#[path = "vcs/e2e_vcs_vector_mvcc_history.rs"]
+mod e2e_vcs_vector_mvcc_history;
+
 #[path = "vcs/e2e_vcs_opt_in.rs"]
 mod e2e_vcs_opt_in;
 

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -66,6 +66,9 @@ mod e2e_vcs_as_of_parse;
 #[path = "vcs/e2e_vcs_kv_mvcc_history.rs"]
 mod e2e_vcs_kv_mvcc_history;
 
+#[path = "vcs/e2e_vcs_kv_write_conflict.rs"]
+mod e2e_vcs_kv_write_conflict;
+
 #[path = "vcs/e2e_vcs_opt_in.rs"]
 mod e2e_vcs_opt_in;
 

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -63,6 +63,9 @@ mod e2e_vcs_as_of_enforce;
 #[path = "vcs/e2e_vcs_as_of_parse.rs"]
 mod e2e_vcs_as_of_parse;
 
+#[path = "vcs/e2e_vcs_kv_mvcc_history.rs"]
+mod e2e_vcs_kv_mvcc_history;
+
 #[path = "vcs/e2e_vcs_opt_in.rs"]
 mod e2e_vcs_opt_in;
 

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -69,6 +69,9 @@ mod e2e_vcs_kv_mvcc_history;
 #[path = "vcs/e2e_vcs_kv_write_conflict.rs"]
 mod e2e_vcs_kv_write_conflict;
 
+#[path = "vcs/e2e_vcs_document_mvcc_history.rs"]
+mod e2e_vcs_document_mvcc_history;
+
 #[path = "vcs/e2e_vcs_opt_in.rs"]
 mod e2e_vcs_opt_in;
 

--- a/tests/grouped/vcs/e2e_vcs_document_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_document_mvcc_history.rs
@@ -1,0 +1,275 @@
+//! Versioned DOCUMENT collections retain MVCC history (Phase 2 of the
+//! multi-model versioning rollout; KV was Phase 1).
+//!
+//! A document collection that has opted into versioning
+//! (`vcs.set_versioned(collection, true)`) must keep prior versions
+//! physically alive so time-travel (`AS OF`) reads resolve the
+//! snapshot-visible version per logical document — exactly like a
+//! versioned table row / KV key. Version-selection keys on the
+//! document's `logical_id` (documents already carry one) rather than
+//! the KV `key` text shim.
+//!
+//! A non-versioned document collection keeps last-writer-wins
+//! semantics (in-place mutation, no history accumulation).
+
+use std::sync::Arc;
+
+use reddb::application::{
+    Author, CreateCommitInput, PatchEntityInput, PatchEntityOperation, PatchEntityOperationType,
+    RuntimeEntityPort, VcsUseCases,
+};
+use reddb::json::Value as RedJsonValue;
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::storage::EntityId;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> Arc<RedDBRuntime> {
+    Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime"))
+}
+
+fn author() -> Author {
+    Author {
+        name: "test".to_string(),
+        email: "test@reddb.io".to_string(),
+    }
+}
+
+fn vcs(rt: &RedDBRuntime) -> VcsUseCases<'_, RedDBRuntime> {
+    VcsUseCases::new(rt)
+}
+
+fn commit(rt: &RedDBRuntime, conn: u64, msg: &str) -> String {
+    vcs(rt)
+        .commit(CreateCommitInput {
+            connection_id: conn,
+            message: msg.to_string(),
+            author: author(),
+            committer: None,
+            amend: false,
+            allow_empty: true,
+        })
+        .expect("commit")
+        .hash
+}
+
+/// Insert a single document `{a: <a>}` into `collection` and return
+/// its stable `rid`.
+fn insert_doc(rt: &RedDBRuntime, collection: &str, a: i64) -> u64 {
+    let sql =
+        format!("INSERT INTO {collection} DOCUMENT (body) VALUES ('{{\"a\":{a}}}') RETURNING *");
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert_eq!(result.result.records.len(), 1, "{sql}");
+    match result.result.records[0].get("rid") {
+        Some(Value::UnsignedInteger(rid)) => *rid,
+        Some(Value::Integer(rid)) => *rid as u64,
+        Some(Value::Text(rid)) => rid.parse().expect("rid text -> u64"),
+        other => panic!("expected rid, got {other:?}"),
+    }
+}
+
+/// PATCH the document body field `a` to `value` via the public patch
+/// core (the body-merge path — produces a merged full document).
+fn patch_doc_a(rt: &RedDBRuntime, collection: &str, rid: u64, value: i64) {
+    rt.patch_entity(PatchEntityInput {
+        collection: collection.to_string(),
+        id: EntityId::new(rid),
+        payload: RedJsonValue::Null,
+        operations: vec![PatchEntityOperation {
+            op: PatchEntityOperationType::Set,
+            path: vec!["body".to_string(), "a".to_string()],
+            value: Some(RedJsonValue::Number(value as f64)),
+        }],
+    })
+    .unwrap_or_else(|err| panic!("patch a={value}: {err:?}"));
+}
+
+/// Read body field `a` for the document with `rid` at a historical
+/// commit via SQL `AS OF`. Returns `None` when not visible.
+fn as_of_a(rt: &RedDBRuntime, collection: &str, rid: u64, commit_hash: &str) -> Option<i64> {
+    let sql =
+        format!("SELECT body.a FROM {collection} AS OF COMMIT '{commit_hash}' WHERE rid = {rid}");
+    read_single_a(rt, &sql)
+}
+
+/// Read body field `a` for the document with `rid` against the current
+/// (live) snapshot.
+fn live_a(rt: &RedDBRuntime, collection: &str, rid: u64) -> Option<i64> {
+    let sql = format!("SELECT body.a FROM {collection} WHERE rid = {rid}");
+    read_single_a(rt, &sql)
+}
+
+fn read_single_a(rt: &RedDBRuntime, sql: &str) -> Option<i64> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert!(
+        result.result.records.len() <= 1,
+        "read must resolve at most one visible version, got {} for `{sql}`",
+        result.result.records.len()
+    );
+    result.result.records.first().map(|record| {
+        let value = record
+            .get("body.A")
+            .or_else(|| record.get("body.a"))
+            .or_else(|| record.get("a"))
+            .or_else(|| record.get("A"));
+        match value {
+            Some(Value::Integer(v)) => *v,
+            Some(Value::UnsignedInteger(v)) => *v as i64,
+            Some(Value::Float(v)) => *v as i64,
+            Some(Value::Json(bytes)) => {
+                let parsed: serde_json::Value = serde_json::from_slice(bytes)
+                    .unwrap_or_else(|err| panic!("decode json a: {err} for `{sql}`"));
+                parsed
+                    .as_i64()
+                    .unwrap_or_else(|| panic!("json a not int: {parsed:?} for `{sql}`"))
+            }
+            other => panic!("expected int a, got {other:?} in {record:?} for `{sql}`"),
+        }
+    })
+}
+
+fn assert_conflict(err: &reddb::RedDBError) {
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("serialization conflict"),
+        "expected serialization conflict, got: {msg}"
+    );
+}
+
+/// Time-travel: versioned document, insert {a:1}@P1, PATCH to {a:2},
+/// AS OF P1 must still see {a:1}.
+#[test]
+fn versioned_document_patch_retains_prior_version_for_as_of() {
+    let rt = rt();
+    set_current_connection_id(60001);
+    rt.execute_query("CREATE DOCUMENT vdoc_hist")
+        .expect("CREATE DOCUMENT");
+    vcs(&rt).set_versioned("vdoc_hist", true).unwrap();
+
+    let rid = insert_doc(&rt, "vdoc_hist", 1);
+    let p1 = commit(&rt, 60001, "p1");
+
+    patch_doc_a(&rt, "vdoc_hist", rid, 2);
+    let _p2 = commit(&rt, 60001, "p2");
+
+    assert_eq!(live_a(&rt, "vdoc_hist", rid), Some(2), "live is newest");
+    assert_eq!(
+        as_of_a(&rt, "vdoc_hist", rid, &p1),
+        Some(1),
+        "AS OF P1 must resolve the prior document version"
+    );
+    clear_current_connection_id();
+}
+
+/// Delete-tombstone: versioned document, insert {a:1}@P1, DELETE,
+/// current read absent, AS OF P1 still resolves the document.
+#[test]
+fn versioned_document_delete_keeps_history_for_as_of() {
+    let rt = rt();
+    set_current_connection_id(60002);
+    rt.execute_query("CREATE DOCUMENT vdoc_del")
+        .expect("CREATE DOCUMENT");
+    vcs(&rt).set_versioned("vdoc_del", true).unwrap();
+
+    let rid = insert_doc(&rt, "vdoc_del", 1);
+    let p1 = commit(&rt, 60002, "p1");
+
+    rt.execute_query(&format!("DELETE FROM vdoc_del WHERE rid = {rid}"))
+        .expect("DELETE document");
+    let _p2 = commit(&rt, 60002, "p2");
+
+    assert_eq!(
+        live_a(&rt, "vdoc_del", rid),
+        None,
+        "deleted document must be absent from the live snapshot"
+    );
+    assert_eq!(
+        as_of_a(&rt, "vdoc_del", rid, &p1),
+        Some(1),
+        "AS OF P1 must still resolve the pre-delete document version"
+    );
+    clear_current_connection_id();
+}
+
+/// First-committer-wins: two txns both snapshot {a:1}, both PATCH,
+/// T1 commits, T2 commit must fail with a serialization conflict.
+#[test]
+fn concurrent_versioned_document_patch_conflicts_on_second_commit() {
+    let rt = rt();
+    set_current_connection_id(60003);
+    rt.execute_query("CREATE DOCUMENT vdoc_wc")
+        .expect("CREATE DOCUMENT");
+    vcs(&rt).set_versioned("vdoc_wc", true).unwrap();
+    let rid = insert_doc(&rt, "vdoc_wc", 1);
+    commit(&rt, 60003, "seed");
+
+    // Two transactions both snapshot the {a:1} state.
+    set_current_connection_id(60004);
+    rt.execute_query("BEGIN").expect("T1 begin");
+    set_current_connection_id(60005);
+    rt.execute_query("BEGIN").expect("T2 begin");
+
+    // T1 PATCH a=2, T2 PATCH a=3 — both tombstone the same version.
+    set_current_connection_id(60004);
+    patch_doc_a(&rt, "vdoc_wc", rid, 2);
+    set_current_connection_id(60005);
+    patch_doc_a(&rt, "vdoc_wc", rid, 3);
+
+    // T1 commits (winner).
+    set_current_connection_id(60004);
+    rt.execute_query("COMMIT").expect("T1 commit");
+    // T2 commits (loser) — must conflict.
+    set_current_connection_id(60005);
+    let err = rt
+        .execute_query("COMMIT")
+        .expect_err("T2 commit must conflict");
+    assert_conflict(&err);
+
+    // Post-state: exactly one live version (the winner's).
+    set_current_connection_id(60006);
+    assert_eq!(
+        live_a(&rt, "vdoc_wc", rid),
+        Some(2),
+        "winner's value survives"
+    );
+    clear_current_connection_id();
+}
+
+/// Regression: a NON-versioned document collection keeps
+/// last-writer-wins — sequential PATCHes do not conflict, the live
+/// read sees the latest value, and no prior versions accumulate (the
+/// physical version count for the logical document stays at 1).
+#[test]
+fn non_versioned_document_is_last_writer_wins() {
+    let rt = rt();
+    set_current_connection_id(60007);
+    rt.execute_query("CREATE DOCUMENT plain_doc")
+        .expect("CREATE DOCUMENT");
+    // No set_versioned — stays non-versioned.
+
+    let rid = insert_doc(&rt, "plain_doc", 1);
+    commit(&rt, 60007, "p1");
+
+    patch_doc_a(&rt, "plain_doc", rid, 2);
+    patch_doc_a(&rt, "plain_doc", rid, 3);
+    commit(&rt, 60007, "p2");
+
+    assert_eq!(live_a(&rt, "plain_doc", rid), Some(3), "last writer wins");
+    // Non-versioned: the live scan resolves exactly one row for the
+    // logical document — no prior versions linger to be selected.
+    let count = rt
+        .execute_query(&format!("SELECT body.a FROM plain_doc WHERE rid = {rid}"))
+        .expect("scan plain_doc")
+        .result
+        .records
+        .len();
+    assert_eq!(
+        count, 1,
+        "non-versioned document must keep no history; got {count} live rows"
+    );
+    clear_current_connection_id();
+}

--- a/tests/grouped/vcs/e2e_vcs_graph_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_graph_mvcc_history.rs
@@ -78,8 +78,9 @@ fn update_score(rt: &RedDBRuntime, collection: &str, label: &str, value: i64) {
 /// Read `score` for the node with `label` at a historical commit via
 /// SQL `AS OF`. Returns `None` when not visible.
 fn as_of_score(rt: &RedDBRuntime, collection: &str, label: &str, commit_hash: &str) -> Option<i64> {
-    let sql =
-        format!("SELECT score FROM {collection} AS OF COMMIT '{commit_hash}' WHERE label = '{label}'");
+    let sql = format!(
+        "SELECT score FROM {collection} AS OF COMMIT '{commit_hash}' WHERE label = '{label}'"
+    );
     read_single_score(rt, &sql)
 }
 

--- a/tests/grouped/vcs/e2e_vcs_graph_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_graph_mvcc_history.rs
@@ -1,0 +1,251 @@
+//! Versioned GRAPH collections retain MVCC history (Phase 3 of the
+//! multi-model versioning rollout; KV was Phase 1, documents Phase 2).
+//!
+//! A graph collection that has opted into versioning
+//! (`vcs.set_versioned(collection, true)`) must keep prior node
+//! versions physically alive so time-travel (`AS OF`) reads resolve the
+//! snapshot-visible version per logical node — exactly like a versioned
+//! table row / document. Graph nodes are stored as their own
+//! `EntityKind::GraphNode`, but they carry the same `logical_id` /
+//! `xmin` / `xmax` MVCC fields a table row does, so the table-row
+//! versioning machinery applies once the node carries an explicit
+//! logical id.
+//!
+//! A non-versioned graph collection keeps last-writer-wins semantics
+//! (in-place mutation, no history accumulation).
+
+use std::sync::Arc;
+
+use reddb::application::{Author, CreateCommitInput, VcsUseCases};
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> Arc<RedDBRuntime> {
+    Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime"))
+}
+
+fn author() -> Author {
+    Author {
+        name: "test".to_string(),
+        email: "test@reddb.io".to_string(),
+    }
+}
+
+fn vcs(rt: &RedDBRuntime) -> VcsUseCases<'_, RedDBRuntime> {
+    VcsUseCases::new(rt)
+}
+
+fn commit(rt: &RedDBRuntime, conn: u64, msg: &str) -> String {
+    vcs(rt)
+        .commit(CreateCommitInput {
+            connection_id: conn,
+            message: msg.to_string(),
+            author: author(),
+            committer: None,
+            amend: false,
+            allow_empty: true,
+        })
+        .expect("commit")
+        .hash
+}
+
+/// Insert a node `(label, node_type, score)` and return its stable `rid`.
+fn insert_node(rt: &RedDBRuntime, collection: &str, label: &str, score: i64) -> u64 {
+    let sql = format!(
+        "INSERT INTO {collection} NODE (label, node_type, score) \
+         VALUES ('{label}', 'person', {score}) RETURNING rid"
+    );
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert_eq!(result.result.records.len(), 1, "{sql}");
+    match result.result.records[0].get("rid") {
+        Some(Value::UnsignedInteger(rid)) => *rid,
+        Some(Value::Integer(rid)) => *rid as u64,
+        Some(Value::Text(rid)) => rid.parse().expect("rid text -> u64"),
+        other => panic!("expected rid, got {other:?}"),
+    }
+}
+
+/// UPDATE the node's `score` to `value`.
+fn update_score(rt: &RedDBRuntime, collection: &str, label: &str, value: i64) {
+    let sql = format!("UPDATE {collection} NODES SET score = {value} WHERE label = '{label}'");
+    rt.execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+/// Read `score` for the node with `label` at a historical commit via
+/// SQL `AS OF`. Returns `None` when not visible.
+fn as_of_score(rt: &RedDBRuntime, collection: &str, label: &str, commit_hash: &str) -> Option<i64> {
+    let sql =
+        format!("SELECT score FROM {collection} AS OF COMMIT '{commit_hash}' WHERE label = '{label}'");
+    read_single_score(rt, &sql)
+}
+
+/// Read `score` for the node with `label` against the live snapshot.
+fn live_score(rt: &RedDBRuntime, collection: &str, label: &str) -> Option<i64> {
+    let sql = format!("SELECT score FROM {collection} WHERE label = '{label}'");
+    read_single_score(rt, &sql)
+}
+
+fn read_single_score(rt: &RedDBRuntime, sql: &str) -> Option<i64> {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert!(
+        result.result.records.len() <= 1,
+        "read must resolve at most one visible version, got {} for `{sql}`",
+        result.result.records.len()
+    );
+    result.result.records.first().map(|record| {
+        let value = record.get("score").or_else(|| record.get("SCORE"));
+        match value {
+            Some(Value::Integer(v)) => *v,
+            Some(Value::UnsignedInteger(v)) => *v as i64,
+            Some(Value::Float(v)) => *v as i64,
+            other => panic!("expected int score, got {other:?} in {record:?} for `{sql}`"),
+        }
+    })
+}
+
+fn assert_conflict(err: &reddb::RedDBError) {
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("serialization conflict"),
+        "expected serialization conflict, got: {msg}"
+    );
+}
+
+/// Time-travel: versioned graph node, insert score=1 @P1, UPDATE to 2,
+/// AS OF P1 must still see score=1.
+#[test]
+fn versioned_graph_node_update_retains_prior_version_for_as_of() {
+    let rt = rt();
+    set_current_connection_id(70001);
+    rt.execute_query("CREATE GRAPH vgraph_hist")
+        .expect("CREATE GRAPH");
+    vcs(&rt).set_versioned("vgraph_hist", true).unwrap();
+
+    let _rid = insert_node(&rt, "vgraph_hist", "alice", 1);
+    let p1 = commit(&rt, 70001, "p1");
+
+    update_score(&rt, "vgraph_hist", "alice", 2);
+    let _p2 = commit(&rt, 70001, "p2");
+
+    assert_eq!(
+        live_score(&rt, "vgraph_hist", "alice"),
+        Some(2),
+        "live is newest"
+    );
+    assert_eq!(
+        as_of_score(&rt, "vgraph_hist", "alice", &p1),
+        Some(1),
+        "AS OF P1 must resolve the prior node version"
+    );
+    clear_current_connection_id();
+}
+
+/// Delete-tombstone: versioned graph node, insert score=1 @P1, DELETE,
+/// current read absent, AS OF P1 still resolves the node.
+#[test]
+fn versioned_graph_node_delete_keeps_history_for_as_of() {
+    let rt = rt();
+    set_current_connection_id(70002);
+    rt.execute_query("CREATE GRAPH vgraph_del")
+        .expect("CREATE GRAPH");
+    vcs(&rt).set_versioned("vgraph_del", true).unwrap();
+
+    let _rid = insert_node(&rt, "vgraph_del", "alice", 1);
+    let p1 = commit(&rt, 70002, "p1");
+
+    rt.execute_query("DELETE FROM vgraph_del WHERE label = 'alice'")
+        .expect("DELETE node");
+    let _p2 = commit(&rt, 70002, "p2");
+
+    assert_eq!(
+        live_score(&rt, "vgraph_del", "alice"),
+        None,
+        "deleted node must be absent from the live snapshot"
+    );
+    assert_eq!(
+        as_of_score(&rt, "vgraph_del", "alice", &p1),
+        Some(1),
+        "AS OF P1 must still resolve the pre-delete node version"
+    );
+    clear_current_connection_id();
+}
+
+/// First-committer-wins: two txns both snapshot score=1, both UPDATE,
+/// T1 commits, T2 commit must fail with a serialization conflict.
+#[test]
+fn concurrent_versioned_graph_node_update_conflicts_on_second_commit() {
+    let rt = rt();
+    set_current_connection_id(70003);
+    rt.execute_query("CREATE GRAPH vgraph_wc")
+        .expect("CREATE GRAPH");
+    vcs(&rt).set_versioned("vgraph_wc", true).unwrap();
+    let _rid = insert_node(&rt, "vgraph_wc", "alice", 1);
+    commit(&rt, 70003, "seed");
+
+    set_current_connection_id(70004);
+    rt.execute_query("BEGIN").expect("T1 begin");
+    set_current_connection_id(70005);
+    rt.execute_query("BEGIN").expect("T2 begin");
+
+    set_current_connection_id(70004);
+    update_score(&rt, "vgraph_wc", "alice", 2);
+    set_current_connection_id(70005);
+    update_score(&rt, "vgraph_wc", "alice", 3);
+
+    set_current_connection_id(70004);
+    rt.execute_query("COMMIT").expect("T1 commit");
+    set_current_connection_id(70005);
+    let err = rt
+        .execute_query("COMMIT")
+        .expect_err("T2 commit must conflict");
+    assert_conflict(&err);
+
+    set_current_connection_id(70006);
+    assert_eq!(
+        live_score(&rt, "vgraph_wc", "alice"),
+        Some(2),
+        "winner's value survives"
+    );
+    clear_current_connection_id();
+}
+
+/// Regression: a NON-versioned graph collection keeps last-writer-wins —
+/// sequential UPDATEs do not conflict, the live read sees the latest
+/// value, and no prior versions accumulate.
+#[test]
+fn non_versioned_graph_node_is_last_writer_wins() {
+    let rt = rt();
+    set_current_connection_id(70007);
+    rt.execute_query("CREATE GRAPH plain_graph")
+        .expect("CREATE GRAPH");
+
+    let _rid = insert_node(&rt, "plain_graph", "alice", 1);
+    commit(&rt, 70007, "p1");
+
+    update_score(&rt, "plain_graph", "alice", 2);
+    update_score(&rt, "plain_graph", "alice", 3);
+    commit(&rt, 70007, "p2");
+
+    assert_eq!(
+        live_score(&rt, "plain_graph", "alice"),
+        Some(3),
+        "last writer wins"
+    );
+    let count = rt
+        .execute_query("SELECT score FROM plain_graph WHERE label = 'alice'")
+        .expect("scan plain_graph")
+        .result
+        .records
+        .len();
+    assert_eq!(
+        count, 1,
+        "non-versioned graph node must keep no history; got {count} live rows"
+    );
+    clear_current_connection_id();
+}

--- a/tests/grouped/vcs/e2e_vcs_kv_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_kv_mvcc_history.rs
@@ -1,0 +1,267 @@
+//! Versioned KV collections retain MVCC history (un-defers the
+//! "full multi-model adoption" deferred by ADR 0014, for KV first).
+//!
+//! A KV collection that has opted into versioning
+//! (`vcs.set_versioned(collection, true)`) must keep prior versions
+//! physically alive so time-travel (`AS OF`) reads resolve the
+//! snapshot-visible version per logical key — exactly like a table
+//! row update. A non-versioned KV collection keeps last-writer-wins
+//! semantics (physical pre-delete on PUT, physical delete on DELETE).
+
+use std::sync::Arc;
+
+use reddb::application::{Author, CreateCommitInput, VcsUseCases};
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> Arc<RedDBRuntime> {
+    Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime"))
+}
+
+fn author() -> Author {
+    Author {
+        name: "test".to_string(),
+        email: "test@reddb.io".to_string(),
+    }
+}
+
+fn vcs(rt: &RedDBRuntime) -> VcsUseCases<'_, RedDBRuntime> {
+    VcsUseCases::new(rt)
+}
+
+fn commit(rt: &RedDBRuntime, conn: u64, msg: &str) -> String {
+    vcs(rt)
+        .commit(CreateCommitInput {
+            connection_id: conn,
+            message: msg.to_string(),
+            author: author(),
+            committer: None,
+            amend: false,
+            allow_empty: true,
+        })
+        .expect("commit")
+        .hash
+}
+
+/// Read `value` for a KV `key` at a historical commit via SQL `AS OF`.
+/// Returns `None` when the key has no snapshot-visible version.
+fn as_of_value(
+    rt: &RedDBRuntime,
+    collection: &str,
+    key: &str,
+    commit_hash: &str,
+) -> Option<String> {
+    let sql =
+        format!("SELECT value FROM {collection} AS OF COMMIT '{commit_hash}' WHERE key = '{key}'");
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert!(
+        result.result.records.len() <= 1,
+        "AS OF must resolve at most one visible version per key, got {} for `{sql}`",
+        result.result.records.len()
+    );
+    result
+        .result
+        .records
+        .first()
+        .map(|record| match record.get("value") {
+            Some(Value::Text(value)) => value.to_string(),
+            other => panic!("expected text value, got {other:?}"),
+        })
+}
+
+/// Read `value` for a KV `key` against the current (live) snapshot via
+/// a SQL scan. Returns `None` when no live version exists.
+fn live_value(rt: &RedDBRuntime, collection: &str, key: &str) -> Option<String> {
+    let sql = format!("SELECT value FROM {collection} WHERE key = '{key}'");
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    assert!(
+        result.result.records.len() <= 1,
+        "live read must resolve at most one visible version per key, got {}",
+        result.result.records.len()
+    );
+    result
+        .result
+        .records
+        .first()
+        .map(|record| match record.get("value") {
+            Some(Value::Text(value)) => value.to_string(),
+            other => panic!("expected text value, got {other:?}"),
+        })
+}
+
+/// Test A — time-travel on a versioned KV collection.
+///
+/// PUT k=v1, commit (capture point P1), PUT k=v2, commit.
+/// `AS OF P1` of k must return v1 (history retained). Without the
+/// fix, the versioned PUT physically pre-deletes the v1 row, so the
+/// AS OF read returns v2 (or nothing) — this must FAIL on unmodified
+/// code and PASS after.
+#[test]
+fn versioned_kv_as_of_returns_prior_version() {
+    let rt = rt();
+    // First PUT auto-creates the KV collection; then opt it into
+    // versioning before the writes whose history we assert on.
+    rt.execute_query("KV PUT vkv.'config:host' = 'v0'").unwrap();
+    vcs(&rt).set_versioned("vkv", true).unwrap();
+
+    rt.execute_query("KV PUT vkv.'config:host' = 'v1'").unwrap();
+    let p1 = commit(&rt, 1, "put v1");
+
+    rt.execute_query("KV PUT vkv.'config:host' = 'v2'").unwrap();
+    let _p2 = commit(&rt, 1, "put v2");
+
+    // Live read sees the latest.
+    assert_eq!(
+        live_value(&rt, "vkv", "config:host"),
+        Some("v2".to_string()),
+        "live read must see latest version"
+    );
+
+    // Time-travel read at P1 must see v1 — history retained.
+    assert_eq!(
+        as_of_value(&rt, "vkv", "config:host", &p1),
+        Some("v1".to_string()),
+        "AS OF P1 must return the prior version v1"
+    );
+}
+
+/// Test B — delete tombstone + history on a versioned KV collection.
+///
+/// PUT k=v1 (commit P1), DELETE k (commit). Current read of k is
+/// ABSENT, but `AS OF P1` returns v1. Without the fix, the versioned
+/// DELETE physically removes the row, so `AS OF P1` cannot find v1.
+#[test]
+fn versioned_kv_delete_tombstones_and_keeps_history() {
+    let rt = rt();
+    // First PUT auto-creates the KV collection; then opt into versioning.
+    rt.execute_query("KV PUT vkv2.'seed' = 'seed'").unwrap();
+    vcs(&rt).set_versioned("vkv2", true).unwrap();
+
+    rt.execute_query("KV PUT vkv2.'flag:beta' = 'v1'").unwrap();
+    let p1 = commit(&rt, 1, "put v1");
+
+    let deleted = rt.execute_query("KV DELETE vkv2.'flag:beta'").unwrap();
+    assert_eq!(deleted.affected_rows, 1, "delete reports the key existed");
+    let _p2 = commit(&rt, 1, "delete");
+
+    // Current read: key is absent (tombstoned).
+    assert_eq!(
+        live_value(&rt, "vkv2", "flag:beta"),
+        None,
+        "current read of a deleted key must be ABSENT"
+    );
+    // KV GET always returns one envelope record; an absent key carries
+    // a Null `value`.
+    let dsl_get = rt.execute_query("KV GET vkv2.'flag:beta'").unwrap();
+    assert_eq!(dsl_get.result.records.len(), 1, "KV GET envelope record");
+    assert_eq!(
+        dsl_get.result.records[0].get("value"),
+        Some(&Value::Null),
+        "KV GET of a deleted key must carry a Null value"
+    );
+
+    // Time-travel read at P1 still returns v1 — history retained.
+    assert_eq!(
+        as_of_value(&rt, "vkv2", "flag:beta", &p1),
+        Some("v1".to_string()),
+        "AS OF P1 must still return v1 after delete"
+    );
+}
+
+/// Test C — non-versioned KV is UNCHANGED (last-writer-wins).
+///
+/// PUT k=v1, PUT k=v2 — only one physical row exists (no history
+/// accumulation). DELETE k physically removes it. This guards the
+/// `is_versioned` gate so config/secret KV keep their fast path.
+#[test]
+fn non_versioned_kv_keeps_last_writer_wins() {
+    let rt = rt();
+    // First PUT auto-creates the KV collection; deliberately NOT versioned.
+    rt.execute_query("KV PUT nvkv.'k' = 'v1'").unwrap();
+    assert!(!vcs(&rt).is_versioned("nvkv").unwrap());
+
+    rt.execute_query("KV PUT nvkv.'k' = 'v2'").unwrap();
+
+    // Exactly one physical row for the key — no history accumulation.
+    let all = rt
+        .execute_query("SELECT key, value FROM nvkv WHERE key = 'k'")
+        .unwrap();
+    assert_eq!(
+        all.result.records.len(),
+        1,
+        "non-versioned KV must keep a single physical row per key (last-writer-wins)"
+    );
+    match all.result.records[0].get("value") {
+        Some(Value::Text(value)) => assert_eq!(&**value, "v2"),
+        other => panic!("expected v2, got {other:?}"),
+    }
+
+    // DELETE physically removes the row.
+    let deleted = rt.execute_query("KV DELETE nvkv.'k'").unwrap();
+    assert_eq!(deleted.affected_rows, 1);
+    let after = rt
+        .execute_query("SELECT key, value FROM nvkv WHERE key = 'k'")
+        .unwrap();
+    assert_eq!(
+        after.result.records.len(),
+        0,
+        "non-versioned DELETE physically removes the row"
+    );
+}
+
+/// Test D — multi-version chain: each commit point resolves to its own
+/// version, and the live read tracks the latest. Exercises version
+/// selection across more than two physical versions per key.
+#[test]
+fn versioned_kv_multi_version_chain_time_travel() {
+    let rt = rt();
+    rt.execute_query("KV PUT chain.'k' = 'seed'").unwrap();
+    vcs(&rt).set_versioned("chain", true).unwrap();
+
+    rt.execute_query("KV PUT chain.'k' = 'v1'").unwrap();
+    let p1 = commit(&rt, 1, "v1");
+    rt.execute_query("KV PUT chain.'k' = 'v2'").unwrap();
+    let p2 = commit(&rt, 1, "v2");
+    rt.execute_query("KV PUT chain.'k' = 'v3'").unwrap();
+    let p3 = commit(&rt, 1, "v3");
+
+    assert_eq!(live_value(&rt, "chain", "k"), Some("v3".to_string()));
+    assert_eq!(as_of_value(&rt, "chain", "k", &p1), Some("v1".to_string()));
+    assert_eq!(as_of_value(&rt, "chain", "k", &p2), Some("v2".to_string()));
+    assert_eq!(as_of_value(&rt, "chain", "k", &p3), Some("v3".to_string()));
+}
+
+/// Test E — resurrection: after a tombstoning DELETE, a fresh PUT of the
+/// same key is visible live again, while the pre-delete history remains
+/// reachable by AS OF.
+#[test]
+fn versioned_kv_put_after_delete_resurrects_key() {
+    let rt = rt();
+    rt.execute_query("KV PUT res.'k' = 'seed'").unwrap();
+    vcs(&rt).set_versioned("res", true).unwrap();
+
+    rt.execute_query("KV PUT res.'k' = 'v1'").unwrap();
+    let p1 = commit(&rt, 1, "v1");
+    rt.execute_query("KV DELETE res.'k'").unwrap();
+    let _pdel = commit(&rt, 1, "delete");
+    assert_eq!(live_value(&rt, "res", "k"), None, "deleted: absent live");
+
+    rt.execute_query("KV PUT res.'k' = 'v2'").unwrap();
+    let p2 = commit(&rt, 1, "v2");
+
+    assert_eq!(
+        live_value(&rt, "res", "k"),
+        Some("v2".to_string()),
+        "re-PUT resurrects the key live"
+    );
+    assert_eq!(
+        as_of_value(&rt, "res", "k", &p1),
+        Some("v1".to_string()),
+        "pre-delete history still reachable"
+    );
+    assert_eq!(as_of_value(&rt, "res", "k", &p2), Some("v2".to_string()));
+}

--- a/tests/grouped/vcs/e2e_vcs_kv_write_conflict.rs
+++ b/tests/grouped/vcs/e2e_vcs_kv_write_conflict.rs
@@ -50,7 +50,9 @@ fn assert_conflict(message: &str) {
 /// leave exactly one live version per key.
 fn live_values(rt: &RedDBRuntime, collection: &str, key: &str) -> Vec<String> {
     let result = rt
-        .execute_query(&format!("SELECT value FROM {collection} WHERE key = '{key}'"))
+        .execute_query(&format!(
+            "SELECT value FROM {collection} WHERE key = '{key}'"
+        ))
         .expect("scan key");
     result
         .result

--- a/tests/grouped/vcs/e2e_vcs_kv_write_conflict.rs
+++ b/tests/grouped/vcs/e2e_vcs_kv_write_conflict.rs
@@ -1,0 +1,182 @@
+//! First-committer-wins write-conflict detection for versioned KV.
+//!
+//! ADR 0014 mandates snapshot isolation with first-committer-wins write
+//! conflict detection across all models. The versioned-KV write path
+//! tombstones the prior version (set_xmax) and inserts a new version —
+//! exactly like a table-row versioned UPDATE. Two concurrent
+//! transactions that both tombstone the SAME prior version must NOT
+//! both commit: the first committer wins, the second must fail with a
+//! serialization conflict, leaving exactly ONE live version.
+//!
+//! These tests drive two explicit transactions deterministically by
+//! switching the thread-local connection id between statements (the same
+//! interleaving primitive the table-row first-committer-wins tests use),
+//! so there is no thread-timing flakiness.
+
+use reddb::application::VcsUseCases;
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn exec_err(rt: &RedDBRuntime, sql: &str) -> String {
+    rt.execute_query(sql)
+        .expect_err("query should fail")
+        .to_string()
+}
+
+fn vcs(rt: &RedDBRuntime) -> VcsUseCases<'_, RedDBRuntime> {
+    VcsUseCases::new(rt)
+}
+
+fn assert_conflict(message: &str) {
+    assert!(
+        message.contains("serialization conflict"),
+        "expected serialization conflict, got {message}"
+    );
+}
+
+/// Every physical version of `key` whose `value` is currently
+/// snapshot-visible (live: xmax == 0 for the reader). Returns the raw
+/// `value` strings. A correct first-committer-wins implementation must
+/// leave exactly one live version per key.
+fn live_values(rt: &RedDBRuntime, collection: &str, key: &str) -> Vec<String> {
+    let result = rt
+        .execute_query(&format!("SELECT value FROM {collection} WHERE key = '{key}'"))
+        .expect("scan key");
+    result
+        .result
+        .records
+        .iter()
+        .map(|record| match record.get("value") {
+            Some(Value::Text(value)) => value.to_string(),
+            other => panic!("expected text value, got {other:?}"),
+        })
+        .collect()
+}
+
+/// RED → GREEN: two concurrent transactions PUT the same versioned KV
+/// key. Both observe v0 at their snapshot, both tombstone the v0 version
+/// and insert their own new version. T1 commits first. Per
+/// first-committer-wins, T2's COMMIT must FAIL with a serialization
+/// conflict — and the post-state must hold exactly ONE live version.
+///
+/// On unmodified code the versioned-KV write path records no pending
+/// conflict marker, so T2 commits silently (no conflict) and two live
+/// versions transiently coexist — this test fails until the conflict
+/// machinery is wired in.
+#[test]
+fn concurrent_versioned_kv_put_conflicts_on_second_commit() {
+    let rt = rt();
+    set_current_connection_id(51001);
+    // Auto-create + opt into versioning, then seed v0 (committed).
+    exec(&rt, "KV PUT wc.'k' = 'v0'");
+    vcs(&rt).set_versioned("wc", true).unwrap();
+    // Re-seed so v0 carries a versioned (monotonic) xmin under the gate.
+    exec(&rt, "KV PUT wc.'k' = 'v0'");
+
+    // Two transactions both snapshot the v0 state.
+    set_current_connection_id(51002);
+    exec(&rt, "BEGIN");
+    set_current_connection_id(51003);
+    exec(&rt, "BEGIN");
+
+    // T1 PUT k=v1, T2 PUT k=v1b — both tombstone the same v0 version.
+    set_current_connection_id(51002);
+    exec(&rt, "KV PUT wc.'k' = 'v1'");
+    set_current_connection_id(51003);
+    exec(&rt, "KV PUT wc.'k' = 'v1b'");
+
+    // T1 commits (winner).
+    set_current_connection_id(51002);
+    exec(&rt, "COMMIT");
+    // T2 commits (loser) — must conflict.
+    set_current_connection_id(51003);
+    assert_conflict(&exec_err(&rt, "COMMIT"));
+
+    // Post-state: exactly one live version, and it is the winner's.
+    set_current_connection_id(51004);
+    let live = live_values(&rt, "wc", "k");
+    assert_eq!(
+        live,
+        vec!["v1".to_string()],
+        "exactly one live version (the first committer's) must survive"
+    );
+    clear_current_connection_id();
+}
+
+/// Serialized case stays correct: T1 commits, THEN T2 starts fresh, sees
+/// v1, PUTs v1b — no false conflict. This guards against the conflict
+/// check firing on a legitimately-sequential workload.
+#[test]
+fn serialized_versioned_kv_put_does_not_conflict() {
+    let rt = rt();
+    set_current_connection_id(52001);
+    exec(&rt, "KV PUT wcs.'k' = 'v0'");
+    vcs(&rt).set_versioned("wcs", true).unwrap();
+    exec(&rt, "KV PUT wcs.'k' = 'v0'");
+
+    // T1 fully commits before T2 begins.
+    set_current_connection_id(52002);
+    exec(&rt, "BEGIN");
+    exec(&rt, "KV PUT wcs.'k' = 'v1'");
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(52003);
+    exec(&rt, "BEGIN");
+    exec(&rt, "KV PUT wcs.'k' = 'v1b'");
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(52004);
+    let live = live_values(&rt, "wcs", "k");
+    assert_eq!(
+        live,
+        vec!["v1b".to_string()],
+        "serialized writes both apply; latest wins, single live version"
+    );
+    clear_current_connection_id();
+}
+
+/// Concurrent DELETE vs PUT on the same versioned key conflicts too:
+/// both tombstone the same prior version. T1 DELETEs (commits), T2 PUTs
+/// (must conflict on COMMIT).
+#[test]
+fn concurrent_versioned_kv_delete_then_put_conflicts() {
+    let rt = rt();
+    set_current_connection_id(53001);
+    exec(&rt, "KV PUT wcd.'k' = 'v0'");
+    vcs(&rt).set_versioned("wcd", true).unwrap();
+    exec(&rt, "KV PUT wcd.'k' = 'v0'");
+
+    set_current_connection_id(53002);
+    exec(&rt, "BEGIN");
+    set_current_connection_id(53003);
+    exec(&rt, "BEGIN");
+
+    set_current_connection_id(53002);
+    exec(&rt, "KV DELETE wcd.'k'");
+    set_current_connection_id(53003);
+    exec(&rt, "KV PUT wcd.'k' = 'v1'");
+
+    set_current_connection_id(53002);
+    exec(&rt, "COMMIT");
+    set_current_connection_id(53003);
+    assert_conflict(&exec_err(&rt, "COMMIT"));
+
+    // The DELETE won: the key is absent live.
+    set_current_connection_id(53004);
+    let live = live_values(&rt, "wcd", "k");
+    assert!(
+        live.is_empty(),
+        "the committed DELETE wins; no live version survives, got {live:?}"
+    );
+    clear_current_connection_id();
+}

--- a/tests/grouped/vcs/e2e_vcs_vector_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_vector_mvcc_history.rs
@@ -1,0 +1,119 @@
+//! Versioned VECTOR collections — SCOPED FOLLOW-UP for Phase 3 of the
+//! multi-model versioning rollout (KV Phase 1, documents Phase 2, graph
+//! Phase 3a SHIPPED). Vector versioning is NOT shipped in this pass; the
+//! `#[ignore]`d tests below are an executable specification of the
+//! remaining work so a follow-up can drive them red→green.
+//!
+//! WHY VECTOR IS DEFERRED (investigated, not assumed):
+//!
+//! 1. No snapshot-honoring read surface. A vector's only read surface is
+//!    `VECTOR SEARCH`. Its read path (runtime/query_exec/vector.rs)
+//!    fetches each index hit via `store.get` and filters with
+//!    `entity_visible_with_context(capture_current_snapshot(), entity)`.
+//!    In autocommit (the common case) there is no active snapshot, so
+//!    `capture_current_snapshot()` is `None` and the visibility check
+//!    returns `true` unconditionally — a tombstoned vector stays in the
+//!    results. `VECTOR SEARCH` also has no `AS OF` clause, so historical
+//!    versions can never be read back. `SELECT ... FROM <vector>` does
+//!    not surface vectors as rows at all (they live in `EntityData::
+//!    Vector`, not a queryable row), so there is no row-scan fallback.
+//!
+//! 2. Derived index is not pruned. The TurboQuant index
+//!    (runtime/vector_turbo_kind.rs) is appended on insert
+//!    (application/ports_impls_entity.rs `create_vector`) but never has
+//!    entries removed on delete (`delete_entities_batch` →
+//!    `store.delete_batch` does not touch the turbo index). So even a
+//!    physically-removed vector lingers in the index and is only hidden
+//!    if the per-hit `store.get` returns `None` AND a snapshot is
+//!    active.
+//!
+//! Shipping write-side vector tombstoning WITHOUT (1) would make a
+//! deleted versioned vector stay searchable in autocommit — strictly
+//! worse than today — so vector versioning is held until the search read
+//! path honors snapshot visibility (always capture a read snapshot) and
+//! the turbo index is pruned/version-filtered. The graph half of Phase 3
+//! ships in this same change set (e2e_vcs_graph_mvcc_history.rs).
+
+use std::sync::Arc;
+
+use reddb::application::VcsUseCases;
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> Arc<RedDBRuntime> {
+    Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime"))
+}
+
+fn rid_of(value: &Value) -> u64 {
+    match value {
+        Value::UnsignedInteger(v) => *v,
+        Value::Integer(v) => *v as u64,
+        Value::Text(v) => v.parse().expect("rid text -> u64"),
+        other => panic!("expected rid, got {other:?}"),
+    }
+}
+
+fn insert_vector(rt: &RedDBRuntime, collection: &str, dense: &str, content: &str) -> u64 {
+    let sql = format!(
+        "INSERT INTO {collection} VECTOR (dense, content) VALUES ({dense}, '{content}') RETURNING rid"
+    );
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    let record = result
+        .result
+        .records
+        .first()
+        .unwrap_or_else(|| panic!("no RETURNING record for `{sql}`"));
+    rid_of(
+        record
+            .get("rid")
+            .unwrap_or_else(|| panic!("no rid in `{sql}`")),
+    )
+}
+
+fn search_contents(rt: &RedDBRuntime, collection: &str, dense: &str, limit: usize) -> Vec<String> {
+    let sql = format!("VECTOR SEARCH {collection} SIMILAR TO {dense} LIMIT {limit}");
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    result
+        .result
+        .records
+        .iter()
+        .filter_map(|record| match record.get("content") {
+            Some(Value::Text(value)) => Some(value.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// FOLLOW-UP SPEC (currently failing — vector versioning not shipped):
+/// after versioning, a live `VECTOR SEARCH` must return only the live
+/// version, not the tombstoned old one. Requires the search read path to
+/// (a) always capture a read snapshot so `entity_visible_with_context`
+/// can hide tombstones in autocommit, and (b) tombstone (not physically
+/// drop) versioned vector deletes while pruning/version-filtering the
+/// TurboQuant index. See module docs for the precise blockers.
+#[test]
+#[ignore = "vector versioning deferred: VECTOR SEARCH read path does not honor snapshot visibility in autocommit; see module docs"]
+fn versioned_vector_search_excludes_tombstoned_version() {
+    let rt = rt();
+    rt.execute_query("CREATE VECTOR vvec_search DIM 2 METRIC cosine")
+        .expect("CREATE VECTOR");
+    VcsUseCases::new(&*rt)
+        .set_versioned("vvec_search", true)
+        .unwrap();
+
+    let rid_v1 = insert_vector(&rt, "vvec_search", "[1.0, 0.0]", "v1");
+    rt.execute_query(&format!("DELETE FROM vvec_search WHERE rid = {rid_v1}"))
+        .expect("DELETE v1");
+    insert_vector(&rt, "vvec_search", "[1.0, 0.0]", "v2");
+
+    let hits = search_contents(&rt, "vvec_search", "[1.0, 0.0]", 5);
+    assert_eq!(
+        hits,
+        vec!["v2".to_string()],
+        "live VECTOR SEARCH must return only the live version, not the tombstoned 'v1'"
+    );
+}

--- a/tests/grouped/vcs/e2e_vcs_vector_mvcc_history.rs
+++ b/tests/grouped/vcs/e2e_vcs_vector_mvcc_history.rs
@@ -1,42 +1,30 @@
-//! Versioned VECTOR collections — SCOPED FOLLOW-UP for Phase 3 of the
-//! multi-model versioning rollout (KV Phase 1, documents Phase 2, graph
-//! Phase 3a SHIPPED). Vector versioning is NOT shipped in this pass; the
-//! `#[ignore]`d tests below are an executable specification of the
-//! remaining work so a follow-up can drive them red→green.
+//! Versioned VECTOR collections retain MVCC history (Phase 3 of the
+//! multi-model versioning rollout; KV Phase 1, documents Phase 2, graph
+//! Phase 3a). A vector's only read surface is `VECTOR SEARCH`, so the
+//! correctness bar here is: a deleted / superseded vector must NOT
+//! appear in `VECTOR SEARCH` results.
 //!
-//! WHY VECTOR IS DEFERRED (investigated, not assumed):
+//! TWO bugs are fixed in this pass:
 //!
-//! 1. No snapshot-honoring read surface. A vector's only read surface is
-//!    `VECTOR SEARCH`. Its read path (runtime/query_exec/vector.rs)
-//!    fetches each index hit via `store.get` and filters with
-//!    `entity_visible_with_context(capture_current_snapshot(), entity)`.
-//!    In autocommit (the common case) there is no active snapshot, so
-//!    `capture_current_snapshot()` is `None` and the visibility check
-//!    returns `true` unconditionally — a tombstoned vector stays in the
-//!    results. `VECTOR SEARCH` also has no `AS OF` clause, so historical
-//!    versions can never be read back. `SELECT ... FROM <vector>` does
-//!    not surface vectors as rows at all (they live in `EntityData::
-//!    Vector`, not a queryable row), so there is no row-scan fallback.
+//! 1. Pre-existing delete bug (ALL vector collections, independent of
+//!    versioning): the derived TurboQuant index is append-only and is
+//!    never pruned on delete, and the per-hit visibility filter used the
+//!    `entity_visible_with_context(None, …)` path which returns `true`
+//!    unconditionally in autocommit. So a physically-deleted vector
+//!    could linger in search results. The search read path now filters
+//!    each hit through `entity_visible_under_current_snapshot`, which in
+//!    autocommit hides any superseded/tombstoned physical version
+//!    (`xmax != 0`).
 //!
-//! 2. Derived index is not pruned. The TurboQuant index
-//!    (runtime/vector_turbo_kind.rs) is appended on insert
-//!    (application/ports_impls_entity.rs `create_vector`) but never has
-//!    entries removed on delete (`delete_entities_batch` →
-//!    `store.delete_batch` does not touch the turbo index). So even a
-//!    physically-removed vector lingers in the index and is only hidden
-//!    if the per-hit `store.get` returns `None` AND a snapshot is
-//!    active.
-//!
-//! Shipping write-side vector tombstoning WITHOUT (1) would make a
-//! deleted versioned vector stay searchable in autocommit — strictly
-//! worse than today — so vector versioning is held until the search read
-//! path honors snapshot visibility (always capture a read snapshot) and
-//! the turbo index is pruned/version-filtered. The graph half of Phase 3
-//! ships in this same change set (e2e_vcs_graph_mvcc_history.rs).
+//! 2. Versioned vector deletes now tombstone (xmax stamp) instead of
+//!    physically dropping, so history is retained — but the same
+//!    visibility post-filter keeps the tombstoned version out of live
+//!    search. Non-versioned vectors keep the legacy physical delete.
 
 use std::sync::Arc;
 
 use reddb::application::VcsUseCases;
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
@@ -88,15 +76,31 @@ fn search_contents(rt: &RedDBRuntime, collection: &str, dense: &str, limit: usiz
         .collect()
 }
 
-/// FOLLOW-UP SPEC (currently failing — vector versioning not shipped):
-/// after versioning, a live `VECTOR SEARCH` must return only the live
-/// version, not the tombstoned old one. Requires the search read path to
-/// (a) always capture a read snapshot so `entity_visible_with_context`
-/// can hide tombstones in autocommit, and (b) tombstone (not physically
-/// drop) versioned vector deletes while pruning/version-filtering the
-/// TurboQuant index. See module docs for the precise blockers.
+/// (a) Pre-existing delete bug — NON-versioned: a deleted vector must
+/// not appear in `VECTOR SEARCH`. Fails on `e4c7a640` because the turbo
+/// index is never pruned and the autocommit visibility filter is a
+/// no-op.
 #[test]
-#[ignore = "vector versioning deferred: VECTOR SEARCH read path does not honor snapshot visibility in autocommit; see module docs"]
+fn non_versioned_vector_delete_excludes_from_search() {
+    let rt = rt();
+    rt.execute_query("CREATE VECTOR pvec_del DIM 2 METRIC cosine")
+        .expect("CREATE VECTOR");
+
+    let rid_a = insert_vector(&rt, "pvec_del", "[1.0, 0.0]", "a");
+    insert_vector(&rt, "pvec_del", "[0.0, 1.0]", "b");
+    rt.execute_query(&format!("DELETE FROM pvec_del WHERE rid = {rid_a}"))
+        .expect("DELETE a");
+
+    let hits = search_contents(&rt, "pvec_del", "[1.0, 0.0]", 5);
+    assert!(
+        !hits.contains(&"a".to_string()),
+        "deleted vector 'a' must not appear in VECTOR SEARCH; got {hits:?}"
+    );
+}
+
+/// (b) Versioned search returns only the live version after a delete +
+/// re-insert that supersedes: the tombstoned old version is excluded.
+#[test]
 fn versioned_vector_search_excludes_tombstoned_version() {
     let rt = rt();
     rt.execute_query("CREATE VECTOR vvec_search DIM 2 METRIC cosine")
@@ -116,4 +120,98 @@ fn versioned_vector_search_excludes_tombstoned_version() {
         vec!["v2".to_string()],
         "live VECTOR SEARCH must return only the live version, not the tombstoned 'v1'"
     );
+}
+
+/// (c) Versioned delete excludes from search, and the tombstone retains
+/// history (the entity stays physically alive with xmax set).
+#[test]
+fn versioned_vector_delete_excludes_from_search() {
+    let rt = rt();
+    rt.execute_query("CREATE VECTOR vvec_del DIM 2 METRIC cosine")
+        .expect("CREATE VECTOR");
+    VcsUseCases::new(&*rt)
+        .set_versioned("vvec_del", true)
+        .unwrap();
+
+    let rid = insert_vector(&rt, "vvec_del", "[1.0, 0.0]", "v1");
+    insert_vector(&rt, "vvec_del", "[0.0, 1.0]", "keep");
+    rt.execute_query(&format!("DELETE FROM vvec_del WHERE rid = {rid}"))
+        .expect("DELETE v1");
+
+    let hits = search_contents(&rt, "vvec_del", "[1.0, 0.0]", 5);
+    assert!(
+        !hits.contains(&"v1".to_string()),
+        "tombstoned versioned vector 'v1' must not appear in search; got {hits:?}"
+    );
+}
+
+/// DEFERRED — time-travel read surface for vectors. `VECTOR SEARCH` has
+/// no `AS OF` clause and `SELECT ... FROM <vector>` surfaces zero rows
+/// (vectors live in `EntityData::Vector`, not a queryable row), so a
+/// historical (tombstoned) vector version cannot be read back today.
+/// Versioned vector deletes already retain history physically (the
+/// tombstoned version stays alive with `xmax` set), so the read surface
+/// can be added later without a data-model change. Adding `AS OF` to the
+/// vector grammar + planner + a historical-version resolver is a large
+/// structural change and is intentionally out of scope for this pass;
+/// live-search correctness (deleted/superseded versions excluded) is the
+/// shipped guarantee. Un-ignore when the read surface lands.
+#[test]
+#[ignore = "time-travel AS OF read surface for vectors is deferred; history is retained physically — see module docs and this test's doc comment"]
+fn versioned_vector_as_of_resolves_prior_version() {
+    let rt = rt();
+    rt.execute_query("CREATE VECTOR vvec_asof DIM 2 METRIC cosine")
+        .expect("CREATE VECTOR");
+    VcsUseCases::new(&*rt)
+        .set_versioned("vvec_asof", true)
+        .unwrap();
+
+    let rid_v1 = insert_vector(&rt, "vvec_asof", "[1.0, 0.0]", "v1");
+    rt.execute_query(&format!("DELETE FROM vvec_asof WHERE rid = {rid_v1}"))
+        .expect("DELETE v1");
+
+    // Intended contract once the read surface lands: an AS OF read taken
+    // before the delete must still resolve "v1".
+    let hits = search_contents(&rt, "vvec_asof", "[1.0, 0.0]", 5);
+    assert_eq!(hits, vec!["v1".to_string()]);
+}
+
+/// (d) First-committer-wins on concurrent versioned vector delete: two
+/// transactions both snapshot the same live vector and DELETE it; T1
+/// commits, T2's commit must fail with a serialization conflict.
+#[test]
+fn concurrent_versioned_vector_delete_conflicts_on_second_commit() {
+    let rt = rt();
+    set_current_connection_id(80001);
+    rt.execute_query("CREATE VECTOR vvec_wc DIM 2 METRIC cosine")
+        .expect("CREATE VECTOR");
+    VcsUseCases::new(&*rt)
+        .set_versioned("vvec_wc", true)
+        .unwrap();
+    let rid = insert_vector(&rt, "vvec_wc", "[1.0, 0.0]", "v1");
+
+    set_current_connection_id(80002);
+    rt.execute_query("BEGIN").expect("T1 begin");
+    set_current_connection_id(80003);
+    rt.execute_query("BEGIN").expect("T2 begin");
+
+    set_current_connection_id(80002);
+    rt.execute_query(&format!("DELETE FROM vvec_wc WHERE rid = {rid}"))
+        .expect("T1 delete");
+    set_current_connection_id(80003);
+    rt.execute_query(&format!("DELETE FROM vvec_wc WHERE rid = {rid}"))
+        .expect("T2 delete");
+
+    set_current_connection_id(80002);
+    rt.execute_query("COMMIT").expect("T1 commit");
+    set_current_connection_id(80003);
+    let err = rt
+        .execute_query("COMMIT")
+        .expect_err("T2 commit must conflict");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("serialization conflict"),
+        "expected serialization conflict, got: {msg}"
+    );
+    clear_current_connection_id();
 }


### PR DESCRIPTION
Un-defers the "full multi-model adoption" that ADR 0014 deferred behind table-row correctness (now shipped in v1.14.0). Non-table collections marked \`versioned\` now retain MVCC history, so AS OF / time-travel / VCS merge work across **all** models — not just tables. Gated strictly on the \`versioned\` flag; **config/secrets and all non-versioned collections are unchanged** (last-writer-wins + zero-scan fast path).

## Per-model status
- **KV** — full: tombstone-on-PUT/DELETE, snapshot version-selection, first-committer-wins. Caught a real bug: autocommit-pool xmin is non-monotonic vs commit xids → restamp via begin()/commit().
- **Document** — full: reads + SQL UPDATE already versioned (TableRow+logical_id); PATCH was the only gap (mutated in place) → now emits a versioned post-image.
- **Graph** (nodes/edges) — full: stamp logical_id + open PATCH/UPDATE/DELETE gates; read path already snapshot-correct.
- **Vector** — live-read correct + write-side history: TurboQuant index is append-only → search post-filters by snapshot/xmax visibility. **Also fixed a pre-existing bug**: \`DELETE FROM <vector> WHERE rid=N\` matched zero rows (vector deletes never took effect; deleted vectors lingered in search). Versioned vector deletes tombstone with first-committer-wins.

Every model reuses the existing table MVCC machinery (resolve_read_candidate, install_versioned_table_row_update / record_pending_*, check_table_row_write_conflicts) — no duplicated rules.

## Tests (red→green per model; CI verifies independently)
New e2e specs in tests/grouped/vcs/ per model (time-travel, delete-tombstone, first-committer-wins, non-versioned baseline). Local regression green: grouped_general_multimodel, grouped_documents_kv_queues (84), grouped_graph_topology (66), grouped_ai_search (107, vector recall unchanged), grouped_auth_iam_security (223), reddb-io-server --lib (4858). fmt + clippy clean.

## Deferred (scoped, \`#[ignore]\`d specs left in-tree)
- **Vector AS OF read surface** — needs VECTOR SEARCH \`AS OF\` grammar + planner + historical resolver; write-side history is retained so it lands later without a data-model change.
- **CDC-at-commit** — KV/document watch events emit eagerly during write, not at commit (table defers to finalize_pending_*).
- **PATCH vs SQL-UPDATE gating** — UPDATE versions table rows unconditionally; non-table PATCH is flag-gated.

ADR 0014 amended with the decision + gating principle + deferrals. HITL: hold for review; the pre-existing Test-Suite leak-guard / RQL-Coverage gates are rotted on main and need the lift-protection dance to merge.

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784955537&installation_id=129708444&pr_number=1383&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1383&signature=cf3bde292ab121c48b2edc69ec63cb73e52bd47e8eadbc969341aad67350d669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added versioned history and conflict handling for KV, documents, graph entities, and vectors.
  * Enabled time-travel reads and live snapshot visibility for supported versioned collections.
  * Extended delete behavior to retain history where applicable, including tombstones.

* **Bug Fixes**
  * Improved search and filtering so deleted or superseded vectors no longer appear in results.
  * Fixed entity lookup for non-row records when matching by entity ID.

* **Tests**
  * Added end-to-end coverage for history, delete behavior, and write conflicts across multiple collection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->