### PR TITLE
chore(afk): enable ci_aware merge — stop failed-CI re-claim churn

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -14,6 +14,17 @@ plugins:
 
     afk:
       # ----------------------------------------------------------------
+      # CI-aware merge (#812). On this enforce_admins base an admin-merge
+      # cannot bypass required checks, so a completed PR whose checks
+      # FAIL or stay PENDING is NOT a merge conflict: mark blocked:ci →
+      # ready-for-human with the PR LEFT OPEN, and never re-run the agent.
+      # Kills the re-claim churn where a failed-CI issue bounced back to
+      # ready-for-agent and a second worker redid the whole thing.
+      # ----------------------------------------------------------------
+      merge:
+        ci_aware: true
+
+      # ----------------------------------------------------------------
       # Backpressure — shell gates that run AFTER the agent's automatic
       # feedback loop (`pnpm test`/cargo check/etc. on touched packages)
       # and BEFORE the merge. If any command exits non-zero, the merge


### PR DESCRIPTION
Enables `plugins.dev.afk.merge.ci_aware: true` in `.red/config.yaml`.

**Why:** with it off (the default), a worker whose PR fails or pends CI had its issue routed through merge-conflict recovery → bounced back to `ready-for-agent` → a second worker redid the whole thing (observed today on #1244/#1345/#1346 — duplicate PRs, wasted tokens).

**Effect:** a completed MERGEABLE PR whose required checks **fail** or stay **pending** past the wait now becomes `blocked:ci` → `ready-for-human` with the **PR left open**, and AFK **never re-runs the agent**. A CI-aware finisher drives the open PR to green instead.

Was applied locally + the running fleet (1.246.3) restarted with it; this commits it so it persists and applies in the AFK CI lanes too.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785077141&installation_id=129708444&pr_number=1465&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1465&signature=481d615a95d659aa447a4b06de207a709f4e98feef84fe196737f184ba93969c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->