### PR TITLE
merge: #1396 document UPDATE over gRPC red connect reports 0 affected_rows

### DIFF
--- a/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
+++ b/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
@@ -40,6 +40,7 @@ use reddb::server::RedDBServer;
 use reddb::wire::redwire::start_redwire_listener_on;
 use reddb::{GrpcServerOptions, RedDBGrpcServer};
 
+use reddb::client::RedDBClient;
 use reddb_client::redwire::{Auth, ConnectOptions, RedWireClient};
 use reddb_client::{QueryResult, Value};
 
@@ -270,4 +271,52 @@ async fn cross_transport_select_envelope_matches() {
         "expected one row across all three transports, got {:?}",
         http_result.rows,
     );
+}
+
+#[tokio::test]
+async fn grpc_connector_document_update_reports_and_applies_affected_row() {
+    let (_db, runtime) = support::persistent_runtime("grpc-document-update-affected-row");
+    let grpc_port = pick_free_port();
+    let grpc_bind = format!("127.0.0.1:{grpc_port}");
+    let auth_store = Arc::new(AuthStore::new(AuthConfig::default()));
+    let grpc_server = RedDBGrpcServer::with_options(
+        runtime,
+        GrpcServerOptions {
+            bind_addr: grpc_bind,
+            tls: None,
+        },
+        auth_store,
+    );
+    tokio::spawn(async move {
+        let _ = grpc_server.serve().await;
+    });
+    await_tcp(grpc_port).await;
+
+    let mut client = RedDBClient::connect(&format!("127.0.0.1:{grpc_port}"), None)
+        .await
+        .expect("gRPC connect");
+    client
+        .query_reply("CREATE DOCUMENT grpc_docs")
+        .await
+        .expect("create document collection");
+    client
+        .query_reply(
+            r#"INSERT INTO grpc_docs DOCUMENT (body) VALUES ('{"name":"doc","score":10}')"#,
+        )
+        .await
+        .expect("insert document");
+
+    let updated = client
+        .query_reply("UPDATE grpc_docs DOCUMENTS SET score = 42 WHERE name = 'doc'")
+        .await
+        .expect("update document over gRPC connector");
+    assert_eq!(updated.affected_rows, 1);
+
+    let selected = client
+        .query_reply("SELECT score FROM grpc_docs WHERE name = 'doc'")
+        .await
+        .expect("select updated document");
+    let result: serde_json::Value =
+        serde_json::from_str(&selected.result_json).expect("select result_json");
+    assert_eq!(result["records"][0]["score"].as_i64(), Some(42));
 }


### PR DESCRIPTION
Automated AFK landing for #1396. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1396

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785089491&installation_id=129708444&pr_number=1475&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1475&signature=1d72320b0e54d6ab518f0dacba00f5c0d0622f7b5b2650dcd0916e0664a75133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->