### PR TITLE
ci: parallelize Fuzz Parsers into a per-target matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -680,15 +680,28 @@ jobs:
       - name: Unit tests
         run: cargo test --locked --lib
 
-  fuzz-parsers:
+  fuzz-targets:
     # Issue #87 — short-window cargo-fuzz run on every PR.
     # Catches panics introduced by grammar changes; the long-window
     # nightly run lives in a separate scheduled workflow.
-    name: Fuzz Parsers
+    #
+    # Each parser fuzzes in its own parallel job. The aggregate
+    # required status check lives in the `fuzz-parsers` job below
+    # (name: "Fuzz Parsers"), which is what main's branch protection
+    # gates on — keep that name in lockstep with branch protection.
+    name: Fuzz ${{ matrix.target }}
     needs: gate
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 40
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - sql_parser
+          - migration_parser
+          - conn_string_parser
+          - query_with_params
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
@@ -702,37 +715,49 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ubuntu-fuzz-nightly
+          # Per-target cache key so parallel jobs don't thrash a
+          # shared cache entry.
+          shared-key: ubuntu-fuzz-nightly-${{ matrix.target }}
           cache-on-failure: "true"
           workspaces: |
             . -> target
             fuzz -> fuzz/target
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked
-      - name: Build fuzz targets
-        run: |
-          cargo +nightly fuzz build sql_parser
-          cargo +nightly fuzz build migration_parser
-          cargo +nightly fuzz build conn_string_parser
-      - name: Run sql_parser fuzz target (5 min)
-        run: cargo +nightly fuzz run sql_parser -- -max_total_time=300
-      - name: Run migration_parser fuzz target (5 min)
-        run: cargo +nightly fuzz run migration_parser -- -max_total_time=300
-      - name: Run conn_string_parser fuzz target (5 min)
-        # Issue #90 — pre-auth parser, panic-resistance is the only
-        # invariant; conn-string sees attacker-controlled bytes
-        # before any handshake completes, so we bake it into the
-        # same per-PR window as the SQL fuzzer.
-        run: cargo +nightly fuzz run conn_string_parser -- -max_total_time=300
+      - name: Build fuzz target
+        run: cargo +nightly fuzz build ${{ matrix.target }}
+      - name: Run fuzz target (5 min)
+        # Issue #90 — conn_string_parser is a pre-auth parser, panic-
+        # resistance is the only invariant; conn-string sees attacker-
+        # controlled bytes before any handshake completes, so we bake
+        # it into the same per-PR window as the SQL fuzzer.
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
       - name: Upload fuzz crash artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: fuzz-crashes
+          name: fuzz-crashes-${{ matrix.target }}
           path: |
             fuzz/artifacts/
             fuzz/corpus/
           retention-days: 14
+
+  fuzz-parsers:
+    # Aggregator that preserves the EXACT required status-check name
+    # "Fuzz Parsers" expected by main's branch protection. It succeeds
+    # iff every matrix job in fuzz-targets succeeded. Do not rename.
+    name: Fuzz Parsers
+    needs: [fuzz-targets]
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Verify all fuzz targets passed
+        run: |
+          if [ "${{ needs.fuzz-targets.result }}" != "success" ]; then
+            echo "a fuzz target failed"
+            exit 1
+          fi
 
   package:
     name: cargo package dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,7 +731,13 @@ jobs:
         # resistance is the only invariant; conn-string sees attacker-
         # controlled bytes before any handshake completes, so we bake
         # it into the same per-PR window as the SQL fuzzer.
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+        #
+        # -rss_limit_mb / -malloc_limit_mb make libFuzzer report an
+        # allocation-DoS (a crafted input that balloons a parser buffer)
+        # as an actionable crash finding instead of a silent runner
+        # OOM/timeout. scripts/fuzz-local.sh mirrors these limits (plus a
+        # systemd memory cgroup) for safe fuzzing on a dev box.
+        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096 -malloc_limit_mb=2048
       - name: Upload fuzz crash artifacts
         if: failure()
         uses: actions/upload-artifact@v7

--- a/scripts/fuzz-local.sh
+++ b/scripts/fuzz-local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Safe local fuzzing on a memory-constrained box. Builds each target
+# (the cargo guard already memory-caps builds), then runs the fuzzer inside
+# a systemd memory cgroup so a runaway parser allocation is OOM-killed in the
+# cgroup — never the desktop — and libFuzzer's -malloc_limit_mb turns a
+# huge single allocation into a reported crash (an actionable DoS finding)
+# instead of a machine hang.
+#
+# Usage:
+#   ./scripts/fuzz-local.sh                 # fuzz all targets
+#   ./scripts/fuzz-local.sh sql_parser      # fuzz one target
+#   FUZZ_TIME=30 ./scripts/fuzz-local.sh    # override per-target seconds
+set -euo pipefail
+
+TIME="${FUZZ_TIME:-60}"             # seconds per target
+MEM_MAX="${FUZZ_MEM_MAX:-10G}"      # cgroup hard cap (box has ~14G; leaves headroom)
+RSS_MB="${FUZZ_RSS_MB:-4096}"       # libFuzzer per-process RSS limit
+MALLOC_MB="${FUZZ_MALLOC_MB:-2048}" # abort+report on a single huge malloc
+
+ALL=(sql_parser migration_parser conn_string_parser query_with_params)
+if [ "$#" -gt 0 ]; then
+  TARGETS=("$@")
+else
+  TARGETS=("${ALL[@]}")
+fi
+
+# Pin nightly via RUSTUP_TOOLCHAIN rather than a `cargo +nightly` prefix: the
+# `+toolchain` form is only understood by the rustup proxy, and some
+# environments shadow that proxy with a wrapper (e.g. a memory-capping cargo
+# guard) that doesn't forward `+nightly`. RUSTUP_TOOLCHAIN works through any
+# such wrapper and is honoured by the nested `cargo build` that cargo-fuzz
+# spawns — so a guard wrapper still memory-caps the heavy build.
+export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly}"
+
+# Use the rustup nightly cargo directly for the RUN phase so we don't nest a
+# second systemd scope inside a cargo guard wrapper (the build below already
+# runs guard-capped). Fall back to `cargo` if rustup can't resolve it.
+REAL_CARGO="$(rustup which --toolchain nightly cargo 2>/dev/null || echo cargo)"
+
+for t in "${TARGETS[@]}"; do
+  echo ">>> fuzz $t  (${TIME}s, MemoryMax=$MEM_MAX, rss=${RSS_MB}MB, malloc=${MALLOC_MB}MB)"
+  cargo fuzz build "$t"    # guard-capped build (nightly via RUSTUP_TOOLCHAIN)
+  if command -v systemd-run >/dev/null 2>&1; then
+    systemd-run --user --scope -q -p MemoryMax="$MEM_MAX" -p MemorySwapMax=0 -- \
+      "$REAL_CARGO" fuzz run "$t" -- \
+        -max_total_time="$TIME" -rss_limit_mb="$RSS_MB" -malloc_limit_mb="$MALLOC_MB"
+  else
+    echo "WARN: systemd-run not available — running with libFuzzer limits only (no cgroup)"
+    "$REAL_CARGO" fuzz run "$t" -- \
+      -max_total_time="$TIME" -rss_limit_mb="$RSS_MB" -malloc_limit_mb="$MALLOC_MB"
+  fi
+done


### PR DESCRIPTION
## What

Splits the single sequential **Fuzz Parsers** job into a per-target matrix so the parsers fuzz in parallel instead of back-to-back, and adds local + CI memory-OOM hardening so an allocation-DoS becomes an actionable finding instead of a silent OOM/timeout.

Before: one job built 3 targets, then ran each for 5 min **sequentially** (`sql_parser` → `migration_parser` → `conn_string_parser`), ~28 min wall-clock for the whole job.

After: a `fuzz-targets` matrix job (`fail-fast: false`) runs one runner per target, each building and fuzzing **only its own** target for 5 min, all in parallel.

## Speedup / tradeoff

The 5-min fuzz windows now overlap instead of running back-to-back. Because each matrix job repeats the full setup (checkout, nightly toolchain, protoc, mold, sccache, `cargo install cargo-fuzz`, fuzz build) on its own runner, the win is roughly **2× wall-clock, not 4×** — the duplicated per-job setup eats part of the parallelism. This **trades runner-minutes for latency**: more total compute across more runners, but a shorter critical path on every PR. Per-job `timeout-minutes` dropped 40 → 20.

Each matrix job uses a **per-target** `Swatinem/rust-cache` `shared-key` (`ubuntu-fuzz-nightly-${{ matrix.target }}`) so the parallel runners don't thrash a single shared cache entry, and uploads crash artifacts under a per-target name (`fuzz-crashes-${{ matrix.target }}`).

## Preserving the required `Fuzz Parsers` check

`Fuzz Parsers` is a **required status check** in main's branch protection. Converting the job straight to a matrix would rename the contexts to `Fuzz Parsers (sql_parser)` etc. and make the exact `Fuzz Parsers` context **disappear**, blocking every PR.

So the matrix lives in a job named `Fuzz ${{ matrix.target }}`, and a tiny **aggregator job** `fuzz-parsers` keeps the **exact** name `Fuzz Parsers`. It `needs: [fuzz-targets]`, runs on `ubuntu-latest` (no build), and fails unless the whole matrix succeeded:

```yaml
if [ "${{ needs.fuzz-targets.result }}" != "success" ]; then
  echo "a fuzz target failed"
  exit 1
fi
```

The matrix `if:` and the aggregator `if:` are **identical** to the original (`pull_request` or `workflow_dispatch && inputs.full_ci`).

## `query_with_params` decision: **added** (now 4 targets)

`query_with_params` existed in `fuzz/fuzz_targets/` but was neither built nor run by the old job. It targets a real, exported, unit-tested function (`reddb_wire::query_with_params::decode_query_with_params`). It builds cleanly (`cargo +nightly fuzz build query_with_params`, exit 0, instrumented binary produced), so it joins the matrix as the 4th parallel target.

## Memory-OOM hardening (local + CI)

The dev box (~14G RAM) was OOMing during the **run** phase: the fuzzer runs outside any cgroup, so a parser that allocates a huge buffer from a crafted input can spike past RAM between libFuzzer's periodic rss checks and hang the desktop.

- **`scripts/fuzz-local.sh`** (new, executable): builds each target (guard-capped) then runs the fuzzer inside a `systemd --user` memory cgroup (`MemoryMax=10G`, `MemorySwapMax=0`) so a runaway allocation is OOM-killed *in the cgroup, never the desktop*, plus libFuzzer `-rss_limit_mb=4096 -malloc_limit_mb=2048` to convert a huge single allocation into a reported crash. Runs all 4 targets by default or a named subset; `FUZZ_TIME` / `FUZZ_MEM_MAX` / `FUZZ_RSS_MB` / `FUZZ_MALLOC_MB` override the defaults. (Nightly is pinned via `RUSTUP_TOOLCHAIN` rather than a `cargo +nightly` prefix so it works through a shadowing cargo-guard wrapper while still letting that guard memory-cap the build.)
- **CI matrix run step** now appends `-rss_limit_mb=4096 -malloc_limit_mb=2048` so an allocation-DoS surfaces as a real fuzz finding instead of a silent runner OOM/timeout.

**Smoke-tested all 4 targets locally for ~30s each WITH the memory-guard flags** via the script — all clean, none tripped `-malloc_limit_mb`, peak rss < 600 MB:

| target | runs in ~30s | peak rss | result |
|---|---|---|---|
| sql_parser | 1,054,108 | 589 MB | clean |
| migration_parser | 662,475 | ~630 MB | clean |
| conn_string_parser | 1,557,166 | ~564 MB | clean |
| query_with_params | 640,167 | ~87 MB | clean |

No pre-existing parser DoS bug, so the CI flags are safe to land (a tripped malloc limit would have been a real finding to fix first, not a red CI change to merge).

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → parses.
- `actionlint .github/workflows/ci.yml` → only the pre-existing `blacksmith-*` custom-runner-label warnings (present on `origin/main` too); **zero** new findings from this change.
- Cannot run GitHub Actions locally — this PR's own CI is the real validator.

Do not merge without review.

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g
