### PR TITLE
merge: #1244 feat(server): record CPU/RAM occupancy samples

### DIFF
--- a/crates/reddb-server/src/presentation/cluster_status_json.rs
+++ b/crates/reddb-server/src/presentation/cluster_status_json.rs
@@ -153,6 +153,28 @@ pub(crate) struct SystemSnapshot {
     /// `0`.
     pub(crate) total_memory_bytes: Option<u64>,
     pub(crate) available_memory_bytes: Option<u64>,
+    /// Issue #1244 — whole-node CPU utilisation occupancy. `Measured` once
+    /// two samples establish a delta; `NotSampled` on a supported platform
+    /// before then; `Unsupported` where the engine cannot probe it.
+    pub(crate) cpu_usage: OccupancyView,
+    /// Issue #1244 — whole-node RAM utilisation occupancy (used/total).
+    pub(crate) ram_usage: OccupancyView,
+}
+
+/// Presentation-side view of a node occupancy gauge (#1244). Mirrors the
+/// runtime sampler's three honest states without coupling the presentation
+/// layer to the sampler type; the handler maps one to the other.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub(crate) enum OccupancyView {
+    /// Measured utilisation ratio in `0.0..=1.0`.
+    Measured(f64),
+    /// Supported platform, but no measured value yet (CPU needs a delta).
+    /// The honest default — a snapshot built without an occupancy reading
+    /// reports "not sampled", never a fabricated zero.
+    #[default]
+    NotSampled,
+    /// Platform cannot measure this field.
+    Unsupported,
 }
 
 #[derive(Debug, Clone)]
@@ -456,13 +478,50 @@ fn system_json(system: &SystemSnapshot) -> JsonValue {
     );
     object.insert(
         "cpu_usage".to_string(),
-        unavailable_json("cpu_usage_not_sampled"),
+        occupancy_json(
+            system.cpu_usage,
+            "cpu_usage_not_sampled",
+            "cpu_usage_not_supported",
+        ),
     );
     object.insert(
         "ram_usage".to_string(),
-        unavailable_json("ram_usage_not_sampled"),
+        occupancy_json(
+            system.ram_usage,
+            "ram_usage_not_sampled",
+            "ram_usage_not_supported",
+        ),
     );
     JsonValue::Object(object)
+}
+
+/// Render a node occupancy gauge (#1244). A measured value carries both the
+/// raw ratio (`0..=1`) and a convenience percent; the unmeasured states fall
+/// through to the stable `unavailable` envelope (§6) with a reason that
+/// distinguishes "no sample yet" from "platform cannot measure".
+fn occupancy_json(
+    view: OccupancyView,
+    not_sampled_reason: &str,
+    unsupported_reason: &str,
+) -> JsonValue {
+    match view {
+        OccupancyView::Measured(ratio) => {
+            let ratio = ratio.clamp(0.0, 1.0);
+            // Round the ratio to 4 decimals; percent is derived from the
+            // same rounded value so the two never disagree.
+            let ratio = (ratio * 10_000.0).round() / 10_000.0;
+            let mut object = Map::new();
+            object.insert("available".to_string(), JsonValue::Bool(true));
+            object.insert("usage_ratio".to_string(), JsonValue::Number(ratio));
+            object.insert(
+                "usage_percent".to_string(),
+                JsonValue::Number((ratio * 1_000.0).round() / 10.0),
+            );
+            JsonValue::Object(object)
+        }
+        OccupancyView::NotSampled => unavailable_json(not_sampled_reason),
+        OccupancyView::Unsupported => unavailable_json(unsupported_reason),
+    }
 }
 
 fn replication_json(repl: &ReplicationSnapshot, current_lsn: u64) -> JsonValue {
@@ -628,6 +687,8 @@ mod tests {
                 hostname: "test-host".to_string(),
                 total_memory_bytes: Some(16 * 1024 * 1024 * 1024),
                 available_memory_bytes: Some(8 * 1024 * 1024 * 1024),
+                cpu_usage: OccupancyView::NotSampled,
+                ram_usage: OccupancyView::NotSampled,
             },
             replication: ReplicationSnapshot {
                 role: ProcessRoleView::Standalone,
@@ -919,6 +980,68 @@ mod tests {
         assert_eq!(n(lat.get("p95_seconds").unwrap()), 0.2);
         assert_eq!(n(lat.get("p99_seconds").unwrap()), 0.9);
         assert_eq!(n(lat.get("sample_count").unwrap()), 100.0);
+    }
+
+    #[test]
+    fn occupancy_measured_carries_ratio_and_percent() {
+        // #1244 — supported platform with real samples: cpu/ram flip from
+        // the honest envelope to measured values.
+        let mut inputs = base_inputs();
+        inputs.system.cpu_usage = OccupancyView::Measured(0.4237);
+        inputs.system.ram_usage = OccupancyView::Measured(0.75);
+        let json = cluster_status_json(&inputs);
+        let sys = obj(obj(&json).get("system").unwrap());
+
+        let cpu = obj(sys.get("cpu_usage").unwrap());
+        assert_eq!(
+            cpu.get("available").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        assert_eq!(n(cpu.get("usage_ratio").unwrap()), 0.4237);
+        assert_eq!(n(cpu.get("usage_percent").unwrap()), 42.4);
+
+        let ram = obj(sys.get("ram_usage").unwrap());
+        assert_eq!(
+            ram.get("available").and_then(JsonValue::as_bool),
+            Some(true)
+        );
+        assert_eq!(n(ram.get("usage_ratio").unwrap()), 0.75);
+        assert_eq!(n(ram.get("usage_percent").unwrap()), 75.0);
+    }
+
+    #[test]
+    fn occupancy_not_sampled_is_honest_envelope() {
+        // #1244 — supported platform, no measured value yet (CPU needs a
+        // delta; the no-sample-yet branch).
+        let json = cluster_status_json(&base_inputs());
+        let sys = obj(obj(&json).get("system").unwrap());
+        assert_eq!(
+            unavail_reason(sys.get("cpu_usage").unwrap()),
+            "cpu_usage_not_sampled"
+        );
+        assert_eq!(
+            unavail_reason(sys.get("ram_usage").unwrap()),
+            "ram_usage_not_sampled"
+        );
+    }
+
+    #[test]
+    fn occupancy_unsupported_platform_is_honest_envelope() {
+        // #1244 — platform that cannot probe occupancy keeps the
+        // `{ available: false, reason }` envelope with a distinct reason.
+        let mut inputs = base_inputs();
+        inputs.system.cpu_usage = OccupancyView::Unsupported;
+        inputs.system.ram_usage = OccupancyView::Unsupported;
+        let json = cluster_status_json(&inputs);
+        let sys = obj(obj(&json).get("system").unwrap());
+        assert_eq!(
+            unavail_reason(sys.get("cpu_usage").unwrap()),
+            "cpu_usage_not_supported"
+        );
+        assert_eq!(
+            unavail_reason(sys.get("ram_usage").unwrap()),
+            "ram_usage_not_supported"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1229,6 +1229,11 @@ struct RuntimeInner {
     /// model that `/metrics`, `/cluster/status`, and the red-ui percentile
     /// panels all consume; counters reset on restart by design.
     query_latency_telemetry: std::sync::Arc<query_latency_telemetry::QueryLatencyTelemetry>,
+    /// Issue #1244 — node CPU/RAM occupancy sampler (ADR 0060 §2 "node
+    /// samples"). Process-local measurement + current-snapshot read model
+    /// `/cluster/status` consumes; sampled on-demand from the status
+    /// handler. See `occupancy_sampler` for the overhead/interval contract.
+    occupancy_sampler: std::sync::Arc<occupancy_sampler::OccupancySampler>,
     /// Issue #742 — consumer presence (heartbeat / lease / lifecycle
     /// state per (queue, group, consumer)). Process-local in this
     /// slice; durability across restart lands in the follow-up that
@@ -1392,6 +1397,7 @@ pub mod locking;
 pub(crate) mod materialization_limit;
 pub(crate) mod metric_descriptor_catalog;
 pub(crate) mod mutation;
+pub(crate) mod occupancy_sampler;
 pub(crate) mod primary_queue_store;
 mod probabilistic_store;
 pub mod query_audit;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2567,6 +2567,9 @@ impl RedDBRuntime {
                 query_latency_telemetry: Arc::new(
                     crate::runtime::query_latency_telemetry::QueryLatencyTelemetry::default(),
                 ),
+                occupancy_sampler: Arc::new(
+                    crate::runtime::occupancy_sampler::OccupancySampler::new(),
+                ),
                 queue_presence: Arc::new(
                     crate::storage::queue::presence::ConsumerPresenceRegistry::new(),
                 ),
@@ -3724,6 +3727,14 @@ impl RedDBRuntime {
         &self,
     ) -> crate::runtime::query_latency_telemetry::QueryLatencyHistogram {
         self.inner.query_latency_telemetry.rollup()
+    }
+
+    /// Issue #1244 — take a fresh node CPU/RAM occupancy reading for
+    /// `/cluster/status`. CPU utilisation is measured over the interval
+    /// since the previous call (the first call only establishes a baseline
+    /// and reports `NotSampled`). See `occupancy_sampler` for overhead.
+    pub fn sample_occupancy(&self) -> crate::runtime::occupancy_sampler::OccupancySample {
+        self.inner.occupancy_sampler.sample()
     }
 
     /// Issue #742 — consumer presence registry. Heartbeats land here

--- a/crates/reddb-server/src/runtime/occupancy_sampler.rs
+++ b/crates/reddb-server/src/runtime/occupancy_sampler.rs
@@ -1,0 +1,374 @@
+//! Node CPU/RAM occupancy sampler — issue #1244 (PRD #1237, Phase C).
+//!
+//! Records whole-node CPU and RAM utilisation as point-in-time gauges
+//! (ADR 0060 §2 "node samples" data class) so `/cluster/status` can show
+//! current resource pressure. Like the latency slice (#1241) this is the
+//! in-process measurement + current-snapshot read model both the status
+//! surface and the red-ui occupancy panels consume; the durable rollup
+//! substrate is a later slice and counters reset on restart by design.
+//!
+//! ## Honesty rule (#738 / ADR 0060 §6)
+//!
+//! Each field is one of three states, never a fabricated zero:
+//!
+//! * [`Occupancy::Measured`] — a real ratio in `0.0..=1.0`.
+//! * [`Occupancy::NotSampled`] — the platform supports measurement but no
+//!   value exists yet. CPU utilisation is a *delta* between two readings,
+//!   so the very first sample after start only establishes a baseline and
+//!   reports `NotSampled`; the next sample carries a measured value.
+//! * [`Occupancy::Unsupported`] — this platform cannot measure the field
+//!   at all (anything without `/proc/stat` + `/proc/meminfo`, i.e. non-Linux).
+//!
+//! The presentation layer maps these to a measured envelope
+//! (`{ available: true, usage_ratio, usage_percent }`) or the stable
+//! `{ available: false, reason }` envelope.
+//!
+//! ## Sampling interval and overhead (documented)
+//!
+//! The sampler is driven on-demand from the `/cluster/status` handler: each
+//! status read calls [`OccupancySampler::sample`], which reads `/proc/stat`
+//! (one line) and `/proc/meminfo` (two lines) and computes the CPU busy
+//! ratio over the wall-clock interval **since the previous status read**.
+//! red-ui polls `/cluster/status` on its own cadence (a few seconds), so the
+//! CPU figure naturally reflects that polling interval. There is no
+//! background thread: cost is two small `procfs` reads plus integer
+//! arithmetic per status call (well under a millisecond, no allocation on
+//! the hot path beyond the two read buffers, no lock contention outside the
+//! sampler's own short critical sections). Because the window is the
+//! status-poll interval rather than a fixed tick, a value is only reported
+//! once two reads exist — consistent with the honesty rule above.
+
+use std::sync::Mutex;
+
+/// Cumulative CPU jiffies from the aggregate `cpu` line of `/proc/stat`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CpuTimes {
+    /// Sum of every field on the line (busy + idle).
+    total: u64,
+    /// `idle + iowait` — the time the CPU was not doing work.
+    idle: u64,
+}
+
+/// One occupancy field's honest state. See module docs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Occupancy {
+    /// Measured utilisation ratio, clamped to `0.0..=1.0`.
+    Measured(f64),
+    /// Platform supports measurement but no value is available yet.
+    NotSampled,
+    /// This platform cannot measure the field.
+    Unsupported,
+}
+
+/// A point-in-time CPU + RAM occupancy reading.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct OccupancySample {
+    pub cpu: Occupancy,
+    pub ram: Occupancy,
+}
+
+/// Process-local CPU/RAM occupancy sampler. Holds the previous CPU jiffies
+/// reading (for delta computation) and the latest computed sample.
+#[derive(Debug, Default)]
+pub struct OccupancySampler {
+    /// Previous `/proc/stat` reading. `None` before the first sample.
+    prev_cpu: Mutex<Option<CpuTimes>>,
+    /// Latest computed sample, so a consumer can read the current value
+    /// without forcing a fresh measurement.
+    latest: Mutex<Option<OccupancySample>>,
+}
+
+impl OccupancySampler {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Take one measurement, update internal state, and return the sample.
+    pub fn sample(&self) -> OccupancySample {
+        let sample = self.measure();
+        *self
+            .latest
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner()) = Some(sample);
+        sample
+    }
+
+    /// The most recent measured sample, without forcing a new reading.
+    /// Before the first [`sample`](Self::sample) call this reports the
+    /// platform's baseline state (`NotSampled` on Linux, `Unsupported`
+    /// elsewhere) so the honesty rule holds even on the cold path.
+    pub fn latest(&self) -> OccupancySample {
+        self.latest
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .unwrap_or_else(unsampled_baseline)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn measure(&self) -> OccupancySample {
+        let ram = std::fs::read_to_string("/proc/meminfo")
+            .ok()
+            .and_then(|c| parse_meminfo_used_ratio(&c))
+            .map(Occupancy::Measured)
+            .unwrap_or(Occupancy::NotSampled);
+
+        let current = std::fs::read_to_string("/proc/stat")
+            .ok()
+            .and_then(|c| parse_proc_stat_cpu(&c));
+
+        let mut prev = self
+            .prev_cpu
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let cpu = match (*prev, current) {
+            (Some(p), Some(c)) => cpu_busy_ratio(p, c)
+                .map(Occupancy::Measured)
+                .unwrap_or(Occupancy::NotSampled),
+            _ => Occupancy::NotSampled,
+        };
+        if let Some(c) = current {
+            *prev = Some(c);
+        }
+        OccupancySample { cpu, ram }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn measure(&self) -> OccupancySample {
+        OccupancySample {
+            cpu: Occupancy::Unsupported,
+            ram: Occupancy::Unsupported,
+        }
+    }
+}
+
+/// Baseline state reported before any sample exists.
+#[cfg(target_os = "linux")]
+fn unsampled_baseline() -> OccupancySample {
+    OccupancySample {
+        cpu: Occupancy::NotSampled,
+        ram: Occupancy::NotSampled,
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn unsampled_baseline() -> OccupancySample {
+    OccupancySample {
+        cpu: Occupancy::Unsupported,
+        ram: Occupancy::Unsupported,
+    }
+}
+
+/// Parse the aggregate `cpu` line of `/proc/stat` into cumulative jiffies.
+/// Fields after the label are: `user nice system idle iowait irq softirq
+/// steal guest guest_nice`. `idle` here is `idle + iowait`.
+fn parse_proc_stat_cpu(contents: &str) -> Option<CpuTimes> {
+    let line = contents.lines().next()?;
+    let mut fields = line.split_whitespace();
+    if fields.next()? != "cpu" {
+        return None;
+    }
+    let vals: Vec<u64> = fields.filter_map(|v| v.parse::<u64>().ok()).collect();
+    // Need at least user/nice/system/idle to be meaningful.
+    if vals.len() < 4 {
+        return None;
+    }
+    let idle = vals[3] + vals.get(4).copied().unwrap_or(0);
+    let total: u64 = vals.iter().sum();
+    Some(CpuTimes { total, idle })
+}
+
+/// Busy ratio between two cumulative CPU readings. `None` when the totals
+/// did not advance (no elapsed time) or went backwards (counter reset).
+fn cpu_busy_ratio(prev: CpuTimes, current: CpuTimes) -> Option<f64> {
+    let total_delta = current.total.checked_sub(prev.total)?;
+    let idle_delta = current.idle.checked_sub(prev.idle)?;
+    if total_delta == 0 {
+        return None;
+    }
+    let busy = total_delta.saturating_sub(idle_delta);
+    Some((busy as f64 / total_delta as f64).clamp(0.0, 1.0))
+}
+
+/// Parse `MemTotal` / `MemAvailable` from `/proc/meminfo` into a used
+/// ratio (`(total - available) / total`). `None` if either line is missing
+/// or `MemTotal` is zero.
+fn parse_meminfo_used_ratio(contents: &str) -> Option<f64> {
+    let mut total: Option<u64> = None;
+    let mut available: Option<u64> = None;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("MemTotal:") {
+            total = rest.split_whitespace().next().and_then(|v| v.parse().ok());
+        } else if let Some(rest) = line.strip_prefix("MemAvailable:") {
+            available = rest.split_whitespace().next().and_then(|v| v.parse().ok());
+        }
+    }
+    let total = total?;
+    let available = available?;
+    if total == 0 {
+        return None;
+    }
+    let used = total.saturating_sub(available);
+    Some((used as f64 / total as f64).clamp(0.0, 1.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_proc_stat_sums_total_and_idle() {
+        // user nice system idle iowait irq softirq steal ...
+        let stat = "cpu  100 0 50 800 40 0 10 0 0 0\ncpu0 ...\n";
+        let times = parse_proc_stat_cpu(stat).unwrap();
+        // idle = idle(800) + iowait(40) = 840
+        assert_eq!(times.idle, 840);
+        // total = 100+0+50+800+40+0+10+0+0+0 = 1000
+        assert_eq!(times.total, 1000);
+    }
+
+    #[test]
+    fn parse_proc_stat_rejects_malformed() {
+        assert!(parse_proc_stat_cpu("").is_none());
+        assert!(parse_proc_stat_cpu("notcpu 1 2 3 4\n").is_none());
+        assert!(parse_proc_stat_cpu("cpu 1 2\n").is_none());
+    }
+
+    #[test]
+    fn cpu_ratio_is_busy_over_total() {
+        let prev = CpuTimes {
+            total: 1000,
+            idle: 840,
+        };
+        // 1000 more jiffies elapse, 250 of them idle -> 75% busy.
+        let current = CpuTimes {
+            total: 2000,
+            idle: 1090,
+        };
+        let ratio = cpu_busy_ratio(prev, current).unwrap();
+        assert!((ratio - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cpu_ratio_none_when_no_time_elapsed() {
+        let t = CpuTimes {
+            total: 1000,
+            idle: 840,
+        };
+        assert_eq!(cpu_busy_ratio(t, t), None);
+    }
+
+    #[test]
+    fn cpu_ratio_none_on_counter_reset() {
+        let prev = CpuTimes {
+            total: 2000,
+            idle: 1000,
+        };
+        let current = CpuTimes {
+            total: 1000,
+            idle: 500,
+        };
+        assert_eq!(cpu_busy_ratio(prev, current), None);
+    }
+
+    #[test]
+    fn cpu_ratio_clamps_to_unit_interval() {
+        // Idle advances more than total (impossible in practice but the
+        // arithmetic must never produce a negative ratio).
+        let prev = CpuTimes {
+            total: 1000,
+            idle: 500,
+        };
+        let current = CpuTimes {
+            total: 1100,
+            idle: 800,
+        };
+        let ratio = cpu_busy_ratio(prev, current).unwrap();
+        assert!((0.0..=1.0).contains(&ratio));
+    }
+
+    #[test]
+    fn meminfo_used_ratio_is_one_minus_available() {
+        let meminfo = "MemTotal:       16000 kB\nMemFree:  1000 kB\nMemAvailable:    4000 kB\n";
+        let ratio = parse_meminfo_used_ratio(meminfo).unwrap();
+        // used = 16000 - 4000 = 12000 -> 0.75
+        assert!((ratio - 0.75).abs() < 1e-9);
+    }
+
+    #[test]
+    fn meminfo_none_when_fields_missing() {
+        assert!(parse_meminfo_used_ratio("MemTotal: 16000 kB\n").is_none());
+        assert!(parse_meminfo_used_ratio("MemAvailable: 4000 kB\n").is_none());
+        assert!(parse_meminfo_used_ratio("MemTotal: 0 kB\nMemAvailable: 0 kB\n").is_none());
+    }
+
+    #[test]
+    fn first_sample_establishes_baseline_only() {
+        // The very first sample cannot produce a CPU delta — it must report
+        // NotSampled (Linux) or Unsupported (other) for CPU, never a number.
+        let sampler = OccupancySampler::new();
+        let first = sampler.sample();
+        assert!(
+            !matches!(first.cpu, Occupancy::Measured(_)),
+            "first CPU sample must not be a measured value, got {:?}",
+            first.cpu
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn second_sample_returns_measured_cpu_on_linux() {
+        // Two consecutive reads establish a delta. On an idle CI runner the
+        // busy ratio can legitimately be ~0; assert the value is *measurable*
+        // (a real ratio in the unit interval), not strictly positive.
+        let sampler = OccupancySampler::new();
+        let _ = sampler.sample(); // baseline
+                                  // Burn a little CPU so the second reading reflects real work, but
+                                  // do not assert on the magnitude — the runner may still be idle.
+        let mut acc: u64 = 0;
+        for i in 0..2_000_000u64 {
+            acc = acc.wrapping_add(i);
+        }
+        std::hint::black_box(acc);
+        // Guarantee the aggregate jiffy counter advances between the two
+        // reads so the CPU delta is `Measured`, not `NotSampled`. Without a
+        // wall-clock gap, two back-to-back reads can land in the same jiffy
+        // window on a fast host (`total_delta == 0`); the busy ratio may
+        // still be ~0 on an idle runner, which the range assertion allows.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let second = sampler.sample();
+        match second.cpu {
+            Occupancy::Measured(ratio) => {
+                assert!(
+                    (0.0..=1.0).contains(&ratio),
+                    "cpu ratio {ratio} must be in 0..=1"
+                );
+            }
+            other => panic!("expected a measured CPU ratio on the second sample, got {other:?}"),
+        }
+        // RAM is a single-shot gauge — measurable on the very first read.
+        assert!(
+            matches!(second.ram, Occupancy::Measured(r) if (0.0..=1.0).contains(&r)),
+            "expected a measured RAM ratio on Linux, got {:?}",
+            second.ram
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_baseline_is_not_sampled_before_first_sample() {
+        let sampler = OccupancySampler::new();
+        assert!(matches!(sampler.latest().cpu, Occupancy::NotSampled));
+        assert!(matches!(sampler.latest().ram, Occupancy::NotSampled));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_is_unsupported() {
+        let sampler = OccupancySampler::new();
+        let sample = sampler.sample();
+        assert!(matches!(sample.cpu, Occupancy::Unsupported));
+        assert!(matches!(sample.ram, Occupancy::Unsupported));
+        assert!(matches!(sampler.latest().cpu, Occupancy::Unsupported));
+    }
+}

--- a/crates/reddb-server/src/server/handlers_admin_status.rs
+++ b/crates/reddb-server/src/server/handlers_admin_status.rs
@@ -278,9 +278,10 @@ impl RedDBServer {
     pub(crate) fn handle_cluster_status(&self) -> HttpResponse {
         use crate::presentation::cluster_status_json::{
             cluster_status_json, ClusterStatusInputs, ConnectionSnapshot, DeploymentShapeView,
-            LatencySample, ProcessRoleView, ReplicaView, ReplicationSnapshot, StorageSnapshot,
-            SystemSnapshot, TransportListenerView, TransportSnapshot, WalSnapshot,
+            LatencySample, OccupancyView, ProcessRoleView, ReplicaView, ReplicationSnapshot,
+            StorageSnapshot, SystemSnapshot, TransportListenerView, TransportSnapshot, WalSnapshot,
         };
+        use crate::runtime::occupancy_sampler::Occupancy;
 
         let lifecycle = self.runtime.lifecycle();
         let phase = lifecycle.phase();
@@ -339,6 +340,16 @@ impl RedDBServer {
 
         let (current_lsn, last_archived_lsn) = self.runtime.wal_archive_progress();
 
+        // Issue #1244 — take a fresh node CPU/RAM occupancy reading. CPU is
+        // measured over the interval since the previous status read; map the
+        // sampler's honest three-state result onto the presentation view.
+        let occupancy = self.runtime.sample_occupancy();
+        let occupancy_view = |o: Occupancy| match o {
+            Occupancy::Measured(ratio) => OccupancyView::Measured(ratio),
+            Occupancy::NotSampled => OccupancyView::NotSampled,
+            Occupancy::Unsupported => OccupancyView::Unsupported,
+        };
+
         let system = &runtime_stats.system;
         let system_view = SystemSnapshot {
             pid: system.pid,
@@ -360,6 +371,8 @@ impl RedDBServer {
             } else {
                 Some(system.available_memory_bytes)
             },
+            cpu_usage: occupancy_view(occupancy.cpu),
+            ram_usage: occupancy_view(occupancy.ram),
         };
 
         let replicas = self


### PR DESCRIPTION
Automated AFK landing for #1244. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1244

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785071378&installation_id=129708444&pr_number=1448&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1448&signature=a7afa3aa9adfa49a9a39eccc648b97a0364bd8200fb1349b45f9d1ecc933134e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->