### PR TITLE
merge: #1285 reddb-io-rql line coverage sits at the 90% knife-edge (RQL Coverage Gate red on main)

### DIFF
--- a/crates/reddb-rql/src/optimizer/decorrelate.rs
+++ b/crates/reddb-rql/src/optimizer/decorrelate.rs
@@ -572,4 +572,234 @@ mod tests {
         assert!(rewrite.group_by.contains(&"customer_id".to_string()));
         assert!(rewrite.result_col.is_some());
     }
+
+    #[test]
+    fn test_scalar_non_aggregation_uses_left_join() {
+        let decorrelator = Decorrelator::new();
+        let analysis = decorrelator.analyze(
+            &["o.customer_id".to_string()],
+            &["customer_id".to_string()],
+            &[("o.customer_id".to_string(), "customer_id".to_string())],
+            SubqueryKind::Scalar,
+            false, // no aggregation
+            false,
+        );
+
+        assert!(analysis.is_correlated);
+        assert!(analysis.can_decorrelate);
+        assert!(matches!(
+            analysis.strategy,
+            Some(DecorrelationStrategy::LeftJoinWithGroupBy { .. })
+        ));
+    }
+
+    #[test]
+    fn test_not_exists_and_not_in_use_anti_join() {
+        let decorrelator = Decorrelator::new();
+        for kind in [SubqueryKind::NotExists, SubqueryKind::NotIn] {
+            let analysis = decorrelator.analyze(
+                &["o.id".to_string()],
+                &["order_id".to_string()],
+                &[("o.id".to_string(), "order_id".to_string())],
+                kind,
+                false,
+                false,
+            );
+
+            assert!(analysis.can_decorrelate);
+            assert!(matches!(
+                analysis.strategy,
+                Some(DecorrelationStrategy::AntiJoin { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn test_in_subquery_uses_semi_join() {
+        let decorrelator = Decorrelator::new();
+        let analysis = decorrelator.analyze(
+            &["o.id".to_string()],
+            &["order_id".to_string()],
+            &[("o.id".to_string(), "order_id".to_string())],
+            SubqueryKind::In,
+            false,
+            false,
+        );
+
+        assert!(matches!(
+            analysis.strategy,
+            Some(DecorrelationStrategy::SemiJoin { .. })
+        ));
+    }
+
+    #[test]
+    fn test_any_all_block_decorrelation_with_lateral_join() {
+        let decorrelator = Decorrelator::new();
+        for kind in [SubqueryKind::Any, SubqueryKind::All] {
+            let analysis = decorrelator.analyze(
+                &["o.id".to_string()],
+                &["order_id".to_string()],
+                &[("o.id".to_string(), "order_id".to_string())],
+                kind,
+                false,
+                false,
+            );
+
+            assert!(analysis.is_correlated);
+            assert!(!analysis.can_decorrelate);
+            assert!(analysis.strategy.is_none());
+            assert_eq!(
+                analysis.decorrelation_blocker,
+                Some(DecorrelationBlocker::RequiresLateralJoin)
+            );
+        }
+    }
+
+    #[test]
+    fn test_speedup_covers_every_strategy() {
+        let decorrelator = Decorrelator::new();
+        let join_condition = vec![("a".to_string(), "b".to_string())];
+
+        // JoinWithGroupBy + LeftJoinWithGroupBy + DistinctJoin + AntiJoin
+        let strategies = [
+            DecorrelationStrategy::JoinWithGroupBy {
+                group_by_cols: vec!["b".to_string()],
+                join_condition: join_condition.clone(),
+            },
+            DecorrelationStrategy::LeftJoinWithGroupBy {
+                group_by_cols: vec!["b".to_string()],
+                join_condition: join_condition.clone(),
+            },
+            DecorrelationStrategy::AntiJoin {
+                join_condition: join_condition.clone(),
+            },
+            DecorrelationStrategy::DistinctJoin {
+                join_condition: join_condition.clone(),
+            },
+        ];
+
+        for strategy in &strategies {
+            let speedup = decorrelator.estimate_speedup(1000, 1000, strategy);
+            assert!(speedup > 1.0, "expected speedup for {strategy:?}");
+        }
+    }
+
+    #[test]
+    fn test_speedup_guards_against_zero_cost() {
+        let decorrelator = Decorrelator::new();
+        // outer=0, inner=0 → decorrelated_cost < 1.0 → returns correlated_cost (0.0)
+        let speedup = decorrelator.estimate_speedup(
+            0,
+            0,
+            &DecorrelationStrategy::SemiJoin {
+                join_condition: vec![("a".to_string(), "b".to_string())],
+            },
+        );
+        assert_eq!(speedup, 0.0);
+    }
+
+    #[test]
+    fn test_should_decorrelate_threshold() {
+        let decorrelator = Decorrelator::new();
+        let strategy = DecorrelationStrategy::SemiJoin {
+            join_condition: vec![("a".to_string(), "b".to_string())],
+        };
+
+        // Large cardinalities → big speedup → worthwhile.
+        assert!(decorrelator.should_decorrelate(1000, 1000, &strategy));
+        // Tiny cardinalities → speedup below the 1.5x bar → not worthwhile.
+        assert!(!decorrelator.should_decorrelate(1, 1, &strategy));
+    }
+
+    #[test]
+    fn test_plan_rewrite_left_join() {
+        let mut decorrelator = Decorrelator::new();
+        let analysis = decorrelator.analyze(
+            &["o.customer_id".to_string()],
+            &["customer_id".to_string()],
+            &[("o.customer_id".to_string(), "customer_id".to_string())],
+            SubqueryKind::Scalar,
+            false,
+            false,
+        );
+
+        let rewrite = decorrelator
+            .plan_rewrite(&analysis, Some("last_total"))
+            .unwrap();
+        assert_eq!(rewrite.join_type, RewriteJoinType::Left);
+        assert!(rewrite.result_col.is_some());
+        assert!(rewrite.group_by.contains(&"customer_id".to_string()));
+    }
+
+    #[test]
+    fn test_plan_rewrite_semi_and_anti_join() {
+        let mut decorrelator = Decorrelator::new();
+
+        let semi = decorrelator.analyze(
+            &["o.id".to_string()],
+            &["order_id".to_string()],
+            &[("o.id".to_string(), "order_id".to_string())],
+            SubqueryKind::Exists,
+            false,
+            false,
+        );
+        let semi_rewrite = decorrelator.plan_rewrite(&semi, None).unwrap();
+        assert_eq!(semi_rewrite.join_type, RewriteJoinType::Semi);
+        assert!(semi_rewrite.result_col.is_none());
+        assert!(semi_rewrite.group_by.is_empty());
+
+        let anti = decorrelator.analyze(
+            &["o.id".to_string()],
+            &["order_id".to_string()],
+            &[("o.id".to_string(), "order_id".to_string())],
+            SubqueryKind::NotExists,
+            false,
+            false,
+        );
+        let anti_rewrite = decorrelator.plan_rewrite(&anti, None).unwrap();
+        assert_eq!(anti_rewrite.join_type, RewriteJoinType::Anti);
+    }
+
+    #[test]
+    fn test_plan_rewrite_distinct_join() {
+        let mut decorrelator = Decorrelator::new();
+        // DistinctJoin is not produced by `analyze`, so build the analysis by hand
+        // to exercise the `plan_rewrite` DistinctJoin arm.
+        let analysis = SubqueryAnalysis {
+            is_correlated: true,
+            correlation_predicates: Vec::new(),
+            can_decorrelate: true,
+            decorrelation_blocker: None,
+            strategy: Some(DecorrelationStrategy::DistinctJoin {
+                join_condition: vec![("o.id".to_string(), "order_id".to_string())],
+            }),
+        };
+
+        let rewrite = decorrelator.plan_rewrite(&analysis, None).unwrap();
+        assert_eq!(rewrite.join_type, RewriteJoinType::Semi);
+        // DISTINCT is expressed via GROUP BY on the inner join column.
+        assert_eq!(rewrite.group_by, vec!["order_id".to_string()]);
+        assert!(rewrite.join_on[0].1.ends_with(".order_id"));
+    }
+
+    #[test]
+    fn test_plan_rewrite_returns_none_without_strategy() {
+        let mut decorrelator = Decorrelator::new();
+        let analysis = decorrelator.analyze(
+            &[],
+            &["id".to_string()],
+            &[],
+            SubqueryKind::Scalar,
+            true,
+            false,
+        );
+        assert!(decorrelator.plan_rewrite(&analysis, None).is_none());
+    }
+
+    #[test]
+    fn test_default_impl() {
+        let decorrelator = Decorrelator::default();
+        let analysis = decorrelator.analyze(&[], &[], &[], SubqueryKind::Scalar, false, false);
+        assert!(!analysis.is_correlated);
+    }
 }

--- a/crates/reddb-rql/src/optimizer/filter_rank.rs
+++ b/crates/reddb-rql/src/optimizer/filter_rank.rs
@@ -647,4 +647,210 @@ mod tests {
         // Prefix match should be more selective (lower)
         assert!(prefix < contains);
     }
+
+    #[test]
+    fn test_filter_value_as_f64() {
+        assert_eq!(FilterValue::Int(7).as_f64(), Some(7.0));
+        assert_eq!(FilterValue::Float(1.5).as_f64(), Some(1.5));
+        assert_eq!(FilterValue::String("x".to_string()).as_f64(), None);
+        assert_eq!(FilterValue::Bool(true).as_f64(), None);
+        assert_eq!(FilterValue::Null.as_f64(), None);
+        assert_eq!(FilterValue::Bytes(vec![1, 2]).as_f64(), None);
+    }
+
+    #[test]
+    fn test_selectivity_for_every_variant() {
+        let ranker = FilterRanker::with_defaults();
+        let col = || "x".to_string();
+        let int = || FilterValue::Int(1);
+
+        // Range comparisons (Lt/Le/Gt/Ge) and Between hit the range estimator.
+        for filter in [
+            FilterExpr::Lt {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Le {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Gt {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Ge {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Between {
+                column: col(),
+                lower: FilterValue::Int(0),
+                upper: FilterValue::Int(10),
+            },
+        ] {
+            let sel = ranker.estimate_selectivity(&filter);
+            assert!((0.0..=1.0).contains(&sel));
+        }
+
+        // IS NOT NULL is the complement of IS NULL.
+        let is_null = ranker.estimate_selectivity(&FilterExpr::IsNull { column: col() });
+        let is_not_null = ranker.estimate_selectivity(&FilterExpr::IsNotNull { column: col() });
+        assert!((is_null + is_not_null - 1.0).abs() < 0.0001);
+
+        // OR combines via inclusion-exclusion.
+        let or_sel = ranker.estimate_selectivity(&FilterExpr::Or(
+            Box::new(FilterExpr::Eq {
+                column: col(),
+                value: int(),
+            }),
+            Box::new(FilterExpr::Eq {
+                column: "y".to_string(),
+                value: int(),
+            }),
+        ));
+        assert!(or_sel > 0.0);
+
+        // NOT inverts.
+        let not_sel = ranker.estimate_selectivity(&FilterExpr::Not(Box::new(FilterExpr::True)));
+        assert!(not_sel <= ranker.config().min_selectivity + 0.0001);
+
+        // Function / Subquery fall back to default equality.
+        let fn_sel = ranker.estimate_selectivity(&FilterExpr::Function {
+            name: "f".to_string(),
+            args: vec![],
+        });
+        let sub_sel = ranker.estimate_selectivity(&FilterExpr::Subquery { id: 9 });
+        assert_eq!(fn_sel, sub_sel);
+
+        // True passes all, False passes none (clamped to min_selectivity).
+        assert_eq!(ranker.estimate_selectivity(&FilterExpr::True), 1.0);
+        assert_eq!(
+            ranker.estimate_selectivity(&FilterExpr::False),
+            ranker.config().min_selectivity
+        );
+    }
+
+    #[test]
+    fn test_cost_for_every_variant() {
+        let ranker = FilterRanker::with_defaults();
+        let col = || "x".to_string();
+        let int = || FilterValue::Int(1);
+
+        // Range comparison costs.
+        for filter in [
+            FilterExpr::Lt {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Le {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Gt {
+                column: col(),
+                value: int(),
+            },
+            FilterExpr::Ge {
+                column: col(),
+                value: int(),
+            },
+        ] {
+            assert!(ranker.estimate_cost(&filter) > 0.0);
+        }
+
+        // Between sums both bound comparisons.
+        let between_cost = ranker.estimate_cost(&FilterExpr::Between {
+            column: col(),
+            lower: FilterValue::Bytes(vec![0u8; 4]),
+            upper: FilterValue::Int(10),
+        });
+        assert!(between_cost > 0.0);
+
+        // IN cost scales with element count.
+        let in_cost = ranker.estimate_cost(&FilterExpr::In {
+            column: col(),
+            values: vec![int(), int(), int()],
+        });
+        assert!(in_cost >= 3.0 * ranker.config().cost_model.in_per_element - 0.0001);
+
+        // Like cost includes the pattern-match base.
+        assert!(
+            ranker.estimate_cost(&FilterExpr::Like {
+                column: col(),
+                pattern: "abc%".to_string(),
+            }) >= ranker.config().cost_model.pattern_match
+        );
+
+        // IS NOT NULL is a null check.
+        assert_eq!(
+            ranker.estimate_cost(&FilterExpr::IsNotNull { column: col() }),
+            ranker.config().cost_model.null_check
+        );
+
+        // And/Or/Not recurse; Function sums arg costs.
+        let and_cost = ranker.estimate_cost(&FilterExpr::And(
+            Box::new(FilterExpr::IsNull { column: col() }),
+            Box::new(FilterExpr::IsNull { column: col() }),
+        ));
+        assert!(and_cost > 0.0);
+        let or_cost = ranker.estimate_cost(&FilterExpr::Or(
+            Box::new(FilterExpr::True),
+            Box::new(FilterExpr::False),
+        ));
+        assert_eq!(or_cost, 0.0);
+        let not_cost = ranker.estimate_cost(&FilterExpr::Not(Box::new(FilterExpr::IsNull {
+            column: col(),
+        })));
+        assert_eq!(not_cost, ranker.config().cost_model.null_check);
+        let fn_cost = ranker.estimate_cost(&FilterExpr::Function {
+            name: "f".to_string(),
+            args: vec![FilterExpr::IsNull { column: col() }],
+        });
+        assert!(fn_cost > ranker.config().cost_model.function_call);
+
+        // True/False are free.
+        assert_eq!(ranker.estimate_cost(&FilterExpr::True), 0.0);
+        assert_eq!(ranker.estimate_cost(&FilterExpr::False), 0.0);
+    }
+
+    #[test]
+    fn test_range_selectivity_with_statistics() {
+        let mut stats = TableStats::new("t".to_string(), 1000);
+        stats.add_column(ColumnStats {
+            name: "age".to_string(),
+            ndv: 100,
+            null_fraction: 0.2,
+            min_value: Some(0.0),
+            max_value: Some(100.0),
+        });
+        let ranker = FilterRanker::with_defaults().with_stats(stats);
+
+        // Range over a known min/max uses the fraction estimate, not the default.
+        let sel = ranker.estimate_selectivity(&FilterExpr::Between {
+            column: "age".to_string(),
+            lower: FilterValue::Int(0),
+            upper: FilterValue::Int(50),
+        });
+        assert!((sel - 0.5).abs() < 0.05);
+
+        // IS NULL / IS NOT NULL read the column's null fraction.
+        let null_sel = ranker.estimate_selectivity(&FilterExpr::IsNull {
+            column: "age".to_string(),
+        });
+        assert!((null_sel - 0.2).abs() < 0.0001);
+        let not_null_sel = ranker.estimate_selectivity(&FilterExpr::IsNotNull {
+            column: "age".to_string(),
+        });
+        assert!((not_null_sel - 0.8).abs() < 0.0001);
+    }
+
+    #[test]
+    fn test_ranked_filter_equality_and_ordering() {
+        let a = RankedFilter::new(FilterExpr::True, 0.5, 0.0, 0);
+        let b = RankedFilter::new(FilterExpr::False, 0.5, 0.0, 1);
+        // Equal scores compare equal (cost == 0.0 → score == selectivity).
+        assert_eq!(a, b);
+        assert_eq!(a.partial_cmp(&b), Some(Ordering::Equal));
+        assert_eq!(a.score, 0.5);
+    }
 }

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -1597,6 +1597,45 @@ fn test_parse_fusion_strategies() {
     }
 }
 
+#[test]
+fn test_parse_fusion_strategy_identifier_forms() {
+    // The keyword tokens (RERANK/RRF/...) are covered above. These spellings
+    // arrive as bare identifiers and route through the ident arm of
+    // `parse_fusion_strategy`.
+    let filter_then = parse(
+        "HYBRID FROM hosts VECTOR SEARCH e SIMILAR TO [0.1] FUSION FILTER_THEN_SEARCH LIMIT 10",
+    )
+    .unwrap();
+    assert!(matches!(
+        filter_then,
+        QueryExpr::Hybrid(hq) if matches!(hq.fusion, FusionStrategy::FilterThenSearch)
+    ));
+
+    let search_then = parse(
+        "HYBRID FROM hosts VECTOR SEARCH e SIMILAR TO [0.1] FUSION SEARCH_THEN_FILTER LIMIT 10",
+    )
+    .unwrap();
+    assert!(matches!(
+        search_then,
+        QueryExpr::Hybrid(hq) if matches!(hq.fusion, FusionStrategy::SearchThenFilter)
+    ));
+
+    // Identifier-spelled RERANK with an explicit weight.
+    let rerank =
+        parse("HYBRID FROM hosts VECTOR SEARCH e SIMILAR TO [0.1] FUSION RERANK(0.25) LIMIT 10")
+            .unwrap();
+    assert!(matches!(
+        rerank,
+        QueryExpr::Hybrid(hq)
+            if matches!(hq.fusion, FusionStrategy::Rerank { weight } if (weight - 0.25).abs() < 0.01)
+    ));
+
+    // Unknown identifier strategy is rejected.
+    assert!(
+        parse("HYBRID FROM hosts VECTOR SEARCH e SIMILAR TO [0.1] FUSION NOPE LIMIT 10").is_err()
+    );
+}
+
 // ========================================================================
 // DML Tests: INSERT, UPDATE, DELETE
 // ========================================================================


### PR DESCRIPTION
Automated AFK landing for #1285. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1285

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1441"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785066896&installation_id=129708444&pr_number=1441&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1441&signature=a0bcbb434dd22dc827c4071a296bc4ea54f8d7f6bf62a879dca39454947cac38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->