### PR TITLE
merge: #1403 DOCUMENT: single source of truth — filter via index, project via offset-read, drop promoted columns

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -2965,8 +2965,7 @@ impl RuntimeEntityPort for RedDBRuntime {
         // `storage.binary_document_body` flag (PRD-1398) this is the native binary
         // container; otherwise plain JSON. Reads decode either form to JSON.
         let binary_body = self.binary_document_body_enabled();
-        let body_bytes =
-            crate::document_body::serialize_document_body(&input.body, binary_body)?;
+        let body_bytes = crate::document_body::serialize_document_body(&input.body, binary_body)?;
         let mut fields: Vec<(String, crate::storage::schema::Value)> = vec![(
             "body".to_string(),
             crate::storage::schema::Value::Json(body_bytes),

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1271,10 +1271,16 @@ fn replace_document_row_body(
     let body_bytes = crate::document_body::serialize_document_body(&body, binary)?;
     fields.insert("body".to_string(), Value::Json(body_bytes));
 
-    if let JsonValue::Object(map) = &body {
-        for (key, value) in map {
-            fields.insert(key.clone(), json_to_storage_value(value)?);
-            modified_columns.push(key.clone());
+    // Single source of truth (PRD-1398): with the binary body on, the body is
+    // the only stored representation — don't re-promote top-level keys into
+    // columns (the loop above already dropped any stale ones). With the flag
+    // off (legacy) keep the promoted columns in sync with the body (#1394).
+    if !binary {
+        if let JsonValue::Object(map) = &body {
+            for (key, value) in map {
+                fields.insert(key.clone(), json_to_storage_value(value)?);
+                modified_columns.push(key.clone());
+            }
         }
     }
 
@@ -1994,6 +2000,7 @@ impl RedDBRuntime {
         apply_row_field_assignments_raw(row, dynamic_field_assignments);
 
         if !document_body_updates.is_empty() {
+            let binary_body = self.binary_document_body_enabled();
             let named = row.named.get_or_insert_with(Default::default);
             let mut body = document_body_from_named(named)?;
             if let JsonValue::Object(map) = &mut body {
@@ -2004,11 +2011,20 @@ impl RedDBRuntime {
                     );
                 }
             }
-            let body_bytes = crate::document_body::serialize_document_body(
-                &body,
-                self.binary_document_body_enabled(),
-            )?;
+            let body_bytes = crate::document_body::serialize_document_body(&body, binary_body)?;
             named.insert("body".to_string(), Value::Json(body_bytes));
+            // Single source of truth (PRD-1398): the assignment lives in the
+            // body now, so don't keep the promoted column the raw assignment
+            // just materialised — strip it back out (the body-derived index is
+            // refreshed from the new body). Legacy mode keeps it in sync (#1394).
+            if binary_body {
+                for (column, _) in &document_body_updates {
+                    named.remove(column);
+                    if !modified_columns.iter().any(|tracked| tracked == column) {
+                        modified_columns.push(column.clone());
+                    }
+                }
+            }
             context_index_dirty = true;
             if !modified_columns.iter().any(|column| column == "body") {
                 modified_columns.push("body".to_string());
@@ -2936,20 +2952,25 @@ impl RuntimeEntityPort for RedDBRuntime {
         // Serialize the full body for the "body" field. Behind the
         // `storage.binary_document_body` flag (PRD-1398) this is the native binary
         // container; otherwise plain JSON. Reads decode either form to JSON.
-        let body_bytes = crate::document_body::serialize_document_body(
-            &input.body,
-            self.binary_document_body_enabled(),
-        )?;
+        let binary_body = self.binary_document_body_enabled();
+        let body_bytes =
+            crate::document_body::serialize_document_body(&input.body, binary_body)?;
         let mut fields: Vec<(String, crate::storage::schema::Value)> = vec![(
             "body".to_string(),
             crate::storage::schema::Value::Json(body_bytes),
         )];
 
-        // Flatten top-level keys from the body into named fields for filtering
-        if let JsonValue::Object(ref map) = input.body {
-            for (key, value) in map {
-                let storage_value = json_to_storage_value(value)?;
-                fields.push((key.clone(), storage_value));
+        // Single source of truth (PRD-1398): when the binary body is on, the
+        // body IS the document — promoted columns are no longer materialised.
+        // Filters resolve via the index, projections offset-read the body. With
+        // the flag off (legacy) we still flatten top-level keys into named
+        // columns for filtering.
+        if !binary_body {
+            if let JsonValue::Object(ref map) = input.body {
+                for (key, value) in map {
+                    let storage_value = json_to_storage_value(value)?;
+                    fields.push((key.clone(), storage_value));
+                }
             }
         }
 

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -2239,19 +2239,31 @@ impl RedDBRuntime {
                     .into_iter()
                     .filter_map(|idx| idx.columns.first().cloned())
                     .collect();
-                let modified_cols: std::collections::HashSet<String> = damage
+                // Single-source documents keep promoted index columns in the
+                // body — surface them so the index sees the value move (a no-op
+                // for ordinary stored columns).
+                let pre_index_fields = self
+                    .index_store_ref()
+                    .augment_body_derived_index_fields(&applied.pre_mutation_fields, &indexed_cols);
+                let post_index_fields = self
+                    .index_store_ref()
+                    .augment_body_derived_index_fields(&post, &indexed_cols);
+                let modified_cols: std::collections::HashSet<String> =
+                    crate::application::entity::row_damage_vector(
+                        &pre_index_fields,
+                        &post_index_fields,
+                    )
                     .touched_columns()
                     .into_iter()
                     .map(str::to_string)
                     .collect();
                 if let Some(old_version) = applied.replaced_entity.as_ref() {
-                    let old_index_fields: Vec<(String, Value)> = applied
-                        .pre_mutation_fields
+                    let old_index_fields: Vec<(String, Value)> = pre_index_fields
                         .iter()
                         .filter(|(col, _)| indexed_cols.contains(col))
                         .cloned()
                         .collect();
-                    let new_index_fields: Vec<(String, Value)> = post
+                    let new_index_fields: Vec<(String, Value)> = post_index_fields
                         .iter()
                         .filter(|(col, _)| indexed_cols.contains(col))
                         .cloned()
@@ -2292,8 +2304,8 @@ impl RedDBRuntime {
                             .index_entity_update(
                                 &applied.collection,
                                 applied.id,
-                                &applied.pre_mutation_fields,
-                                &post,
+                                &pre_index_fields,
+                                &post_index_fields,
                             )
                             .map_err(crate::RedDBError::Internal)?;
                     } else {

--- a/crates/reddb-server/src/document_body.rs
+++ b/crates/reddb-server/src/document_body.rs
@@ -45,6 +45,46 @@ pub(crate) fn decode_container_to_json(bytes: &[u8]) -> Option<JsonValue> {
     Some(JsonValue::Object(map))
 }
 
+/// Offset-read a single promoted field from a stored document body.
+///
+/// Returns the field's storage [`Value`] decoded directly from the binary
+/// container by offset ([`document_body_codec::read_field_by_name`]) — no
+/// other field is touched. Returns `None` when `bytes` is not a binary
+/// container (legacy plain-JSON bodies still carry materialised promoted
+/// columns, so this fallback is never needed for them) or the field is absent.
+///
+/// This is the read seam that makes the body the single source of truth: with
+/// promoted columns no longer materialised on the write path, a `WHERE`/
+/// projection on a top-level field routes here to read it straight from the body.
+pub(crate) fn read_promoted_field(bytes: &[u8], name: &str) -> Option<Value> {
+    if !is_binary_container(bytes) {
+        return None;
+    }
+    document_body_codec::read_field_by_name(bytes, name)
+        .ok()
+        .flatten()
+}
+
+/// Decode every top-level field of a binary document body as storage values.
+///
+/// Returns `None` when `bytes` is not a binary container. Used to expand a
+/// `SELECT *` over a single-source document back into its promoted columns.
+pub(crate) fn promoted_fields(bytes: &[u8]) -> Option<Vec<(String, Value)>> {
+    if !is_binary_container(bytes) {
+        return None;
+    }
+    document_body_codec::decode(bytes).ok()
+}
+
+/// List the top-level field names of a binary document body (offset-read of
+/// the keys section only). Returns `None` for non-container bytes.
+pub(crate) fn container_field_names(bytes: &[u8]) -> Option<Vec<String>> {
+    if !is_binary_container(bytes) {
+        return None;
+    }
+    document_body_codec::field_names(bytes).ok()
+}
+
 /// Serialise a document body for storage in the `body` field.
 ///
 /// With `binary` set and an object body, produce the native binary container;
@@ -130,6 +170,38 @@ mod tests {
         let bytes = serialize_document_body(&original, true).expect("serialize");
         let decoded = decode_container_to_json(&bytes).expect("decode");
         assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn read_promoted_field_offset_reads_from_binary_body() {
+        let bytes = serialize_document_body(&body(), true).expect("serialize");
+        assert_eq!(
+            read_promoted_field(&bytes, "name"),
+            Some(Value::text("Alice"))
+        );
+        assert_eq!(read_promoted_field(&bytes, "age"), Some(Value::Integer(30)));
+        assert_eq!(read_promoted_field(&bytes, "missing"), None);
+    }
+
+    #[test]
+    fn promoted_field_helpers_ignore_plain_json_bodies() {
+        // Legacy plain-JSON bodies still carry materialised promoted columns,
+        // so the body-read fallback must stay inert for them.
+        let bytes = serialize_document_body(&body(), false).expect("serialize");
+        assert_eq!(read_promoted_field(&bytes, "name"), None);
+        assert_eq!(promoted_fields(&bytes), None);
+        assert_eq!(container_field_names(&bytes), None);
+    }
+
+    #[test]
+    fn promoted_fields_and_names_cover_top_level_keys() {
+        let bytes = serialize_document_body(&body(), true).expect("serialize");
+        let names = container_field_names(&bytes).expect("names");
+        for key in ["name", "age", "email", "tags", "profile"] {
+            assert!(names.contains(&key.to_string()), "missing {key}");
+        }
+        let fields = promoted_fields(&bytes).expect("fields");
+        assert_eq!(fields.len(), names.len());
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -578,9 +578,19 @@ impl RedDBRuntime {
             return Ok(());
         }
 
+        // Single-source documents keep promoted index columns (`score`) in the
+        // body, not as stored fields. Resolve each indexed column from the body
+        // and fold it into the field snapshots so the diff below sees the value
+        // move — for an ordinary stored column this adds nothing.
+        let pre = self
+            .index_store_ref()
+            .augment_body_derived_index_fields(&applied.pre_mutation_fields, &indexed_cols);
+        let post = self
+            .index_store_ref()
+            .augment_body_derived_index_fields(&post, &indexed_cols);
+
         if let Some(old_version) = applied.replaced_entity.as_ref() {
-            let old_index_fields: Vec<(String, crate::storage::schema::Value)> = applied
-                .pre_mutation_fields
+            let old_index_fields: Vec<(String, crate::storage::schema::Value)> = pre
                 .iter()
                 .filter(|(col, _)| indexed_cols.contains(col))
                 .cloned()
@@ -603,20 +613,14 @@ impl RedDBRuntime {
             return Ok(());
         }
 
-        let damage =
-            crate::application::entity::row_damage_vector(&applied.pre_mutation_fields, &post);
+        let damage = crate::application::entity::row_damage_vector(&pre, &post);
         if damage
             .touched_columns()
             .into_iter()
             .any(|col| indexed_cols.contains(col))
         {
             self.index_store_ref()
-                .index_entity_update(
-                    &applied.collection,
-                    applied.id,
-                    &applied.pre_mutation_fields,
-                    &post,
-                )
+                .index_entity_update(&applied.collection, applied.id, &pre, &post)
                 .map_err(crate::RedDBError::Internal)?;
         }
         Ok(())

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1646,6 +1646,52 @@ impl IndexStore {
             }
             self.index_entity_insert(collection, entity_id, &[(col.clone(), new_value.clone())])?;
         }
+
+        // Single-source documents: an index on a promoted field (`score` or a
+        // dotted `body.score`) is backed by the body, not a stored column, so
+        // the field-name damage vector above never sees it change — it only
+        // sees `body` change. Re-evaluate every such index column directly from
+        // the old/new body. No-op for non-document collections, where these
+        // columns resolve to nothing in both snapshots.
+        for col in &indexed_cols {
+            if old_fields.iter().any(|(f, _)| f == col) || new_fields.iter().any(|(f, _)| f == col) {
+                // A real stored column — already handled by the damage loop.
+                continue;
+            }
+            let old_value = index_field_value(old_fields, col);
+            let new_value = index_field_value(new_fields, col);
+            match (old_value, new_value) {
+                (Some(old), Some(new)) => {
+                    if old.as_ref() != new.as_ref() {
+                        self.index_entity_delete(
+                            collection,
+                            entity_id,
+                            &[(col.clone(), old.into_owned())],
+                        )?;
+                        self.index_entity_insert(
+                            collection,
+                            entity_id,
+                            &[(col.clone(), new.into_owned())],
+                        )?;
+                    }
+                }
+                (Some(old), None) => {
+                    self.index_entity_delete(
+                        collection,
+                        entity_id,
+                        &[(col.clone(), old.into_owned())],
+                    )?;
+                }
+                (None, Some(new)) => {
+                    self.index_entity_insert(
+                        collection,
+                        entity_id,
+                        &[(col.clone(), new.into_owned())],
+                    )?;
+                }
+                (None, None) => {}
+            }
+        }
         Ok(())
     }
 }
@@ -1760,6 +1806,12 @@ fn index_field_value<'a>(fields: &'a [(String, Value)], column: &str) -> Option<
         return Some(Cow::Borrowed(value));
     }
     if !column.contains('.') {
+        // Single-source document: an index on a bare promoted field (`score`)
+        // is backed by the body, since the column is no longer materialised.
+        // Offset-read it from the binary `body` container (inert otherwise).
+        if let Some((_, Value::Json(bytes))) = fields.iter().find(|(field, _)| field == "body") {
+            return crate::document_body::read_promoted_field(bytes, column).map(Cow::Owned);
+        }
         return None;
     }
 

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1227,15 +1227,18 @@ impl IndexStore {
                     let count = self.sorted.build_composite(collection, columns, entities);
                     return Ok(count);
                 }
-                // Build sorted in-memory index for range scans (single col)
-                let derived_entities;
-                let sorted_entities = if col.contains('.') {
-                    derived_entities = derive_index_entities_for_column(entities, col);
-                    derived_entities.as_slice()
-                } else {
-                    entities
-                };
-                let count = self.sorted.build_index(collection, col, sorted_entities);
+                // Build sorted in-memory index for range scans (single col).
+                // Derive the indexed value for every row via `index_field_value`,
+                // which resolves a bare promoted field (or a dotted path) from
+                // the document body when it is no longer a materialised column
+                // (single source of truth). For an ordinary stored column it
+                // returns the value directly, so this is a no-op there — but it
+                // ensures the sorted index is actually populated for a document
+                // field, instead of silently building an empty index.
+                let derived_entities = derive_index_entities_for_column(entities, col);
+                let count = self
+                    .sorted
+                    .build_index(collection, col, &derived_entities);
                 // Also build hash index for equality lookups on same column
                 self.hash
                     .create_index(&HashIndexConfig {
@@ -1798,6 +1801,47 @@ impl SecondaryIndexBackend for IndexStore {
             }
             IncMethodKind::Spatial => {}
         }
+    }
+}
+
+impl IndexStore {
+    /// Resolve the value an index on `column` would store for a row, including a
+    /// bare/dotted document field offset-read from the `body` container when the
+    /// column is no longer a materialised field (single source of truth).
+    ///
+    /// Used by the update path to rebuild old/new index keys for body-derived
+    /// columns, which the field-name damage vector cannot see change on its own.
+    pub fn resolve_index_field_value(
+        &self,
+        fields: &[(String, Value)],
+        column: &str,
+    ) -> Option<Value> {
+        index_field_value(fields, column).map(Cow::into_owned)
+    }
+
+    /// Fold body-derived index columns into a row's field snapshot.
+    ///
+    /// Single-source documents keep promoted index columns (e.g. `score`) in
+    /// the `body` container, not as stored fields, so secondary-index
+    /// maintenance must surface their values as ordinary columns — otherwise
+    /// the diff between the old and new snapshots never sees a body-only change.
+    /// For each indexed column absent from `fields`, resolve it from the body
+    /// and append it; ordinary stored columns are returned untouched.
+    pub fn augment_body_derived_index_fields(
+        &self,
+        fields: &[(String, Value)],
+        indexed_cols: &std::collections::HashSet<String>,
+    ) -> Vec<(String, Value)> {
+        let mut out = fields.to_vec();
+        for col in indexed_cols {
+            if out.iter().any(|(existing, _)| existing == col) {
+                continue;
+            }
+            if let Some(value) = self.resolve_index_field_value(fields, col) {
+                out.push((col.clone(), value));
+            }
+        }
+        out
     }
 }
 

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1236,9 +1236,7 @@ impl IndexStore {
                 // ensures the sorted index is actually populated for a document
                 // field, instead of silently building an empty index.
                 let derived_entities = derive_index_entities_for_column(entities, col);
-                let count = self
-                    .sorted
-                    .build_index(collection, col, &derived_entities);
+                let count = self.sorted.build_index(collection, col, &derived_entities);
                 // Also build hash index for equality lookups on same column
                 self.hash
                     .create_index(&HashIndexConfig {
@@ -1657,7 +1655,8 @@ impl IndexStore {
         // the old/new body. No-op for non-document collections, where these
         // columns resolve to nothing in both snapshots.
         for col in &indexed_cols {
-            if old_fields.iter().any(|(f, _)| f == col) || new_fields.iter().any(|(f, _)| f == col) {
+            if old_fields.iter().any(|(f, _)| f == col) || new_fields.iter().any(|(f, _)| f == col)
+            {
                 // A real stored column — already handled by the damage loop.
                 continue;
             }

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -362,7 +362,10 @@ pub(crate) fn resolve_kind<'a>(
 /// common case — legacy documents keep materialised columns, non-document rows
 /// have no `body`). This is what lets a bare `WHERE field`/`SELECT field` keep
 /// resolving once promoted columns stop being materialised.
-fn document_promoted_field(row: &crate::storage::unified::entity::RowData, name: &str) -> Option<Value> {
+fn document_promoted_field(
+    row: &crate::storage::unified::entity::RowData,
+    name: &str,
+) -> Option<Value> {
     match row.get_field("body") {
         Some(Value::Json(bytes)) => crate::document_body::read_promoted_field(bytes, name),
         _ => None,

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -258,6 +258,11 @@ pub(crate) fn resolve_kind<'a>(
                 if let Some(v) = row.get_field(name) {
                     return Some(Cow::Borrowed(v));
                 }
+                // Single-source document: a promoted field is no longer
+                // materialised as a column — offset-read it from the body.
+                if let Some(v) = document_promoted_field(row, name) {
+                    return Some(Cow::Owned(v));
+                }
             }
             // Graph node / edge property fallback for queries that
             // run against graph data with column-style references.
@@ -325,6 +330,11 @@ pub(crate) fn resolve_kind<'a>(
                 if let Some(v) = row.get_field(name) {
                     return Some(Cow::Borrowed(v));
                 }
+                // Single-source document: offset-read the promoted field
+                // straight from the body when it is no longer materialised.
+                if let Some(v) = document_promoted_field(row, name) {
+                    return Some(Cow::Owned(v));
+                }
             }
             if let Some(value) = resolve_timeseries_field(entity, name) {
                 return Some(value);
@@ -342,6 +352,20 @@ pub(crate) fn resolve_kind<'a>(
             None
         }
         EntityFieldKind::Unknown => None,
+    }
+}
+
+/// Offset-read a single-source document's promoted field from its body.
+///
+/// Returns the value of top-level field `name` decoded from the row's binary
+/// `body` container, or `None` when the row has no binary-container body (the
+/// common case — legacy documents keep materialised columns, non-document rows
+/// have no `body`). This is what lets a bare `WHERE field`/`SELECT field` keep
+/// resolving once promoted columns stop being materialised.
+fn document_promoted_field(row: &crate::storage::unified::entity::RowData, name: &str) -> Option<Value> {
+    match row.get_field("body") {
+        Some(Value::Json(bytes)) => crate::document_body::read_promoted_field(bytes, name),
+        _ => None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -533,6 +533,39 @@ pub(super) fn runtime_table_record_lean_in_collection(
 }
 
 #[inline(never)]
+/// Fill a single-source document's promoted columns into `record` by reading
+/// them from the binary `body` already placed on the record.
+///
+/// `columns = None` expands every top-level body field (SELECT *); `Some(cols)`
+/// offset-reads only the requested fields. A no-op unless the record's `body`
+/// is a binary container, so it never touches legacy plain-JSON documents (which
+/// still carry materialised promoted columns) or non-document rows.
+pub(super) fn fill_document_promoted_columns(record: &mut UnifiedRecord, columns: Option<&[String]>) {
+    // Decode into owned `(name, value)` pairs while borrowing the body, so the
+    // immutable borrow is released before we mutate the record below.
+    let promoted: Vec<(String, Value)> = match record.get("body") {
+        Some(Value::Json(bytes)) => match columns {
+            None => match crate::document_body::promoted_fields(bytes) {
+                Some(fields) => fields,
+                None => return,
+            },
+            // `read_promoted_field` self-gates on the container magic, so this
+            // collects nothing for legacy plain-JSON / non-document bodies.
+            Some(cols) => cols
+                .iter()
+                .filter_map(|col| {
+                    crate::document_body::read_promoted_field(bytes, col)
+                        .map(|value| (col.clone(), value))
+                })
+                .collect(),
+        },
+        _ => return,
+    };
+    for (name, value) in promoted {
+        record.set(&name, value);
+    }
+}
+
 pub(super) fn runtime_table_record_from_entity(entity: UnifiedEntity) -> Option<UnifiedRecord> {
     // Issue #414: surface graph/vector/queue/etc. entities in SELECT scans.
     if !matches!(entity.data, EntityData::Row(_) | EntityData::TimeSeries(_)) {
@@ -578,6 +611,10 @@ pub(super) fn runtime_table_record_from_entity(entity: UnifiedEntity) -> Option<
                 sys_key_updated_at(),
                 Value::UnsignedInteger(entity.updated_at),
             );
+
+            // SELECT * over a single-source document: expand the promoted
+            // columns back out of the body (no-op for legacy/non-document rows).
+            fill_document_promoted_columns(&mut record, None);
 
             Some(record)
         }
@@ -659,6 +696,9 @@ pub(super) fn runtime_table_record_from_entity_ref_with_schema(
                 }
             }
             set_public_row_envelope(&mut record, entity, row);
+
+            // SELECT * over a single-source document — expand promoted columns.
+            fill_document_promoted_columns(&mut record, None);
 
             Some(record)
         }
@@ -769,6 +809,10 @@ pub(super) fn runtime_table_record_from_entity_projected(
                 Value::UnsignedInteger(entity.updated_at),
             );
 
+            // Single-source document: offset-read just the projected promoted
+            // fields from the body (no-op for legacy/non-document rows).
+            fill_document_promoted_columns(&mut record, Some(columns));
+
             Some(record)
         }
         EntityData::TimeSeries(ts) => {
@@ -876,6 +920,8 @@ pub(super) fn runtime_table_record_from_entity_ref_projected(
         }
     }
     set_public_row_envelope(&mut record, entity, row);
+    // Single-source document: offset-read the projected promoted fields.
+    fill_document_promoted_columns(&mut record, Some(columns));
     Some(record)
 }
 

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -718,7 +718,11 @@ pub(super) fn runtime_table_record_from_entity_ref_with_schema(
             set_public_row_envelope(&mut record, entity, row);
 
             // SELECT * over a single-source document — expand promoted columns.
-            fill_document_promoted_columns(&mut record, None, document_row_body_bytes(row).as_deref());
+            fill_document_promoted_columns(
+                &mut record,
+                None,
+                document_row_body_bytes(row).as_deref(),
+            );
 
             Some(record)
         }
@@ -943,7 +947,11 @@ pub(super) fn runtime_table_record_from_entity_ref_projected(
     }
     set_public_row_envelope(&mut record, entity, row);
     // Single-source document: offset-read the projected promoted fields.
-    fill_document_promoted_columns(&mut record, Some(columns), document_row_body_bytes(row).as_deref());
+    fill_document_promoted_columns(
+        &mut record,
+        Some(columns),
+        document_row_body_bytes(row).as_deref(),
+    );
     Some(record)
 }
 

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -478,6 +478,8 @@ pub(super) fn runtime_table_record_lean(entity: UnifiedEntity) -> Option<Unified
     let collection = entity.kind.collection().to_string();
     let tenant = runtime_row_tenant_value(&row);
     let kind = public_row_kind(&row).to_string();
+    // Capture the document body before `named` is consumed below.
+    let doc_body = document_row_body_bytes(&row);
     if let Some(named) = row.named {
         let mut record = UnifiedRecord::with_capacity(6 + named.len());
         // `set_owned` consumes the already-heap-allocated String key
@@ -492,6 +494,8 @@ pub(super) fn runtime_table_record_lean(entity: UnifiedEntity) -> Option<Unified
         record.set_arc(sys_key_tenant(), tenant);
         record.set_arc_if_absent(sys_key_created_at(), Value::UnsignedInteger(created_at));
         record.set_arc_if_absent(sys_key_updated_at(), Value::UnsignedInteger(updated_at));
+        // Lean SELECT * over a single-source document — expand promoted columns.
+        fill_document_promoted_columns(&mut record, None, doc_body.as_deref());
         Some(record)
     } else if let Some(ref schema) = row.schema {
         let mut record = UnifiedRecord::with_capacity(6 + schema.len());
@@ -533,33 +537,47 @@ pub(super) fn runtime_table_record_lean_in_collection(
 }
 
 #[inline(never)]
+/// Clone a row's stored binary document `body` bytes, if any.
+///
+/// Sourced from the row rather than the record because a projection that does
+/// not SELECT `body` would never place it on the record — yet the promoted
+/// fields still have to be read out of it.
+fn document_row_body_bytes(row: &crate::storage::unified::entity::RowData) -> Option<Vec<u8>> {
+    match row.get_field("body") {
+        Some(Value::Json(bytes)) if crate::document_body::is_binary_container(bytes) => {
+            Some(bytes.clone())
+        }
+        _ => None,
+    }
+}
+
 /// Fill a single-source document's promoted columns into `record` by reading
-/// them from the binary `body` already placed on the record.
+/// them from the binary `body` (`body` = the row's container bytes).
 ///
 /// `columns = None` expands every top-level body field (SELECT *); `Some(cols)`
-/// offset-reads only the requested fields. A no-op unless the record's `body`
-/// is a binary container, so it never touches legacy plain-JSON documents (which
-/// still carry materialised promoted columns) or non-document rows.
-pub(super) fn fill_document_promoted_columns(record: &mut UnifiedRecord, columns: Option<&[String]>) {
-    // Decode into owned `(name, value)` pairs while borrowing the body, so the
-    // immutable borrow is released before we mutate the record below.
-    let promoted: Vec<(String, Value)> = match record.get("body") {
-        Some(Value::Json(bytes)) => match columns {
-            None => match crate::document_body::promoted_fields(bytes) {
-                Some(fields) => fields,
-                None => return,
-            },
-            // `read_promoted_field` self-gates on the container magic, so this
-            // collects nothing for legacy plain-JSON / non-document bodies.
-            Some(cols) => cols
-                .iter()
-                .filter_map(|col| {
-                    crate::document_body::read_promoted_field(bytes, col)
-                        .map(|value| (col.clone(), value))
-                })
-                .collect(),
+/// offset-reads only the requested fields. A no-op when `body` is `None` (legacy
+/// plain-JSON documents still carry materialised promoted columns, and
+/// non-document rows have no container body), so existing behaviour is untouched.
+pub(super) fn fill_document_promoted_columns(
+    record: &mut UnifiedRecord,
+    columns: Option<&[String]>,
+    body: Option<&[u8]>,
+) {
+    let Some(bytes) = body else {
+        return;
+    };
+    let promoted: Vec<(String, Value)> = match columns {
+        None => match crate::document_body::promoted_fields(bytes) {
+            Some(fields) => fields,
+            None => return,
         },
-        _ => return,
+        Some(cols) => cols
+            .iter()
+            .filter_map(|col| {
+                crate::document_body::read_promoted_field(bytes, col)
+                    .map(|value| (col.clone(), value))
+            })
+            .collect(),
     };
     for (name, value) in promoted {
         record.set(&name, value);
@@ -574,6 +592,8 @@ pub(super) fn runtime_table_record_from_entity(entity: UnifiedEntity) -> Option<
     let logical_id = entity.logical_id().raw();
     match entity.data {
         EntityData::Row(row) => {
+            // Capture the document body before `named` is consumed below.
+            let doc_body = document_row_body_bytes(&row);
             // Pre-allocate: ~9 system fields + user fields
             let user_field_count = row
                 .named
@@ -614,7 +634,7 @@ pub(super) fn runtime_table_record_from_entity(entity: UnifiedEntity) -> Option<
 
             // SELECT * over a single-source document: expand the promoted
             // columns back out of the body (no-op for legacy/non-document rows).
-            fill_document_promoted_columns(&mut record, None);
+            fill_document_promoted_columns(&mut record, None, doc_body.as_deref());
 
             Some(record)
         }
@@ -698,7 +718,7 @@ pub(super) fn runtime_table_record_from_entity_ref_with_schema(
             set_public_row_envelope(&mut record, entity, row);
 
             // SELECT * over a single-source document — expand promoted columns.
-            fill_document_promoted_columns(&mut record, None);
+            fill_document_promoted_columns(&mut record, None, document_row_body_bytes(row).as_deref());
 
             Some(record)
         }
@@ -763,6 +783,8 @@ pub(super) fn runtime_table_record_from_entity_projected(
 
     match entity.data {
         EntityData::Row(row) => {
+            // Capture the document body before `named` is consumed below.
+            let doc_body = document_row_body_bytes(&row);
             let mut record = UnifiedRecord::with_capacity(6 + columns.len());
             let collection = entity.kind.collection().to_string();
             let tenant = runtime_row_tenant_value(&row);
@@ -811,7 +833,7 @@ pub(super) fn runtime_table_record_from_entity_projected(
 
             // Single-source document: offset-read just the projected promoted
             // fields from the body (no-op for legacy/non-document rows).
-            fill_document_promoted_columns(&mut record, Some(columns));
+            fill_document_promoted_columns(&mut record, Some(columns), doc_body.as_deref());
 
             Some(record)
         }
@@ -921,7 +943,7 @@ pub(super) fn runtime_table_record_from_entity_ref_projected(
     }
     set_public_row_envelope(&mut record, entity, row);
     // Single-source document: offset-read the projected promoted fields.
-    fill_document_promoted_columns(&mut record, Some(columns));
+    fill_document_promoted_columns(&mut record, Some(columns), document_row_body_bytes(row).as_deref());
     Some(record)
 }
 

--- a/crates/reddb-server/src/storage/unified/entity.rs
+++ b/crates/reddb-server/src/storage/unified/entity.rs
@@ -629,7 +629,22 @@ pub fn compute_entity_field_bloom(data: &EntityData) -> u64 {
                 return 0;
             }
             if let Some(named) = &row.named {
-                named.keys().fold(0u64, |acc, k| acc | field_name_bloom(k))
+                let mut bloom = named.keys().fold(0u64, |acc, k| acc | field_name_bloom(k));
+                // Single-source documents no longer materialise promoted
+                // columns, so the body's top-level keys are the only place a
+                // `WHERE`/projection field lives. Fold them into the bloom so
+                // the field-bloom gate doesn't reject a row before the body
+                // read fallback ever runs. Inert for non-document rows (no
+                // binary-container `body` field) — `container_field_names`
+                // self-gates on the RDOC magic.
+                if let Some(Value::Json(bytes)) = named.get("body") {
+                    if let Some(names) = crate::document_body::container_field_names(bytes) {
+                        for name in names {
+                            bloom |= field_name_bloom(&name);
+                        }
+                    }
+                }
+                bloom
             } else {
                 0
             }

--- a/crates/reddb-types/src/document_body_codec.rs
+++ b/crates/reddb-types/src/document_body_codec.rs
@@ -197,6 +197,33 @@ pub fn decode(data: &[u8]) -> Result<Vec<(String, Value)>, DocBodyError> {
     Ok(result)
 }
 
+/// Return the top-level field names in encode order without decoding any value.
+///
+/// Reads only the offset table and the keys section — the values section is
+/// never touched. Used to build a field-name index/bloom over a stored body
+/// (e.g. so a `WHERE`/projection on a promoted field can route to the body)
+/// without paying the cost of a full [`decode`].
+pub fn field_names(data: &[u8]) -> Result<Vec<String>, DocBodyError> {
+    let (n, table) = parse_header(data)?;
+    let header_end = 7 + n * ENTRY_SIZE; // where the keys section begins
+    let mut key_cursor = header_end;
+    let mut names = Vec::with_capacity(n);
+
+    for &(key_len, _val_offset) in &table {
+        let key_end = key_cursor + key_len as usize;
+        if key_end > data.len() {
+            return Err(DocBodyError::OffsetOutOfBounds);
+        }
+        let key = std::str::from_utf8(&data[key_cursor..key_end])
+            .map_err(|_| DocBodyError::InvalidFieldName)?
+            .to_string();
+        key_cursor = key_end;
+        names.push(key);
+    }
+
+    Ok(names)
+}
+
 /// Read a single field by name without decoding any other value.
 ///
 /// Returns `None` when the field is absent.  Only the matching field's
@@ -534,6 +561,24 @@ mod tests {
 
         let missing = read_field_by_name(&buf, "z").expect("lookup");
         assert!(missing.is_none());
+    }
+
+    /// `field_names` lists the keys in encode order without decoding values.
+    #[test]
+    fn field_names_lists_keys_in_encode_order() {
+        let fields = [
+            ("name", Value::text("Alice")),
+            ("score", Value::Integer(30)),
+            ("active", Value::Boolean(true)),
+        ];
+        let refs: Vec<(&str, &Value)> = fields.iter().map(|(k, v)| (*k, v)).collect();
+        let mut buf = Vec::new();
+        encode(&refs, &mut buf).expect("encode");
+
+        let names = field_names(&buf).expect("field_names");
+        assert_eq!(names, vec!["name", "score", "active"]);
+
+        assert!(field_names(&[]).is_err());
     }
 
     /// decode_value_at_offset provides direct O(1) access given a known offset.

--- a/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
@@ -1,0 +1,288 @@
+// Issue #1403 — DOCUMENT single source of truth (PRD-1398 / ADR-0063).
+//
+// With the `storage.binary_document_body` flag on, the body IS the document:
+//   - Document writes no longer materialise promoted columns (only `body`).
+//   - A `WHERE` on a top-level field resolves via the index (when one exists)
+//     or by reading the body; projections offset-read the field from the body.
+//   - Versioned (MVCC, ADR-0014) documents stay correct, including `AS OF`.
+//
+// Everything here is exercised through the high-level RQL seam
+// (`RedDBRuntime::execute_query`), the same surface every client speaks.
+
+#[path = "../../support/mod.rs"]
+mod support;
+
+use std::collections::BTreeSet;
+
+use reddb::application::{Author, CreateCommitInput, VcsUseCases};
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::storage::EntityData;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+/// In-memory runtime with the single-source binary body enabled.
+fn binary_runtime() -> RedDBRuntime {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("SET CONFIG storage.binary_document_body = true")
+        .expect("enable storage.binary_document_body");
+    rt
+}
+
+fn insert(rt: &RedDBRuntime, collection: &str, body_json: &str) {
+    rt.execute_query(&format!(
+        "INSERT INTO {collection} DOCUMENT (body) VALUES ('{body_json}')"
+    ))
+    .unwrap_or_else(|err| panic!("insert {body_json}: {err:?}"));
+}
+
+/// The set of distinct stored column names across every row of `collection`.
+/// Promoted columns, if materialised, would show up here next to `body`.
+fn stored_columns(rt: &RedDBRuntime, collection: &str) -> BTreeSet<String> {
+    let page = rt
+        .scan_collection(collection, None, 10_000)
+        .expect("scan_collection");
+    let mut cols = BTreeSet::new();
+    for entity in &page.items {
+        if let EntityData::Row(row) = &entity.data {
+            for (name, _) in row.iter_fields() {
+                cols.insert(name.to_string());
+            }
+        }
+    }
+    cols
+}
+
+fn as_text(value: Option<&Value>) -> String {
+    match value {
+        Some(Value::Text(text)) => text.to_string(),
+        other => panic!("expected text, got {other:?}"),
+    }
+}
+
+fn as_int(value: Option<&Value>) -> i64 {
+    match value {
+        Some(Value::Integer(v)) => *v,
+        Some(Value::UnsignedInteger(v)) => i64::try_from(*v).expect("u64 fits i64"),
+        other => panic!("expected int, got {other:?}"),
+    }
+}
+
+/// Run `sql` and collect the text column `col` from every record, in order.
+fn texts(rt: &RedDBRuntime, sql: &str, col: &str) -> Vec<String> {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
+        .result
+        .records
+        .iter()
+        .map(|record| as_text(record.get(col)))
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: writes no longer materialise promoted columns.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn writes_do_not_materialise_promoted_columns() {
+    let rt = binary_runtime();
+    rt.execute_query("CREATE DOCUMENT docs").expect("create");
+    insert(&rt, "docs", r#"{"name":"alice","score":30,"city":"SP"}"#);
+    insert(&rt, "docs", r#"{"name":"bob","score":10,"city":"RJ"}"#);
+
+    let cols = stored_columns(&rt, "docs");
+    assert!(cols.contains("body"), "the body is always stored: {cols:?}");
+    for promoted in ["name", "score", "city"] {
+        assert!(
+            !cols.contains(promoted),
+            "promoted column `{promoted}` must NOT be materialised: {cols:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: WHERE resolves from the body (no index needed); projections
+// offset-read the field from the body.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn bare_filter_and_projection_resolve_through_the_body() {
+    let rt = binary_runtime();
+    rt.execute_query("CREATE DOCUMENT docs").expect("create");
+    insert(&rt, "docs", r#"{"name":"alice","score":30}"#);
+    insert(&rt, "docs", r#"{"name":"bob","score":10}"#);
+    insert(&rt, "docs", r#"{"name":"carol","score":50}"#);
+
+    // Equality filter on a bare promoted field, with NO index — must read the
+    // value straight from the body.
+    assert_eq!(
+        texts(&rt, "SELECT name FROM docs WHERE score = 30", "name"),
+        vec!["alice"],
+    );
+    assert!(
+        texts(&rt, "SELECT name FROM docs WHERE score = 999", "name").is_empty(),
+        "a non-matching predicate returns nothing"
+    );
+
+    // Projection of bare promoted fields comes from the body by offset-read.
+    let rows = rt
+        .execute_query("SELECT name, score FROM docs WHERE name = 'carol'")
+        .expect("project");
+    assert_eq!(rows.result.records.len(), 1);
+    assert_eq!(as_text(rows.result.records[0].get("name")), "carol");
+    assert_eq!(as_int(rows.result.records[0].get("score")), 50);
+
+    // SELECT * expands the promoted columns back out of the body.
+    let star = rt.execute_query("SELECT * FROM docs WHERE name = 'alice'").expect("star");
+    let row = &star.result.records[0];
+    assert_eq!(as_text(row.get("name")), "alice");
+    assert_eq!(as_int(row.get("score")), 30);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: range / ORDER BY route through the ordered (BTREE) index, which
+// is backed by the body — and the body stays the single source of truth.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn range_and_order_by_route_through_the_ordered_index() {
+    let rt = binary_runtime();
+    rt.execute_query("CREATE DOCUMENT docs").expect("create");
+    for (name, score) in [("alice", 30), ("bob", 10), ("carol", 50), ("dave", 20)] {
+        insert(&rt, "docs", &format!(r#"{{"name":"{name}","score":{score}}}"#));
+    }
+    rt.execute_query("CREATE INDEX idx_score ON docs (score) USING BTREE")
+        .expect("ordered index on a promoted field");
+    assert!(
+        rt.index_store_ref().sorted.has_index("docs", "score"),
+        "the ordered index is registered on the document field"
+    );
+
+    assert_eq!(
+        texts(&rt, "SELECT name FROM docs WHERE score > 20 ORDER BY score ASC", "name"),
+        vec!["alice", "carol"],
+    );
+    assert_eq!(
+        texts(&rt, "SELECT name FROM docs WHERE score BETWEEN 15 AND 35 ORDER BY score ASC", "name"),
+        vec!["dave", "alice"],
+    );
+    assert_eq!(
+        texts(&rt, "SELECT name FROM docs ORDER BY score DESC", "name"),
+        vec!["carol", "alice", "dave", "bob"],
+    );
+
+    // The index is an accelerator, not a second copy of the data: still no
+    // promoted columns on disk.
+    assert!(
+        !stored_columns(&rt, "docs").contains("score"),
+        "indexed field must still live only in the body"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: UPDATE keeps the body the single source of truth and refreshes
+// the body-backed index.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn update_keeps_single_source_and_refreshes_index() {
+    let rt = binary_runtime();
+    rt.execute_query("CREATE DOCUMENT docs").expect("create");
+    insert(&rt, "docs", r#"{"name":"alice","score":30}"#);
+    rt.execute_query("CREATE INDEX idx_score ON docs (score) USING BTREE")
+        .expect("index");
+
+    rt.execute_query("UPDATE docs DOCUMENTS SET score = 80 WHERE name = 'alice'")
+        .expect("update");
+
+    // Still no promoted columns after the update.
+    assert!(
+        !stored_columns(&rt, "docs").contains("score"),
+        "update must not re-materialise the promoted column"
+    );
+
+    // The new value is found via the refreshed index; the old key is gone.
+    assert_eq!(
+        texts(&rt, "SELECT name FROM docs WHERE score > 50 ORDER BY score", "name"),
+        vec!["alice"],
+    );
+    assert!(
+        texts(&rt, "SELECT name FROM docs WHERE score = 30", "name").is_empty(),
+        "the stale index key must be removed on update"
+    );
+
+    // The projected value reflects the update too.
+    let rows = rt.execute_query("SELECT score FROM docs WHERE name = 'alice'").expect("read");
+    assert_eq!(as_int(rows.result.records[0].get("score")), 80);
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance: versioned (MVCC) documents stay correct, including AS OF — the
+// historical version is projected from its own body.
+// ---------------------------------------------------------------------------
+
+fn commit(rt: &RedDBRuntime, conn: u64, message: &str) -> String {
+    VcsUseCases::new(rt)
+        .commit(CreateCommitInput {
+            connection_id: conn,
+            message: message.to_string(),
+            author: Author {
+                name: "t".to_string(),
+                email: "t@reddb.io".to_string(),
+            },
+            committer: None,
+            amend: false,
+            allow_empty: true,
+        })
+        .expect("commit")
+        .hash
+}
+
+#[test]
+fn versioned_document_as_of_projects_the_historical_body() {
+    let rt = binary_runtime();
+    let conn = 14_030_001;
+    set_current_connection_id(conn);
+
+    rt.execute_query("CREATE DOCUMENT vdocs").expect("create");
+    VcsUseCases::new(&rt)
+        .set_versioned("vdocs", true)
+        .expect("versioned");
+
+    insert(&rt, "vdocs", r#"{"name":"alice","score":1}"#);
+    let p1 = commit(&rt, conn, "p1");
+
+    rt.execute_query("UPDATE vdocs DOCUMENTS SET score = 2 WHERE name = 'alice'")
+        .expect("update");
+    let _p2 = commit(&rt, conn, "p2");
+
+    // Live read: newest version, projected from its body.
+    let live = rt
+        .execute_query("SELECT score FROM vdocs WHERE name = 'alice'")
+        .expect("live");
+    assert_eq!(as_int(live.result.records[0].get("score")), 2, "live is newest");
+
+    // AS OF P1: the prior version, projected from the prior body.
+    let historical = rt
+        .execute_query(&format!(
+            "SELECT score FROM vdocs AS OF COMMIT '{p1}' WHERE name = 'alice'"
+        ))
+        .expect("as of");
+    assert_eq!(
+        historical.result.records.len(),
+        1,
+        "AS OF must resolve exactly one historical version"
+    );
+    assert_eq!(
+        as_int(historical.result.records[0].get("score")),
+        1,
+        "AS OF P1 must project the historical body value"
+    );
+
+    // History keeps the body as the single source of truth too.
+    assert!(
+        !stored_columns(&rt, "vdocs").contains("score"),
+        "versioned writes must not materialise promoted columns"
+    );
+
+    clear_current_connection_id();
+}

--- a/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
@@ -132,7 +132,9 @@ fn bare_filter_and_projection_resolve_through_the_body() {
     assert_eq!(as_int(rows.result.records[0].get("score")), 50);
 
     // SELECT * expands the promoted columns back out of the body.
-    let star = rt.execute_query("SELECT * FROM docs WHERE name = 'alice'").expect("star");
+    let star = rt
+        .execute_query("SELECT * FROM docs WHERE name = 'alice'")
+        .expect("star");
     let row = &star.result.records[0];
     assert_eq!(as_text(row.get("name")), "alice");
     assert_eq!(as_int(row.get("score")), 30);
@@ -148,7 +150,11 @@ fn range_and_order_by_route_through_the_ordered_index() {
     let rt = binary_runtime();
     rt.execute_query("CREATE DOCUMENT docs").expect("create");
     for (name, score) in [("alice", 30), ("bob", 10), ("carol", 50), ("dave", 20)] {
-        insert(&rt, "docs", &format!(r#"{{"name":"{name}","score":{score}}}"#));
+        insert(
+            &rt,
+            "docs",
+            &format!(r#"{{"name":"{name}","score":{score}}}"#),
+        );
     }
     rt.execute_query("CREATE INDEX idx_score ON docs (score) USING BTREE")
         .expect("ordered index on a promoted field");
@@ -158,11 +164,19 @@ fn range_and_order_by_route_through_the_ordered_index() {
     );
 
     assert_eq!(
-        texts(&rt, "SELECT name FROM docs WHERE score > 20 ORDER BY score ASC", "name"),
+        texts(
+            &rt,
+            "SELECT name FROM docs WHERE score > 20 ORDER BY score ASC",
+            "name"
+        ),
         vec!["alice", "carol"],
     );
     assert_eq!(
-        texts(&rt, "SELECT name FROM docs WHERE score BETWEEN 15 AND 35 ORDER BY score ASC", "name"),
+        texts(
+            &rt,
+            "SELECT name FROM docs WHERE score BETWEEN 15 AND 35 ORDER BY score ASC",
+            "name"
+        ),
         vec!["dave", "alice"],
     );
     assert_eq!(
@@ -202,7 +216,11 @@ fn update_keeps_single_source_and_refreshes_index() {
 
     // The new value is found via the refreshed index; the old key is gone.
     assert_eq!(
-        texts(&rt, "SELECT name FROM docs WHERE score > 50 ORDER BY score", "name"),
+        texts(
+            &rt,
+            "SELECT name FROM docs WHERE score > 50 ORDER BY score",
+            "name"
+        ),
         vec!["alice"],
     );
     assert!(
@@ -211,7 +229,9 @@ fn update_keeps_single_source_and_refreshes_index() {
     );
 
     // The projected value reflects the update too.
-    let rows = rt.execute_query("SELECT score FROM docs WHERE name = 'alice'").expect("read");
+    let rows = rt
+        .execute_query("SELECT score FROM docs WHERE name = 'alice'")
+        .expect("read");
     assert_eq!(as_int(rows.result.records[0].get("score")), 80);
 }
 
@@ -259,7 +279,11 @@ fn versioned_document_as_of_projects_the_historical_body() {
     let live = rt
         .execute_query("SELECT score FROM vdocs WHERE name = 'alice'")
         .expect("live");
-    assert_eq!(as_int(live.result.records[0].get("score")), 2, "live is newest");
+    assert_eq!(
+        as_int(live.result.records[0].get("score")),
+        2,
+        "live is newest"
+    );
 
     // AS OF P1: the prior version, projected from the prior body.
     let historical = rt

--- a/tests/grouped/documents_kv_queues.rs
+++ b/tests/grouped/documents_kv_queues.rs
@@ -21,6 +21,9 @@ mod e2e_issue_540_documents_basics;
 #[path = "docs_kv_queue/e2e_issue_1402_document_binary_body.rs"]
 mod e2e_issue_1402_document_binary_body;
 
+#[path = "docs_kv_queue/e2e_issue_1403_document_single_source.rs"]
+mod e2e_issue_1403_document_single_source;
+
 #[path = "docs_kv_queue/e2e_issue_541_kv_namespaced_keys.rs"]
 mod e2e_issue_541_kv_namespaced_keys;
 
@@ -50,3 +53,8 @@ mod e2e_red_queue_pending;
 
 #[path = "docs_kv_queue/integration_queue_timeseries.rs"]
 mod integration_queue_timeseries;
+
+
+
+
+

--- a/tests/grouped/documents_kv_queues.rs
+++ b/tests/grouped/documents_kv_queues.rs
@@ -53,8 +53,3 @@ mod e2e_red_queue_pending;
 
 #[path = "docs_kv_queue/integration_queue_timeseries.rs"]
 mod integration_queue_timeseries;
-
-
-
-
-


### PR DESCRIPTION
Closes #1403 — document body as the single source of truth: filter promoted-field predicates from the body, project promoted columns by offset-read, back indexes with the body, refresh body-backed indexes on UPDATE, and stop materialising promoted columns on the write path. Includes an e2e test through the RQL seam.

Implemented by AFK worker wKTGE (opus/high) across 11 commits (tip 27133aea); this branch is that exact tree + a cargo-fmt pass (rustfmt 1.91). Landed on a stable branch because the worker was force-pushing fmt-churn over its own branch during verification.

Closes #1403

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785051152&installation_id=129708444&pr_number=1423&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1423&signature=80df2aef151e54ad7cb436666586629a98f54358c4015f88fd6a87b8182723e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->