### PR TITLE
merge: #1307 CI gate gap: docs-only (**.md) PRs can't satisfy required checks → permanently BLOCKED

### DIFF
--- a/.github/workflows/ci-docs-shim.yml
+++ b/.github/workflows/ci-docs-shim.yml
@@ -1,0 +1,91 @@
+name: CI Docs-Only Gate Shim
+
+# Issue #1307 — make docs-only PRs satisfiable by main's merge gate.
+#
+# `main` branch protection (#975 / ADR 0059, strict + enforce_admins) requires
+# 25 status checks, all produced by `ci.yml`. But `ci.yml` is path-filtered:
+#
+#     pull_request:
+#       paths-ignore: ['**.md', 'docs/**', 'CHANGELOG**', 'LICENSE**']
+#
+# When a PR changes ONLY those paths, `ci.yml` never runs, so none of the 25
+# required checks ever report — branch protection treats them as pending and
+# the PR is BLOCKED forever (PR #1306 had to be landed by briefly lifting
+# protection). A *job* skipped by an `if:` reports "skipped" and satisfies the
+# gate; an entire *workflow* skipped by a path filter reports nothing.
+#
+# This shim is the complement of ci.yml's path filter: it triggers on EXACTLY
+# the doc paths ci.yml ignores, and reports every required context as a cheap
+# no-op success. So:
+#   - code-only PR  -> only ci.yml runs (real checks).
+#   - docs-only PR  -> only this shim runs (green checks; gate satisfied).
+#   - mixed PR      -> both run. They emit the same context names; the shim's
+#                      no-ops finish in seconds while ci.yml's real checks take
+#                      minutes, so the real result is the latest-to-complete and
+#                      is the one branch protection honors — a failing real
+#                      check is NOT masked by the shim.
+#
+# Keep the matrix below in lockstep with branch protection's required set and
+# with ci.yml's job names — scripts/ci_docs_shim_contract.test.mjs enforces it.
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG**'
+      - 'LICENSE**'
+
+# Mirror ci.yml's cost guard so a follow-up push cancels stale shim runs.
+concurrency:
+  group: ci-docs-shim-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Mirror of ci.yml's `gate` sentinel: short-circuit Dependabot and draft PRs.
+  # When this is skipped, the dependent `required` matrix is skipped too — and
+  # skipped jobs still satisfy required status checks, exactly like ci.yml.
+  gate:
+    name: gate
+    runs-on: ubuntu-latest
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    steps:
+      - run: echo "docs-only PR — ci.yml is path-skipped; this shim satisfies the required gate"
+
+  required:
+    name: ${{ matrix.context }}
+    needs: gate
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        context:
+          - 'Quality (fmt, check, clippy)'
+          - 'Lint (no untyped serialization)'
+          - 'Version integrity'
+          - 'Contract Matrix Gate'
+          - 'Docs Match Contract Matrix'
+          - 'Helm Chart'
+          - 'AFK Validation Sidecar'
+          - 'RQL Conformance (sqllogictest)'
+          - 'Drivers / Python (cargo check)'
+          - 'Feature Matrix (all-features)'
+          - 'Feature Matrix (backend-d1)'
+          - 'Feature Matrix (backend-s3)'
+          - 'Feature Matrix (backend-turso)'
+          - 'Feature Matrix (no-default)'
+          - 'Feature Matrix (otel)'
+          - 'Driver Param Conformance'
+          - 'Chaos & Drill Suite'
+          - 'Fuzz Parsers'
+          - 'Container Stack'
+          - 'Publish Dry-Run (crates.io)'
+          - 'cargo package dry-run'
+          - 'Windows (build + unit tests)'
+          - 'macOS (build + unit tests)'
+          - 'Test Suite'
+    steps:
+      - run: echo "docs-only PR — required check '${{ matrix.context }}' satisfied by shim (ci.yml is path-skipped)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,11 @@ jobs:
           node-version: '22'
       - name: Sidecar tooling contract test
         run: node --test scripts/check-afk-validation-diff.test.mjs
+      - name: Docs-only gate shim lockstep contract test
+        # Issue #1307 — the docs-only shim (.github/workflows/ci-docs-shim.yml)
+        # must keep emitting exactly main's required status checks; this test
+        # fails the build if the shim drifts from the required set / ci.yml.
+        run: node --test scripts/ci_docs_shim_contract.test.mjs
       - name: Check supplied AFK validation sidecar against diff
         run: |
           if [ -z "${RED_AFK_VALIDATION_SIDECAR:-}" ]; then

--- a/scripts/ci_docs_shim_contract.test.mjs
+++ b/scripts/ci_docs_shim_contract.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+const CI = ".github/workflows/ci.yml";
+const SHIM = ".github/workflows/ci-docs-shim.yml";
+
+// Issue #1307 — these are the contexts main's branch protection requires
+// (`repos/reddb-io/reddb/branches/main/protection/required_status_checks`,
+// #975 / ADR 0059). They are produced by ci.yml, which is path-filtered with
+// `paths-ignore: ['**.md', 'docs/**', 'CHANGELOG**', 'LICENSE**']`. On a
+// docs-only PR ci.yml never runs, so none of these report and the PR is
+// BLOCKED forever. The shim workflow reports them green on docs-only PRs.
+//
+// This list is the source of truth for the shim. If branch protection's
+// required set changes, update BOTH this list and ci-docs-shim.yml together —
+// that lockstep is exactly what this test guards.
+const REQUIRED_CONTEXTS = [
+  "gate",
+  "Quality (fmt, check, clippy)",
+  "Lint (no untyped serialization)",
+  "Version integrity",
+  "Contract Matrix Gate",
+  "Docs Match Contract Matrix",
+  "Helm Chart",
+  "AFK Validation Sidecar",
+  "RQL Conformance (sqllogictest)",
+  "Drivers / Python (cargo check)",
+  "Feature Matrix (all-features)",
+  "Feature Matrix (backend-d1)",
+  "Feature Matrix (backend-s3)",
+  "Feature Matrix (backend-turso)",
+  "Feature Matrix (no-default)",
+  "Feature Matrix (otel)",
+  "Driver Param Conformance",
+  "Chaos & Drill Suite",
+  "Fuzz Parsers",
+  "Container Stack",
+  "Publish Dry-Run (crates.io)",
+  "cargo package dry-run",
+  "Windows (build + unit tests)",
+  "macOS (build + unit tests)",
+  "Test Suite",
+];
+
+// The doc-path globs ci.yml ignores on pull_request. The shim must trigger on
+// exactly these so the two workflows partition cleanly: code-only PR -> only
+// ci.yml; docs-only PR -> only the shim.
+const DOC_PATHS = ["**.md", "docs/**", "CHANGELOG**", "LICENSE**"];
+
+// Extract the YAML block-list items nested under a `context:` key (the matrix
+// dimension that names each emitted check). Items may be single-quoted.
+function matrixContexts(yaml) {
+  const lines = yaml.split("\n");
+  const start = lines.findIndex((l) => /^\s*context:\s*$/.test(l));
+  assert.notEqual(start, -1, "shim must declare a `context:` matrix dimension");
+  const indent = lines[start].match(/^\s*/)[0].length;
+  const out = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)-\s+(.*\S)\s*$/);
+    if (!m || m[1].length <= indent) break;
+    out.push(m[2].replace(/^['"]|['"]$/g, ""));
+  }
+  return out;
+}
+
+test("the docs-only shim workflow exists", () => {
+  assert.ok(
+    fs.existsSync(path.join(repoRoot, SHIM)),
+    `${SHIM} must exist so docs-only PRs can satisfy the merge gate`,
+  );
+});
+
+test("shim triggers on pull_request for the exact doc paths ci.yml ignores", () => {
+  const shim = read(SHIM);
+  // Must be a pull_request workflow with a positive `paths:` filter (not
+  // paths-ignore) so it fires precisely when ci.yml is path-skipped.
+  assert.match(shim, /pull_request:/, "shim must run on pull_request");
+  assert.match(shim, /^\s*paths:\s*$/m, "shim must use a positive `paths:` filter");
+  for (const glob of DOC_PATHS) {
+    assert.ok(
+      shim.includes(`'${glob}'`) || shim.includes(`"${glob}"`) || new RegExp(`-\\s*${glob.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "m").test(shim),
+      `shim paths must include ${glob} (lockstep with ci.yml paths-ignore)`,
+    );
+  }
+});
+
+test("ci.yml still path-ignores the doc paths on pull_request", () => {
+  const ci = read(CI);
+  assert.match(ci, /paths-ignore:/, "ci.yml must keep its paths-ignore filter");
+  for (const glob of DOC_PATHS) {
+    assert.ok(
+      ci.includes(`'${glob}'`) || ci.includes(`"${glob}"`),
+      `ci.yml paths-ignore must include ${glob} (lockstep with the shim)`,
+    );
+  }
+});
+
+test("shim emits exactly the branch-protection required contexts", () => {
+  const shim = read(SHIM);
+  // `gate` is its own job; the remaining 24 come from the matrix.
+  assert.match(shim, /name:\s*gate\b/, "shim must emit the `gate` context");
+  const emitted = new Set(["gate", ...matrixContexts(shim)]);
+  const required = new Set(REQUIRED_CONTEXTS);
+
+  const missing = [...required].filter((c) => !emitted.has(c));
+  const extra = [...emitted].filter((c) => !required.has(c));
+  assert.deepEqual(missing, [], `shim is missing required contexts: ${missing.join(", ")}`);
+  assert.deepEqual(extra, [], `shim emits non-required contexts: ${extra.join(", ")}`);
+});
+
+test("shim is a no-op (cheap) — no cargo/docker/build commands", () => {
+  const shim = read(SHIM);
+  // Inspect only `run:` command lines — context NAMES legitimately contain the
+  // words "cargo"/"docker" (e.g. "cargo package dry-run"), but no step may
+  // actually invoke them.
+  const runCmds = shim
+    .split("\n")
+    .map((l) => l.match(/^\s*-?\s*run:\s*(.*)$/))
+    .filter(Boolean)
+    .map((m) => m[1]);
+  for (const cmd of runCmds) {
+    assert.doesNotMatch(cmd, /\b(cargo|docker|node|cmake|gradlew)\b/, `shim run step must be a no-op, got: ${cmd}`);
+  }
+});


### PR DESCRIPTION
Automated AFK landing for #1307. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1307

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785068369&installation_id=129708444&pr_number=1444&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1444&signature=0bad0a30be71f8b929c8bc89a7aedb4d0801db9df38f0b8f85281cbdaee7d93b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->