### PR TITLE
ci(test-suite): make leak-guard advisory — wholesale-clean residue, un-rot main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,13 +384,14 @@ jobs:
           CARGO_TARGET_DIR: target/persistent-tests
         run: >-
           cargo test --locked --test grouped_general_multimodel integration_persistent_multimodel -- --ignored
-      - name: Check for temp-file residue (leak guard)
-        # Issue #972 — fail the build if any reddb-*/reddb_*/*.rdb/*.wal
-        # temp residue remains in TMPDIR after the full test suite.  All
-        # test-DB helpers in tests/support/mod.rs use TempDir guards that
-        # clean up on drop (including on panic), so a clean suite leaves
-        # nothing behind.  A non-zero count means a test bypassed the
-        # helpers and the leak must be fixed.
+      - name: Report temp-file residue (advisory leak guard)
+        # Issue #972 — report reddb-*/reddb_*/*.rdb/*.wal residue left in the
+        # dedicated per-run TMPDIR after the full test suite. The TMPDIR
+        # (RUNNER_TEMP/reddb-test-suite-tmp) is ephemeral, so individual test
+        # leaks are harmless; the guard now cleans them wholesale and emits a
+        # CI warning rather than failing the build (see the script header).
+        # Per-test cleanup via tests/support/mod.rs remains the hygiene goal,
+        # surfaced as a warning instead of a merge gate.
         run: bash scripts/check-temp-residue.sh
       - name: Show sccache stats
         if: always()

--- a/scripts/check-temp-residue.sh
+++ b/scripts/check-temp-residue.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
-# CI guard: fail if the test suite left reddb-*/reddb_*/*.rdb/*.wal
-# residue in the OS temp directory ($TMPDIR, default /tmp).
+# CI guard: report (and wholesale-clean) reddb-*/reddb_*/*.rdb/*.wal residue
+# left in the OS temp directory ($TMPDIR, default /tmp) by the test suite.
 #
-# Run this after `cargo test` to detect tests that created persistent
-# databases without using the auto-cleaning temp helpers in
-# tests/support/mod.rs, turning silent disk leaks into a hard CI failure.
+# History (issue #972): this guard used to FAIL the build on any residue, to
+# pressure tests into using the auto-cleaning helpers in tests/support/mod.rs.
+# In practice dozens of test families leak into the dedicated, per-run CI
+# TMPDIR (RUNNER_TEMP/reddb-test-suite-tmp, which is itself discarded after the
+# run), so a per-file hard failure rotted the required Test Suite check on main
+# and forced a lift-protection dance on every merge.
+#
+# Structural fix: the dedicated TMPDIR is ephemeral, so individual test leaks
+# are harmless to the host. This guard now REMOVES the matched residue
+# wholesale and downgrades the signal to a CI ::warning:: — visibility into
+# which tests leak is preserved (each LEAK line is still printed and counted),
+# but the build is no longer blocked. Per-test cleanup remains the right
+# long-term hygiene goal; it is just no longer a merge gate.
 #
 # Usage (from repo root, after running the test suite):
 #   ./scripts/check-temp-residue.sh
 #
-# Exit codes:
-#   0 - no residue found
-#   1 - residue found (paths listed to stdout)
+# Exit code: always 0 (residue is cleaned, never fatal).
 
 set -euo pipefail
 
@@ -34,12 +42,15 @@ fi
 
 for entry in "${entries[@]}"; do
     echo "LEAK: $entry"
+    # Only ever remove reddb-owned residue (the find filter guarantees this),
+    # so this is safe even when $TMPDIR is a shared /tmp.
+    rm -rf -- "$entry" 2>/dev/null || true
 done
 
 count=${#entries[@]}
 printf '\n'
-printf '::error::Test suite left %d temp residue path(s) in %s.\n' "$count" "$tmpdir" >&2
-printf 'Each LEAK line above is a file or directory that was not cleaned up.\n' >&2
-printf 'Fix: use temp_data_dir()/temp_db_file()/PersistentDbPath from tests/support/mod.rs\n' >&2
-printf 'so cleanup happens on drop (including on panic).\n' >&2
-exit 1
+printf '::warning::Test suite left %d temp residue path(s) in %s; cleaned wholesale (non-fatal).\n' "$count" "$tmpdir" >&2
+printf 'Each LEAK line above is a test that did not clean up. Long-term fix:\n' >&2
+printf 'use temp_data_dir()/temp_db_file()/PersistentDbPath from tests/support/mod.rs\n' >&2
+printf 'so cleanup happens on drop (including on panic). This is advisory, not a gate.\n' >&2
+exit 0


### PR DESCRIPTION
## Problem
The required **Test Suite** check has been red on `main` for a long time — not from any test failure (nextest is 9190/9190 green) but from `scripts/check-temp-residue.sh`, which **fails the build** on any `reddb-*` residue left in `$TMPDIR`. Dozens of test families leak into the dedicated per-run CI TMPDIR (`RUNNER_TEMP/reddb-test-suite-tmp`), so the guard rots and **every PR inherits the failure**, forcing a lift-protection dance on each merge. A naive per-test cleanup pass (#1406) fixed ~10 of the families and introduced a regression — the leak surface is too broad to whack-a-mole.

## Structural fix
The dedicated TMPDIR is **ephemeral** (discarded after the run), so individual test leaks are harmless to the host. The guard now:
- **removes** the matched residue **wholesale** (`rm -rf` each `reddb-*`/`reddb_*`/`*.rdb`/`*.wal` match — the find filter guarantees we only ever delete reddb-owned paths, safe even on a shared `/tmp`), and
- downgrades the signal to a CI **`::warning::`** (each `LEAK:` line is still printed + counted for visibility) instead of `exit 1`.

Per-test cleanup via `tests/support/mod.rs` remains the long-term hygiene goal — it's just **advisory**, not a merge gate.

## Effect
`main`'s nextest is already green, so with the residue scan no longer fatal the **Test Suite check goes genuinely green** → clean merges, no more lift-protection dance, AFK can auto-merge again.

## Verify
- Script smoke-tested: seeds 3 fake `reddb-*` residue paths in an isolated TMPDIR → logs all 3, cleans them (0 remaining), emits the warning, **exits 0**.
- This PR's own **Test Suite** going green IS the proof.

Supersedes #1406 (partial per-test fix + regression — to be closed). Chosen over a broad multi-agent per-test sweep per maintainer decision (structural harness fix).

https://claude.ai/code/session_01FZP6QHDPXtXv6eZsJ9G73g

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785007655&installation_id=129708444&pr_number=1408&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1408&signature=e3224083f49be52dfd452ea0b9b67e8ca7718be52d06013a246b1ed35c0265d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->