### PR TITLE
merge: #1409 document partial update silently diverges body from promoted columns

### DIFF
--- a/tests/grouped/dml_updates/e2e_explicit_update_targets.rs
+++ b/tests/grouped/dml_updates/e2e_explicit_update_targets.rs
@@ -28,6 +28,15 @@ fn text_field(record: &UnifiedRecord, field: &str) -> String {
     }
 }
 
+fn json_field(record: &UnifiedRecord, field: &str) -> reddb::json::Value {
+    match record.get(field) {
+        Some(Value::Json(value)) => {
+            reddb::json::from_slice(value).expect("json field should decode")
+        }
+        other => panic!("expected {field} json field, got {other:?} in {record:?}"),
+    }
+}
+
 fn uint_field(record: &UnifiedRecord, field: &str) -> u64 {
     match record.get(field) {
         Some(Value::UnsignedInteger(value)) => *value,
@@ -83,6 +92,28 @@ fn explicit_rows_documents_and_kv_targets_update_compatible_collections() {
     assert_eq!(kv.affected_rows, 1);
     let selected_kv = exec(&rt, "SELECT value FROM settings WHERE key = 'feature'");
     assert_eq!(text_field(only_record(&selected_kv), "value"), "on");
+}
+
+#[test]
+fn document_update_keeps_body_and_promoted_columns_in_sync() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT docs_sync");
+    exec(
+        &rt,
+        r#"INSERT INTO docs_sync DOCUMENT (body) VALUES ('{"name":"orig","score":1}')"#,
+    );
+
+    let updated = exec(
+        &rt,
+        "UPDATE docs_sync DOCUMENTS SET score = 99 WHERE name = 'orig'",
+    );
+
+    assert_eq!(updated.affected_rows, 1);
+    let selected = exec(&rt, "SELECT body, score FROM docs_sync WHERE name = 'orig'");
+    let record = only_record(&selected);
+    let body = json_field(record, "body");
+    assert_eq!(body["score"].as_i64(), Some(99));
+    assert_eq!(uint_field(record, "score"), 99);
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1409. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1409

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785091998&installation_id=129708444&pr_number=1476&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1476&signature=2a1bf5596e0f04617e6601d5a6762f88d66b7d359025642a0dd06cf3c5ea284e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->