### PR TITLE
merge: #1342 Benchmark array display formatting allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
 name = "reddb-io-types"
 version = "1.15.0"
 dependencies = [
+ "criterion",
  "proptest",
  "zstd",
 ]

--- a/bench/array-display-formatting-2026-06-26.md
+++ b/bench/array-display-formatting-2026-06-26.md
@@ -1,0 +1,98 @@
+# Array display / plain-text formatting allocation — benchmark & verdict (#1342)
+
+Parent: #1337
+
+## What this measures
+
+`Value::display_string()` and `Value::plain_text()` render a `Value::Array` by
+building an intermediate `Vec<String>` and joining it:
+
+```rust
+// crates/reddb-types/src/types.rs
+Value::Array(elems) => {
+    let items: Vec<String> = elems.iter().map(|e| e.display_string()).collect();
+    format!("[{}]", items.join(", "))
+}
+```
+
+That is one heap `Vec`, one owned `String` per element, then a second
+allocation for the joined result. This slice isolates the **output-formatting**
+cost of that path from query execution, and asks whether eliminating the
+intermediate `Vec<String>` is justified.
+
+The benchmark (`crates/reddb-types/benches/array_display_bench.rs`) compares the
+production path against a **direct-write candidate** that writes into a single
+reused `String` buffer (no per-array `Vec<String>`, no separate join
+allocation). The candidate is asserted byte-for-byte identical to the baseline
+for every case before timing, so any delta is a pure formatting win and never an
+output change. It covers scalar arrays, nested arrays, and a mixed
+text/scalar/nested array, across `display_string` and `plain_text`.
+
+## Results
+
+Criterion, `--measurement-time 2 --sample-size 30`, release build,
+`RUSTFLAGS="-C debuginfo=0"`, 14 GB guard host. Times are per call (median).
+Cross-run swing on this host is ±5–10%; only deltas well outside that are
+meaningful.
+
+### `display_string`
+
+| case          | elements | baseline | direct-write | speedup |
+|---------------|---------:|---------:|-------------:|--------:|
+| scalar/16     |       16 |  1.42 µs |      1.35 µs |   ~5%   |
+| scalar/256    |      256 | 26.6 µs  |     20.4 µs  |  ~23%   |
+| nested/16×16  |      256 | 26.1 µs  |     18.9 µs  |  ~28%   |
+| mixed/64      |       64 | 13.7 µs  |      9.1 µs  |  ~33%   |
+
+### `plain_text`
+
+| case          | elements | baseline | direct-write | speedup |
+|---------------|---------:|---------:|-------------:|--------:|
+| scalar/16     |       16 |  1.59 µs |      1.32 µs |  ~17%   |
+| scalar/256    |      256 | 29.8 µs  |     24.8 µs  |  ~17%   |
+| nested/16×16  |      256 | 33.3 µs  |     22.0 µs  |  ~34%   |
+| mixed/64      |       64 | 14.9 µs  |      8.9 µs  |  ~40%   |
+
+## Reading
+
+- The direct-write approach is **consistently faster** — ~20–40% on arrays of
+  64+ elements and on nested arrays, where the per-element `String` + `Vec`
+  churn dominates. For tiny scalar arrays (16 elements) the win collapses into
+  host noise (~5% for `display_string`).
+- The win **grows with array size and nesting depth**, exactly as expected from
+  removing the intermediate `Vec<String>` and the second join allocation.
+- Absolute cost stays in the **single-digit-to-tens-of-microseconds** range per
+  call. This is a formatting-side cost, not a per-byte storage or index cost.
+
+## Is avoiding the intermediate `Vec<String>` justified?
+
+**Verdict: no production change in this slice.** The optimisation is real and
+provably output-preserving, but the evidence does not place array formatting on
+a hot path that warrants the change now:
+
+- The only production callers of `display_string` / `plain_text` are in SQL
+  expression evaluation (`crates/reddb-server/src/runtime/expr_eval.rs`:
+  `CONCAT`, `CAST … AS TEXT`, string functions, `LIKE`/`contains`) plus
+  `join_filter` and `blockchain_kind` key digests. These run per row, so they
+  are query-execution-adjacent rather than purely cosmetic display.
+- **But** the `Vec<String>` cost only materialises when the value being coerced
+  is actually a `Value::Array`. Scalars — the overwhelmingly common operand for
+  these string operators — never hit the array branch, and the scalar case shows
+  no meaningful win. A query that pushes large or nested arrays through
+  `CONCAT`/`CAST`-to-text on a hot per-row path is an uncommon workload, and no
+  current profile points to it.
+
+Per the parent framing ("RedDB only optimizes formatting if it appears on a
+relevant hot output path"), the disciplined outcome is to **land the benchmark
+as the standing guard / evidence** and defer the code change until a real
+workload demonstrates array-through-string-coercion is hot. If that profile ever
+appears, the direct-write candidate in the bench is the drop-in replacement for
+the two array branches in `types.rs`, already shown identical in output and
+~20–40% cheaper.
+
+## Reproduce
+
+```sh
+CARGO_BUILD_JOBS=1 RUSTFLAGS="-C debuginfo=0" \
+  cargo bench -p reddb-io-types --bench array_display_bench
+```

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -20,6 +20,12 @@ zstd = { version = "0.13", default-features = false }
 
 [dev-dependencies]
 proptest = "1"
+# Array display/plain-text formatting allocation benchmark (#1342).
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "array_display_bench"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/reddb-types/benches/array_display_bench.rs
+++ b/crates/reddb-types/benches/array_display_bench.rs
@@ -1,0 +1,183 @@
+//! Array display / plain-text formatting allocation benchmark (#1342).
+//!
+//! Run with:
+//!   cargo bench -p reddb-io-types --bench array_display_bench
+//!
+//! Goal: isolate the *output formatting* cost of `Value::display_string` and
+//! `Value::plain_text` for `Value::Array` from any query-execution cost, so we
+//! can decide whether the intermediate `Vec<String>` those paths build is worth
+//! eliminating.
+//!
+//! Both paths today render an array as:
+//!
+//! ```ignore
+//! let items: Vec<String> = elems.iter().map(|e| e.display_string()).collect();
+//! format!("[{}]", items.join(", "))
+//! ```
+//!
+//! i.e. one heap `Vec` plus one owned `String` per element, then a second
+//! allocation for the joined result. The candidate optimisation writes directly
+//! into a single reused `String` buffer (`write_display` / `write_plain` below),
+//! avoiding the per-array `Vec<String>` and the separate join allocation.
+//!
+//! The benchmark measures the *baseline* (production `display_string` /
+//! `plain_text`) against the *direct-write* candidate across scalar, nested, and
+//! mixed arrays at two sizes. The candidate is asserted byte-for-byte identical
+//! to the baseline before timing, so any reported delta is a pure formatting
+//! win, never an output change.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use reddb_types::Value;
+
+// --- Direct-write candidate (no intermediate `Vec<String>`) -----------------
+//
+// Mirrors the production `Array` branch exactly: `[`, elements separated by
+// `, `, `]`. Non-array leaves defer to the existing `display_string` /
+// `plain_text`, so output is identical by construction.
+
+fn write_display(value: &Value, out: &mut String) {
+    match value {
+        Value::Array(elems) => {
+            out.push('[');
+            for (i, elem) in elems.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                write_display(elem, out);
+            }
+            out.push(']');
+        }
+        other => out.push_str(&other.display_string()),
+    }
+}
+
+fn write_plain(value: &Value, out: &mut String) {
+    match value {
+        Value::Array(elems) => {
+            out.push('[');
+            for (i, elem) in elems.iter().enumerate() {
+                if i > 0 {
+                    out.push_str(", ");
+                }
+                write_plain(elem, out);
+            }
+            out.push(']');
+        }
+        Value::Text(text) => out.push_str(text),
+        other => out.push_str(&other.display_string()),
+    }
+}
+
+fn candidate_display(value: &Value) -> String {
+    let mut out = String::new();
+    write_display(value, &mut out);
+    out
+}
+
+fn candidate_plain(value: &Value) -> String {
+    let mut out = String::new();
+    write_plain(value, &mut out);
+    out
+}
+
+// --- Workload builders ------------------------------------------------------
+
+/// Array of scalar values (integers, floats, booleans) — the common case.
+fn scalar_array(n: usize) -> Value {
+    let elems = (0..n)
+        .map(|i| match i % 3 {
+            0 => Value::Integer(i as i64),
+            1 => Value::Float(i as f64 * 1.5),
+            _ => Value::Boolean(i % 2 == 0),
+        })
+        .collect();
+    Value::Array(elems)
+}
+
+/// Array of arrays of scalars — exercises the recursive allocation amplification.
+fn nested_array(outer: usize, inner: usize) -> Value {
+    let elems = (0..outer).map(|_| scalar_array(inner)).collect();
+    Value::Array(elems)
+}
+
+/// Mixed array: text (distinguishes display vs plain-text), scalars, and a
+/// nested array — the worst case for the intermediate-`Vec` path.
+fn mixed_array(n: usize) -> Value {
+    let elems = (0..n)
+        .map(|i| match i % 4 {
+            0 => Value::text(format!("item-{i}")),
+            1 => Value::Integer(i as i64),
+            2 => Value::Float(i as f64),
+            _ => scalar_array(4),
+        })
+        .collect();
+    Value::Array(elems)
+}
+
+// --- Benchmark groups -------------------------------------------------------
+
+fn bench_display(c: &mut Criterion) {
+    let cases: Vec<(&str, Value)> = vec![
+        ("scalar/16", scalar_array(16)),
+        ("scalar/256", scalar_array(256)),
+        ("nested/16x16", nested_array(16, 16)),
+        ("mixed/64", mixed_array(64)),
+    ];
+
+    let mut group = c.benchmark_group("array_display_string");
+    for (name, value) in &cases {
+        // Equivalence guard: the candidate must match production output exactly.
+        assert_eq!(
+            value.display_string(),
+            candidate_display(value),
+            "candidate display must equal baseline for {name}"
+        );
+        let elems = match value {
+            Value::Array(e) => e.len() as u64,
+            _ => 1,
+        };
+        group.throughput(Throughput::Elements(elems));
+        group.bench_with_input(BenchmarkId::new("baseline", name), value, |b, v| {
+            b.iter(|| black_box(black_box(v).display_string()))
+        });
+        group.bench_with_input(BenchmarkId::new("direct_write", name), value, |b, v| {
+            b.iter(|| black_box(candidate_display(black_box(v))))
+        });
+    }
+    group.finish();
+}
+
+fn bench_plain(c: &mut Criterion) {
+    let cases: Vec<(&str, Value)> = vec![
+        ("scalar/16", scalar_array(16)),
+        ("scalar/256", scalar_array(256)),
+        ("nested/16x16", nested_array(16, 16)),
+        ("mixed/64", mixed_array(64)),
+    ];
+
+    let mut group = c.benchmark_group("array_plain_text");
+    for (name, value) in &cases {
+        assert_eq!(
+            value.plain_text(),
+            candidate_plain(value),
+            "candidate plain_text must equal baseline for {name}"
+        );
+        let elems = match value {
+            Value::Array(e) => e.len() as u64,
+            _ => 1,
+        };
+        group.throughput(Throughput::Elements(elems));
+        group.bench_with_input(BenchmarkId::new("baseline", name), value, |b, v| {
+            b.iter(|| black_box(black_box(v).plain_text()))
+        });
+        group.bench_with_input(BenchmarkId::new("direct_write", name), value, |b, v| {
+            b.iter(|| black_box(candidate_plain(black_box(v))))
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_display, bench_plain);
+criterion_main!(benches);


### PR DESCRIPTION
Automated AFK landing for #1342. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1342

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785068810&installation_id=129708444&pr_number=1445&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1445&signature=36a747b7266f49874794e6ee24bd6ce9b01898fb7671f67cabd7b62636459a1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->