### PR TITLE
merge: #1317 feat(mcp): reddb_rql_validate/explain tool (parse via real reddb-io-rql)

### DIFF
--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -312,6 +312,8 @@ impl McpServer {
             "reddb_graph_clustering" => self.tool_graph_clustering(args),
             "reddb_create_collection" => self.tool_create_collection(args),
             "reddb_drop_collection" => self.tool_drop_collection(args),
+            "reddb_rql_validate" => self.tool_rql_validate(args),
+            "reddb_rql_explain" => self.tool_rql_explain(args),
             "reddb_auth_bootstrap" => self.tool_auth_bootstrap(args),
             "reddb_auth_create_user" => self.tool_auth_create_user(args),
             "reddb_auth_login" => self.tool_auth_login(args),
@@ -427,6 +429,32 @@ impl McpServer {
             .execute_ask("ASK <mcp>", &ask)
             .map_err(|e| format!("{}", e))?;
         let json = crate::rpc_stdio::query_result_to_json(&result);
+        json_to_string(&json).map_err(|e| format!("serialization error: {}", e))
+    }
+
+    /// Parse a submitted RQL/SQL string through the real `reddb-io-rql`
+    /// parser and return the verdict (ADR 0061). No execution, no side
+    /// effects — the tool exists so an agent learns the dialect by
+    /// submitting a query and reading the structured result.
+    fn tool_rql_validate(&self, args: &JsonValue) -> Result<String, String> {
+        let rql = args
+            .get("rql")
+            .and_then(|v| v.as_str())
+            .ok_or("missing required field 'rql'")?;
+        let json = rql_validate_json(rql);
+        json_to_string(&json).map_err(|e| format!("serialization error: {}", e))
+    }
+
+    /// Parse a submitted RQL/SQL string through the real `reddb-io-rql`
+    /// parser and, on success, run it through the real query optimizer to
+    /// surface the plan (applied passes + optimized AST). Returns the same
+    /// structured parse error as `reddb_rql_validate` on invalid input.
+    fn tool_rql_explain(&self, args: &JsonValue) -> Result<String, String> {
+        let rql = args
+            .get("rql")
+            .and_then(|v| v.as_str())
+            .ok_or("missing required field 'rql'")?;
+        let json = rql_explain_json(rql);
         json_to_string(&json).map_err(|e| format!("serialization error: {}", e))
     }
 
@@ -1420,6 +1448,140 @@ fn reject_mcp_volatile_options(args: &JsonValue, domain: &str) -> Result<(), Str
     Ok(())
 }
 
+// ------------------------------------------------------------------
+// RQL validate / explain helpers (ADR 0061)
+//
+// These parse a submitted RQL/SQL string through the *real*
+// `reddb-io-rql` parser (never a reimplementation) and shape the verdict
+// as JSON. `rql_validate_json` stops at the parse; `rql_explain_json`
+// additionally runs the real query optimizer to surface the plan.
+// ------------------------------------------------------------------
+
+/// Stable name for a `ParseErrorKind` discriminant, so callers can branch
+/// on the failure category (DoS refusal vs. plain syntax) without string
+/// matching on the message.
+fn rql_error_kind_name(kind: &reddb_rql::ParseErrorKind) -> &'static str {
+    use reddb_rql::ParseErrorKind as K;
+    match kind {
+        K::Syntax => "syntax",
+        K::DepthLimit { .. } => "depth_limit",
+        K::InputTooLarge { .. } => "input_too_large",
+        K::IdentifierTooLong { .. } => "identifier_too_long",
+        K::TokenLimit { .. } => "token_limit",
+        K::ValueOutOfRange { .. } => "value_out_of_range",
+        K::UnsupportedToken { .. } => "unsupported_token",
+    }
+}
+
+/// Short discriminant name for a parsed statement (e.g. `"Insert"`,
+/// `"Table"`), derived from the `QueryExpr` `Debug` repr so it tracks the
+/// AST without an exhaustive match that would rot as variants are added.
+fn rql_statement_kind(query: &reddb_rql::ast::QueryExpr) -> String {
+    let dbg = format!("{:?}", query);
+    dbg.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Build the shared structured parse-error object.
+fn rql_parse_error_json(err: &reddb_rql::ParseError) -> JsonValue {
+    let mut e = Map::new();
+    e.insert("message".into(), JsonValue::String(err.message.clone()));
+    e.insert(
+        "line".into(),
+        JsonValue::Number(f64::from(err.position.line)),
+    );
+    e.insert(
+        "column".into(),
+        JsonValue::Number(f64::from(err.position.column)),
+    );
+    e.insert(
+        "offset".into(),
+        JsonValue::Number(f64::from(err.position.offset)),
+    );
+    e.insert(
+        "kind".into(),
+        JsonValue::String(rql_error_kind_name(&err.kind).into()),
+    );
+    e.insert("display".into(), JsonValue::String(err.to_string()));
+    if !err.expected.is_empty() {
+        e.insert(
+            "expected".into(),
+            JsonValue::Array(
+                err.expected
+                    .iter()
+                    .cloned()
+                    .map(JsonValue::String)
+                    .collect(),
+            ),
+        );
+    }
+    JsonValue::Object(e)
+}
+
+/// `{valid:false, error:{...}}` for a failed parse.
+fn rql_invalid_json(err: &reddb_rql::ParseError) -> JsonValue {
+    let mut obj = Map::new();
+    obj.insert("valid".into(), JsonValue::Bool(false));
+    obj.insert("error".into(), rql_parse_error_json(err));
+    JsonValue::Object(obj)
+}
+
+/// Parse-only verdict for `reddb_rql_validate`.
+fn rql_validate_json(rql: &str) -> JsonValue {
+    match reddb_rql::parse(rql) {
+        Ok(parsed) => {
+            let mut obj = Map::new();
+            obj.insert("valid".into(), JsonValue::Bool(true));
+            obj.insert(
+                "statement".into(),
+                JsonValue::String(rql_statement_kind(&parsed.query)),
+            );
+            obj.insert(
+                "ast".into(),
+                JsonValue::String(format!("{:#?}", parsed.query)),
+            );
+            JsonValue::Object(obj)
+        }
+        Err(err) => rql_invalid_json(&err),
+    }
+}
+
+/// Parse + plan verdict for `reddb_rql_explain`.
+fn rql_explain_json(rql: &str) -> JsonValue {
+    match reddb_rql::parse(rql) {
+        Ok(parsed) => {
+            let mut obj = Map::new();
+            obj.insert("valid".into(), JsonValue::Bool(true));
+            obj.insert(
+                "statement".into(),
+                JsonValue::String(rql_statement_kind(&parsed.query)),
+            );
+            obj.insert(
+                "ast".into(),
+                JsonValue::String(format!("{:#?}", parsed.query)),
+            );
+
+            // Run the real query optimizer to surface the plan.
+            let optimizer = reddb_rql::planner::QueryOptimizer::new();
+            let (optimized, applied) = optimizer.optimize(parsed.query.clone());
+            let mut plan = Map::new();
+            plan.insert(
+                "optimizations".into(),
+                JsonValue::Array(applied.into_iter().map(JsonValue::String).collect()),
+            );
+            plan.insert(
+                "optimized_ast".into(),
+                JsonValue::String(format!("{:#?}", optimized)),
+            );
+            obj.insert("plan".into(), JsonValue::Object(plan));
+            JsonValue::Object(obj)
+        }
+        Err(err) => rql_invalid_json(&err),
+    }
+}
+
 // Convert a storage Value to JSON (local helper to avoid visibility issues).
 fn get_str_field<'a>(args: &'a JsonValue, field: &str) -> Result<&'a str, String> {
     args.get(field)
@@ -1660,6 +1822,115 @@ mod tests {
             "value type missing: {text:.120}"
         );
         assert!(text.contains("Multi-model map"), "multi-model map missing");
+    }
+
+    // Helper: invoke a tool over the JSON-RPC `tools/call` seam and return the
+    // re-parsed JSON text content of a non-error result.
+    fn call_tool_ok(srv: &McpServer, name: &str, args: &str) -> JsonValue {
+        let params = parse_json(&format!(r#"{{"name":"{name}","arguments":{args}}}"#));
+        let response = srv.handle_tools_call(Some(&JsonValue::Number(1.0)), Some(&params));
+        let parsed = parse_json(&response);
+        let result = parsed.get("result").expect("result");
+        assert_ne!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true),
+            "unexpected error: {response}"
+        );
+        let text = result
+            .get("content")
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("content text");
+        parse_json(text)
+    }
+
+    #[test]
+    fn tools_call_rql_validate_accepts_valid_rql() {
+        let srv = make_server();
+        let verdict = call_tool_ok(
+            &srv,
+            "reddb_rql_validate",
+            r#"{"rql":"SELECT id, name FROM users WHERE age > 21"}"#,
+        );
+        assert_eq!(
+            verdict.get("valid").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        // The statement kind tracks the real AST variant.
+        assert_eq!(
+            verdict.get("statement").and_then(JsonValue::as_str),
+            Some("Table")
+        );
+        // The AST is the real parser output, not a stub.
+        let ast = verdict
+            .get("ast")
+            .and_then(JsonValue::as_str)
+            .expect("ast text");
+        assert!(ast.contains("TableQuery"), "ast: {ast:.200}");
+    }
+
+    #[test]
+    fn tools_call_rql_validate_reports_structured_parse_error() {
+        let srv = make_server();
+        let verdict = call_tool_ok(&srv, "reddb_rql_validate", r#"{"rql":"SELECT FROM WHERE"}"#);
+        assert_eq!(
+            verdict.get("valid").and_then(JsonValue::as_bool),
+            Some(false)
+        );
+        let error = verdict.get("error").expect("error object");
+        assert!(
+            error
+                .get("message")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|m| !m.is_empty()),
+            "error message missing"
+        );
+        // Position is surfaced structurally so an agent can locate the fault.
+        assert!(error.get("line").and_then(JsonValue::as_u64).is_some());
+        assert!(error.get("column").and_then(JsonValue::as_u64).is_some());
+        assert!(error.get("kind").and_then(JsonValue::as_str).is_some());
+    }
+
+    #[test]
+    fn tools_call_rql_explain_returns_ast_and_plan() {
+        let srv = make_server();
+        let verdict = call_tool_ok(
+            &srv,
+            "reddb_rql_explain",
+            r#"{"rql":"SELECT id FROM users WHERE age > 21 LIMIT 5"}"#,
+        );
+        assert_eq!(
+            verdict.get("valid").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        let plan = verdict.get("plan").expect("plan object");
+        // The plan carries the optimizer's applied-pass list and the
+        // resulting optimized AST — both produced by the real optimizer.
+        assert!(
+            plan.get("optimizations")
+                .and_then(JsonValue::as_array)
+                .is_some(),
+            "optimizations list missing"
+        );
+        assert!(
+            plan.get("optimized_ast")
+                .and_then(JsonValue::as_str)
+                .is_some_and(|a| !a.is_empty()),
+            "optimized_ast missing"
+        );
+    }
+
+    #[test]
+    fn tools_call_rql_explain_reports_structured_parse_error() {
+        let srv = make_server();
+        let verdict = call_tool_ok(&srv, "reddb_rql_explain", r#"{"rql":"SELCT oops"}"#);
+        assert_eq!(
+            verdict.get("valid").and_then(JsonValue::as_bool),
+            Some(false)
+        );
+        assert!(verdict.get("error").is_some(), "error object missing");
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -678,6 +678,25 @@ pub fn all_tools() -> Vec<ToolDef> {
                 vec!["name"],
             ),
         },
+        // RQL learning tools (ADR 0061) — parse a submitted RQL/SQL string
+        // through the real `reddb-io-rql` parser so an agent learns the
+        // dialect by submitting, not by guessing.
+        ToolDef {
+            name: "reddb_rql_validate",
+            description: "Validate an RQL/SQL statement by parsing it through RedDB's real query parser (reddb-io-rql) — no execution, no side effects. Returns `{valid:true, statement, ast}` on success or `{valid:false, error:{message,line,column,kind,expected}}` on a parse error. Submit a query and read the verdict to learn the RQL dialect instead of guessing.",
+            input_schema: schema(
+                vec![("rql", "string", "The RQL/SQL statement to parse and validate.")],
+                vec!["rql"],
+            ),
+        },
+        ToolDef {
+            name: "reddb_rql_explain",
+            description: "Parse an RQL/SQL statement through RedDB's real parser (reddb-io-rql) and return the parsed AST plus the optimizer plan — the passes the query optimizer would apply and the resulting optimized AST. Returns a structured parse error on invalid input. No execution, no side effects. Use it to understand how RedDB plans a query.",
+            input_schema: schema(
+                vec![("rql", "string", "The RQL/SQL statement to parse and explain.")],
+                vec!["rql"],
+            ),
+        },
     ]
 }
 
@@ -721,6 +740,33 @@ mod tests {
         assert!(names.contains(&"reddb_graph_clustering"));
         assert!(names.contains(&"reddb_create_collection"));
         assert!(names.contains(&"reddb_drop_collection"));
+        // RQL learning tools (ADR 0061)
+        assert!(names.contains(&"reddb_rql_validate"));
+        assert!(names.contains(&"reddb_rql_explain"));
+    }
+
+    #[test]
+    fn test_rql_tools_schema() {
+        let tools = all_tools();
+        for name in ["reddb_rql_validate", "reddb_rql_explain"] {
+            let tool = tools
+                .iter()
+                .find(|t| t.name == name)
+                .unwrap_or_else(|| panic!("tool '{name}' missing"));
+            let props = tool
+                .input_schema
+                .get("properties")
+                .and_then(|v| v.as_object())
+                .unwrap();
+            assert!(props.contains_key("rql"), "{name} must take 'rql'");
+            let required = tool
+                .input_schema
+                .get("required")
+                .and_then(|v| v.as_array())
+                .unwrap();
+            let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+            assert!(required_strs.contains(&"rql"), "{name} must require 'rql'");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1317. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1317

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785032585&installation_id=129708444&pr_number=1413&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1413&signature=8d1bcef5efae1886cb7971f93d0d1385889661df21a5b792b73b373e4764f6f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new query helper tools to validate RQL and explain its execution plan.
  * These tools now return structured results, including parse details, query kind, and optimization information.

* **Bug Fixes**
  * Improved error reporting for invalid RQL input with clearer structured parse error details.
  * Updated tool dispatch so the new helpers are available through the standard request path.

* **Tests**
  * Expanded coverage for successful and failing validation/explanation flows.
  * Verified the new tools and their input schemas are included in the available tool list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->