### PR TITLE
merge: #1451 Add Exact claim all-or-nothing cardinality

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -1866,8 +1866,10 @@ pub struct UpdateQuery {
     pub with_metadata: Vec<(String, Value)>,
     /// Optional RETURNING clause items.
     pub returning: Option<Vec<ReturningItem>>,
-    /// Optional partial Concurrent claim cardinality.
+    /// Optional Concurrent claim cardinality.
     pub claim_limit: Option<u64>,
+    /// Require the claim cardinality to be fully satisfied before mutating.
+    pub claim_exact: bool,
     /// Optional deterministic target ordering for limited UPDATE batches.
     pub order_by: Vec<OrderByClause>,
     /// Optional `LIMIT N` cap. Caps the number of targets the executor

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -387,11 +387,15 @@ impl<'a> Parser<'a> {
 
         let (ttl_ms, expires_at_ms, with_metadata, _auto_embed) = self.parse_with_clauses()?;
 
-        let claim_limit = if self.consume_ident_ci("CLAIM")? {
-            self.expect(Token::Limit)?;
-            Some(self.parse_integer()? as u64)
+        let (claim_limit, claim_exact) = if self.consume_ident_ci("CLAIM")? {
+            if self.consume_ident_ci("EXACT")? {
+                (Some(self.parse_integer()? as u64), true)
+            } else {
+                self.expect(Token::Limit)?;
+                (Some(self.parse_integer()? as u64), false)
+            }
         } else {
-            None
+            (None, false)
         };
 
         let mut order_by = if self.consume(&Token::Order)? {
@@ -461,6 +465,7 @@ impl<'a> Parser<'a> {
             with_metadata,
             returning,
             claim_limit,
+            claim_exact,
             order_by,
             limit,
             suppress_events,
@@ -1225,6 +1230,7 @@ mod tests {
         assert_eq!(query.ttl_ms, Some(30_000));
         assert_eq!(query.with_metadata.len(), 1);
         assert_eq!(query.claim_limit, None);
+        assert!(!query.claim_exact);
         assert_eq!(query.limit, Some(5));
         assert_eq!(query.order_by.len(), 2);
         assert!(matches!(
@@ -1251,6 +1257,20 @@ mod tests {
              CLAIM LIMIT 2 ORDER BY priority ASC RETURNING id",
         );
         assert_eq!(query.claim_limit, Some(2));
+        assert!(!query.claim_exact);
+        assert_eq!(query.limit, None);
+        assert_eq!(query.order_by.len(), 2);
+        assert!(matches!(
+            &query.order_by[1].field,
+            FieldRef::TableColumn { column, .. } if column == "rid"
+        ));
+
+        let query = update(
+            "UPDATE docs SET status = 'reserved' WHERE status = 'available' \
+             CLAIM EXACT 2 ORDER BY priority ASC RETURNING id",
+        );
+        assert_eq!(query.claim_limit, Some(2));
+        assert!(query.claim_exact);
         assert_eq!(query.limit, None);
         assert_eq!(query.order_by.len(), 2);
         assert!(matches!(

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -97,6 +97,14 @@ fn render_update(uq: &UpdateQuery) -> String {
         sql.push_str(" WHERE ");
         sql.push_str(&render_filter(filter));
     }
+    if let Some(claim_limit) = uq.claim_limit {
+        if uq.claim_exact {
+            sql.push_str(" CLAIM EXACT ");
+        } else {
+            sql.push_str(" CLAIM LIMIT ");
+        }
+        sql.push_str(&claim_limit.to_string());
+    }
     sql
 }
 

--- a/crates/reddb-rql/src/sql_lowering.rs
+++ b/crates/reddb-rql/src/sql_lowering.rs
@@ -1580,6 +1580,7 @@ mod tests {
             order_by: vec![OrderByClause::asc(field("id"))],
             limit: Some(1),
             claim_limit: None,
+            claim_exact: false,
             suppress_events: false,
         };
         assert!(matches!(

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1808,6 +1808,27 @@ impl RedDBRuntime {
         let effective_filter = effective_update_filter(query);
         let compiled_plan = self.compile_update_plan(query)?;
         let needs_rmw_lock = update_needs_rmw_lock(query);
+        let claim_lock = query.claim_limit.map(|_| {
+            self.inner
+                .rmw_locks
+                .lock_for(&query.table, "__table_claim_update__")
+        });
+        let _claim_guard = if let Some(lock) = claim_lock.as_ref() {
+            let Some(guard) = lock.try_lock() else {
+                return Ok((
+                    RuntimeQueryResult::dml_result(
+                        raw_query.to_string(),
+                        0,
+                        "update",
+                        "runtime-dml",
+                    ),
+                    Vec::new(),
+                ));
+            };
+            Some(guard)
+        } else {
+            None
+        };
         let table_rmw_lock = if needs_rmw_lock {
             Some(
                 self.inner
@@ -1819,7 +1840,8 @@ impl RedDBRuntime {
         };
         let _table_rmw_guard = table_rmw_lock.as_ref().map(|lock| lock.lock());
         let mut touched_ids: Vec<EntityId> = Vec::new();
-        let limit_cap = query.limit.map(|l| l as usize);
+        let claim_cap = query.claim_limit.map(|limit| limit as usize);
+        let limit_cap = claim_cap.or_else(|| query.limit.map(|limit| limit as usize));
         let manager = store
             .get_collection(&query.table)
             .ok_or_else(|| RedDBError::NotFound(query.table.clone()))?;
@@ -1844,6 +1866,14 @@ impl RedDBRuntime {
         } else {
             ordered_update_target_ids(&manager, &ids_to_update, &query.order_by, limit_cap)
         };
+        if query.claim_exact
+            && claim_cap.is_some_and(|claim_count| ids_to_update.len() < claim_count)
+        {
+            return Ok((
+                RuntimeQueryResult::dml_result(raw_query.to_string(), 0, "update", "runtime-dml"),
+                Vec::new(),
+            ));
+        }
 
         if needs_rmw_lock {
             return self.execute_update_inner_tracked_locked(

--- a/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
+++ b/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
@@ -31,10 +31,73 @@ fn selected_ids(rt: &RedDBRuntime, table: &str) -> Vec<i64> {
     .collect()
 }
 
+fn status_ids(rt: &RedDBRuntime, table: &str, status: &str) -> Vec<i64> {
+    exec(
+        rt,
+        &format!("SELECT id FROM {table} WHERE status = '{status}' ORDER BY id ASC"),
+    )
+    .result
+    .records
+    .iter()
+    .map(|record| int_field(record, "id"))
+    .collect()
+}
+
 fn err_string(rt: &RedDBRuntime, sql: &str) -> String {
     rt.execute_query(sql)
         .expect_err("query should fail")
         .to_string()
+}
+
+#[test]
+fn claim_exact_updates_requested_cardinality_when_available() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE exact_claim_success (id INT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO exact_claim_success (id, rank, status) VALUES \
+         (1, 30, 'ready'), (2, 10, 'ready'), (3, 20, 'ready')",
+    );
+
+    let updated = exec(
+        &rt,
+        "UPDATE exact_claim_success SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM EXACT 2 ORDER BY rank ASC",
+    );
+
+    assert_eq!(updated.affected_rows, 2);
+    assert_eq!(
+        status_ids(&rt, "exact_claim_success", "claimed"),
+        vec![2, 3]
+    );
+    assert_eq!(status_ids(&rt, "exact_claim_success", "ready"), vec![1]);
+}
+
+#[test]
+fn claim_exact_miss_reports_zero_and_applies_no_partial_write() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE exact_claim_miss (id INT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO exact_claim_miss (id, rank, status) VALUES \
+         (1, 10, 'ready'), (2, 20, 'ready')",
+    );
+
+    let updated = exec(
+        &rt,
+        "UPDATE exact_claim_miss SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM EXACT 3 ORDER BY rank ASC",
+    );
+
+    assert_eq!(updated.affected_rows, 0);
+    assert!(status_ids(&rt, "exact_claim_miss", "claimed").is_empty());
+    assert_eq!(status_ids(&rt, "exact_claim_miss", "ready"), vec![1, 2]);
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1451. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1451

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785101652&installation_id=129708444&pr_number=1482&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1482&signature=836287b1e887102b7bd8d9b64a6ca1806f3a4e05016dc763abf66903108ecf66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->