### PR TITLE
merge: #1317 feat(mcp): reddb_rql_validate/explain tool (parse via real reddb-io-rql)

### DIFF
--- a/crates/reddb-rql/src/knowledge.rs
+++ b/crates/reddb-rql/src/knowledge.rs
@@ -17,6 +17,10 @@
 
 use reddb_types::function_catalog::{FunctionKind, FUNCTION_CATALOG};
 
+use crate::ast::QueryExpr;
+use crate::parser::{parse as parse_rql, ParseError, ParseErrorKind};
+use crate::planner::QueryOptimizer;
+
 /// Canonical URI for the RQL knowledge resource served over MCP.
 pub const RESOURCE_URI: &str = "reddb://knowledge/rql";
 
@@ -340,6 +344,159 @@ pub fn rql_llms_section() -> String {
     )
 }
 
+// ---------------------------------------------------------------------------
+// Active RQL validate / explain surface (ADR 0061, #1317)
+//
+// These functions drive the engine's *real* parser ([`crate::parser::parse`])
+// and optimizer ([`QueryOptimizer`]) so an agent learns the dialect by
+// submitting a query and reading the verdict, instead of guessing from docs.
+// The MCP `reddb_rql_validate` / `reddb_rql_explain` active tools are thin JSON
+// adapters over these neutral structs; the parsing authority lives here, in the
+// owning crate (the same generate-from-the-engine discipline as the resources
+// above), so the tool surface cannot reimplement or drift from the grammar.
+// ---------------------------------------------------------------------------
+
+/// A structured diagnostic for an RQL string the parser rejected. Every field
+/// comes straight from the real [`ParseError`], so callers get the engine's own
+/// message, source position, error category, and expected-token hints without
+/// scraping a formatted string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RqlDiagnostic {
+    /// Human-readable parser message.
+    pub message: String,
+    /// 1-indexed line where parsing failed.
+    pub line: u32,
+    /// 1-indexed column where parsing failed.
+    pub column: u32,
+    /// Byte offset from the start of the input where parsing failed.
+    pub offset: u32,
+    /// Stable category for the failure (e.g. `"syntax"`, `"depth_limit"`),
+    /// derived from [`ParseErrorKind`] so callers branch without string-matching
+    /// the message.
+    pub kind: String,
+    /// Tokens the parser expected at the failure point, when it tracked any.
+    pub expected: Vec<String>,
+}
+
+/// The verdict of parsing an RQL string through the real `reddb-io-rql` parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RqlValidation {
+    /// True when the input parsed cleanly.
+    pub valid: bool,
+    /// The top-level statement kind (the [`QueryExpr`] variant name, e.g.
+    /// `"Table"`, `"Insert"`) when valid.
+    pub statement: Option<String>,
+    /// True when the query carried a leading `WITH` (CTE) prelude.
+    pub has_with_clause: bool,
+    /// The structured parse error when invalid.
+    pub error: Option<RqlDiagnostic>,
+}
+
+/// The verdict plus the parsed AST and the optimizer plan, for the
+/// `reddb_rql_explain` tool. `ast` / `optimized_ast` / `applied_passes` are only
+/// populated when the input parsed.
+#[derive(Debug, Clone)]
+pub struct RqlExplanation {
+    /// The same verdict [`validate_rql`] returns.
+    pub validation: RqlValidation,
+    /// Pretty-printed AST of the parsed query, when valid.
+    pub ast: Option<String>,
+    /// Pretty-printed AST after the default optimization passes, when valid.
+    pub optimized_ast: Option<String>,
+    /// Names of the optimization passes that actually rewrote the query.
+    pub applied_passes: Vec<String>,
+}
+
+/// Stable, lower-snake-case label for a [`ParseErrorKind`] so agents can branch
+/// on the failure category without parsing the message.
+fn parse_error_kind_label(kind: &ParseErrorKind) -> &'static str {
+    match kind {
+        ParseErrorKind::Syntax => "syntax",
+        ParseErrorKind::DepthLimit { .. } => "depth_limit",
+        ParseErrorKind::InputTooLarge { .. } => "input_too_large",
+        ParseErrorKind::IdentifierTooLong { .. } => "identifier_too_long",
+        ParseErrorKind::TokenLimit { .. } => "token_limit",
+        ParseErrorKind::ValueOutOfRange { .. } => "value_out_of_range",
+        ParseErrorKind::UnsupportedToken { .. } => "unsupported_token",
+    }
+}
+
+fn diagnostic_from_error(err: &ParseError) -> RqlDiagnostic {
+    RqlDiagnostic {
+        message: err.message.clone(),
+        line: err.position.line,
+        column: err.position.column,
+        offset: err.position.offset,
+        kind: parse_error_kind_label(&err.kind).to_string(),
+        expected: err.expected.clone(),
+    }
+}
+
+/// The [`QueryExpr`] variant name, e.g. `"Table"` or `"Insert"`. Read from the
+/// derived `Debug` representation (its leading identifier is the variant name)
+/// so this never drifts as variants are added to the enum.
+fn statement_kind(expr: &QueryExpr) -> String {
+    format!("{expr:?}")
+        .chars()
+        .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect()
+}
+
+/// Parse an RQL string through the real `reddb-io-rql` parser and report the
+/// verdict: the statement kind on success, or a structured diagnostic on
+/// failure. No reimplementation — this is the engine's own front-end.
+pub fn validate_rql(input: &str) -> RqlValidation {
+    match parse_rql(input) {
+        Ok(query) => RqlValidation {
+            valid: true,
+            statement: Some(statement_kind(&query.query)),
+            has_with_clause: query.with_clause.is_some(),
+            error: None,
+        },
+        Err(err) => RqlValidation {
+            valid: false,
+            statement: None,
+            has_with_clause: false,
+            error: Some(diagnostic_from_error(&err)),
+        },
+    }
+}
+
+/// Parse an RQL string and, when valid, also return its AST and the result of
+/// running the default optimization passes — the same passes the engine plans
+/// with. Invalid input yields the structured diagnostic with no AST/plan.
+pub fn explain_rql(input: &str) -> RqlExplanation {
+    match parse_rql(input) {
+        Ok(query) => {
+            let validation = RqlValidation {
+                valid: true,
+                statement: Some(statement_kind(&query.query)),
+                has_with_clause: query.with_clause.is_some(),
+                error: None,
+            };
+            let ast = format!("{:#?}", query.query);
+            let (optimized, applied_passes) = QueryOptimizer::new().optimize(query.query);
+            RqlExplanation {
+                validation,
+                ast: Some(ast),
+                optimized_ast: Some(format!("{optimized:#?}")),
+                applied_passes,
+            }
+        }
+        Err(err) => RqlExplanation {
+            validation: RqlValidation {
+                valid: false,
+                statement: None,
+                has_with_clause: false,
+                error: Some(diagnostic_from_error(&err)),
+            },
+            ast: None,
+            optimized_ast: None,
+            applied_passes: Vec::new(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,6 +573,61 @@ RQL reference"
     #[test]
     fn reference_is_deterministic() {
         assert_eq!(rql_reference_markdown(), rql_reference_markdown());
+    }
+
+    /// A well-formed SELECT validates and reports its statement kind.
+    #[test]
+    fn validate_accepts_valid_select() {
+        let verdict = validate_rql("SELECT * FROM users");
+        assert!(verdict.valid, "expected valid: {verdict:?}");
+        assert_eq!(verdict.statement.as_deref(), Some("Table"));
+        assert!(verdict.error.is_none());
+    }
+
+    /// A leading `WITH` prelude is reported on a valid query.
+    #[test]
+    fn validate_reports_with_clause() {
+        let verdict = validate_rql("WITH t AS (SELECT * FROM users) SELECT * FROM t");
+        assert!(verdict.valid, "expected valid: {verdict:?}");
+        assert!(
+            verdict.has_with_clause,
+            "expected has_with_clause: {verdict:?}"
+        );
+    }
+
+    /// Invalid RQL produces a structured diagnostic with a real source position
+    /// and a stable kind label — not a valid verdict.
+    #[test]
+    fn validate_rejects_invalid_with_structured_error() {
+        let verdict = validate_rql("SELECT * FROM");
+        assert!(!verdict.valid, "expected invalid: {verdict:?}");
+        assert!(verdict.statement.is_none());
+        let err = verdict.error.expect("structured error");
+        assert!(!err.message.is_empty(), "message should be populated");
+        assert!(err.line >= 1, "line is 1-indexed: {err:?}");
+        assert!(!err.kind.is_empty(), "kind label should be populated");
+    }
+
+    /// `explain_rql` returns the AST and the optimizer plan for valid input.
+    #[test]
+    fn explain_returns_ast_and_plan() {
+        let explanation = explain_rql("SELECT * FROM users WHERE id = 1");
+        assert!(explanation.validation.valid);
+        let ast = explanation.ast.expect("ast present");
+        assert!(ast.contains("Table"), "ast should render the query: {ast}");
+        assert!(explanation.optimized_ast.is_some());
+        // applied_passes is a (possibly empty) list, never populated on error.
+    }
+
+    /// `explain_rql` on invalid input mirrors the validation error and omits the
+    /// AST/plan.
+    #[test]
+    fn explain_on_invalid_omits_ast() {
+        let explanation = explain_rql("NOT REAL RQL @@@");
+        assert!(!explanation.validation.valid);
+        assert!(explanation.ast.is_none());
+        assert!(explanation.optimized_ast.is_none());
+        assert!(explanation.applied_passes.is_empty());
     }
 
     /// The `docs/llms.txt` block wraps exactly the reference between markers.

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -312,6 +312,8 @@ impl McpServer {
             "reddb_graph_clustering" => self.tool_graph_clustering(args),
             "reddb_create_collection" => self.tool_create_collection(args),
             "reddb_drop_collection" => self.tool_drop_collection(args),
+            "reddb_rql_validate" => self.tool_rql_validate(args),
+            "reddb_rql_explain" => self.tool_rql_explain(args),
             "reddb_auth_bootstrap" => self.tool_auth_bootstrap(args),
             "reddb_auth_create_user" => self.tool_auth_create_user(args),
             "reddb_auth_login" => self.tool_auth_login(args),
@@ -1298,6 +1300,45 @@ impl McpServer {
         resp.insert("dropped".into(), JsonValue::String(name.to_string()));
         json_to_string(&JsonValue::Object(resp)).map_err(|e| format!("serialization error: {}", e))
     }
+
+    fn tool_rql_validate(&self, args: &JsonValue) -> Result<String, String> {
+        let rql = get_str_field(args, "rql")?;
+        let verdict = reddb_rql::knowledge::validate_rql(rql);
+        let json = rql_validation_json(&verdict);
+        json_to_string(&json).map_err(|e| format!("serialization error: {}", e))
+    }
+
+    fn tool_rql_explain(&self, args: &JsonValue) -> Result<String, String> {
+        let rql = get_str_field(args, "rql")?;
+        let explanation = reddb_rql::knowledge::explain_rql(rql);
+
+        let mut obj = Map::new();
+        obj.insert(
+            "validation".to_string(),
+            rql_validation_json(&explanation.validation),
+        );
+        if let Some(ast) = &explanation.ast {
+            obj.insert("ast".to_string(), JsonValue::String(ast.clone()));
+        }
+        if let Some(optimized) = &explanation.optimized_ast {
+            obj.insert(
+                "optimized_ast".to_string(),
+                JsonValue::String(optimized.clone()),
+            );
+        }
+        obj.insert(
+            "applied_passes".to_string(),
+            JsonValue::Array(
+                explanation
+                    .applied_passes
+                    .iter()
+                    .cloned()
+                    .map(JsonValue::String)
+                    .collect(),
+            ),
+        );
+        json_to_string(&JsonValue::Object(obj)).map_err(|e| format!("serialization error: {}", e))
+    }
 }
 
 // ------------------------------------------------------------------
@@ -1322,6 +1363,51 @@ fn format_mcp_ask_parse_error(err: crate::runtime::ai::mcp_ask_tool::ParseError)
         }
         ParseError::UnknownOption { path } => format!("unknown option {path}"),
     }
+}
+
+/// Render an RQL parse verdict (ADR 0061, #1317) as the JSON the
+/// `reddb_rql_validate` / `reddb_rql_explain` tools return.
+fn rql_validation_json(verdict: &reddb_rql::knowledge::RqlValidation) -> JsonValue {
+    let mut obj = Map::new();
+    obj.insert("valid".to_string(), JsonValue::Bool(verdict.valid));
+    if let Some(statement) = &verdict.statement {
+        obj.insert(
+            "statement".to_string(),
+            JsonValue::String(statement.clone()),
+        );
+    }
+    obj.insert(
+        "has_with_clause".to_string(),
+        JsonValue::Bool(verdict.has_with_clause),
+    );
+    if let Some(error) = &verdict.error {
+        obj.insert("error".to_string(), rql_diagnostic_json(error));
+    }
+    JsonValue::Object(obj)
+}
+
+/// Render a structured RQL parse diagnostic as JSON.
+fn rql_diagnostic_json(diag: &reddb_rql::knowledge::RqlDiagnostic) -> JsonValue {
+    let mut obj = Map::new();
+    obj.insert(
+        "message".to_string(),
+        JsonValue::String(diag.message.clone()),
+    );
+    obj.insert("line".to_string(), JsonValue::Number(diag.line as f64));
+    obj.insert("column".to_string(), JsonValue::Number(diag.column as f64));
+    obj.insert("offset".to_string(), JsonValue::Number(diag.offset as f64));
+    obj.insert("kind".to_string(), JsonValue::String(diag.kind.clone()));
+    obj.insert(
+        "expected".to_string(),
+        JsonValue::Array(
+            diag.expected
+                .iter()
+                .cloned()
+                .map(JsonValue::String)
+                .collect(),
+        ),
+    );
+    JsonValue::Object(obj)
 }
 
 fn parse_direction(s: Option<&str>) -> RuntimeGraphDirection {
@@ -1921,6 +2007,138 @@ mod tests {
                 "param did not bind: {e}"
             );
         }
+    }
+
+    // ------------------------------------------------------------------
+    // RQL validate / explain tools (ADR 0061, #1317), exercised at the
+    // JSON-RPC tools/call seam.
+    // ------------------------------------------------------------------
+
+    fn call_tool(srv: &McpServer, name: &str, rql: &str) -> JsonValue {
+        let params = parse_json(
+            &json_to_string(&{
+                let mut p = Map::new();
+                p.insert("name".to_string(), JsonValue::String(name.to_string()));
+                let mut args = Map::new();
+                args.insert("rql".to_string(), JsonValue::String(rql.to_string()));
+                p.insert("arguments".to_string(), JsonValue::Object(args));
+                JsonValue::Object(p)
+            })
+            .expect("serialize params"),
+        );
+        let response = srv.handle_tools_call(Some(&JsonValue::Number(1.0)), Some(&params));
+        parse_json(&response)
+    }
+
+    fn tool_result_text(parsed: &JsonValue) -> String {
+        parsed
+            .get("result")
+            .and_then(|r| r.get("content"))
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("tool text")
+            .to_string()
+    }
+
+    #[test]
+    fn tools_list_registers_rql_validate_and_explain() {
+        let srv = make_server();
+        let response = srv.handle_tools_list(Some(&JsonValue::Number(1.0)));
+        let parsed = parse_json(&response);
+        let tools = parsed
+            .get("result")
+            .and_then(|result| result.get("tools"))
+            .and_then(JsonValue::as_array)
+            .expect("tools array");
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(JsonValue::as_str))
+            .collect();
+        assert!(names.contains(&"reddb_rql_validate"), "{names:?}");
+        assert!(names.contains(&"reddb_rql_explain"), "{names:?}");
+    }
+
+    #[test]
+    fn tools_call_rql_validate_accepts_valid_query() {
+        let srv = make_server();
+        let parsed = call_tool(&srv, "reddb_rql_validate", "SELECT * FROM users");
+        let result = parsed.get("result").expect("result");
+        assert_ne!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        let envelope = parse_json(&tool_result_text(&parsed));
+        assert_eq!(
+            envelope.get("valid").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            envelope.get("statement").and_then(JsonValue::as_str),
+            Some("Table")
+        );
+    }
+
+    #[test]
+    fn tools_call_rql_validate_reports_structured_error() {
+        let srv = make_server();
+        let parsed = call_tool(&srv, "reddb_rql_validate", "SELECT * FROM");
+        let envelope = parse_json(&tool_result_text(&parsed));
+        assert_eq!(
+            envelope.get("valid").and_then(JsonValue::as_bool),
+            Some(false)
+        );
+        let error = envelope.get("error").expect("structured error");
+        assert!(error
+            .get("message")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|m| !m.is_empty()));
+        assert!(error.get("line").and_then(JsonValue::as_f64).is_some());
+        assert!(error
+            .get("kind")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|k| !k.is_empty()));
+    }
+
+    #[test]
+    fn tools_call_rql_explain_returns_ast_and_plan() {
+        let srv = make_server();
+        let parsed = call_tool(
+            &srv,
+            "reddb_rql_explain",
+            "SELECT * FROM users WHERE id = 1",
+        );
+        let envelope = parse_json(&tool_result_text(&parsed));
+        assert_eq!(
+            envelope
+                .get("validation")
+                .and_then(|v| v.get("valid"))
+                .and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        assert!(envelope.get("ast").and_then(JsonValue::as_str).is_some());
+        assert!(envelope
+            .get("optimized_ast")
+            .and_then(JsonValue::as_str)
+            .is_some());
+        assert!(envelope
+            .get("applied_passes")
+            .and_then(JsonValue::as_array)
+            .is_some());
+    }
+
+    #[test]
+    fn tools_call_rql_validate_missing_field_errors() {
+        let srv = make_server();
+        let params = parse_json(r#"{"name":"reddb_rql_validate","arguments":{}}"#);
+        let response = srv.handle_tools_call(Some(&JsonValue::Number(1.0)), Some(&params));
+        let parsed = parse_json(&response);
+        let result = parsed.get("result").expect("result");
+        assert_eq!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
     }
 
     struct EnvVarGuard {

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -678,6 +678,25 @@ pub fn all_tools() -> Vec<ToolDef> {
                 vec!["name"],
             ),
         },
+        // RQL knowledge tools (ADR 0061): parse a submitted query through the
+        // real `reddb-io-rql` parser so an agent learns the dialect by
+        // submitting, not by guessing.
+        ToolDef {
+            name: "reddb_rql_validate",
+            description: "Validate an RQL (RedDB Query Language) string by parsing it with the real reddb-io-rql parser. Returns `{ valid: true, statement }` with the statement kind on success, or `{ valid: false, error }` with a structured diagnostic (message, line, column, offset, kind, expected) on failure. Submit a query to learn the dialect instead of guessing.",
+            input_schema: schema(
+                vec![("rql", "string", "RQL query string to validate")],
+                vec!["rql"],
+            ),
+        },
+        ToolDef {
+            name: "reddb_rql_explain",
+            description: "Explain an RQL (RedDB Query Language) string: parse it with the real reddb-io-rql parser and, when valid, also return its AST and the optimizer plan (`ast`, `optimized_ast`, `applied_passes`). Invalid input returns the same structured diagnostic as reddb_rql_validate with no AST/plan.",
+            input_schema: schema(
+                vec![("rql", "string", "RQL query string to parse and explain")],
+                vec!["rql"],
+            ),
+        },
     ]
 }
 
@@ -721,6 +740,53 @@ mod tests {
         assert!(names.contains(&"reddb_graph_clustering"));
         assert!(names.contains(&"reddb_create_collection"));
         assert!(names.contains(&"reddb_drop_collection"));
+        // RQL knowledge tools (ADR 0061).
+        assert!(names.contains(&"reddb_rql_validate"));
+        assert!(names.contains(&"reddb_rql_explain"));
+    }
+
+    #[test]
+    fn test_rql_validate_tool_schema() {
+        let tools = all_tools();
+        let tool = tools
+            .iter()
+            .find(|t| t.name == "reddb_rql_validate")
+            .expect("reddb_rql_validate registered");
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert!(props.contains_key("rql"));
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(required_strs.contains(&"rql"));
+    }
+
+    #[test]
+    fn test_rql_explain_tool_schema() {
+        let tools = all_tools();
+        let tool = tools
+            .iter()
+            .find(|t| t.name == "reddb_rql_explain")
+            .expect("reddb_rql_explain registered");
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert!(props.contains_key("rql"));
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(required_strs.contains(&"rql"));
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1317. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1317

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785028053&installation_id=129708444&pr_number=1411&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1411&signature=4958d1b64ca9fea44f21c5eeea62c5fdcbb4b906eef0e5d6378fd9c98032eb13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RQL validation and explanation tools with structured results, including success status, statement type, and optimizer output.
  * Exposed richer diagnostic details for invalid queries, such as message, location, error kind, and expected tokens.
  * Added the new tools to the available MCP tool list with required `rql` input.

* **Tests**
  * Expanded coverage for valid queries, `WITH` handling, structured errors, tool listing, schema requirements, and missing input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->