### PR TITLE
merge: #1455 Route queue-shaped claim through QueueLifecycle

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -1321,6 +1321,7 @@ impl RedDBRuntime {
 
                 let mut result = UnifiedResult::with_columns(vec![
                     "message_id".into(),
+                    "delivery_id".into(),
                     "payload".into(),
                     "consumer".into(),
                     "delivery_count".into(),
@@ -1332,6 +1333,7 @@ impl RedDBRuntime {
                         "message_id",
                         Value::text(message_id_string(EntityId::new(message.message_id))),
                     );
+                    record.set("delivery_id", Value::text(message.delivery_id));
                     record.set("payload", message.payload);
                     record.set("consumer", Value::text(message.consumer));
                     record.set(

--- a/crates/reddb-server/src/runtime/queue_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/queue_lifecycle.rs
@@ -94,20 +94,20 @@ pub(crate) struct QueueMessageView {
 }
 
 /// Result of a delivering lifecycle method ([`QueueLifecycle::group_read`],
-/// [`QueueLifecycle::claim_delivering`]) — the exact column projection the
-/// legacy `GROUP READ` / `CLAIM` commands return to clients today
-/// (`message_id, payload, consumer, delivery_count`). Unlike [`Delivery`],
-/// which exposes only the opaque `delivery_id` + payload, this surfaces:
+/// [`QueueLifecycle::claim_delivering`]). Carries the opaque
+/// `delivery_id` used by ACK/NACK plus the consumer-facing projection:
 ///
+/// - the opaque `delivery_id` that identifies the pending delivery,
 /// - the entity `message_id` clients key on (NOT the opaque `delivery_id`),
 /// - the `consumer` echoed back (the lifecycle store keys pending by
 ///   consumer *group*, not consumer, so the value is the caller-supplied
 ///   consumer threaded straight through — matching the legacy projection),
 /// - the `delivery_count` after this delivery's bump.
 ///
-/// Preserves the client-visible columns from the pre-lifecycle read path.
+/// Runtime call sites decide which fields to expose on each public surface.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct DeliveredMessage {
+    pub(crate) delivery_id: DeliveryId,
     pub(crate) message_id: MessageId,
     pub(crate) payload: Value,
     pub(crate) consumer: String,
@@ -291,6 +291,7 @@ impl<S: QueueStore> QueueLifecycle<S> {
                 .read_message(queue, message_id)
                 .ok_or_else(|| QueueStoreError::UnknownQueue(queue.to_string()))?;
             out.push(DeliveredMessage {
+                delivery_id,
                 message_id,
                 payload,
                 consumer: consumer.to_string(),
@@ -433,12 +434,11 @@ impl<S: QueueStore> QueueLifecycle<S> {
     }
 
     /// Delivering counterpart to [`claim`]: identical steal-after-min-idle
-    /// semantics, but returns the legacy `CLAIM` projection
-    /// (`message_id, payload, consumer, delivery_count`) instead of opaque
-    /// delivery handles. `new_consumer` is echoed into each returned
-    /// `consumer` field (the lifecycle store keys pending by group, not
-    /// consumer, so the value is threaded straight through — matching the
-    /// legacy `CLAIM` projection). The
+    /// semantics, but returns delivery-shaped rows with the opaque
+    /// `delivery_id` plus the `CLAIM` projection fields. `new_consumer`
+    /// is echoed into each returned `consumer` field (the lifecycle store
+    /// keys pending by group, not consumer, so the value is threaded
+    /// straight through — matching the legacy `CLAIM` projection). The
     /// `delivery_count` is the attempt counter after the claim's bump.
     ///
     /// [`claim`]: Self::claim
@@ -510,8 +510,9 @@ impl<S: QueueStore> QueueLifecycle<S> {
                 new_deadline,
             )?;
             claimed.push(ClaimedDelivery {
-                delivery_id: entry.delivery_id,
+                delivery_id: entry.delivery_id.clone(),
                 message: DeliveredMessage {
+                    delivery_id: entry.delivery_id,
                     message_id: entry.message_id,
                     payload,
                     consumer: new_consumer.to_string(),
@@ -1731,16 +1732,20 @@ mod tests {
 
     #[test]
     fn group_read_returns_legacy_projection_in_work_mode() {
-        // Field set must equal the legacy GROUP READ projection:
-        // message_id, payload, consumer, delivery_count.
+        // The lifecycle projection carries the opaque delivery handle
+        // alongside the legacy GROUP READ columns.
         let lc = lifecycle(store_with(&[(1, "first"), (2, "second")]));
         let got = lc
             .group_read(&QueueTxn::new(), "q", "workers", "consumer-1", 2)
             .expect("group_read");
         assert_eq!(got.len(), 2);
+        assert!(!got[0].delivery_id.is_empty());
+        assert!(!got[1].delivery_id.is_empty());
+        assert_ne!(got[0].delivery_id, got[1].delivery_id);
         assert_eq!(
             got[0],
             DeliveredMessage {
+                delivery_id: got[0].delivery_id.clone(),
                 message_id: 1,
                 payload: Value::text("first"),
                 consumer: "consumer-1".to_string(),
@@ -1750,6 +1755,7 @@ mod tests {
         assert_eq!(
             got[1],
             DeliveredMessage {
+                delivery_id: got[1].delivery_id.clone(),
                 message_id: 2,
                 payload: Value::text("second"),
                 consumer: "consumer-1".to_string(),
@@ -1902,9 +1908,14 @@ mod tests {
             .claim_delivering("q", "consumer-z", 100, &QueueTxn::new())
             .expect("claim_delivering");
         assert_eq!(claimed.len(), 1);
+        assert!(
+            !claimed[0].delivery_id.is_empty(),
+            "claim_delivering must preserve the lifecycle delivery identity",
+        );
         assert_eq!(
             claimed[0],
             DeliveredMessage {
+                delivery_id: claimed[0].delivery_id.clone(),
                 message_id: 1,
                 payload: Value::text("payload"),
                 consumer: "consumer-z".to_string(),

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -141,6 +141,11 @@ fn test_queue_group_pending_claim_and_ack_flow() {
     );
     assert_eq!(text(&claimed.result.records[0], "message_id"), message_id);
     assert_eq!(text(&claimed.result.records[0], "consumer"), "worker2");
+    let claimed_delivery_id = text(&claimed.result.records[0], "delivery_id");
+    assert!(
+        !claimed_delivery_id.is_empty(),
+        "queue claim must return the lifecycle delivery identity"
+    );
 
     let pending_after_claim = exec(&rt, "QUEUE PENDING tasks GROUP workers");
     assert_eq!(pending_after_claim.result.records.len(), 1);
@@ -151,7 +156,7 @@ fn test_queue_group_pending_claim_and_ack_flow() {
 
     exec(
         &rt,
-        &format!("QUEUE ACK tasks GROUP workers '{}'", message_id),
+        &format!("QUEUE ACK tasks WITH delivery_id = '{claimed_delivery_id}'"),
     );
 
     let pending_after_ack = exec(&rt, "QUEUE PENDING tasks GROUP workers");
@@ -165,6 +170,56 @@ fn test_queue_group_pending_claim_and_ack_flow() {
         uint(&len.result.records[0], "len"),
         0,
         "single-group ack should remove the message from the queue"
+    );
+}
+
+#[test]
+fn test_queue_claim_delivery_id_nack_routes_retry_budget_to_dlq() {
+    let rt = rt();
+
+    exec(
+        &rt,
+        "CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 3 LOCK_DEADLINE_MS 1",
+    );
+    exec(&rt, "QUEUE GROUP CREATE tasks workers");
+    exec(&rt, "QUEUE PUSH tasks 'job-claim-dlq'");
+
+    let read = exec(
+        &rt,
+        "QUEUE READ tasks GROUP workers CONSUMER worker1 COUNT 1",
+    );
+    assert_eq!(read.result.records.len(), 1);
+
+    sleep(Duration::from_millis(5));
+    let claimed = exec(
+        &rt,
+        "QUEUE CLAIM tasks GROUP workers CONSUMER worker2 MIN_IDLE 0",
+    );
+    assert_eq!(claimed.result.records.len(), 1);
+    assert_eq!(uint(&claimed.result.records[0], "delivery_count"), 2);
+    let delivery_id = text(&claimed.result.records[0], "delivery_id");
+
+    exec(
+        &rt,
+        &format!("QUEUE NACK tasks WITH delivery_id = '{delivery_id}'"),
+    );
+
+    let pending_after_nack = exec(&rt, "QUEUE PENDING tasks GROUP workers");
+    assert!(
+        pending_after_nack.result.records.is_empty(),
+        "over-budget claim NACK must retire the lifecycle pending row"
+    );
+
+    let main_len = exec(&rt, "QUEUE LEN tasks");
+    assert_eq!(uint(&main_len.result.records[0], "len"), 0);
+
+    let dlq_len = exec(&rt, "QUEUE LEN failed_tasks");
+    assert_eq!(uint(&dlq_len.result.records[0], "len"), 1);
+
+    let dlq_peek = exec(&rt, "QUEUE PEEK failed_tasks");
+    assert_eq!(
+        text(&dlq_peek.result.records[0], "payload"),
+        "job-claim-dlq"
     );
 }
 


### PR DESCRIPTION
Automated AFK landing for #1455. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1455

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785198644&installation_id=129708444&pr_number=1503&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1503&signature=e86f1191123c3f1ffd82ceeb3fcb9c57b3c8816f00230b319e68a856b75ba1db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->