### PR TITLE
merge: #1367 feat(http): document PATCH via JSON Merge Patch (RFC 7396)

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1544,12 +1544,7 @@ impl RedDBRuntime {
                     )?;
                     if body != previous_body {
                         context_index_dirty = true;
-                        replace_document_row_body(
-                            named,
-                            body,
-                            binary_body,
-                            &mut modified_columns,
-                        )?;
+                        replace_document_row_body(named, body, binary_body, &mut modified_columns)?;
                     }
                 }
 

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1274,6 +1274,94 @@ fn replace_document_row_body(
     Ok(())
 }
 
+fn document_merge_patch_payload(payload: &JsonValue) -> &JsonValue {
+    if let JsonValue::Object(object) = payload {
+        if object.len() == 1 {
+            if let Some(body) = object.get("body") {
+                return body;
+            }
+        }
+    }
+    payload
+}
+
+fn apply_document_json_merge_patch(body: &mut JsonValue, patch: &JsonValue) -> RedDBResult<()> {
+    if !matches!(patch, JsonValue::Object(_)) {
+        *body = patch.clone();
+        return Ok(());
+    }
+
+    if matches!(patch, JsonValue::Object(object) if object.is_empty()) {
+        if !matches!(body, JsonValue::Object(_)) {
+            *body = JsonValue::Object(Default::default());
+        }
+        return Ok(());
+    }
+
+    let mut operations = Vec::new();
+    collect_document_json_merge_patch_operations(body, Vec::new(), patch, &mut operations);
+    apply_patch_operations_to_json(body, &operations).map_err(crate::RedDBError::Query)
+}
+
+fn collect_document_json_merge_patch_operations(
+    target: &JsonValue,
+    path: Vec<String>,
+    patch: &JsonValue,
+    operations: &mut Vec<PatchEntityOperation>,
+) {
+    let JsonValue::Object(patch_object) = patch else {
+        operations.push(PatchEntityOperation {
+            op: PatchEntityOperationType::Set,
+            path,
+            value: Some(patch.clone()),
+        });
+        return;
+    };
+
+    for (key, value) in patch_object {
+        let mut child_path = path.clone();
+        child_path.push(key.clone());
+        match value {
+            JsonValue::Null => operations.push(PatchEntityOperation {
+                op: PatchEntityOperationType::Unset,
+                path: child_path,
+                value: None,
+            }),
+            JsonValue::Object(object) if object.is_empty() => {
+                let child_target = match target {
+                    JsonValue::Object(target_object) => target_object.get(key),
+                    _ => None,
+                };
+                if !matches!(child_target, Some(JsonValue::Object(_))) {
+                    operations.push(PatchEntityOperation {
+                        op: PatchEntityOperationType::Set,
+                        path: child_path,
+                        value: Some(JsonValue::Object(Default::default())),
+                    });
+                }
+            }
+            JsonValue::Object(_) => {
+                let child_target = match target {
+                    JsonValue::Object(target_object) => target_object.get(key),
+                    _ => None,
+                }
+                .unwrap_or(&JsonValue::Null);
+                collect_document_json_merge_patch_operations(
+                    child_target,
+                    child_path,
+                    value,
+                    operations,
+                );
+            }
+            _ => operations.push(PatchEntityOperation {
+                op: PatchEntityOperationType::Set,
+                path: child_path,
+                value: Some(value.clone()),
+            }),
+        }
+    }
+}
+
 impl RedDBRuntime {
     pub(crate) fn apply_loaded_patch_entity_core(
         &self,
@@ -1356,6 +1444,7 @@ impl RedDBRuntime {
                 let mut field_ops = Vec::new();
                 let mut metadata_ops = Vec::new();
                 let mut document_body_ops = Vec::new();
+                let has_patch_operations = !operations.is_empty();
 
                 for mut op in operations {
                     let Some(root) = op.path.first().map(String::as_str) else {
@@ -1421,11 +1510,17 @@ impl RedDBRuntime {
                     replace_document_row_body(named, body, &mut modified_columns)?;
                 }
 
-                if is_document_collection {
-                    if let Some(body) = payload.get("body") {
+                if is_document_collection && !has_patch_operations {
+                    let named = row.named.get_or_insert_with(Default::default);
+                    let mut body = document_body_from_named(named)?;
+                    let previous_body = body.clone();
+                    apply_document_json_merge_patch(
+                        &mut body,
+                        document_merge_patch_payload(&payload),
+                    )?;
+                    if body != previous_body {
                         context_index_dirty = true;
-                        let named = row.named.get_or_insert_with(Default::default);
-                        replace_document_row_body(named, body.clone(), &mut modified_columns)?;
+                        replace_document_row_body(named, body, &mut modified_columns)?;
                     }
                 }
 

--- a/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
+++ b/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
@@ -241,32 +241,44 @@ fn http_document_insert_get_scan_and_delete() {
         "array positional error should be helpful: {array_error}"
     );
 
-    let replacement = json!({
-        "body": {
-            "event_type": "replaced",
-            "details": { "ip": "127.0.0.1" }
-        }
+    let merge_patch = json!({
+        "event_type": "patched",
+        "details": { "ip": "127.0.0.1", "reviewed": null },
+        "owner": { "team": "security" }
     });
-    let (status, replaced) = http_request(
+    let (status, merged) = http_request(
         &addr,
         "PATCH",
         &format!("/collections/events/entities/{id}"),
-        Some(replacement),
+        Some(merge_patch),
     );
-    assert_eq!(status, 200, "replaced={replaced}");
+    assert_eq!(status, 200, "merged={merged}");
     assert_eq!(
-        replaced["entity"]["data"]["named"]["body"]["event_type"],
-        json!("replaced")
+        merged["entity"]["data"]["named"]["body"]["event_type"],
+        json!("patched")
     );
     assert!(
-        replaced["entity"]["data"]["named"]["body"]
-            .get("roles")
+        merged["entity"]["data"]["named"]["body"]["details"]
+            .get("reviewed")
             .is_none(),
-        "full body replacement should remove old document fields: {replaced}"
+        "RFC 7396 null values delete keys: {merged}"
     );
     assert_eq!(
-        replaced["entity"]["data"]["named"]["event_type"],
-        json!("replaced")
+        merged["entity"]["data"]["named"]["body"]["details"]["ip"],
+        json!("127.0.0.1")
+    );
+    assert_eq!(
+        merged["entity"]["data"]["named"]["body"]["owner"]["team"],
+        json!("security")
+    );
+    assert_eq!(
+        merged["entity"]["data"]["named"]["body"]["roles"],
+        json!(["reader", "ops"]),
+        "merge patch must preserve untouched sibling fields: {merged}"
+    );
+    assert_eq!(
+        merged["entity"]["data"]["named"]["event_type"],
+        json!("patched")
     );
 
     let (status, deleted) = http_request(


### PR DESCRIPTION
Automated AFK landing for #1367. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1367

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785098791&installation_id=129708444&pr_number=1480&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1480&signature=c6604a068189c7397afa340d042c6d442314cac3e88f10a98618a229cdaa34be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->