### PR TITLE
merge: #1320 feat(mcp): reddb_type_of tool (type/cast lookup from generated catalog)

### DIFF
--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -312,6 +312,7 @@ impl McpServer {
             "reddb_graph_clustering" => self.tool_graph_clustering(args),
             "reddb_create_collection" => self.tool_create_collection(args),
             "reddb_drop_collection" => self.tool_drop_collection(args),
+            "reddb_type_of" => self.tool_type_of(args),
             "reddb_auth_bootstrap" => self.tool_auth_bootstrap(args),
             "reddb_auth_create_user" => self.tool_auth_create_user(args),
             "reddb_auth_login" => self.tool_auth_login(args),
@@ -932,6 +933,89 @@ impl McpServer {
         obj.insert("count".to_string(), JsonValue::Number(items.len() as f64));
         obj.insert("results".to_string(), JsonValue::Array(items));
         json_to_string(&JsonValue::Object(obj)).map_err(|e| format!("serialization error: {}", e))
+    }
+
+    /// `reddb_type_of` — resolve the canonical type for a value or type name,
+    /// answering from the generated `reddb-io-types` catalogs (ADR 0061). The
+    /// engine does no storage or evaluation here: a `value` is classified by the
+    /// value codec's `data_type()`, a `type` name by the SQL-name parser, and
+    /// the casts/operators come straight from the function/operator/cast tables.
+    fn tool_type_of(&self, args: &JsonValue) -> Result<String, String> {
+        use reddb_types::knowledge::{
+            cast_context_label, category_label, resolve_type_name, type_facts, CastFact,
+        };
+
+        let has_value = args.get("value").is_some();
+        let type_name = args.get("type").and_then(|v| v.as_str());
+
+        // Build the input echo and resolve the canonical type from exactly one
+        // of `value` / `type`.
+        let mut input_echo = Map::new();
+        let canonical = match (has_value, type_name) {
+            (true, Some(_)) => {
+                return Err("provide either 'value' or 'type', not both".to_string());
+            }
+            (false, None) => {
+                return Err("missing required field: provide 'value' or 'type'".to_string());
+            }
+            (true, None) => {
+                let raw = args.get("value").expect("value present");
+                input_echo.insert("value".to_string(), raw.clone());
+                crate::rpc_stdio::json_value_to_schema_value(raw).data_type()
+            }
+            (false, Some(name)) => {
+                input_echo.insert("type".to_string(), JsonValue::String(name.to_string()));
+                resolve_type_name(name).ok_or_else(|| format!("unknown type name: {name:?}"))?
+            }
+        };
+
+        let facts = type_facts(canonical);
+
+        let render_cast = |cast: &CastFact| {
+            let mut obj = Map::new();
+            obj.insert("src".to_string(), JsonValue::String(cast.src.to_string()));
+            obj.insert(
+                "target".to_string(),
+                JsonValue::String(cast.target.to_string()),
+            );
+            obj.insert(
+                "context".to_string(),
+                JsonValue::String(cast_context_label(cast.context).to_string()),
+            );
+            obj.insert("lossy".to_string(), JsonValue::Bool(cast.lossy));
+            JsonValue::Object(obj)
+        };
+
+        let mut out = Map::new();
+        out.insert("input".to_string(), JsonValue::Object(input_echo));
+        out.insert(
+            "canonical_type".to_string(),
+            JsonValue::String(facts.canonical.to_string()),
+        );
+        out.insert(
+            "category".to_string(),
+            JsonValue::String(category_label(facts.category).to_string()),
+        );
+        out.insert(
+            "operators".to_string(),
+            JsonValue::Array(
+                facts
+                    .operators
+                    .iter()
+                    .map(|op| JsonValue::String((*op).to_string()))
+                    .collect(),
+            ),
+        );
+        out.insert(
+            "casts_from".to_string(),
+            JsonValue::Array(facts.casts_from.iter().map(render_cast).collect()),
+        );
+        out.insert(
+            "casts_to".to_string(),
+            JsonValue::Array(facts.casts_to.iter().map(render_cast).collect()),
+        );
+
+        json_to_string(&JsonValue::Object(out)).map_err(|e| format!("serialization error: {}", e))
     }
 
     fn tool_health(&self) -> Result<String, String> {
@@ -1754,6 +1838,109 @@ mod tests {
             .and_then(JsonValue::as_str)
             .expect("error text");
         assert!(text.contains("options.tempurature"), "text: {text}");
+    }
+
+    /// Helper: drive `tools/call` for `reddb_type_of` and return the parsed
+    /// result object (or panic with the raw response).
+    fn type_of_call(srv: &McpServer, arguments: &str) -> JsonValue {
+        let params = parse_json(&format!(
+            r#"{{"name":"reddb_type_of","arguments":{arguments}}}"#
+        ));
+        let response = srv.handle_tools_call(Some(&JsonValue::Number(1.0)), Some(&params));
+        let parsed = parse_json(&response);
+        parsed.get("result").cloned().unwrap_or_else(|| {
+            panic!("no result in response: {response}");
+        })
+    }
+
+    fn type_of_envelope(result: &JsonValue) -> JsonValue {
+        let text = result
+            .get("content")
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("tool text");
+        parse_json(text)
+    }
+
+    #[test]
+    fn tools_call_reddb_type_of_resolves_type_name_from_catalog() {
+        let srv = make_server();
+        let result = type_of_call(&srv, r#"{"type":"int"}"#);
+        assert_ne!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true),
+            "result: {result:?}"
+        );
+        let env = type_of_envelope(&result);
+        assert_eq!(
+            env.get("canonical_type").and_then(JsonValue::as_str),
+            Some("INTEGER")
+        );
+        assert_eq!(
+            env.get("category").and_then(JsonValue::as_str),
+            Some("Numeric")
+        );
+
+        let operators: Vec<&str> = env
+            .get("operators")
+            .and_then(JsonValue::as_array)
+            .expect("operators")
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .collect();
+        assert!(operators.contains(&"+"), "operators: {operators:?}");
+
+        // Integer widens implicitly to float — the cast comes from the catalog.
+        let casts_from = env
+            .get("casts_from")
+            .and_then(JsonValue::as_array)
+            .expect("casts_from");
+        assert!(
+            casts_from.iter().any(|c| {
+                c.get("target").and_then(JsonValue::as_str) == Some("FLOAT")
+                    && c.get("context").and_then(JsonValue::as_str) == Some("implicit")
+            }),
+            "expected implicit int->float cast: {casts_from:?}"
+        );
+    }
+
+    #[test]
+    fn tools_call_reddb_type_of_infers_value_type() {
+        let srv = make_server();
+        let result = type_of_call(&srv, r#"{"value":"hello"}"#);
+        let env = type_of_envelope(&result);
+        assert_eq!(
+            env.get("canonical_type").and_then(JsonValue::as_str),
+            Some("TEXT")
+        );
+        assert_eq!(
+            env.get("input")
+                .and_then(|i| i.get("value"))
+                .and_then(JsonValue::as_str),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn tools_call_reddb_type_of_rejects_unknown_and_missing_input() {
+        let srv = make_server();
+
+        let unknown = type_of_call(&srv, r#"{"type":"not-a-type"}"#);
+        assert_eq!(
+            unknown.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+
+        let missing = type_of_call(&srv, r#"{}"#);
+        assert_eq!(
+            missing.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+
+        let both = type_of_call(&srv, r#"{"type":"int","value":1}"#);
+        assert_eq!(both.get("isError").and_then(JsonValue::as_bool), Some(true));
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -678,6 +678,43 @@ pub fn all_tools() -> Vec<ToolDef> {
                 vec!["name"],
             ),
         },
+        ToolDef {
+            name: "reddb_type_of",
+            description: "Resolve the canonical RedDB type for a value or a type name, with the casts and operators that apply to it.\n\nPass either `value` (a literal classified by the engine's value codec) or `type` (a type name such as `INT`, `TEXT`, or a canonical reddb name). Returns the canonical type, its coercion category, the applicable operator symbols, and the casts that flow out of (`casts_from`) and into (`casts_to`) it. Answers entirely from the generated `reddb-io-types` function/operator/cast catalogs — no value is stored or evaluated.",
+            input_schema: schema_with_nested(
+                vec![
+                    ("value", {
+                        let mut f = Map::new();
+                        f.insert(
+                            "description".to_string(),
+                            JsonValue::String(
+                                "A literal value to classify. Accepts null, boolean, number, string, array, or object; its canonical RedDB type is inferred by the value codec."
+                                    .to_string(),
+                            ),
+                        );
+                        f.insert(
+                            "anyOf".to_string(),
+                            JsonValue::Array(vec![
+                                type_field("null"),
+                                type_field("boolean"),
+                                type_field("number"),
+                                type_field("string"),
+                                type_field("array"),
+                                type_field("object"),
+                            ]),
+                        );
+                        JsonValue::Object(f)
+                    }),
+                    (
+                        "type",
+                        string_field(
+                            "A type name to look up instead of a value — an SQL alias (`INT`, `STRING`) or a canonical reddb name (`INTEGER`, `TEXT`), case-insensitive.",
+                        ),
+                    ),
+                ],
+                vec![],
+            ),
+        },
     ]
 }
 
@@ -721,6 +758,28 @@ mod tests {
         assert!(names.contains(&"reddb_graph_clustering"));
         assert!(names.contains(&"reddb_create_collection"));
         assert!(names.contains(&"reddb_drop_collection"));
+        assert!(names.contains(&"reddb_type_of"));
+    }
+
+    #[test]
+    fn test_type_of_tool_schema_accepts_value_or_type() {
+        let tools = all_tools();
+        let tool = tools.iter().find(|t| t.name == "reddb_type_of").unwrap();
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert!(props.contains_key("value"));
+        assert!(props.contains_key("type"));
+
+        // Neither field is required — the tool validates "exactly one" at call time.
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert!(required.is_empty());
     }
 
     #[test]

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -205,8 +205,108 @@ pub fn implicit_casts() -> Vec<(DataType, DataType)> {
     pairs
 }
 
-/// Human label for a [`TypeCategory`], used by the generated map.
-fn category_label(category: TypeCategory) -> &'static str {
+/// Human label for the minimum context a cast requires, as published by the
+/// type-of lookup. Mirrors [`CastContext`] one-for-one.
+pub fn cast_context_label(context: CastContext) -> &'static str {
+    match context {
+        CastContext::Implicit => "implicit",
+        CastContext::Assignment => "assignment",
+        CastContext::Explicit => "explicit",
+    }
+}
+
+/// One cast edge in a type's cast neighbourhood, read live from
+/// [`CAST_CATALOG`]. The `context` is the minimum coercion context the cast
+/// requires and `lossy` flags conversions that may drop information.
+#[derive(Debug, Clone, Copy)]
+pub struct CastFact {
+    /// Source type of the cast.
+    pub src: DataType,
+    /// Target type of the cast.
+    pub target: DataType,
+    /// Minimum context in which the cast is legal (implicit/assignment/explicit).
+    pub context: CastContext,
+    /// Whether the cast may lose information.
+    pub lossy: bool,
+}
+
+/// The catalog facts for one value type: its coercion category, the operator
+/// symbols whose overloads accept it, and the casts that flow out of and into
+/// it. Every field is read live from the function/operator/cast authorities in
+/// this crate, so a type-of answer cannot drift from the engine.
+pub struct TypeFacts {
+    /// The canonical value type these facts describe.
+    pub canonical: DataType,
+    /// The coercion category the canonical type belongs to.
+    pub category: TypeCategory,
+    /// Distinct operator symbols whose [`OPERATOR_CATALOG`] overloads name the
+    /// canonical type as an operand, sorted.
+    pub operators: Vec<&'static str>,
+    /// Casts whose source is the canonical type, sorted by target then context.
+    pub casts_from: Vec<CastFact>,
+    /// Casts whose target is the canonical type, sorted by source then context.
+    pub casts_to: Vec<CastFact>,
+}
+
+/// Resolve a type name — an SQL alias (`INT`, `STRING`) or a canonical reddb
+/// name (`INTEGER`, `TEXT`), case-insensitive — to its canonical [`DataType`].
+///
+/// Delegates to the engine's own [`DataType::from_sql_name`] parser so no
+/// separate name table is maintained here; returns `None` for unknown names.
+pub fn resolve_type_name(name: &str) -> Option<DataType> {
+    DataType::from_sql_name(name)
+}
+
+/// Look up the catalog facts for a value type. Operators are the distinct
+/// symbols whose [`OPERATOR_CATALOG`] overloads name `ty` as an operand; casts
+/// are every [`CAST_CATALOG`] edge with `ty` as source (`casts_from`) or target
+/// (`casts_to`). Pure function of the static catalogs — see
+/// [`tests::type_facts_read_only_from_catalogs`].
+pub fn type_facts(ty: DataType) -> TypeFacts {
+    let mut operators: Vec<&'static str> = OPERATOR_CATALOG
+        .iter()
+        .filter(|entry| entry.lhs_type == ty || entry.rhs_type == ty)
+        .map(|entry| entry.name)
+        .collect();
+    operators.sort_unstable();
+    operators.dedup();
+
+    let mut casts_from: Vec<CastFact> = CAST_CATALOG
+        .iter()
+        .filter(|entry| entry.src == ty)
+        .map(|entry| CastFact {
+            src: entry.src,
+            target: entry.target,
+            context: entry.context,
+            lossy: entry.lossy,
+        })
+        .collect();
+    casts_from.sort_by_key(|cast| (cast.target as u8, cast.context as u8));
+
+    let mut casts_to: Vec<CastFact> = CAST_CATALOG
+        .iter()
+        .filter(|entry| entry.target == ty)
+        .map(|entry| CastFact {
+            src: entry.src,
+            target: entry.target,
+            context: entry.context,
+            lossy: entry.lossy,
+        })
+        .collect();
+    casts_to.sort_by_key(|cast| (cast.src as u8, cast.context as u8));
+
+    TypeFacts {
+        canonical: ty,
+        category: ty.category(),
+        operators,
+        casts_from,
+        casts_to,
+    }
+}
+
+/// Human label for a [`TypeCategory`], used by the generated map and the
+/// type-of lookup.
+pub fn category_label(category: TypeCategory) -> &'static str {
     match category {
         TypeCategory::Numeric => "Numeric",
         TypeCategory::String => "String",
@@ -509,6 +609,82 @@ reference"
     #[test]
     fn reference_is_deterministic() {
         assert_eq!(type_reference_markdown(), type_reference_markdown());
+    }
+
+    /// `resolve_type_name` answers from the engine's own SQL-name parser:
+    /// aliases and canonical names both resolve, unknown names return `None`.
+    #[test]
+    fn resolve_type_name_accepts_aliases_and_rejects_unknown() {
+        assert_eq!(resolve_type_name("int"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("INTEGER"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("string"), Some(DataType::Text));
+        assert_eq!(resolve_type_name("BIGINT"), Some(DataType::BigInt));
+        assert_eq!(resolve_type_name("not-a-type"), None);
+    }
+
+    /// `type_facts` surfaces an integer's catalogued casts and operators: the
+    /// implicit widening to a wider numeric type and the arithmetic/comparison
+    /// operators it participates in.
+    #[test]
+    fn type_facts_integer_has_widening_casts_and_operators() {
+        let facts = type_facts(DataType::Integer);
+        assert_eq!(facts.canonical, DataType::Integer);
+        assert_eq!(facts.category, TypeCategory::Numeric);
+
+        assert!(
+            facts.operators.contains(&"+"),
+            "integer should support `+`: {:?}",
+            facts.operators
+        );
+        assert!(
+            facts.operators.contains(&"="),
+            "integer should support `=`: {:?}",
+            facts.operators
+        );
+
+        assert!(
+            facts
+                .casts_from
+                .iter()
+                .any(|c| c.target == DataType::Float && c.context == CastContext::Implicit),
+            "integer should widen implicitly to float: {:?}",
+            facts.casts_from
+        );
+    }
+
+    /// `type_facts` reads only from the catalogs: every `casts_from` edge names
+    /// the queried type as its source and every `casts_to` edge as its target,
+    /// and the operator list is sorted and deduplicated.
+    #[test]
+    fn type_facts_read_only_from_catalogs() {
+        for ty in catalogued_value_types() {
+            let facts = type_facts(ty);
+            for cast in &facts.casts_from {
+                assert_eq!(cast.src, ty, "casts_from edge must originate at {ty}");
+            }
+            for cast in &facts.casts_to {
+                assert_eq!(cast.target, ty, "casts_to edge must arrive at {ty}");
+            }
+            let mut sorted = facts.operators.clone();
+            sorted.sort_unstable();
+            assert_eq!(facts.operators, sorted, "operators must be sorted for {ty}");
+            let mut deduped = facts.operators.clone();
+            deduped.dedup();
+            assert_eq!(
+                deduped.len(),
+                facts.operators.len(),
+                "operators must be unique for {ty}"
+            );
+        }
+    }
+
+    /// Cast-context labels are the lowercase three-state vocabulary the type-of
+    /// lookup publishes.
+    #[test]
+    fn cast_context_labels_are_stable() {
+        assert_eq!(cast_context_label(CastContext::Implicit), "implicit");
+        assert_eq!(cast_context_label(CastContext::Assignment), "assignment");
+        assert_eq!(cast_context_label(CastContext::Explicit), "explicit");
     }
 
     /// The `docs/llms.txt` block wraps exactly the reference between markers.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -76,6 +76,12 @@ is the RedDB ID and `kind` is the item kind such as `row`, `document`, `kv`,
 |:-----|:------------|
 | `reddb_health` | Check database health and runtime stats |
 
+### Type System
+
+| Tool | Description |
+|:-----|:------------|
+| `reddb_type_of` | Resolve the canonical type for a value or type name, with applicable casts and operators (answered from the generated `reddb-io-types` catalog) |
+
 ## Tool Examples
 
 ### Execute a Query


### PR DESCRIPTION
Automated AFK landing for #1320. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1320

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785028097&installation_id=129708444&pr_number=1412&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1412&signature=47799177bf26b52dcaea22e568fcef7ad78cec74681b16a4f973192ae2bf97b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->