### PR TITLE
fix(hll): reject precision-mismatched unions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,10 @@ name = "grouped_materialized_views_events_config_audit"
 path = "tests/grouped/materialized_views_events_config_audit.rs"
 
 [[test]]
+name = "grouped_probabilistic"
+path = "tests/grouped_probabilistic.rs"
+
+[[test]]
 name = "grouped_replication"
 path = "tests/grouped/replication.rs"
 

--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -52,6 +52,18 @@ fn probabilistic_collection_contract(
     }
 }
 
+fn hll_precision_mismatch_error(
+    operation: &str,
+    expected_name: &str,
+    expected_precision: u8,
+    actual_name: &str,
+    actual_precision: u8,
+) -> RedDBError {
+    RedDBError::Query(format!(
+        "HLL {operation} requires matching precision; '{expected_name}' uses precision {expected_precision}, but '{actual_name}' uses precision {actual_precision}"
+    ))
+}
+
 enum ProbabilisticReadProjection {
     Cardinality { label: String },
     Freq { element: String, label: String },
@@ -382,6 +394,11 @@ impl RedDBRuntime {
             ProbabilisticCommand::HllCount { names } => {
                 let hlls =
                     probabilistic_read(&self.inner.probabilistic.hlls, "probabilistic HLL store");
+                if names.is_empty() {
+                    return Err(RedDBError::Query(
+                        "HLL COUNT requires at least one HLL name".to_string(),
+                    ));
+                }
                 if names.len() == 1 {
                     let hll = hlls.get(&names[0]).ok_or_else(|| {
                         RedDBError::NotFound(format!("HLL '{}' not found", names[0]))
@@ -403,11 +420,29 @@ impl RedDBRuntime {
                     })
                 } else {
                     // Multi-HLL count = union count
-                    let mut merged = crate::storage::primitives::hyperloglog::HyperLogLog::new();
+                    let first_name = &names[0];
+                    let first = hlls.get(first_name).ok_or_else(|| {
+                        RedDBError::NotFound(format!("HLL '{}' not found", first_name))
+                    })?;
+                    let expected_precision = first.precision();
+                    let mut merged =
+                        crate::storage::primitives::hyperloglog::HyperLogLog::with_precision(
+                            expected_precision,
+                        )
+                        .expect("loaded HLL precision is valid");
                     for name in names {
                         let hll = hlls.get(name).ok_or_else(|| {
                             RedDBError::NotFound(format!("HLL '{}' not found", name))
                         })?;
+                        if hll.precision() != expected_precision {
+                            return Err(hll_precision_mismatch_error(
+                                "COUNT",
+                                first_name,
+                                expected_precision,
+                                name,
+                                hll.precision(),
+                            ));
+                        }
                         merged.merge(hll);
                     }
                     let count = merged.count();
@@ -430,11 +465,31 @@ impl RedDBRuntime {
             ProbabilisticCommand::HllMerge { dest, sources } => {
                 let mut hlls =
                     probabilistic_write(&self.inner.probabilistic.hlls, "probabilistic HLL store");
-                let mut merged = crate::storage::primitives::hyperloglog::HyperLogLog::new();
+                let first_src = sources.first().ok_or_else(|| {
+                    RedDBError::Query("HLL MERGE requires at least one source HLL".to_string())
+                })?;
+                let first = hlls.get(first_src).ok_or_else(|| {
+                    RedDBError::NotFound(format!("HLL '{}' not found", first_src))
+                })?;
+                let expected_precision = first.precision();
+                let mut merged =
+                    crate::storage::primitives::hyperloglog::HyperLogLog::with_precision(
+                        expected_precision,
+                    )
+                    .expect("loaded HLL precision is valid");
                 for src in sources {
                     let hll = hlls
                         .get(src)
                         .ok_or_else(|| RedDBError::NotFound(format!("HLL '{}' not found", src)))?;
+                    if hll.precision() != expected_precision {
+                        return Err(hll_precision_mismatch_error(
+                            "MERGE",
+                            first_src,
+                            expected_precision,
+                            src,
+                            hll.precision(),
+                        ));
+                    }
                     merged.merge(hll);
                 }
                 self.persist_probabilistic_blob(PROB_HLL_STATE_PREFIX, dest, merged.as_bytes())?;

--- a/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
+++ b/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
@@ -180,6 +180,74 @@ fn probabilistic_state_survives_reopen_for_commands_and_sql_read_forms() {
 }
 
 #[test]
+fn hll_union_preserves_non_default_precision() {
+    let rt = runtime();
+
+    exec(&rt, "CREATE HLL visitors_a PRECISION 12");
+    exec(&rt, "CREATE HLL visitors_b PRECISION 12");
+    exec(&rt, "HLL ADD visitors_a 'alice' 'bob'");
+    exec(&rt, "HLL ADD visitors_b 'carol' 'dave'");
+
+    let count = exec(&rt, "HLL COUNT visitors_a visitors_b");
+    assert_eq!(uint_value(only_record(&count), "count"), 4);
+
+    exec(&rt, "HLL MERGE visitors_all visitors_a visitors_b");
+    let info = exec(&rt, "HLL INFO visitors_all");
+    let row = only_record(&info);
+    assert_eq!(uint_value(row, "precision"), 12);
+    assert_eq!(uint_value(row, "count"), 4);
+}
+
+#[test]
+fn hll_union_rejects_precision_mismatch() {
+    let rt = runtime();
+
+    exec(&rt, "CREATE HLL visitors_a PRECISION 12");
+    exec(&rt, "CREATE HLL visitors_b PRECISION 14");
+
+    let count_err = rt
+        .execute_query("HLL COUNT visitors_a visitors_b")
+        .expect_err("multi-HLL count must reject mixed precision");
+    let count_message = format!("{count_err:?}");
+    assert!(
+        count_message.contains("HLL COUNT requires matching precision"),
+        "unexpected error: {count_message}"
+    );
+
+    let merge_err = rt
+        .execute_query("HLL MERGE visitors_all visitors_a visitors_b")
+        .expect_err("HLL merge must reject mixed precision");
+    let merge_message = format!("{merge_err:?}");
+    assert!(
+        merge_message.contains("HLL MERGE requires matching precision"),
+        "unexpected error: {merge_message}"
+    );
+}
+
+#[test]
+fn hll_count_and_merge_require_operands() {
+    let rt = runtime();
+
+    let count_err = rt
+        .execute_query("HLL COUNT")
+        .expect_err("HLL COUNT without names should fail");
+    let count_message = format!("{count_err:?}");
+    assert!(
+        count_message.contains("HLL COUNT requires at least one HLL name"),
+        "unexpected error: {count_message}"
+    );
+
+    let merge_err = rt
+        .execute_query("HLL MERGE visitors_all")
+        .expect_err("HLL MERGE without sources should fail");
+    let merge_message = format!("{merge_err:?}");
+    assert!(
+        merge_message.contains("HLL MERGE requires at least one source HLL"),
+        "unexpected error: {merge_message}"
+    );
+}
+
+#[test]
 fn http_query_covers_probabilistic_commands_and_sql_read_forms() {
     let (_db, addr) = spawn_http_server();
 


### PR DESCRIPTION
## Summary
- preserve non-default HLL precision when counting or merging multiple HLLs
- reject mixed-precision HLL COUNT/MERGE operations instead of silently dropping incompatible inputs
- register the grouped probabilistic test target and add public-contract regressions

## Validation
- `rustfmt --edition 2021 --check crates/reddb-server/src/runtime/impl_probabilistic.rs tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs`
- `git diff --check`
- `CARGO_TARGET_DIR=/home/cyber/.cache/reddb-hll-hardening-target cargo test -q --test grouped_probabilistic hll -- --test-threads=1`
- `CARGO_TARGET_DIR=/home/cyber/.cache/reddb-hll-hardening-target cargo test -q --test grouped_probabilistic -- --test-threads=1`

## Notes
- A repeated `cargo test -q -p reddb-io-server --lib hyperloglog` attempt was killed with exit 137 during heavy lib compilation; the grouped probabilistic target completed green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785204669&installation_id=129708444&pr_number=1504&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1504&signature=b7a361ff6320e1346c7ce685318a01cb97f8c00afda42d953cbce1cdf811af54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->