### PR TITLE
merge: #1402 DOCUMENT: binary body write + binary→JSON read decode (flag-gated)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1232,9 +1232,17 @@ fn reject_document_array_position_path(path: &[String]) -> RedDBResult<()> {
 
 fn document_body_from_named(fields: &HashMap<String, Value>) -> RedDBResult<JsonValue> {
     match fields.get("body") {
-        Some(Value::Json(bytes)) => crate::json::from_slice(bytes).map_err(|err| {
-            crate::RedDBError::Query(format!("failed to decode document body: {err}"))
-        }),
+        Some(Value::Json(bytes)) => {
+            // The stored body may be the native binary container (PRD-1398) or
+            // plain JSON; decode either form back to JSON.
+            if let Some(body) = crate::document_body::decode_container_to_json(bytes) {
+                Ok(body)
+            } else {
+                crate::json::from_slice(bytes).map_err(|err| {
+                    crate::RedDBError::Query(format!("failed to decode document body: {err}"))
+                })
+            }
+        }
         Some(_) => Err(crate::RedDBError::Query(
             "document body field must contain JSON".to_string(),
         )),
@@ -1245,6 +1253,7 @@ fn document_body_from_named(fields: &HashMap<String, Value>) -> RedDBResult<Json
 fn replace_document_row_body(
     fields: &mut HashMap<String, Value>,
     body: JsonValue,
+    binary: bool,
     modified_columns: &mut Vec<String>,
 ) -> RedDBResult<()> {
     modified_columns.push("body".to_string());
@@ -1259,9 +1268,7 @@ fn replace_document_row_body(
         modified_columns.push(key);
     }
 
-    let body_bytes = json_to_vec(&body).map_err(|err| {
-        crate::RedDBError::Query(format!("failed to serialize document body: {err}"))
-    })?;
+    let body_bytes = crate::document_body::serialize_document_body(&body, binary)?;
     fields.insert("body".to_string(), Value::Json(body_bytes));
 
     if let JsonValue::Object(map) = &body {
@@ -1353,6 +1360,7 @@ impl RedDBRuntime {
                         contract.declared_model == crate::catalog::CollectionModel::Document
                     })
                     .unwrap_or(false);
+                let binary_body = self.binary_document_body_enabled();
                 let mut field_ops = Vec::new();
                 let mut metadata_ops = Vec::new();
                 let mut document_body_ops = Vec::new();
@@ -1418,14 +1426,19 @@ impl RedDBRuntime {
                     let mut body = document_body_from_named(named)?;
                     apply_patch_operations_to_json(&mut body, &document_body_ops)
                         .map_err(crate::RedDBError::Query)?;
-                    replace_document_row_body(named, body, &mut modified_columns)?;
+                    replace_document_row_body(named, body, binary_body, &mut modified_columns)?;
                 }
 
                 if is_document_collection {
                     if let Some(body) = payload.get("body") {
                         context_index_dirty = true;
                         let named = row.named.get_or_insert_with(Default::default);
-                        replace_document_row_body(named, body.clone(), &mut modified_columns)?;
+                        replace_document_row_body(
+                            named,
+                            body.clone(),
+                            binary_body,
+                            &mut modified_columns,
+                        )?;
                     }
                 }
 
@@ -1441,7 +1454,7 @@ impl RedDBRuntime {
                         let mut body = document_body_from_named(named)?;
                         apply_patch_operations_to_json(&mut body, &field_ops)
                             .map_err(crate::RedDBError::Query)?;
-                        replace_document_row_body(named, body, &mut modified_columns)?;
+                        replace_document_row_body(named, body, binary_body, &mut modified_columns)?;
                     } else {
                         for op in &field_ops {
                             if let Some(col) = op.path.first() {
@@ -1477,7 +1490,7 @@ impl RedDBRuntime {
                                 map.insert(key.clone(), value.clone());
                             }
                         }
-                        replace_document_row_body(named, body, &mut modified_columns)?;
+                        replace_document_row_body(named, body, binary_body, &mut modified_columns)?;
                     } else {
                         for (key, value) in fields {
                             modified_columns.push(key.clone());
@@ -1991,9 +2004,10 @@ impl RedDBRuntime {
                     );
                 }
             }
-            let body_bytes = json_to_vec(&body).map_err(|err| {
-                crate::RedDBError::Query(format!("failed to serialize document body: {err}"))
-            })?;
+            let body_bytes = crate::document_body::serialize_document_body(
+                &body,
+                self.binary_document_body_enabled(),
+            )?;
             named.insert("body".to_string(), Value::Json(body_bytes));
             context_index_dirty = true;
             if !modified_columns.iter().any(|column| column == "body") {
@@ -2919,10 +2933,13 @@ impl RuntimeEntityPort for RedDBRuntime {
             )?;
         }
 
-        // Serialize the full body as Value::Json for the "body" field
-        let body_bytes = json_to_vec(&input.body).map_err(|err| {
-            crate::RedDBError::Query(format!("failed to serialize document body: {err}"))
-        })?;
+        // Serialize the full body for the "body" field. Behind the
+        // `storage.binary_document_body` flag (PRD-1398) this is the native binary
+        // container; otherwise plain JSON. Reads decode either form to JSON.
+        let body_bytes = crate::document_body::serialize_document_body(
+            &input.body,
+            self.binary_document_body_enabled(),
+        )?;
         let mut fields: Vec<(String, crate::storage::schema::Value)> = vec![(
             "body".to_string(),
             crate::storage::schema::Value::Json(body_bytes),

--- a/crates/reddb-server/src/document_body.rs
+++ b/crates/reddb-server/src/document_body.rs
@@ -1,0 +1,142 @@
+//! Native binary document-body container wiring (PRD-1398, ADR-0063).
+//!
+//! DOCUMENT collections keep the canonical document under a `body` field.
+//! Behind the `storage.binary_document_body` flag, writes serialise that body into the
+//! native binary container ([`reddb_types::document_body_codec`]) instead of
+//! plain UTF-8 JSON. The container is self-describing — it starts with the
+//! `RDOC` magic — so every read path decodes it back to JSON transparently,
+//! regardless of the flag, keeping the wire/clients on JSON (no driver change).
+//!
+//! The binary form lives only inside the stored `Value::Json` bytes; the rest
+//! of the engine continues to see a JSON body in memory. This is the
+//! flag-gated write + binary→JSON read slice; routing filters to indexes and
+//! projection to offset-reads (and removing the promoted columns) are later
+//! PRD-1398 slices.
+
+use reddb_types::document_body_codec;
+
+use crate::application::entity::json_to_storage_value;
+use crate::json::{to_vec as json_to_vec, Map, Value as JsonValue};
+use crate::presentation::entity_json::storage_value_to_json;
+use crate::storage::schema::Value;
+use crate::{RedDBError, RedDBResult};
+
+/// True when `bytes` begin with the document-body container magic.
+///
+/// A legacy UTF-8 JSON document body is an object and starts with `{`, so this
+/// magic check never collides with a JSON body.
+pub(crate) fn is_binary_container(bytes: &[u8]) -> bool {
+    bytes.starts_with(document_body_codec::MAGIC)
+}
+
+/// Decode a binary document-body container back to its JSON object.
+///
+/// Returns `None` when `bytes` is not a container — so callers fall back to
+/// their existing JSON parse — or when a container fails to decode.
+pub(crate) fn decode_container_to_json(bytes: &[u8]) -> Option<JsonValue> {
+    if !is_binary_container(bytes) {
+        return None;
+    }
+    let fields = document_body_codec::decode(bytes).ok()?;
+    let mut map = Map::new();
+    for (key, value) in fields {
+        map.insert(key, storage_value_to_json(&value));
+    }
+    Some(JsonValue::Object(map))
+}
+
+/// Serialise a document body for storage in the `body` field.
+///
+/// With `binary` set and an object body, produce the native binary container;
+/// otherwise (or for a non-object body, which the container cannot represent)
+/// fall back to UTF-8 JSON bytes. The caller wraps the result in `Value::Json`.
+pub(crate) fn serialize_document_body(body: &JsonValue, binary: bool) -> RedDBResult<Vec<u8>> {
+    if binary {
+        if let JsonValue::Object(map) = body {
+            let typed: Vec<(String, Value)> = map
+                .iter()
+                .map(|(key, value)| Ok((key.clone(), json_to_storage_value(value)?)))
+                .collect::<RedDBResult<_>>()?;
+            let refs: Vec<(&str, &Value)> = typed
+                .iter()
+                .map(|(key, value)| (key.as_str(), value))
+                .collect();
+            let mut out = Vec::new();
+            document_body_codec::encode(&refs, &mut out).map_err(|err| {
+                RedDBError::Query(format!("failed to encode binary document body: {err}"))
+            })?;
+            return Ok(out);
+        }
+    }
+    json_to_vec(body)
+        .map_err(|err| RedDBError::Query(format!("failed to serialize document body: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(text: &str) -> JsonValue {
+        crate::json::from_str(text).expect("valid JSON fixture")
+    }
+
+    fn body() -> JsonValue {
+        parse(
+            r#"{"name":"Alice","age":30,"email":"alice@example.com",
+               "tags":["admin","ops"],"profile":{"city":"SP","active":true}}"#,
+        )
+    }
+
+    #[test]
+    fn binary_off_emits_plain_json_bytes() {
+        let bytes = serialize_document_body(&body(), false).expect("serialize");
+        assert!(!is_binary_container(&bytes), "flag off must stay JSON");
+        assert_eq!(bytes.first(), Some(&b'{'));
+        assert!(decode_container_to_json(&bytes).is_none());
+    }
+
+    #[test]
+    fn binary_on_emits_container_that_decodes_to_equal_json() {
+        let original = body();
+        let bytes = serialize_document_body(&original, true).expect("serialize");
+        assert!(is_binary_container(&bytes), "flag on must produce RDOC");
+        let decoded = decode_container_to_json(&bytes).expect("decode");
+        assert_eq!(
+            decoded, original,
+            "binary body must round-trip to equal JSON"
+        );
+    }
+
+    #[test]
+    fn non_object_body_falls_back_to_json_even_with_binary_on() {
+        let scalar = JsonValue::String("just-a-string".to_string());
+        let bytes = serialize_document_body(&scalar, true).expect("serialize");
+        assert!(!is_binary_container(&bytes));
+        assert_eq!(
+            json_to_vec(&scalar).unwrap(),
+            bytes,
+            "non-object body must serialise as plain JSON"
+        );
+    }
+
+    #[test]
+    fn rich_semantic_string_types_survive_round_trip() {
+        // On the JSON wire these are strings; the container must round-trip the
+        // exact JSON the client sent (Email/Ipv4/Subnet/Color string forms).
+        let original = parse(
+            r##"{"email":"user@example.com","ipv4":"127.0.0.1",
+               "subnet":"10.0.0.0/8","color":"#DEADBE","url":"https://reddb.io"}"##,
+        );
+        let bytes = serialize_document_body(&original, true).expect("serialize");
+        let decoded = decode_container_to_json(&bytes).expect("decode");
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn empty_object_round_trips() {
+        let original = parse("{}");
+        let bytes = serialize_document_body(&original, true).expect("serialize");
+        assert!(is_binary_container(&bytes));
+        assert_eq!(decode_container_to_json(&bytes), Some(original));
+    }
+}

--- a/crates/reddb-server/src/grpc/scan_json.rs
+++ b/crates/reddb-server/src/grpc/scan_json.rs
@@ -227,7 +227,11 @@ fn json_field(
     key: &str,
 ) -> Option<crate::json::Value> {
     match record_field(record, key)? {
-        crate::storage::schema::Value::Json(bytes) => crate::json::from_slice(bytes).ok(),
+        crate::storage::schema::Value::Json(bytes) => {
+            // Decode the native binary document-body container (PRD-1398) if present.
+            crate::document_body::decode_container_to_json(bytes)
+                .or_else(|| crate::json::from_slice(bytes).ok())
+        }
         crate::storage::schema::Value::Text(text) => crate::json::from_str(text).ok(),
         _ => None,
     }
@@ -447,10 +451,16 @@ pub fn write_value_json(buf: &mut String, value: &crate::storage::schema::Value)
             buf.push_str(&hex::encode(bytes));
             buf.push('"');
         }
-        Value::Json(bytes) => match crate::json::from_slice::<crate::json::Value>(bytes) {
-            Ok(json) => buf.push_str(&json.to_string_compact()),
-            Err(_) => buf.push_str("null"),
-        },
+        Value::Json(bytes) => {
+            // A document body may be the native binary container (PRD-1398);
+            // decode it to JSON for the gRPC wire.
+            match crate::document_body::decode_container_to_json(bytes)
+                .or_else(|| crate::json::from_slice::<crate::json::Value>(bytes).ok())
+            {
+                Some(json) => buf.push_str(&json.to_string_compact()),
+                None => buf.push_str("null"),
+            }
+        }
         _ => buf.push_str("null"),
     }
 }

--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -31,6 +31,7 @@ pub mod cli;
 pub mod cluster;
 pub mod config;
 pub mod crypto;
+pub mod document_body;
 pub mod ec;
 pub mod engine;
 pub mod geo;

--- a/crates/reddb-server/src/presentation/entity_json.rs
+++ b/crates/reddb-server/src/presentation/entity_json.rs
@@ -206,6 +206,11 @@ pub(crate) fn storage_value_to_json(value: &Value) -> JsonValue {
 }
 
 pub(crate) fn storage_json_bytes_to_json(bytes: &[u8]) -> JsonValue {
+    // A document body may be stored as the native binary container (PRD-1398);
+    // decode it back to JSON for the wire. Plain-JSON bytes fall through.
+    if let Some(body) = crate::document_body::decode_container_to_json(bytes) {
+        return body;
+    }
     json_from_slice::<JsonValue>(bytes).unwrap_or_else(|_| {
         JsonValue::Object(
             [

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -1347,7 +1347,11 @@ fn bool_field(record: &UnifiedRecord, name: &str) -> Option<bool> {
 
 fn json_field(record: &UnifiedRecord, name: &str) -> Option<Value> {
     match record_field(record, name)? {
-        SchemaValue::Json(bytes) => json::from_slice(bytes).ok(),
+        SchemaValue::Json(bytes) => {
+            // Decode the native binary document-body container (PRD-1398) if present.
+            crate::document_body::decode_container_to_json(bytes)
+                .or_else(|| json::from_slice(bytes).ok())
+        }
         SchemaValue::Text(text) => json::from_str(text).ok(),
         _ => None,
     }

--- a/crates/reddb-server/src/runtime/config_matrix.rs
+++ b/crates/reddb-server/src/runtime/config_matrix.rs
@@ -118,6 +118,17 @@ pub const MATRIX: &[ConfigDefault] = &[
         tier: Tier::Critical,
         default: || num(crate::storage::cache::DEFAULT_BLOB_MAX_NAMESPACES as f64),
     },
+    // storage.binary_document_body — DOCUMENT native binary body container
+    // (PRD-1398, ADR-0063). Opt-in: when true, document writes store the body
+    // as the native binary container; reads decode it back to JSON
+    // transparently. Default false so existing deployments keep the plain-JSON
+    // body until they choose to flip. (Keyed off `storage.*`, not `document.*`,
+    // because `document` is a reserved RQL keyword and would break SET CONFIG.)
+    ConfigDefault {
+        key: "storage.binary_document_body",
+        tier: Tier::Optional,
+        default: || JsonValue::Bool(false),
+    },
     // durability.*
     ConfigDefault {
         key: "durability.mode",

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1637,7 +1637,12 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
 fn value_to_json(value: &Value) -> Option<crate::serde_json::Value> {
     match value {
         Value::Null => Some(crate::serde_json::Value::Null),
+        // A document body may be the native binary container (PRD-1398); decode
+        // it to JSON so json builtins see the same shape as a plain JSON body.
         Value::Json(bytes) => {
+            if let Some(body) = crate::document_body::decode_container_to_json(bytes) {
+                return Some(body);
+            }
             let text = String::from_utf8_lossy(bytes);
             crate::serde_json::from_str(&text).ok()
         }
@@ -1690,6 +1695,10 @@ fn value_as_json(value: &Value) -> crate::serde_json::Value {
         Value::Float(n) => crate::serde_json::Value::Number(*n),
         Value::Text(s) => crate::serde_json::Value::String(s.to_string()),
         Value::Json(bytes) => {
+            // Decode the native binary container (PRD-1398) if present.
+            if let Some(body) = crate::document_body::decode_container_to_json(bytes) {
+                return body;
+            }
             let text = String::from_utf8_lossy(bytes);
             crate::serde_json::from_str(&text)
                 .unwrap_or_else(|_| crate::serde_json::Value::String(text.into_owned()))

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3366,6 +3366,15 @@ impl RedDBRuntime {
         result
     }
 
+    /// Whether DOCUMENT writes should store the body as the native binary
+    /// container (PRD-1398, ADR-0063). Off by default; flip via
+    /// `SET CONFIG storage.binary_document_body = true` or the
+    /// `REDDB_STORAGE_BINARY_DOCUMENT_BODY` env var. Reads decode the container
+    /// transparently regardless of this flag.
+    pub(crate) fn binary_document_body_enabled(&self) -> bool {
+        self.config_bool("storage.binary_document_body", false)
+    }
+
     pub(crate) fn config_u64(&self, key: &str, default: u64) -> u64 {
         if let Some(raw) = self.inner.env_config_overrides.get(key) {
             if let Some(crate::storage::schema::Value::UnsignedInteger(n)) =

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -1584,7 +1584,10 @@ pub(crate) fn resolve_runtime_document_path_from_value(
 
     match value {
         Value::Json(bytes) | Value::Blob(bytes) => {
-            let json = crate::json::from_slice::<JsonValue>(bytes).ok()?;
+            // A document body may be the native binary container (PRD-1398);
+            // decode it to JSON so dotted `body.field` paths resolve.
+            let json = crate::document_body::decode_container_to_json(bytes)
+                .or_else(|| crate::json::from_slice::<JsonValue>(bytes).ok())?;
             resolve_runtime_document_json_path(&json, path)
         }
         // Phase 2 dotted tenancy: users commonly declare JSON columns

--- a/crates/reddb-server/src/server/handlers_query.rs
+++ b/crates/reddb-server/src/server/handlers_query.rs
@@ -2329,7 +2329,8 @@ fn schema_json_field(
     name: &str,
 ) -> Option<JsonValue> {
     match schema_field(record, name)? {
-        Value::Json(bytes) => crate::json::from_slice(bytes).ok(),
+        Value::Json(bytes) => crate::document_body::decode_container_to_json(bytes)
+            .or_else(|| crate::json::from_slice(bytes).ok()),
         Value::Text(text) => crate::json::from_str(text).ok(),
         _ => None,
     }

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -954,7 +954,11 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
 fn value_to_json(value: &Value) -> Option<crate::serde_json::Value> {
     match value {
         Value::Null => Some(crate::serde_json::Value::Null),
-        Value::Json(bytes) => crate::serde_json::from_slice(bytes).ok(),
+        // A document body may be the native binary container (PRD-1398); decode
+        // it to JSON so json_extract / CONTAINS see the same shape as a plain
+        // JSON body.
+        Value::Json(bytes) => crate::document_body::decode_container_to_json(bytes)
+            .or_else(|| crate::serde_json::from_slice(bytes).ok()),
         Value::Text(value) => crate::serde_json::from_str(value).ok(),
         _ => None,
     }

--- a/crates/reddb-server/src/storage/unified/tokenization.rs
+++ b/crates/reddb-server/src/storage/unified/tokenization.rs
@@ -113,6 +113,13 @@ pub fn push_json_tokens(tokens: &mut BTreeSet<String>, bytes: &[u8]) {
         }
     }
 
+    // A document body may be the native binary container (PRD-1398); decode it
+    // to JSON so its index tokens match those of an equivalent plain JSON body.
+    if let Some(value) = crate::document_body::decode_container_to_json(bytes) {
+        let mut budget = MAX_JSON_TOKEN_BUDGET;
+        collect(&value, tokens, &mut budget);
+        return;
+    }
     if let Ok(value) = crate::serde_json::from_slice::<crate::serde_json::Value>(bytes) {
         let mut budget = MAX_JSON_TOKEN_BUDGET;
         collect(&value, tokens, &mut budget);

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -1093,7 +1093,9 @@ fn f64_field(record: &UnifiedRecord, key: &str) -> Option<f64> {
 
 fn json_field(record: &UnifiedRecord, key: &str) -> Option<crate::json::Value> {
     match record_field(record, key)? {
-        Value::Json(bytes) => crate::json::from_slice(bytes).ok(),
+        // Decode the native binary document-body container (PRD-1398) if present.
+        Value::Json(bytes) => crate::document_body::decode_container_to_json(bytes)
+            .or_else(|| crate::json::from_slice(bytes).ok()),
         Value::Text(text) => crate::json::from_str(text).ok(),
         _ => None,
     }

--- a/tests/grouped/docs_kv_queue/e2e_issue_1402_document_binary_body.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1402_document_binary_body.rs
@@ -1,0 +1,235 @@
+// Issue #1402 — DOCUMENT: binary body write + binary→JSON read decode
+// (flag-gated, PRD-1398 / ADR-0063).
+//
+// Acceptance bullets:
+//   1. With the flag on, a written document is stored as a binary body
+//      container (the stored `body` bytes start with the `RDOC` magic).
+//   2. `SELECT body` and field projection return JSON equal to today's
+//      behaviour (flag-on results match flag-off results).
+//   3. Rich types (Email, Ipv4, Subnet, Color, …) survive write→read.
+//   4. Existing document RQL behaviour (json_extract, body.field, UPDATE SET,
+//      PATCH, reopen) is unchanged with the flag on.
+
+#[path = "../../support/mod.rs"]
+mod support;
+
+use reddb::storage::schema::Value;
+use reddb::RedDBRuntime;
+use support::PersistentDbPath;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::in_memory().expect("runtime")
+}
+
+fn enable_binary_body(rt: &RedDBRuntime) {
+    rt.execute_query("SET CONFIG storage.binary_document_body = true")
+        .expect("enable storage.binary_document_body");
+}
+
+fn text_field<'a>(row: &'a reddb::storage::query::UnifiedRecord, field: &str) -> String {
+    match row.get(field) {
+        Some(Value::Text(value)) => value.to_string(),
+        other => panic!("expected {field} text, got {other:?} in {row:?}"),
+    }
+}
+
+/// Extract a top-level body field via `json_extract`, returning its compact
+/// JSON text (strings come back quoted). This exercises the binary→JSON decode
+/// path and avoids the case-folding of dotted `body.field` column names.
+fn body_json_extract(rt: &RedDBRuntime, collection: &str, field: &str) -> String {
+    let out = rt
+        .execute_query(&format!(
+            "SELECT json_extract(body, '$.{field}') FROM {collection}"
+        ))
+        .expect("json_extract");
+    let column = format!("JSON_EXTRACT(body, '$.{field}')");
+    match out.result.records[0].get(&column) {
+        Some(Value::Text(value)) => value.to_string(),
+        other => panic!("expected text at {column}, got {other:?}"),
+    }
+}
+
+/// The single in-memory record `body` field as raw stored bytes.
+fn body_bytes(rt: &RedDBRuntime, collection: &str) -> Vec<u8> {
+    let out = rt
+        .execute_query(&format!("SELECT body FROM {collection}"))
+        .expect("SELECT body");
+    assert_eq!(out.result.records.len(), 1, "exactly one document");
+    match out.result.records[0].get("body") {
+        Some(Value::Json(bytes)) => bytes.clone(),
+        other => panic!("expected body Json, got {other:?}"),
+    }
+}
+
+const RDOC_MAGIC: &[u8; 4] = b"RDOC";
+
+#[test]
+fn flag_on_stores_body_as_binary_container() {
+    let rt = runtime();
+    enable_binary_body(&rt);
+    rt.execute_query("CREATE DOCUMENT events").expect("create");
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT (body) VALUES ('{"event_type":"login","attempts":2}')"#,
+    )
+    .expect("insert");
+
+    let bytes = body_bytes(&rt, "events");
+    assert_eq!(
+        &bytes[..4],
+        RDOC_MAGIC,
+        "flag on must store the native binary container"
+    );
+}
+
+#[test]
+fn flag_off_keeps_plain_json_body() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT events").expect("create");
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT (body) VALUES ('{"event_type":"login","attempts":2}')"#,
+    )
+    .expect("insert");
+
+    let bytes = body_bytes(&rt, "events");
+    assert_ne!(&bytes[..4], RDOC_MAGIC, "flag off stays JSON");
+    assert_eq!(bytes.first(), Some(&b'{'), "JSON object body");
+}
+
+/// Run the same document script with and without the flag and assert every
+/// observable RQL result matches — `SELECT body.field`, `json_extract`,
+/// promoted-column projection, and a tag-array CONTAINS predicate.
+#[test]
+fn flag_on_observable_behaviour_matches_flag_off() {
+    fn observe(binary: bool) -> Vec<(String, String, String, usize)> {
+        let rt = runtime();
+        if binary {
+            enable_binary_body(&rt);
+        }
+        rt.execute_query("CREATE DOCUMENT docs").expect("create");
+        for doc in [
+            r#"{"level":"info","seq":1,"tags":["page_view","checkout"]}"#,
+            r#"{"level":"warn","seq":2,"tags":["page_view"]}"#,
+            r#"{"level":"info","seq":3,"tags":["checkout","logout"]}"#,
+        ] {
+            rt.execute_query(&format!(
+                "INSERT INTO docs DOCUMENT (body) VALUES ('{doc}')"
+            ))
+            .expect("insert");
+        }
+
+        // body.field access + json_extract + promoted column projection.
+        let rows = rt
+            .execute_query(
+                "SELECT level, body.level, json_extract(body, '$.level') \
+                 FROM docs WHERE body.level = 'info' ORDER BY seq",
+            )
+            .expect("select");
+        let mut observed = Vec::new();
+        for row in &rows.result.records {
+            observed.push((
+                text_field(row, "level"),
+                text_field(row, "body.LEVEL"),
+                match row.get("JSON_EXTRACT(body, '$.level')") {
+                    Some(Value::Text(v)) => v.to_string(),
+                    other => format!("{other:?}"),
+                },
+                rows.result.records.len(),
+            ));
+        }
+
+        // Array-membership predicate over the document body's tag array.
+        let contains = rt
+            .execute_query("SELECT seq FROM docs WHERE body.tags CONTAINS 'checkout' ORDER BY seq")
+            .expect("contains");
+        observed.push((
+            "contains_count".to_string(),
+            contains.result.records.len().to_string(),
+            String::new(),
+            0,
+        ));
+        observed
+    }
+
+    assert_eq!(
+        observe(true),
+        observe(false),
+        "binary-body reads must match plain-JSON reads"
+    );
+}
+
+/// Rich semantic types arrive on the JSON wire as strings; the binary body
+/// must round-trip exactly the JSON the client sent.
+#[test]
+fn rich_types_survive_write_then_read() {
+    let rt = runtime();
+    enable_binary_body(&rt);
+    rt.execute_query("CREATE DOCUMENT assets").expect("create");
+    rt.execute_query(
+        r##"INSERT INTO assets DOCUMENT (body) VALUES ('{"email":"user@example.com","ipv4":"127.0.0.1","subnet":"10.0.0.0/8","color":"#DEADBE"}')"##,
+    )
+    .expect("insert");
+
+    let bytes = body_bytes(&rt, "assets");
+    assert_eq!(&bytes[..4], RDOC_MAGIC, "stored binary");
+
+    // These arrive on the JSON wire as strings; the body must round-trip them
+    // exactly (json_extract returns the JSON-quoted form).
+    for (field, expected) in [
+        ("email", "user@example.com"),
+        ("ipv4", "127.0.0.1"),
+        ("subnet", "10.0.0.0/8"),
+        ("color", "#DEADBE"),
+    ] {
+        assert_eq!(
+            body_json_extract(&rt, "assets", field),
+            format!("\"{expected}\""),
+            "rich type {field} must survive"
+        );
+    }
+}
+
+/// UPDATE SET on a promoted column keeps `body` and the column in sync (#1394)
+/// even when the body is stored as a binary container.
+#[test]
+fn update_set_keeps_binary_body_in_sync() {
+    let rt = runtime();
+    enable_binary_body(&rt);
+    rt.execute_query("CREATE DOCUMENT users").expect("create");
+    rt.execute_query(
+        r#"INSERT INTO users DOCUMENT (body) VALUES ('{"name":"Alice","tier":"free"}')"#,
+    )
+    .expect("insert");
+
+    rt.execute_query("UPDATE users DOCUMENTS SET tier = 'pro' WHERE name = 'Alice'")
+        .expect("update");
+
+    // Still binary on disk after the update.
+    assert_eq!(&body_bytes(&rt, "users")[..4], RDOC_MAGIC);
+
+    // Promoted column and body agree (#1394 invariant under binary storage).
+    let col = rt
+        .execute_query("SELECT tier FROM users")
+        .expect("select tier");
+    assert_eq!(text_field(&col.result.records[0], "tier"), "pro");
+    assert_eq!(body_json_extract(&rt, "users", "tier"), "\"pro\"");
+    // The untargeted field must survive.
+    assert_eq!(body_json_extract(&rt, "users", "name"), "\"Alice\"");
+}
+
+/// A binary body persists across a checkpoint + reopen and still reads as JSON.
+#[test]
+fn binary_body_survives_reopen() {
+    let path = PersistentDbPath::new("issue1402_binary_body");
+    {
+        let rt = path.open_runtime();
+        enable_binary_body(&rt);
+        rt.execute_query("CREATE DOCUMENT events").expect("create");
+        rt.execute_query(
+            r#"INSERT INTO events DOCUMENT (body) VALUES ('{"label":"hello","n":7}')"#,
+        )
+        .expect("insert");
+        assert_eq!(&body_bytes(&rt, "events")[..4], RDOC_MAGIC);
+    }
+    let rt = path.open_runtime();
+    assert_eq!(body_json_extract(&rt, "events", "label"), "\"hello\"");
+}

--- a/tests/grouped/documents_kv_queues.rs
+++ b/tests/grouped/documents_kv_queues.rs
@@ -18,6 +18,9 @@ mod e2e_issue_535_red_queues_virtual_table;
 #[path = "docs_kv_queue/e2e_issue_540_documents_basics.rs"]
 mod e2e_issue_540_documents_basics;
 
+#[path = "docs_kv_queue/e2e_issue_1402_document_binary_body.rs"]
+mod e2e_issue_1402_document_binary_body;
+
 #[path = "docs_kv_queue/e2e_issue_541_kv_namespaced_keys.rs"]
 mod e2e_issue_541_kv_namespaced_keys;
 


### PR DESCRIPTION
Automated AFK landing for #1402. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1402

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785045619&installation_id=129708444&pr_number=1420&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1420&signature=bcfe47678f68193b36eb8d807de7b2b2ad2db7b1f99440802173aa8cf8950fe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->