### PR TITLE
fix(dml): re-serialize document body on UPDATE/PATCH SET (#1394)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1964,9 +1964,7 @@ impl RedDBRuntime {
         // top-level keys here and patch them into the body before promoting.
         let is_document_collection = db
             .collection_contract(&collection)
-            .map(|contract| {
-                contract.declared_model == crate::catalog::CollectionModel::Document
-            })
+            .map(|contract| contract.declared_model == crate::catalog::CollectionModel::Document)
             .unwrap_or(false);
         let document_body_updates: Vec<(String, Value)> = if is_document_collection {
             static_field_assignments

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1431,13 +1431,25 @@ impl RedDBRuntime {
 
                 if !field_ops.is_empty() {
                     context_index_dirty = true;
-                    for op in &field_ops {
-                        if let Some(col) = op.path.first() {
-                            modified_columns.push(col.clone());
-                        }
-                    }
                     let named = row.named.get_or_insert_with(Default::default);
-                    apply_patch_operations_to_storage_map(named, &field_ops)?;
+                    if is_document_collection {
+                        // Document fields are projections of the canonical `body`
+                        // JSON. Apply the assignment to the body so the stored
+                        // document and its promoted columns stay in sync, then
+                        // re-promote every top-level key. Patching only the
+                        // promoted column would leave `SELECT body` stale (#1394).
+                        let mut body = document_body_from_named(named)?;
+                        apply_patch_operations_to_json(&mut body, &field_ops)
+                            .map_err(crate::RedDBError::Query)?;
+                        replace_document_row_body(named, body, &mut modified_columns)?;
+                    } else {
+                        for op in &field_ops {
+                            if let Some(col) = op.path.first() {
+                                modified_columns.push(col.clone());
+                            }
+                        }
+                        apply_patch_operations_to_storage_map(named, &field_ops)?;
+                    }
                 }
 
                 if let Some(fields) = payload
@@ -1456,9 +1468,21 @@ impl RedDBRuntime {
                     }
                     context_index_dirty = true;
                     let named = row.named.get_or_insert_with(Default::default);
-                    for (key, value) in fields {
-                        modified_columns.push(key.clone());
-                        named.insert(key.clone(), json_to_storage_value(value)?);
+                    if is_document_collection {
+                        // Mirror the `field_ops` path above: keep the canonical
+                        // `body` JSON in sync with its promoted columns (#1394).
+                        let mut body = document_body_from_named(named)?;
+                        if let JsonValue::Object(map) = &mut body {
+                            for (key, value) in fields {
+                                map.insert(key.clone(), value.clone());
+                            }
+                        }
+                        replace_document_row_body(named, body, &mut modified_columns)?;
+                    } else {
+                        for (key, value) in fields {
+                            modified_columns.push(key.clone());
+                            named.insert(key.clone(), json_to_storage_value(value)?);
+                        }
                     }
                 }
 
@@ -1932,8 +1956,52 @@ impl RedDBRuntime {
         };
 
         let _ = row_contract_plan;
+
+        // Documents store the full JSON under the `body` column plus promoted
+        // top-level columns for filtering. A SET on a promoted column must also
+        // be reflected in `body`, otherwise `SELECT body` keeps the old value
+        // while `SELECT <col>` shows the new one (#1394). Collect the assigned
+        // top-level keys here and patch them into the body before promoting.
+        let is_document_collection = db
+            .collection_contract(&collection)
+            .map(|contract| {
+                contract.declared_model == crate::catalog::CollectionModel::Document
+            })
+            .unwrap_or(false);
+        let document_body_updates: Vec<(String, Value)> = if is_document_collection {
+            static_field_assignments
+                .iter()
+                .cloned()
+                .chain(dynamic_field_assignments.iter().cloned())
+                .filter(|(column, _)| column != "body")
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         apply_row_field_assignments_raw(row, static_field_assignments.iter().cloned());
         apply_row_field_assignments_raw(row, dynamic_field_assignments);
+
+        if !document_body_updates.is_empty() {
+            let named = row.named.get_or_insert_with(Default::default);
+            let mut body = document_body_from_named(named)?;
+            if let JsonValue::Object(map) = &mut body {
+                for (column, value) in &document_body_updates {
+                    map.insert(
+                        column.clone(),
+                        crate::presentation::entity_json::storage_value_to_json(value),
+                    );
+                }
+            }
+            let body_bytes = json_to_vec(&body).map_err(|err| {
+                crate::RedDBError::Query(format!("failed to serialize document body: {err}"))
+            })?;
+            named.insert("body".to_string(), Value::Json(body_bytes));
+            context_index_dirty = true;
+            if !modified_columns.iter().any(|column| column == "body") {
+                modified_columns.push("body".to_string());
+            }
+        }
 
         for (key, value) in static_metadata_assignments
             .iter()

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -365,10 +365,16 @@ fn document_compound_update_keeps_body_json_in_sync() {
         "UPDATE body_compound_docs DOCUMENTS SET score += 5 WHERE name = 'doc'",
     );
 
-    let promoted = exec(&rt, "SELECT score FROM body_compound_docs WHERE name = 'doc'");
+    let promoted = exec(
+        &rt,
+        "SELECT score FROM body_compound_docs WHERE name = 'doc'",
+    );
     assert_eq!(int_field(only_record(&promoted), "score"), 15);
 
-    let with_body = exec(&rt, "SELECT body FROM body_compound_docs WHERE name = 'doc'");
+    let with_body = exec(
+        &rt,
+        "SELECT body FROM body_compound_docs WHERE name = 'doc'",
+    );
     let body = json_field(only_record(&with_body), "body");
     assert_eq!(
         body["score"].as_i64(),

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -307,6 +307,77 @@ fn explicit_document_update_emits_event_and_cdc_identity() {
     assert_eq!(update.kind(), "document");
 }
 
+fn json_field(record: &UnifiedRecord, field: &str) -> serde_json::Value {
+    match record.get(field) {
+        Some(Value::Json(bytes)) => {
+            serde_json::from_slice(bytes).expect("body field should be valid JSON")
+        }
+        other => panic!("expected {field} json field, got {other:?} in {record:?}"),
+    }
+}
+
+#[test]
+fn document_update_keeps_body_json_in_sync_with_promoted_column() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT body_sync_docs");
+    exec(
+        &rt,
+        r#"INSERT INTO body_sync_docs DOCUMENT (body) VALUES ('{"name":"doc","score":10,"keep":"me"}')"#,
+    );
+
+    exec(
+        &rt,
+        "UPDATE body_sync_docs DOCUMENTS SET score = 42 WHERE name = 'doc'",
+    );
+
+    // The promoted top-level column reflects the new value.
+    let promoted = exec(&rt, "SELECT score FROM body_sync_docs WHERE name = 'doc'");
+    assert_eq!(int_field(only_record(&promoted), "score"), 42);
+
+    // The full document body JSON must be re-serialized so it agrees with the
+    // promoted column. Other fields must be preserved untouched.
+    let with_body = exec(&rt, "SELECT body FROM body_sync_docs WHERE name = 'doc'");
+    let body = json_field(only_record(&with_body), "body");
+    assert_eq!(
+        body["score"].as_i64(),
+        Some(42),
+        "body JSON should reflect the updated promoted column, got {body:?}"
+    );
+    assert_eq!(body["name"].as_str(), Some("doc"));
+    assert_eq!(
+        body["keep"].as_str(),
+        Some("me"),
+        "untargeted document fields must survive the UPDATE, got {body:?}"
+    );
+}
+
+#[test]
+fn document_compound_update_keeps_body_json_in_sync() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT body_compound_docs");
+    exec(
+        &rt,
+        r#"INSERT INTO body_compound_docs DOCUMENT (body) VALUES ('{"name":"doc","score":10}')"#,
+    );
+
+    exec(
+        &rt,
+        "UPDATE body_compound_docs DOCUMENTS SET score += 5 WHERE name = 'doc'",
+    );
+
+    let promoted = exec(&rt, "SELECT score FROM body_compound_docs WHERE name = 'doc'");
+    assert_eq!(int_field(only_record(&promoted), "score"), 15);
+
+    let with_body = exec(&rt, "SELECT body FROM body_compound_docs WHERE name = 'doc'");
+    let body = json_field(only_record(&with_body), "body");
+    assert_eq!(
+        body["score"].as_i64(),
+        Some(15),
+        "body JSON should reflect the compound-updated column, got {body:?}"
+    );
+    assert_eq!(body["name"].as_str(), Some("doc"));
+}
+
 #[test]
 fn explicit_updates_recheck_changed_indexed_fields() {
     let rt = runtime();


### PR DESCRIPTION
Fixes #1394.

## Root cause
Document collections store the full document as a `body` column (`Value::Json`) **plus** promoted top-level columns (e.g. `score`, `name`) for filtering. A partial `UPDATE … DOCUMENTS SET score = …` went through `apply_loaded_sql_update_row_core`, which wrote **only the promoted column** via `apply_row_field_assignments_raw` — it never re-serialized `body`. So `SELECT score` saw the new value while `SELECT body` stayed stale. The HTTP JSON-pointer PATCH path (`apply_loaded_patch_entity_core`) had the same gap on its `field_ops` / `payload.fields` branches.

## Fix
Mirror every promoted-column assignment into the `body` JSON before promotion, preserving untargeted fields — enforcing the invariant `body ⊇ promoted columns` on every write. The MVCC body rewrite happens **before** the post-image re-stamp, so versioned documents keep first-committer-wins (ADR 0014). Three entry points: SQL UPDATE + PATCH `field_ops` + PATCH `payload.fields`.

## Tests (red→green)
- `document_update_keeps_body_json_in_sync_with_promoted_column`
- `document_compound_update_keeps_body_json_in_sync`

Scoped runs: `e2e_update_conformance_pack` 7/7 (was 2 red), `grouped_documents_kv_queues` 84/84, `grouped_general_multimodel` 153/153 (compound/explicit doc updates + versioned-MVCC docs). `cargo check -p reddb-io-server` clean.

## Residual (not in this PR)
The reported **gRPC `red connect` "0 affected_rows"** is a *separate, likely client-side* issue: the connect client appears to parse the UPDATE with a default `UpdateTarget::Rows` rather than `Documents`, so the contract gate matches zero. SQL over connect dispatches through the same `execute_update`, so this body-serialization fix flows through gRPC — but the 0-row count needs a live gRPC harness to confirm/fix (couldn't stand one up under the no-full-build memory constraint). Tracked as residual on #1394.

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784999756&installation_id=129708444&pr_number=1395&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1395&signature=dab25539718c929061bde8af6eabc296c6d7f14962ad663d7db21928038a3bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->