### PR TITLE
ci(afk): install RedSkills AFK Actions lane (dispatch-only)

### DIFF
--- a/.github/workflows/rs-afk-attempt.yml
+++ b/.github/workflows/rs-afk-attempt.yml
@@ -1,0 +1,50 @@
+# rs-afk-attempt — reddb's caller for the RedSkills AFK Actions lane (ADR 0059/0062).
+#
+# Runs ONE attempt per dispatch against an executable ready-for-agent issue —
+# no fleet, no admin-merge in CI. The PR is the deliverable; the merge decision
+# stays human. Delegates triggers + trust gate to the published reusable.
+#
+# Auth: org-level secrets are inherited (`secrets: inherit`); the reusable picks
+# up MINIMAX_API_KEY (case-insensitive match to its `minimax_api_key` input).
+#
+# Dispatch-only by design: the reusable's `issues: labeled` auto-trigger is off
+# upstream, so issues are processed via the Actions UI or:
+#   gh workflow run rs-afk-attempt.yml -f issue_number=1245
+
+name: rs-afk-attempt
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to process. Leave EMPTY to auto-pick the oldest open ready-for-agent issue."
+        required: false
+        type: string
+        default: ""
+      runner:
+        description: "AFK runner to drive (claude|codex|opencode)."
+        required: false
+        type: string
+        default: "opencode"
+      model:
+        description: "Model override for every tier (e.g. minimax/MiniMax-M3). Empty = config."
+        required: false
+        type: string
+        default: "minimax/MiniMax-M3"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  attempt:
+    uses: reddb-io/red-skills/.github/workflows/reusable-afk-attempt.yml@v1
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      runner: ${{ inputs.runner }}
+      model: ${{ inputs.model }}
+      enforce_trust_gate: "true"
+      allowlist_authors: "filipeforattini"
+      allowlist_label_actors: "filipeforattini"
+    secrets: inherit


### PR DESCRIPTION
Installs the RedSkills **AFK Actions lane** (ADR 0059/0062) in reddb as a thin caller for the published reusable `reddb-io/red-skills/.github/workflows/reusable-afk-attempt.yml@v1`.

## What it does
- **One attempt per dispatch** against an executable `ready-for-agent` issue — no fleet, no admin-merge in CI. The **PR is the deliverable**; the merge decision stays human.
- Runs on a GitHub-hosted runner, so it does **not** contend with the local cargo-guard / OOM constraints — good for parallelizing the backlog off-host.

## Auth
- Inherits org-level secrets via `secrets: inherit`; the reusable matches `MINIMAX_API_KEY` (case-insensitive) to its `minimax_api_key` input.
- Trust gate on (ADR 0056): author **and** label-actor must be allowlisted (`filipeforattini`).

## Trigger
- **Dispatch-only** — the reusable removed the `issues: labeled` auto-trigger upstream (was failing auth on every label). Run via the Actions UI or:
  `gh workflow run rs-afk-attempt.yml -f issue_number=1245`

## Verify
After merge: `gh workflow run rs-afk-attempt.yml` (empty input → auto-picks oldest open `ready-for-agent`) → expect one worker branch + PR, issue left `running` until the PR merges.

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784989897&installation_id=129708444&pr_number=1390&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1390&signature=949f4ebddb0b37a635ff08f64565af298df4fa34270a66eac73cd40b1877b8b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->