### PR TITLE
merge: #1358 test(dst): in-process replication network simulator + election-safety under partition

### DIFF
--- a/.github/workflows/replication-sim-nightly.yml
+++ b/.github/workflows/replication-sim-nightly.yml
@@ -1,0 +1,39 @@
+name: Nightly Replication Simulation
+
+on:
+  schedule:
+    - cron: '30 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  replication-sim:
+    name: Replication Network Simulator
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-replication-sim-rust-1.91.0
+          cache-on-failure: "true"
+      - name: Run heavy seeded simulator profile
+        run: |
+          cargo test --locked --test grouped_replication \
+            replication_network_simulator_heavy_profile \
+            -- --ignored --nocapture

--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -38,6 +38,7 @@ pub mod reconnect;
 pub mod replica;
 pub mod rollback;
 pub mod scheduler;
+pub mod simulation;
 pub mod swap_db;
 pub mod topology_advertiser;
 pub mod witness;

--- a/crates/reddb-server/src/replication/simulation.rs
+++ b/crates/reddb-server/src/replication/simulation.rs
@@ -1,0 +1,255 @@
+//! Deterministic in-process transport for replication control-plane tests.
+//!
+//! This is a fault-injection seam, not a runtime socket replacement. Tests can
+//! drive election, lease, quorum, CDC, and logical-replication state machines
+//! through one seed-controlled queue with an explicit simulation clock.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use super::election::{VoteDecision, VoteRequest};
+
+/// Control-plane messages the simulator can carry without opening sockets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReplicationControlMessage {
+    PrimaryHeartbeat {
+        term: u64,
+        lsn: u64,
+    },
+    ReplicaFrontier {
+        replica_id: String,
+        term: u64,
+        lsn: u64,
+    },
+    ElectionVoteRequest(VoteRequest),
+    ElectionVoteDecision(VoteDecision),
+    FailoverCommit {
+        new_primary: String,
+        term: u64,
+    },
+    LeaseFence {
+        holder_id: String,
+        term: u64,
+    },
+    QuorumAck {
+        replica_id: String,
+        term: u64,
+        lsn: u64,
+    },
+    CdcRecord {
+        term: u64,
+        lsn: u64,
+    },
+    LogicalApply {
+        term: u64,
+        lsn: u64,
+    },
+}
+
+/// What happened when a message was offered to the in-process transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryOutcome {
+    Queued,
+    Partitioned,
+    Lost,
+}
+
+/// A delivered message with the simulator metadata retained for assertions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimulatedMessage<M> {
+    pub from: String,
+    pub to: String,
+    pub sequence: u64,
+    pub sent_at: Duration,
+    pub deliver_at: Duration,
+    pub payload: M,
+}
+
+/// Manual simulation clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SimulationClock {
+    now: Duration,
+}
+
+impl SimulationClock {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn now(&self) -> Duration {
+        self.now
+    }
+
+    pub fn advance(&mut self, delta: Duration) {
+        self.now = self.now.saturating_add(delta);
+    }
+}
+
+/// Small deterministic RNG so simulator tests do not depend on OS entropy.
+#[derive(Debug, Clone)]
+pub struct SeededRng {
+    state: u64,
+}
+
+impl SeededRng {
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut value = self.state;
+        value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        value ^ (value >> 31)
+    }
+
+    pub fn gen_below(&mut self, upper: u64) -> u64 {
+        if upper == 0 {
+            return 0;
+        }
+        self.next_u64() % upper
+    }
+
+    fn gen_index(&mut self, upper: usize) -> usize {
+        if upper == 0 {
+            return 0;
+        }
+        let bound = u64::try_from(upper).expect("usize fits into u64 on supported targets");
+        let value = self.gen_below(bound);
+        usize::try_from(value).expect("value is below original usize bound")
+    }
+}
+
+/// Seed-controlled in-process transport for replication control-plane traffic.
+#[derive(Debug, Clone)]
+pub struct InProcessReplicationTransport<M> {
+    clock: SimulationClock,
+    rng: SeededRng,
+    partitions: BTreeSet<(String, String)>,
+    queue: Vec<SimulatedMessage<M>>,
+    max_delay: Duration,
+    loss_per_million: u32,
+    reorder_window: usize,
+    next_sequence: u64,
+    last_sender: Option<String>,
+}
+
+impl<M> InProcessReplicationTransport<M> {
+    pub fn new(seed: u64) -> Self {
+        Self {
+            clock: SimulationClock::new(),
+            rng: SeededRng::new(seed),
+            partitions: BTreeSet::new(),
+            queue: Vec::new(),
+            max_delay: Duration::ZERO,
+            loss_per_million: 0,
+            reorder_window: 0,
+            next_sequence: 0,
+            last_sender: None,
+        }
+    }
+
+    pub fn now(&self) -> Duration {
+        self.clock.now()
+    }
+
+    pub fn advance(&mut self, delta: Duration) {
+        self.clock.advance(delta);
+    }
+
+    pub fn set_max_delay(&mut self, delay: Duration) {
+        self.max_delay = delay;
+    }
+
+    pub fn set_loss_per_million(&mut self, loss_per_million: u32) {
+        self.loss_per_million = loss_per_million.min(1_000_000);
+    }
+
+    pub fn set_reorder_window(&mut self, reorder_window: usize) {
+        self.reorder_window = reorder_window;
+    }
+
+    pub fn partition(&mut self, a: &str, b: &str) {
+        self.partitions.insert(Self::edge(a, b));
+    }
+
+    pub fn heal(&mut self, a: &str, b: &str) {
+        self.partitions.remove(&Self::edge(a, b));
+    }
+
+    pub fn last_sender(&self) -> Option<&str> {
+        self.last_sender.as_deref()
+    }
+
+    pub fn send(&mut self, from: &str, to: &str, payload: M) -> DeliveryOutcome {
+        self.last_sender = Some(from.to_string());
+        if self.partitions.contains(&Self::edge(from, to)) {
+            return DeliveryOutcome::Partitioned;
+        }
+        if self.message_is_lost() {
+            return DeliveryOutcome::Lost;
+        }
+
+        let delay = self.next_delay();
+        let message = SimulatedMessage {
+            from: from.to_string(),
+            to: to.to_string(),
+            sequence: self.next_sequence,
+            sent_at: self.clock.now(),
+            deliver_at: self.clock.now().saturating_add(delay),
+            payload,
+        };
+        self.next_sequence = self.next_sequence.saturating_add(1);
+        self.insert_with_reorder(message);
+        DeliveryOutcome::Queued
+    }
+
+    pub fn drain_ready(&mut self, to: &str) -> Vec<SimulatedMessage<M>> {
+        let now = self.clock.now();
+        let mut ready = Vec::new();
+        let mut pending = Vec::new();
+        for message in self.queue.drain(..) {
+            if message.to == to && message.deliver_at <= now {
+                ready.push(message);
+            } else {
+                pending.push(message);
+            }
+        }
+        self.queue = pending;
+        ready
+    }
+
+    fn edge(a: &str, b: &str) -> (String, String) {
+        if a <= b {
+            (a.to_string(), b.to_string())
+        } else {
+            (b.to_string(), a.to_string())
+        }
+    }
+
+    fn message_is_lost(&mut self) -> bool {
+        self.loss_per_million > 0
+            && self.rng.gen_below(1_000_000) < u64::from(self.loss_per_million)
+    }
+
+    fn next_delay(&mut self) -> Duration {
+        let max_millis = u64::try_from(self.max_delay.as_millis()).unwrap_or(u64::MAX);
+        if max_millis == 0 {
+            Duration::ZERO
+        } else {
+            Duration::from_millis(self.rng.gen_below(max_millis).saturating_add(1))
+        }
+    }
+
+    fn insert_with_reorder(&mut self, message: SimulatedMessage<M>) {
+        if self.reorder_window == 0 || self.queue.is_empty() {
+            self.queue.push(message);
+            return;
+        }
+        let max_back = self.reorder_window.min(self.queue.len());
+        let back = self.rng.gen_index(max_back.saturating_add(1));
+        let index = self.queue.len().saturating_sub(back);
+        self.queue.insert(index, message);
+    }
+}

--- a/tests/grouped/replication.rs
+++ b/tests/grouped/replication.rs
@@ -51,5 +51,8 @@ mod e2e_issue_833_replication_failover;
 #[path = "replication/e2e_issue_840_replication_auto_rollback.rs"]
 mod e2e_issue_840_replication_auto_rollback;
 
+#[path = "replication/e2e_issue_1358_replication_network_sim.rs"]
+mod e2e_issue_1358_replication_network_sim;
+
 #[path = "replication/e2e_replica_readonly.rs"]
 mod e2e_replica_readonly;

--- a/tests/grouped/replication/e2e_issue_1358_replication_network_sim.rs
+++ b/tests/grouped/replication/e2e_issue_1358_replication_network_sim.rs
@@ -1,0 +1,375 @@
+//! Issue #1358 — in-process replication network simulator.
+//!
+//! The simulator is intentionally single-threaded: it injects transport faults
+//! without sockets, while the safety checks drive the existing election,
+//! failover, lease, and fence state machines through their public seams.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use reddb::replication::election::{
+    ElectionCoordinator, ElectionRequest, ElectionTransport, LastVote, Member, MemoryLastVoteStore,
+    RefusalReason, VoteDecision, VoteRequest, Voter,
+};
+use reddb::replication::failover::{
+    FailoverCoordinator, FailoverMode, FailoverNode, FailoverRequest, FailoverTransport, NodeRole,
+};
+use reddb::replication::fence::{
+    FenceBoundary, FenceVerdict, MemoryTermStore, StreamHandshake, TermFence,
+};
+use reddb::replication::lease::WriterLease;
+use reddb::replication::simulation::{
+    DeliveryOutcome, InProcessReplicationTransport, ReplicationControlMessage,
+};
+
+#[test]
+fn simulator_injects_partition_delay_reorder_and_loss_by_seed() {
+    let mut network = InProcessReplicationTransport::new(13);
+    network.set_max_delay(Duration::from_millis(4));
+    network.set_reorder_window(4);
+    network.partition("primary-a", "replica-b");
+
+    let blocked = network.send(
+        "primary-a",
+        "replica-b",
+        ReplicationControlMessage::PrimaryHeartbeat { term: 1, lsn: 10 },
+    );
+    assert_eq!(blocked, DeliveryOutcome::Partitioned);
+
+    network.heal("primary-a", "replica-b");
+    for lsn in 1..=6 {
+        assert_eq!(
+            network.send(
+                "primary-a",
+                "replica-b",
+                ReplicationControlMessage::CdcRecord { term: 1, lsn },
+            ),
+            DeliveryOutcome::Queued
+        );
+    }
+
+    assert!(
+        network.drain_ready("replica-b").is_empty(),
+        "delayed messages must not be visible before the simulated clock advances"
+    );
+    network.advance(Duration::from_millis(5));
+    let delivered: Vec<u64> = network
+        .drain_ready("replica-b")
+        .into_iter()
+        .filter_map(|message| match message.payload {
+            ReplicationControlMessage::CdcRecord { lsn, .. } => Some(lsn),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(delivered.len(), 6);
+    assert_ne!(
+        delivered,
+        vec![1, 2, 3, 4, 5, 6],
+        "seeded reorder should perturb FIFO delivery"
+    );
+
+    network.set_loss_per_million(1_000_000);
+    let lost = network.send(
+        "primary-a",
+        "replica-b",
+        ReplicationControlMessage::LogicalApply { term: 1, lsn: 7 },
+    );
+    assert_eq!(lost, DeliveryOutcome::Lost);
+}
+
+#[test]
+fn election_safety_holds_under_seeded_partition() {
+    for seed in 0..32 {
+        let leaders = run_partitioned_elections(seed, false);
+        assert_no_two_leaders_in_same_term(&leaders, seed);
+    }
+}
+
+#[test]
+fn no_split_brain_and_no_lost_committed_writes_under_partition() {
+    let seed = 1358;
+    let mut cluster = SimElectionCluster::new(seed, 8);
+    cluster.network.partition("node-a", "node-d");
+    cluster.network.partition("node-a", "node-e");
+    cluster.network.partition("node-b", "node-d");
+    cluster.network.partition("node-b", "node-e");
+    cluster.frontiers.insert("node-a".to_string(), 10);
+    cluster.frontiers.insert("node-b".to_string(), 10);
+    cluster.frontiers.insert("node-c".to_string(), 10);
+    cluster.frontiers.insert("node-d".to_string(), 8);
+    cluster.frontiers.insert("node-e".to_string(), 8);
+
+    let leaders = cluster.try_candidates(&["node-d", "node-a", "node-e"], 1);
+    assert_no_two_leaders_in_same_term(&leaders, seed);
+    for (_, leader) in &leaders {
+        assert!(
+            cluster.frontiers[leader] >= cluster.commit_watermark,
+            "an elected leader must carry every committed write at or below the watermark"
+        );
+    }
+
+    let mut failover = LaggingFailover::new(10, vec![8, 8, 8]);
+    let request = failover_request(FailoverMode::Coordinated {
+        catch_up_deadline: Duration::from_millis(3),
+    });
+    let err = FailoverCoordinator::run(&request, &mut failover)
+        .expect_err("coordinated failover must abort before losing committed writes");
+    assert!(format!("{err}").contains("no write lost"));
+    assert_eq!(failover.role, NodeRole::Primary { term: 1 });
+    assert!(failover.writes_resumed);
+}
+
+#[test]
+fn lease_fencing_rejects_partitioned_stale_primary() {
+    let mut network = InProcessReplicationTransport::new(99);
+    network.partition("old-primary", "replica-b");
+    network.partition("old-primary", "replica-c");
+
+    let stale = network.send(
+        "old-primary",
+        "replica-b",
+        ReplicationControlMessage::LeaseFence {
+            holder_id: "old-primary".to_string(),
+            term: 5,
+        },
+    );
+    assert_eq!(stale, DeliveryOutcome::Partitioned);
+
+    let fence = TermFence::new(MemoryTermStore::seeded(6));
+    let rejected = match fence
+        .admit_stream_handshake(&StreamHandshake::new("old-primary", 5))
+        .expect("term store readable")
+    {
+        FenceVerdict::Fenced(rejection) => rejection,
+        other => panic!("expected stale primary to be fenced, got {other:?}"),
+    };
+    assert_eq!(rejected.boundary, FenceBoundary::Handshake);
+
+    let stale_lease = WriterLease {
+        database_key: "main".to_string(),
+        holder_id: "old-primary".to_string(),
+        term: 5,
+        generation: 7,
+        acquired_at_ms: 0,
+        expires_at_ms: u64::MAX,
+    };
+    assert!(
+        stale_lease.fenced_by_term(6),
+        "a partitioned old primary must fail closed even if its local TTL has not expired"
+    );
+}
+
+#[test]
+#[ignore = "heavy seeded replication-network safety profile; scheduled nightly in CI"]
+fn replication_network_simulator_heavy_profile() {
+    for seed in 0..512 {
+        let leaders = run_partitioned_elections(seed, true);
+        assert_no_two_leaders_in_same_term(&leaders, seed);
+    }
+}
+
+fn run_partitioned_elections(seed: u64, lossy: bool) -> Vec<(u64, String)> {
+    let mut cluster = SimElectionCluster::new(seed, 8);
+    cluster.network.partition("node-a", "node-d");
+    cluster.network.partition("node-a", "node-e");
+    cluster.network.partition("node-b", "node-d");
+    cluster.network.partition("node-b", "node-e");
+    if lossy {
+        cluster.network.set_loss_per_million(250_000);
+        cluster.network.set_max_delay(Duration::from_millis(3));
+        cluster.network.set_reorder_window(3);
+    }
+    cluster.try_candidates(&["node-a", "node-b", "node-c", "node-d", "node-e"], 1)
+}
+
+fn assert_no_two_leaders_in_same_term(leaders: &[(u64, String)], seed: u64) {
+    let mut seen = BTreeMap::new();
+    for (term, node) in leaders {
+        let previous = seen.insert(*term, node.clone());
+        assert!(
+            previous.is_none(),
+            "seed {seed} elected two leaders in term {term}: {previous:?} and {node}"
+        );
+    }
+}
+
+struct SimElectionCluster {
+    network: InProcessReplicationTransport<ReplicationControlMessage>,
+    voters: BTreeMap<String, Voter<MemoryLastVoteStore>>,
+    frontiers: BTreeMap<String, u64>,
+    members: Vec<Member>,
+    commit_watermark: u64,
+    promoted: Vec<(u64, String)>,
+    refused_self_votes: BTreeSet<(u64, String)>,
+}
+
+impl SimElectionCluster {
+    fn new(seed: u64, commit_watermark: u64) -> Self {
+        let ids = ["node-a", "node-b", "node-c", "node-d", "node-e"];
+        let voters = ids
+            .iter()
+            .map(|id| {
+                (
+                    (*id).to_string(),
+                    Voter::new(*id, MemoryLastVoteStore::seeded(LastVote::default())),
+                )
+            })
+            .collect();
+        let frontiers = ids.iter().map(|id| ((*id).to_string(), 10)).collect();
+        let members = ids.iter().map(|id| Member::data_voting(*id)).collect();
+        Self {
+            network: InProcessReplicationTransport::new(seed),
+            voters,
+            frontiers,
+            members,
+            commit_watermark,
+            promoted: Vec::new(),
+            refused_self_votes: BTreeSet::new(),
+        }
+    }
+
+    fn try_candidates(&mut self, candidates: &[&str], current_term: u64) -> Vec<(u64, String)> {
+        for candidate in candidates {
+            let req = ElectionRequest {
+                candidate: Member::data_voting(*candidate),
+                current_term,
+                last_log_lsn: self
+                    .frontiers
+                    .get(*candidate)
+                    .copied()
+                    .expect("candidate frontier seeded"),
+                commit_watermark: self.commit_watermark,
+            };
+            let timeout = Duration::from_millis(100);
+            let _ = ElectionCoordinator::run(&req, self, timeout);
+        }
+        self.promoted.clone()
+    }
+}
+
+impl ElectionTransport for SimElectionCluster {
+    fn members(&self) -> Vec<Member> {
+        self.members.clone()
+    }
+
+    fn request_vote(&mut self, peer_id: &str, req: &VoteRequest) -> VoteDecision {
+        if self
+            .refused_self_votes
+            .contains(&(req.term, req.candidate_id.clone()))
+        {
+            return VoteDecision::Refused(RefusalReason::AlreadyVoted {
+                term: req.term,
+                voted_for: "durable self-vote refused".to_string(),
+            });
+        }
+        let payload = ReplicationControlMessage::ElectionVoteRequest(req.clone());
+        if self.network.send(&req.candidate_id, peer_id, payload) != DeliveryOutcome::Queued {
+            return VoteDecision::Refused(RefusalReason::StaleTerm {
+                candidate_term: req.term,
+                voter_term: req.term,
+            });
+        }
+
+        self.network.advance(Duration::from_millis(10));
+        let Some(message) = self.network.drain_ready(peer_id).into_iter().next() else {
+            return VoteDecision::Refused(RefusalReason::StaleTerm {
+                candidate_term: req.term,
+                voter_term: req.term,
+            });
+        };
+        let ReplicationControlMessage::ElectionVoteRequest(vote) = message.payload else {
+            panic!("unexpected simulator payload");
+        };
+        self.voters[peer_id]
+            .consider(&vote, self.commit_watermark)
+            .expect("in-memory voter cannot fail")
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.network.now()
+    }
+
+    fn bump_term(&mut self, new_term: u64) {
+        let Some(candidate) = self.network.last_sender().map(str::to_string) else {
+            return;
+        };
+        let self_vote = VoteRequest::real(
+            candidate.clone(),
+            new_term,
+            self.frontiers
+                .get(&candidate)
+                .copied()
+                .expect("candidate frontier seeded"),
+        );
+        if !self.voters[&candidate]
+            .consider(&self_vote, self.commit_watermark)
+            .expect("in-memory voter cannot fail")
+            .is_granted()
+        {
+            self.refused_self_votes.insert((new_term, candidate));
+        }
+    }
+
+    fn promote(&mut self, new_term: u64) {
+        let candidate = self
+            .network
+            .last_sender()
+            .unwrap_or("<unknown>")
+            .to_string();
+        self.promoted.push((new_term, candidate));
+    }
+}
+
+struct LaggingFailover {
+    frontier: u64,
+    target_readings: Vec<u64>,
+    elapsed: Duration,
+    writes_resumed: bool,
+    role: NodeRole,
+}
+
+impl LaggingFailover {
+    fn new(frontier: u64, target_readings: Vec<u64>) -> Self {
+        Self {
+            frontier,
+            target_readings,
+            elapsed: Duration::ZERO,
+            writes_resumed: false,
+            role: NodeRole::Primary { term: 1 },
+        }
+    }
+}
+
+impl FailoverTransport for LaggingFailover {
+    fn freeze_primary(&mut self) -> u64 {
+        self.frontier
+    }
+
+    fn resume_primary(&mut self) {
+        self.writes_resumed = true;
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    fn poll_target_frontier(&mut self) -> u64 {
+        self.elapsed += Duration::from_millis(1);
+        self.target_readings.pop().unwrap_or(0)
+    }
+
+    fn commit_handover(&mut self, new_term: u64) {
+        self.role = NodeRole::Primary { term: new_term };
+    }
+}
+
+fn failover_request(mode: FailoverMode) -> FailoverRequest {
+    FailoverRequest {
+        old_primary: FailoverNode::new("old", "http://old:55055", "us-east"),
+        target: FailoverNode::new("new", "http://new:55055", "us-west"),
+        current_term: 1,
+        target_frontier_hint: 8,
+        timeline_history: reddb::TimelineHistory::new(10),
+        mode,
+    }
+}


### PR DESCRIPTION
Automated AFK landing for #1358. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1358

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785099266&installation_id=129708444&pr_number=1481&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1481&signature=3902241a4350bf8d7bc4406a5ceb66bcaa7e626bd40f81e563f4b697d7f91957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->