### PR TITLE
merge: #1452 Make claim locks transaction-scoped across commit and rollback

### DIFF
--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1129,6 +1129,12 @@ struct RuntimeInner {
         parking_lot::RwLock<HashMap<u64, Vec<crate::replication::cdc::KvWatchEvent>>>,
     pending_store_wal_actions:
         parking_lot::RwLock<HashMap<u64, crate::storage::unified::DeferredStoreWalActions>>,
+    /// Transaction-scoped table UPDATE CLAIM ownership.
+    ///
+    /// Keyed by `(collection, logical_row_id)` and valued by connection id.
+    /// Only claim selection consults this map: ordinary DML still follows
+    /// MVCC first-committer-wins instead of waiting on claim locks.
+    pending_claim_locks: parking_lot::RwLock<HashMap<(String, EntityId), u64>>,
     /// Table-scoped tenancy registry (Phase 2.5.4).
     ///
     /// Maps `table_name → tenant_column`. DML auto-fill looks here to

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -2425,6 +2425,7 @@ impl RedDBRuntime {
                 pending_versioned_updates: parking_lot::RwLock::new(HashMap::new()),
                 pending_kv_watch_events: parking_lot::RwLock::new(HashMap::new()),
                 pending_store_wal_actions: parking_lot::RwLock::new(HashMap::new()),
+                pending_claim_locks: parking_lot::RwLock::new(HashMap::new()),
                 queue_wait_registry: std::sync::Arc::new(
                     crate::runtime::queue_wait_registry::QueueWaitRegistry::new(),
                 ),
@@ -5375,6 +5376,7 @@ impl RedDBRuntime {
                                     self.discard_pending_kv_watch_events(conn_id);
                                     self.discard_pending_queue_wakes(conn_id);
                                     self.discard_pending_store_wal_actions(conn_id);
+                                    self.release_pending_claim_locks(conn_id);
                                     return Err(err);
                                 }
                                 self.restore_pending_write_stamps(conn_id);
@@ -5389,6 +5391,8 @@ impl RedDBRuntime {
                                     self.revive_pending_versioned_updates(conn_id);
                                     self.revive_pending_tombstones(conn_id);
                                     self.discard_pending_kv_watch_events(conn_id);
+                                    self.discard_pending_queue_wakes(conn_id);
+                                    self.release_pending_claim_locks(conn_id);
                                     return Err(err);
                                 }
                                 // Phase 2.3.2e: commit every open sub-xid
@@ -5407,6 +5411,7 @@ impl RedDBRuntime {
                                 self.finalize_pending_tombstones(conn_id);
                                 self.finalize_pending_kv_watch_events(conn_id);
                                 self.finalize_pending_queue_wakes(conn_id);
+                                self.release_pending_claim_locks(conn_id);
                                 ("commit", format!("COMMIT — xid={} committed", ctx.xid))
                             }
                             None => (
@@ -5437,6 +5442,7 @@ impl RedDBRuntime {
                                 self.discard_pending_kv_watch_events(conn_id);
                                 self.discard_pending_queue_wakes(conn_id);
                                 self.discard_pending_store_wal_actions(conn_id);
+                                self.release_pending_claim_locks(conn_id);
                                 ("rollback", format!("ROLLBACK — xid={} aborted", ctx.xid))
                             }
                             None => (
@@ -8794,6 +8800,13 @@ impl RedDBRuntime {
 
     pub(crate) fn discard_pending_queue_wakes(&self, conn_id: u64) {
         self.inner.pending_queue_wakes.write().remove(&conn_id);
+    }
+
+    pub(crate) fn release_pending_claim_locks(&self, conn_id: u64) {
+        self.inner
+            .pending_claim_locks
+            .write()
+            .retain(|_, owner| *owner != conn_id);
     }
 
     pub(crate) fn finalize_pending_kv_watch_events(&self, conn_id: u64) {

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -19,6 +19,7 @@ use crate::application::ports::{
 };
 use crate::application::ttl_payload::has_internal_ttl_metadata;
 use crate::presentation::entity_json::storage_value_to_json;
+use crate::runtime::mvcc::current_connection_id;
 use crate::storage::query::ast::{BinOp, Expr, FieldRef, ReturningItem, UpdateTarget};
 use crate::storage::query::sql_lowering::{
     effective_delete_filter, effective_insert_rows, effective_update_filter, fold_expr_to_value,
@@ -1861,11 +1862,24 @@ impl RedDBRuntime {
             target_scan = target_scan.with_live_table_rows();
         }
         let ids_to_update = target_scan.find_target_ids()?;
+        let order_limit = if query.claim_limit.is_some() {
+            None
+        } else {
+            limit_cap
+        };
         let ids_to_update = if query.order_by.is_empty() {
             ids_to_update
         } else {
-            ordered_update_target_ids(&manager, &ids_to_update, &query.order_by, limit_cap)
+            ordered_update_target_ids(&manager, &ids_to_update, &query.order_by, order_limit)
         };
+        let mut ids_to_update = if query.claim_limit.is_some() {
+            self.filter_claim_locked_target_ids(&query.table, ids_to_update)
+        } else {
+            ids_to_update
+        };
+        if let Some(claim_cap) = claim_cap {
+            ids_to_update.truncate(claim_cap);
+        }
         if query.claim_exact
             && claim_cap.is_some_and(|claim_count| ids_to_update.len() < claim_count)
         {
@@ -1876,13 +1890,17 @@ impl RedDBRuntime {
         }
 
         if needs_rmw_lock {
-            return self.execute_update_inner_tracked_locked(
+            let result = self.execute_update_inner_tracked_locked(
                 raw_query,
                 query,
                 &compiled_plan,
                 &ids_to_update,
                 effective_filter.as_ref(),
-            );
+            )?;
+            if query.claim_limit.is_some() {
+                self.record_pending_claim_locks_for_touched_ids(&query.table, &result.1);
+            }
+            return Ok(result);
         }
 
         let mut affected: u64 = 0;
@@ -1911,6 +1929,9 @@ impl RedDBRuntime {
         if affected > 0 {
             self.note_table_write(&query.table);
         }
+        if query.claim_limit.is_some() {
+            self.record_pending_claim_locks_for_touched_ids(&query.table, &touched_ids);
+        }
 
         Ok((
             RuntimeQueryResult::dml_result(
@@ -1921,6 +1942,38 @@ impl RedDBRuntime {
             ),
             touched_ids,
         ))
+    }
+
+    fn filter_claim_locked_target_ids(&self, table: &str, ids: Vec<EntityId>) -> Vec<EntityId> {
+        let conn_id = current_connection_id();
+        let locks = self.inner.pending_claim_locks.read();
+        ids.into_iter()
+            .filter(|id| {
+                let Some(entity) = self.inner.db.store().get(table, *id) else {
+                    return false;
+                };
+                let key = (table.to_string(), entity.logical_id());
+                locks
+                    .get(&key)
+                    .is_none_or(|owner_conn_id| *owner_conn_id == conn_id)
+            })
+            .collect()
+    }
+
+    fn record_pending_claim_locks_for_touched_ids(&self, table: &str, ids: &[EntityId]) {
+        if self.current_xid().is_none() || ids.is_empty() {
+            return;
+        }
+
+        let conn_id = current_connection_id();
+        let store = self.inner.db.store();
+        let mut locks = self.inner.pending_claim_locks.write();
+        for id in ids {
+            let Some(entity) = store.get(table, *id) else {
+                continue;
+            };
+            locks.insert((table.to_string(), entity.logical_id()), conn_id);
+        }
     }
 
     fn execute_update_inner_tracked_locked(

--- a/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
+++ b/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
@@ -1,3 +1,4 @@
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
@@ -98,6 +99,155 @@ fn claim_exact_miss_reports_zero_and_applies_no_partial_write() {
     assert_eq!(updated.affected_rows, 0);
     assert!(status_ids(&rt, "exact_claim_miss", "claimed").is_empty());
     assert_eq!(status_ids(&rt, "exact_claim_miss", "ready"), vec![1, 2]);
+}
+
+#[test]
+fn claim_inside_transaction_publishes_on_commit() {
+    let rt = runtime();
+    set_current_connection_id(145201);
+    exec(
+        &rt,
+        "CREATE TABLE tx_claim_commit (id INT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO tx_claim_commit (id, rank, status) VALUES \
+         (1, 10, 'ready'), (2, 20, 'ready')",
+    );
+
+    exec(&rt, "BEGIN");
+    let claimed = exec(
+        &rt,
+        "UPDATE tx_claim_commit SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(claimed.affected_rows, 1);
+
+    set_current_connection_id(145202);
+    assert_eq!(status_ids(&rt, "tx_claim_commit", "ready"), vec![1, 2]);
+
+    set_current_connection_id(145201);
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(145202);
+    assert_eq!(status_ids(&rt, "tx_claim_commit", "claimed"), vec![1]);
+    assert_eq!(status_ids(&rt, "tx_claim_commit", "ready"), vec![2]);
+    clear_current_connection_id();
+}
+
+#[test]
+fn claim_inside_transaction_releases_on_rollback() {
+    let rt = runtime();
+    set_current_connection_id(145203);
+    exec(
+        &rt,
+        "CREATE TABLE tx_claim_rollback (id INT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO tx_claim_rollback (id, rank, status) VALUES \
+         (1, 10, 'ready'), (2, 20, 'ready')",
+    );
+
+    exec(&rt, "BEGIN");
+    let claimed = exec(
+        &rt,
+        "UPDATE tx_claim_rollback SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(claimed.affected_rows, 1);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(145204);
+    assert!(status_ids(&rt, "tx_claim_rollback", "claimed").is_empty());
+    assert_eq!(status_ids(&rt, "tx_claim_rollback", "ready"), vec![1, 2]);
+    let claimed_after_rollback = exec(
+        &rt,
+        "UPDATE tx_claim_rollback SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(claimed_after_rollback.affected_rows, 1);
+    assert_eq!(status_ids(&rt, "tx_claim_rollback", "claimed"), vec![1]);
+    clear_current_connection_id();
+}
+
+#[test]
+fn competing_claim_skips_uncommitted_claim_lock() {
+    let rt = runtime();
+    set_current_connection_id(145205);
+    exec(
+        &rt,
+        "CREATE TABLE tx_claim_skip (id INT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO tx_claim_skip (id, rank, status) VALUES \
+         (1, 10, 'ready'), (2, 20, 'ready'), (3, 30, 'ready')",
+    );
+
+    exec(&rt, "BEGIN");
+    let first = exec(
+        &rt,
+        "UPDATE tx_claim_skip SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(first.affected_rows, 1);
+
+    set_current_connection_id(145206);
+    let second = exec(
+        &rt,
+        "UPDATE tx_claim_skip SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(second.affected_rows, 1);
+    assert_eq!(status_ids(&rt, "tx_claim_skip", "claimed"), vec![2]);
+
+    set_current_connection_id(145205);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(145206);
+    assert_eq!(status_ids(&rt, "tx_claim_skip", "ready"), vec![1, 3]);
+    clear_current_connection_id();
+}
+
+#[test]
+fn ordinary_dml_against_claimed_row_keeps_mvcc_conflict_behavior() {
+    let rt = runtime();
+    set_current_connection_id(145207);
+    exec(
+        &rt,
+        "CREATE TABLE tx_claim_dml (id INT, rank INT, status TEXT, note TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO tx_claim_dml (id, rank, status, note) VALUES \
+         (1, 10, 'ready', 'seed')",
+    );
+
+    exec(&rt, "BEGIN");
+    let claimed = exec(
+        &rt,
+        "UPDATE tx_claim_dml SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY rank ASC",
+    );
+    assert_eq!(claimed.affected_rows, 1);
+
+    set_current_connection_id(145208);
+    let ordinary = exec(
+        &rt,
+        "UPDATE tx_claim_dml SET note = 'ordinary' WHERE id = 1",
+    );
+    assert_eq!(
+        ordinary.affected_rows, 0,
+        "ordinary DML keeps the existing MVCC visibility behavior while the claim update is open"
+    );
+
+    set_current_connection_id(145207);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(145208);
+    assert_eq!(status_ids(&rt, "tx_claim_dml", "ready"), vec![1]);
+    clear_current_connection_id();
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1452. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1452

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785196338&installation_id=129708444&pr_number=1501&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1501&signature=b2b04c3e37336553f06a90eb225f62ffc3bbf6f038ffc527a65dba985e4b9933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->