### PR TITLE
merge: #1320 feat(mcp): reddb_type_of tool (type/cast lookup from generated catalog)

### DIFF
--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -312,6 +312,7 @@ impl McpServer {
             "reddb_graph_clustering" => self.tool_graph_clustering(args),
             "reddb_create_collection" => self.tool_create_collection(args),
             "reddb_drop_collection" => self.tool_drop_collection(args),
+            "reddb_type_of" => self.tool_type_of(args),
             "reddb_auth_bootstrap" => self.tool_auth_bootstrap(args),
             "reddb_auth_create_user" => self.tool_auth_create_user(args),
             "reddb_auth_login" => self.tool_auth_login(args),
@@ -1298,6 +1299,81 @@ impl McpServer {
         resp.insert("dropped".into(), JsonValue::String(name.to_string()));
         json_to_string(&JsonValue::Object(resp)).map_err(|e| format!("serialization error: {}", e))
     }
+
+    /// `reddb_type_of` — resolve a value or type name to its canonical type and
+    /// the casts/operators the engine's catalogs make available (ADR 0061 §4).
+    ///
+    /// The answer is produced entirely by `reddb_types::knowledge`, which reads
+    /// the cast/operator authorities live, so the tool never reimplements the
+    /// type system. Accepts exactly one of `value` (type inferred) or `type`
+    /// (named type resolved).
+    fn tool_type_of(&self, args: &JsonValue) -> Result<String, String> {
+        use reddb_types::knowledge;
+
+        let has_value = matches!(args.get("value"), Some(v) if !matches!(v, JsonValue::Null));
+        let type_name = args.get("type").and_then(|v| v.as_str());
+
+        let canonical = match (has_value, type_name) {
+            (true, Some(_)) => {
+                return Err("provide either 'value' or 'type', not both".to_string());
+            }
+            (false, None) => {
+                return Err("missing input: provide 'value' or 'type'".to_string());
+            }
+            (true, None) => {
+                let value = args.get("value").expect("value present");
+                knowledge::canonical_type_of_json(value).ok_or_else(|| {
+                    "JSON null has no value type; provide a non-null 'value' or a 'type' name"
+                        .to_string()
+                })?
+            }
+            (false, Some(name)) => knowledge::resolve_type_name(name)
+                .ok_or_else(|| format!("unknown type name: {name:?}"))?,
+        };
+
+        let answer = knowledge::type_of(canonical);
+
+        let mut obj = Map::new();
+        obj.insert(
+            "canonical_type".to_string(),
+            JsonValue::String(answer.canonical.to_string()),
+        );
+        obj.insert(
+            "category".to_string(),
+            JsonValue::String(knowledge::category_label(answer.category).to_string()),
+        );
+        obj.insert(
+            "implicit_casts".to_string(),
+            JsonValue::Array(
+                answer
+                    .implicit_cast_targets
+                    .iter()
+                    .map(|ty| JsonValue::String(ty.to_string()))
+                    .collect(),
+            ),
+        );
+        obj.insert(
+            "explicit_casts".to_string(),
+            JsonValue::Array(
+                answer
+                    .explicit_cast_targets
+                    .iter()
+                    .map(|ty| JsonValue::String(ty.to_string()))
+                    .collect(),
+            ),
+        );
+        obj.insert(
+            "operators".to_string(),
+            JsonValue::Array(
+                answer
+                    .operators
+                    .iter()
+                    .map(|op| JsonValue::String(op.to_string()))
+                    .collect(),
+            ),
+        );
+        json_to_string(&JsonValue::Object(obj)).map_err(|e| format!("serialization error: {}", e))
+    }
 }
 
 // ------------------------------------------------------------------
@@ -1660,6 +1736,135 @@ mod tests {
             "value type missing: {text:.120}"
         );
         assert!(text.contains("Multi-model map"), "multi-model map missing");
+    }
+
+    /// Parse the text payload out of a successful `tools/call` JSON-RPC reply.
+    fn tools_call_text(srv: &McpServer, params_json: &str) -> JsonValue {
+        let request =
+            format!(r#"{{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{params_json}}}"#);
+        let response = srv.handle_tools_call(
+            Some(&JsonValue::Number(42.0)),
+            parse_json(&request).get("params"),
+        );
+        let parsed = parse_json(&response);
+        let result = parsed.get("result").expect("result");
+        assert!(
+            result.get("isError").and_then(JsonValue::as_bool) != Some(true),
+            "unexpected tool error: {response}"
+        );
+        let text = result
+            .get("content")
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("content text");
+        parse_json(text)
+    }
+
+    #[test]
+    fn tools_list_includes_type_of() {
+        let srv = make_server();
+        let response = srv.handle_tools_list(Some(&JsonValue::Number(1.0)));
+        let parsed = parse_json(&response);
+        let tools = parsed
+            .get("result")
+            .and_then(|result| result.get("tools"))
+            .and_then(JsonValue::as_array)
+            .expect("tools array");
+        assert!(
+            tools
+                .iter()
+                .any(|t| t.get("name").and_then(JsonValue::as_str) == Some("reddb_type_of")),
+            "reddb_type_of must be advertised"
+        );
+    }
+
+    #[test]
+    fn tools_call_type_of_by_type_name_answers_from_catalog() {
+        let srv = make_server();
+        let answer = tools_call_text(
+            &srv,
+            r#"{"name":"reddb_type_of","arguments":{"type":"int"}}"#,
+        );
+        assert_eq!(
+            answer.get("canonical_type").and_then(JsonValue::as_str),
+            Some("INTEGER")
+        );
+        assert_eq!(
+            answer.get("category").and_then(JsonValue::as_str),
+            Some("Numeric")
+        );
+        let casts: Vec<&str> = answer
+            .get("implicit_casts")
+            .and_then(JsonValue::as_array)
+            .expect("implicit_casts")
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .collect();
+        assert!(casts.contains(&"FLOAT"), "implicit casts: {casts:?}");
+        let ops: Vec<&str> = answer
+            .get("operators")
+            .and_then(JsonValue::as_array)
+            .expect("operators")
+            .iter()
+            .filter_map(JsonValue::as_str)
+            .collect();
+        assert!(ops.contains(&"+"), "operators: {ops:?}");
+    }
+
+    #[test]
+    fn tools_call_type_of_infers_value_type() {
+        let srv = make_server();
+        let answer = tools_call_text(
+            &srv,
+            r#"{"name":"reddb_type_of","arguments":{"value":"hello"}}"#,
+        );
+        assert_eq!(
+            answer.get("canonical_type").and_then(JsonValue::as_str),
+            Some("TEXT")
+        );
+    }
+
+    #[test]
+    fn tools_call_type_of_rejects_unknown_and_missing_input() {
+        let srv = make_server();
+        for (params, needle) in [
+            (
+                r#"{"name":"reddb_type_of","arguments":{"type":"not_a_type"}}"#,
+                "unknown type name",
+            ),
+            (
+                r#"{"name":"reddb_type_of","arguments":{}}"#,
+                "missing input",
+            ),
+            (
+                r#"{"name":"reddb_type_of","arguments":{"type":"int","value":1}}"#,
+                "not both",
+            ),
+        ] {
+            let request =
+                format!(r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{params}}}"#);
+            let response = srv.handle_tools_call(
+                Some(&JsonValue::Number(1.0)),
+                parse_json(&request).get("params"),
+            );
+            let parsed = parse_json(&response);
+            let result = parsed.get("result").expect("result");
+            assert_eq!(
+                result.get("isError").and_then(JsonValue::as_bool),
+                Some(true),
+                "expected error for {params}"
+            );
+            let text = result
+                .get("content")
+                .and_then(JsonValue::as_array)
+                .and_then(|content| content.first())
+                .and_then(|item| item.get("text"))
+                .and_then(JsonValue::as_str)
+                .expect("error text");
+            assert!(text.contains(needle), "want {needle:?} in {text:?}");
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -678,6 +678,33 @@ pub fn all_tools() -> Vec<ToolDef> {
                 vec!["name"],
             ),
         },
+        // Knowledge tool — answers from the generated reddb-io-types catalog (ADR 0061).
+        ToolDef {
+            name: "reddb_type_of",
+            description: "Look up a RedDB value type from the generated type catalog. Provide either `value` (a JSON value whose canonical type is inferred) or `type` (a type name like \"int\", \"TEXT\", \"BIGINT\"). Returns the canonical type, its coercion category, the implicit (silent, lossless) and explicit (CAST-required) cast targets, and the operators that accept it — all read live from the `reddb-io-types` function/operator/cast authorities, so the answer never drifts from the engine.",
+            input_schema: schema_with_nested(
+                vec![
+                    ("value", {
+                        let mut f = Map::new();
+                        f.insert(
+                            "description".to_string(),
+                            JsonValue::String(
+                                "A JSON value whose canonical RedDB type is inferred. Mutually exclusive with `type`."
+                                    .to_string(),
+                            ),
+                        );
+                        JsonValue::Object(f)
+                    }),
+                    (
+                        "type",
+                        string_field(
+                            "A RedDB or SQL type name (case-insensitive), e.g. \"int\", \"TEXT\", \"BIGINT\". Mutually exclusive with `value`.",
+                        ),
+                    ),
+                ],
+                vec![],
+            ),
+        },
     ]
 }
 
@@ -721,6 +748,27 @@ mod tests {
         assert!(names.contains(&"reddb_graph_clustering"));
         assert!(names.contains(&"reddb_create_collection"));
         assert!(names.contains(&"reddb_drop_collection"));
+        assert!(names.contains(&"reddb_type_of"));
+    }
+
+    #[test]
+    fn test_type_of_tool_schema() {
+        let tools = all_tools();
+        let tool = tools.iter().find(|t| t.name == "reddb_type_of").unwrap();
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
+        assert!(props.contains_key("value"));
+        assert!(props.contains_key("type"));
+        // Both inputs are optional; the handler enforces that exactly one is given.
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert!(required.is_empty());
     }
 
     #[test]

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -205,8 +205,9 @@ pub fn implicit_casts() -> Vec<(DataType, DataType)> {
     pairs
 }
 
-/// Human label for a [`TypeCategory`], used by the generated map.
-fn category_label(category: TypeCategory) -> &'static str {
+/// Human label for a [`TypeCategory`], used by the generated map and the
+/// `reddb_type_of` lookup tool.
+pub fn category_label(category: TypeCategory) -> &'static str {
     match category {
         TypeCategory::Numeric => "Numeric",
         TypeCategory::String => "String",
@@ -352,6 +353,98 @@ pub fn type_llms_section() -> String {
         body = type_reference_markdown(),
         end = LLMS_END_MARKER,
     )
+}
+
+// ── Type-of lookup (the `reddb_type_of` active MCP tool, ADR 0061 §4) ──
+
+/// The resolved answer for a `reddb_type_of` lookup: a value's or named type's
+/// canonical [`DataType`] plus the casts and operators the engine's catalogs
+/// make available to it. Every field is read live from the cast / operator
+/// authorities in this crate, so the answer cannot drift from the engine.
+pub struct TypeOf {
+    /// The canonical value type the input resolves to.
+    pub canonical: DataType,
+    /// The coercion category the canonical type belongs to.
+    pub category: TypeCategory,
+    /// Targets the engine widens to silently (lossless [`CastContext::Implicit`]
+    /// casts) — usable anywhere without writing `CAST(...)`. Sorted, deduped.
+    pub implicit_cast_targets: Vec<DataType>,
+    /// Targets reachable only via an explicit `CAST(...)` / `expr::type` or an
+    /// assignment-context coercion (everything in the cast catalog whose minimum
+    /// context is above implicit). Sorted, deduped.
+    pub explicit_cast_targets: Vec<DataType>,
+    /// Operator symbols for which the canonical type is a declared operand
+    /// (either side of an infix overload, or the operand of a prefix overload).
+    /// Sorted, deduped.
+    pub operators: Vec<&'static str>,
+}
+
+/// Resolve an SQL-level or canonical type name (case-insensitive) to its
+/// [`DataType`]. Thin pass-through to [`DataType::from_sql_name`] so the
+/// knowledge layer is the single resolver the MCP tool calls. Returns `None`
+/// for unknown names.
+pub fn resolve_type_name(name: &str) -> Option<DataType> {
+    DataType::from_sql_name(name)
+}
+
+/// Infer the canonical value type of a JSON value as the type system would see
+/// it. `Null` carries no type, so it returns `None`; an integral JSON number is
+/// reported as `INTEGER` and a fractional one as `FLOAT`. Strings map to the
+/// general `TEXT` type (domain refinements like `EMAIL` are opt-in, not
+/// inferred), arrays to `ARRAY`, and objects to `JSON`.
+pub fn canonical_type_of_json(value: &crate::json::Value) -> Option<DataType> {
+    use crate::json::Value;
+    Some(match value {
+        Value::Null => return None,
+        Value::Bool(_) => DataType::Boolean,
+        Value::Number(n) => {
+            if n.fract() == 0.0 && n.is_finite() {
+                DataType::Integer
+            } else {
+                DataType::Float
+            }
+        }
+        Value::String(_) => DataType::Text,
+        Value::Array(_) => DataType::Array,
+        Value::Object(_) => DataType::Json,
+    })
+}
+
+/// Build the [`TypeOf`] answer for `ty` straight from the cast and operator
+/// catalogs. The applicable casts and operators are the catalog rows that name
+/// `ty`, so adding a row to either authority flows automatically into the tool.
+pub fn type_of(ty: DataType) -> TypeOf {
+    let mut implicit_cast_targets: Vec<DataType> = CAST_CATALOG
+        .iter()
+        .filter(|cast| cast.src == ty && cast.context == CastContext::Implicit)
+        .map(|cast| cast.target)
+        .collect();
+    implicit_cast_targets.sort_by_key(|target| *target as u8);
+    implicit_cast_targets.dedup();
+
+    let mut explicit_cast_targets: Vec<DataType> = CAST_CATALOG
+        .iter()
+        .filter(|cast| cast.src == ty && cast.context != CastContext::Implicit)
+        .map(|cast| cast.target)
+        .collect();
+    explicit_cast_targets.sort_by_key(|target| *target as u8);
+    explicit_cast_targets.dedup();
+
+    let mut operators: Vec<&'static str> = OPERATOR_CATALOG
+        .iter()
+        .filter(|entry| entry.lhs_type == ty || entry.rhs_type == ty)
+        .map(|entry| entry.name)
+        .collect();
+    operators.sort_unstable();
+    operators.dedup();
+
+    TypeOf {
+        canonical: ty,
+        category: ty.category(),
+        implicit_cast_targets,
+        explicit_cast_targets,
+        operators,
+    }
 }
 
 #[cfg(test)]
@@ -518,5 +611,115 @@ reference"
         assert!(section.starts_with(LLMS_BEGIN_MARKER));
         assert!(section.ends_with(LLMS_END_MARKER));
         assert!(section.contains(&type_reference_markdown()));
+    }
+
+    /// Type names resolve case-insensitively, accepting both SQL aliases and the
+    /// canonical names `Display` renders.
+    #[test]
+    fn resolve_type_name_accepts_aliases_and_canonical() {
+        assert_eq!(resolve_type_name("int"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("INTEGER"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("string"), Some(DataType::Text));
+        assert_eq!(resolve_type_name("BIGINT"), Some(DataType::BigInt));
+        assert_eq!(resolve_type_name("not_a_type"), None);
+    }
+
+    /// JSON values infer to their canonical value type; `null` carries none.
+    #[test]
+    fn canonical_type_of_json_infers_by_kind() {
+        use crate::json::Value;
+        assert_eq!(canonical_type_of_json(&Value::Null), None);
+        assert_eq!(
+            canonical_type_of_json(&Value::Bool(true)),
+            Some(DataType::Boolean)
+        );
+        assert_eq!(
+            canonical_type_of_json(&Value::Number(42.0)),
+            Some(DataType::Integer)
+        );
+        assert_eq!(
+            canonical_type_of_json(&Value::Number(3.5)),
+            Some(DataType::Float)
+        );
+        assert_eq!(
+            canonical_type_of_json(&Value::String("hi".to_string())),
+            Some(DataType::Text)
+        );
+        assert_eq!(
+            canonical_type_of_json(&Value::Array(vec![])),
+            Some(DataType::Array)
+        );
+        assert_eq!(
+            canonical_type_of_json(&Value::Object(Default::default())),
+            Some(DataType::Json)
+        );
+    }
+
+    /// `type_of` reports the canonical type, its category, and the casts &
+    /// operators the catalogs make available — all read from the authorities.
+    #[test]
+    fn type_of_integer_reports_catalog_casts_and_operators() {
+        let answer = type_of(DataType::Integer);
+        assert_eq!(answer.canonical, DataType::Integer);
+        assert_eq!(answer.category, TypeCategory::Numeric);
+
+        // Integer widens implicitly to the wider numeric types (lossless).
+        assert!(answer.implicit_cast_targets.contains(&DataType::Float));
+        assert!(answer.implicit_cast_targets.contains(&DataType::BigInt));
+
+        // Arithmetic operators name Integer as an operand.
+        assert!(answer.operators.contains(&"+"));
+        assert!(answer.operators.contains(&"*"));
+    }
+
+    /// Every cast/operator the tool reports is actually present in the source
+    /// catalogs for that type — the anti-drift guarantee for the lookup tool.
+    #[test]
+    fn type_of_answers_are_backed_by_the_catalogs() {
+        for ty in catalogued_value_types() {
+            let answer = type_of(ty);
+            for target in &answer.implicit_cast_targets {
+                assert!(
+                    CAST_CATALOG.iter().any(|cast| cast.src == ty
+                        && cast.target == *target
+                        && cast.context == CastContext::Implicit),
+                    "implicit cast {ty} → {target} is not in CAST_CATALOG"
+                );
+            }
+            for target in &answer.explicit_cast_targets {
+                assert!(
+                    CAST_CATALOG.iter().any(|cast| cast.src == ty
+                        && cast.target == *target
+                        && cast.context != CastContext::Implicit),
+                    "explicit cast {ty} → {target} is not in CAST_CATALOG"
+                );
+            }
+            for op in &answer.operators {
+                assert!(
+                    OPERATOR_CATALOG
+                        .iter()
+                        .any(|entry| entry.name == *op
+                            && (entry.lhs_type == ty || entry.rhs_type == ty)),
+                    "operator {op:?} is not declared for {ty} in OPERATOR_CATALOG"
+                );
+            }
+        }
+    }
+
+    /// The implicit and explicit cast target lists never overlap and are sorted.
+    #[test]
+    fn type_of_cast_lists_are_disjoint_and_sorted() {
+        for ty in catalogued_value_types() {
+            let answer = type_of(ty);
+            for target in &answer.implicit_cast_targets {
+                assert!(
+                    !answer.explicit_cast_targets.contains(target),
+                    "{ty} → {target} appears in both implicit and explicit lists"
+                );
+            }
+            let mut sorted = answer.implicit_cast_targets.clone();
+            sorted.sort_by_key(|t| *t as u8);
+            assert_eq!(answer.implicit_cast_targets, sorted);
+        }
     }
 }


### PR DESCRIPTION
Automated AFK landing for #1320. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1320

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785032760&installation_id=129708444&pr_number=1414&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1414&signature=e25180c93a1eb9057a47dfa1a6e19525068c179272ea78cdf0e82a77484fd558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->