### PR TITLE
merge: #1316 feat(mcp): connection-model knowledge (RedWire schemes + topologies)

### DIFF
--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -1608,6 +1608,32 @@ mod tests {
     }
 
     #[test]
+    fn resources_list_includes_connection_knowledge() {
+        let mut srv = make_server();
+        let request = parse_json(r#"{"jsonrpc":"2.0","id":11,"method":"resources/list"}"#);
+        let response = srv.handle_message(&request).expect("response");
+        let parsed = parse_json(&response);
+        let resources = parsed
+            .get("result")
+            .and_then(|result| result.get("resources"))
+            .and_then(JsonValue::as_array)
+            .expect("resources array");
+
+        let connection = resources
+            .iter()
+            .find(|res| {
+                res.get("uri").and_then(JsonValue::as_str)
+                    == Some(reddb_wire::knowledge::RESOURCE_URI)
+            })
+            .expect("connection knowledge resource listed");
+        assert_eq!(
+            connection.get("mimeType").and_then(JsonValue::as_str),
+            Some("text/markdown")
+        );
+        assert!(connection.get("name").and_then(JsonValue::as_str).is_some());
+    }
+
+    #[test]
     fn resources_read_returns_generated_rql_reference() {
         let mut srv = make_server();
         let request = parse_json(
@@ -1660,6 +1686,44 @@ mod tests {
             "value type missing: {text:.120}"
         );
         assert!(text.contains("Multi-model map"), "multi-model map missing");
+    }
+
+    #[test]
+    fn resources_read_returns_generated_connection_reference() {
+        let mut srv = make_server();
+        let request = parse_json(
+            r#"{"jsonrpc":"2.0","id":12,"method":"resources/read","params":{"uri":"reddb://knowledge/connections"}}"#,
+        );
+        let response = srv.handle_message(&request).expect("response");
+        let parsed = parse_json(&response);
+        let text = parsed
+            .get("result")
+            .and_then(|result| result.get("contents"))
+            .and_then(JsonValue::as_array)
+            .and_then(|contents| contents.first())
+            .and_then(|item| item.get("text"))
+            .and_then(JsonValue::as_str)
+            .expect("resource text");
+
+        // The body is exactly what the wire authority generates — same source as
+        // docs/llms.txt.
+        assert_eq!(text, reddb_wire::knowledge::connection_reference_markdown());
+        assert!(text.contains("`red://`"), "red scheme missing: {text:.120}");
+        assert!(text.contains("`reds://`"), "reds scheme missing");
+        assert!(
+            text.contains("principal transport"),
+            "principal transport narrative missing"
+        );
+        assert!(
+            text.contains("Embedded / standalone"),
+            "embedded topology missing"
+        );
+        assert!(text.contains("Serverless"), "serverless topology missing");
+        assert!(
+            text.contains("Primary-replica"),
+            "primary-replica topology missing"
+        );
+        assert!(text.contains("Cluster"), "cluster topology missing");
     }
 
     #[test]

--- a/crates/reddb-server/src/mcp/tools.rs
+++ b/crates/reddb-server/src/mcp/tools.rs
@@ -29,7 +29,7 @@ pub struct ResourceDef {
 /// The static set of knowledge resources `red mcp` serves. Each domain is
 /// generated from the engine's own authorities (ADR 0061): the RQL reference
 /// from `reddb-io-rql`, and the value-type catalog + multi-model map from
-/// `reddb-io-types`.
+/// `reddb-io-types`, and the connection model from `reddb-io-wire`.
 pub fn knowledge_resources() -> Vec<ResourceDef> {
     vec![
         ResourceDef {
@@ -45,6 +45,13 @@ pub fn knowledge_resources() -> Vec<ResourceDef> {
             description: reddb_types::knowledge::RESOURCE_DESCRIPTION,
             mime_type: "text/markdown",
             body: reddb_types::knowledge::type_reference_markdown,
+        },
+        ResourceDef {
+            uri: reddb_wire::knowledge::RESOURCE_URI,
+            title: reddb_wire::knowledge::RESOURCE_TITLE,
+            description: reddb_wire::knowledge::RESOURCE_DESCRIPTION,
+            mime_type: "text/markdown",
+            body: reddb_wire::knowledge::connection_reference_markdown,
         },
     ]
 }

--- a/crates/reddb-wire/src/conn_string.rs
+++ b/crates/reddb-wire/src/conn_string.rs
@@ -84,6 +84,127 @@ pub const DEFAULT_PORT_GRPCS: u16 = 55555;
 pub const DEFAULT_PORT_WS: u16 = 80;
 pub const DEFAULT_PORT_WSS: u16 = 443;
 
+/// URI schemes accepted by the connection-string parser.
+///
+/// This enum is the connection-layer source for generated agent knowledge:
+/// [`crate::knowledge`] iterates [`SUPPORTED_SCHEMES`] instead of carrying a
+/// separate hand-maintained scheme list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionScheme {
+    Memory,
+    File,
+    Red,
+    Reds,
+    RedWs,
+    RedWss,
+    Grpc,
+    Grpcs,
+    Http,
+    Https,
+}
+
+/// Stable parser-owned list of supported URI schemes.
+pub const SUPPORTED_SCHEMES: &[ConnectionScheme] = &[
+    ConnectionScheme::Red,
+    ConnectionScheme::Reds,
+    ConnectionScheme::Grpc,
+    ConnectionScheme::Grpcs,
+    ConnectionScheme::Http,
+    ConnectionScheme::Https,
+    ConnectionScheme::Memory,
+    ConnectionScheme::File,
+    ConnectionScheme::RedWs,
+    ConnectionScheme::RedWss,
+];
+
+impl ConnectionScheme {
+    pub fn from_uri_scheme(scheme: &str) -> Option<Self> {
+        match scheme {
+            "memory" => Some(Self::Memory),
+            "file" => Some(Self::File),
+            "red" => Some(Self::Red),
+            "reds" => Some(Self::Reds),
+            "red+ws" => Some(Self::RedWs),
+            "red+wss" => Some(Self::RedWss),
+            "grpc" => Some(Self::Grpc),
+            "grpcs" => Some(Self::Grpcs),
+            "http" => Some(Self::Http),
+            "https" => Some(Self::Https),
+            _ => None,
+        }
+    }
+
+    pub fn uri_prefix(self) -> &'static str {
+        match self {
+            Self::Memory => "memory://",
+            Self::File => "file://",
+            Self::Red => "red://",
+            Self::Reds => "reds://",
+            Self::RedWs => "red+ws://",
+            Self::RedWss => "red+wss://",
+            Self::Grpc => "grpc://",
+            Self::Grpcs => "grpcs://",
+            Self::Http => "http://",
+            Self::Https => "https://",
+        }
+    }
+
+    pub fn transport(self) -> &'static str {
+        match self {
+            Self::Memory => "embedded in-memory engine",
+            Self::File => "embedded file-backed engine",
+            Self::Red | Self::Reds => "RedWire TCP",
+            Self::RedWs | Self::RedWss => "RedWire WebSocket",
+            Self::Grpc | Self::Grpcs => "gRPC",
+            Self::Http | Self::Https => "HTTP REST",
+        }
+    }
+
+    pub fn mode(self) -> &'static str {
+        match self {
+            Self::Memory | Self::File => "embedded",
+            Self::Red
+            | Self::Reds
+            | Self::RedWs
+            | Self::RedWss
+            | Self::Grpc
+            | Self::Grpcs
+            | Self::Http
+            | Self::Https => "remote",
+        }
+    }
+
+    pub fn example(self) -> &'static str {
+        match self {
+            Self::Memory => "memory://",
+            Self::File => "file:///var/lib/reddb/app.db",
+            Self::Red => "red://db.example.com:5050",
+            Self::Reds => "reds://db.example.com:5050",
+            Self::RedWs => "red+ws://db.example.com",
+            Self::RedWss => "red+wss://db.example.com",
+            Self::Grpc => "grpc://db.example.com:55055",
+            Self::Grpcs => "grpcs://db.example.com:55555",
+            Self::Http => "http://db.example.com:80",
+            Self::Https => "https://db.example.com:443",
+        }
+    }
+
+    pub fn notes(self) -> &'static str {
+        match self {
+            Self::Memory => "Zero-config ephemeral engine, commonly used by local MCP hosts.",
+            Self::File => "Embedded durable engine rooted at the URI path.",
+            Self::Red => "Principal RedWire transport without TLS.",
+            Self::Reds => "Principal RedWire transport with TLS.",
+            Self::RedWs => "Browser-native RedWire over WebSocket without TLS.",
+            Self::RedWss => "Browser-native RedWire over WebSocket with TLS.",
+            Self::Grpc => "Compatibility transport for existing gRPC clients.",
+            Self::Grpcs => "TLS variant of the gRPC compatibility transport.",
+            Self::Http => "REST/admin transport without TLS.",
+            Self::Https => "REST/admin transport with TLS.",
+        }
+    }
+}
+
 /// DoS guardrails applied by [`parse`] before any URI work happens.
 ///
 /// The connection-string parser is the only entry point an attacker
@@ -233,8 +354,8 @@ pub fn parse_with_limits(
 
     enforce_query_param_limit(&parsed, &limits)?;
 
-    match parsed.scheme() {
-        "red" | "reds" => {
+    match ConnectionScheme::from_uri_scheme(parsed.scheme()) {
+        Some(ConnectionScheme::Red | ConnectionScheme::Reds) => {
             let host = parsed.host_str().ok_or_else(|| {
                 ParseError::new(ParseErrorKind::InvalidUri, "red:// URI is missing a host")
             })?;
@@ -245,7 +366,7 @@ pub fn parse_with_limits(
                 tls: parsed.scheme() == "reds",
             })
         }
-        "red+ws" | "red+wss" => {
+        Some(ConnectionScheme::RedWs | ConnectionScheme::RedWss) => {
             let host = parsed.host_str().ok_or_else(|| {
                 ParseError::new(
                     ParseErrorKind::InvalidUri,
@@ -264,7 +385,7 @@ pub fn parse_with_limits(
                 tls,
             })
         }
-        "grpc" | "grpcs" => {
+        Some(ConnectionScheme::Grpc | ConnectionScheme::Grpcs) => {
             let host = parsed.host_str().ok_or_else(|| {
                 ParseError::new(ParseErrorKind::InvalidUri, "grpc:// URI is missing a host")
             })?;
@@ -279,7 +400,7 @@ pub fn parse_with_limits(
                 endpoint: format!("http://{host}:{port}"),
             })
         }
-        "http" | "https" => {
+        Some(ConnectionScheme::Http | ConnectionScheme::Https) => {
             let host = parsed.host_str().ok_or_else(|| {
                 ParseError::new(
                     ParseErrorKind::InvalidUri,
@@ -294,9 +415,9 @@ pub fn parse_with_limits(
                 base_url: format!("{scheme}://{host}:{port}"),
             })
         }
-        other => Err(ParseError::new(
+        Some(ConnectionScheme::Memory | ConnectionScheme::File) | None => Err(ParseError::new(
             ParseErrorKind::UnsupportedScheme,
-            format!("unsupported scheme: {other}"),
+            format!("unsupported scheme: {}", parsed.scheme()),
         )),
     }
 }

--- a/crates/reddb-wire/src/knowledge.rs
+++ b/crates/reddb-wire/src/knowledge.rs
@@ -1,0 +1,160 @@
+//! Agent-facing connection-model knowledge reference.
+//!
+//! Supported URI schemes are generated from the connection layer's
+//! [`crate::conn_string::SUPPORTED_SCHEMES`] catalog. The deployment topology
+//! guidance is hand-authored narrative per ADR 0061.
+
+use crate::conn_string::{ConnectionScheme, SUPPORTED_SCHEMES};
+
+/// Canonical URI for the connection-model knowledge resource served over MCP.
+pub const RESOURCE_URI: &str = "reddb://knowledge/connections";
+
+/// Short human title for the connection knowledge resource.
+pub const RESOURCE_TITLE: &str = "RedDB Connection Model";
+
+/// One-line description of the connection knowledge resource.
+pub const RESOURCE_DESCRIPTION: &str =
+    "Generated URI scheme/transport catalog plus the RedDB deployment topology guide.";
+
+/// Markers delimiting the generated connection block inside `docs/llms.txt`.
+pub const LLMS_BEGIN_MARKER: &str = "<!-- BEGIN GENERATED: connections -->";
+/// Closing marker for the generated connection block in `docs/llms.txt`.
+pub const LLMS_END_MARKER: &str = "<!-- END GENERATED: connections -->";
+
+struct Topology {
+    name: &'static str,
+    summary: &'static str,
+}
+
+const TOPOLOGIES: &[Topology] = &[
+    Topology {
+        name: "Embedded / standalone",
+        summary: "`memory://` and `file://` run the engine in the caller's process; \
+a standalone server exposes the same engine over RedWire, gRPC, and HTTP.",
+    },
+    Topology {
+        name: "Serverless",
+        summary: "Serverless callers usually keep no local state and connect to a managed \
+endpoint. Prefer `reds://` when RedWire is reachable; use HTTPS/gRPC only when the platform \
+requires those transports.",
+    },
+    Topology {
+        name: "Primary-replica",
+        summary: "A primary accepts writes while replicas serve read traffic after replication. \
+Multi-host remote URIs express primary-first routing, with `?route=primary` available when reads \
+must stay on the primary.",
+    },
+    Topology {
+        name: "Cluster",
+        summary: "Cluster deployments coordinate multiple RedDB nodes behind the same logical \
+database. RedWire (`red://` / `reds://`) is the principal data-plane transport; gRPC and HTTP are \
+compatibility/admin surfaces, not the only way to connect.",
+    },
+];
+
+/// Full Markdown body served by the MCP resource.
+pub fn connection_reference_markdown() -> String {
+    let mut out = String::new();
+    push_intro(&mut out);
+    push_supported_schemes(&mut out);
+    push_topologies(&mut out);
+    out
+}
+
+/// The connection block as embedded in `docs/llms.txt`.
+pub fn connection_llms_section() -> String {
+    format!(
+        "{LLMS_BEGIN_MARKER}\n{}\n{LLMS_END_MARKER}",
+        connection_reference_markdown().trim_end()
+    )
+}
+
+fn push_intro(out: &mut String) {
+    out.push_str("# RedDB Connection Model\n\n");
+    out.push_str(
+        "RedWire (`red://` / `reds://`) is RedDB's principal transport. \
+gRPC, HTTP(S), browser WebSocket variants, `memory://`, and `file://` are supported connection \
+surfaces, but agents should not collapse the model to \"only gRPC\" or \"only WebSocket\".\n\n",
+    );
+}
+
+fn push_supported_schemes(out: &mut String) {
+    out.push_str("## Supported URI Schemes and Transports\n\n");
+    out.push_str("| URI scheme | Transport | Mode | Example | Notes |\n");
+    out.push_str("|---|---|---|---|---|\n");
+    for scheme in SUPPORTED_SCHEMES {
+        push_scheme_row(out, *scheme);
+    }
+    out.push('\n');
+}
+
+fn push_scheme_row(out: &mut String, scheme: ConnectionScheme) {
+    out.push_str("| `");
+    out.push_str(scheme.uri_prefix());
+    out.push_str("` | ");
+    out.push_str(scheme.transport());
+    out.push_str(" | ");
+    out.push_str(scheme.mode());
+    out.push_str(" | `");
+    out.push_str(scheme.example());
+    out.push_str("` | ");
+    out.push_str(scheme.notes());
+    out.push_str(" |\n");
+}
+
+fn push_topologies(out: &mut String) {
+    out.push_str("## Deployment Topologies\n\n");
+    for topology in TOPOLOGIES {
+        out.push_str("### ");
+        out.push_str(topology.name);
+        out.push_str("\n\n");
+        out.push_str(topology.summary);
+        out.push_str("\n\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn supported_scheme_examples_parse() {
+        for scheme in SUPPORTED_SCHEMES {
+            crate::conn_string::parse(scheme.example()).unwrap_or_else(|err| {
+                panic!("{} example did not parse: {err}", scheme.uri_prefix())
+            });
+        }
+    }
+
+    #[test]
+    fn reference_lists_supported_schemes_from_connection_layer() {
+        let markdown = connection_reference_markdown();
+        for scheme in SUPPORTED_SCHEMES {
+            let needle = format!("`{}`", scheme.uri_prefix());
+            assert!(markdown.contains(&needle), "missing {needle}");
+        }
+    }
+
+    #[test]
+    fn reference_covers_principal_transport_and_topologies() {
+        let markdown = connection_reference_markdown();
+        assert!(markdown.contains("principal transport"));
+        assert!(markdown.contains("RedWire (`red://` / `reds://`)"));
+        for topology in TOPOLOGIES {
+            assert!(
+                markdown.contains(topology.name),
+                "missing {}",
+                topology.name
+            );
+        }
+    }
+
+    #[test]
+    fn llms_section_wraps_reference() {
+        let section = connection_llms_section();
+        assert!(section.starts_with(LLMS_BEGIN_MARKER));
+        assert!(section.ends_with(LLMS_END_MARKER));
+        let reference = connection_reference_markdown();
+        assert!(section.contains(reference.trim_end()));
+    }
+}

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -20,6 +20,7 @@
 pub mod auth;
 pub mod conn_string;
 pub mod jsonrpc;
+pub mod knowledge;
 pub mod legacy;
 pub mod query_with_params;
 pub mod redwire;
@@ -28,10 +29,11 @@ pub mod sanitizer;
 pub mod topology;
 
 pub use conn_string::{
-    is_embedded_connection_uri, parse, parse_with_limits, ConnStringLimits, ConnectionTarget,
-    ParseError, ParseErrorKind, DEFAULT_PORT_GRPC, DEFAULT_PORT_GRPCS, DEFAULT_PORT_RED,
-    DEFAULT_PORT_WS, DEFAULT_PORT_WSS,
+    is_embedded_connection_uri, parse, parse_with_limits, ConnStringLimits, ConnectionScheme,
+    ConnectionTarget, ParseError, ParseErrorKind, DEFAULT_PORT_GRPC, DEFAULT_PORT_GRPCS,
+    DEFAULT_PORT_RED, DEFAULT_PORT_WS, DEFAULT_PORT_WSS, SUPPORTED_SCHEMES,
 };
+pub use knowledge::*;
 pub use redwire::{BuildError, FrameBuilder};
 pub use sanitizer::{
     audit_safe_log_field, Boundary, ConnStringSanitizer, EscapeError, EscapedFor, ParsedConnString,

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -158,3 +158,42 @@ Relational tables with typed columns queried through RQL; columns bind directly 
 Type families: `Numeric`, `String`, `Boolean`, `DateTime`, `Domain`
 
 <!-- END GENERATED: types -->
+
+<!-- BEGIN GENERATED: connections -->
+# RedDB Connection Model
+
+RedWire (`red://` / `reds://`) is RedDB's principal transport. gRPC, HTTP(S), browser WebSocket variants, `memory://`, and `file://` are supported connection surfaces, but agents should not collapse the model to "only gRPC" or "only WebSocket".
+
+## Supported URI Schemes and Transports
+
+| URI scheme | Transport | Mode | Example | Notes |
+|---|---|---|---|---|
+| `red://` | RedWire TCP | remote | `red://db.example.com:5050` | Principal RedWire transport without TLS. |
+| `reds://` | RedWire TCP | remote | `reds://db.example.com:5050` | Principal RedWire transport with TLS. |
+| `grpc://` | gRPC | remote | `grpc://db.example.com:55055` | Compatibility transport for existing gRPC clients. |
+| `grpcs://` | gRPC | remote | `grpcs://db.example.com:55555` | TLS variant of the gRPC compatibility transport. |
+| `http://` | HTTP REST | remote | `http://db.example.com:80` | REST/admin transport without TLS. |
+| `https://` | HTTP REST | remote | `https://db.example.com:443` | REST/admin transport with TLS. |
+| `memory://` | embedded in-memory engine | embedded | `memory://` | Zero-config ephemeral engine, commonly used by local MCP hosts. |
+| `file://` | embedded file-backed engine | embedded | `file:///var/lib/reddb/app.db` | Embedded durable engine rooted at the URI path. |
+| `red+ws://` | RedWire WebSocket | remote | `red+ws://db.example.com` | Browser-native RedWire over WebSocket without TLS. |
+| `red+wss://` | RedWire WebSocket | remote | `red+wss://db.example.com` | Browser-native RedWire over WebSocket with TLS. |
+
+## Deployment Topologies
+
+### Embedded / standalone
+
+`memory://` and `file://` run the engine in the caller's process; a standalone server exposes the same engine over RedWire, gRPC, and HTTP.
+
+### Serverless
+
+Serverless callers usually keep no local state and connect to a managed endpoint. Prefer `reds://` when RedWire is reachable; use HTTPS/gRPC only when the platform requires those transports.
+
+### Primary-replica
+
+A primary accepts writes while replicas serve read traffic after replication. Multi-host remote URIs express primary-first routing, with `?route=primary` available when reads must stay on the primary.
+
+### Cluster
+
+Cluster deployments coordinate multiple RedDB nodes behind the same logical database. RedWire (`red://` / `reds://`) is the principal data-plane transport; gRPC and HTTP are compatibility/admin surfaces, not the only way to connect.
+<!-- END GENERATED: connections -->

--- a/tests/llms_txt_generated.rs
+++ b/tests/llms_txt_generated.rs
@@ -37,6 +37,8 @@ emitted from source so it cannot drift from the engine.\n\n",
     out.push_str(&reddb_rql::knowledge::rql_llms_section());
     out.push_str("\n\n");
     out.push_str(&reddb_types::knowledge::type_llms_section());
+    out.push_str("\n\n");
+    out.push_str(&reddb_wire::knowledge::connection_llms_section());
     out.push('\n');
     out
 }
@@ -104,4 +106,19 @@ fn types_section_matches_mcp_resource() {
     // The same generated source feeds docs/llms.txt and the MCP resource.
     assert_eq!(section, reddb_types::knowledge::type_llms_section());
     assert!(section.contains(&reddb_types::knowledge::type_reference_markdown()));
+}
+
+#[test]
+fn connection_section_matches_mcp_resource() {
+    let path = llms_txt_path();
+    let on_disk = fs::read_to_string(&path).expect("read docs/llms.txt");
+    let section = extract_section(
+        &on_disk,
+        reddb_wire::knowledge::LLMS_BEGIN_MARKER,
+        reddb_wire::knowledge::LLMS_END_MARKER,
+    );
+    // The same generated source feeds docs/llms.txt and the MCP resource.
+    assert_eq!(section, reddb_wire::knowledge::connection_llms_section());
+    let reference = reddb_wire::knowledge::connection_reference_markdown();
+    assert!(section.contains(reference.trim_end()));
 }


### PR DESCRIPTION
Automated AFK landing for #1316. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1316

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785109739&installation_id=129708444&pr_number=1483&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1483&signature=2981453bf7dda8b331424f176188867b1c99cd4ca49fb459c1e7437d4708f91e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->