### PR TITLE
merge: #1453 Enforce claim authorization through read visibility and update policy

### DIFF
--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1730,12 +1730,12 @@ impl RedDBRuntime {
         let rls_gated = crate::runtime::impl_core::rls_is_enabled(self, &query.table);
         let augmented_query: UpdateQuery;
         let effective_query: &UpdateQuery = if rls_gated {
-            let rls_filter = crate::runtime::impl_core::rls_policy_filter(
+            let update_filter = crate::runtime::impl_core::rls_policy_filter(
                 self,
                 &query.table,
                 crate::storage::query::ast::PolicyAction::Update,
             );
-            let Some(policy) = rls_filter else {
+            let Some(mut policy) = update_filter else {
                 // No admitting policy: zero rows affected, empty
                 // RETURNING (never leak rows the caller can't touch).
                 let mut response = RuntimeQueryResult::dml_result(
@@ -1749,6 +1749,29 @@ impl RedDBRuntime {
                 }
                 return Ok(response);
             };
+            if query.claim_limit.is_some() {
+                let read_filter = crate::runtime::impl_core::rls_policy_filter(
+                    self,
+                    &query.table,
+                    crate::storage::query::ast::PolicyAction::Select,
+                );
+                let Some(read_policy) = read_filter else {
+                    let mut response = RuntimeQueryResult::dml_result(
+                        raw_query.to_string(),
+                        0,
+                        "update",
+                        "runtime-dml-rls",
+                    );
+                    if let Some(items) = query.returning.clone() {
+                        response.result = build_returning_result(&items, &[], None);
+                    }
+                    return Ok(response);
+                };
+                policy = crate::storage::query::ast::Filter::And(
+                    Box::new(read_policy),
+                    Box::new(policy),
+                );
+            }
             let mut augmented = query.clone();
             augmented.filter = Some(match augmented.filter.take() {
                 Some(existing) => {

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -268,6 +268,151 @@ fn update_returning_obeys_rls_and_column_policy() {
 }
 
 #[test]
+fn claim_candidate_selection_requires_read_visibility() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE claim_read_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO claim_read_tasks (id, tenant_id, rank, status) VALUES \
+         (1, 'globex', 10, 'ready'), (2, 'acme', 20, 'ready')",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_read_visible ON claim_read_tasks FOR SELECT \
+         USING (tenant_id = CURRENT_TENANT())",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_read_update_all ON claim_read_tasks FOR UPDATE USING (status = 'ready')",
+    );
+    exec(
+        &rt,
+        "ALTER TABLE claim_read_tasks ENABLE ROW LEVEL SECURITY",
+    );
+
+    let claimed = {
+        set_current_tenant("acme".to_string());
+        let result = exec(
+            &rt,
+            "UPDATE claim_read_tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 2 ORDER BY rank ASC RETURNING id, tenant_id",
+        );
+        clear_current_tenant();
+        result
+    };
+
+    assert_eq!(claimed.affected_rows, 1);
+    let row = only_record(&claimed);
+    assert_eq!(int_field(row, "id"), 2);
+    assert_eq!(text_field(row, "tenant_id"), "acme");
+    set_current_tenant("globex".to_string());
+    let hidden = exec(&rt, "SELECT status FROM claim_read_tasks WHERE id = 1");
+    clear_current_tenant();
+    assert_eq!(text_field(only_record(&hidden), "status"), "ready");
+}
+
+#[test]
+fn claim_exact_miss_counts_only_read_visible_candidates() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE claim_exact_read_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO claim_exact_read_tasks (id, tenant_id, rank, status) VALUES \
+         (1, 'globex', 10, 'ready'), (2, 'acme', 20, 'ready')",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_exact_read_visible ON claim_exact_read_tasks FOR SELECT \
+         USING (tenant_id = CURRENT_TENANT())",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_exact_update_all ON claim_exact_read_tasks FOR UPDATE USING (status = 'ready')",
+    );
+    exec(
+        &rt,
+        "ALTER TABLE claim_exact_read_tasks ENABLE ROW LEVEL SECURITY",
+    );
+
+    let claimed = {
+        set_current_tenant("acme".to_string());
+        let result = exec(
+            &rt,
+            "UPDATE claim_exact_read_tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM EXACT 2 ORDER BY rank ASC RETURNING id, tenant_id",
+        );
+        clear_current_tenant();
+        result
+    };
+
+    assert_eq!(claimed.affected_rows, 0);
+    assert!(claimed.result.records.is_empty());
+    set_current_tenant("acme".to_string());
+    let acme = exec(
+        &rt,
+        "SELECT status FROM claim_exact_read_tasks WHERE id = 2",
+    );
+    clear_current_tenant();
+    assert_eq!(text_field(only_record(&acme), "status"), "ready");
+    set_current_tenant("globex".to_string());
+    let globex = exec(
+        &rt,
+        "SELECT status FROM claim_exact_read_tasks WHERE id = 1",
+    );
+    clear_current_tenant();
+    assert_eq!(text_field(only_record(&globex), "status"), "ready");
+}
+
+#[test]
+fn claim_state_transition_requires_update_policy() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE claim_update_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO claim_update_tasks (id, tenant_id, rank, status) VALUES \
+         (1, 'globex', 10, 'ready'), (2, 'acme', 20, 'ready')",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_update_read_all ON claim_update_tasks FOR SELECT USING (status = 'ready')",
+    );
+    exec(
+        &rt,
+        "CREATE POLICY claim_update_mutable ON claim_update_tasks FOR UPDATE \
+         USING (tenant_id = CURRENT_TENANT())",
+    );
+    exec(
+        &rt,
+        "ALTER TABLE claim_update_tasks ENABLE ROW LEVEL SECURITY",
+    );
+
+    let claimed = {
+        set_current_tenant("acme".to_string());
+        let result = exec(
+            &rt,
+            "UPDATE claim_update_tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 2 ORDER BY rank ASC RETURNING id, tenant_id",
+        );
+        clear_current_tenant();
+        result
+    };
+
+    assert_eq!(claimed.affected_rows, 1);
+    let row = only_record(&claimed);
+    assert_eq!(int_field(row, "id"), 2);
+    assert_eq!(text_field(row, "tenant_id"), "acme");
+}
+
+#[test]
 fn explicit_document_update_emits_event_and_cdc_identity() {
     let rt = runtime();
     exec(&rt, "CREATE DOCUMENT conformance_docs");


### PR DESCRIPTION
Automated AFK landing for #1453. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1453

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785197258&installation_id=129708444&pr_number=1502&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1502&signature=f67f1a81e53f1109d345d99f816e967d7eb9c29c2ca4434bd523796028f0f8da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row-level security handling for claim-based updates so claimed rows must satisfy both visibility and update permissions.
  * Ensured updates return no rows when claim limits can’t be satisfied under security rules.
  * Kept `RETURNING` results empty when no eligible rows are available.

* **Tests**
  * Added end-to-end coverage for claim behavior under row-level security, including visibility checks, exact claim counts, and restricted state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->