### PR TITLE
fix(tests): eliminate TMPDIR leaks — Test Suite leak-guard green

### DIFF
--- a/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
+++ b/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
@@ -38,29 +38,21 @@ fn l2_cache(path: &Path) -> BlobCache {
 
 fn remove_l2(path: &Path) {
     // Remove the L2 `.rdb` AND every sidecar so nothing is left for the leak
-    // guard (scripts/check-temp-residue.sh). Match on the STEM (filename minus
-    // the `.rdb` extension): the control sidecar replaces the extension
-    // (`...rdb` → `...blob-cache.ctl`), so a full-name prefix match (which
-    // includes `.rdb`) would miss it; the pager sidecars (`.rdb-hdr`,
-    // `.rdb-dwb`) append to the full name and are still covered. The L2 stem
-    // (`reddb-blob-cache-<name>-<pid>-<nanos>`) is unique per file, so a stem
-    // prefix never clobbers a sibling.
-    if let (Some(dir), Some(name)) = (
-        path.parent(),
-        path.file_name().and_then(|name| name.to_str()),
-    ) {
-        let stem = name.strip_suffix(".rdb").unwrap_or(name);
-        if let Ok(entries) = std::fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                if entry
-                    .file_name()
-                    .to_str()
-                    .is_some_and(|entry_name| entry_name.starts_with(stem))
-                {
-                    let _ = std::fs::remove_file(entry.path());
-                }
-            }
-        }
+    // guard (scripts/check-temp-residue.sh). The blob-cache L2 file format is
+    // owned by reddb-file, so derive each sidecar path through its authoritative
+    // helpers rather than re-declaring suffix literals here (enforced by
+    // reddb-file's `server_does_not_redeclare_blob_cache_l2_file_format`).
+    let control = reddb_file::blob_cache_control_path(path);
+    for sidecar in [
+        path.to_path_buf(),
+        reddb_file::layout::pager_header_path(path),
+        reddb_file::layout::pager_meta_path(path),
+        reddb_file::layout::pager_dwb_path(path),
+        reddb_file::blob_cache_double_write_path(path),
+        reddb_file::blob_cache_control_temp_path(&control),
+        control,
+    ] {
+        let _ = std::fs::remove_file(sidecar);
     }
 }
 
@@ -1103,12 +1095,10 @@ fn blob_cache_is_send_and_sync_across_thread_boundary() {
 // -- Async promotion wiring (issue #193, lane 1/5) ----------------------
 
 fn cleanup_l2(path: &Path) {
-    // Prefix-remove the L2 `.rdb` AND every sidecar (`.rdb-hdr`, `.rdb-dwb`,
-    // control, …). The previous fixed-suffix removal missed the pager header
-    // (`.rdb-hdr`) the async tests leave behind, which the leak guard
-    // (scripts/check-temp-residue.sh) flags. Callers must drop the cache
-    // BEFORE calling this so the pager's drop-time flush cannot re-create a
-    // sidecar after removal.
+    // Remove the L2 `.rdb` and every sidecar via the authoritative reddb-file
+    // path helpers (see `remove_l2`). Callers must drop the cache BEFORE calling
+    // this so the pager's drop-time flush cannot re-create a sidecar after
+    // removal.
     remove_l2(path);
 }
 

--- a/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
+++ b/crates/reddb-server/src/storage/cache/blob/cache/tests.rs
@@ -37,20 +37,25 @@ fn l2_cache(path: &Path) -> BlobCache {
 }
 
 fn remove_l2(path: &Path) {
-    // Remove the L2 `.rdb` AND every sidecar (control, control-temp,
-    // double-write, synopsis, …) so nothing is left for the leak guard
-    // (scripts/check-temp-residue.sh) — the per-sidecar removals missed the
-    // control-temp file written by the synopsis tests.
+    // Remove the L2 `.rdb` AND every sidecar so nothing is left for the leak
+    // guard (scripts/check-temp-residue.sh). Match on the STEM (filename minus
+    // the `.rdb` extension): the control sidecar replaces the extension
+    // (`...rdb` → `...blob-cache.ctl`), so a full-name prefix match (which
+    // includes `.rdb`) would miss it; the pager sidecars (`.rdb-hdr`,
+    // `.rdb-dwb`) append to the full name and are still covered. The L2 stem
+    // (`reddb-blob-cache-<name>-<pid>-<nanos>`) is unique per file, so a stem
+    // prefix never clobbers a sibling.
     if let (Some(dir), Some(name)) = (
         path.parent(),
         path.file_name().and_then(|name| name.to_str()),
     ) {
+        let stem = name.strip_suffix(".rdb").unwrap_or(name);
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 if entry
                     .file_name()
                     .to_str()
-                    .is_some_and(|entry_name| entry_name.starts_with(name))
+                    .is_some_and(|entry_name| entry_name.starts_with(stem))
                 {
                     let _ = std::fs::remove_file(entry.path());
                 }
@@ -692,6 +697,7 @@ fn l2_rejects_put_when_hard_byte_cap_is_exceeded() {
         .expect_err("L2 cap rejects");
     assert_eq!(err, CacheError::L2Full { size: 3, max: 2 });
     assert_eq!(cache.stats().l2_full_rejections, 1);
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -726,6 +732,7 @@ fn l2_synopsis_negative_skip_avoids_metadata_read() {
     assert_eq!(stats.l2_negative_skips, 1);
     assert_eq!(stats.l2_metadata_reads, 0);
 
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -740,6 +747,7 @@ fn l2_synopsis_maybe_present_verifies_authoritative_metadata() {
     assert_eq!(stats.l2_negative_skips, 0);
     assert_eq!(stats.l2_metadata_reads, 1);
 
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -767,6 +775,7 @@ fn stale_synopsis_bits_after_delete_cannot_produce_present() {
     assert_eq!(stats.l2_metadata_reads, 1);
     assert_eq!(stats.synopsis_metadata_reads, 1);
 
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -799,6 +808,7 @@ fn stale_synopsis_bits_after_expiry_cannot_produce_present() {
     assert_eq!(stats.l2_metadata_reads, 1);
     assert_eq!(stats.l2_bytes_in_use, 0);
 
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -856,6 +866,7 @@ fn deleted_l2_entries_never_return_present_under_repeated_stale_synopsis() {
     // metadata and finds nothing; that's the false-positive cost. Filter
     // sizing (10K capacity / 1% FPR) means most lookups hit fast.
     assert_eq!(cache.stats().l2_metadata_reads, 1_000);
+    drop(cache);
     remove_l2(&path);
 }
 
@@ -1092,9 +1103,13 @@ fn blob_cache_is_send_and_sync_across_thread_boundary() {
 // -- Async promotion wiring (issue #193, lane 1/5) ----------------------
 
 fn cleanup_l2(path: &Path) {
-    let _ = std::fs::remove_file(path);
-    let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-    let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+    // Prefix-remove the L2 `.rdb` AND every sidecar (`.rdb-hdr`, `.rdb-dwb`,
+    // control, …). The previous fixed-suffix removal missed the pager header
+    // (`.rdb-hdr`) the async tests leave behind, which the leak guard
+    // (scripts/check-temp-residue.sh) flags. Callers must drop the cache
+    // BEFORE calling this so the pager's drop-time flush cannot re-create a
+    // sidecar after removal.
+    remove_l2(path);
 }
 
 /// Slow executor that sleeps `delay` then increments a counter.
@@ -1160,6 +1175,7 @@ async fn l2_hit_with_async_on_returns_immediately() {
     assert!(executed.load(Ordering::Relaxed) >= 1, "worker did not run");
 
     cache.shutdown_async_promotion();
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1197,6 +1213,7 @@ async fn l2_hit_with_async_off_uses_legacy_sync_path() {
     assert_eq!(s.promotion_dropped(), 0);
     assert_eq!(s.promotion_queue_depth(), 0);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1247,6 +1264,7 @@ async fn drop_on_saturation_never_loses_correctness() {
     );
 
     cache.shutdown_async_promotion();
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1298,6 +1316,7 @@ async fn shutdown_drains_pool_within_budget() {
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1413,6 +1432,7 @@ fn l2_round_trip_compresses_text_payload_and_returns_original_bytes() {
     assert!(stats.l2_compression_ratio_observed() > 1.0);
     assert!(stats.l2_bytes_saved_total() > 0);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1442,6 +1462,7 @@ fn l2_round_trip_with_compression_off_stores_raw_bytes() {
     assert_eq!(stats.l2_bytes_saved_total(), 0);
     assert_eq!(stats.l2_compression_ratio_observed(), 1.0);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1472,6 +1493,7 @@ fn l2_round_trip_with_image_content_type_stores_raw() {
     assert_eq!(stats.l2_compression_skipped_total(), 1);
     assert_eq!(stats.l2_bytes_saved_total(), 0);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1499,6 +1521,7 @@ fn l2_round_trip_with_high_entropy_payload_falls_back_to_raw_via_ratio_gate() {
     assert_eq!(stats.l2_bytes_in_use, payload.len() as u64);
     assert_eq!(stats.l2_compression_skipped_total(), 1);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1517,6 +1540,7 @@ fn l2_forward_compat_reads_legacy_v1_entry_written_before_compression() {
     let hit = cache.get("n", "legacy").expect("L2 hit");
     assert_eq!(&*hit.bytes, &payload[..]);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1565,6 +1589,7 @@ fn l2_budget_amplifies_when_entries_compress() {
     // Sanity: would have blown past the budget at raw sizing.
     assert!(stats.l2_bytes_in_use < raw_total / 2);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 
@@ -1607,6 +1632,7 @@ fn l2_compression_metrics_partition_compressible_and_skipped_entries() {
     );
     assert!(stats.l2_bytes_saved_total() > 0);
 
+    drop(cache);
     cleanup_l2(&path);
 }
 

--- a/crates/reddb-server/src/storage/cache/blob/l2.rs
+++ b/crates/reddb-server/src/storage/cache/blob/l2.rs
@@ -687,32 +687,24 @@ mod tests {
     }
 
     fn cleanup_l2(path: &Path) {
-        // Prefix-remove the L2 `.rdb` AND every sidecar (`.rdb-hdr`, `.rdb-dwb`,
-        // `.blob-cache.ctl`, …). The previous fixed-suffix removal missed the
-        // pager header (`.rdb-hdr`) the L2 store leaves behind, which the leak
-        // guard (scripts/check-temp-residue.sh) flags. Match on the STEM
-        // (filename minus the `.rdb` extension) so the control sidecar — which
-        // replaces the extension (`...rdb` → `...blob-cache.ctl`) — is covered
-        // alongside the dash-suffix pager sidecars. The L2 stem is unique per
-        // file, so a stem prefix never clobbers a sibling. Callers must drop the
-        // cache BEFORE calling this so the pager's drop-time flush cannot
-        // re-create a sidecar after removal.
-        if let (Some(dir), Some(name)) = (
-            path.parent(),
-            path.file_name().and_then(|name| name.to_str()),
-        ) {
-            let stem = name.strip_suffix(".rdb").unwrap_or(name);
-            if let Ok(entries) = std::fs::read_dir(dir) {
-                for entry in entries.flatten() {
-                    if entry
-                        .file_name()
-                        .to_str()
-                        .is_some_and(|entry_name| entry_name.starts_with(stem))
-                    {
-                        let _ = std::fs::remove_file(entry.path());
-                    }
-                }
-            }
+        // Remove the L2 `.rdb` AND every sidecar so nothing is left for the leak
+        // guard (scripts/check-temp-residue.sh). The blob-cache L2 file format is
+        // owned by reddb-file, so derive each sidecar path through its
+        // authoritative helpers rather than re-declaring suffix literals here
+        // (enforced by `server_does_not_redeclare_blob_cache_l2_file_format`).
+        // Callers must drop the cache BEFORE calling this so the pager's
+        // drop-time flush cannot re-create a sidecar after removal.
+        let control = reddb_file::blob_cache_control_path(path);
+        for sidecar in [
+            path.to_path_buf(),
+            reddb_file::layout::pager_header_path(path),
+            reddb_file::layout::pager_meta_path(path),
+            reddb_file::layout::pager_dwb_path(path),
+            reddb_file::blob_cache_double_write_path(path),
+            reddb_file::blob_cache_control_temp_path(&control),
+            control,
+        ] {
+            let _ = std::fs::remove_file(sidecar);
         }
     }
 

--- a/crates/reddb-server/src/storage/cache/blob/l2.rs
+++ b/crates/reddb-server/src/storage/cache/blob/l2.rs
@@ -687,9 +687,33 @@ mod tests {
     }
 
     fn cleanup_l2(path: &Path) {
-        let _ = std::fs::remove_file(path);
-        let _ = std::fs::remove_file(reddb_file::blob_cache_control_path(&path));
-        let _ = std::fs::remove_file(reddb_file::blob_cache_double_write_path(path));
+        // Prefix-remove the L2 `.rdb` AND every sidecar (`.rdb-hdr`, `.rdb-dwb`,
+        // `.blob-cache.ctl`, …). The previous fixed-suffix removal missed the
+        // pager header (`.rdb-hdr`) the L2 store leaves behind, which the leak
+        // guard (scripts/check-temp-residue.sh) flags. Match on the STEM
+        // (filename minus the `.rdb` extension) so the control sidecar — which
+        // replaces the extension (`...rdb` → `...blob-cache.ctl`) — is covered
+        // alongside the dash-suffix pager sidecars. The L2 stem is unique per
+        // file, so a stem prefix never clobbers a sibling. Callers must drop the
+        // cache BEFORE calling this so the pager's drop-time flush cannot
+        // re-create a sidecar after removal.
+        if let (Some(dir), Some(name)) = (
+            path.parent(),
+            path.file_name().and_then(|name| name.to_str()),
+        ) {
+            let stem = name.strip_suffix(".rdb").unwrap_or(name);
+            if let Ok(entries) = std::fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|entry_name| entry_name.starts_with(stem))
+                    {
+                        let _ = std::fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
     }
 
     fn l2_cache(path: &Path) -> BlobCache {
@@ -866,6 +890,7 @@ mod tests {
             "rebuilt filter FPR {observed_fpr:.4} exceeded target+tolerance"
         );
 
+        drop(cache);
         cleanup_l2(&path);
     }
 
@@ -898,6 +923,7 @@ mod tests {
         assert!(stats.l2_compression_ratio_observed() > 1.0);
         assert!(stats.l2_bytes_saved_total() > 0);
 
+        drop(cache);
         cleanup_l2(&path);
     }
 
@@ -925,6 +951,7 @@ mod tests {
         assert_eq!(stats.l2_bytes_saved_total(), 0);
         assert_eq!(stats.l2_compression_ratio_observed(), 1.0);
 
+        drop(cache);
         cleanup_l2(&path);
     }
 
@@ -953,6 +980,7 @@ mod tests {
         assert_eq!(stats.l2_compression_skipped_total(), 1);
         assert_eq!(stats.l2_bytes_saved_total(), 0);
 
+        drop(cache);
         cleanup_l2(&path);
     }
 
@@ -978,6 +1006,7 @@ mod tests {
         assert_eq!(stats.l2_bytes_in_use, payload.len() as u64);
         assert_eq!(stats.l2_compression_skipped_total(), 1);
 
+        drop(cache);
         cleanup_l2(&path);
     }
 }

--- a/crates/reddb-server/src/storage/engine/btree.rs
+++ b/crates/reddb-server/src/storage/engine/btree.rs
@@ -1406,6 +1406,17 @@ mod tests {
                     expected.into_iter().collect();
                 prop_assert_eq!(&candidate_contents, &expected_contents);
 
+                // Drop the trees and pagers BEFORE cleanup. The pager flushes
+                // its header (`.db-hdr`) on drop, so cleaning up while an
+                // `Arc<Pager>` is still alive lets the final drop re-create the
+                // sidecar AFTER removal — exactly the leak the guard
+                // (scripts/check-temp-residue.sh) flags (128 `.db-hdr` files,
+                // one per tree per proptest case). Explicit drops make cleanup
+                // the last thing to touch these paths.
+                drop(baseline);
+                drop(candidate);
+                drop(_baseline_pager);
+                drop(_candidate_pager);
                 cleanup(&baseline_path);
                 cleanup(&candidate_path);
             }

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -239,34 +239,16 @@ mod tests {
     }
 
     fn cleanup(path: &Path) {
-        // Prefix-remove the `.db` AND every sidecar the pager writes next to it
-        // (`.db-hdr`, `.rdb-hdr`, `.rdb-dwb`, …). The previous fixed-suffix
-        // removal only cleared the three dash-suffix shadows and missed the
-        // extension-replaced sidecars (`.rdb-hdr`/`.rdb-dwb`), which the leak
-        // guard (scripts/check-temp-residue.sh) flags. Tests must drop the
-        // pager BEFORE calling this so the drop-time flush cannot re-create a
-        // sidecar after removal (every call site already uses an inner block).
-        if let (Some(dir), Some(name)) = (
-            path.parent(),
-            path.file_name().and_then(|name| name.to_str()),
-        ) {
-            // Match on the stem (filename without the `.db` extension) so both
-            // dash-suffix (`foo.db-hdr`) and extension-replaced
-            // (`foo.rdb-hdr`) sidecars are covered. Require the next byte after
-            // the stem to be a separator (`.` or `-`) so a numeric-suffixed
-            // sibling (`reddb_test_5_1` vs `reddb_test_5_10`) is never clobbered.
-            let stem = name.strip_suffix(".db").unwrap_or(name);
-            if let Ok(entries) = fs::read_dir(dir) {
-                for entry in entries.flatten() {
-                    if entry.file_name().to_str().is_some_and(|entry_name| {
-                        entry_name
-                            .strip_prefix(stem)
-                            .is_some_and(|rest| rest.is_empty() || rest.starts_with(['.', '-']))
-                    }) {
-                        let _ = fs::remove_file(entry.path());
-                    }
-                }
-            }
+        // Remove the data file AND every pager shadow sidecar via reddb-file's
+        // authoritative path helpers (the pager writes only these three shadows
+        // next to the data file). Deriving the paths through reddb-file keeps the
+        // file-suffix contract out of the server source (enforced by reddb-file's
+        // `server_source_does_not_embed_owned_file_suffixes`). Tests drop the
+        // pager BEFORE calling this (every call site uses an inner block) so the
+        // drop-time flush cannot re-create a sidecar after removal.
+        let _ = fs::remove_file(path);
+        for sidecar in reddb_file::layout::pager_shadow_sidecar_paths(path) {
+            let _ = fs::remove_file(sidecar);
         }
     }
 

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -239,11 +239,35 @@ mod tests {
     }
 
     fn cleanup(path: &Path) {
-        let _ = fs::remove_file(path);
-        // Clean up companion files
-        let _ = fs::remove_file(reddb_file::layout::pager_header_shadow_path(path));
-        let _ = fs::remove_file(reddb_file::layout::pager_meta_shadow_path(path));
-        let _ = fs::remove_file(reddb_file::layout::pager_dwb_shadow_path(path));
+        // Prefix-remove the `.db` AND every sidecar the pager writes next to it
+        // (`.db-hdr`, `.rdb-hdr`, `.rdb-dwb`, …). The previous fixed-suffix
+        // removal only cleared the three dash-suffix shadows and missed the
+        // extension-replaced sidecars (`.rdb-hdr`/`.rdb-dwb`), which the leak
+        // guard (scripts/check-temp-residue.sh) flags. Tests must drop the
+        // pager BEFORE calling this so the drop-time flush cannot re-create a
+        // sidecar after removal (every call site already uses an inner block).
+        if let (Some(dir), Some(name)) = (
+            path.parent(),
+            path.file_name().and_then(|name| name.to_str()),
+        ) {
+            // Match on the stem (filename without the `.db` extension) so both
+            // dash-suffix (`foo.db-hdr`) and extension-replaced
+            // (`foo.rdb-hdr`) sidecars are covered. Require the next byte after
+            // the stem to be a separator (`.` or `-`) so a numeric-suffixed
+            // sibling (`reddb_test_5_1` vs `reddb_test_5_10`) is never clobbered.
+            let stem = name.strip_suffix(".db").unwrap_or(name);
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    if entry.file_name().to_str().is_some_and(|entry_name| {
+                        entry_name
+                            .strip_prefix(stem)
+                            .is_some_and(|rest| rest.is_empty() || rest.starts_with(['.', '-']))
+                    }) {
+                        let _ = fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
     }
 
     fn dwb_path_for(path: &Path) -> PathBuf {


### PR DESCRIPTION
## Problem
The CI `Test Suite` job ends with `scripts/check-temp-residue.sh`, which fails (exit 1) if any `reddb-*`/`reddb_*`/`*.rdb`/`*.wal` residue survives the nextest run in `$TMPDIR`. It was reliably **red**, so every merge needed a `gh api DELETE` of the required `Test Suite` context (the "lift-protection dance"). This PR makes the guard genuinely green.

## Reproduced leak (RED)
Running the suspect lib-test binaries under an isolated `TMPDIR` then the guard:
- **btree** `storage::engine::btree::tests`: **128** `reddb_btree_test_*.db-hdr` files (64 proptest cases × 2 trees).
- **blob cache** `storage::cache::blob::cache::tests`: `.rdb-hdr`, `.rdb-dwb`, `.blob-cache.ctl` sidecars.
- **blob L2** `storage::cache::blob::l2::tests`: same `.rdb-hdr` + `.blob-cache.ctl`.

## Root cause
Drop-order race. Test helpers (`populate_tree`, the L2 cache builders) returned a `BTree`/`BlobCache` (each holding an `Arc<Pager>`) that **outlived** the explicit `cleanup`/`remove_l2` call. The pager flushes its header (`.rdb-hdr`/`.db-hdr`) and double-write buffer on `Drop`, so when the last `Arc<Pager>` dropped at end of scope it **re-created the sidecar after** cleanup had already removed it. Separately, the cleanup helpers prefix-matched on the full filename **including the `.rdb` extension**, so the control sidecar — which *replaces* the extension (`...rdb` → `...blob-cache.ctl`) — was never matched.

## Fix (test-path hygiene only — no production flush/durability change)
- Drop the trees/pagers/caches **before** cleanup so the pager's drop-time flush happens first (executor closures hold only a `Weak<BlobCache>`, so dropping the last strong ref triggers the flush).
- Cleanup helpers now prefix-match on the file **stem** (name minus `.rdb`/`.db`) so the extension-replaced `.blob-cache.ctl` and the dash-suffix `.rdb-hdr`/`.rdb-dwb` are all swept. Stem matching requires a `.`/`-` separator (pager) or relies on the unique nanos suffix (blob) so a numeric-suffixed sibling is never clobbered.

## Verification (GREEN)
Each binary run under an isolated `TMPDIR` + `check-temp-residue.sh`:
- **115 tests pass** across btree + pager + blob::cache + blob::l2.
- Guard prints `OK — no reddb temp residue` (exit 0); TMPDIR empty.
- `cargo fmt` clean; `cargo clippy -p reddb-io-server --lib` clean.

The full suite OOMs this host, so the PR's own `Test Suite` CI run is the final verifier.

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784987067&installation_id=129708444&pr_number=1389&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1389&signature=6ecf50f7a660ea5c559a69560d74ea074ee2ead39abc4f9351cf3573c09d35fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file cleanup so cache and pager-related side files are removed more reliably.
  * Updated test teardown to ensure resources are released before cleanup runs, preventing leftover artifacts and leak-check failures.
  * Strengthened cleanup behavior for temporary database files by removing all matching sidecar files, including previously missed ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->