### PR TITLE
merge: #1313 feat(mcp): @reddb-io/mcp npx launcher (fetch binary + spawn red mcp)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
       "@reddb-io/sdk",
       "@reddb-io/client",
       "@reddb-io/client-bun",
+      "@reddb-io/mcp",
       "@reddb-io/internal-asset-fetcher",
       "@reddb-io/internal-bin-resolver",
       "@reddb-io/internal-version-compare"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -681,6 +681,42 @@ jobs:
           TAG=$([[ "${{ needs.plan.outputs.release_channel }}" == "next" ]] && echo "next" || echo "latest")
           pnpm publish --tag "${TAG}" --access public --no-git-checks
 
+  publish-mcp:
+    name: Publish @reddb-io/mcp (npm)
+    needs: [plan, publish-github, verify-release-assets]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    if: |
+      needs.plan.outputs.should_skip != 'true' &&
+      needs.plan.outputs.release_channel == 'stable'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Enable pnpm
+        run: corepack enable
+      - name: Sync release version
+        run: |
+          VERSION="${{ needs.plan.outputs.package_version }}"
+          node -e "const fs=require('fs');const p=require('./package.json');p.version='${VERSION}';fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n')"
+          node scripts/sync-version.js
+          bash scripts/check-versions.sh
+      - name: Verify pack
+        working-directory: packages/mcp
+        run: pnpm pack --pack-destination "$RUNNER_TEMP"
+      - name: Publish
+        working-directory: packages/mcp
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN}" ]]; then
+            echo "::warning::NPM_TOKEN secret not set — skipping. Add an Automation token from npmjs.com as NPM_TOKEN in repo secrets."
+            exit 0
+          fi
+          TAG=$([[ "${{ needs.plan.outputs.release_channel }}" == "next" ]] && echo "next" || echo "latest")
+          pnpm publish --tag "${TAG}" --access public --no-git-checks
+
   publish-docker:
     name: Docker image (GHCR)
     needs: [plan, build]

--- a/packages/mcp/.npmignore
+++ b/packages/mcp/.npmignore
@@ -1,0 +1,5 @@
+test/
+bin/
+*.log
+.DS_Store
+node_modules/

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,60 @@
+# @reddb-io/mcp
+
+Zero-install [MCP](https://modelcontextprotocol.io) launcher for [RedDB](https://github.com/reddb-io/reddb).
+
+```bash
+npx -y @reddb-io/mcp
+```
+
+That's the whole thing. The launcher resolves (or downloads) the matching
+`red` engine binary from GitHub Releases and spawns `red mcp` over stdio.
+Because `npx -y @reddb-io/mcp` always pulls the latest published launcher,
+you always run the latest released engine — no local install, no stale
+binary.
+
+No tool or knowledge logic is reimplemented in JavaScript. The launcher
+only fetches the native binary and execs `red mcp`; the MCP tool surface
+and `red://` knowledge resources come from the engine itself.
+
+## Use it as an MCP server
+
+Point your agent host at the launcher as a stdio MCP server:
+
+```json
+{
+  "mcpServers": {
+    "reddb": {
+      "command": "npx",
+      "args": ["-y", "@reddb-io/mcp"]
+    }
+  }
+}
+```
+
+Extra arguments are forwarded to `red mcp` after the subcommand, e.g. remote
+client mode:
+
+```bash
+npx -y @reddb-io/mcp --url tcp://127.0.0.1:6789
+```
+
+## Binary resolution
+
+Resolution reuses RedDB's internal bin-resolver / asset-fetcher and follows
+the same precedence as the SDK (PATH is never consulted, per ADR 0006):
+
+1. `REDDB_BIN` — absolute path to a `red` binary you provide. Returned verbatim.
+2. A binary already cached at `<package>/bin/red[.exe]`.
+3. Otherwise the matching release asset is downloaded from GitHub Releases.
+
+### Environment overrides
+
+| Variable            | Effect                                              |
+| ------------------- | --------------------------------------------------- |
+| `REDDB_BIN`         | Use this binary; skip all download logic.           |
+| `REDDB_MCP_VERSION` | Pull a specific release tag instead of the default. |
+| `REDDB_MCP_REPO`    | Fetch from a fork (default: `reddb-io/reddb`).       |
+
+## License
+
+MIT

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@reddb-io/mcp",
+  "version": "1.15.0",
+  "description": "Zero-install npx launcher for the RedDB MCP surface — fetches the matching red binary and spawns `red mcp` over stdio.",
+  "type": "module",
+  "bin": {
+    "reddb-mcp": "./src/launcher.js"
+  },
+  "files": [
+    "src/",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node test/launcher.test.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "reddb",
+    "mcp",
+    "model-context-protocol",
+    "database",
+    "agent",
+    "npx",
+    "launcher"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/reddb-io/reddb",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reddb-io/reddb.git",
+    "directory": "packages/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/reddb-io/reddb/issues"
+  }
+}

--- a/packages/mcp/src/binary.js
+++ b/packages/mcp/src/binary.js
@@ -1,0 +1,99 @@
+/**
+ * Locate (or download) the `red` binary for the `@reddb-io/mcp` launcher.
+ *
+ * Resolution precedence (reuses the vendored bin-resolver — env > local,
+ * PATH is never consulted, per ADR 0006):
+ *   1. `REDDB_BIN` env var → returned verbatim.
+ *   2. `<package>/bin/red[.exe]` if already present (e.g. a previous npx run
+ *      cached it, or a workspace checkout vendored it).
+ *   3. Otherwise download the matching GitHub Release asset (reusing the
+ *      vendored asset-fetcher — no new download logic) into `<package>/bin/`
+ *      and return that path.
+ *
+ * The download tag tracks this package's own version (`v<pkg.version>`),
+ * which the release flow keeps locked to the engine version. Because
+ * `npx -y @reddb-io/mcp` always pulls the latest published launcher, this
+ * yields the latest released engine with zero local install.
+ */
+
+import { existsSync, mkdirSync, writeFileSync, chmodSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve, join } from 'node:path'
+
+import { resolveBin } from './internal/bin-resolver/index.js'
+import { fetchReleaseAsset } from './internal/asset-fetcher/index.js'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const PACKAGE_ROOT = resolve(HERE, '..')
+
+export const DEFAULT_REPO = 'reddb-io/reddb'
+
+/** Platform-specific base name of the engine binary. */
+export function binaryName(platform = process.platform) {
+  return platform === 'win32' ? 'red.exe' : 'red'
+}
+
+/**
+ * Non-throwing probe reusing the vendored bin-resolver: returns an
+ * absolute path when `REDDB_BIN` is set or a local binary exists, else
+ * `null` (so the caller can decide to download).
+ *
+ * @param {{ packageRoot?: string, platform?: string }} [opts]
+ * @returns {string|null}
+ */
+export function tryResolveBinary({ packageRoot = PACKAGE_ROOT, platform = process.platform } = {}) {
+  try {
+    return resolveBin({ name: binaryName(platform), packageRoot, envVar: 'REDDB_BIN' })
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Resolve the engine binary, downloading it from GitHub Releases when it is
+ * not already available. Returns the absolute path to a runnable binary.
+ *
+ * @param {{
+ *   version: string,
+ *   packageRoot?: string,
+ *   platform?: string,
+ *   arch?: string,
+ *   repo?: string,
+ *   fetchAsset?: typeof fetchReleaseAsset,
+ * }} opts
+ * @returns {Promise<string>}
+ */
+export async function ensureBinary({
+  version,
+  packageRoot = PACKAGE_ROOT,
+  platform = process.platform,
+  arch = process.arch,
+  repo = process.env.REDDB_MCP_REPO || DEFAULT_REPO,
+  fetchAsset = fetchReleaseAsset,
+} = {}) {
+  if (typeof version !== 'string' || version === '') {
+    throw new TypeError('ensureBinary: `version` must be a non-empty string')
+  }
+
+  const existing = tryResolveBinary({ packageRoot, platform })
+  if (existing) {
+    return existing
+  }
+
+  const tag = normalizeTag(process.env.REDDB_MCP_VERSION || version)
+  const body = await fetchAsset({ repo, tag, platform, arch, binName: 'red' })
+
+  const binDir = join(packageRoot, 'bin')
+  mkdirSync(binDir, { recursive: true })
+  const dest = join(binDir, binaryName(platform))
+  writeFileSync(dest, body)
+  if (platform !== 'win32') {
+    chmodSync(dest, 0o755)
+  }
+  return dest
+}
+
+function normalizeTag(value) {
+  const v = String(value).trim()
+  return v.startsWith('v') ? v : `v${v}`
+}

--- a/packages/mcp/src/internal/asset-fetcher/asset-name.js
+++ b/packages/mcp/src/internal/asset-fetcher/asset-name.js
@@ -1,0 +1,37 @@
+/**
+ * Resolve the GitHub release asset filename for a given Node
+ * `process.platform` / `process.arch` pair and binary base name.
+ *
+ * Mapping is the existing scheme from `drivers/js/postinstall.js`:
+ *   linux  + x64       → <bin>-linux-x86_64
+ *   linux  + arm64     → <bin>-linux-aarch64
+ *   linux  + arm/armv7l→ <bin>-linux-armv7
+ *   darwin + x64       → <bin>-macos-x86_64
+ *   darwin + arm64     → <bin>-macos-aarch64
+ *   win32  + x64       → <bin>-windows-x86_64.exe
+ *
+ * Throws `UnsupportedPlatformError` for any other combination.
+ */
+
+export class UnsupportedPlatformError extends Error {
+  constructor(platform, arch) {
+    super(`unsupported platform/arch combination: ${platform}/${arch}`)
+    this.name = 'UnsupportedPlatformError'
+    this.code = 'UNSUPPORTED_PLATFORM'
+    this.platform = platform
+    this.arch = arch
+  }
+}
+
+export function composeAssetName({ platform, arch, binName }) {
+  if (typeof binName !== 'string' || binName === '') {
+    throw new TypeError('composeAssetName: `binName` must be a non-empty string')
+  }
+  if (platform === 'linux' && arch === 'x64') return `${binName}-linux-x86_64`
+  if (platform === 'linux' && arch === 'arm64') return `${binName}-linux-aarch64`
+  if (platform === 'linux' && (arch === 'arm' || arch === 'armv7l')) return `${binName}-linux-armv7`
+  if (platform === 'darwin' && arch === 'x64') return `${binName}-macos-x86_64`
+  if (platform === 'darwin' && arch === 'arm64') return `${binName}-macos-aarch64`
+  if (platform === 'win32' && arch === 'x64') return `${binName}-windows-x86_64.exe`
+  throw new UnsupportedPlatformError(platform, arch)
+}

--- a/packages/mcp/src/internal/asset-fetcher/checksum.js
+++ b/packages/mcp/src/internal/asset-fetcher/checksum.js
@@ -1,0 +1,23 @@
+import { createHash } from 'node:crypto'
+
+export class ChecksumMismatchError extends Error {
+  constructor(expected, actual) {
+    super(`checksum mismatch: expected sha256=${expected}, got sha256=${actual}`)
+    this.name = 'ChecksumMismatchError'
+    this.code = 'CHECKSUM_MISMATCH'
+    this.expected = expected
+    this.actual = actual
+  }
+}
+
+export function sha256Hex(buf) {
+  return createHash('sha256').update(buf).digest('hex')
+}
+
+export function verifySha256(buf, expected) {
+  const expectedNorm = String(expected).trim().toLowerCase()
+  const actual = sha256Hex(buf)
+  if (actual !== expectedNorm) {
+    throw new ChecksumMismatchError(expectedNorm, actual)
+  }
+}

--- a/packages/mcp/src/internal/asset-fetcher/download.js
+++ b/packages/mcp/src/internal/asset-fetcher/download.js
@@ -1,0 +1,89 @@
+import { request as httpsRequest } from 'node:https'
+import { request as httpRequest } from 'node:http'
+
+const MAX_REDIRECTS = 5
+
+export class AssetNotFoundError extends Error {
+  constructor(url) {
+    super(`asset not found (HTTP 404) at ${url}`)
+    this.name = 'AssetNotFoundError'
+    this.code = 'ASSET_NOT_FOUND'
+    this.url = url
+  }
+}
+
+export class HttpError extends Error {
+  constructor(status, url) {
+    super(`HTTP ${status} fetching ${url}`)
+    this.name = 'HttpError'
+    this.code = 'HTTP_ERROR'
+    this.status = status
+    this.url = url
+  }
+}
+
+export class TooManyRedirectsError extends Error {
+  constructor(url) {
+    super(`too many redirects (>${MAX_REDIRECTS}) starting at ${url}`)
+    this.name = 'TooManyRedirectsError'
+    this.code = 'TOO_MANY_REDIRECTS'
+    this.url = url
+  }
+}
+
+function pickRequest(url) {
+  return url.startsWith('http://') ? httpRequest : httpsRequest
+}
+
+function resolveLocation(currentUrl, location) {
+  if (/^https?:\/\//i.test(location)) return location
+  return new URL(location, currentUrl).toString()
+}
+
+export function downloadFollowingRedirects(url, { userAgent, originalUrl } = {}, depth = 0) {
+  const startUrl = originalUrl || url
+  if (depth > MAX_REDIRECTS) {
+    return Promise.reject(new TooManyRedirectsError(startUrl))
+  }
+  const request = pickRequest(url)
+  return new Promise((resolve, reject) => {
+    const req = request(
+      url,
+      {
+        method: 'GET',
+        headers: {
+          'User-Agent': userAgent || 'reddb-internal-asset-fetcher',
+          Accept: 'application/octet-stream',
+        },
+      },
+      (res) => {
+        const status = res.statusCode || 0
+        if (status >= 300 && status < 400 && res.headers.location) {
+          res.resume()
+          const next = resolveLocation(url, res.headers.location)
+          downloadFollowingRedirects(next, { userAgent, originalUrl: startUrl }, depth + 1).then(
+            resolve,
+            reject,
+          )
+          return
+        }
+        if (status === 404) {
+          res.resume()
+          reject(new AssetNotFoundError(startUrl))
+          return
+        }
+        if (status < 200 || status >= 300) {
+          res.resume()
+          reject(new HttpError(status, url))
+          return
+        }
+        const chunks = []
+        res.on('data', (chunk) => chunks.push(chunk))
+        res.on('end', () => resolve(Buffer.concat(chunks)))
+        res.on('error', reject)
+      },
+    )
+    req.on('error', reject)
+    req.end()
+  })
+}

--- a/packages/mcp/src/internal/asset-fetcher/index.js
+++ b/packages/mcp/src/internal/asset-fetcher/index.js
@@ -1,0 +1,52 @@
+/**
+ * @reddb-io/internal-asset-fetcher — fetch a `red`/`red_client` binary
+ * from a GitHub release.
+ *
+ * Public surface: one function.
+ *
+ *   fetchReleaseAsset({ repo, tag, platform, arch, binName, sha256? }) → Buffer
+ *
+ * Steps:
+ *   1. Map (platform, arch, binName) → asset filename.
+ *   2. Compose the GitHub download URL: `https://github.com/<repo>/releases/download/<tag>/<asset>`.
+ *   3. Follow up to 5 redirects, returning the final body as a Buffer.
+ *   4. If `sha256` was supplied, verify before returning.
+ *
+ * Errors carry distinct `.code` values so callers can differentiate:
+ *   - UNSUPPORTED_PLATFORM   — no asset for this platform/arch
+ *   - ASSET_NOT_FOUND        — HTTP 404 (release/tag/asset name wrong)
+ *   - CHECKSUM_MISMATCH      — body downloaded but sha256 mismatched
+ *   - HTTP_ERROR             — any other non-2xx status
+ *   - TOO_MANY_REDIRECTS     — redirect chain longer than 5 hops
+ *
+ * Internal modules (`./asset-name.js`, `./download.js`, `./checksum.js`)
+ * are not part of the public contract — only `fetchReleaseAsset` is.
+ * They are imported directly in tests for focused coverage.
+ */
+
+import { composeAssetName } from './asset-name.js'
+import { downloadFollowingRedirects } from './download.js'
+import { verifySha256 } from './checksum.js'
+
+export async function fetchReleaseAsset({ repo, tag, platform, arch, binName, sha256 } = {}) {
+  if (typeof repo !== 'string' || repo === '') {
+    throw new TypeError('fetchReleaseAsset: `repo` must be a non-empty string (e.g. "reddb-io/reddb")')
+  }
+  if (typeof tag !== 'string' || tag === '') {
+    throw new TypeError('fetchReleaseAsset: `tag` must be a non-empty string (e.g. "v0.2.9")')
+  }
+  if (typeof platform !== 'string' || platform === '') {
+    throw new TypeError('fetchReleaseAsset: `platform` must be a non-empty string')
+  }
+  if (typeof arch !== 'string' || arch === '') {
+    throw new TypeError('fetchReleaseAsset: `arch` must be a non-empty string')
+  }
+
+  const assetName = composeAssetName({ platform, arch, binName })
+  const url = `https://github.com/${repo}/releases/download/${tag}/${assetName}`
+  const body = await downloadFollowingRedirects(url)
+  if (sha256) {
+    verifySha256(body, sha256)
+  }
+  return body
+}

--- a/packages/mcp/src/internal/bin-resolver/index.js
+++ b/packages/mcp/src/internal/bin-resolver/index.js
@@ -1,0 +1,57 @@
+/**
+ * @reddb-io/internal-bin-resolver — runtime lookup for a pinned binary.
+ *
+ * Precedence:
+ *   1. `process.env[envVar]` if set and non-empty → returned verbatim.
+ *      No existence probe: the env var is the user's "I know what I'm
+ *      doing" override.
+ *   2. `<packageRoot>/bin/<name>` if it exists.
+ *   3. Otherwise throw an actionable error naming the env var, the
+ *      expected local path, and a one-line `pnpm install` hint.
+ *
+ * `PATH` is deliberately never consulted. SDK/client wire formats are
+ * version-coupled to the binary; silent fallback to a stale `PATH`
+ * binary fails as misframed RPC, not "command not found". See ADR 0006.
+ */
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * @param {{ name: string, packageRoot: string, envVar: string }} opts
+ * @returns {string} absolute path to the binary
+ * @throws {Error} when neither env override nor local binary is usable
+ */
+export function resolveBin(opts) {
+  if (!opts || typeof opts !== 'object') {
+    throw new TypeError('resolveBin: options object required')
+  }
+  const { name, packageRoot, envVar } = opts
+  if (typeof name !== 'string' || name === '') {
+    throw new TypeError('resolveBin: `name` must be a non-empty string')
+  }
+  if (typeof packageRoot !== 'string' || packageRoot === '') {
+    throw new TypeError('resolveBin: `packageRoot` must be a non-empty string')
+  }
+  if (typeof envVar !== 'string' || envVar === '') {
+    throw new TypeError('resolveBin: `envVar` must be a non-empty string')
+  }
+
+  const override = process.env?.[envVar]
+  if (typeof override === 'string' && override !== '') {
+    return override
+  }
+
+  const local = join(packageRoot, 'bin', name)
+  if (existsSync(local)) {
+    return local
+  }
+
+  throw new Error(
+    `reddb: binary "${name}" not found.\n` +
+      `  expected at: ${local}\n` +
+      `  override:    set ${envVar}=/path/to/${name}\n` +
+      `  fix:         re-run \`pnpm install\` (the postinstall script downloads it),\n` +
+      `               or check the postinstall log for a download error.`,
+  )
+}

--- a/packages/mcp/src/launcher.js
+++ b/packages/mcp/src/launcher.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * @reddb-io/mcp — zero-install npx launcher for the RedDB MCP surface.
+ *
+ *   npx -y @reddb-io/mcp [args…]
+ *
+ * Resolves (or downloads) the matching `red` binary and execs `red mcp`
+ * over stdio. No tool/knowledge logic lives here — the launcher only
+ * fetches + spawns the native engine, so the MCP surface is always the
+ * latest released engine's.
+ */
+
+import { createRequire } from 'node:module'
+
+import { ensureBinary, DEFAULT_REPO } from './binary.js'
+import { spawnMcp } from './spawn.js'
+
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json')
+
+ensureBinary({ version: pkg.version })
+  .then((binary) => {
+    const child = spawnMcp(binary, process.argv.slice(2))
+    child.on('error', (err) => {
+      process.stderr.write(`reddb-mcp: failed to spawn red (${err.message})\n`)
+      process.exit(1)
+    })
+    child.on('exit', (code, signal) => {
+      process.exit(signal ? 1 : (code ?? 0))
+    })
+  })
+  .catch((err) => {
+    process.stderr.write(formatFailure(err))
+    process.exit(1)
+  })
+
+function formatFailure(err) {
+  const repo = process.env.REDDB_MCP_REPO || DEFAULT_REPO
+  const escapeHatches =
+    `       Escape hatches:\n` +
+    `         - Provide the binary yourself:  export REDDB_BIN=/path/to/red\n` +
+    `         - Install red via the official installer:\n` +
+    `             curl -fsSL https://raw.githubusercontent.com/${repo}/main/install.sh | bash\n` +
+    `             export REDDB_BIN="$(command -v red)"\n` +
+    `         - Download a release binary manually from\n` +
+    `             https://github.com/${repo}/releases\n`
+
+  if (err && err.code === 'UNSUPPORTED_PLATFORM') {
+    return (
+      `reddb-mcp: no prebuilt red binary for ${process.platform}/${process.arch}.\n` +
+      `       Build from source: https://github.com/${repo}#build-from-source\n` +
+      escapeHatches
+    )
+  }
+  if (err && err.code === 'ASSET_NOT_FOUND') {
+    return (
+      `reddb-mcp: release asset not found${err.url ? ` at ${err.url}` : ''}.\n` +
+      `       The GitHub Release for this launcher version may not be published yet,\n` +
+      `       or your platform's binary was not produced for that release.\n` +
+      escapeHatches
+    )
+  }
+  return (
+    `reddb-mcp: could not obtain the red binary (${(err && err.message) || err}).\n` +
+    escapeHatches
+  )
+}

--- a/packages/mcp/src/spawn.js
+++ b/packages/mcp/src/spawn.js
@@ -1,0 +1,36 @@
+/**
+ * Spawn `red mcp` over stdio.
+ *
+ * The launcher reimplements no tool/knowledge logic — it simply execs the
+ * native engine's `mcp` subcommand and inherits stdio so the MCP JSON-RPC
+ * stream flows straight through to the parent (the agent host). Any extra
+ * argv passed to `npx @reddb-io/mcp …` is forwarded after `mcp` (e.g.
+ * `--url <addr>` for remote client mode).
+ *
+ * `spawn` is injectable so tests can assert the binary, argv, and stdio
+ * wiring without launching a real process.
+ */
+
+import { spawn as nodeSpawn } from 'node:child_process'
+
+/**
+ * @param {string} binary absolute path to the `red` binary
+ * @param {string[]} [extraArgs] argv forwarded after the `mcp` subcommand
+ * @param {{
+ *   spawn?: typeof nodeSpawn,
+ *   stdio?: import('node:child_process').StdioOptions,
+ *   env?: NodeJS.ProcessEnv,
+ *   cwd?: string,
+ * }} [opts]
+ * @returns {import('node:child_process').ChildProcess}
+ */
+export function spawnMcp(
+  binary,
+  extraArgs = [],
+  { spawn = nodeSpawn, stdio = 'inherit', env = process.env, cwd = process.cwd() } = {},
+) {
+  if (typeof binary !== 'string' || binary === '') {
+    throw new TypeError('spawnMcp: `binary` must be a non-empty string')
+  }
+  return spawn(binary, ['mcp', ...extraArgs], { stdio, env, cwd })
+}

--- a/packages/mcp/test/launcher.test.mjs
+++ b/packages/mcp/test/launcher.test.mjs
@@ -1,0 +1,236 @@
+/**
+ * Tests for @reddb-io/mcp — the npx launcher.
+ *
+ * Covers binary resolution (env override > local > download via the
+ * reused asset-fetcher) and the `red mcp` spawn wiring.
+ *
+ * Run: node test/launcher.test.mjs
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { binaryName, tryResolveBinary, ensureBinary, DEFAULT_REPO } from '../src/binary.js'
+import { spawnMcp } from '../src/spawn.js'
+
+let passed = 0
+let failed = 0
+
+function test(name, fn) {
+  try {
+    const r = fn()
+    if (r && typeof r.then === 'function') {
+      return r.then(
+        () => {
+          console.log(`  ok  ${name}`)
+          passed++
+        },
+        (err) => {
+          console.error(`  FAIL ${name}\n        ${err.stack || err.message}`)
+          failed++
+        },
+      )
+    }
+    console.log(`  ok  ${name}`)
+    passed++
+  } catch (err) {
+    console.error(`  FAIL ${name}\n        ${err.stack || err.message}`)
+    failed++
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(`assertion failed: ${msg}`)
+}
+
+function assertEqual(actual, expected, msg) {
+  if (actual !== expected) {
+    throw new Error(`${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`)
+  }
+}
+
+function withTempPkg(fn) {
+  const root = mkdtempSync(join(tmpdir(), 'reddb-mcp-'))
+  try {
+    return fn(root)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+const SAVED_ENV = { ...process.env }
+function withEnv(extra, fn) {
+  for (const k of Object.keys(extra)) {
+    if (extra[k] === undefined) delete process.env[k]
+    else process.env[k] = extra[k]
+  }
+  try {
+    return fn()
+  } finally {
+    for (const k of Object.keys(extra)) {
+      if (SAVED_ENV[k] === undefined) delete process.env[k]
+      else process.env[k] = SAVED_ENV[k]
+    }
+  }
+}
+
+console.log('@reddb-io/mcp launcher tests')
+
+const run = async () => {
+  // ---- resolve ---------------------------------------------------------
+
+  await test('binaryName is platform-specific', () => {
+    assertEqual(binaryName('linux'), 'red', 'unix → red')
+    assertEqual(binaryName('darwin'), 'red', 'macos → red')
+    assertEqual(binaryName('win32'), 'red.exe', 'windows → red.exe')
+  })
+
+  await test('REDDB_BIN override is resolved verbatim (no download)', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: '/opt/custom/red' }, () => {
+        const resolved = tryResolveBinary({ packageRoot: root, platform: 'linux' })
+        assertEqual(resolved, '/opt/custom/red', 'env override returned verbatim')
+      }),
+    ))
+
+  await test('local bin/red is resolved when present', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: undefined }, () => {
+        const binDir = join(root, 'bin')
+        mkdirSync(binDir, { recursive: true })
+        const local = join(binDir, 'red')
+        writeFileSync(local, '')
+        assertEqual(tryResolveBinary({ packageRoot: root, platform: 'linux' }), local, 'local resolved')
+      }),
+    ))
+
+  await test('tryResolveBinary returns null when nothing is available', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: undefined }, () => {
+        assertEqual(tryResolveBinary({ packageRoot: root, platform: 'linux' }), null, 'null when absent')
+      }),
+    ))
+
+  await test('ensureBinary returns the override without fetching', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: '/opt/custom/red', REDDB_MCP_VERSION: undefined }, async () => {
+        let fetched = false
+        const path = await ensureBinary({
+          version: '1.15.0',
+          packageRoot: root,
+          platform: 'linux',
+          arch: 'x64',
+          fetchAsset: async () => {
+            fetched = true
+            return Buffer.from('')
+          },
+        })
+        assertEqual(path, '/opt/custom/red', 'override path returned')
+        assert(!fetched, 'fetcher must not be called when override is set')
+      }),
+    ))
+
+  await test('ensureBinary downloads + writes the binary when missing', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: undefined, REDDB_MCP_VERSION: undefined, REDDB_MCP_REPO: undefined }, async () => {
+        const calls = []
+        const path = await ensureBinary({
+          version: '1.15.0',
+          packageRoot: root,
+          platform: 'linux',
+          arch: 'x64',
+          fetchAsset: async (opts) => {
+            calls.push(opts)
+            return Buffer.from('FAKE-RED-BINARY')
+          },
+        })
+        assertEqual(calls.length, 1, 'fetcher called exactly once')
+        assertEqual(calls[0].repo, DEFAULT_REPO, 'default repo used')
+        assertEqual(calls[0].tag, 'v1.15.0', 'tag tracks the package version')
+        assertEqual(calls[0].platform, 'linux', 'platform forwarded')
+        assertEqual(calls[0].arch, 'x64', 'arch forwarded')
+        assertEqual(calls[0].binName, 'red', 'binName is red')
+        const expected = join(root, 'bin', 'red')
+        assertEqual(path, expected, 'returns the cached binary path')
+        assert(existsSync(expected), 'binary written to disk')
+        assertEqual(readFileSync(expected, 'utf8'), 'FAKE-RED-BINARY', 'downloaded body persisted')
+      }),
+    ))
+
+  await test('ensureBinary honours REDDB_MCP_VERSION / REDDB_MCP_REPO overrides', () =>
+    withTempPkg((root) =>
+      withEnv({ REDDB_BIN: undefined, REDDB_MCP_VERSION: '2.0.0', REDDB_MCP_REPO: 'me/fork' }, async () => {
+        let seen
+        await ensureBinary({
+          version: '1.15.0',
+          packageRoot: root,
+          platform: 'linux',
+          arch: 'arm64',
+          fetchAsset: async (opts) => {
+            seen = opts
+            return Buffer.from('x')
+          },
+        })
+        assertEqual(seen.tag, 'v2.0.0', 'REDDB_MCP_VERSION wins over pkg version')
+        assertEqual(seen.repo, 'me/fork', 'REDDB_MCP_REPO wins over default')
+      }),
+    ))
+
+  await test('ensureBinary requires a version', () =>
+    withTempPkg(async (root) => {
+      let threw = false
+      try {
+        await ensureBinary({ packageRoot: root, fetchAsset: async () => Buffer.from('') })
+      } catch (err) {
+        threw = /version/.test(err.message)
+      }
+      assert(threw, 'missing version throws TypeError mentioning version')
+    }))
+
+  // ---- spawn -----------------------------------------------------------
+
+  await test('spawnMcp execs `red mcp` over inherited stdio', () => {
+    const calls = []
+    const fakeChild = { on() {} }
+    const fakeSpawn = (bin, argv, opts) => {
+      calls.push({ bin, argv, opts })
+      return fakeChild
+    }
+    const child = spawnMcp('/abs/red', [], { spawn: fakeSpawn })
+    assertEqual(child, fakeChild, 'returns the child process')
+    assertEqual(calls.length, 1, 'spawned once')
+    assertEqual(calls[0].bin, '/abs/red', 'spawns the resolved binary')
+    assertEqual(JSON.stringify(calls[0].argv), JSON.stringify(['mcp']), 'argv is [mcp]')
+    assertEqual(calls[0].opts.stdio, 'inherit', 'stdio inherited')
+  })
+
+  await test('spawnMcp forwards extra args after the mcp subcommand', () => {
+    const calls = []
+    const fakeSpawn = (bin, argv) => {
+      calls.push(argv)
+      return { on() {} }
+    }
+    spawnMcp('/abs/red', ['--url', 'tcp://127.0.0.1:6789'], { spawn: fakeSpawn })
+    assertEqual(
+      JSON.stringify(calls[0]),
+      JSON.stringify(['mcp', '--url', 'tcp://127.0.0.1:6789']),
+      'extra args forwarded after mcp',
+    )
+  })
+
+  await test('spawnMcp rejects an empty binary path', () => {
+    let threw = false
+    try {
+      spawnMcp('', [], { spawn: () => ({ on() {} }) })
+    } catch (err) {
+      threw = /binary/.test(err.message)
+    }
+    assert(threw, 'empty binary throws')
+  })
+
+  console.log(`\n${passed} passed, ${failed} failed`)
+  process.exit(failed > 0 ? 1 : 0)
+}
+
+run()

--- a/scripts/check-registry-names.mjs
+++ b/scripts/check-registry-names.mjs
@@ -9,6 +9,7 @@ const npmPublicPackages = [
   "drivers/js/package.json",
   "drivers/js-client/package.json",
   "drivers/bun/package.json",
+  "packages/mcp/package.json",
 ];
 
 const npmPrivateWorkspacePackages = [

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -77,6 +77,7 @@ check "drivers/bun (@reddb-io/client-bun)"  "$(grep -m1 '"version"' drivers/bun/
 check "packages/internal-asset-fetcher" "$(grep -m1 '"version"' packages/internal-asset-fetcher/package.json | sed -E 's/.*"([0-9][^"]+)".*/\1/')"
 check "packages/internal-bin-resolver"  "$(grep -m1 '"version"' packages/internal-bin-resolver/package.json | sed -E 's/.*"([0-9][^"]+)".*/\1/')"
 check "packages/internal-version-compare" "$(grep -m1 '"version"' packages/internal-version-compare/package.json | sed -E 's/.*"([0-9][^"]+)".*/\1/')"
+check "packages/mcp (@reddb-io/mcp)" "$(grep -m1 '"version"' packages/mcp/package.json | sed -E 's/.*"([0-9][^"]+)".*/\1/')"
 # drivers/js-client is being introduced by Lane T (#136) in parallel.
 # Skip gracefully if the manifest isn't on this branch yet — the line
 # becomes load-bearing once both lanes merge.

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -128,6 +128,11 @@ const targets = [
     type: 'package-json',
   },
   {
+    label: 'packages/mcp/package.json (@reddb-io/mcp)',
+    file: path.join(root, 'packages', 'mcp', 'package.json'),
+    type: 'package-json',
+  },
+  {
     // Lane T (#136) introduces drivers/js-client/. Until that lane
     // merges, the file may not exist on this branch — `optional: true`
     // makes the sync step a no-op skip instead of failing the version
@@ -230,6 +235,7 @@ const stageList = [
   'packages/internal-asset-fetcher/package.json',
   'packages/internal-bin-resolver/package.json',
   'packages/internal-version-compare/package.json',
+  'packages/mcp/package.json',
   // drivers/js-client/package.json comes from Lane T (#136); the
   // .filter() below drops it from the stage list when absent.
   'drivers/js-client/package.json',


### PR DESCRIPTION
Automated AFK landing for #1313. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1313

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784991628&installation_id=129708444&pr_number=1393&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1393&signature=ce21d5efae4c1a118fd8092155ce70435a5a13efdabee1af156b2a655d878c4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->