### PR TITLE
merge: #1365 feat(rql): document partial update via path-targeted SET

### DIFF
--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -342,7 +342,7 @@ impl<'a> Parser<'a> {
         let mut assignment_exprs = Vec::new();
         let mut compound_assignment_ops = Vec::new();
         loop {
-            let col = self.expect_column_ident()?;
+            let col = self.parse_update_assignment_target(target)?;
             let compound_op = if self.consume(&Token::Eq)? {
                 None
             } else {
@@ -448,6 +448,19 @@ impl<'a> Parser<'a> {
             limit,
             suppress_events,
         }))
+    }
+
+    fn parse_update_assignment_target(
+        &mut self,
+        target: UpdateTarget,
+    ) -> Result<String, ParseError> {
+        let mut segments = vec![self.expect_column_ident()?];
+        if matches!(target, UpdateTarget::Documents) {
+            while self.consume(&Token::Dot)? {
+                segments.push(self.expect_column_ident()?);
+            }
+        }
+        Ok(segments.join("."))
     }
 
     fn parse_update_target(&mut self) -> Result<UpdateTarget, ParseError> {

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2091,6 +2091,20 @@ fn test_parse_update_explicit_item_targets() {
 }
 
 #[test]
+fn test_parse_update_documents_path_target_round_trips() {
+    let sql = "UPDATE docs DOCUMENTS SET profile.address.city = 'Lisbon' WHERE name = 'ada'";
+    let query = parse(sql).unwrap();
+    let QueryExpr::Update(update) = &query else {
+        panic!("Expected UpdateQuery");
+    };
+
+    assert_eq!(update.target, crate::ast::UpdateTarget::Documents);
+    assert_eq!(update.assignment_exprs[0].0, "profile.address.city");
+    assert_eq!(update.assignments[0].0, "profile.address.city");
+    assert_eq!(crate::renderer::render(&query), sql);
+}
+
+#[test]
 fn test_parse_update_from_any_remains_rejected() {
     let err = parse("UPDATE FROM ANY SET status = 'bad'").unwrap_err();
     assert!(err.to_string().contains("expected: identifier"));

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -11,7 +11,8 @@
 //! ```
 
 use crate::ast::{
-    CompareOp, FieldRef, Filter, InsertQuery, Projection, QueryExpr, QueueCommand, TableQuery,
+    BinOp, CompareOp, Expr, FieldRef, Filter, InsertQuery, Projection, QueryExpr, QueueCommand,
+    TableQuery, UpdateQuery, UpdateTarget,
 };
 use reddb_types::types::Value;
 
@@ -22,6 +23,7 @@ pub fn render(expr: &QueryExpr) -> String {
     match expr {
         QueryExpr::Table(tq) => render_table(tq),
         QueryExpr::Insert(iq) => render_insert(iq),
+        QueryExpr::Update(uq) => render_update(uq),
         QueryExpr::QueueCommand(qc) => render_queue_command(qc),
         _ => String::new(),
     }
@@ -67,12 +69,97 @@ fn render_insert(iq: &InsertQuery) -> String {
     )
 }
 
+fn render_update(uq: &UpdateQuery) -> String {
+    let mut sql = format!("UPDATE {}", uq.table);
+    if let Some(target) = render_update_target(uq.target) {
+        sql.push(' ');
+        sql.push_str(target);
+    }
+    sql.push_str(" SET ");
+    let assignments = uq
+        .assignment_exprs
+        .iter()
+        .enumerate()
+        .map(|(idx, (column, expr))| {
+            let op = uq
+                .compound_assignment_ops
+                .get(idx)
+                .copied()
+                .flatten()
+                .map(render_compound_assignment_op)
+                .unwrap_or("=");
+            format!("{} {} {}", column, op, render_expr_sql(expr))
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    sql.push_str(&assignments);
+    if let Some(filter) = &uq.filter {
+        sql.push_str(" WHERE ");
+        sql.push_str(&render_filter(filter));
+    }
+    sql
+}
+
+fn render_update_target(target: UpdateTarget) -> Option<&'static str> {
+    match target {
+        UpdateTarget::Rows => None,
+        UpdateTarget::Documents => Some("DOCUMENTS"),
+        UpdateTarget::Kv => Some("KV"),
+        UpdateTarget::Nodes => Some("NODES"),
+        UpdateTarget::Edges => Some("EDGES"),
+    }
+}
+
+fn render_compound_assignment_op(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+=",
+        BinOp::Sub => "-=",
+        BinOp::Mul => "*=",
+        BinOp::Div => "/=",
+        BinOp::Mod => "%=",
+        _ => "=",
+    }
+}
+
 fn render_queue_command(qc: &QueueCommand) -> String {
     match qc {
         QueueCommand::Push { queue, value, .. } => {
             format!("QUEUE PUSH {} {}", queue, render_value_sql(value))
         }
         _ => String::new(),
+    }
+}
+
+fn render_expr_sql(expr: &Expr) -> String {
+    match expr {
+        Expr::Literal { value, .. } => render_value_sql(value),
+        Expr::Column { field, .. } => render_field_ref(field),
+        Expr::BinaryOp { op, lhs, rhs, .. } => format!(
+            "{} {} {}",
+            render_expr_sql(lhs),
+            render_bin_op(*op),
+            render_expr_sql(rhs)
+        ),
+        _ => "NULL".to_string(),
+    }
+}
+
+fn render_bin_op(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Mod => "%",
+        BinOp::Eq => "=",
+        BinOp::Ne => "!=",
+        BinOp::Lt => "<",
+        BinOp::Le => "<=",
+        BinOp::Gt => ">",
+        BinOp::Ge => ">=",
+        BinOp::And => "AND",
+        BinOp::Or => "OR",
+        _ => "",
     }
 }
 

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1242,6 +1242,16 @@ fn document_body_from_named(fields: &HashMap<String, Value>) -> RedDBResult<Json
     }
 }
 
+fn document_body_set_operation(column: &str, value: Value) -> PatchEntityOperation {
+    PatchEntityOperation {
+        op: PatchEntityOperationType::Set,
+        path: column.split('.').map(str::to_string).collect(),
+        value: Some(crate::presentation::entity_json::storage_value_to_json(
+            &value,
+        )),
+    }
+}
+
 fn replace_document_row_body(
     fields: &mut HashMap<String, Value>,
     body: JsonValue,
@@ -1966,39 +1976,39 @@ impl RedDBRuntime {
             .collection_contract(&collection)
             .map(|contract| contract.declared_model == crate::catalog::CollectionModel::Document)
             .unwrap_or(false);
-        let document_body_updates: Vec<(String, Value)> = if is_document_collection {
-            static_field_assignments
-                .iter()
-                .cloned()
-                .chain(dynamic_field_assignments.iter().cloned())
-                .filter(|(column, _)| column != "body")
-                .collect()
-        } else {
-            Vec::new()
-        };
-
-        apply_row_field_assignments_raw(row, static_field_assignments.iter().cloned());
-        apply_row_field_assignments_raw(row, dynamic_field_assignments);
-
-        if !document_body_updates.is_empty() {
-            let named = row.named.get_or_insert_with(Default::default);
-            let mut body = document_body_from_named(named)?;
-            if let JsonValue::Object(map) = &mut body {
-                for (column, value) in &document_body_updates {
-                    map.insert(
-                        column.clone(),
-                        crate::presentation::entity_json::storage_value_to_json(value),
-                    );
+        let mut static_row_assignments = Vec::new();
+        let mut dynamic_row_assignments = Vec::new();
+        let mut document_body_ops = Vec::new();
+        if is_document_collection {
+            for (column, value) in static_field_assignments.iter().cloned() {
+                if column == "body" {
+                    static_row_assignments.push((column, value));
+                } else {
+                    document_body_ops.push(document_body_set_operation(&column, value));
                 }
             }
-            let body_bytes = json_to_vec(&body).map_err(|err| {
-                crate::RedDBError::Query(format!("failed to serialize document body: {err}"))
-            })?;
-            named.insert("body".to_string(), Value::Json(body_bytes));
-            context_index_dirty = true;
-            if !modified_columns.iter().any(|column| column == "body") {
-                modified_columns.push("body".to_string());
+            for (column, value) in dynamic_field_assignments {
+                if column == "body" {
+                    dynamic_row_assignments.push((column, value));
+                } else {
+                    document_body_ops.push(document_body_set_operation(&column, value));
+                }
             }
+        } else {
+            static_row_assignments.extend(static_field_assignments.iter().cloned());
+            dynamic_row_assignments = dynamic_field_assignments;
+        }
+
+        apply_row_field_assignments_raw(row, static_row_assignments);
+        apply_row_field_assignments_raw(row, dynamic_row_assignments);
+
+        if !document_body_ops.is_empty() {
+            let named = row.named.get_or_insert_with(Default::default);
+            let mut body = document_body_from_named(named)?;
+            apply_patch_operations_to_json(&mut body, &document_body_ops)
+                .map_err(crate::RedDBError::Query)?;
+            replace_document_row_body(named, body, &mut modified_columns)?;
+            context_index_dirty = true;
         }
 
         for (key, value) in static_metadata_assignments

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -352,6 +352,30 @@ fn document_update_keeps_body_json_in_sync_with_promoted_column() {
 }
 
 #[test]
+fn document_path_update_keeps_nested_sibling_fields() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT body_path_docs");
+    exec(
+        &rt,
+        r#"INSERT INTO body_path_docs DOCUMENT (body)
+           VALUES ('{"name":"doc","profile":{"address":{"city":"Porto","zip":"4000"},"active":true},"keep":"me"}')"#,
+    );
+
+    let updated = exec(
+        &rt,
+        "UPDATE body_path_docs DOCUMENTS SET profile.address.city = 'Lisbon' WHERE name = 'doc'",
+    );
+    assert_eq!(updated.affected_rows, 1);
+
+    let with_body = exec(&rt, "SELECT body FROM body_path_docs WHERE name = 'doc'");
+    let body = json_field(only_record(&with_body), "body");
+    assert_eq!(body["profile"]["address"]["city"].as_str(), Some("Lisbon"));
+    assert_eq!(body["profile"]["address"]["zip"].as_str(), Some("4000"));
+    assert_eq!(body["profile"]["active"].as_bool(), Some(true));
+    assert_eq!(body["keep"].as_str(), Some("me"));
+}
+
+#[test]
 fn document_compound_update_keeps_body_json_in_sync() {
     let rt = runtime();
     exec(&rt, "CREATE DOCUMENT body_compound_docs");


### PR DESCRIPTION
Automated AFK landing for #1365. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785087333&installation_id=129708444&pr_number=1472&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1472&signature=aa32db60e9dfdcf23ac70ad28d0588d0fb59d62d1dd6ff458234ed306e738eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->