### PR TITLE
fix(migrations): align native migration contracts

### DIFF
--- a/crates/reddb-rql/src/modes/detect.rs
+++ b/crates/reddb-rql/src/modes/detect.rs
@@ -349,6 +349,7 @@ mod tests {
         assert_eq!(detect_mode("SHOW INDICES"), QueryMode::Sql);
         assert_eq!(detect_mode("SHOW INDEXES"), QueryMode::Sql);
         assert_eq!(detect_mode("SHOW STATS users"), QueryMode::Sql);
+        assert_eq!(detect_mode("EXPLAIN MIGRATION *"), QueryMode::Sql);
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/migration.rs
+++ b/crates/reddb-rql/src/parser/migration.rs
@@ -35,11 +35,20 @@ impl<'a> Parser<'a> {
                     }
                 }
             } else if self.consume_ident_ci("BATCH")? {
-                if let Token::Integer(n) = self.peek().clone() {
-                    self.advance()?;
-                    batch_size = Some(n as u64);
-                }
-                self.consume(&Token::Rows)?;
+                let n = match self.peek().clone() {
+                    Token::Integer(n) if n > 0 => {
+                        self.advance()?;
+                        n as u64
+                    }
+                    _ => {
+                        return Err(ParseError::new(
+                            "expected positive BATCH size".to_string(),
+                            self.position(),
+                        ));
+                    }
+                };
+                self.expect(Token::Rows)?;
+                batch_size = Some(n);
             } else if self.consume_ident_ci("NO")? {
                 let _ = self.consume(&Token::Rollback)? || self.consume_ident_ci("ROLLBACK")?;
                 no_rollback = true;
@@ -128,7 +137,11 @@ impl<'a> Parser<'a> {
     /// Parse: EXPLAIN MIGRATION name  (called after EXPLAIN is consumed)
     pub fn parse_explain_migration_after_keyword(&mut self) -> Result<QueryExpr, ParseError> {
         self.consume_ident_ci("MIGRATION")?;
-        let name = self.expect_ident()?;
+        let name = if self.consume(&Token::Star)? {
+            "*".to_string()
+        } else {
+            self.expect_ident()?
+        };
         Ok(QueryExpr::ExplainMigration(ExplainMigrationQuery { name }))
     }
 

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -5560,6 +5560,9 @@ fn test_parse_migration_forms() {
     let query = parse("EXPLAIN MIGRATION m2").unwrap();
     assert!(matches!(query, QueryExpr::ExplainMigration(e) if e.name == "m2"));
 
+    let query = parse("EXPLAIN MIGRATION *").unwrap();
+    assert!(matches!(query, QueryExpr::ExplainMigration(e) if e.name == "*"));
+
     let query = parse("APPLY MIGRATION m2 FOR TENANT 'tenant-string'").unwrap();
     assert!(matches!(
         query,
@@ -5578,6 +5581,13 @@ fn test_parse_migration_forms() {
                 && !migration.no_rollback
                 && migration.body == "CREATE INDEX idx ON accounts ( id )"
     ));
+
+    let err = parse("CREATE MIGRATION m4 BATCH 0 ROWS AS UPDATE accounts SET done = true")
+        .expect_err("BATCH 0 ROWS must be rejected");
+    assert!(
+        err.to_string().contains("positive BATCH size"),
+        "unexpected error: {err}"
+    );
 
     for sql in [
         "APPLY m2",

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1940,12 +1940,13 @@ fn query_expr_result_cache_scopes(expr: &QueryExpr) -> HashSet<String> {
 /// ASCII case-insensitive substring match. False positives (the
 /// token appears in a quoted string) only skip caching, which is
 /// the conservative direction.
-/// If `sql` starts with `EXPLAIN` followed by a non-`ALTER` token,
+/// If `sql` starts with `EXPLAIN` followed by a generic explainable statement,
 /// return the trimmed inner statement; otherwise `None`.
 ///
 /// `EXPLAIN ALTER FOR CREATE TABLE ...` is a separate schema-diff
 /// command handled inside the normal SQL parser, so we leave it
-/// alone here.
+/// alone here. `EXPLAIN ASK` and `EXPLAIN MIGRATION` are also executable
+/// read paths handled by the parser/runtime directly.
 fn strip_explain_prefix(sql: &str) -> Option<&str> {
     let trimmed = sql.trim_start();
     let (head, rest) = trimmed.split_at(
@@ -1960,12 +1961,12 @@ fn strip_explain_prefix(sql: &str) -> Option<&str> {
     if rest.is_empty() {
         return None;
     }
-    // Peek the next token — if ALTER or ASK, defer to the normal parser.
-    // `EXPLAIN ASK` is an executable read path: it runs retrieval and
-    // provider selection, then short-circuits before the LLM call.
+    // Peek the next token; command-specific EXPLAIN forms defer to
+    // the normal parser.
     let next_head_end = rest.find(|c: char| c.is_whitespace()).unwrap_or(rest.len());
     if rest[..next_head_end].eq_ignore_ascii_case("ALTER")
         || rest[..next_head_end].eq_ignore_ascii_case("ASK")
+        || rest[..next_head_end].eq_ignore_ascii_case("MIGRATION")
     {
         return None;
     }

--- a/crates/reddb-server/src/runtime/impl_migrations.rs
+++ b/crates/reddb-server/src/runtime/impl_migrations.rs
@@ -236,7 +236,11 @@ impl RedDBRuntime {
         fields.insert("status".to_string(), Value::text("pending"));
         fields.insert(
             "kind".to_string(),
-            Value::text(if q.no_rollback { "data" } else { "ddl" }),
+            Value::text(if q.batch_size.is_some() {
+                "data"
+            } else {
+                "schema"
+            }),
         );
         fields.insert("body".to_string(), Value::text(q.body.as_str()));
         fields.insert(
@@ -559,17 +563,30 @@ impl RedDBRuntime {
             }
             Ok(rows_processed) => {
                 let author = migration_author(self);
-                let commit_hash = self
-                    .vcs_commit(CreateCommitInput {
-                        connection_id: 0,
-                        message: format!("migration: {name}"),
-                        author,
-                        committer: None,
-                        amend: false,
-                        allow_empty: true,
-                    })
-                    .map(|c| c.hash)
-                    .unwrap_or_default();
+                let commit_hash = match self.vcs_commit(CreateCommitInput {
+                    connection_id: 0,
+                    message: format!("migration: apply {name}"),
+                    author,
+                    committer: None,
+                    amend: false,
+                    allow_empty: true,
+                }) {
+                    Ok(commit) => commit.hash,
+                    Err(e) => {
+                        let err_msg = format!("VCS commit failed: {e}");
+                        let _ =
+                            update_migration_field(store, name, "status", Value::text("failed"));
+                        let _ = update_migration_field(
+                            store,
+                            name,
+                            "error",
+                            Value::text(err_msg.as_str()),
+                        );
+                        return Err(RedDBError::Query(format!(
+                            "migration '{name}' applied but {err_msg}"
+                        )));
+                    }
+                };
 
                 let _ = update_migration_field(store, name, "status", Value::text("applied"));
                 let _ =
@@ -714,16 +731,41 @@ impl RedDBRuntime {
             )));
         }
 
+        for (migration, dep) in load_all_edges(store) {
+            if dep != q.name {
+                continue;
+            }
+            let Some((_, dependent_fields)) = find_migration(store, &migration) else {
+                continue;
+            };
+            if dependent_fields.get("status").and_then(|v| val_text(v)) == Some("applied") {
+                return Err(RedDBError::Query(format!(
+                    "cannot rollback '{}' - applied migration '{}' depends on it",
+                    q.name, migration
+                )));
+            }
+        }
+
         let commit_hash = fields
             .get("vcs_commit_hash")
             .and_then(|v| val_text(v))
             .unwrap_or("")
             .to_string();
 
-        if !commit_hash.is_empty() {
-            let author = migration_author(self);
-            let _ = self.vcs_revert(0, &commit_hash, author);
+        if commit_hash.is_empty() {
+            return Err(RedDBError::Query(format!(
+                "migration '{}' has no VCS commit hash to revert",
+                q.name
+            )));
         }
+
+        let author = migration_author(self);
+        self.vcs_revert(0, &commit_hash, author).map_err(|e| {
+            RedDBError::Query(format!(
+                "rollback of migration '{}' failed: VCS revert failed: {e}",
+                q.name
+            ))
+        })?;
 
         let _ = update_migration_field(store, &q.name, "status", Value::text("pending"));
         let _ = update_migration_field(store, &q.name, "applied_at", Value::Null);
@@ -745,25 +787,6 @@ impl RedDBRuntime {
         let store_arc = self.inner.db.store();
         let store: &UnifiedStore = &store_arc;
 
-        let (_, fields) = find_migration(store, &q.name)
-            .ok_or_else(|| RedDBError::NotFound(format!("migration '{}' not found", q.name)))?;
-
-        let status = fields
-            .get("status")
-            .and_then(|v| val_text(v))
-            .unwrap_or("unknown")
-            .to_string();
-        let body = fields
-            .get("body")
-            .and_then(|v| val_text(v))
-            .unwrap_or("")
-            .to_string();
-        let kind = fields
-            .get("kind")
-            .and_then(|v| val_text(v))
-            .unwrap_or("ddl")
-            .to_string();
-
         let columns = vec![
             "migration".to_string(),
             "status".to_string(),
@@ -773,20 +796,51 @@ impl RedDBRuntime {
             "lock_duration_ms".to_string(),
         ];
 
-        let row: Vec<(String, Value)> = vec![
-            ("migration".to_string(), Value::text(q.name.as_str())),
-            ("status".to_string(), Value::text(status.as_str())),
-            ("kind".to_string(), Value::text(kind.as_str())),
-            ("body".to_string(), Value::text(body.as_str())),
-            ("estimated_rows".to_string(), Value::Null),
-            ("lock_duration_ms".to_string(), Value::UnsignedInteger(0)),
-        ];
+        if q.name == "*" {
+            let mut rows = Vec::new();
+            for name in self.collect_pending_migrations(store) {
+                let Some((_, fields)) = find_migration(store, &name) else {
+                    continue;
+                };
+                rows.push(explain_migration_row(&name, &fields));
+            }
+            return Ok(RuntimeQueryResult::ok_records(
+                raw_query.to_string(),
+                columns,
+                rows,
+                "explain_migration",
+            ));
+        }
+
+        let (_, fields) = find_migration(store, &q.name)
+            .ok_or_else(|| RedDBError::NotFound(format!("migration '{}' not found", q.name)))?;
 
         Ok(RuntimeQueryResult::ok_records(
             raw_query.to_string(),
             columns,
-            vec![row],
+            vec![explain_migration_row(&q.name, &fields)],
             "explain_migration",
         ))
     }
+}
+
+fn explain_migration_row(name: &str, fields: &HashMap<String, Value>) -> Vec<(String, Value)> {
+    let status = fields
+        .get("status")
+        .and_then(|v| val_text(v))
+        .unwrap_or("unknown");
+    let body = fields.get("body").and_then(|v| val_text(v)).unwrap_or("");
+    let kind = fields
+        .get("kind")
+        .and_then(|v| val_text(v))
+        .unwrap_or("schema");
+
+    vec![
+        ("migration".to_string(), Value::text(name)),
+        ("status".to_string(), Value::text(status)),
+        ("kind".to_string(), Value::text(kind)),
+        ("body".to_string(), Value::text(body)),
+        ("estimated_rows".to_string(), Value::Null),
+        ("lock_duration_ms".to_string(), Value::UnsignedInteger(0)),
+    ]
 }

--- a/docs/migrations/commands.md
+++ b/docs/migrations/commands.md
@@ -30,7 +30,7 @@ rollback_migration :=
     ROLLBACK MIGRATION <name>
 
 explain_migration :=
-    EXPLAIN MIGRATION <name>
+    EXPLAIN MIGRATION ( <name> | * )
 
 name   := identifier | quoted_identifier
 dep    := identifier | quoted_identifier
@@ -88,9 +88,10 @@ ERROR: unknown migration 'add_score_column' referenced in DEPENDS ON
 #### `BATCH <n> ROWS`
 
 Marks this migration as a batched data migration. `n` must be a positive
-integer. When applied, RedDB rewrites the body's `WHERE` clause to add
-`LIMIT n` and loops until no rows remain, persisting the `rows_processed`
-checkpoint after each iteration.
+integer. The body must currently be a single idempotent `UPDATE` statement.
+When applied, RedDB appends `LIMIT n` and loops until no rows remain,
+persisting the `rows_processed` checkpoint after each iteration. Batched
+`DELETE` bodies are not supported yet.
 
 See [Data Migrations](./data-migrations.md) for full mechanics.
 
@@ -187,9 +188,11 @@ AS
 **Batched and irreversible**
 
 ```sql
-CREATE MIGRATION purge_deleted_users BATCH 1000 ROWS NO ROLLBACK
+CREATE MIGRATION redact_deleted_users BATCH 1000 ROWS NO ROLLBACK
 AS
-  DELETE FROM users WHERE deleted_at < now() - INTERVAL '2 years';
+  UPDATE users
+  SET email = NULL, display_name = NULL
+  WHERE deleted_at IS NOT NULL AND email IS NOT NULL;
 ```
 
 ---
@@ -239,19 +242,26 @@ APPLY MIGRATION backfill_scores FOR TENANT 'tenant-42';
 
 `<id>` may be a string or integer, matching the type of your RLS tenant key.
 
+Current limitation: migration status is still global in `red_migrations`.
+After a tenant-scoped apply succeeds, the migration is `status = 'applied'`
+for the whole database and later attempts for other tenants are treated as
+already applied. There is no `red_migration_tenants` per-tenant status table
+yet.
+
 ### `FOR TENANT *`
 
-Fans out the migration to every known tenant. RedDB iterates the tenant
-registry, sets the RLS context to each tenant in turn, and executes the
-migration body. Progress is tracked per tenant in `rows_processed`.
+Iterates known tenants and sets the RLS context for each tenant in turn.
+Because migration status is global today, this is not an independent
+per-tenant fanout mechanism: after the first successful tenant applies the
+migration, subsequent tenants may see the migration as already applied.
+Use this form carefully until per-tenant migration state is implemented.
 
 ```sql
 APPLY MIGRATION backfill_scores FOR TENANT *;
 ```
 
-If the migration fails for one tenant, that tenant's row is marked `failed`
-and the fanout continues to remaining tenants. A summary of failures is
-returned at the end.
+The result is a textual per-tenant summary, not a durable per-tenant progress
+table.
 
 ### Permissions
 
@@ -259,14 +269,17 @@ returned at the end.
 
 ### What happens on success
 
-- The SQL body is executed within a transaction.
+- The SQL body is executed.
 - `status` is updated to `'applied'`, `applied_at` is set.
 - A VCS commit is created. The commit message is:
-  `migration: apply <name>` (or `migration: apply <name> tenant <id>` for
-  tenant-scoped applications).
+  `migration: apply <name>`.
 - `vcs_commit_hash` is set to the new commit's hash.
 - For batched migrations, `rows_processed` is updated incrementally during
   execution.
+
+If the body succeeds but the VCS commit fails, the command returns an error,
+records the migration as `failed`, and stores the commit error in
+`red_migrations.error`.
 
 ### Examples
 
@@ -277,10 +290,11 @@ APPLY MIGRATION create_accounts_table;
 -- Apply all pending in dependency order
 APPLY MIGRATION *;
 
--- Apply to a specific tenant
+-- Apply with a specific tenant RLS context.
+-- Status is still global after success.
 APPLY MIGRATION backfill_display_name FOR TENANT 'acme-corp';
 
--- Fan out to all tenants
+-- Iterate known tenants with the same global migration status limitation.
 APPLY MIGRATION backfill_display_name FOR TENANT *;
 ```
 
@@ -316,7 +330,7 @@ If another migration depends on the target and is currently `applied`, the
 command returns:
 
 ```
-ERROR: cannot rollback 'add_score_column' — applied migration 'add_score_index' depends on it
+ERROR: cannot rollback 'add_score_column' - applied migration 'add_score_index' depends on it
 ```
 
 You must roll back dependents first, in reverse dependency order.
@@ -340,10 +354,9 @@ ROLLBACK MIGRATION add_archived_at;
 
 ## `EXPLAIN MIGRATION`
 
-Returns the full execution plan for a migration without running it. Shows the
-resolved dependency chain, the SQL that will be executed, estimated row
-counts for data migrations, inferred vs explicit dependency edges, and the
-batch strategy if applicable.
+Returns the current stored migration plan without running it. The current
+output is intentionally basic: migration name, status, kind, body, estimated
+rows, and lock duration.
 
 ```sql
 EXPLAIN MIGRATION backfill_scores;
@@ -353,15 +366,12 @@ EXPLAIN MIGRATION backfill_scores;
 
 | Field | Description |
 |---|---|
-| `name` | Migration name |
+| `migration` | Migration name |
 | `status` | Current status |
-| `no_rollback` | Whether ROLLBACK is blocked |
-| `batch_size` | Batch size, or null |
-| `dependency_chain` | Ordered list of migrations that must be applied first |
-| `dependencies` | Array of `{ name, status, inferred }` objects |
+| `kind` | `schema` or `data` |
 | `body` | The SQL that will be executed |
-| `estimated_rows` | Row count estimate from the query planner (data migrations) |
-| `execution_plan` | Query plan for each statement in the body |
+| `estimated_rows` | Reserved for future planner estimates; currently null |
+| `lock_duration_ms` | Reserved for future lock estimates; currently 0 |
 
 ### Permissions
 
@@ -379,7 +389,7 @@ EXPLAIN MIGRATION *;
 ```
 
 `EXPLAIN MIGRATION *` returns the full topological order of all pending
-migrations with their estimated execution costs.
+migrations using the same output fields.
 
 ---
 
@@ -392,7 +402,7 @@ migrations with their estimated execution costs.
 | `cycle detected: <a> → <b> → ... → <a>` | New edges would create a DAG cycle |
 | `migration '<name>' has unresolved dependency '<dep>'` | Dependency is `pending` or `failed` |
 | `migration '<name>' is marked NO ROLLBACK` | `ROLLBACK MIGRATION` on a `NO ROLLBACK` migration |
-| `cannot rollback '<name>' — applied migration '<dep>' depends on it` | Dependent migration is still applied |
+| `cannot rollback '<name>' - applied migration '<dep>' depends on it` | Dependent migration is still applied |
 | `migration '<name>' not found` | Any command referencing a non-existent migration name |
 | `insufficient privileges — Admin role required` | `APPLY` or `ROLLBACK` without Admin role |
 | `insufficient privileges — Write role required` | `CREATE MIGRATION` without Write role |

--- a/docs/migrations/data-migrations.md
+++ b/docs/migrations/data-migrations.md
@@ -15,7 +15,7 @@ engine.
 When you declare `BATCH N ROWS`, RedDB does not execute the body as a single
 statement. It rewrites the body into an iterative loop:
 
-1. Execute the body with `LIMIT N` appended to the `WHERE` clause.
+1. Execute the body with `LIMIT N` appended to the statement.
 2. Count the affected rows. Persist `rows_processed += count` to
    `red_migrations`.
 3. If the affected count equals `N`, there may be more rows. Go to step 1.
@@ -29,9 +29,10 @@ checkpoint.
 
 ### The loop body requirement
 
-The body of a batched migration must be a single `UPDATE` or `DELETE`
+The body of a batched migration must currently be a single `UPDATE`
 statement with a `WHERE` clause that filters for unprocessed rows. RedDB
-appends `LIMIT N` to that `WHERE` clause.
+appends `LIMIT N` to the statement. Batched `DELETE` bodies are not supported
+yet.
 
 ```sql
 -- Correct: the WHERE clause identifies unprocessed rows
@@ -138,7 +139,10 @@ For these cases, declare `NO ROLLBACK`:
 ```sql
 CREATE MIGRATION purge_deleted_accounts BATCH 500 ROWS NO ROLLBACK
 AS
-  DELETE FROM users WHERE deleted_at < now() - INTERVAL '90 days';
+  UPDATE users
+  SET email = NULL, display_name = NULL
+  WHERE deleted_at < now() - INTERVAL '90 days'
+    AND email IS NOT NULL;
 ```
 
 Attempting to roll back this migration returns:
@@ -202,8 +206,6 @@ granularity.
   contention.
 - Prefer smaller batches if the table receives heavy writes during the migration
   — shorter lock windows reduce the chance of blocking application queries.
-- For pure `DELETE` purges on append-only or low-write tables, 10,000–50,000
-  rows per batch is usually fine.
 - Never use `BATCH 1 ROW` — the per-row overhead of the checkpoint write
   dominates.
 
@@ -211,8 +213,8 @@ granularity.
 
 ## Multi-statement bodies in data migrations
 
-`BATCH N ROWS` applies to the first (and typically only) DML statement in
-the body. If you need to update multiple tables in a coordinated migration,
+`BATCH N ROWS` applies to one `UPDATE` statement. If you need to update
+multiple tables in a coordinated migration,
 write separate migrations with explicit `DEPENDS ON`:
 
 ```sql

--- a/docs/migrations/dependency-graph.md
+++ b/docs/migrations/dependency-graph.md
@@ -149,33 +149,30 @@ dependency that closes the cycle.
 
 ## `EXPLAIN MIGRATION` for dependency inspection
 
-`EXPLAIN MIGRATION <name>` shows the full dependency chain resolved at
-query time:
+`EXPLAIN MIGRATION <name>` shows the stored migration plan for one migration:
 
 ```sql
 EXPLAIN MIGRATION build_leaderboard_view;
 ```
 
 ```
-name              : build_leaderboard_view
-status            : pending
-dependency_chain  : [add_score_column, add_rank_column]
-
-dependencies:
-  - add_score_column  (applied, explicit)
-  - add_rank_column   (pending, explicit)
+migration        : build_leaderboard_view
+status           : pending
+kind             : schema
+body             : CREATE VIEW leaderboard AS ...
+estimated_rows   : null
+lock_duration_ms : 0
 ```
 
 `EXPLAIN MIGRATION *` returns the full topological ordering of all pending
-migrations:
+migrations using the same row shape:
 
 ```
-pending migrations (topological order):
-  1. add_rank_column         (no dependencies)
-  2. build_leaderboard_view  (depends on: add_score_column ✓, add_rank_column)
+migration                | status  | kind
+-------------------------+---------+-------
+add_rank_column          | pending | schema
+build_leaderboard_view   | pending | schema
 ```
-
-The `✓` marker indicates a dependency that is already applied.
 
 ---
 

--- a/docs/migrations/multi-tenancy.md
+++ b/docs/migrations/multi-tenancy.md
@@ -1,261 +1,116 @@
 # Multi-Tenant Migrations
 
-RedDB's row-level security (RLS) and the migration system are integrated
-directly. You can apply a migration to a single tenant, fan it out across
-all tenants, or run schema migrations globally while scoping data migrations
-per-tenant — all from SQL.
+RedDB migrations can run with a row-level-security (RLS) tenant context via
+`APPLY MIGRATION ... FOR TENANT ...`, but migration status is global today.
+There is no per-tenant migration registry yet.
 
 See [Multi-Tenancy](/security/multi-tenancy.md) and
 [Row Level Security](/security/rls.md) for background on RedDB's RLS model.
 
 ---
 
+## Current contract
+
+`red_migrations` is the only migration status table. When a migration is
+applied successfully, its row becomes `status = 'applied'` for the database as
+a whole. The same row stores `applied_at`, `rows_processed`, and
+`vcs_commit_hash`.
+
+This means tenant-scoped apply is useful for setting the RLS context during a
+single execution, but it is not a safe per-tenant rollout tracker. After one
+tenant-scoped apply succeeds, later attempts for other tenants will usually see
+the migration as already applied.
+
+There is currently no `red_migration_tenants` collection, no per-tenant
+`vcs_commit_hash`, and no `ROLLBACK MIGRATION ... FOR TENANT` syntax.
+
+---
+
 ## `FOR TENANT <id>`
 
-`FOR TENANT <id>` sets the RLS tenant context for the duration of the
-migration's execution. The migration body sees only rows belonging to that
-tenant — inserts carry the tenant key automatically, and reads are scoped
-by the RLS policy.
+`FOR TENANT <id>` sets the active RLS tenant context while the migration body
+executes:
 
 ```sql
 APPLY MIGRATION backfill_scores FOR TENANT 'acme-corp';
 ```
 
-What happens:
+`<id>` may be a string or integer, matching your RLS tenant key.
 
-1. The RLS context is set to `tenant_id = 'acme-corp'`.
-2. The migration body executes. Every `SELECT`, `INSERT`, `UPDATE`, and
-   `DELETE` is automatically filtered by the RLS policy.
-3. The context is cleared after execution.
-4. A VCS commit is created with message:
-   `migration: apply backfill_scores tenant acme-corp`
-
-The `vcs_commit_hash` in `red_migrations` records this specific tenant's
-commit.
-
-### Tenant ID types
-
-`<id>` may be a string or integer, matching the type of your RLS tenant key:
-
-```sql
--- String tenant key
-APPLY MIGRATION backfill_profiles FOR TENANT 'tenant-42';
-
--- Integer tenant key
-APPLY MIGRATION backfill_profiles FOR TENANT 42;
-```
+Use this form only when it is acceptable for the migration to become globally
+applied after the execution. For canary-style tenant rollouts, track progress
+outside the native migration registry until per-tenant state is implemented.
 
 ---
 
 ## `FOR TENANT *`
 
-`FOR TENANT *` fans out the migration to every tenant in the tenant registry.
-RedDB iterates the tenant list, applies the migration for each tenant
-sequentially (with RLS context set per iteration), and tracks progress
-independently.
+`FOR TENANT *` iterates known tenants and sets the RLS context for each one:
 
 ```sql
 APPLY MIGRATION backfill_scores FOR TENANT *;
 ```
 
-Output:
-
-```
-fanning out to 47 tenants...
-  tenant acme-corp      — ok (vcs: c8a3...) — 1,240 rows
-  tenant beta-inc       — ok (vcs: d912...) — 830 rows
-  tenant gamma-llc      — failed: constraint violation on row id=5029
-  tenant delta-co       — ok (vcs: e017...) — 2,100 rows
-  ...
-
-47 tenants processed. 46 ok, 1 failed.
-Failed tenants: gamma-llc
-```
-
-Failures in one tenant do not stop the fanout. All other tenants continue
-processing. Failed tenants are listed at the end.
-
-To retry a failed tenant:
-
-```sql
-APPLY MIGRATION backfill_scores FOR TENANT 'gamma-llc';
-```
+Because status is global, this is not a durable per-tenant fanout contract.
+The first successful tenant can mark the migration as applied, and subsequent
+tenants may be skipped as already applied. The command returns a textual
+summary only; it does not persist per-tenant progress.
 
 ---
 
-## Schema migrations vs. data migrations in multi-tenant setups
+## Schema migrations
 
-### Schema migrations: apply globally, not per-tenant
-
-Schema changes (adding a column, creating an index, altering a type) affect
-the collection structure, which is shared across all tenants. Apply schema
-migrations without a `FOR TENANT` clause:
+Schema changes affect shared collection structure, so apply them without a
+tenant clause:
 
 ```sql
--- Correct: schema change is global
+CREATE MIGRATION add_score_column
+AS
+  ALTER TABLE users ADD COLUMN score INT DEFAULT 0;
+
 APPLY MIGRATION add_score_column;
-
--- Incorrect: FOR TENANT on a schema migration is redundant
--- and may produce unexpected behavior on non-targeted tenants
-APPLY MIGRATION add_score_column FOR TENANT 'acme-corp';
 ```
 
-When you add a column without `FOR TENANT`, all tenants immediately see the
-new column (with its default value or null). No per-tenant application is
-needed.
-
-### Data migrations: apply per-tenant for isolation
-
-Data migrations (backfills, normalizations, purges) operate on rows. Because
-RLS isolates rows by tenant, applying a data migration without `FOR TENANT`
-executes with a superuser context that bypasses RLS and touches all tenants'
-rows in one pass.
-
-Depending on your RLS policy, this may be correct (all tenants get identical
-treatment) or incorrect (you want per-tenant isolation for audit, progress
-tracking, or partial rollout).
-
-Use `FOR TENANT *` for the safe, auditable path:
-
-```sql
--- Each tenant gets its own VCS commit and independent progress tracking
-APPLY MIGRATION backfill_display_names FOR TENANT *;
-```
-
-Use the global path only when:
-- The migration logic is identical for all tenants and you want a single
-  commit in history.
-- You explicitly need to cross tenant boundaries (super-admin operation).
+Adding `FOR TENANT` to a schema migration does not create tenant-local schema.
 
 ---
 
-## Partial rollout pattern
+## Data migrations
 
-You can use `FOR TENANT <id>` to roll out a data migration to a subset of
-tenants before committing to a full fanout. This is useful for validating
-correctness on a representative tenant before touching all tenants.
+For data migrations, choose between:
 
-```sql
--- Step 1: Apply to one tenant as a canary
-APPLY MIGRATION backfill_scores FOR TENANT 'canary-tenant';
+- A global migration that intentionally touches all visible rows.
+- A tenant-context migration that executes once under one tenant's RLS context
+  and then becomes globally applied.
+- An external per-tenant rollout process that registers separate migration
+  names per tenant or tracks tenant progress outside `red_migrations`.
 
--- Step 2: Verify results
-SELECT avg(score), count(*) FROM profiles
-WHERE tenant_id = 'canary-tenant';
-
--- Step 3: Fan out to all remaining tenants
-APPLY MIGRATION backfill_scores FOR TENANT *;
--- RedDB skips tenants that are already applied
-```
-
-When `FOR TENANT *` is run after a partial rollout, tenants where the
-migration was already applied (via a prior `FOR TENANT <id>`) are skipped
-automatically — they remain `status = 'applied'` and are not re-executed.
-
----
-
-## Tracking per-tenant migration status
-
-`red_migrations` stores the global status of each migration. For multi-tenant
-fanout, per-tenant status is tracked in a companion system collection:
-`red_migration_tenants`.
+Example of separate migration names for explicit tenant canaries:
 
 ```sql
-SELECT
-  migration_name,
-  tenant_id,
-  status,
-  rows_processed,
-  applied_at,
-  vcs_commit_hash
-FROM red_migration_tenants
-WHERE migration_name = 'backfill_scores'
-ORDER BY applied_at;
-```
-
-```
- migration_name  | tenant_id   | status  | rows_processed | applied_at
------------------+-------------+---------+----------------+---------------------
- backfill_scores | acme-corp   | applied | 1240           | 2026-05-01 10:05:01
- backfill_scores | beta-inc    | applied | 830            | 2026-05-01 10:05:03
- backfill_scores | gamma-llc   | failed  | 400            | 2026-05-01 10:05:07
- backfill_scores | delta-co    | applied | 2100           | 2026-05-01 10:05:09
-```
-
-For batched migrations, `rows_processed` is updated per-tenant after each
-batch, giving you per-tenant progress tracking.
-
----
-
-## RLS interaction with migration execution
-
-During migration execution, the RLS policy applies to every statement in the
-body. This means:
-
-- `UPDATE users SET score = 0 WHERE score IS NULL` — with `FOR TENANT 'acme-corp'`
-  set, this touches only `acme-corp` rows. Rows belonging to other tenants
-  are invisible.
-- `INSERT INTO profiles (user_id, score) VALUES (...)` — the `tenant_id`
-  column is automatically populated from the RLS context. You do not need to
-  include it in the migration body.
-
-If your migration body explicitly sets `tenant_id`, it must match the
-active RLS context — the engine rejects cross-tenant writes:
-
-```
-ERROR: RLS violation: cannot insert row with tenant_id 'other-tenant' while
-       RLS context is set to 'acme-corp'
-```
-
----
-
-## Rollback for tenant-scoped migrations
-
-`ROLLBACK MIGRATION <name>` without a tenant clause reverts the global
-migration state (only applicable for schema migrations applied globally).
-
-For tenant-scoped migrations, rollback must specify the tenant:
-
-```sql
--- Roll back for a specific tenant
-ROLLBACK MIGRATION backfill_scores FOR TENANT 'gamma-llc';
-```
-
-This calls `vcs_revert` on the commit recorded in `red_migration_tenants`
-for that tenant, restoring only that tenant's rows to their pre-migration
-state. Other tenants are unaffected.
-
-`ROLLBACK MIGRATION <name> FOR TENANT *` rolls back all tenants that have
-`status = 'applied'` for that migration, in reverse application order.
-
----
-
-## Pattern: coordinating schema and data migrations in a multi-tenant system
-
-```sql
--- Step 1: Schema migration — no tenant scope, affects all tenants
-CREATE MIGRATION add_tier_column
+CREATE MIGRATION backfill_scores_acme
 AS
-  ALTER TABLE accounts ADD COLUMN tier TEXT NOT NULL DEFAULT 'free';
+  UPDATE profiles
+  SET score = 0
+  WHERE score IS NULL;
 
-APPLY MIGRATION add_tier_column;
-
--- Step 2: Data migration — per-tenant scope for isolation
-CREATE MIGRATION backfill_paid_tiers BATCH 1000 ROWS
-DEPENDS ON add_tier_column
-AS
-  UPDATE accounts
-  SET tier = 'paid'
-  WHERE subscription_status = 'active';
-
--- Apply to a canary tenant first
-APPLY MIGRATION backfill_paid_tiers FOR TENANT 'canary-corp';
-
--- Validate
-SELECT tier, count(*) FROM accounts
-WHERE tenant_id = 'canary-corp'
-GROUP BY tier;
-
--- Fan out to all
-APPLY MIGRATION backfill_paid_tiers FOR TENANT *;
+APPLY MIGRATION backfill_scores_acme FOR TENANT 'acme-corp';
 ```
+
+This makes the global registry honest: the applied migration name encodes the
+rollout unit.
+
+---
+
+## Rollback
+
+Rollback is global:
+
+```sql
+ROLLBACK MIGRATION backfill_scores_acme;
+```
+
+The engine reverts the VCS commit stored in `red_migrations.vcs_commit_hash`
+and then returns the migration row to `pending`. Tenant-specific rollback is
+not implemented; `ROLLBACK MIGRATION <name> FOR TENANT <id>` is not valid
+syntax today.

--- a/docs/migrations/overview.md
+++ b/docs/migrations/overview.md
@@ -130,9 +130,9 @@ ordering with explicit `DEPENDS ON` edges after both migration definitions exist
 
 ### Multi-tenant fanout
 
-`FOR TENANT *` applies a migration to every known tenant in a single statement,
-setting the row-level-security context before each execution. Per-tenant progress
-is tracked individually so a failure in one tenant does not block the others.
+`FOR TENANT` sets the row-level-security context while the migration executes.
+Migration status is still global in `red_migrations`, so native per-tenant
+progress tracking and tenant-specific rollback are not implemented yet.
 
 ### Irreversibility is explicit
 
@@ -155,7 +155,7 @@ doing nothing or applying a broken compensating migration.
 | **Irreversible migration guard** | yes (`NO ROLLBACK`) | no | no | no | no |
 | **VCS commit per migration** | yes | no | no | no | no |
 | **Branch-scoped application** | no, definitions are global | no | no | no | no |
-| **Multi-tenant fanout** | yes (`FOR TENANT *`) | no | no | no | no |
+| **Multi-tenant fanout** | limited (`FOR TENANT` context, global status) | no | no | no | no |
 | **Stored in database** | yes (`red_migrations`) | separate table | separate table | separate table | separate table |
 | **Inspect via SQL** | yes | limited | limited | no | no |
 | **EXPLAIN before apply** | yes | no | dry-run only | no | no |
@@ -201,5 +201,5 @@ directly with `SELECT`.
 - [Data Migrations](./data-migrations.md) — `BATCH N ROWS`, checkpoint resume, `NO ROLLBACK`
 - [Dependency Graph](./dependency-graph.md) — DAG management, auto-inference, cycle detection
 - [VCS Integration](./vcs-integration.md) — commits, rollback via revert, current VCS scope
-- [Multi-Tenancy](./multi-tenancy.md) — `FOR TENANT`, RLS context, fanout patterns
+- [Multi-Tenancy](./multi-tenancy.md) — `FOR TENANT`, RLS context, current global-status limitation
 - [Cookbook](./cookbook.md) — recipes for common real-world migration patterns

--- a/docs/migrations/vcs-integration.md
+++ b/docs/migrations/vcs-integration.md
@@ -15,26 +15,26 @@ VCS layer.
 
 When `APPLY MIGRATION <name>` succeeds:
 
-1. The SQL body executes inside a transaction.
+1. The SQL body executes.
 2. On commit, the engine calls `vcs.commit` with the message:
    `migration: apply <name>`
-   (or `migration: apply <name> tenant <id>` for tenant-scoped applications).
 3. The resulting commit hash is written to `red_migrations.vcs_commit_hash`.
 4. `status` is updated to `'applied'` and `applied_at` is set.
 
-All of this happens atomically — either the SQL, the VCS commit, and the
-status update all succeed, or none of them do.
+If the VCS commit fails after the migration body has executed, the command
+returns an error, marks the migration `failed`, and records the commit error in
+`red_migrations.error`. The migration is not marked `applied` with an empty
+commit hash.
 
 ### Commit message format
 
 | Scenario | Commit message |
 |---|---|
 | Plain apply | `migration: apply add_verified_at` |
-| Tenant-scoped | `migration: apply backfill_scores tenant acme-corp` |
-| Tenant fanout (per-tenant commit) | `migration: apply backfill_scores tenant acme-corp` |
+| Apply with `FOR TENANT` context | `migration: apply backfill_scores` |
 
-Each tenant in a `FOR TENANT *` fanout gets its own commit with the
-tenant ID in the message.
+Migration status and commit hash are global today. Native per-tenant commit
+tracking is not implemented yet.
 
 ### Reading the commit hash
 
@@ -74,6 +74,9 @@ What happens:
    original commit's changes.
 3. `status` is reset to `'pending'`, `applied_at` and `vcs_commit_hash` are
    cleared.
+
+If `vcs_commit_hash` is missing or `vcs_revert` fails, rollback returns an
+error and leaves the migration status as `applied`.
 
 The revert commit is itself recorded in the VCS log, so you have full
 history: the original apply commit, then the revert commit.
@@ -178,8 +181,9 @@ APPLY MIGRATION add_score_column;
 ```
 
 The migration definition is global immediately. The apply step still creates a
-`migration: add_score_column` commit through the VCS layer, but schema state and
-data reconciliation are not isolated behind a branch-local migration registry.
+`migration: apply add_score_column` commit through the VCS layer, but schema
+state and data reconciliation are not isolated behind a branch-local migration
+registry.
 
 ### Merge and conflict detection status
 

--- a/docs/migrations/walkthrough.md
+++ b/docs/migrations/walkthrough.md
@@ -221,7 +221,7 @@ ROLLBACK MIGRATION add_verified_at;
 ```
 
 ```
-ERROR: cannot rollback 'add_verified_at' — applied migration 'backfill_verified_at' depends on it
+ERROR: cannot rollback 'add_verified_at' - applied migration 'backfill_verified_at' depends on it
 ```
 
 ---

--- a/tests/grouped/storage_durability/e2e_migrations_bootstrap.rs
+++ b/tests/grouped/storage_durability/e2e_migrations_bootstrap.rs
@@ -184,3 +184,106 @@ fn apply_migration_all_applies_pending_migrations_in_dependency_order() {
         .expect("audit visible after independent migration apply");
     assert_eq!(audit.result.records.len(), 1);
 }
+
+#[test]
+fn explain_migration_all_lists_pending_migrations_in_dependency_order() {
+    let rt = rt();
+
+    rt.execute_query(
+        "CREATE MIGRATION a_root AS \
+         CREATE TABLE explain_root (id BIGINT)",
+    )
+    .expect("a_root migration");
+    rt.execute_query(
+        "CREATE MIGRATION b_child \
+         DEPENDS ON a_root AS \
+         INSERT INTO explain_root (id) VALUES (1)",
+    )
+    .expect("b_child migration");
+    rt.execute_query(
+        "CREATE MIGRATION c_independent AS \
+         CREATE TABLE explain_independent (id BIGINT)",
+    )
+    .expect("c_independent migration");
+
+    let explained = rt
+        .execute_query("EXPLAIN MIGRATION *")
+        .expect("explain all migrations");
+    let names: Vec<&str> = explained
+        .result
+        .records
+        .iter()
+        .map(|record| text(record.get("migration")))
+        .collect();
+
+    assert_eq!(names, vec!["a_root", "c_independent", "b_child"]);
+}
+
+#[test]
+fn rollback_migration_refuses_when_applied_dependents_exist() {
+    let rt = rt();
+
+    rt.execute_query(
+        "CREATE MIGRATION create_parent AS \
+         CREATE TABLE rollback_parent (id BIGINT)",
+    )
+    .expect("create_parent migration");
+    rt.execute_query(
+        "CREATE MIGRATION seed_child \
+         DEPENDS ON create_parent AS \
+         INSERT INTO rollback_parent (id) VALUES (1)",
+    )
+    .expect("seed_child migration");
+    rt.execute_query("APPLY MIGRATION *")
+        .expect("apply migrations");
+
+    let err = rt
+        .execute_query("ROLLBACK MIGRATION create_parent")
+        .expect_err("rollback must reject applied dependents");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cannot rollback") && msg.contains("seed_child"),
+        "rollback error should name the applied dependent, got: {msg}"
+    );
+
+    let migrations = rt
+        .execute_query("SELECT name, status FROM red_migrations")
+        .expect("list migrations");
+    for record in &migrations.result.records {
+        assert_eq!(text(record.get("status")), "applied");
+    }
+}
+
+#[test]
+fn rollback_migration_keeps_status_when_vcs_revert_fails() {
+    let rt = rt();
+
+    rt.execute_query(
+        "CREATE MIGRATION revert_target AS \
+         CREATE TABLE rollback_vcs_failure (id BIGINT)",
+    )
+    .expect("revert_target migration");
+    rt.execute_query("APPLY MIGRATION revert_target")
+        .expect("apply migration");
+    rt.execute_query(
+        "UPDATE red_migrations \
+         SET vcs_commit_hash = 'not-a-real-commit' \
+         WHERE name = 'revert_target'",
+    )
+    .expect("replace commit hash");
+
+    let err = rt
+        .execute_query("ROLLBACK MIGRATION revert_target")
+        .expect_err("rollback must propagate VCS revert failure");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("VCS revert failed"),
+        "rollback error should expose VCS revert failure, got: {msg}"
+    );
+
+    let migrations = rt
+        .execute_query("SELECT name, status FROM red_migrations WHERE name = 'revert_target'")
+        .expect("list migration");
+    assert_eq!(migrations.result.records.len(), 1);
+    assert_eq!(text(migrations.result.records[0].get("status")), "applied");
+}


### PR DESCRIPTION
## Summary
- Reject non-positive migration batch sizes and require ROWS.
- Support EXPLAIN MIGRATION * through parser/runtime routing and pending topological output.
- Make rollback refuse applied dependents and propagate VCS revert failures.
- Propagate VCS commit failures on apply instead of recording empty hashes.
- Align migration docs with current single global status and UPDATE-only batching contract.

## Validation
- cargo fmt --all
- cargo test -p reddb-io-rql test_parse_migration_forms
- cargo test -p reddb-io-rql test_sql_detection
- grouped_chaos_drill_persistence::e2e_migrations_bootstrap::explain_migration_all_lists_pending_migrations_in_dependency_order
- grouped_chaos_drill_persistence::e2e_migrations_bootstrap::rollback_migration_refuses_when_applied_dependents_exist
- grouped_chaos_drill_persistence::e2e_migrations_bootstrap::rollback_migration_keeps_status_when_vcs_revert_fails
- grouped_chaos_drill_persistence::e2e_migrations_bootstrap::apply_migration_all_applies_pending_migrations_in_dependency_order

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785087777&installation_id=129708444&pr_number=1473&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1473&signature=1875300621e81428863f414b36546e026acbbb24a42882fcb3872e8464c551d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->