### PR TITLE
merge: #1320 feat(mcp): reddb_type_of tool (type/cast lookup from generated catalog)

### DIFF
--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -1350,14 +1350,17 @@ impl McpServer {
         let type_name = args.get("type").and_then(|v| v.as_str());
         let value = args.get("value");
         if type_name.is_none() && value.is_none() {
-            return Err("provide one of 'type' (a type name) or 'value' (a JSON literal)".to_string());
+            return Err(
+                "provide one of 'type' (a type name) or 'value' (a JSON literal)".to_string(),
+            );
         }
-        let facts = reddb_types::knowledge::type_of_json(type_name, value).ok_or_else(|| {
-            match type_name {
-                Some(name) => format!("unknown type name '{name}'"),
-                None => "could not resolve a type from the request".to_string(),
-            }
-        })?;
+        let facts =
+            reddb_types::knowledge::type_of_json(type_name, value).ok_or_else(
+                || match type_name {
+                    Some(name) => format!("unknown type name '{name}'"),
+                    None => "could not resolve a type from the request".to_string(),
+                },
+            )?;
         json_to_string(&facts).map_err(|e| format!("serialization error: {}", e))
     }
 }
@@ -1937,7 +1940,10 @@ mod tests {
             "casts: {casts:?}"
         );
         // Applicable operators include arithmetic +.
-        let operators = facts.get("operators").and_then(JsonValue::as_array).unwrap();
+        let operators = facts
+            .get("operators")
+            .and_then(JsonValue::as_array)
+            .unwrap();
         assert!(
             operators
                 .iter()

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -314,6 +314,7 @@ impl McpServer {
             "reddb_drop_collection" => self.tool_drop_collection(args),
             "reddb_rql_validate" => self.tool_rql_validate(args),
             "reddb_rql_explain" => self.tool_rql_explain(args),
+            "reddb_type_of" => self.tool_type_of(args),
             "reddb_auth_bootstrap" => self.tool_auth_bootstrap(args),
             "reddb_auth_create_user" => self.tool_auth_create_user(args),
             "reddb_auth_login" => self.tool_auth_login(args),
@@ -1339,6 +1340,26 @@ impl McpServer {
         );
         json_to_string(&JsonValue::Object(obj)).map_err(|e| format!("serialization error: {}", e))
     }
+
+    /// `reddb_type_of`: resolve a type name or a literal value to its canonical
+    /// type plus applicable casts/operators, answered entirely from the
+    /// generated `reddb-io-types` catalog (ADR 0061). This handler owns no type
+    /// knowledge — it only marshals arguments into and JSON out of
+    /// [`reddb_types::knowledge::type_of_json`].
+    fn tool_type_of(&self, args: &JsonValue) -> Result<String, String> {
+        let type_name = args.get("type").and_then(|v| v.as_str());
+        let value = args.get("value");
+        if type_name.is_none() && value.is_none() {
+            return Err("provide one of 'type' (a type name) or 'value' (a JSON literal)".to_string());
+        }
+        let facts = reddb_types::knowledge::type_of_json(type_name, value).ok_or_else(|| {
+            match type_name {
+                Some(name) => format!("unknown type name '{name}'"),
+                None => "could not resolve a type from the request".to_string(),
+            }
+        })?;
+        json_to_string(&facts).map_err(|e| format!("serialization error: {}", e))
+    }
 }
 
 // ------------------------------------------------------------------
@@ -1840,6 +1861,128 @@ mod tests {
             .and_then(JsonValue::as_str)
             .expect("error text");
         assert!(text.contains("options.tempurature"), "text: {text}");
+    }
+
+    /// Helper: drive a `reddb_type_of` `tools/call` over the JSON-RPC seam and
+    /// return the parsed result object (`content`/`isError`), exercising the
+    /// real dispatcher.
+    fn call_type_of(srv: &mut McpServer, arguments: &str) -> JsonValue {
+        let request = parse_json(&format!(
+            r#"{{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{{"name":"reddb_type_of","arguments":{arguments}}}}}"#
+        ));
+        let response = srv.handle_message(&request).expect("response");
+        parse_json(&response)
+            .get("result")
+            .cloned()
+            .expect("result object")
+    }
+
+    /// Extract the text payload of a (non-error) tool result and parse it as JSON.
+    fn type_of_result_json(result: &JsonValue) -> JsonValue {
+        assert_ne!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true),
+            "tool returned an error: {result:?}"
+        );
+        let text = result
+            .get("content")
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("result text");
+        parse_json(text)
+    }
+
+    #[test]
+    fn tools_list_includes_reddb_type_of() {
+        let srv = make_server();
+        let response = srv.handle_tools_list(Some(&JsonValue::Number(1.0)));
+        let parsed = parse_json(&response);
+        let tools = parsed
+            .get("result")
+            .and_then(|result| result.get("tools"))
+            .and_then(JsonValue::as_array)
+            .expect("tools array");
+        assert!(
+            tools
+                .iter()
+                .any(|tool| tool.get("name").and_then(JsonValue::as_str) == Some("reddb_type_of")),
+            "reddb_type_of must be advertised in tools/list"
+        );
+    }
+
+    #[test]
+    fn tools_call_type_of_resolves_type_name_from_catalog() {
+        let mut srv = make_server();
+        let result = call_type_of(&mut srv, r#"{"type":"int"}"#);
+        let facts = type_of_result_json(&result);
+
+        // Canonical type + category come from the catalog authority.
+        assert_eq!(
+            facts.get("canonical_type").and_then(JsonValue::as_str),
+            Some("INTEGER")
+        );
+        assert_eq!(
+            facts.get("category").and_then(JsonValue::as_str),
+            Some("Numeric")
+        );
+        // Applicable casts include the implicit INTEGER → FLOAT widening.
+        let casts = facts.get("casts").and_then(JsonValue::as_array).unwrap();
+        assert!(
+            casts.iter().any(|c| {
+                c.get("target").and_then(JsonValue::as_str) == Some("FLOAT")
+                    && c.get("context").and_then(JsonValue::as_str) == Some("implicit")
+            }),
+            "casts: {casts:?}"
+        );
+        // Applicable operators include arithmetic +.
+        let operators = facts.get("operators").and_then(JsonValue::as_array).unwrap();
+        assert!(
+            operators
+                .iter()
+                .any(|o| o.get("symbol").and_then(JsonValue::as_str) == Some("+")),
+            "operators: {operators:?}"
+        );
+    }
+
+    #[test]
+    fn tools_call_type_of_infers_type_from_literal_value() {
+        let mut srv = make_server();
+        let result = call_type_of(&mut srv, r#"{"value":true}"#);
+        let facts = type_of_result_json(&result);
+        assert_eq!(
+            facts.get("canonical_type").and_then(JsonValue::as_str),
+            Some("BOOLEAN")
+        );
+    }
+
+    #[test]
+    fn tools_call_type_of_unknown_name_is_error() {
+        let mut srv = make_server();
+        let result = call_type_of(&mut srv, r#"{"type":"frobnicate"}"#);
+        assert_eq!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        let text = result
+            .get("content")
+            .and_then(JsonValue::as_array)
+            .and_then(|content| content.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("error text");
+        assert!(text.contains("frobnicate"), "text: {text}");
+    }
+
+    #[test]
+    fn tools_call_type_of_requires_an_argument() {
+        let mut srv = make_server();
+        let result = call_type_of(&mut srv, r#"{}"#);
+        assert_eq!(
+            result.get("isError").and_then(JsonValue::as_bool),
+            Some(true)
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -697,6 +697,34 @@ pub fn all_tools() -> Vec<ToolDef> {
                 vec!["rql"],
             ),
         },
+        // Type knowledge tool (ADR 0061): answer a type/cast lookup from the
+        // generated reddb-io-types catalog.
+        ToolDef {
+            name: "reddb_type_of",
+            description: "Look up a RedDB value type from the generated `reddb-io-types` catalog. Given either a type name (`type`, e.g. \"INTEGER\" or the SQL alias \"int\") or a literal JSON value (`value`, e.g. 42 or true), returns the canonical type, its coercion category, the casts available out of it, and the operator overloads that accept it. Provide exactly one of `type` or `value`; `type` wins if both are given.\n\nThe answer is read live from the engine's function/operator/cast catalogs — it never drifts from the type system.",
+            input_schema: schema_with_nested(
+                vec![
+                    ("type", string_field("Type name to look up: a canonical RedDB type (e.g. \"INTEGER\", \"TEXT\") or a common SQL alias (e.g. \"int\", \"string\"), case-insensitive.")),
+                    ("value", {
+                        let mut f = Map::new();
+                        f.insert("description".to_string(), JsonValue::String("A literal JSON value (null, boolean, number, string, array, or object) whose canonical type to look up. Used only when `type` is omitted.".to_string()));
+                        f.insert(
+                            "anyOf".to_string(),
+                            JsonValue::Array(vec![
+                                type_field("null"),
+                                type_field("boolean"),
+                                type_field("number"),
+                                type_field("string"),
+                                type_field("array"),
+                                type_field("object"),
+                            ]),
+                        );
+                        JsonValue::Object(f)
+                    }),
+                ],
+                vec![],
+            ),
+        },
     ]
 }
 
@@ -743,6 +771,8 @@ mod tests {
         // RQL knowledge tools (ADR 0061).
         assert!(names.contains(&"reddb_rql_validate"));
         assert!(names.contains(&"reddb_rql_explain"));
+        // Type knowledge tool (ADR 0061).
+        assert!(names.contains(&"reddb_type_of"));
     }
 
     #[test]
@@ -1027,5 +1057,26 @@ mod tests {
             .unwrap();
         let required_strs: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
         assert!(required_strs.contains(&"name"));
+    }
+
+    #[test]
+    fn test_type_of_tool_schema() {
+        let tools = all_tools();
+        let tool = tools.iter().find(|t| t.name == "reddb_type_of").unwrap();
+        let props = tool
+            .input_schema
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .unwrap();
+        // Accepts either a type name or a literal value; neither is required so
+        // the handler can validate "exactly one of" and surface a clear error.
+        assert!(props.contains_key("type"));
+        assert!(props.contains_key("value"));
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert!(required.is_empty());
     }
 }

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -27,7 +27,8 @@
 
 use crate::cast_catalog::{CastContext, CAST_CATALOG};
 use crate::function_catalog::FUNCTION_CATALOG;
-use crate::operator_catalog::OPERATOR_CATALOG;
+use crate::json::{Map, Value as JsonValue};
+use crate::operator_catalog::{OperatorKind, OPERATOR_CATALOG};
 use crate::types::{DataType, TypeCategory};
 
 /// Canonical URI for the type & multi-model knowledge resource served over MCP.
@@ -354,6 +355,168 @@ pub fn type_llms_section() -> String {
     )
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Active type/cast lookup (ADR 0061 §4 — the `reddb_type_of` MCP tool seam)
+//
+// Where the markdown reference above is the *passive* knowledge resource, the
+// functions below answer a *targeted* question — "what is this value or type
+// name, and what can I cast/operate it to?" — by reading the same three
+// catalogs live. The MCP `reddb_type_of` tool is a thin wrapper over
+// [`type_of_json`]: it owns no type knowledge of its own.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Resolve a type *name* (canonical reddb spelling or a common SQL alias, both
+/// case-insensitive — e.g. `INTEGER`, `int`, `string`) to its [`DataType`].
+///
+/// Delegates to [`DataType::from_sql_name`] so the accepted spellings stay in
+/// lockstep with the engine's own SQL type parser; returns `None` for names the
+/// engine does not recognise.
+pub fn resolve_type_name(name: &str) -> Option<DataType> {
+    DataType::from_sql_name(name)
+}
+
+/// Infer the [`DataType`] of a bare JSON literal as the engine would type it on
+/// the wire: `null → NULLABLE`, booleans → `BOOLEAN`, integral numbers →
+/// `INTEGER`, fractional numbers → `FLOAT`, strings → `TEXT`, arrays → `ARRAY`,
+/// objects → `JSON`.
+///
+/// This is deliberately the *structural* type of the literal, not a re-parse
+/// into a richer domain type (an email-shaped string is still `TEXT` here);
+/// callers wanting the domain type pass the type name explicitly.
+pub fn infer_literal_type(value: &JsonValue) -> DataType {
+    match value {
+        JsonValue::Null => DataType::Nullable,
+        JsonValue::Bool(_) => DataType::Boolean,
+        JsonValue::Number(n) => {
+            if n.fract() == 0.0 && *n >= i64::MIN as f64 && *n <= i64::MAX as f64 {
+                DataType::Integer
+            } else {
+                DataType::Float
+            }
+        }
+        JsonValue::String(_) => DataType::Text,
+        JsonValue::Array(_) => DataType::Array,
+        JsonValue::Object(_) => DataType::Json,
+    }
+}
+
+/// Human label for a [`CastContext`], matching the engine's coercion vocabulary.
+fn cast_context_label(context: CastContext) -> &'static str {
+    match context {
+        CastContext::Implicit => "implicit",
+        CastContext::Assignment => "assignment",
+        CastContext::Explicit => "explicit",
+    }
+}
+
+/// Human label for an [`OperatorKind`].
+fn operator_kind_label(kind: OperatorKind) -> &'static str {
+    match kind {
+        OperatorKind::Infix => "infix",
+        OperatorKind::Prefix => "prefix",
+        OperatorKind::Postfix => "postfix",
+    }
+}
+
+/// Every cast *out of* `ty` registered in [`CAST_CATALOG`], in catalog order.
+/// Each tuple is `(target, context, lossy)` read straight from the catalog row.
+pub fn casts_from(ty: DataType) -> Vec<(DataType, CastContext, bool)> {
+    CAST_CATALOG
+        .iter()
+        .filter(|cast| cast.src == ty)
+        .map(|cast| (cast.target, cast.context, cast.lossy))
+        .collect()
+}
+
+/// Every operator overload in [`OPERATOR_CATALOG`] that accepts `ty` as one of
+/// its operands, in catalog order. The `Nullable` left-operand marker on prefix
+/// operators is treated as "no left operand", so a prefix `-` matches only when
+/// `ty` is its (right) operand, never via the marker.
+pub fn operators_for(ty: DataType) -> Vec<&'static crate::operator_catalog::OperatorEntry> {
+    OPERATOR_CATALOG
+        .iter()
+        .filter(|entry| {
+            let lhs_matches =
+                entry.kind != OperatorKind::Prefix && entry.lhs_type == ty;
+            lhs_matches || entry.rhs_type == ty
+        })
+        .collect()
+}
+
+/// Build the structured `reddb_type_of` answer for a resolved [`DataType`]: its
+/// canonical name + category, the casts available out of it, and the operator
+/// overloads that accept it — all read live from the catalogs.
+pub fn type_facts_json(ty: DataType) -> JsonValue {
+    let casts: Vec<JsonValue> = casts_from(ty)
+        .into_iter()
+        .map(|(target, context, lossy)| {
+            let mut obj = Map::new();
+            obj.insert("target".to_string(), JsonValue::String(target.to_string()));
+            obj.insert(
+                "context".to_string(),
+                JsonValue::String(cast_context_label(context).to_string()),
+            );
+            obj.insert("lossy".to_string(), JsonValue::Bool(lossy));
+            JsonValue::Object(obj)
+        })
+        .collect();
+
+    let operators: Vec<JsonValue> = operators_for(ty)
+        .into_iter()
+        .map(|entry| {
+            let mut obj = Map::new();
+            obj.insert("symbol".to_string(), JsonValue::String(entry.name.to_string()));
+            obj.insert(
+                "kind".to_string(),
+                JsonValue::String(operator_kind_label(entry.kind).to_string()),
+            );
+            // Prefix operators carry a `Nullable` left-operand marker, not a real
+            // operand — surface that as JSON null rather than leaking the marker.
+            let lhs = if entry.kind == OperatorKind::Prefix {
+                JsonValue::Null
+            } else {
+                JsonValue::String(entry.lhs_type.to_string())
+            };
+            obj.insert("lhs".to_string(), lhs);
+            obj.insert("rhs".to_string(), JsonValue::String(entry.rhs_type.to_string()));
+            obj.insert(
+                "returns".to_string(),
+                JsonValue::String(entry.return_type.to_string()),
+            );
+            JsonValue::Object(obj)
+        })
+        .collect();
+
+    let mut obj = Map::new();
+    obj.insert(
+        "canonical_type".to_string(),
+        JsonValue::String(ty.to_string()),
+    );
+    obj.insert(
+        "category".to_string(),
+        JsonValue::String(category_label(ty.category()).to_string()),
+    );
+    obj.insert("is_preferred".to_string(), JsonValue::Bool(ty.is_preferred()));
+    obj.insert("casts".to_string(), JsonValue::Array(casts));
+    obj.insert("operators".to_string(), JsonValue::Array(operators));
+    JsonValue::Object(obj)
+}
+
+/// Answer a `reddb_type_of` query. Exactly one of `type_name` or `value` should
+/// carry the lookup subject: a type name (resolved with [`resolve_type_name`])
+/// or a JSON literal whose structural type is inferred with
+/// [`infer_literal_type`]. Returns the structured facts from [`type_facts_json`]
+/// wrapped with the resolved canonical type, or `None` when a supplied type name
+/// is unknown to the engine.
+pub fn type_of_json(type_name: Option<&str>, value: Option<&JsonValue>) -> Option<JsonValue> {
+    let ty = match (type_name, value) {
+        (Some(name), _) => resolve_type_name(name)?,
+        (None, Some(literal)) => infer_literal_type(literal),
+        (None, None) => return None,
+    };
+    Some(type_facts_json(ty))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,5 +681,134 @@ reference"
         assert!(section.starts_with(LLMS_BEGIN_MARKER));
         assert!(section.ends_with(LLMS_END_MARKER));
         assert!(section.contains(&type_reference_markdown()));
+    }
+
+    /// Type names resolve through the engine's own SQL parser — canonical
+    /// spelling and common aliases, case-insensitively.
+    #[test]
+    fn resolve_type_name_accepts_canonical_and_aliases() {
+        assert_eq!(resolve_type_name("INTEGER"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("int"), Some(DataType::Integer));
+        assert_eq!(resolve_type_name("string"), Some(DataType::Text));
+        assert_eq!(resolve_type_name("TEXT"), Some(DataType::Text));
+        assert_eq!(resolve_type_name("not-a-type"), None);
+    }
+
+    /// Bare JSON literals are typed structurally, the way the wire sees them.
+    #[test]
+    fn infer_literal_type_maps_json_shapes() {
+        assert_eq!(infer_literal_type(&JsonValue::Null), DataType::Nullable);
+        assert_eq!(infer_literal_type(&JsonValue::Bool(true)), DataType::Boolean);
+        assert_eq!(
+            infer_literal_type(&JsonValue::Number(42.0)),
+            DataType::Integer
+        );
+        assert_eq!(
+            infer_literal_type(&JsonValue::Number(3.5)),
+            DataType::Float
+        );
+        assert_eq!(
+            infer_literal_type(&JsonValue::String("hi".to_string())),
+            DataType::Text
+        );
+        assert_eq!(
+            infer_literal_type(&JsonValue::Array(vec![])),
+            DataType::Array
+        );
+        assert_eq!(
+            infer_literal_type(&JsonValue::Object(Map::new())),
+            DataType::Json
+        );
+    }
+
+    /// `casts_from` reports exactly the catalog rows whose `src` is the type,
+    /// and the catalog says INTEGER widens to FLOAT implicitly and losslessly.
+    #[test]
+    fn casts_from_reads_catalog_rows() {
+        let casts = casts_from(DataType::Integer);
+        let widen = casts
+            .iter()
+            .find(|(target, _, _)| *target == DataType::Float)
+            .expect("INTEGER → FLOAT cast present in catalog");
+        assert_eq!(widen.1, CastContext::Implicit);
+        assert!(!widen.2, "INTEGER → FLOAT must be lossless");
+        // Every returned row genuinely has INTEGER as its source.
+        for (target, _, _) in &casts {
+            assert!(CAST_CATALOG
+                .iter()
+                .any(|c| c.src == DataType::Integer && c.target == *target));
+        }
+    }
+
+    /// `operators_for` matches a type as either operand, and skips the prefix
+    /// `Nullable` left-operand marker.
+    #[test]
+    fn operators_for_matches_either_operand() {
+        let ops = operators_for(DataType::Integer);
+        assert!(
+            ops.iter().any(|e| e.name == "+"),
+            "INTEGER should accept the + operator"
+        );
+        // The prefix-`-` overload (unary negation) carries a Nullable lhs marker;
+        // it is matched via its (right) operand, never via the marker. So every
+        // matched entry that *does* carry a Nullable lhs must be a prefix whose
+        // right operand is the looked-up type.
+        for entry in &ops {
+            if entry.lhs_type == DataType::Nullable {
+                assert_eq!(entry.kind, OperatorKind::Prefix);
+                assert_eq!(entry.rhs_type, DataType::Integer);
+            } else {
+                assert!(entry.lhs_type == DataType::Integer || entry.rhs_type == DataType::Integer);
+            }
+        }
+    }
+
+    /// The structured answer carries the canonical type, category, casts and
+    /// operators — all sourced from the catalogs.
+    #[test]
+    fn type_facts_json_reports_canonical_casts_and_operators() {
+        let facts = type_facts_json(DataType::Integer);
+        assert_eq!(
+            facts.get("canonical_type").and_then(JsonValue::as_str),
+            Some("INTEGER")
+        );
+        assert_eq!(
+            facts.get("category").and_then(JsonValue::as_str),
+            Some("Numeric")
+        );
+        let casts = facts.get("casts").and_then(JsonValue::as_array).unwrap();
+        assert!(
+            casts.iter().any(|c| c.get("target").and_then(JsonValue::as_str)
+                == Some("FLOAT")),
+            "INTEGER → FLOAT must appear in the casts"
+        );
+        let operators = facts.get("operators").and_then(JsonValue::as_array).unwrap();
+        assert!(
+            operators.iter().any(|o| o.get("symbol").and_then(JsonValue::as_str)
+                == Some("+")),
+            "the + operator must appear in the operators"
+        );
+    }
+
+    /// The query entry point resolves by type name, infers from a value, and
+    /// rejects an unknown type name.
+    #[test]
+    fn type_of_json_resolves_name_and_value() {
+        // By type name (alias).
+        let by_name = type_of_json(Some("int"), None).expect("known type name");
+        assert_eq!(
+            by_name.get("canonical_type").and_then(JsonValue::as_str),
+            Some("INTEGER")
+        );
+        // By JSON value literal.
+        let by_value = type_of_json(None, Some(&JsonValue::Bool(false))).expect("value");
+        assert_eq!(
+            by_value.get("canonical_type").and_then(JsonValue::as_str),
+            Some("BOOLEAN")
+        );
+        // Unknown name → None so the caller can surface a parse error.
+        assert!(type_of_json(Some("frobnicate"), None).is_none());
+        // Nothing supplied → None.
+        assert!(type_of_json(None, None).is_none());
     }
 }

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -436,8 +436,7 @@ pub fn operators_for(ty: DataType) -> Vec<&'static crate::operator_catalog::Oper
     OPERATOR_CATALOG
         .iter()
         .filter(|entry| {
-            let lhs_matches =
-                entry.kind != OperatorKind::Prefix && entry.lhs_type == ty;
+            let lhs_matches = entry.kind != OperatorKind::Prefix && entry.lhs_type == ty;
             lhs_matches || entry.rhs_type == ty
         })
         .collect()
@@ -465,7 +464,10 @@ pub fn type_facts_json(ty: DataType) -> JsonValue {
         .into_iter()
         .map(|entry| {
             let mut obj = Map::new();
-            obj.insert("symbol".to_string(), JsonValue::String(entry.name.to_string()));
+            obj.insert(
+                "symbol".to_string(),
+                JsonValue::String(entry.name.to_string()),
+            );
             obj.insert(
                 "kind".to_string(),
                 JsonValue::String(operator_kind_label(entry.kind).to_string()),
@@ -478,7 +480,10 @@ pub fn type_facts_json(ty: DataType) -> JsonValue {
                 JsonValue::String(entry.lhs_type.to_string())
             };
             obj.insert("lhs".to_string(), lhs);
-            obj.insert("rhs".to_string(), JsonValue::String(entry.rhs_type.to_string()));
+            obj.insert(
+                "rhs".to_string(),
+                JsonValue::String(entry.rhs_type.to_string()),
+            );
             obj.insert(
                 "returns".to_string(),
                 JsonValue::String(entry.return_type.to_string()),
@@ -496,7 +501,10 @@ pub fn type_facts_json(ty: DataType) -> JsonValue {
         "category".to_string(),
         JsonValue::String(category_label(ty.category()).to_string()),
     );
-    obj.insert("is_preferred".to_string(), JsonValue::Bool(ty.is_preferred()));
+    obj.insert(
+        "is_preferred".to_string(),
+        JsonValue::Bool(ty.is_preferred()),
+    );
     obj.insert("casts".to_string(), JsonValue::Array(casts));
     obj.insert("operators".to_string(), JsonValue::Array(operators));
     JsonValue::Object(obj)
@@ -698,15 +706,15 @@ reference"
     #[test]
     fn infer_literal_type_maps_json_shapes() {
         assert_eq!(infer_literal_type(&JsonValue::Null), DataType::Nullable);
-        assert_eq!(infer_literal_type(&JsonValue::Bool(true)), DataType::Boolean);
+        assert_eq!(
+            infer_literal_type(&JsonValue::Bool(true)),
+            DataType::Boolean
+        );
         assert_eq!(
             infer_literal_type(&JsonValue::Number(42.0)),
             DataType::Integer
         );
-        assert_eq!(
-            infer_literal_type(&JsonValue::Number(3.5)),
-            DataType::Float
-        );
+        assert_eq!(infer_literal_type(&JsonValue::Number(3.5)), DataType::Float);
         assert_eq!(
             infer_literal_type(&JsonValue::String("hi".to_string())),
             DataType::Text
@@ -778,14 +786,19 @@ reference"
         );
         let casts = facts.get("casts").and_then(JsonValue::as_array).unwrap();
         assert!(
-            casts.iter().any(|c| c.get("target").and_then(JsonValue::as_str)
-                == Some("FLOAT")),
+            casts
+                .iter()
+                .any(|c| c.get("target").and_then(JsonValue::as_str) == Some("FLOAT")),
             "INTEGER → FLOAT must appear in the casts"
         );
-        let operators = facts.get("operators").and_then(JsonValue::as_array).unwrap();
+        let operators = facts
+            .get("operators")
+            .and_then(JsonValue::as_array)
+            .unwrap();
         assert!(
-            operators.iter().any(|o| o.get("symbol").and_then(JsonValue::as_str)
-                == Some("+")),
+            operators
+                .iter()
+                .any(|o| o.get("symbol").and_then(JsonValue::as_str) == Some("+")),
             "the + operator must appear in the operators"
         );
     }


### PR DESCRIPTION
Implements #1320 — `reddb_type_of` MCP tool (ADR 0061 §4): type/cast lookup from the generated reddb-io-types catalog.

- `crates/reddb-types/src/knowledge.rs` (+294): type catalog knowledge surface
- `crates/reddb-server/src/mcp/server.rs` (+142): tool handler
- `crates/reddb-server/src/mcp/tools.rs` (+48): tool registration

Authored by AFK worker wVJB4 (opus/high), committed at 8680a836. PR opened by supervisor to start CI; closes #1320 on merge.

Closes #1320

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785035324&installation_id=129708444&pr_number=1415&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1415&signature=12e026675ec768c5c2b98472a48f1a1281d0e00f94e570f12b76703b734fb223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `reddb_type_of` tool to the server, allowing clients to look up a type from either a type name or a JSON value.
  * Returned results now include a type’s canonical name, category, preferred status, available casts, and supported operators.

* **Bug Fixes**
  * Improved error handling for missing inputs and unknown type names when using type lookup.
  * Type inference now handles common JSON values more consistently, including numbers, strings, arrays, objects, booleans, and null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->