### PR TITLE
merge: #1307 CI gate gap: docs-only (**.md) PRs can't satisfy required checks → permanently BLOCKED

### DIFF
--- a/.github/required-status-checks.json
+++ b/.github/required-status-checks.json
@@ -1,0 +1,40 @@
+{
+  "comment": [
+    "Single source of truth for the status-check contexts required to merge to",
+    "`main` (issue #975 / ADR 0059). These contexts are produced by ci.yml on a",
+    "normal PR. ci.yml is path-filtered (paths-ignore: **.md, docs/**, CHANGELOG**,",
+    "LICENSE**), so a docs-only PR skips ci.yml and none of these contexts ever",
+    "report -> the PR is BLOCKED forever (issue #1307). ci-docs.yml is the shim",
+    "that re-reports every one of these contexts as success on docs-only PRs so the",
+    "gate stays satisfiable without lifting branch protection.",
+    "scripts/ci-docs-shim-contract.test.mjs keeps this list, ci.yml, and",
+    "ci-docs.yml in lock-step."
+  ],
+  "required_contexts": [
+    "gate",
+    "Quality (fmt, check, clippy)",
+    "Lint (no untyped serialization)",
+    "Version integrity",
+    "Contract Matrix Gate",
+    "Docs Match Contract Matrix",
+    "Helm Chart",
+    "AFK Validation Sidecar",
+    "RQL Conformance (sqllogictest)",
+    "Drivers / Python (cargo check)",
+    "Feature Matrix (no-default)",
+    "Feature Matrix (otel)",
+    "Feature Matrix (backend-s3)",
+    "Feature Matrix (backend-turso)",
+    "Feature Matrix (backend-d1)",
+    "Feature Matrix (all-features)",
+    "Test Suite",
+    "Driver Param Conformance",
+    "Chaos & Drill Suite",
+    "Fuzz Parsers",
+    "Container Stack",
+    "Publish Dry-Run (crates.io)",
+    "cargo package dry-run",
+    "Windows (build + unit tests)",
+    "macOS (build + unit tests)"
+  ]
+}

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,188 @@
+name: CI (docs shim)
+
+# Issue #1307 — docs-only / `**.md`-only PRs could not satisfy the `main` merge
+# gate. ci.yml is path-filtered (paths-ignore: **.md, docs/**, CHANGELOG**,
+# LICENSE**), so a docs-only PR skips ci.yml and none of the required status
+# checks (ADR 0059) ever report -> branch protection treats them as pending ->
+# the PR is BLOCKED forever, and `gh pr merge --admin` cannot bypass it
+# (enforce_admins). PR #1306 had to be landed by temporarily lifting protection.
+#
+# This shim has NO paths-ignore: it triggers EXACTLY on the paths ci.yml ignores
+# and re-reports every required context (each job `name:` below is a required
+# context from ADR 0059) as a fast `echo`-only success. GitHub matches required
+# status checks by context NAME regardless of which workflow produced them, so a
+# same-named success here satisfies the gate without running the heavy suite.
+#
+# Mixed PRs (touching both docs and code) trigger BOTH this shim and ci.yml, so
+# each required context gets two check runs: a fast green one here and the real
+# one from ci.yml. GitHub uses the most-recent run for a context, and the real
+# job always finishes after this echo, so the real result stays authoritative —
+# the shim never masks a genuine failure.
+#
+# scripts/ci-docs-shim-contract.test.mjs (run by ci.yml) locks the job names
+# here to .github/required-status-checks.json and to ci.yml, so this list cannot
+# silently drift out of sync with the gate.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG**'
+      - 'LICENSE**'
+
+concurrency:
+  group: ci-docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only PR — gate satisfied by ci-docs shim (#1307)"
+
+  quality:
+    name: Quality (fmt, check, clippy)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no Rust changed"
+
+  serialization-lint:
+    name: Lint (no untyped serialization)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no Rust changed"
+
+  version-integrity:
+    name: Version integrity
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no version manifests changed"
+
+  contract-matrix:
+    name: Contract Matrix Gate
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — contract matrix unaffected"
+
+  docs-matrix:
+    name: Docs Match Contract Matrix
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — covered by ci.yml on code PRs"
+
+  helm-chart:
+    name: Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no chart changed"
+
+  afk-validation-sidecar:
+    name: AFK Validation Sidecar
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no code diff to validate"
+
+  rql-conformance:
+    name: RQL Conformance (sqllogictest)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — engine unchanged"
+
+  drivers-python-build:
+    name: Drivers / Python (cargo check)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — drivers unchanged"
+
+  feature-matrix-no-default:
+    name: Feature Matrix (no-default)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  feature-matrix-otel:
+    name: Feature Matrix (otel)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  feature-matrix-backend-s3:
+    name: Feature Matrix (backend-s3)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  feature-matrix-backend-turso:
+    name: Feature Matrix (backend-turso)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  feature-matrix-backend-d1:
+    name: Feature Matrix (backend-d1)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  feature-matrix-all-features:
+    name: Feature Matrix (all-features)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — features unchanged"
+
+  tests:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no behavior changed"
+
+  driver-param-conformance:
+    name: Driver Param Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — driver params unchanged"
+
+  chaos:
+    name: Chaos & Drill Suite
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — chaos/drill unaffected"
+
+  fuzz-parsers:
+    name: Fuzz Parsers
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — parsers unchanged"
+
+  containers:
+    name: Container Stack
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — container stack unchanged"
+
+  publish-dry-run:
+    name: Publish Dry-Run (crates.io)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — packaging unaffected"
+
+  package:
+    name: cargo package dry-run
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — packaging unaffected"
+
+  windows:
+    name: Windows (build + unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no Rust changed"
+
+  macos:
+    name: macOS (build + unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only — no Rust changed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,8 @@ jobs:
         run: node scripts/verify-contract-matrix.mjs
       - name: Contract-matrix tooling contract test
         run: node --test scripts/contract_matrix_contract.test.mjs
+      - name: Docs-shim ⇔ required-checks ⇔ ci.yml lock-step (#1307)
+        run: node --test scripts/ci-docs-shim-contract.test.mjs
 
   docs-matrix:
     # Issue #568 — public docs (README, docs/query/*.md, driver READMEs) are

--- a/.red/adr/0059-binding-merge-gate-green-ratchet.md
+++ b/.red/adr/0059-binding-merge-gate-green-ratchet.md
@@ -41,6 +41,30 @@ branch in a permanent-pending state); the changeset-automation jobs
 (`Auto-approve patch/minor bumps`, `Verify update compiles`); and third-party
 review bots (`CodeRabbit`).
 
+### Docs-only PRs and the path-filter gap (issue #1307)
+
+`ci.yml` is path-filtered (`paths-ignore: **.md, docs/**, CHANGELOG**,
+LICENSE**`) to keep the heavy suite off doc edits. But the required contexts
+above are *produced by* `ci.yml`, so a PR that changes only those paths skips
+`ci.yml` entirely, none of the 25 contexts ever report, branch protection holds
+them pending, and the PR is **BLOCKED forever** — `gh pr merge --admin` cannot
+bypass it under `enforce_admins`. PR #1306 (issue #1247, an ADR-only change) hit
+exactly this and had to be landed by temporarily lifting protection.
+
+The fix is an **always-green shim** workflow, `.github/workflows/ci-docs.yml`,
+with **no `paths-ignore`** that triggers on exactly the ignored paths and
+re-reports every required context as a fast `echo`-only success. GitHub matches
+required checks by context **name** regardless of the producing workflow, so the
+shim satisfies the gate on doc-only PRs without running the suite or lifting
+protection. On a *mixed* PR (docs + code) both workflows run; the real `ci.yml`
+job always finishes after the shim's echo, so GitHub's most-recent-run rule keeps
+the real result authoritative and the shim never masks a failure.
+
+`.github/required-status-checks.json` is the canonical list of the 25 contexts;
+`scripts/ci-docs-shim-contract.test.mjs` (run inside the `Contract Matrix Gate`
+job) locks the manifest, `ci.yml`, and `ci-docs.yml` together so the shim cannot
+drift out of sync with the gate.
+
 ## Why
 
 The merge gate is the keystone of PRD #964: without it, AFK pushes land on `main`

--- a/scripts/ci-docs-shim-contract.test.mjs
+++ b/scripts/ci-docs-shim-contract.test.mjs
@@ -1,0 +1,100 @@
+// Issue #1307 — a docs-only / `**.md`-only PR cannot satisfy the `main` merge
+// gate. ci.yml is path-filtered (paths-ignore: **.md, docs/**, ...), so a
+// docs-only PR skips ci.yml and none of the required status checks (ADR 0059)
+// ever report -> branch protection treats them as pending -> the PR is BLOCKED
+// forever, even to `gh pr merge --admin` (enforce_admins).
+//
+// ci-docs.yml is the always-green shim: a workflow with NO paths-ignore that
+// re-reports every required context as success on docs-only PRs, so the gate is
+// satisfiable without lifting protection. GitHub matches required checks by
+// context NAME regardless of producing workflow, so a same-named success from
+// the shim satisfies the requirement.
+//
+// This contract test is the lock that keeps three artifacts in agreement:
+//   - .github/required-status-checks.json  (the canonical list)
+//   - .github/workflows/ci.yml             (produces the contexts on code PRs)
+//   - .github/workflows/ci-docs.yml        (re-produces them on docs PRs)
+// If a required job is renamed/added in ci.yml without updating the manifest and
+// the shim, this test fails on the (non-docs) PR that makes the change.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const read = (rel) => fs.readFileSync(path.join(repoRoot, rel), "utf8");
+
+const MANIFEST = ".github/required-status-checks.json";
+const CI = ".github/workflows/ci.yml";
+const SHIM = ".github/workflows/ci-docs.yml";
+
+// Job-level `name:` lines are indented exactly four spaces (jobs: 0, job-key: 2,
+// name: 4). Step names sit deeper (>=6) and the workflow name at 0, so this
+// regex isolates job display names == status-check contexts.
+function jobNames(yaml) {
+  return [...yaml.matchAll(/^ {4}name: (.+)$/gm)].map((m) => m[1].trim());
+}
+
+const manifest = JSON.parse(read(MANIFEST));
+const required = manifest.required_contexts;
+
+test("manifest is a well-formed, unique, non-empty list of context strings", () => {
+  assert.ok(Array.isArray(required) && required.length > 0);
+  for (const ctx of required) {
+    assert.equal(typeof ctx, "string");
+    assert.ok(ctx.length > 0);
+  }
+  assert.equal(new Set(required).size, required.length, "duplicate contexts in manifest");
+});
+
+test("manifest matches the 25 required contexts recorded in ADR 0059", () => {
+  // ADR 0059 fixes the gate at 25 contexts. Locking the count makes any silent
+  // expansion/contraction of the manifest a test failure, not a surprise.
+  assert.equal(required.length, 25);
+});
+
+test("the docs shim re-produces every required context (and nothing extra)", () => {
+  const shimContexts = new Set(jobNames(read(SHIM)));
+  for (const ctx of required) {
+    assert.ok(shimContexts.has(ctx), `ci-docs.yml is missing required context: ${ctx}`);
+  }
+  // The shim must not claim contexts outside the required set — a stray green
+  // job named like a real one could mask a genuine failure on a mixed PR.
+  for (const ctx of shimContexts) {
+    assert.ok(required.includes(ctx), `ci-docs.yml emits a non-required context: ${ctx}`);
+  }
+});
+
+test("every required context is actually produced by ci.yml (manifest reflects reality)", () => {
+  const ci = read(CI);
+  const ciNames = jobNames(ci);
+  const featureLabels = ["no-default", "otel", "backend-s3", "backend-turso", "backend-d1", "all-features"];
+
+  for (const ctx of required) {
+    const fm = ctx.match(/^Feature Matrix \((.+)\)$/);
+    if (fm) {
+      // ci.yml renders this context via the matrix template
+      // `Feature Matrix (${{ matrix.features.label }})`.
+      assert.ok(ciNames.includes("Feature Matrix (${{ matrix.features.label }})"),
+        "ci.yml lost the Feature Matrix job");
+      assert.ok(featureLabels.includes(fm[1]), `unknown Feature Matrix label: ${fm[1]}`);
+      assert.match(ci, new RegExp(`label: ${fm[1]}\\b`),
+        `ci.yml feature-matrix is missing label: ${fm[1]}`);
+      continue;
+    }
+    assert.ok(ciNames.includes(ctx), `ci.yml no longer produces required context: ${ctx}`);
+  }
+});
+
+test("the shim triggers exactly on the paths ci.yml ignores (so it covers the gap)", () => {
+  const shim = read(SHIM);
+  // ci.yml's PR paths-ignore set; the shim must allow-list the same globs.
+  for (const glob of ["**.md", "docs/**", "CHANGELOG**", "LICENSE**"]) {
+    assert.ok(shim.includes(`- '${glob}'`), `ci-docs.yml does not trigger on ${glob}`);
+  }
+  // It must be a pull_request workflow with no paths-ignore (else it would be
+  // skipped on the very docs-only PRs it exists to cover).
+  assert.match(shim, /pull_request:/);
+  assert.ok(!/^\s*paths-ignore:/m.test(shim), "ci-docs.yml must not use paths-ignore");
+});


### PR DESCRIPTION
Automated AFK landing for #1307. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785066231&installation_id=129708444&pr_number=1429&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1429&signature=8792eda537b2ef8436c4b21f8195567930d67d4a89b533e5fdb34a66c076557c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docs-only pull requests now receive the required checks they need to merge without running the full CI suite.
  * A shared list of required status checks now keeps branch protection and CI behavior aligned.

* **Bug Fixes**
  * Fixed an issue where documentation-only changes could get stuck behind unmet required checks.
  * Added safeguards so the documented check list stays consistent across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->