### PR TITLE
merge: #1391 fix(tests): eliminate remaining TMPDIR leak families — make Test Suite leak-guard green on main

### DIFF
--- a/crates/reddb-server/src/runtime/audit_log.rs
+++ b/crates/reddb-server/src/runtime/audit_log.rs
@@ -1219,17 +1219,43 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
 mod tests {
     use super::*;
 
-    fn temp_data_path(tag: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
+    /// RAII guard owning a per-test audit data directory; removes it wholesale
+    /// on drop (including the audit log and any rotated siblings inside it) so
+    /// nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). Derefs to the `data.rdb` `PathBuf` so
+    /// existing `&data` call sites keep working via deref coercion.
+    struct TempAuditData {
+        dir: PathBuf,
+        path: PathBuf,
+    }
+    impl std::ops::Deref for TempAuditData {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+    impl AsRef<std::path::Path> for TempAuditData {
+        fn as_ref(&self) -> &std::path::Path {
+            self.path.as_ref()
+        }
+    }
+    impl Drop for TempAuditData {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn temp_data_path(tag: &str) -> TempAuditData {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
             "reddb-audit-{}-{}-{}",
             tag,
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        std::fs::create_dir_all(&p).unwrap();
-        p.push("data.rdb");
-        p
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.rdb");
+        TempAuditData { dir, path }
     }
 
     fn drain(logger: &AuditLogger) {

--- a/crates/reddb-server/src/runtime/audit_query.rs
+++ b/crates/reddb-server/src/runtime/audit_query.rs
@@ -265,17 +265,42 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    fn temp_path(tag: &str) -> PathBuf {
-        let mut p = std::env::temp_dir();
-        p.push(format!(
+    /// RAII guard owning a per-test audit data directory; removes it wholesale
+    /// on drop so nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). Derefs to the `data.rdb` `PathBuf` so
+    /// existing `&data` call sites keep working via deref coercion.
+    struct TempAuditData {
+        dir: PathBuf,
+        path: PathBuf,
+    }
+    impl std::ops::Deref for TempAuditData {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.path
+        }
+    }
+    impl AsRef<std::path::Path> for TempAuditData {
+        fn as_ref(&self) -> &std::path::Path {
+            self.path.as_ref()
+        }
+    }
+    impl Drop for TempAuditData {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn temp_path(tag: &str) -> TempAuditData {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
             "reddb-audit-query-{}-{}-{}",
             tag,
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        std::fs::create_dir_all(&p).unwrap();
-        p.push("data.rdb");
-        p
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("data.rdb");
+        TempAuditData { dir, path }
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/cache/spill.rs
+++ b/crates/reddb-server/src/storage/cache/spill.rs
@@ -763,25 +763,45 @@ mod tests {
     use super::*;
     use std::env;
 
-    fn test_config() -> SpillConfig {
+    /// RAII guard that removes a test spill directory (and any files spilled
+    /// into it) on drop so nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). The whole per-test directory is removed
+    /// wholesale, so no file-format suffixes are embedded here.
+    struct SpillDirGuard(std::path::PathBuf);
+    impl Drop for SpillDirGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn unique_spill_dir() -> std::path::PathBuf {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+        env::temp_dir().join(format!("reddb-spill-test-{}-{}", std::process::id(), id))
+    }
+
+    fn test_config_in(dir: std::path::PathBuf) -> SpillConfig {
         SpillConfig::new()
             .max_memory(1024 * 1024) // 1MB for testing
             .spill_threshold(0.5)
             .target_after_spill(0.3)
             .min_spill_size(100)
-            .spill_dir(env::temp_dir().join(format!(
-                "reddb-spill-test-{}-{}",
-                std::process::id(),
-                id
-            )))
+            .spill_dir(dir)
+    }
+
+    /// Build a `SpillManager` over a unique temp spill dir, returning a guard
+    /// that wipes that dir on drop. Bind the guard (`let (manager, _guard)`)
+    /// for the lifetime of the test.
+    fn test_manager() -> (SpillManager, SpillDirGuard) {
+        let dir = unique_spill_dir();
+        let manager = SpillManager::new(test_config_in(dir.clone()));
+        (manager, SpillDirGuard(dir))
     }
 
     #[test]
     fn test_register_segment() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         manager.register_segment("seg2", 200_000);
@@ -794,7 +814,7 @@ mod tests {
 
     #[test]
     fn test_update_size() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         assert_eq!(manager.memory_usage(), 100_000);
@@ -808,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_needs_spill() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         // Below threshold
         manager.register_segment("seg1", 400_000); // 40%
@@ -830,7 +850,7 @@ mod tests {
 
     #[test]
     fn test_spill_and_reload() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("test_seg", 1000);
 
@@ -848,7 +868,7 @@ mod tests {
 
     #[test]
     fn test_checksum_validation() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         // Use unique segment name to avoid conflicts
         manager.register_segment("checksum_test_seg", 100);
@@ -864,7 +884,7 @@ mod tests {
 
     #[test]
     fn test_list_segments() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("alpha", 1000);
         manager.register_segment("beta", 2000);
@@ -881,7 +901,7 @@ mod tests {
 
     #[test]
     fn test_unregister_segment() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         manager.register_segment("seg2", 200_000);
@@ -896,7 +916,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
 
         manager.register_segment("seg1", 100);
         manager.spill("seg1", b"test data").unwrap();
@@ -921,7 +941,7 @@ mod tests {
 
     #[test]
     fn test_v2_round_trip() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
         manager.register_segment("rt_seg", 100);
         let data: Vec<u8> = (0u8..=127).collect();
         manager.spill("rt_seg", &data).unwrap();
@@ -931,7 +951,7 @@ mod tests {
 
     #[test]
     fn test_single_byte_mutation_detected() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
         manager.register_segment("mut_seg", 100);
         let data = b"hello world mutation test data!!";
         let path = manager.spill("mut_seg", data).unwrap();
@@ -953,7 +973,7 @@ mod tests {
     fn test_byte_permutation_detected() {
         // The old fold checksum is commutative — swapping two bytes leaves the
         // sum unchanged. CRC-32 is not commutative, so v2 catches this.
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
         manager.register_segment("perm_seg", 100);
         let data = b"abcdefghij"; // all distinct bytes
         let path = manager.spill("perm_seg", data).unwrap();
@@ -976,7 +996,7 @@ mod tests {
 
     #[test]
     fn test_path_traversal_rejected() {
-        let manager = SpillManager::new(test_config());
+        let (manager, _guard) = test_manager();
         for bad_name in &["../foo", "/etc/passwd", "a/b"] {
             manager.register_segment(bad_name, 100);
             let result = manager.spill(bad_name, b"data");

--- a/crates/reddb-server/src/storage/engine/database.rs
+++ b/crates/reddb-server/src/storage/engine/database.rs
@@ -470,9 +470,28 @@ mod tests {
     }
 
     fn cleanup(path: &Path) {
-        let _ = fs::remove_file(path);
-        let wal_path = reddb_file::layout::engine_wal_path(path);
-        let _ = fs::remove_file(wal_path);
+        // Remove the `.rdb` AND every pager sidecar written next to it
+        // (`-dwb`/`-hdr`/`-meta`/WAL/shadows) by prefix-matching the file name,
+        // so nothing is left in TMPDIR for the leak guard
+        // (scripts/check-temp-residue.sh). Prefix-matching embeds no owned
+        // file-format suffix literals (the `layout_authority` tests forbid them
+        // in server source).
+        if let (Some(dir), Some(name)) = (
+            path.parent(),
+            path.file_name().and_then(|name| name.to_str()),
+        ) {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    if entry
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|entry_name| entry_name.starts_with(name))
+                    {
+                        let _ = fs::remove_file(entry.path());
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/engine/turboquant/extent.rs
+++ b/crates/reddb-server/src/storage/engine/turboquant/extent.rs
@@ -104,17 +104,47 @@ mod tests {
     use super::*;
     use crate::storage::engine::PagerConfig;
 
+    /// RAII guard: removes the temp `.db` file and every pager sidecar
+    /// (`-dwb`/`-hdr`/…) on drop by prefix-matching the file name, so nothing
+    /// is left in TMPDIR for the leak guard (scripts/check-temp-residue.sh).
+    /// Prefix-matching embeds no owned file-format suffix literals.
+    struct TempExtentPath(std::path::PathBuf);
+    impl Drop for TempExtentPath {
+        fn drop(&mut self) {
+            if let (Some(dir), Some(name)) = (
+                self.0.parent(),
+                self.0.file_name().and_then(|name| name.to_str()),
+            ) {
+                if let Ok(entries) = std::fs::read_dir(dir) {
+                    for entry in entries.flatten() {
+                        if entry
+                            .file_name()
+                            .to_str()
+                            .is_some_and(|entry_name| entry_name.starts_with(name))
+                        {
+                            let _ = std::fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn turbo_extent_reads_across_page_boundaries() {
-        let path =
-            std::env::temp_dir().join(format!("reddb-turbo-extent-{}.db", std::process::id()));
-        let _ = std::fs::remove_file(&path);
-        let pager = Arc::new(Pager::open(&path, PagerConfig::default()).unwrap());
+        let path = TempExtentPath(
+            std::env::temp_dir().join(format!("reddb-turbo-extent-{}.db", std::process::id())),
+        );
+        let _ = std::fs::remove_file(&path.0);
+        let pager = Arc::new(Pager::open(&path.0, PagerConfig::default()).unwrap());
         let mut extent = TurboExtent::new(pager).unwrap();
         extent.write_offset = PAYLOAD_BYTES_PER_PAGE - 2;
         extent.ensure_capacity(PAYLOAD_BYTES_PER_PAGE + 2).unwrap();
         let offset = extent.append(&[1, 2, 3, 4]).unwrap();
         assert_eq!(extent.read(offset, 4).unwrap(), vec![1, 2, 3, 4]);
-        let _ = std::fs::remove_file(path);
+        // Drop the extent (and its pager) before the guard so the pager's
+        // drop-time header flush happens before the prefix cleanup runs.
+        drop(extent);
+        drop(path);
     }
 }

--- a/crates/reddb-server/src/storage/keyring.rs
+++ b/crates/reddb-server/src/storage/keyring.rs
@@ -249,12 +249,38 @@ mod tests {
     // XDG_CONFIG_HOME at a process-unique temp dir so every test process gets
     // its own keyring file; the Mutex still serializes the in-process case for
     // a plain `cargo test` run.
-    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| {
-        let dir = std::env::temp_dir().join(format!("reddb-keyring-test-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
-        std::env::set_var("XDG_CONFIG_HOME", dir);
-        Mutex::new(())
-    });
+    static KEYRING_TEST_DIR: std::sync::LazyLock<std::path::PathBuf> =
+        std::sync::LazyLock::new(|| {
+            let dir =
+                std::env::temp_dir().join(format!("reddb-keyring-test-{}", std::process::id()));
+            let _ = std::fs::create_dir_all(&dir);
+            std::env::set_var("XDG_CONFIG_HOME", &dir);
+            dir
+        });
+    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> =
+        std::sync::LazyLock::new(|| Mutex::new(()));
+
+    /// Holds the keyring test lock and wipes the process-unique keyring temp
+    /// dir on drop, so nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). The whole dir is removed wholesale (no
+    /// file-format suffixes embedded); `save_to_keyring` recreates the `reddb/`
+    /// subtree via `create_dir_all` on the next test that needs it. The custom
+    /// `Drop` runs before the inner `MutexGuard` field drops, so the directory
+    /// is removed while the lock is still held (serialised in-process).
+    struct KeyringTestGuard(std::sync::MutexGuard<'static, ()>);
+    impl Drop for KeyringTestGuard {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&*KEYRING_TEST_DIR);
+        }
+    }
+
+    /// Acquire the keyring test lock after ensuring the process-unique temp
+    /// dir + `XDG_CONFIG_HOME` override are initialised. Bind the returned
+    /// guard (`let _lock = keyring_test_lock();`) for the test body.
+    fn keyring_test_lock() -> KeyringTestGuard {
+        std::sync::LazyLock::force(&KEYRING_TEST_DIR);
+        KeyringTestGuard(KEYRING_TEST_LOCK.lock().unwrap())
+    }
 
     #[test]
     fn test_password_source_is_encrypted() {
@@ -327,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_empty_flag() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 
@@ -338,7 +364,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_env_var() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         let _ = clear_keyring();
 
         std::env::set_var("REDDB_KEY", "env_test_password");
@@ -362,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_keyring_save_and_retrieve() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
 
         // Clear any existing keyring
         let _ = clear_keyring();
@@ -382,7 +408,7 @@ mod tests {
 
     #[test]
     fn test_keyring_has_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
 
         let _ = clear_keyring();
         assert!(!has_keyring_password());
@@ -396,7 +422,7 @@ mod tests {
 
     #[test]
     fn test_clear_keyring_nonexistent() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
 
         // Should not error if keyring doesn't exist
         let _ = clear_keyring();
@@ -406,7 +432,7 @@ mod tests {
 
     #[test]
     fn test_keyring_special_characters() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         let _ = clear_keyring();
 
         // Test password with special characters
@@ -422,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_keyring_unicode_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         let _ = clear_keyring();
 
         // Test password with unicode characters
@@ -438,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_keyring_empty_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         let _ = clear_keyring();
 
         // Even empty password should work
@@ -453,7 +479,7 @@ mod tests {
 
     #[test]
     fn test_keyring_long_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         let _ = clear_keyring();
 
         // Test very long password
@@ -469,7 +495,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_keyring_integration() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 
@@ -488,7 +514,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_none_when_empty() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _lock = keyring_test_lock();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -1281,6 +1281,14 @@ mod ephemeral_cleanup_tests {
         let path = options.data_path.as_ref().expect("in-memory data path");
 
         assert!(should_cleanup_ephemeral_data_path(&options, path));
+
+        // `in_memory()` eagerly creates the per-instance `reddb-ephemeral-*`
+        // dir, but this test never builds a runtime to arm the drop-time
+        // cleanup — so remove the dir wholesale here, otherwise it leaks into
+        // TMPDIR for the leak guard (scripts/check-temp-residue.sh).
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/telemetry/admin_intent_log.rs
+++ b/crates/reddb-server/src/telemetry/admin_intent_log.rs
@@ -599,7 +599,44 @@ mod tests {
     use super::*;
     use crate::json::Value as JsonValue;
 
-    fn tmp_path(label: &str) -> PathBuf {
+    /// RAII guard owning a per-test intent-log file; removes it (and any rotated
+    /// siblings) on drop by prefix-matching the file name, so nothing is left in
+    /// TMPDIR for the leak guard (scripts/check-temp-residue.sh). Derefs to
+    /// `PathBuf` so existing `&path` call sites keep working via deref coercion.
+    struct TempIntentLog(PathBuf);
+    impl std::ops::Deref for TempIntentLog {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+    impl AsRef<Path> for TempIntentLog {
+        fn as_ref(&self) -> &Path {
+            self.0.as_ref()
+        }
+    }
+    impl Drop for TempIntentLog {
+        fn drop(&mut self) {
+            if let (Some(dir), Some(name)) = (
+                self.0.parent(),
+                self.0.file_name().and_then(|name| name.to_str()),
+            ) {
+                if let Ok(entries) = std::fs::read_dir(dir) {
+                    for entry in entries.flatten() {
+                        if entry
+                            .file_name()
+                            .to_str()
+                            .is_some_and(|entry_name| entry_name.starts_with(name))
+                        {
+                            let _ = std::fs::remove_file(entry.path());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn tmp_path(label: &str) -> TempIntentLog {
         let mut p = std::env::temp_dir();
         p.push(format!(
             "reddb-intent-{}-{}-{}.log",
@@ -607,7 +644,7 @@ mod tests {
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        p
+        TempIntentLog(p)
     }
 
     fn last_line_json(path: &Path) -> JsonValue {

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -536,7 +536,32 @@ mod tests {
     use super::*;
     use crate::runtime::audit_log::AuditLogger;
 
-    fn make_logger() -> (AuditLogger, std::path::PathBuf) {
+    /// RAII guard owning a per-test operator-event log directory; removes it
+    /// wholesale on drop so nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). Derefs to the audit-log `PathBuf` inside
+    /// the dir so existing `&path` call sites keep working via deref coercion.
+    struct TempEventLog {
+        dir: std::path::PathBuf,
+        path: std::path::PathBuf,
+    }
+    impl std::ops::Deref for TempEventLog {
+        type Target = std::path::PathBuf;
+        fn deref(&self) -> &std::path::PathBuf {
+            &self.path
+        }
+    }
+    impl AsRef<std::path::Path> for TempEventLog {
+        fn as_ref(&self) -> &std::path::Path {
+            self.path.as_ref()
+        }
+    }
+    impl Drop for TempEventLog {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn make_logger() -> (AuditLogger, TempEventLog) {
         let mut dir = std::env::temp_dir();
         dir.push(format!(
             "reddb-op-event-{}-{}",
@@ -546,7 +571,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join(".audit.log");
         let logger = AuditLogger::with_path(path.clone());
-        (logger, path)
+        (logger, TempEventLog { dir, path })
     }
 
     fn drain(logger: &AuditLogger) {

--- a/crates/reddb-server/src/telemetry/slow_query_logger.rs
+++ b/crates/reddb-server/src/telemetry/slow_query_logger.rs
@@ -268,14 +268,36 @@ mod tests {
     use crate::runtime::EffectiveScope;
     use crate::storage::transaction::snapshot::Snapshot;
 
-    fn tmp_dir() -> PathBuf {
+    /// RAII guard owning a per-test log directory; removes it wholesale on drop
+    /// so nothing is left in TMPDIR for the leak guard
+    /// (scripts/check-temp-residue.sh). Derefs to `PathBuf` so existing `&dir`
+    /// call sites keep working via deref coercion.
+    struct TempLogDir(PathBuf);
+    impl std::ops::Deref for TempLogDir {
+        type Target = PathBuf;
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+    impl AsRef<std::path::Path> for TempLogDir {
+        fn as_ref(&self) -> &std::path::Path {
+            self.0.as_ref()
+        }
+    }
+    impl Drop for TempLogDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn tmp_dir() -> TempLogDir {
         let mut d = std::env::temp_dir();
         d.push(format!(
             "reddb-slow-{}-{}",
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        d
+        TempLogDir(d)
     }
 
     fn logger(dir: &PathBuf, threshold_ms: u64, sample_pct: u8) -> Arc<SlowQueryLogger> {


### PR DESCRIPTION
Automated AFK landing for #1391. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785006302&installation_id=129708444&pr_number=1406&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1406&signature=0c320dd5c0fdf32d7d438bfed26ca58c785f081e2626cf0cca279fabd4e45d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->