### PR TITLE
feat: partial concurrent claim for indexed table reservations (#1450)

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -1866,6 +1866,8 @@ pub struct UpdateQuery {
     pub with_metadata: Vec<(String, Value)>,
     /// Optional RETURNING clause items.
     pub returning: Option<Vec<ReturningItem>>,
+    /// Optional partial Concurrent claim cardinality.
+    pub claim_limit: Option<u64>,
     /// Optional deterministic target ordering for limited UPDATE batches.
     pub order_by: Vec<OrderByClause>,
     /// Optional `LIMIT N` cap. Caps the number of targets the executor

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -412,7 +412,10 @@ impl<'a> Parser<'a> {
         } else {
             None
         };
-        if !order_by.is_empty() && limit.is_none() {
+        // CLAIM LIMIT acts as the LIMIT for the purpose of ORDER BY semantics:
+        // a claim without a conventional LIMIT still has a deterministic bound.
+        let effective_limit = limit.is_some() || claim_limit.is_some();
+        if !order_by.is_empty() && !effective_limit {
             return Err(ParseError::new(
                 "UPDATE ORDER BY requires LIMIT",
                 self.position(),

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -387,6 +387,13 @@ impl<'a> Parser<'a> {
 
         let (ttl_ms, expires_at_ms, with_metadata, _auto_embed) = self.parse_with_clauses()?;
 
+        let claim_limit = if self.consume_ident_ci("CLAIM")? {
+            self.expect(Token::Limit)?;
+            Some(self.parse_integer()? as u64)
+        } else {
+            None
+        };
+
         let mut order_by = if self.consume(&Token::Order)? {
             self.expect(Token::By)?;
             let clauses = self.parse_order_by_list()?;
@@ -408,6 +415,12 @@ impl<'a> Parser<'a> {
         if !order_by.is_empty() && limit.is_none() {
             return Err(ParseError::new(
                 "UPDATE ORDER BY requires LIMIT",
+                self.position(),
+            ));
+        }
+        if claim_limit.is_some() && order_by.is_empty() {
+            return Err(ParseError::new(
+                "UPDATE CLAIM requires ORDER BY",
                 self.position(),
             ));
         }
@@ -444,6 +457,7 @@ impl<'a> Parser<'a> {
             expires_at_ms,
             with_metadata,
             returning,
+            claim_limit,
             order_by,
             limit,
             suppress_events,
@@ -1194,6 +1208,7 @@ mod tests {
         assert!(query.where_expr.is_some());
         assert_eq!(query.ttl_ms, Some(30_000));
         assert_eq!(query.with_metadata.len(), 1);
+        assert_eq!(query.claim_limit, None);
         assert_eq!(query.limit, Some(5));
         assert_eq!(query.order_by.len(), 2);
         assert!(matches!(
@@ -1211,6 +1226,27 @@ mod tests {
             )
         );
         assert!(query.suppress_events);
+    }
+
+    #[test]
+    fn update_claim_limit_requires_order_by() {
+        let query = update(
+            "UPDATE docs SET status = 'reserved' WHERE status = 'available' \
+             CLAIM LIMIT 2 ORDER BY priority ASC RETURNING id",
+        );
+        assert_eq!(query.claim_limit, Some(2));
+        assert_eq!(query.limit, None);
+        assert_eq!(query.order_by.len(), 2);
+        assert!(matches!(
+            &query.order_by[1].field,
+            FieldRef::TableColumn { column, .. } if column == "rid"
+        ));
+
+        let mut parser = make_parser("UPDATE docs SET status = 'reserved' CLAIM LIMIT 1");
+        let err = parser
+            .parse_update_query()
+            .expect_err("claim without order should fail");
+        assert!(err.to_string().contains("CLAIM requires ORDER BY"));
     }
 
     #[test]

--- a/crates/reddb-rql/src/sql_lowering.rs
+++ b/crates/reddb-rql/src/sql_lowering.rs
@@ -1579,6 +1579,7 @@ mod tests {
             returning: None,
             order_by: vec![OrderByClause::asc(field("id"))],
             limit: Some(1),
+            claim_limit: None,
             suppress_events: false,
         };
         assert!(matches!(


### PR DESCRIPTION
Recovered work from worker wBEU4 (committed on branch, no PR opened before fleet teardown).

Closes #1450 — PRD #1449. RQL parser support for concurrent claim / indexed table reservations.

https://claude.ai/code/session_01QGmZ4a4h8i8CRGz7CUS62x

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785096236&installation_id=129708444&pr_number=1478&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1478&signature=47da59250801dec23f5a8870bc3428c12bc6c7d28298e916148ec630428e1f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->