### PR TITLE
merge: #1357 test(dst): seeded RNG + buggify!() + determinism meta-test

### DIFF
--- a/crates/reddb-file/src/dst.rs
+++ b/crates/reddb-file/src/dst.rs
@@ -11,7 +11,7 @@ const DEFAULT_BUGGIFY_PPM: u64 = 10_000;
 const PPM_DENOMINATOR: u64 = 1_000_000;
 
 thread_local! {
-    static ACTIVE: RefCell<Option<Rc<RefCell<ActiveSimulation>>>> = RefCell::new(None);
+    static ACTIVE: RefCell<Option<Rc<RefCell<ActiveSimulation>>>> = const { RefCell::new(None) };
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/reddb-file/src/dst.rs
+++ b/crates/reddb-file/src/dst.rs
@@ -1,0 +1,210 @@
+//! Deterministic simulation context for DST fault decisions.
+//!
+//! `buggify!()` is intentionally debug-only. Release builds compile the macro
+//! to `false`, so production crash hooks keep their legacy env-var behavior.
+
+use crate::clock::{Clock, SimClock};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const DEFAULT_BUGGIFY_PPM: u64 = 10_000;
+const PPM_DENOMINATOR: u64 = 1_000_000;
+
+thread_local! {
+    static ACTIVE: RefCell<Option<Rc<RefCell<ActiveSimulation>>>> = RefCell::new(None);
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SimulationContext {
+    seed: u64,
+    clock_start_ms: u64,
+    buggify_ppm: u64,
+}
+
+impl SimulationContext {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            seed,
+            clock_start_ms: seed,
+            buggify_ppm: DEFAULT_BUGGIFY_PPM,
+        }
+    }
+
+    pub fn with_buggify_ppm(seed: u64, buggify_ppm: u64) -> Self {
+        Self {
+            buggify_ppm: buggify_ppm.min(PPM_DENOMINATOR),
+            ..Self::new(seed)
+        }
+    }
+
+    pub fn install(self) -> SimulationGuard {
+        let active = Rc::new(RefCell::new(ActiveSimulation::new(self)));
+        let previous = ACTIVE.with(|slot| slot.replace(Some(Rc::clone(&active))));
+        SimulationGuard { active, previous }
+    }
+}
+
+pub struct SimulationGuard {
+    active: Rc<RefCell<ActiveSimulation>>,
+    previous: Option<Rc<RefCell<ActiveSimulation>>>,
+}
+
+impl SimulationGuard {
+    pub fn trace(&self) -> Vec<u8> {
+        self.active.borrow().trace.clone()
+    }
+}
+
+impl Drop for SimulationGuard {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        ACTIVE.with(|slot| {
+            slot.replace(previous);
+        });
+    }
+}
+
+struct ActiveSimulation {
+    clock: SimClock,
+    rng: SplitMix64,
+    buggify_ppm: u64,
+    tick: u64,
+    trace: Vec<u8>,
+}
+
+impl ActiveSimulation {
+    fn new(context: SimulationContext) -> Self {
+        let mut trace = Vec::new();
+        trace.extend_from_slice(format!("seed={}\n", context.seed).as_bytes());
+        Self {
+            clock: SimClock::from_seed(context.clock_start_ms),
+            rng: SplitMix64::new(context.seed ^ 0x4255_4747_4946_595F), // "BUGGIFY_"
+            buggify_ppm: context.buggify_ppm,
+            tick: 0,
+            trace,
+        }
+    }
+
+    fn boundary(&mut self, env: &str, point: &str, ppm: u64) -> bool {
+        self.tick = self.tick.saturating_add(1);
+        self.clock.advance_ms(1);
+        let roll = self.rng.below(PPM_DENOMINATOR);
+        let threshold = ppm.min(PPM_DENOMINATOR);
+        let fired = roll < threshold;
+        self.trace.extend_from_slice(
+            format!(
+                "tick={} clock_ms={} env={} point={} roll={} ppm={} fired={}\n",
+                self.tick,
+                self.clock.now_unix_millis(),
+                env,
+                point,
+                roll,
+                threshold,
+                fired
+            )
+            .as_bytes(),
+        );
+        fired
+    }
+}
+
+pub fn buggify(env: &str, point: &str) -> bool {
+    ACTIVE.with(|slot| {
+        let Some(active) = slot.borrow().clone() else {
+            return false;
+        };
+        let ppm = { active.borrow().buggify_ppm };
+        let fired = active.borrow_mut().boundary(env, point, ppm);
+        fired
+    })
+}
+
+pub fn buggify_at(env: &str, point: &str, ppm: u64) -> bool {
+    ACTIVE.with(|slot| {
+        let Some(active) = slot.borrow().clone() else {
+            return false;
+        };
+        let fired = active.borrow_mut().boundary(env, point, ppm);
+        fired
+    })
+}
+
+pub fn is_active() -> bool {
+    ACTIVE.with(|slot| slot.borrow().is_some())
+}
+
+#[derive(Debug, Clone)]
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    fn below(&mut self, bound: u64) -> u64 {
+        if bound == 0 {
+            0
+        } else {
+            self.next_u64() % bound
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! buggify {
+    ($env:expr, $point:expr) => {{
+        #[cfg(debug_assertions)]
+        {
+            $crate::dst::buggify($env, $point)
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = ($env, $point);
+            false
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::SimulationContext;
+
+    const ENV: &str = "REDDB_EMBEDDED_RDB_CRASH_AT";
+
+    fn trace_for(seed: u64) -> Vec<u8> {
+        let context = SimulationContext::with_buggify_ppm(seed, 1_000_000);
+        let guard = context.install();
+        assert!(crate::buggify!(ENV, "wal_after_frame_write"));
+        assert!(crate::buggify!(ENV, "wal_after_frame_sync"));
+        assert!(crate::buggify!(ENV, "wal_after_superblock_write"));
+        guard.trace()
+    }
+
+    #[test]
+    fn same_seed_produces_byte_identical_buggify_trace() {
+        let first = trace_for(0x5EED);
+        let second = trace_for(0x5EED);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn buggify_can_fire_at_named_crash_boundary() {
+        let context = SimulationContext::with_buggify_ppm(123, 1_000_000);
+        let guard = context.install();
+        assert!(crate::buggify!(ENV, "snapshot_after_manifest_write"));
+        let trace = String::from_utf8(guard.trace()).unwrap();
+        assert!(trace.contains("env=REDDB_EMBEDDED_RDB_CRASH_AT"));
+        assert!(trace.contains("point=snapshot_after_manifest_write"));
+        assert!(trace.contains("fired=true"));
+    }
+}

--- a/crates/reddb-file/src/embedded.rs
+++ b/crates/reddb-file/src/embedded.rs
@@ -948,6 +948,9 @@ fn crash_inject(point: &str) {
     if std::env::var(CRASH_INJECT_ENV).ok().as_deref() == Some(point) {
         std::process::exit(173);
     }
+    if crate::buggify!(CRASH_INJECT_ENV, point) {
+        std::process::exit(173);
+    }
 }
 
 fn now_unix_ms() -> u128 {

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -26,6 +26,7 @@ pub mod btree_value_layout;
 pub mod clock;
 pub mod column_block;
 pub mod control_store;
+pub mod dst;
 pub mod embedded;
 pub mod file_format;
 pub mod graph_label_registry;
@@ -120,6 +121,7 @@ pub use control_store::{
     DurableLastVote, FileLastVoteStore, FileTermStore, DEFAULT_FILE_TERM, LAST_VOTE_TEMP_EXTENSION,
     TERM_TEMP_EXTENSION,
 };
+pub use dst::SimulationContext;
 pub use embedded::{
     EmbeddedRdbArtifact, EmbeddedRdbManifest, EmbeddedRdbOpen, EmbeddedRdbSuperblock, RdbFileError,
     RdbFileResult, DEFAULT_FORMAT_VERSION, EMBEDDED_RDB_MANIFEST_OFFSET,

--- a/crates/reddb-file/src/primary_replica/mod.rs
+++ b/crates/reddb-file/src/primary_replica/mod.rs
@@ -157,6 +157,9 @@ fn crash_inject(point: &str) {
     {
         std::process::exit(173);
     }
+    if crate::buggify!(PRIMARY_REPLICA_CRASH_INJECT_ENV, point) {
+        std::process::exit(173);
+    }
 }
 
 fn now_unix_nanos() -> u128 {

--- a/crates/reddb-file/src/serverless/mod.rs
+++ b/crates/reddb-file/src/serverless/mod.rs
@@ -198,6 +198,9 @@ fn crash_inject(point: &str) {
     if std::env::var(SERVERLESS_CRASH_INJECT_ENV).ok().as_deref() == Some(point) {
         std::process::exit(173);
     }
+    if crate::buggify!(SERVERLESS_CRASH_INJECT_ENV, point) {
+        std::process::exit(173);
+    }
 }
 
 fn verify_checksum(bytes: &[u8]) -> RdbFileResult<()> {

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -42,6 +42,8 @@ use std::io::{self, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+const TURBO_CRASH_INJECT_ENV: &str = "REDDB_TURBO_CRASH_AT";
+
 /// How a file is opened. Mirrors the subset of `OpenOptions` the durable
 /// writers actually use.
 #[derive(Debug, Clone, Copy)]
@@ -214,7 +216,10 @@ struct SimState {
 }
 
 impl SimState {
-    fn fires(&mut self, ppm: u64) -> bool {
+    fn fires(&mut self, point: &str, ppm: u64) -> bool {
+        if reddb_file::dst::is_active() {
+            return reddb_file::dst::buggify_at(TURBO_CRASH_INJECT_ENV, point, ppm);
+        }
         ppm != 0 && self.rng.below(1_000_000) < ppm
     }
 
@@ -395,7 +400,7 @@ impl VfsFile for SimFileHandle {
         let mut state = self.lock();
         state.charge()?;
         let enospc_ppm = state.cfg.enospc_ppm;
-        if state.fires(enospc_ppm) {
+        if state.fires("simvfs_enospc", enospc_ppm) {
             return Err(enospc_error());
         }
         let offset = usize::try_from(self.pos).unwrap_or(usize::MAX);
@@ -456,8 +461,8 @@ impl VfsFile for SimFileHandle {
         // meant to tolerate and that a correct writer cannot defend against.
         // Both coins are drawn so the seed stream stays stable.
         let (drop_ppm, reorder_ppm) = (state.cfg.drop_fsync_ppm, state.cfg.reorder_fsync_ppm);
-        let dropped = state.fires(drop_ppm);
-        let reordered = state.fires(reorder_ppm);
+        let dropped = state.fires("simvfs_drop_fsync", drop_ppm);
+        let reordered = state.fires("simvfs_reorder_fsync", reorder_ppm);
         if dropped || reordered {
             return Err(fsync_failed_error());
         }
@@ -505,8 +510,8 @@ impl Vfs for SimVfs {
             .remove(from)
             .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "rename source missing"))?;
         let (revert_ppm, torn_ppm) = (state.cfg.revert_rename_ppm, state.cfg.torn_rename_ppm);
-        let revert = state.fires(revert_ppm);
-        let torn = !revert && state.fires(torn_ppm);
+        let revert = state.fires("simvfs_revert_rename", revert_ppm);
+        let torn = !revert && state.fires("simvfs_torn_rename", torn_ppm);
         // POSIX rename is atomic, so the writer's *live* view always sees the
         // full new contents at `to`. The fault only governs what survives a
         // crash before a `sync_dir`: a revert keeps the old durable target, and

--- a/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
+++ b/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
@@ -13,6 +13,7 @@
 
 #![allow(clippy::unwrap_used)]
 
+use reddb_file::SimulationContext;
 use std::path::Path;
 use unreliable_libc::vfs::POWER_CUT_MESSAGE;
 use unreliable_libc::wal_workload::{MANIFEST_FILE_NAME, MANIFEST_TEMP_NAME};
@@ -172,6 +173,27 @@ fn dropped_and_reordered_fsync_never_resurrect_data() {
     for seed in 0..64u64 {
         run_seed(seed, cfg);
     }
+}
+
+#[test]
+fn same_seed_produces_byte_identical_buggify_trace_log() {
+    fn trace_for(seed: u64) -> Vec<u8> {
+        let context = SimulationContext::new(seed);
+        let guard = context.install();
+        let _ = run_seed(seed, config_for(seed));
+        guard.trace()
+    }
+
+    let first = trace_for(4242);
+    let second = trace_for(4242);
+    assert_eq!(
+        first, second,
+        "same seed must produce byte-identical trace logs"
+    );
+
+    let trace = String::from_utf8(first).unwrap();
+    assert!(trace.contains("env=REDDB_TURBO_CRASH_AT"));
+    assert!(trace.contains("point=simvfs_"));
 }
 
 /// Pinned regression: a specific seed whose interleaving previously exercised a


### PR DESCRIPTION
Automated AFK landing for #1357. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1357

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785086550&installation_id=129708444&pr_number=1471&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1471&signature=ee823606270dc846a529e3b535a371f0b249b52be01f91e640f9cf73d62a0d44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->