### PR TITLE
fix(document): dot-path index parent-expansion + B-tree index tests + coordination glossary

### DIFF
--- a/.red/adr/0063-concurrent-claim-resource-reservation.md
+++ b/.red/adr/0063-concurrent-claim-resource-reservation.md
@@ -1,0 +1,162 @@
+# ADR 0063: Concurrent claim for transactional resource reservation
+
+Status: proposed
+Date: 2026-06-26
+
+## Context
+
+RedDB already exposes tables, KV, queues, events, and transactions inside one
+engine. The resource-reservation problem that motivated this ADR is the classic
+oversell race: multiple callers try to reserve the same finite capacity, such as
+stock units, seats, slots, or quotas, while the application also needs
+idempotency and downstream workflow delivery.
+
+The tempting external architecture is to coordinate reservation in Redis or a
+queue, then write the source of truth in RedDB. That repeats the dual-write
+window ADR 0015 closed for `WITH EVENTS`: two systems must agree on one logical
+business action without sharing one commit boundary.
+
+RedDB needs a native claim primitive that lets competing transactions make
+progress on different eligible records, while keeping reservation state,
+idempotency state, and event/queue side effects inside the RedDB authority.
+
+## Decision
+
+**Concurrent claim is a state-changing mutation.** The public shape is an
+`UPDATE`-like operation with claim semantics, not a lock-only
+`SELECT ... FOR UPDATE` surface. The operation chooses eligible records, applies
+the requested state transition, and may return the claimed identities through
+`RETURNING`. This keeps the user-facing operation aligned with the business act:
+available capacity becomes reserved capacity.
+
+**Claim candidates require deterministic, index-backed ordering.** A claim must
+specify an explicit order backed by a compatible index. RedDB chooses from that
+ordered candidate set, but skips records that are already held by another
+in-flight claim. Without an explicit order, or with an order the planner cannot
+serve through an index, the statement is rejected rather than relying on
+physical layout, incidental scan order, or a broad write-path sort.
+
+The compatible index should cover the principal equality filters as a prefix and
+then the claim order columns. A typical reservation shape is
+`product_id, location_id, state, expires_at, rid`: narrow to one stock pool,
+then claim in a deterministic order.
+
+If the user-provided order is not total, RedDB appends the model's stable claim
+identity as an implicit tie-breaker. Ties must never fall back to physical scan
+order.
+
+**Claim locks are transaction-scoped and claim-scoped.** When a transaction
+claims a candidate, RedDB takes a `Claim lock` on the model-owned `Claim
+identity`. Other claimers skip that candidate until the transaction commits or
+rolls back. Ordinary DML keeps the normal MVCC conflict policy; a claim lock is
+not a broad write lock for every update path.
+
+**Claim identity is model-owned.** Tables and documents use stable logical
+identity. KV uses key identity. Queues participate through `QueueLifecycle`
+delivery identity, not by exposing a second raw claim path over queue storage.
+This preserves ADR 0020's single authority for queue delivery, ACK/NACK, retry,
+DLQ, and replica replay.
+
+**Partial claim is the default; exact claim is explicit.** `CLAIM LIMIT n`
+returns as many immediately claimable records as it can. `CLAIM EXACT n` commits
+only when the requested cardinality is fully satisfied by immediately claimable
+records. If exact cardinality cannot be satisfied, the statement is a normal
+`Claim miss`: it applies no writes and reports zero affected rows rather than a
+storage error.
+
+**No wait mode in the first contract.** A claim skips in-flight candidates and
+does not wait for them. Waiting inside explicit transactions would hold
+transaction-local state while another writer determines progress, repeating the
+same caution that keeps `QUEUE READ ... WAIT` autocommit-only. A future wait
+mode needs its own decision.
+
+**The isolation contract is snapshot plus candidate claim locks.** RedDB does
+not introduce predicate locks, gap locks, SSI, or phantom prevention as part of
+the first claim contract. A range predicate claims from the transaction snapshot
+and skips currently claim-locked candidates. Records inserted later by other
+transactions may be claimed by those transactions if they are otherwise eligible.
+
+**Explicit transactions are supported.** A claim lock lives until
+`COMMIT`/`ROLLBACK`, so an application can claim capacity, write the order or
+reservation record, store a reservation idempotency key, and emit events or queue
+work in one transaction boundary.
+
+**Claim authorization composes read and update policy.** Candidate selection
+obeys the same read visibility rules as the underlying model, including tenant
+scope and RLS where applicable. The state transition then obeys the update policy
+for the changed fields. A caller must not claim a record it cannot see, and must
+not use claim to bypass update restrictions.
+
+**Idempotency is a recipe requirement, not built into the primitive.** RedDB
+does not add an `IDEMPOTENCY KEY` clause to claim itself. The canonical
+reservation recipe stores an application-defined idempotency key in a table or
+KV collection inside the same transaction so retried requests observe the prior
+outcome rather than creating a duplicate reservation.
+
+**Claim authority follows write ownership.** A claim is a non-deterministic
+write decision and must be made only by the write primary or range owner.
+Replicas route or reject according to normal write rules and replay outcomes;
+they never choose claim winners locally.
+
+**The first cluster contract is owner-local.** Cross-owner exactness is outside
+the first claim contract. In sharded clusters, the first productive claim path is
+restricted to one write owner or range owner. Claims that require multiple owners
+are rejected rather than partially committed or coordinated with two-phase
+commit.
+
+## Consequences
+
+- RedDB can express the Shopify-like reservation shape without requiring Redis
+  as a coordination sidecar.
+- The primitive depends on record-level claim-locking beneath the current
+  collection-level runtime lock adapter.
+- Query planning must distinguish deterministic index-backed candidate ordering
+  from incidental scan order or unbounded sort.
+- `Exact claim` is all-or-nothing over immediately claimable records, not over
+  possible future records or records currently locked by other transactions.
+- Claim planning must apply read visibility before acquiring candidates and
+  update authorization before publishing the state transition.
+- Range claims remain snapshot-isolation operations. Users needing full
+  serializable predicate protection need a future SSI/predicate-lock design, not
+  hidden behavior in claim.
+- Claim contention, skipped candidates, and claim misses are normal hot-path
+  signals. They belong in metrics/tracing, not per-attempt audit logs.
+- Queue claims must route through `QueueLifecycle`; duplicating queue delivery
+  decisions would violate ADR 0020.
+- Cluster claims stay owner-local until RedDB has a separate distributed write
+  transaction decision.
+
+## Alternatives considered
+
+- **Lock-only `SELECT ... FOR UPDATE SKIP LOCKED`.** Rejected for the first
+  product shape because it exposes a low-level lock act while the business need
+  is a state transition.
+- **Allow non-indexed `ORDER BY`.** Rejected for the first contract because a
+  claim is a concurrent write path; broad scans and sorts are likely to create
+  the bottleneck this primitive exists to avoid.
+- **Persistent lease fields in user data.** Rejected as the primitive contract
+  because it pollutes every model with application-visible lock metadata and
+  makes crash/expiry semantics part of user schema.
+- **Optimistic conflict-only claim.** Rejected because it does not provide true
+  skip-locked progress; many transactions can choose the same candidate and only
+  discover the race at commit.
+- **Predicate/gap locking in the first cut.** Rejected because it would smuggle
+  serializable-style behavior into a snapshot-isolation engine.
+- **Raw claim over queue internals.** Rejected because `QueueLifecycle` is the
+  queue state-machine authority.
+- **Cross-owner claim in v1.** Rejected because exact cross-owner reservation is
+  a distributed transaction problem.
+- **Built-in idempotency clause.** Rejected for the primitive; idempotency is
+  required by the canonical recipe but stays modeled as ordinary transactional
+  data.
+
+## References
+
+- ADR 0014: mvcc-history-store-and-transaction-recovery
+- ADR 0015: events-dual-write-window
+- ADR 0020: queue-lifecycle-module-contract
+- ADR 0037: shard-range-ownership-catalog
+- ADR 0055: cluster-slot-map-and-cross-shard-operations
+- `.red/context/data-model.md`: Resource reservation, Concurrent claim, Claim
+  lock, Claim identity, Exact claim, Claim miss, Claim authority, Owner-local
+  claim, Claim authorization, Claim order, Reservation idempotency key

--- a/.red/context/data-model.md
+++ b/.red/context/data-model.md
@@ -58,6 +58,18 @@ Part of the [glossary map](../CONTEXT-MAP.md). How data is shaped and accessed, 
 - **Ephemeral notification** — a lightweight pub/sub signal with no replay, ACK, consumer offset, or DLQ. Offline listeners miss it; use a queue or stream when durability matters. The RedDB-native contract is canonical; Postgres-like `LISTEN`/`NOTIFY` forms are compatibility translations rather than engine concepts. Channels are tenant-scoped by default; cross-tenant or global notification requires explicit capability.
 - **Durable stream** — a Collection model for an append-only event log with per-consumer offsets and stream-specific retention. Unlike a queue, reading does not create pending delivery state; unlike an ephemeral notification, a consumer can resume from its saved offset. First use is app-level publish/read; the event shape should remain compatible with future materialized CDC.
 
+## Coordination
+
+- **Resource reservation** — a transactional claim over finite user-domain capacity, such as stock, seats, slots, or quotas, whose availability and reservation state must share one authoritative commit boundary.
+- **Concurrent claim** — a state-changing coordination primitive where competing transactions acquire and update different eligible records instead of serializing behind the same candidate; queues participate through **Queue delivery** semantics rather than a parallel claim path.
+- **Claim lock** — a transaction-scoped record lock used by **Concurrent claim** to make an in-flight candidate temporarily unavailable to other claimers without storing lease fields in user data; ordinary DML keeps the normal MVCC conflict policy.
+- **Claim identity** — the model-owned identity used by **Claim lock**: table/document records use stable logical identity, KV uses key identity, and queues use **Queue delivery** identity.
+- **Exact claim** — a **Concurrent claim** mode that commits only if the requested claim cardinality is fully satisfied by immediately claimable records.
+- **Claim miss** — a normal **Concurrent claim** result where the requested claim cardinality cannot be satisfied immediately and the statement applies no writes.
+- **Claim authority** — the write authority allowed to decide a **Concurrent claim**; replicas replay or route the resulting write instead of choosing claim winners locally.
+- **Owner-local claim** — a **Concurrent claim** restricted to one write owner or range owner; cross-owner exactness is outside the first claim contract.
+- **Reservation idempotency key** — an application-defined key stored transactionally with a **Resource reservation** so retried requests observe the existing outcome instead of creating a duplicate claim.
+
 ## Queue modes
 
 - **`FANOUT` queue** — every consumer (or consumer group) receives every message. Equivalent to publishing across multiple Kafka consumer groups or RabbitMQ fanout exchange. Default mode for auto-event queues.

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -2203,12 +2203,12 @@ impl RedDBRuntime {
                 // — avoiding it saves a few microseconds per UPDATE.
                 // Page-local replace + t_ctid chain support (true
                 // HOT) lives in a follow-up storage spec.
+                // Use the parent-expanded set so that dot-path indexes
+                // (e.g. "body.service.tier") are triggered when the root
+                // field ("body") appears in modified_columns.
                 let indexed_cols: std::collections::HashSet<String> = self
                     .index_store_ref()
-                    .list_indices(applied.collection.as_str())
-                    .into_iter()
-                    .filter_map(|idx| idx.columns.first().cloned())
-                    .collect();
+                    .indexed_columns_set_with_parents(applied.collection.as_str());
                 let modified_cols: std::collections::HashSet<String> = damage
                     .touched_columns()
                     .into_iter()

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -571,9 +571,12 @@ impl RedDBRuntime {
             return Ok(());
         }
 
+        // Use the parent-expanded set so that dot-path indexes (e.g.
+        // "body.service.tier") are triggered when the root field ("body")
+        // is modified.
         let indexed_cols = self
             .index_store_ref()
-            .indexed_columns_set(&applied.collection);
+            .indexed_columns_set_with_parents(&applied.collection);
         if indexed_cols.is_empty() {
             return Ok(());
         }

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1398,6 +1398,37 @@ impl IndexStore {
         out
     }
 
+    /// Like `indexed_columns_set` but also includes every parent path segment
+    /// of dot-path indexed columns so that entity-field change detection works
+    /// for document body indexes (e.g. a `"body.service.tier"` index also adds
+    /// `"body"` and `"body.service"` so that a changed `"body"` field triggers
+    /// the index refresh path for that nested column).
+    pub fn indexed_columns_set_with_parents(
+        &self,
+        collection: &str,
+    ) -> std::collections::HashSet<String> {
+        let registry = read_unpoisoned(&self.registry);
+        let mut out = std::collections::HashSet::new();
+        for idx in registry.values() {
+            if idx.collection == collection {
+                for col in &idx.columns {
+                    out.insert(col.clone());
+                    if col.contains('.') {
+                        let mut prefix = String::new();
+                        for segment in col.split('.') {
+                            if !prefix.is_empty() {
+                                out.insert(prefix.clone());
+                                prefix.push('.');
+                            }
+                            prefix.push_str(segment);
+                        }
+                    }
+                }
+            }
+        }
+        out
+    }
+
     /// Batched counterpart of `index_entity_insert`: takes a full
     /// slice of `(EntityId, Vec<(String, Value)>)` pairs and walks
     /// the index registry ONCE, then loops inside each registered
@@ -1610,21 +1641,36 @@ impl IndexStore {
     ) -> Result<(), String> {
         // Snapshot the indexed columns once to avoid holding the registry
         // lock across delete/insert sub-calls (those re-acquire it).
+        // Also include parent path segments (e.g. "body" for "body.service.tier")
+        // so that a changed top-level "body" field triggers re-indexing for
+        // nested path indexes.
         let indexed_cols: std::collections::HashSet<String> = {
             let registry = self.registry.read();
-            registry
-                .values()
-                .filter(|idx| idx.collection == collection)
-                .filter_map(|idx| idx.columns.first().cloned())
-                .collect()
+            let mut cols = std::collections::HashSet::new();
+            for idx in registry.values().filter(|idx| idx.collection == collection) {
+                for col in &idx.columns {
+                    cols.insert(col.clone());
+                    if col.contains('.') {
+                        let mut prefix = String::new();
+                        for segment in col.split('.') {
+                            if !prefix.is_empty() {
+                                cols.insert(prefix.clone());
+                                prefix.push('.');
+                            }
+                            prefix.push_str(segment);
+                        }
+                    }
+                }
+            }
+            cols
         };
         if indexed_cols.is_empty() {
             return Ok(());
         }
 
         // Compute the full damage-vector once, then filter to the
-        // indexed columns. Drops the previous O(indexed × old.len)
-        // pairwise scan to a single pass over old + new.
+        // indexed columns (or their parent path segments). Drops the
+        // previous O(indexed × old.len) pairwise scan to a single pass.
         let damage = crate::application::entity::row_damage_vector(old_fields, new_fields);
 
         for (col, old_value, new_value) in &damage.changed {

--- a/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
@@ -226,3 +226,153 @@ fn http_query_document_fields_json_paths_arrays_and_groups() {
     assert_eq!(json_value(&grouped_rows[0], "severity"), &json!("error"));
     assert_eq!(json_value(&grouped_rows[0], "count"), &json!(2));
 }
+
+// --- Ordered B-tree index tests (#1400) ---
+
+/// CREATE INDEX on a document body path; verify range predicates (>, <, BETWEEN),
+/// ORDER BY, and top-N (LIMIT) all resolve through the index.
+#[test]
+fn runtime_btree_document_path_range_order_and_limit() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT range_docs");
+    // Tier values in lexicographic order: bronze < copper < gold < platinum < silver
+    exec(
+        &rt,
+        r#"INSERT INTO range_docs DOCUMENT (body) VALUES
+        ('{"name":"aaa","tier":"bronze"}'),
+        ('{"name":"bbb","tier":"copper"}'),
+        ('{"name":"ccc","tier":"gold"}'),
+        ('{"name":"ddd","tier":"platinum"}'),
+        ('{"name":"eee","tier":"silver"}')"#,
+    );
+    exec(
+        &rt,
+        "CREATE INDEX idx_range_tier ON range_docs (body.tier)",
+    );
+
+    // Equality — uses the companion hash index auto-created by BTree.
+    let eq = exec(&rt, "SELECT name FROM range_docs WHERE body.tier = 'gold'");
+    assert_eq!(eq.result.records.len(), 1, "equality hit: {eq:?}");
+    assert_eq!(text(&eq.result.records[0], "name"), "ccc");
+
+    // Range >: body.tier > 'copper' → gold(ccc), platinum(ddd), silver(eee)
+    let gt = exec(
+        &rt,
+        "SELECT name FROM range_docs WHERE body.tier > 'copper' ORDER BY body.tier",
+    );
+    assert_eq!(gt.result.records.len(), 3, "gt={gt:?}");
+    assert_eq!(text(&gt.result.records[0], "name"), "ccc"); // gold
+    assert_eq!(text(&gt.result.records[1], "name"), "ddd"); // platinum
+    assert_eq!(text(&gt.result.records[2], "name"), "eee"); // silver
+
+    // Range <: body.tier < 'gold' → bronze(aaa), copper(bbb)
+    let lt = exec(
+        &rt,
+        "SELECT name FROM range_docs WHERE body.tier < 'gold' ORDER BY body.tier",
+    );
+    assert_eq!(lt.result.records.len(), 2, "lt={lt:?}");
+    assert_eq!(text(&lt.result.records[0], "name"), "aaa"); // bronze
+    assert_eq!(text(&lt.result.records[1], "name"), "bbb"); // copper
+
+    // Range BETWEEN: body.tier BETWEEN 'copper' AND 'platinum' → copper, gold, platinum
+    let between = exec(
+        &rt,
+        "SELECT name FROM range_docs WHERE body.tier BETWEEN 'copper' AND 'platinum' ORDER BY body.tier",
+    );
+    assert_eq!(between.result.records.len(), 3, "between={between:?}");
+    assert_eq!(text(&between.result.records[0], "name"), "bbb"); // copper
+    assert_eq!(text(&between.result.records[1], "name"), "ccc"); // gold
+    assert_eq!(text(&between.result.records[2], "name"), "ddd"); // platinum
+
+    // ORDER BY via index: all docs sorted ascending by tier
+    let sorted = exec(
+        &rt,
+        "SELECT name FROM range_docs ORDER BY body.tier",
+    );
+    assert_eq!(sorted.result.records.len(), 5, "sorted={sorted:?}");
+    assert_eq!(text(&sorted.result.records[0], "name"), "aaa"); // bronze
+    assert_eq!(text(&sorted.result.records[4], "name"), "eee"); // silver
+
+    // Top-N: LIMIT 2 returns the two lowest-tier docs in sorted order
+    let top2 = exec(
+        &rt,
+        "SELECT name FROM range_docs ORDER BY body.tier LIMIT 2",
+    );
+    assert_eq!(top2.result.records.len(), 2, "top2={top2:?}");
+    assert_eq!(text(&top2.result.records[0], "name"), "aaa"); // bronze
+    assert_eq!(text(&top2.result.records[1], "name"), "bbb"); // copper
+}
+
+/// Verify that INSERT / UPDATE / DELETE correctly refresh the BTree index on a
+/// document body path, so range queries return up-to-date results.
+/// This specifically exercises the bug-fix for HOT-path and damage-vector checks
+/// that previously skipped refresh for dot-path indexed columns.
+#[test]
+fn runtime_btree_document_path_index_refresh_on_dml() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT refresh_docs");
+    // Initial documents:  svc1=gold (in range), svc2=bronze (boundary), svc3=silver (in range)
+    exec(
+        &rt,
+        r#"INSERT INTO refresh_docs DOCUMENT (body) VALUES
+        ('{"name":"svc1","tier":"gold"}'),
+        ('{"name":"svc2","tier":"bronze"}'),
+        ('{"name":"svc3","tier":"silver"}')"#,
+    );
+    exec(
+        &rt,
+        "CREATE INDEX idx_refresh_docs_tier ON refresh_docs (body.tier)",
+    );
+
+    let above_bronze = |rt: &RedDBRuntime| {
+        exec(
+            rt,
+            "SELECT name FROM refresh_docs WHERE body.tier > 'bronze' ORDER BY body.tier",
+        )
+        .result
+        .records
+        .into_iter()
+        .map(|r| match r.get("name") {
+            Some(Value::Text(s)) => s.to_string(),
+            other => panic!("expected name text, got {other:?}"),
+        })
+        .collect::<Vec<_>>()
+    };
+
+    // Baseline: > 'bronze' → gold(svc1), silver(svc3)
+    let initial = above_bronze(&rt);
+    assert_eq!(initial, vec!["svc1", "svc3"], "initial={initial:?}");
+
+    // INSERT: add svc4 with tier=platinum (platinum > bronze)
+    exec(
+        &rt,
+        r#"INSERT INTO refresh_docs DOCUMENT (body) VALUES ('{"name":"svc4","tier":"platinum"}')"#,
+    );
+    let after_insert = above_bronze(&rt);
+    assert_eq!(
+        after_insert,
+        vec!["svc1", "svc4", "svc3"],
+        "after INSERT of platinum svc4: {after_insert:?}"
+    );
+
+    // UPDATE: move svc1 from gold → aaa (aaa < bronze, drops out of range)
+    exec(
+        &rt,
+        "UPDATE refresh_docs DOCUMENTS SET tier = 'aaa' WHERE name = 'svc1'",
+    );
+    let after_update = above_bronze(&rt);
+    assert_eq!(
+        after_update,
+        vec!["svc4", "svc3"],
+        "after UPDATE svc1 tier→aaa: {after_update:?}"
+    );
+
+    // DELETE: remove svc3
+    exec(&rt, "DELETE FROM refresh_docs WHERE name = 'svc3'");
+    let after_delete = above_bronze(&rt);
+    assert_eq!(
+        after_delete,
+        vec!["svc4"],
+        "after DELETE svc3: {after_delete:?}"
+    );
+}

--- a/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
@@ -245,10 +245,7 @@ fn runtime_btree_document_path_range_order_and_limit() {
         ('{"name":"ddd","tier":"platinum"}'),
         ('{"name":"eee","tier":"silver"}')"#,
     );
-    exec(
-        &rt,
-        "CREATE INDEX idx_range_tier ON range_docs (body.tier)",
-    );
+    exec(&rt, "CREATE INDEX idx_range_tier ON range_docs (body.tier)");
 
     // Equality — uses the companion hash index auto-created by BTree.
     let eq = exec(&rt, "SELECT name FROM range_docs WHERE body.tier = 'gold'");
@@ -285,10 +282,7 @@ fn runtime_btree_document_path_range_order_and_limit() {
     assert_eq!(text(&between.result.records[2], "name"), "ddd"); // platinum
 
     // ORDER BY via index: all docs sorted ascending by tier
-    let sorted = exec(
-        &rt,
-        "SELECT name FROM range_docs ORDER BY body.tier",
-    );
+    let sorted = exec(&rt, "SELECT name FROM range_docs ORDER BY body.tier");
     assert_eq!(sorted.result.records.len(), 5, "sorted={sorted:?}");
     assert_eq!(text(&sorted.result.records[0], "name"), "aaa"); // bronze
     assert_eq!(text(&sorted.result.records[4], "name"), "eee"); // silver


### PR DESCRIPTION
Commits work that was sitting uncommitted in the primary checkout (predates today's drain). Two logical commits:

1. **fix(document)**: `indexed_columns_set_with_parents()` — expand dot-path indexes to parent path segments so a change to a root field (e.g. `body`) triggers refresh of nested-path indexes (`body.service.tier`). Wired into impl_dml + ports_impls_entity change-detection. Plus B-tree document index e2e tests (#1400).
2. **docs(data-model)**: Concurrent claim / Resource reservation coordination glossary.

⚠️ **Conflicts with main** in `ports_impls_entity.rs` — today's #1403 (single source of truth) already reworked the same index-detection path. This branch is based on the pre-drain main; the dot-path fix may be partially superseded by #1403 and needs a conscious rebase/reconcile against the body-backed index work before merge. Pushed as-is to preserve the work; not auto-resolving a conflict in code I don't fully own.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785069866&installation_id=129708444&pr_number=1446&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1446&signature=2bb85a12cc9cf8675ce3c868169c47f84bdec0606eb26c0c796f9c2023c9de23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for indexing and querying nested document fields, including range filters, sorting, and top-N results.

* **Bug Fixes**
  * Updated index refresh behavior so changes to parent fields in dotted paths are reflected correctly after inserts, updates, and deletes.
  * Secondary indexes now stay consistent more reliably when related document paths change.

* **Tests**
  * Added end-to-end coverage for nested-field index lookups and index updates during data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->