### PR TITLE
merge: #1312 feat(mcp): knowledge pipeline + generated RQL reference resource

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,10 @@ path = "src/lib.rs"
 workspace = true
 
 [[test]]
+name = "llms_txt_generated"
+path = "tests/llms_txt_generated.rs"
+
+[[test]]
 name = "grouped_ai_search"
 path = "tests/grouped/ai_search.rs"
 

--- a/crates/reddb-rql/src/knowledge.rs
+++ b/crates/reddb-rql/src/knowledge.rs
@@ -1,0 +1,429 @@
+//! Agent-facing RQL knowledge reference — generated from the engine's own
+//! authorities (ADR 0061, "Agent-Facing Knowledge & MCP Surface").
+//!
+//! The volatile facts about the RQL surface are emitted straight from the
+//! source of truth so the reference cannot drift from the engine:
+//!
+//! - the keyword vocabulary comes from the lexer ([`crate::lexer`]), the RQL
+//!   keyword authority, and
+//! - the built-in function catalog comes from
+//!   [`reddb_types::function_catalog`].
+//!
+//! Nothing in this module hand-maintains *which* keywords or functions exist —
+//! that is read from the catalogs above. The same generated content is served
+//! two ways from this one source: as the `reddb://knowledge/rql` MCP resource
+//! and as the RQL section of the generated `docs/llms.txt`. The anti-drift
+//! tests at the bottom pin the "generated, exhaustive, in-sync" contract.
+
+use reddb_types::function_catalog::{FunctionKind, FUNCTION_CATALOG};
+
+/// Canonical URI for the RQL knowledge resource served over MCP.
+pub const RESOURCE_URI: &str = "reddb://knowledge/rql";
+
+/// Short human title for the RQL knowledge resource.
+pub const RESOURCE_TITLE: &str = "RedDB RQL Reference";
+
+/// One-line description of the RQL knowledge resource.
+pub const RESOURCE_DESCRIPTION: &str =
+    "Generated RQL grammar reference: every keyword and built-in function the engine knows.";
+
+/// Markers delimiting the generated RQL block inside `docs/llms.txt`. The
+/// `docs/llms.txt` sync test reads the text between these markers and asserts
+/// it equals [`rql_reference_markdown`], so the file is generated, not
+/// hand-maintained.
+pub const LLMS_BEGIN_MARKER: &str = "<!-- BEGIN GENERATED: rql -->";
+/// Closing marker for the generated RQL block in `docs/llms.txt`.
+pub const LLMS_END_MARKER: &str = "<!-- END GENERATED: rql -->";
+
+/// Canonical RQL keyword catalog: every reserved word the lexer recognises as a
+/// dedicated token.
+///
+/// This list MUST mirror the keyword match in
+/// `crate::lexer::Lexer::scan_identifier`; the [`tests::keywords_are_recognised`]
+/// anti-drift test fails the build if any entry here is not actually a keyword.
+///
+/// The list-queue verbs (`LPUSH` / `RPUSH` / `LPOP` / `RPOP`) are intentionally
+/// excluded: the lexer maps them to `Token::Ident`, so they are operations
+/// resolved later, not reserved words.
+pub const KEYWORDS: &[&str] = &[
+    "ACK",
+    "ADD",
+    "ALGORITHM",
+    "ALL",
+    "ALTER",
+    "ANALYZE",
+    "AND",
+    "AS",
+    "ASC",
+    "ATTACH",
+    "AVG",
+    "BEGIN",
+    "BETWEEN",
+    "BY",
+    "CASCADE",
+    "CENTRALITY",
+    "CLUSTERING",
+    "COLLECTION",
+    "COLUMN",
+    "COMMIT",
+    "COMMUNITY",
+    "COMPONENTS",
+    "COMPRESS",
+    "CONTAINS",
+    "COPY",
+    "COSINE",
+    "COUNT",
+    "CREATE",
+    "CROSS",
+    "CURRENT",
+    "CYCLES",
+    "DATA",
+    "DEFAULT",
+    "DELETE",
+    "DELIMITER",
+    "DEPTH",
+    "DESC",
+    "DETACH",
+    "DIRECTION",
+    "DISABLE",
+    "DISTINCT",
+    "DOCUMENT",
+    "DROP",
+    "EDGE",
+    "ENABLE",
+    "ENDS",
+    "ENRICH",
+    "EXISTS",
+    "EXPLAIN",
+    "FALSE",
+    "FIRST",
+    "FOLLOWING",
+    "FOR",
+    "FOREIGN",
+    "FORMAT",
+    "FROM",
+    "FULL",
+    "FUSION",
+    "FUZZY",
+    "GAP",
+    "GRAPH",
+    "GROUP",
+    "HASH",
+    "HEADER",
+    "HYBRID",
+    "IF",
+    "IN",
+    "INCLUDE",
+    "INCREMENT",
+    "INDEX",
+    "INNER",
+    "INNERPRODUCT",
+    "INNER_PRODUCT",
+    "INSERT",
+    "INTERSECTION",
+    "INTO",
+    "IS",
+    "JOIN",
+    "JSON",
+    "K",
+    "KEY",
+    "KV",
+    "L2",
+    "LAST",
+    "LEFT",
+    "LEVEL",
+    "LIKE",
+    "LIMIT",
+    "LIST",
+    "MATCH",
+    "MATERIALIZED",
+    "MAX",
+    "MAXITERATIONS",
+    "MAXLENGTH",
+    "MAX_ITERATIONS",
+    "MAX_LENGTH",
+    "METADATA",
+    "METRIC",
+    "MIN",
+    "MINSCORE",
+    "MIN_SCORE",
+    "MODE",
+    "NACK",
+    "NEIGHBORHOOD",
+    "NODE",
+    "NOT",
+    "NULL",
+    "NULLS",
+    "OF",
+    "OFFSET",
+    "ON",
+    "OPTIONS",
+    "OR",
+    "ORDER",
+    "OUTER",
+    "OVER",
+    "PARTITION",
+    "PATH",
+    "PEEK",
+    "POLICY",
+    "POP",
+    "PRECEDING",
+    "PRIMARY",
+    "PRIORITY",
+    "PROPERTIES",
+    "PURGE",
+    "PUSH",
+    "QUEUE",
+    "RANGE",
+    "RECURSIVE",
+    "REFRESH",
+    "RELEASE",
+    "RENAME",
+    "RERANK",
+    "RETENTION",
+    "RETURN",
+    "RETURNING",
+    "RIGHT",
+    "ROLLBACK",
+    "ROW",
+    "ROWS",
+    "RRF",
+    "SAVEPOINT",
+    "SCHEMA",
+    "SEARCH",
+    "SECURITY",
+    "SELECT",
+    "SEQUENCE",
+    "SERVER",
+    "SESSIONIZE",
+    "SET",
+    "SHORTESTPATH",
+    "SHORTEST_PATH",
+    "SIMILAR",
+    "START",
+    "STARTS",
+    "STRATEGY",
+    "SUM",
+    "TABLE",
+    "TEXT",
+    "THRESHOLD",
+    "TIMESERIES",
+    "TO",
+    "TOPOLOGICALSORT",
+    "TOPOLOGICAL_SORT",
+    "TRANSACTION",
+    "TRAVERSE",
+    "TREE",
+    "TRUE",
+    "TRUNCATE",
+    "UNBOUNDED",
+    "UNION",
+    "UNIQUE",
+    "UPDATE",
+    "USING",
+    "VACUUM",
+    "VALUES",
+    "VECTOR",
+    "VECTORS",
+    "VIA",
+    "VIEW",
+    "WEIGHT",
+    "WHERE",
+    "WITH",
+    "WORK",
+    "WRAPPER",
+];
+
+/// Distinct built-in function names, sorted, taken from the engine's static
+/// [`FUNCTION_CATALOG`]. The catalog carries one row per overload, so a name
+/// (e.g. `COUNT`) can appear several times — this collapses them.
+pub fn function_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = FUNCTION_CATALOG.iter().map(|entry| entry.name).collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+/// Distinct function names of a single [`FunctionKind`], sorted. A name is
+/// classified by the kind of its first catalog row (overloads of one name share
+/// a kind in the engine's catalog).
+fn function_names_of_kind(kind: FunctionKind) -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = Vec::new();
+    for entry in FUNCTION_CATALOG {
+        if entry.kind == kind && !names.contains(&entry.name) {
+            // Only count a name under its first-seen kind so a name is never
+            // listed twice across kind sections.
+            let first_kind = FUNCTION_CATALOG
+                .iter()
+                .find(|candidate| candidate.name == entry.name)
+                .map(|first| first.kind);
+            if first_kind == Some(kind) {
+                names.push(entry.name);
+            }
+        }
+    }
+    names.sort_unstable();
+    names.dedup();
+    names
+}
+
+fn render_code_list(names: &[&str]) -> String {
+    names
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Generate the canonical RQL reference as Markdown, sourced entirely from the
+/// engine's keyword and function authorities. This single string is what the
+/// MCP `reddb://knowledge/rql` resource serves and what `docs/llms.txt` embeds.
+pub fn rql_reference_markdown() -> String {
+    let keywords = KEYWORDS;
+    let functions = function_names();
+
+    let mut out = String::new();
+    out.push_str("# RedDB RQL Reference\n\n");
+    out.push_str(
+        "RQL (RedDB Query Language) is RedDB's SQL-family query surface across its \
+multi-model store (documents, key-value, queues, graph, vault, config, and \
+RQL-tabular collections).\n\n",
+    );
+    out.push_str(
+        "This reference is generated from the `reddb-io-rql` lexer (keyword authority) \
+and the `reddb-io-types` function catalog. Do not edit by hand — regenerate from \
+the engine.\n\n",
+    );
+
+    out.push_str(&format!("## Keywords ({})\n\n", keywords.len()));
+    out.push_str(
+        "RQL recognises the following reserved keywords (case-insensitive at the \
+lexer):\n\n",
+    );
+    out.push_str(&render_code_list(keywords));
+    out.push_str("\n\n");
+
+    out.push_str(&format!("## Functions ({})\n\n", functions.len()));
+    out.push_str("RQL provides these built-in functions, grouped by kind:\n\n");
+
+    for (kind, title) in [
+        (FunctionKind::Aggregate, "Aggregate functions"),
+        (FunctionKind::Scalar, "Scalar functions"),
+        (FunctionKind::Window, "Window functions"),
+        (FunctionKind::Volatile, "Volatile functions"),
+    ] {
+        let names = function_names_of_kind(kind);
+        if names.is_empty() {
+            continue;
+        }
+        out.push_str(&format!("### {title}\n\n"));
+        out.push_str(&render_code_list(&names));
+        out.push_str("\n\n");
+    }
+
+    // Trim the trailing blank line so the body ends with exactly one newline.
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+    out
+}
+
+/// The RQL block as embedded in `docs/llms.txt`: the generated reference fenced
+/// by the begin/end markers. Emitting the markers here keeps `docs/llms.txt`
+/// and the MCP resource fed by one source.
+pub fn rql_llms_section() -> String {
+    format!(
+        "{begin}\n{body}\n{end}",
+        begin = LLMS_BEGIN_MARKER,
+        body = rql_reference_markdown(),
+        end = LLMS_END_MARKER,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::{Lexer, Token};
+
+    /// catalog ⊆ engine: every keyword we publish must really be recognised by
+    /// the lexer as a dedicated token (not fall through to a bare identifier).
+    #[test]
+    fn keywords_are_recognised() {
+        for &keyword in KEYWORDS {
+            let mut lexer = Lexer::new(keyword);
+            let spanned = lexer
+                .next_token()
+                .unwrap_or_else(|err| panic!("keyword {keyword:?} failed to lex: {err:?}"));
+            assert!(
+                !matches!(spanned.token, Token::Ident(_)),
+                "{keyword:?} is in the knowledge catalog but the lexer treats it as a \
+plain identifier — it is not a real RQL keyword"
+            );
+        }
+    }
+
+    /// The published keyword list is sorted and deduplicated, so the generated
+    /// reference is stable and reviewable.
+    #[test]
+    fn keyword_list_is_sorted_and_unique() {
+        let mut sorted = KEYWORDS.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(KEYWORDS.to_vec(), sorted, "KEYWORDS must be sorted");
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            KEYWORDS.len(),
+            "KEYWORDS must not contain duplicates"
+        );
+    }
+
+    /// A sanity guard that the recognised-keyword check has teeth: a word that
+    /// is not a keyword must lex to an identifier.
+    #[test]
+    fn non_keyword_lexes_as_identifier() {
+        let mut lexer = Lexer::new("not_a_keyword_xyzzy");
+        let spanned = lexer.next_token().expect("lex");
+        assert!(matches!(spanned.token, Token::Ident(_)));
+    }
+
+    /// engine ⊆ catalog (functions): every function the engine knows, from the
+    /// authoritative `FUNCTION_CATALOG`, appears in the generated reference.
+    #[test]
+    fn reference_lists_every_function() {
+        let reference = rql_reference_markdown();
+        for name in function_names() {
+            assert!(
+                reference.contains(&format!("`{name}`")),
+                "function {name:?} from FUNCTION_CATALOG is missing from the generated \
+RQL reference"
+            );
+        }
+    }
+
+    /// Every catalogued keyword appears in the generated reference too.
+    #[test]
+    fn reference_lists_every_keyword() {
+        let reference = rql_reference_markdown();
+        for &keyword in KEYWORDS {
+            assert!(
+                reference.contains(&format!("`{keyword}`")),
+                "keyword {keyword:?} is missing from the generated RQL reference"
+            );
+        }
+    }
+
+    /// The reference is deterministic (pure function of the catalogs).
+    #[test]
+    fn reference_is_deterministic() {
+        assert_eq!(rql_reference_markdown(), rql_reference_markdown());
+    }
+
+    /// The `docs/llms.txt` block wraps exactly the reference between markers.
+    #[test]
+    fn llms_section_wraps_reference() {
+        let section = rql_llms_section();
+        assert!(section.starts_with(LLMS_BEGIN_MARKER));
+        assert!(section.ends_with(LLMS_END_MARKER));
+        assert!(section.contains(&rql_reference_markdown()));
+    }
+}

--- a/crates/reddb-rql/src/lib.rs
+++ b/crates/reddb-rql/src/lib.rs
@@ -49,6 +49,7 @@ pub mod ast;
 pub mod conformance;
 pub mod expr_typing;
 pub mod filter_optimizer;
+pub mod knowledge;
 pub mod lexer;
 pub mod limits;
 pub mod modes;

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -246,7 +246,10 @@ impl McpServer {
         };
 
         let mut contents = Map::new();
-        contents.insert("uri".to_string(), JsonValue::String(resource.uri.to_string()));
+        contents.insert(
+            "uri".to_string(),
+            JsonValue::String(resource.uri.to_string()),
+        );
         contents.insert(
             "mimeType".to_string(),
             JsonValue::String(resource.mime_type.to_string()),
@@ -1595,9 +1598,7 @@ mod tests {
 
         let rql = resources
             .iter()
-            .find(|res| {
-                res.get("uri").and_then(JsonValue::as_str) == Some("reddb://knowledge/rql")
-            })
+            .find(|res| res.get("uri").and_then(JsonValue::as_str) == Some("reddb://knowledge/rql"))
             .expect("rql knowledge resource listed");
         assert_eq!(
             rql.get("mimeType").and_then(JsonValue::as_str),

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -111,6 +111,8 @@ impl McpServer {
             }
             "tools/list" => Some(self.handle_tools_list(id)),
             "tools/call" => Some(self.handle_tools_call(id, msg.get("params"))),
+            "resources/list" => Some(self.handle_resources_list(id)),
+            "resources/read" => Some(self.handle_resources_read(id, msg.get("params"))),
             "ping" => {
                 let mut result = Map::new();
                 result.insert("status".to_string(), JsonValue::String("ok".to_string()));
@@ -139,6 +141,14 @@ impl McpServer {
             let mut tools_cap = Map::new();
             tools_cap.insert("listChanged".to_string(), JsonValue::Bool(false));
             capabilities.insert("tools".to_string(), JsonValue::Object(tools_cap));
+        }
+        {
+            // Read-only knowledge resources (ADR 0061). No subscriptions and
+            // the set is static, so both change-notification flags are false.
+            let mut resources_cap = Map::new();
+            resources_cap.insert("subscribe".to_string(), JsonValue::Bool(false));
+            resources_cap.insert("listChanged".to_string(), JsonValue::Bool(false));
+            capabilities.insert("resources".to_string(), JsonValue::Object(resources_cap));
         }
 
         let mut server_info = Map::new();
@@ -185,6 +195,69 @@ impl McpServer {
 
         let mut result = Map::new();
         result.insert("tools".to_string(), JsonValue::Array(tools_json));
+        protocol::build_result_message(id, JsonValue::Object(result))
+    }
+
+    // ------------------------------------------------------------------
+    // resources/list + resources/read (knowledge surface, ADR 0061)
+    // ------------------------------------------------------------------
+
+    fn handle_resources_list(&self, id: Option<&JsonValue>) -> String {
+        let resources: Vec<JsonValue> = tools::knowledge_resources()
+            .iter()
+            .map(|res| {
+                let mut obj = Map::new();
+                obj.insert("uri".to_string(), JsonValue::String(res.uri.to_string()));
+                obj.insert("name".to_string(), JsonValue::String(res.title.to_string()));
+                obj.insert(
+                    "description".to_string(),
+                    JsonValue::String(res.description.to_string()),
+                );
+                obj.insert(
+                    "mimeType".to_string(),
+                    JsonValue::String(res.mime_type.to_string()),
+                );
+                JsonValue::Object(obj)
+            })
+            .collect();
+
+        let mut result = Map::new();
+        result.insert("resources".to_string(), JsonValue::Array(resources));
+        protocol::build_result_message(id, JsonValue::Object(result))
+    }
+
+    fn handle_resources_read(&self, id: Option<&JsonValue>, params: Option<&JsonValue>) -> String {
+        let uri = params.and_then(|p| p.get("uri")).and_then(|v| v.as_str());
+        let uri = match uri {
+            Some(u) => u,
+            None => return protocol::build_error_message(id, -32602, "missing resource uri"),
+        };
+
+        let resources = tools::knowledge_resources();
+        let resource = match resources.iter().find(|res| res.uri == uri) {
+            Some(res) => res,
+            None => {
+                return protocol::build_error_message(
+                    id,
+                    -32602,
+                    &format!("unknown resource: {uri}"),
+                );
+            }
+        };
+
+        let mut contents = Map::new();
+        contents.insert("uri".to_string(), JsonValue::String(resource.uri.to_string()));
+        contents.insert(
+            "mimeType".to_string(),
+            JsonValue::String(resource.mime_type.to_string()),
+        );
+        contents.insert("text".to_string(), JsonValue::String((resource.body)()));
+
+        let mut result = Map::new();
+        result.insert(
+            "contents".to_string(),
+            JsonValue::Array(vec![JsonValue::Object(contents)]),
+        );
         protocol::build_result_message(id, JsonValue::Object(result))
     }
 
@@ -1490,6 +1563,87 @@ mod tests {
 
     fn parse_json(s: &str) -> JsonValue {
         json_from_str(s).expect("valid json")
+    }
+
+    #[test]
+    fn initialize_advertises_resources_capability() {
+        let mut srv = make_server();
+        let response = srv.handle_initialize(Some(&JsonValue::Number(1.0)));
+        let parsed = parse_json(&response);
+        let resources = parsed
+            .get("result")
+            .and_then(|result| result.get("capabilities"))
+            .and_then(|caps| caps.get("resources"))
+            .expect("resources capability advertised");
+        assert_eq!(
+            resources.get("subscribe").and_then(JsonValue::as_bool),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn resources_list_includes_rql_knowledge() {
+        let mut srv = make_server();
+        let request = parse_json(r#"{"jsonrpc":"2.0","id":7,"method":"resources/list"}"#);
+        let response = srv.handle_message(&request).expect("response");
+        let parsed = parse_json(&response);
+        let resources = parsed
+            .get("result")
+            .and_then(|result| result.get("resources"))
+            .and_then(JsonValue::as_array)
+            .expect("resources array");
+
+        let rql = resources
+            .iter()
+            .find(|res| {
+                res.get("uri").and_then(JsonValue::as_str) == Some("reddb://knowledge/rql")
+            })
+            .expect("rql knowledge resource listed");
+        assert_eq!(
+            rql.get("mimeType").and_then(JsonValue::as_str),
+            Some("text/markdown")
+        );
+        assert!(rql.get("name").and_then(JsonValue::as_str).is_some());
+    }
+
+    #[test]
+    fn resources_read_returns_generated_rql_reference() {
+        let mut srv = make_server();
+        let request = parse_json(
+            r#"{"jsonrpc":"2.0","id":8,"method":"resources/read","params":{"uri":"reddb://knowledge/rql"}}"#,
+        );
+        let response = srv.handle_message(&request).expect("response");
+        let parsed = parse_json(&response);
+        let text = parsed
+            .get("result")
+            .and_then(|result| result.get("contents"))
+            .and_then(JsonValue::as_array)
+            .and_then(|contents| contents.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("resource text");
+
+        // The body is exactly what the RQL authority generates — same source as
+        // docs/llms.txt.
+        assert_eq!(text, reddb_rql::knowledge::rql_reference_markdown());
+        // And it is genuinely generated from the engine: a sampled keyword and
+        // function from the authorities are present.
+        assert!(text.contains("`SELECT`"), "keyword missing: {text:.120}");
+        assert!(text.contains("`COUNT`"), "function missing");
+    }
+
+    #[test]
+    fn resources_read_unknown_uri_errors() {
+        let mut srv = make_server();
+        let request = parse_json(
+            r#"{"jsonrpc":"2.0","id":9,"method":"resources/read","params":{"uri":"reddb://knowledge/nope"}}"#,
+        );
+        let response = srv.handle_message(&request).expect("response");
+        let parsed = parse_json(&response);
+        assert!(
+            parsed.get("error").is_some(),
+            "unknown resource must error: {response}"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -12,6 +12,32 @@ pub struct ToolDef {
     pub input_schema: JsonValue,
 }
 
+/// Definition of a read-only MCP knowledge resource (ADR 0061).
+///
+/// The body is produced lazily by `body()` from the engine's own authorities
+/// (e.g. `reddb_rql::knowledge` reads the lexer keyword set and the
+/// `reddb-io-types` function catalog), so the served text cannot drift from the
+/// engine and the resource carries no mutable state.
+pub struct ResourceDef {
+    pub uri: &'static str,
+    pub title: &'static str,
+    pub description: &'static str,
+    pub mime_type: &'static str,
+    pub body: fn() -> String,
+}
+
+/// The static set of knowledge resources `red mcp` serves. The first domain is
+/// the RQL reference, generated from `reddb-io-rql` (ADR 0061).
+pub fn knowledge_resources() -> Vec<ResourceDef> {
+    vec![ResourceDef {
+        uri: reddb_rql::knowledge::RESOURCE_URI,
+        title: reddb_rql::knowledge::RESOURCE_TITLE,
+        description: reddb_rql::knowledge::RESOURCE_DESCRIPTION,
+        mime_type: "text/markdown",
+        body: reddb_rql::knowledge::rql_reference_markdown,
+    }]
+}
+
 /// Build a JSON Schema object from a list of field descriptors.
 fn schema(properties: Vec<(&str, &str, &str)>, required: Vec<&str>) -> JsonValue {
     let mut props = Map::new();

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,36 @@
+# RedDB — LLM Reference (llms.txt)
+
+> RedDB is a multi-model database (documents, key-value, queues, graph, vault, config, and RQL-tabular collections) with its own SQL-family query language (RQL). RedWire (`red://` / `reds://`) is the principal transport.
+
+This file is generated from the engine's own authorities — do not edit by hand. See `AGENTS.md` for the human/agent overview. Each section below is emitted from source so it cannot drift from the engine.
+
+<!-- BEGIN GENERATED: rql -->
+# RedDB RQL Reference
+
+RQL (RedDB Query Language) is RedDB's SQL-family query surface across its multi-model store (documents, key-value, queues, graph, vault, config, and RQL-tabular collections).
+
+This reference is generated from the `reddb-io-rql` lexer (keyword authority) and the `reddb-io-types` function catalog. Do not edit by hand — regenerate from the engine.
+
+## Keywords (186)
+
+RQL recognises the following reserved keywords (case-insensitive at the lexer):
+
+`ACK`, `ADD`, `ALGORITHM`, `ALL`, `ALTER`, `ANALYZE`, `AND`, `AS`, `ASC`, `ATTACH`, `AVG`, `BEGIN`, `BETWEEN`, `BY`, `CASCADE`, `CENTRALITY`, `CLUSTERING`, `COLLECTION`, `COLUMN`, `COMMIT`, `COMMUNITY`, `COMPONENTS`, `COMPRESS`, `CONTAINS`, `COPY`, `COSINE`, `COUNT`, `CREATE`, `CROSS`, `CURRENT`, `CYCLES`, `DATA`, `DEFAULT`, `DELETE`, `DELIMITER`, `DEPTH`, `DESC`, `DETACH`, `DIRECTION`, `DISABLE`, `DISTINCT`, `DOCUMENT`, `DROP`, `EDGE`, `ENABLE`, `ENDS`, `ENRICH`, `EXISTS`, `EXPLAIN`, `FALSE`, `FIRST`, `FOLLOWING`, `FOR`, `FOREIGN`, `FORMAT`, `FROM`, `FULL`, `FUSION`, `FUZZY`, `GAP`, `GRAPH`, `GROUP`, `HASH`, `HEADER`, `HYBRID`, `IF`, `IN`, `INCLUDE`, `INCREMENT`, `INDEX`, `INNER`, `INNERPRODUCT`, `INNER_PRODUCT`, `INSERT`, `INTERSECTION`, `INTO`, `IS`, `JOIN`, `JSON`, `K`, `KEY`, `KV`, `L2`, `LAST`, `LEFT`, `LEVEL`, `LIKE`, `LIMIT`, `LIST`, `MATCH`, `MATERIALIZED`, `MAX`, `MAXITERATIONS`, `MAXLENGTH`, `MAX_ITERATIONS`, `MAX_LENGTH`, `METADATA`, `METRIC`, `MIN`, `MINSCORE`, `MIN_SCORE`, `MODE`, `NACK`, `NEIGHBORHOOD`, `NODE`, `NOT`, `NULL`, `NULLS`, `OF`, `OFFSET`, `ON`, `OPTIONS`, `OR`, `ORDER`, `OUTER`, `OVER`, `PARTITION`, `PATH`, `PEEK`, `POLICY`, `POP`, `PRECEDING`, `PRIMARY`, `PRIORITY`, `PROPERTIES`, `PURGE`, `PUSH`, `QUEUE`, `RANGE`, `RECURSIVE`, `REFRESH`, `RELEASE`, `RENAME`, `RERANK`, `RETENTION`, `RETURN`, `RETURNING`, `RIGHT`, `ROLLBACK`, `ROW`, `ROWS`, `RRF`, `SAVEPOINT`, `SCHEMA`, `SEARCH`, `SECURITY`, `SELECT`, `SEQUENCE`, `SERVER`, `SESSIONIZE`, `SET`, `SHORTESTPATH`, `SHORTEST_PATH`, `SIMILAR`, `START`, `STARTS`, `STRATEGY`, `SUM`, `TABLE`, `TEXT`, `THRESHOLD`, `TIMESERIES`, `TO`, `TOPOLOGICALSORT`, `TOPOLOGICAL_SORT`, `TRANSACTION`, `TRAVERSE`, `TREE`, `TRUE`, `TRUNCATE`, `UNBOUNDED`, `UNION`, `UNIQUE`, `UPDATE`, `USING`, `VACUUM`, `VALUES`, `VECTOR`, `VECTORS`, `VIA`, `VIEW`, `WEIGHT`, `WHERE`, `WITH`, `WORK`, `WRAPPER`
+
+## Functions (81)
+
+RQL provides these built-in functions, grouped by kind:
+
+### Aggregate functions
+
+`AVG`, `COUNT`, `GROUP_CONCAT`, `MAX`, `MIN`, `STDDEV`, `STRING_AGG`, `SUM`, `VARIANCE`
+
+### Scalar functions
+
+`ABS`, `ACOS`, `ARCCOS`, `ARCSIN`, `ARCTAN`, `ASIN`, `ATAN`, `ATAN2`, `BIT_LENGTH`, `BTRIM`, `CEIL`, `CHARACTER_LENGTH`, `CHAR_LENGTH`, `COALESCE`, `CONCAT`, `CONCAT_WS`, `CONTAINS`, `COS`, `COT`, `DEGREES`, `EXP`, `FLOOR`, `GEO_BEARING`, `GEO_DISTANCE`, `HAVERSINE`, `JSON_ARRAY`, `JSON_ARRAY_LENGTH`, `JSON_EXTRACT`, `JSON_EXTRACT_TEXT`, `JSON_OBJECT`, `JSON_SET`, `JSON_TYPEOF`, `JSON_VALID`, `LEFT`, `LENGTH`, `LN`, `LOG`, `LOG10`, `LOWER`, `LTRIM`, `MONEY`, `MONEY_ASSET`, `MONEY_MINOR`, `MONEY_SCALE`, `OCTET_LENGTH`, `PI`, `POSITION`, `POW`, `POWER`, `QUOTE_LITERAL`, `RADIANS`, `REVERSE`, `RIGHT`, `ROUND`, `RTRIM`, `SIN`, `SQRT`, `SUBSTR`, `SUBSTRING`, `TAN`, `TIME_BUCKET`, `TRIM`, `UPPER`, `VINCENTY`
+
+### Volatile functions
+
+`CURRENT_DATE`, `CURRENT_ROLE`, `CURRENT_TENANT`, `CURRENT_TIMESTAMP`, `CURRENT_USER`, `NOW`, `SESSION_USER`, `VERIFY_PASSWORD`
+
+<!-- END GENERATED: rql -->

--- a/tests/llms_txt_generated.rs
+++ b/tests/llms_txt_generated.rs
@@ -1,0 +1,90 @@
+//! `docs/llms.txt` is generated, not hand-maintained (ADR 0061).
+//!
+//! The file is assembled from the engine's own authorities: the RQL section is
+//! emitted by `reddb_rql::knowledge`, the same source the `reddb://knowledge/rql`
+//! MCP resource serves. This test owns the assembly and pins the contract:
+//!
+//! - `llms_txt_is_in_sync` fails if `docs/llms.txt` drifts from the generator.
+//! - run with `REGENERATE_LLMS=1` to (re)write `docs/llms.txt` from source.
+//! - `rql_section_matches_mcp_resource` proves the file's RQL section is byte
+//!   identical to what `red mcp` serves, so the two surfaces share one source.
+
+use std::fs;
+use std::path::PathBuf;
+
+fn llms_txt_path() -> PathBuf {
+    // CARGO_MANIFEST_DIR is the umbrella crate root == repo root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("llms.txt")
+}
+
+/// Assemble the full, generated `docs/llms.txt`. The stable header is the only
+/// hand-authored prose; every fact-bearing section is generated from source.
+fn generate_llms_txt() -> String {
+    let mut out = String::new();
+    out.push_str("# RedDB — LLM Reference (llms.txt)\n\n");
+    out.push_str(
+        "> RedDB is a multi-model database (documents, key-value, queues, graph, \
+vault, config, and RQL-tabular collections) with its own SQL-family query \
+language (RQL). RedWire (`red://` / `reds://`) is the principal transport.\n\n",
+    );
+    out.push_str(
+        "This file is generated from the engine's own authorities — do not edit by \
+hand. See `AGENTS.md` for the human/agent overview. Each section below is \
+emitted from source so it cannot drift from the engine.\n\n",
+    );
+    out.push_str(&reddb_rql::knowledge::rql_llms_section());
+    out.push('\n');
+    out
+}
+
+/// Extract the RQL block between the generated markers.
+fn extract_rql_section(contents: &str) -> &str {
+    let begin = reddb_rql::knowledge::LLMS_BEGIN_MARKER;
+    let end = reddb_rql::knowledge::LLMS_END_MARKER;
+    let start = contents
+        .find(begin)
+        .expect("docs/llms.txt is missing the RQL begin marker");
+    let stop = contents
+        .find(end)
+        .expect("docs/llms.txt is missing the RQL end marker");
+    contents[start..stop + end.len()].trim()
+}
+
+#[test]
+fn llms_txt_is_in_sync() {
+    let path = llms_txt_path();
+    let generated = generate_llms_txt();
+
+    if std::env::var_os("REGENERATE_LLMS").is_some() {
+        fs::write(&path, &generated).expect("write docs/llms.txt");
+        return;
+    }
+
+    let on_disk = fs::read_to_string(&path).unwrap_or_else(|err| {
+        panic!(
+            "could not read {}: {err}. Run `REGENERATE_LLMS=1 cargo test --test \
+llms_txt_generated llms_txt_is_in_sync` to generate it.",
+            path.display()
+        )
+    });
+
+    assert_eq!(
+        on_disk,
+        generated,
+        "docs/llms.txt is out of sync with the generator. Run \
+`REGENERATE_LLMS=1 cargo test --test llms_txt_generated llms_txt_is_in_sync` to \
+regenerate it."
+    );
+}
+
+#[test]
+fn rql_section_matches_mcp_resource() {
+    let path = llms_txt_path();
+    let on_disk = fs::read_to_string(&path).expect("read docs/llms.txt");
+    let section = extract_rql_section(&on_disk);
+    // The same generated source feeds docs/llms.txt and the MCP resource.
+    assert_eq!(section, reddb_rql::knowledge::rql_llms_section());
+    assert!(section.contains(&reddb_rql::knowledge::rql_reference_markdown()));
+}

--- a/tests/llms_txt_generated.rs
+++ b/tests/llms_txt_generated.rs
@@ -71,8 +71,7 @@ llms_txt_generated llms_txt_is_in_sync` to generate it.",
     });
 
     assert_eq!(
-        on_disk,
-        generated,
+        on_disk, generated,
         "docs/llms.txt is out of sync with the generator. Run \
 `REGENERATE_LLMS=1 cargo test --test llms_txt_generated llms_txt_is_in_sync` to \
 regenerate it."


### PR DESCRIPTION
Automated AFK landing for #1312. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1312

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784990691&installation_id=129708444&pr_number=1392&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1392&signature=7f0f8f7a0e5dfccc5aebffd1a3f7617d2b1fdbc813e875a99579bfef9ddb8c1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browsable knowledge resource for RQL reference content.
  * Exposed the same generated reference through both the server API and documentation.

* **Documentation**
  * Added a generated `llms.txt` reference with RQL keywords and built-in functions.
  * Included clear markers around the generated RQL section.

* **Tests**
  * Added checks to keep the generated documentation in sync with the served reference.
  * Verified the knowledge resource is listed, readable, and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->