### PR TITLE
merge: #1403 DOCUMENT: single source of truth — filter via index, project via offset-read, drop promoted columns

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -2965,8 +2965,7 @@ impl RuntimeEntityPort for RedDBRuntime {
         // `storage.binary_document_body` flag (PRD-1398) this is the native binary
         // container; otherwise plain JSON. Reads decode either form to JSON.
         let binary_body = self.binary_document_body_enabled();
-        let body_bytes =
-            crate::document_body::serialize_document_body(&input.body, binary_body)?;
+        let body_bytes = crate::document_body::serialize_document_body(&input.body, binary_body)?;
         let mut fields: Vec<(String, crate::storage::schema::Value)> = vec![(
             "body".to_string(),
             crate::storage::schema::Value::Json(body_bytes),

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1236,9 +1236,7 @@ impl IndexStore {
                 // ensures the sorted index is actually populated for a document
                 // field, instead of silently building an empty index.
                 let derived_entities = derive_index_entities_for_column(entities, col);
-                let count = self
-                    .sorted
-                    .build_index(collection, col, &derived_entities);
+                let count = self.sorted.build_index(collection, col, &derived_entities);
                 // Also build hash index for equality lookups on same column
                 self.hash
                     .create_index(&HashIndexConfig {
@@ -1657,7 +1655,8 @@ impl IndexStore {
         // the old/new body. No-op for non-document collections, where these
         // columns resolve to nothing in both snapshots.
         for col in &indexed_cols {
-            if old_fields.iter().any(|(f, _)| f == col) || new_fields.iter().any(|(f, _)| f == col) {
+            if old_fields.iter().any(|(f, _)| f == col) || new_fields.iter().any(|(f, _)| f == col)
+            {
                 // A real stored column — already handled by the damage loop.
                 continue;
             }

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -362,7 +362,10 @@ pub(crate) fn resolve_kind<'a>(
 /// common case — legacy documents keep materialised columns, non-document rows
 /// have no `body`). This is what lets a bare `WHERE field`/`SELECT field` keep
 /// resolving once promoted columns stop being materialised.
-fn document_promoted_field(row: &crate::storage::unified::entity::RowData, name: &str) -> Option<Value> {
+fn document_promoted_field(
+    row: &crate::storage::unified::entity::RowData,
+    name: &str,
+) -> Option<Value> {
     match row.get_field("body") {
         Some(Value::Json(bytes)) => crate::document_body::read_promoted_field(bytes, name),
         _ => None,

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -718,7 +718,11 @@ pub(super) fn runtime_table_record_from_entity_ref_with_schema(
             set_public_row_envelope(&mut record, entity, row);
 
             // SELECT * over a single-source document — expand promoted columns.
-            fill_document_promoted_columns(&mut record, None, document_row_body_bytes(row).as_deref());
+            fill_document_promoted_columns(
+                &mut record,
+                None,
+                document_row_body_bytes(row).as_deref(),
+            );
 
             Some(record)
         }
@@ -943,7 +947,11 @@ pub(super) fn runtime_table_record_from_entity_ref_projected(
     }
     set_public_row_envelope(&mut record, entity, row);
     // Single-source document: offset-read the projected promoted fields.
-    fill_document_promoted_columns(&mut record, Some(columns), document_row_body_bytes(row).as_deref());
+    fill_document_promoted_columns(
+        &mut record,
+        Some(columns),
+        document_row_body_bytes(row).as_deref(),
+    );
     Some(record)
 }
 


### PR DESCRIPTION
Automated AFK landing for #1403. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1403

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785052255&installation_id=129708444&pr_number=1425&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1425&signature=4a4afa06d5da86f8f8368d0bb585f9c9401423ff87dab6597bc2c12384ebe74d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->