### PR TITLE
merge: #1285 reddb-io-rql line coverage sits at the 90% knife-edge (RQL Coverage Gate red on main)

### DIFF
--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -2169,4 +2169,86 @@ mod tests {
             .unwrap_err()
             .contains("non-hex char"));
     }
+
+    #[test]
+    fn parse_ai_policy_missing_required_fields_report_specific_errors() {
+        // Each AI clause that parses its options but lacks a required slot
+        // surfaces the dedicated `ok_or_else` / empty-collection error.
+        for (sql, needle) in [
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (fields = ('body'), model = 'm'))",
+                "MODERATE policy requires provider",
+            ),
+            (
+                "t (id INT, body TEXT) WITH (MODERATE (fields = ('body'), provider = 'o'))",
+                "MODERATE policy requires model",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (outputs = ('caption'), provider = 'o', model = 'm'))",
+                "VISION policy requires image_field",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (image_field = 'photo', provider = 'o', model = 'm'))",
+                "VISION policy requires outputs",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (image_field = 'photo', outputs = ('caption'), model = 'm'))",
+                "VISION policy requires provider",
+            ),
+            (
+                "t (id INT, photo TEXT) WITH (VISION (image_field = 'photo', outputs = ('caption'), provider = 'o'))",
+                "VISION policy requires model",
+            ),
+        ] {
+            let err = parser(sql)
+                .parse_create_table_body()
+                .expect_err("missing required AI policy field should error");
+            assert!(format!("{err}").contains(needle), "sql={sql:?} err={err}");
+        }
+    }
+
+    #[test]
+    fn parse_create_table_ttl_clause_covers_units_and_errors() {
+        // Bare `WITH TTL <n> [unit]` happy path: no unit defaults to seconds.
+        let QueryExpr::CreateTable(table) = parser("t (id INT) WITH TTL 5")
+            .parse_create_table_body()
+            .expect("ttl defaults to seconds")
+        else {
+            panic!("Expected CreateTableQuery");
+        };
+        assert_eq!(table.default_ttl_ms, Some(5_000));
+
+        // Explicit minute unit multiplies through to milliseconds.
+        let QueryExpr::CreateTable(table) = parser("t (id INT) WITH TTL 2 m")
+            .parse_create_table_body()
+            .expect("ttl with minute unit")
+        else {
+            panic!("Expected CreateTableQuery");
+        };
+        assert_eq!(table.default_ttl_ms, Some(120_000));
+
+        for (sql, needle) in [
+            (
+                "t (id INT) WITH BOGUS",
+                "unsupported CREATE TABLE option",
+            ),
+            (
+                "t (id INT) WITH TTL 30 lightyears",
+                "unsupported TTL unit",
+            ),
+            (
+                "t (id INT) WITH TTL 1.5 ms",
+                "must resolve to a whole number of milliseconds",
+            ),
+            (
+                "t (id INT) WITH TTL 1e25 d",
+                "TTL duration is too large",
+            ),
+        ] {
+            let err = parser(sql)
+                .parse_create_table_body()
+                .expect_err("malformed TTL clause should error");
+            assert!(format!("{err}").contains(needle), "sql={sql:?} err={err}");
+        }
+    }
 }

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -148,3 +148,172 @@ pub fn render_value_sql(v: &Value) -> String {
         _ => "NULL".to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{InsertEntityType, QueueSide};
+
+    /// Build a minimal `TableQuery` carrying only the fields the renderer reads
+    /// (`table`, `columns`, `filter`); every other slot stays at its inert
+    /// default so the helper survives struct-field churn elsewhere.
+    fn table_query(table: &str, columns: Vec<Projection>, filter: Option<Filter>) -> TableQuery {
+        TableQuery {
+            table: table.to_string(),
+            source: None,
+            alias: None,
+            select_items: Vec::new(),
+            columns,
+            where_expr: None,
+            filter,
+            group_by_exprs: Vec::new(),
+            group_by: Vec::new(),
+            having_expr: None,
+            having: None,
+            order_by: Vec::new(),
+            limit: None,
+            limit_param: None,
+            offset: None,
+            offset_param: None,
+            expand: None,
+            as_of: None,
+            sessionize: None,
+            distinct: false,
+        }
+    }
+
+    #[test]
+    fn render_table_handles_star_columns_and_filter() {
+        // Empty column list renders the SQL star.
+        let star = render(&QueryExpr::Table(table_query("users", Vec::new(), None)));
+        assert_eq!(star, "SELECT * FROM users");
+
+        // Explicit columns plus an AND/OR filter tree exercise the
+        // projection list and the recursive filter renderer.
+        let filter = Filter::Or(
+            Box::new(Filter::And(
+                Box::new(Filter::Compare {
+                    field: FieldRef::column("u", "age"),
+                    op: CompareOp::Gt,
+                    value: Value::Integer(18),
+                }),
+                Box::new(Filter::Compare {
+                    field: FieldRef::column("", "active"),
+                    op: CompareOp::Eq,
+                    value: Value::Boolean(true),
+                }),
+            )),
+            // A variant the renderer cannot express falls back to `1=1`.
+            Box::new(Filter::Not(Box::new(Filter::Compare {
+                field: FieldRef::column("", "banned"),
+                op: CompareOp::Eq,
+                value: Value::Boolean(false),
+            }))),
+        );
+        let rendered = render(&QueryExpr::Table(table_query(
+            "users",
+            vec![
+                Projection::All,
+                Projection::Column("name".to_string()),
+                Projection::Alias("name".to_string(), "n".to_string()),
+                Projection::Field(FieldRef::column("u", "age"), Some("a".to_string())),
+                Projection::Field(FieldRef::column("", "active"), None),
+                // Window/Function variants are outside the renderer subset.
+                Projection::Function("count".to_string(), Vec::new()),
+            ],
+            Some(filter),
+        )));
+        assert_eq!(
+            rendered,
+            "SELECT *, name, name AS n, u.age AS a, active, * FROM users \
+             WHERE ((u.age > 18) AND (active = true)) OR (1=1)"
+        );
+    }
+
+    #[test]
+    fn render_insert_joins_columns_and_value_rows() {
+        let insert = InsertQuery {
+            table: "metrics".to_string(),
+            entity_type: InsertEntityType::Row,
+            columns: vec!["id".to_string(), "ratio".to_string(), "whole".to_string()],
+            value_exprs: Vec::new(),
+            values: vec![vec![
+                Value::UnsignedInteger(7),
+                Value::Float(1.5),
+                Value::Float(2.0),
+            ]],
+            returning: None,
+            ttl_ms: None,
+            expires_at_ms: None,
+            with_metadata: Vec::new(),
+            auto_embed: None,
+            suppress_events: false,
+        };
+        // UnsignedInteger, fractional Float, and whole-number Float all
+        // render through their dedicated `render_value_sql` arms.
+        assert_eq!(
+            render(&QueryExpr::Insert(insert)),
+            "INSERT INTO metrics (id, ratio, whole) VALUES (7, 1.5, 2.0)"
+        );
+    }
+
+    #[test]
+    fn render_queue_command_only_renders_push() {
+        let push = QueueCommand::Push {
+            queue: "jobs".to_string(),
+            value: Value::Text("o'brien".into()),
+            side: QueueSide::Right,
+            priority: None,
+            available: None,
+        };
+        // Text literals escape embedded single quotes.
+        assert_eq!(
+            render(&QueryExpr::QueueCommand(push)),
+            "QUEUE PUSH jobs 'o''brien'",
+        );
+
+        // Non-Push queue commands are outside the renderer subset.
+        let len = QueueCommand::Len {
+            queue: "jobs".to_string(),
+        };
+        assert_eq!(render(&QueryExpr::QueueCommand(len)), "");
+    }
+
+    #[test]
+    fn render_field_ref_falls_back_for_graph_refs() {
+        // Empty-table column renders bare; populated table dots them together;
+        // non-TableColumn refs collapse to the `field` placeholder.
+        assert_eq!(render_field_ref(&FieldRef::column("", "bare")), "bare");
+        assert_eq!(render_field_ref(&FieldRef::column("t", "c")), "t.c");
+        assert_eq!(
+            render_field_ref(&FieldRef::NodeProperty {
+                alias: "n".to_string(),
+                property: "p".to_string(),
+            }),
+            "field"
+        );
+    }
+
+    #[test]
+    fn render_value_sql_covers_scalar_arms() {
+        assert_eq!(render_value_sql(&Value::Null), "NULL");
+        assert_eq!(render_value_sql(&Value::Integer(-3)), "-3");
+        assert_eq!(render_value_sql(&Value::UnsignedInteger(9)), "9");
+        assert_eq!(render_value_sql(&Value::Float(2.0)), "2.0");
+        assert_eq!(render_value_sql(&Value::Float(0.25)), "0.25");
+        assert_eq!(render_value_sql(&Value::Boolean(true)), "true");
+        assert_eq!(render_value_sql(&Value::Boolean(false)), "false");
+        assert_eq!(render_value_sql(&Value::Text("it's".into())), "'it''s'");
+        assert_eq!(
+            render_value_sql(&Value::Json(b"{\"k\":1}".to_vec())),
+            "{\"k\":1}"
+        );
+        // Unsupported scalar kinds fall back to NULL.
+        assert_eq!(render_value_sql(&Value::Blob(vec![1, 2, 3])), "NULL");
+    }
+
+    #[test]
+    fn render_returns_empty_for_unsupported_query_expr() {
+        assert_eq!(render(&QueryExpr::ShowTenant), "");
+    }
+}

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -1223,6 +1223,54 @@ mod tests {
     }
 
     #[test]
+    fn parse_sql_command_covers_admin_set_reset_events_and_dispatch_errors() {
+        // SET TENANT / RESET TENANT through the lower `parse_sql_command`
+        // surface — the `expr()` helper routes these through
+        // `parse_sql_statement` instead, leaving this arm uncovered.
+        assert!(matches!(
+            sql_command("SET TENANT 'acme'"),
+            SqlCommand::SetTenant(Some(t)) if t == "acme"
+        ));
+        assert!(matches!(
+            sql_command("SET TENANT = 'beta'"),
+            SqlCommand::SetTenant(Some(t)) if t == "beta"
+        ));
+        assert!(matches!(
+            sql_command("SET TENANT NULL"),
+            SqlCommand::SetTenant(None)
+        ));
+        assert!(matches!(
+            sql_command("RESET TENANT"),
+            SqlCommand::SetTenant(None)
+        ));
+        assert!(matches!(sql_command("SHOW TENANT"), SqlCommand::ShowTenant));
+
+        // EVENTS STATUS happy path attaches a `collection =` filter onto the
+        // synthetic red.subscriptions table query.
+        let SqlCommand::Select(query) = sql_command("EVENTS STATUS users") else {
+            panic!("EVENTS STATUS should select red.subscriptions");
+        };
+        assert_eq!(query.table, "red.subscriptions");
+        assert!(query.filter.is_some());
+
+        // Error arms threaded across the dispatch.
+        for sql in [
+            "SET TENANT 42",     // non-text literal
+            "SET BOGUS",         // unknown SET target
+            "RESET BOGUS",       // RESET expects TENANT
+            "MIGRATE TABLE x",   // MIGRATE expects POLICY
+            "EVENTS FOO",        // EVENTS expects STATUS / BACKFILL
+            "SHOW BOGUS",        // unknown SHOW catalog
+            "42",                // unrecognized leading token → catch-all
+        ] {
+            assert!(
+                sql_command_result(sql).is_err(),
+                "{sql} should be rejected by parse_sql_command"
+            );
+        }
+    }
+
+    #[test]
     fn parse_sql_command_covers_iam_and_hypertable_dispatch_edges() {
         assert!(matches!(
             expr("CREATE HYPERTABLE metrics TIME_COLUMN ts CHUNK_INTERVAL '1d'"),

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -1223,6 +1223,35 @@ mod tests {
     }
 
     #[test]
+    fn parse_create_command_covers_view_refresh_and_modifier_errors() {
+        // CREATE MATERIALIZED VIEW with a REFRESH EVERY cadence — the
+        // refresh-clause block lives on the parse_create_command surface,
+        // distinct from the parse_sql_statement path the expr() helper uses.
+        let SqlCommand::CreateView(view) =
+            sql_command("CREATE MATERIALIZED VIEW mv AS SELECT id FROM users REFRESH EVERY 5 s")
+        else {
+            panic!("expected CreateView");
+        };
+        assert_eq!(view.name, "mv");
+        assert!(view.materialized);
+        assert_eq!(view.refresh_every_ms, Some(5_000));
+
+        for sql in [
+            // REFRESH EVERY is rejected on a non-materialized view.
+            "CREATE VIEW v AS SELECT id FROM users REFRESH EVERY 5 s",
+            // REFRESH without the EVERY keyword.
+            "CREATE MATERIALIZED VIEW mv AS SELECT id FROM users REFRESH 5",
+            // OR REPLACE / MATERIALIZED modifiers without a VIEW target.
+            "CREATE OR REPLACE TABLE t (id INT)",
+        ] {
+            assert!(
+                sql_command_result(sql).is_err(),
+                "{sql} should be rejected by parse_create_command"
+            );
+        }
+    }
+
+    #[test]
     fn parse_sql_command_covers_admin_set_reset_events_and_dispatch_errors() {
         // SET TENANT / RESET TENANT through the lower `parse_sql_command`
         // surface — the `expr()` helper routes these through


### PR DESCRIPTION
Automated AFK landing for #1285. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1285

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785068120&installation_id=129708444&pr_number=1443&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1443&signature=1a53b5f3dc5d36d082e9389594154f5fe1a87922634e99173078b7720a3d81c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->