### PR TITLE
merge: #1243 feat(replication): record primary-replica reconnect telemetry

### DIFF
--- a/crates/reddb-server/src/presentation/cluster_status_json.rs
+++ b/crates/reddb-server/src/presentation/cluster_status_json.rs
@@ -167,6 +167,11 @@ pub(crate) struct ReplicationSnapshot {
     /// `(kind, count)` pairs sourced from
     /// `runtime.replica_apply_error_counts()`.
     pub(crate) apply_errors: Vec<(String, u64)>,
+    /// Issue #1243 (PRD #1237 Phase B) — primary<->replica reconnects since
+    /// process start, from `runtime.replication_reconnects_count()`. Lets
+    /// the UI explain link instability instead of a last-error snapshot.
+    /// Rendered as a number on a replica; `not_applicable` elsewhere.
+    pub(crate) reconnects_total: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -554,6 +559,18 @@ fn replication_json(repl: &ReplicationSnapshot, current_lsn: u64) -> JsonValue {
     }
     object.insert("apply_errors".to_string(), JsonValue::Object(errors_obj));
 
+    // Issue #1243 — reconnect count. Honest by role: a number on a replica
+    // (the loop that produces it ran), `not_applicable` on standalone /
+    // primary where there is no upstream link to reconnect to.
+    let reconnects_json = match repl.role {
+        ProcessRoleView::Replica => JsonValue::Number(repl.reconnects_total as f64),
+        ProcessRoleView::Standalone | ProcessRoleView::Primary => {
+            JsonValue::String("not_applicable".to_string())
+        }
+        ProcessRoleView::Unknown => unavailable_json("process_role_unknown"),
+    };
+    object.insert("reconnects_total".to_string(), reconnects_json);
+
     JsonValue::Object(object)
 }
 
@@ -618,6 +635,7 @@ mod tests {
                 replicas: vec![],
                 apply_health: None,
                 apply_errors: vec![],
+                reconnects_total: 0,
             },
             latency: None,
         }
@@ -792,6 +810,7 @@ mod tests {
             }],
             apply_health: Some("stalled_gap".to_string()),
             apply_errors: vec![("gap".to_string(), 3), ("apply".to_string(), 0)],
+            reconnects_total: 4,
         };
 
         let json = cluster_status_json(&inputs);
@@ -842,6 +861,8 @@ mod tests {
         let errs = obj(repl.get("apply_errors").unwrap());
         assert_eq!(n(errs.get("gap").unwrap()), 3.0);
         assert_eq!(n(errs.get("apply").unwrap()), 0.0);
+        // Issue #1243 — reconnect count rendered as a number on a replica.
+        assert_eq!(n(repl.get("reconnects_total").unwrap()), 4.0);
     }
 
     #[test]

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -34,6 +34,7 @@ pub mod lease;
 pub mod logical;
 pub mod primary;
 pub mod quorum;
+pub mod reconnect;
 pub mod replica;
 pub mod rollback;
 pub mod scheduler;

--- a/crates/reddb-server/src/replication/reconnect.rs
+++ b/crates/reddb-server/src/replication/reconnect.rs
@@ -1,0 +1,201 @@
+//! Primary↔replica reconnect telemetry (issue #1243, PRD #1237 Phase B).
+//!
+//! A replica drives a long-lived gRPC pull loop against its primary
+//! (`run_replica_loop`). When that link drops — a failed `pull_wal_records`
+//! or the initial `connect` retry — the loop persists the `connecting`
+//! health state and keeps retrying. When a pull succeeds again the loop
+//! persists `healthy`. A **reconnect** is exactly that transition: a link
+//! that was up, went down, and came back up.
+//!
+//! This module records that signal as a monotonic counter so red-ui can
+//! explain instability ("this replica has reconnected 14 times in the last
+//! hour") instead of showing only a last-error snapshot. It is the
+//! reconnect-counter producer/consumer slice of the operational telemetry
+//! substrate (ADR 0060): measurement here, export through `/metrics`
+//! (`reddb_replication_reconnects_total`) and the red-ui status read model.
+//!
+//! # What is *not* counted
+//!
+//! - The **initial** connect on startup. A replica coming up for the first
+//!   time is not "reconnecting"; the counter only moves once the link has
+//!   been healthy at least once and then recovers from a drop.
+//! - Apply-side failures (`apply_error`, `divergence`, `relay_error`,
+//!   `ack_error`, …). Those are not link drops — the gRPC stream is still
+//!   up — and have their own counters
+//!   (`reddb_replica_apply_errors_total`). Treating them as drops would
+//!   inflate the reconnect count, so only the `connecting` state marks the
+//!   link down.
+//!
+//! # Privacy (ADR 0060 §5)
+//!
+//! Reconnect telemetry stores **no** endpoint, URL, credential, or
+//! authorization material — only a monotonic count and the bounded
+//! transition state. The exported series carries the node's own stable
+//! `replica_id` as its single dimension, never the primary's address.
+//!
+//! # Reset / restart behavior
+//!
+//! The counter is an in-memory `AtomicU64` scoped to the process lifetime.
+//! It starts at `0` on every boot and is **not** persisted across restarts
+//! — a process restart resets it to `0`, exactly like the sibling
+//! `reddb_replication_full_resync_total` / `_partial_resync_total` counters.
+//! Prometheus treats a counter that drops to `0` as a reset (via the
+//! process-start timestamp), so `rate()`/`increase()` stay correct across a
+//! restart. red-ui reads the live value; it does not assume monotonicity
+//! across a process boundary.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+/// The replica's view of the link to its primary, as projected from the
+/// health states the pull loop persists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LinkState {
+    /// No health state observed yet (pre-connect).
+    Unknown,
+    /// The link has been healthy at least once and is currently up.
+    Up,
+    /// The link was up before and is currently down (retrying connect).
+    Down,
+}
+
+#[derive(Debug)]
+struct LinkTracker {
+    state: LinkState,
+}
+
+/// Process-lifetime reconnect telemetry for the local replica's link to its
+/// primary. Lives on the runtime beside [`super::logical::ReplicaApplyMetrics`]
+/// and is driven from the single health-persist chokepoint in the replica
+/// loop, so every link-state transition is observed exactly once.
+#[derive(Debug)]
+pub struct ReplicaLinkMetrics {
+    reconnects_total: AtomicU64,
+    tracker: Mutex<LinkTracker>,
+}
+
+impl Default for ReplicaLinkMetrics {
+    fn default() -> Self {
+        Self {
+            reconnects_total: AtomicU64::new(0),
+            tracker: Mutex::new(LinkTracker {
+                state: LinkState::Unknown,
+            }),
+        }
+    }
+}
+
+impl ReplicaLinkMetrics {
+    /// Observe a persisted replica health `state` string and advance the
+    /// reconnect counter when the link transitions from down back to up.
+    ///
+    /// Only `"healthy"` counts as the link being up and only `"connecting"`
+    /// counts as the link being down; every other state (apply errors,
+    /// rebootstrap phases, rejoining, …) is neither a clean up nor a link
+    /// drop and leaves the tracked state unchanged, so it can neither arm
+    /// nor fire a reconnect.
+    pub fn observe_state(&self, state: &str) {
+        let mut tracker = match self.tracker.lock() {
+            Ok(guard) => guard,
+            // A poisoned lock means a prior observer panicked mid-update.
+            // Reconnect telemetry must never take down the loop that feeds
+            // it, so recover the guard and carry on; the worst case is a
+            // single mis-attributed transition.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        match state {
+            "healthy" => {
+                if tracker.state == LinkState::Down {
+                    // down -> up after having been up before: a reconnect.
+                    self.reconnects_total.fetch_add(1, Ordering::Relaxed);
+                }
+                tracker.state = LinkState::Up;
+            }
+            // Only arm a reconnect once the link has been up at least once;
+            // the initial connect (state still `Unknown`) must not be counted.
+            "connecting" if tracker.state == LinkState::Up => {
+                tracker.state = LinkState::Down;
+            }
+            _ => {}
+        }
+    }
+
+    /// Total reconnects observed since process start. Monotonic within a
+    /// process; resets to `0` on restart (see module docs).
+    pub fn reconnects_total(&self) -> u64 {
+        self.reconnects_total.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_connect_is_not_a_reconnect() {
+        let metrics = ReplicaLinkMetrics::default();
+        // Startup: the loop persists `connecting` while it waits for the
+        // primary, then `healthy` once the first pull lands.
+        metrics.observe_state("connecting");
+        metrics.observe_state("healthy");
+        assert_eq!(metrics.reconnects_total(), 0);
+    }
+
+    #[test]
+    fn drop_and_restore_counts_one_reconnect() {
+        let metrics = ReplicaLinkMetrics::default();
+        metrics.observe_state("connecting");
+        metrics.observe_state("healthy");
+        // Link drops (a failed pull) then restores.
+        metrics.observe_state("connecting");
+        metrics.observe_state("healthy");
+        assert_eq!(metrics.reconnects_total(), 1);
+    }
+
+    #[test]
+    fn repeated_connecting_during_one_outage_counts_once() {
+        let metrics = ReplicaLinkMetrics::default();
+        metrics.observe_state("healthy");
+        // A multi-poll outage persists `connecting` several times.
+        metrics.observe_state("connecting");
+        metrics.observe_state("connecting");
+        metrics.observe_state("connecting");
+        metrics.observe_state("healthy");
+        assert_eq!(metrics.reconnects_total(), 1);
+    }
+
+    #[test]
+    fn multiple_outages_accumulate() {
+        let metrics = ReplicaLinkMetrics::default();
+        metrics.observe_state("healthy");
+        for _ in 0..5 {
+            metrics.observe_state("connecting");
+            metrics.observe_state("healthy");
+        }
+        assert_eq!(metrics.reconnects_total(), 5);
+    }
+
+    #[test]
+    fn apply_errors_are_not_reconnects() {
+        let metrics = ReplicaLinkMetrics::default();
+        metrics.observe_state("healthy");
+        // The stream is still up; these are apply-side, not link drops.
+        metrics.observe_state("apply_error");
+        metrics.observe_state("divergence");
+        metrics.observe_state("relay_error");
+        metrics.observe_state("ack_error");
+        metrics.observe_state("healthy");
+        assert_eq!(metrics.reconnects_total(), 0);
+    }
+
+    #[test]
+    fn apply_error_during_outage_does_not_disarm_reconnect() {
+        let metrics = ReplicaLinkMetrics::default();
+        metrics.observe_state("healthy");
+        metrics.observe_state("connecting");
+        // An interleaved non-link state must not clear the armed drop.
+        metrics.observe_state("apply_error");
+        metrics.observe_state("healthy");
+        assert_eq!(metrics.reconnects_total(), 1);
+    }
+}

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1191,6 +1191,11 @@ struct RuntimeInner {
     /// loop on `Gap` / `Divergence` / `Apply` errors so /metrics
     /// surfaces them as `reddb_replica_apply_errors_total{kind}`.
     replica_apply_metrics: Arc<crate::replication::logical::ReplicaApplyMetrics>,
+    /// Issue #1243 (PRD #1237 Phase B) — primary↔replica reconnect counter
+    /// bumped by the replica loop's health-persist chokepoint when the link
+    /// drops and restores. Surfaced as `reddb_replication_reconnects_total`
+    /// and in the red-ui replica status read model.
+    replica_link_metrics: Arc<crate::replication::reconnect::ReplicaLinkMetrics>,
     /// PLAN.md Phase 4.4 — per-caller QPS quotas. Disabled (no-op)
     /// when `RED_MAX_QPS_PER_CALLER` is unset.
     quota_bucket: crate::runtime::quota_bucket::QuotaBucket,

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2462,6 +2462,9 @@ impl RedDBRuntime {
                 replica_apply_metrics: std::sync::Arc::new(
                     crate::replication::logical::ReplicaApplyMetrics::default(),
                 ),
+                replica_link_metrics: std::sync::Arc::new(
+                    crate::replication::reconnect::ReplicaLinkMetrics::default(),
+                ),
                 quota_bucket: crate::runtime::quota_bucket::QuotaBucket::from_env(),
                 schema_vocabulary: parking_lot::RwLock::new(
                     crate::runtime::schema_vocabulary::SchemaVocabulary::new(),

--- a/crates/reddb-server/src/runtime/impl_replica_loop.rs
+++ b/crates/reddb-server/src/runtime/impl_replica_loop.rs
@@ -302,6 +302,11 @@ impl RedDBRuntime {
         oldest_available_lsn: Option<u64>,
         catchup_mode: Option<reddb_file::ReplicaCatchupMode>,
     ) {
+        // Issue #1243 — observe every persisted health transition for
+        // reconnect telemetry. This is the single chokepoint the replica
+        // loop routes all state changes through, so the counter sees each
+        // link drop (`connecting`) and restore (`healthy`) exactly once.
+        self.inner.replica_link_metrics.observe_state(state);
         self.inner.db.store().set_config_tree(
             "red.replication",
             &crate::json!({

--- a/crates/reddb-server/src/runtime/impl_replication_commit.rs
+++ b/crates/reddb-server/src/runtime/impl_replication_commit.rs
@@ -48,6 +48,35 @@ impl RedDBRuntime {
             .unwrap_or(0)
     }
 
+    /// Issue #1243 (PRD #1237 Phase B) — count of primary↔replica
+    /// reconnects observed by this node's replica loop since process
+    /// start. A reconnect is a link that was healthy, dropped (the pull
+    /// loop fell back to `connecting`), and recovered. The initial connect
+    /// is **not** counted. Always `0` on a node whose replica loop never
+    /// ran (e.g. a standalone or primary instance). In-memory only: resets
+    /// to `0` on process restart, like the resync counters above.
+    pub fn replication_reconnects_count(&self) -> u64 {
+        self.inner.replica_link_metrics.reconnects_total()
+    }
+
+    /// Issue #1243 — this node's persisted replica identity, read-only.
+    /// Unlike [`node_id`](Self::node_id) / `resolve_replica_id` this never
+    /// generates or persists a new id; it returns the empty string when one
+    /// has not been assigned yet. Used as the bounded `replica_id`
+    /// dimension on `reddb_replication_reconnects_total`.
+    pub fn replication_replica_id(&self) -> String {
+        self.config_string("red.replication.replica_id", "")
+    }
+
+    /// Issue #1243 — drive the reconnect tracker from a replica health
+    /// state string. Production code reaches this through the replica
+    /// loop's health-persist chokepoint; exposed on the runtime so an
+    /// integration test can drive a deterministic link drop/restore
+    /// without standing up a full gRPC link on a memory-constrained host.
+    pub fn observe_replica_link_state(&self, state: &str) {
+        self.inner.replica_link_metrics.observe_state(state);
+    }
+
     pub fn enforce_primary_replica_retention_limits(
         &self,
     ) -> Vec<(String, reddb_file::ReplicationSlotInvalidationCause)> {

--- a/crates/reddb-server/src/server/handlers_admin_metrics.rs
+++ b/crates/reddb-server/src/server/handlers_admin_metrics.rs
@@ -551,6 +551,33 @@ impl RedDBServer {
             self.runtime.replication_partial_resync_count()
         );
 
+        // Issue #1243 (PRD #1237 Phase B) — primary↔replica reconnect
+        // counter. A reconnect is a link that was healthy, dropped, and
+        // recovered; the initial connect is not counted. The series is
+        // dimensioned by this node's own stable `replica_id` (a bounded
+        // identity, ADR 0060 §4) and never carries the primary's address,
+        // URL, or any credential (ADR 0060 §5). Resets to 0 on restart.
+        let replica_id = self.runtime.replication_replica_id();
+        let _ = writeln!(
+            body,
+            "# HELP reddb_replication_reconnects_total Primary<->replica link reconnects since process start (initial connect excluded)."
+        );
+        let _ = writeln!(body, "# TYPE reddb_replication_reconnects_total counter");
+        if replica_id.is_empty() {
+            let _ = writeln!(
+                body,
+                "reddb_replication_reconnects_total {}",
+                self.runtime.replication_reconnects_count()
+            );
+        } else {
+            let _ = writeln!(
+                body,
+                "reddb_replication_reconnects_total{{replica_id=\"{}\"}} {}",
+                sanitize_label(&replica_id),
+                self.runtime.replication_reconnects_count()
+            );
+        }
+
         // PLAN.md Phase 11.5 — replica apply error counters and
         // current health label. Counters are global across the
         // instance lifetime; the health label reflects whatever the

--- a/crates/reddb-server/src/server/handlers_admin_status.rs
+++ b/crates/reddb-server/src/server/handlers_admin_status.rs
@@ -147,6 +147,14 @@ impl RedDBServer {
             errors_obj.insert(kind.label().to_string(), JsonValue::Number(count as f64));
         }
         replica_obj.insert("apply_errors".to_string(), JsonValue::Object(errors_obj));
+        // Issue #1243 (PRD #1237 Phase B) — primary<->replica reconnects
+        // since process start, fed to the red-ui status read model so it
+        // can explain link instability instead of a last-error snapshot.
+        // Privacy: a count only, never the primary's address (ADR 0060 §5).
+        replica_obj.insert(
+            "reconnects_total".to_string(),
+            JsonValue::Number(self.runtime.replication_reconnects_count() as f64),
+        );
 
         // Per-replica array (primary view). Empty on replica/standalone.
         let snaps = self.runtime.primary_replica_snapshots();
@@ -431,6 +439,7 @@ impl RedDBServer {
                 replicas,
                 apply_health: self.runtime.replica_apply_health(),
                 apply_errors,
+                reconnects_total: self.runtime.replication_reconnects_count(),
             },
             latency,
         };

--- a/crates/reddb-server/tests/replication_reconnect_telemetry.rs
+++ b/crates/reddb-server/tests/replication_reconnect_telemetry.rs
@@ -1,0 +1,151 @@
+//! Issue #1243 (PRD #1237 Phase B) — primary↔replica reconnect telemetry.
+//!
+//! A replica's pull loop persists `connecting` when the link to its primary
+//! drops and `healthy` when a pull succeeds again. Those transitions flow
+//! through the runtime's reconnect tracker, which the `/metrics` endpoint
+//! exports as `reddb_replication_reconnects_total` and the status read
+//! model surfaces for red-ui.
+//!
+//! Standing up two real gRPC nodes and tearing down a live TCP link mid-pull
+//! would be slow and flaky on the memory-constrained drain host, so this
+//! test drives the *exact* production signal the loop emits — the persisted
+//! link-state transitions — through the runtime's public observe seam, then
+//! asserts the counter end-to-end over the real `/metrics` HTTP surface.
+
+use std::io::{Read, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+use reddb_server::{RedDBOptions, RedDBRuntime, RedDBServer};
+
+struct HttpReply {
+    status: u16,
+    body: String,
+}
+
+fn http_get(addr: SocketAddr, path: &str) -> HttpReply {
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    let mut stream = TcpStream::connect(addr).expect("connect");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .unwrap();
+    stream.write_all(request.as_bytes()).expect("write request");
+    stream.shutdown(Shutdown::Write).expect("shutdown write");
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).expect("read response");
+    let split = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("http framing");
+    let head = String::from_utf8_lossy(&raw[..split]);
+    let status: u16 = head
+        .lines()
+        .next()
+        .and_then(|l| l.split_whitespace().nth(1))
+        .and_then(|s| s.parse().ok())
+        .expect("status");
+    let body = String::from_utf8_lossy(&raw[split + 4..]).to_string();
+    HttpReply { status, body }
+}
+
+/// Pull the integer value of `reddb_replication_reconnects_total` out of an
+/// OpenMetrics body, tolerating the optional `{replica_id="…"}` label.
+fn reconnects_total(body: &str) -> u64 {
+    for line in body.lines() {
+        if line.starts_with('#') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("reddb_replication_reconnects_total") {
+            // `rest` is either ` <n>` or `{labels} <n>`.
+            let value = rest.rsplit(' ').next().expect("metric value");
+            return value.trim().parse().expect("counter value parses");
+        }
+    }
+    panic!("reddb_replication_reconnects_total not found in /metrics body:\n{body}");
+}
+
+/// Scrape `/metrics` over HTTP, assert a 200, and return the current value of
+/// `reddb_replication_reconnects_total`.
+fn scrape_reconnects(addr: SocketAddr) -> u64 {
+    let reply = http_get(addr, "/metrics");
+    assert_eq!(reply.status, 200, "/metrics must answer 200");
+    reconnects_total(&reply.body)
+}
+
+#[test]
+fn reconnect_counter_increments_once_per_link_drop_and_restore() {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    // The runtime is `Clone` (Arc inner); keep a handle to drive link-state
+    // transitions while the server clone serves `/metrics`.
+    let handle = runtime.clone();
+    let server = RedDBServer::new(runtime);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback");
+    let addr = listener.local_addr().expect("server addr");
+    let _join = server.serve_in_background_on(listener);
+
+    // Give the background edge a moment to start accepting connections.
+    let metrics = poll_metrics(addr);
+    assert_eq!(
+        reconnects_total(&metrics),
+        0,
+        "counter starts at zero before any link activity"
+    );
+
+    // Initial connect — `connecting` then `healthy`. This is the first time
+    // the link comes up; it must NOT count as a reconnect.
+    handle.observe_replica_link_state("connecting");
+    handle.observe_replica_link_state("healthy");
+    assert_eq!(
+        scrape_reconnects(addr),
+        0,
+        "the initial connect is not a reconnect"
+    );
+
+    // Drop the link (a failed pull falls back to `connecting`) and restore
+    // it (`healthy`). That is one reconnect.
+    handle.observe_replica_link_state("connecting");
+    handle.observe_replica_link_state("healthy");
+    assert_eq!(
+        scrape_reconnects(addr),
+        1,
+        "one drop+restore increments the counter exactly once"
+    );
+
+    // A multi-poll outage persists `connecting` several times but is still a
+    // single reconnect when the link recovers.
+    handle.observe_replica_link_state("connecting");
+    handle.observe_replica_link_state("connecting");
+    handle.observe_replica_link_state("healthy");
+    assert_eq!(
+        scrape_reconnects(addr),
+        2,
+        "a multi-poll outage counts once, not once per failed poll"
+    );
+
+    // The runtime accessor agrees with the exported series.
+    assert_eq!(handle.replication_reconnects_count(), 2);
+}
+
+/// The edge thread builds its own tokio runtime before it can accept; retry
+/// the first scrape briefly so the test is not racy on a loaded host.
+fn poll_metrics(addr: SocketAddr) -> String {
+    for _ in 0..50 {
+        if let Ok(mut stream) = TcpStream::connect(addr) {
+            let request = "GET /metrics HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n";
+            if stream.write_all(request.as_bytes()).is_ok() {
+                let _ = stream.shutdown(Shutdown::Write);
+                let mut raw = Vec::new();
+                if stream.read_to_end(&mut raw).is_ok() && !raw.is_empty() {
+                    let text = String::from_utf8_lossy(&raw);
+                    if let Some(idx) = text.find("\r\n\r\n") {
+                        return text[idx + 4..].to_string();
+                    }
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    panic!("server did not serve /metrics within the poll window");
+}

--- a/docs/spec/metrics.md
+++ b/docs/spec/metrics.md
@@ -56,6 +56,7 @@ Per-replica metrics on the primary; absent on replicas / standalone. Replicas re
 | `reddb_slo_lag_budget_remaining_seconds` | gauge | `replica_id` | `RED_SLO_REPLICA_LAG_BUDGET_SECONDS` (default 60) minus `reddb_replica_lag_seconds`; negative means SLO breach. |
 | `reddb_replica_apply_errors_total` | counter | `kind` | `gap|divergence|apply|decode`. **`divergence > 0` = page operator immediately**. |
 | `reddb_replica_apply_health` | gauge (label-only) | `state` | Current apply state (`ok|healthy|connecting|stalled_gap|divergence|apply_error`). |
+| `reddb_replication_reconnects_total` | counter | `replica_id` (this node, when assigned) | Primary↔replica link reconnects since process start — a link that was healthy, dropped, and recovered. The initial connect is **not** counted; a multi-poll outage counts once. Emitted on the replica side; `0` where the replica loop never ran. Carries only the node's own `replica_id`, never the primary address or any credential. Issue #1243 (PRD #1237 Phase B). |
 | `reddb_primary_commit_policy` | gauge (label-only) | `policy` | `local|remote_wal|ack_n|quorum`. |
 | `reddb_commit_wait_total` | counter | `outcome` | `reached|timed_out|not_required`. |
 | `reddb_commit_wait_last_seconds` | gauge | — | Wall-clock seconds of the most recent commit wait. |
@@ -84,6 +85,24 @@ Tune to your SLA; these are starting points used by `red doctor` defaults:
 | `reddb_commit_wait_total{outcome="timed_out"} rising` | 10/min | 100/min | `ack_n` policy too tight or replicas can't keep up. |
 | `reddb_quota_rejected_total{principal=...} sustained` | 10/min | 100/min | Caller exceeded budget. |
 | `reddb_cold_start_duration_seconds > 2.0` | 1 occurrence | 3 occurrences | Cold start past target. |
+
+## Reset / restart behavior
+
+All `*_total` counters above are **process-lifetime, in-memory** values: they
+start at `0` on boot and are not persisted across restarts. A process restart
+resets them to `0`. Prometheus detects this via the process-start timestamp and
+keeps `rate()` / `increase()` correct across the gap, so dashboards should use
+those functions rather than reading raw counter deltas across a restart.
+
+`reddb_replication_reconnects_total` follows this rule specifically: a restarted
+replica re-establishes its link to the primary, but that first post-restart
+connect is the *initial* connect for the new process and is **not** counted as a
+reconnect. The same reconnect count is mirrored, un-reset, in the replica
+status read model (`replication.reconnects_total` in `/cluster/status`), which
+red-ui reads; it too is process-scoped and resets on restart. There is no
+durable event log of individual reconnects in this slice — only the live
+counter and snapshot; durable reconnect *events* land if/when the operational
+telemetry event store (ADR 0060) is implemented.
 
 ## Stability promise
 


### PR DESCRIPTION
Automated AFK landing for #1243. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1243

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784984357&installation_id=129708444&pr_number=1388&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1388&signature=e6612fb3831b27af79bd7590efa530049229fb844aeafc7a7bb2d016a7c0a96e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->