### PR TITLE
feat(wire): accept browser websocket uri schemes

### DIFF
--- a/crates/reddb-wire/src/conn_string.rs
+++ b/crates/reddb-wire/src/conn_string.rs
@@ -78,7 +78,7 @@ impl std::error::Error for ParseError {}
 pub const DEFAULT_PORT_RED: u16 = 5050;
 pub const DEFAULT_PORT_GRPC: u16 = 55055;
 pub const DEFAULT_PORT_GRPCS: u16 = 55555;
-/// Default ports for `red+ws://` and `red+wss://` — align with the
+/// Default ports for `ws://` / `red+ws://` and `wss://` / `red+wss://` — align with the
 /// standard WS / WSS browser defaults (80 and 443) so a hosted endpoint
 /// like `*.db.reddb.io` works without an explicit port.
 pub const DEFAULT_PORT_WS: u16 = 80;
@@ -97,6 +97,8 @@ pub enum ConnectionScheme {
     Reds,
     RedWs,
     RedWss,
+    Ws,
+    Wss,
     Grpc,
     Grpcs,
     Http,
@@ -115,6 +117,8 @@ pub const SUPPORTED_SCHEMES: &[ConnectionScheme] = &[
     ConnectionScheme::File,
     ConnectionScheme::RedWs,
     ConnectionScheme::RedWss,
+    ConnectionScheme::Ws,
+    ConnectionScheme::Wss,
 ];
 
 impl ConnectionScheme {
@@ -126,6 +130,8 @@ impl ConnectionScheme {
             "reds" => Some(Self::Reds),
             "red+ws" => Some(Self::RedWs),
             "red+wss" => Some(Self::RedWss),
+            "ws" => Some(Self::Ws),
+            "wss" => Some(Self::Wss),
             "grpc" => Some(Self::Grpc),
             "grpcs" => Some(Self::Grpcs),
             "http" => Some(Self::Http),
@@ -142,6 +148,8 @@ impl ConnectionScheme {
             Self::Reds => "reds://",
             Self::RedWs => "red+ws://",
             Self::RedWss => "red+wss://",
+            Self::Ws => "ws://",
+            Self::Wss => "wss://",
             Self::Grpc => "grpc://",
             Self::Grpcs => "grpcs://",
             Self::Http => "http://",
@@ -154,7 +162,7 @@ impl ConnectionScheme {
             Self::Memory => "embedded in-memory engine",
             Self::File => "embedded file-backed engine",
             Self::Red | Self::Reds => "RedWire TCP",
-            Self::RedWs | Self::RedWss => "RedWire WebSocket",
+            Self::RedWs | Self::RedWss | Self::Ws | Self::Wss => "RedWire WebSocket",
             Self::Grpc | Self::Grpcs => "gRPC",
             Self::Http | Self::Https => "HTTP REST",
         }
@@ -167,6 +175,8 @@ impl ConnectionScheme {
             | Self::Reds
             | Self::RedWs
             | Self::RedWss
+            | Self::Ws
+            | Self::Wss
             | Self::Grpc
             | Self::Grpcs
             | Self::Http
@@ -182,6 +192,8 @@ impl ConnectionScheme {
             Self::Reds => "reds://db.example.com:5050",
             Self::RedWs => "red+ws://db.example.com",
             Self::RedWss => "red+wss://db.example.com",
+            Self::Ws => "ws://db.example.com",
+            Self::Wss => "wss://db.example.com",
             Self::Grpc => "grpc://db.example.com:55055",
             Self::Grpcs => "grpcs://db.example.com:55555",
             Self::Http => "http://db.example.com:80",
@@ -197,6 +209,8 @@ impl ConnectionScheme {
             Self::Reds => "Principal RedWire transport with TLS.",
             Self::RedWs => "Browser-native RedWire over WebSocket without TLS.",
             Self::RedWss => "Browser-native RedWire over WebSocket with TLS.",
+            Self::Ws => "Browser-friendly alias for RedWire over WebSocket without TLS.",
+            Self::Wss => "Browser-friendly alias for RedWire over WebSocket with TLS.",
             Self::Grpc => "Compatibility transport for existing gRPC clients.",
             Self::Grpcs => "TLS variant of the gRPC compatibility transport.",
             Self::Http => "REST/admin transport without TLS.",
@@ -262,7 +276,8 @@ pub enum ConnectionTarget {
     /// speaks framed binary directly; it does NOT route through
     /// tonic.
     RedWire { host: String, port: u16, tls: bool },
-    /// `red+ws://host:port` (plain WS) or `red+wss://host:port` (WSS).
+    /// `red+ws://host:port` / `ws://host:port` (plain WS) or
+    /// `red+wss://host:port` / `wss://host:port` (WSS).
     /// Browser-native WebSocket transport (ADR 0047 direct-when-reachable).
     /// The UI connects directly — no local RedWire-over-TCP bridge needed.
     WsNative { host: String, port: u16, tls: bool },
@@ -441,14 +456,19 @@ pub fn parse_with_limits(
                 tls: parsed.scheme() == "reds",
             })
         }
-        Some(ConnectionScheme::RedWs | ConnectionScheme::RedWss) => {
+        Some(
+            ConnectionScheme::RedWs
+            | ConnectionScheme::RedWss
+            | ConnectionScheme::Ws
+            | ConnectionScheme::Wss,
+        ) => {
             let host = parsed.host_str().ok_or_else(|| {
                 ParseError::new(
                     ParseErrorKind::InvalidUri,
-                    "red+ws(s):// URI is missing a host",
+                    "RedWire WebSocket URI is missing a host",
                 )
             })?;
-            let tls = parsed.scheme() == "red+wss";
+            let tls = parsed.scheme() == "red+wss" || parsed.scheme() == "wss";
             let port = parsed.port().unwrap_or(if tls {
                 DEFAULT_PORT_WSS
             } else {

--- a/crates/reddb-wire/src/redwire/mod.rs
+++ b/crates/reddb-wire/src/redwire/mod.rs
@@ -122,7 +122,7 @@ pub const DEFAULT_REDWIRE_PORT: u16 = 5050;
 /// defining its own.
 pub const REDWIRE_WS_SUBPROTOCOL: &str = "reddb.redwire.v1";
 
-/// HTTP path the browser client (`red+wss://host:port`) upgrades on to
+/// HTTP path the browser client (`wss://host:port` / `red+wss://host:port`) upgrades on to
 /// reach the RedWire-over-WebSocket edge (ADR 0036).
 pub const REDWIRE_WS_PATH: &str = "/redwire";
 

--- a/crates/reddb-wire/tests/parser_table.rs
+++ b/crates/reddb-wire/tests/parser_table.rs
@@ -211,6 +211,33 @@ fn ok_cases() -> Vec<OkCase> {
                 tls: true,
             },
         },
+        OkCase {
+            name: "wss:// default port 443 tls",
+            input: "wss://mydb.db.reddb.io",
+            expect: ConnectionTarget::WsNative {
+                host: "mydb.db.reddb.io".into(),
+                port: 443,
+                tls: true,
+            },
+        },
+        OkCase {
+            name: "ws:// default port 80 plaintext",
+            input: "ws://host",
+            expect: ConnectionTarget::WsNative {
+                host: "host".into(),
+                port: 80,
+                tls: false,
+            },
+        },
+        OkCase {
+            name: "wss:// explicit port",
+            input: "wss://host:55055",
+            expect: ConnectionTarget::WsNative {
+                host: "host".into(),
+                port: 55055,
+                tls: true,
+            },
+        },
     ]
 }
 

--- a/docs/clients/connection-strings.md
+++ b/docs/clients/connection-strings.md
@@ -17,6 +17,8 @@ the URL or via the `options.tls` object.
 | `red://host:55555?proto=grpcs` / `grpcs://host:55555`                   | gRPC + TLS         | HTTP/2 + TLS                | bearer / mTLS / OAuth-JWT |
 | `red://host:5050` / `red://host:5050` / `grpc://host:5050`          | RedWire plain      | TCP framed binary           | bearer / anonymous       |
 | `reds://host:5443` / `red://host:5443?proto=redwires`                | RedWire + TLS      | TLS-wrapped framed binary   | bearer / mTLS            |
+| `ws://host` / `red+ws://host`                                        | RedWire WebSocket  | WS binary frames            | bearer / anonymous       |
+| `wss://host` / `red+wss://host`                                      | RedWire WebSocket + TLS | WSS binary frames       | bearer / login           |
 | `red://host:5443?tls=true&cert=/c.pem&key=/k.pem&ca=/ca.pem`             | RedWire + mTLS     | TLS + client cert           | mTLS (CN→user) + bearer  |
 | `red://host:5432?proto=pg`                                              | PostgreSQL wire    | PG F+B v3 (via psql / node-pg) | SCRAM/MD5/cleartext   |
 
@@ -52,6 +54,24 @@ const db = await connect('red://reddb.example.com:5050', {
 // Or anonymous (server has auth.enabled=false):
 const db = await connect('red://reddb.example.com:5050')
 ```
+
+### RedWire over WebSocket (browser)
+
+Browsers cannot open raw TCP sockets, so browser bundles use RedWire over a
+binary WebSocket. Use `wss://` for production browser clients; `ws://` is for
+plaintext local development origins.
+
+```js
+import { connect } from '@reddb-io/client/browser'
+
+const db = await connect('wss://reddb.example.com', {
+  auth: { token: 'sk-abc' },
+})
+```
+
+`wss://reddb.example.com` is equivalent to `red+wss://reddb.example.com` and
+upgrades to `/redwire` internally. The plaintext aliases are `ws://host` and
+`red+ws://host`.
 
 ### RedWire + mTLS (production)
 

--- a/docs/clients/drivers.md
+++ b/docs/clients/drivers.md
@@ -37,6 +37,8 @@ Every driver accepts the same URI shapes (where the transport applies):
 ```
 red://host:5050                       # RedWire TCP (default port)
 reds://host:5050                      # RedWire over TLS, ALPN redwire/1
+wss://host                            # RedWire over WebSocket for browsers
+ws://localhost                        # RedWire over WebSocket for local browser dev
 http://host:5000                      # HTTP REST
 https://host:55555                     # HTTPS REST
 grpc://host:55055                      # gRPC

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -178,6 +178,8 @@ RedWire (`red://` / `reds://`) is RedDB's principal transport. gRPC, HTTP(S), br
 | `file://` | embedded file-backed engine | embedded | `file:///var/lib/reddb/app.db` | Embedded durable engine rooted at the URI path. |
 | `red+ws://` | RedWire WebSocket | remote | `red+ws://db.example.com` | Browser-native RedWire over WebSocket without TLS. |
 | `red+wss://` | RedWire WebSocket | remote | `red+wss://db.example.com` | Browser-native RedWire over WebSocket with TLS. |
+| `ws://` | RedWire WebSocket | remote | `ws://db.example.com` | Browser-friendly alias for RedWire over WebSocket without TLS. |
+| `wss://` | RedWire WebSocket | remote | `wss://db.example.com` | Browser-friendly alias for RedWire over WebSocket with TLS. |
 
 ## Deployment Topologies
 

--- a/drivers/js-client/README.md
+++ b/drivers/js-client/README.md
@@ -147,6 +147,14 @@ The client follows the SDK Helper Spec for the shared JS/TS surface:
 | `grpcs://`     | gRPC over TLS                 | 55555         |
 | `http://`      | HTTP JSON                     | 5000         |
 | `https://`     | HTTPS JSON                    | 55555         |
+| `ws://`        | RedWire over WebSocket        | 80           |
+| `wss://`       | RedWire over WebSocket + TLS  | 443          |
+| `red+ws://`    | RedWire over WebSocket        | 80           |
+| `red+wss://`   | RedWire over WebSocket + TLS  | 443          |
+
+Browser bundles cannot open raw TCP, so use `wss://host` (or `ws://host`
+for plaintext development origins) when connecting directly from browser
+JavaScript.
 
 ## Rejected URI schemes
 

--- a/drivers/js-client/index.browser.d.ts
+++ b/drivers/js-client/index.browser.d.ts
@@ -13,8 +13,9 @@
  *   - It omits `splitNdjson()` (a `node:stream` `Transform`), which has no
  *     browser counterpart.
  *
- * `connect()` reaches `http(s)://` and `red+wss://` (RedWire-over-binary-
- * WebSocket, #937) from a browser; `grpc(s)://`, `red(s)://`, and `pg`
+ * `connect()` reaches `http(s)://`, `ws(s)://`, and `red+ws(s)://`
+ * (RedWire-over-binary-WebSocket, #937) from a browser; `grpc(s)://`,
+ * `red(s)://`, and `pg`
  * throw `RedDBError` with code `'BROWSER_TRANSPORT_UNSUPPORTED'`, and
  * embedded URIs throw `EmbeddedNotSupported`.
  */
@@ -422,8 +423,8 @@ export class RedDB {
 /**
  * Connect to a remote RedDB instance from a browser.
  *
- * `http://host:port`, `https://host:port`, and `red+wss://host:port`
- * (RedWire-over-binary-WebSocket, #937) are reachable from a browser
+ * `http://host:port`, `https://host:port`, `ws(s)://host:port`, and
+ * `red+ws(s)://host:port` (RedWire-over-binary-WebSocket, #937) are reachable from a browser
  * sandbox. `grpc(s)://`, `red(s)://`, and `pg` throw `RedDBError` with code
  * `'BROWSER_TRANSPORT_UNSUPPORTED'`. Embedded URIs (`memory://`, `memory:`,
  * `file:///path`, `red:///`, `red://:memory[:]`) throw `EmbeddedNotSupported`.
@@ -437,9 +438,10 @@ export function login(
 ): Promise<LoginResult>
 
 export interface ParsedUri {
-  kind: 'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redwss' | 'grpc' | 'grpcs' | 'pg'
+  kind: 'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redws' | 'redwss' | 'grpc' | 'grpcs' | 'pg'
   host?: string
   port?: number
+  tls?: boolean
   path?: string
   username?: string
   password?: string

--- a/drivers/js-client/index.d.ts
+++ b/drivers/js-client/index.d.ts
@@ -443,9 +443,10 @@ export function login(
 ): Promise<LoginResult>
 
 export interface ParsedUri {
-  kind: 'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redwss' | 'grpc' | 'grpcs' | 'pg'
+  kind: 'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redws' | 'redwss' | 'grpc' | 'grpcs' | 'pg'
   host?: string
   port?: number
+  tls?: boolean
   path?: string
   username?: string
   password?: string

--- a/drivers/js-client/src/core/url.js
+++ b/drivers/js-client/src/core/url.js
@@ -20,7 +20,7 @@ import { RedDBError } from './errors.js'
 
 /**
  * @typedef {object} ParsedUri
- * @property {'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redwss' | 'grpc' | 'grpcs' | 'pg'} kind
+ * @property {'embedded' | 'http' | 'https' | 'red' | 'reds' | 'redws' | 'redwss' | 'grpc' | 'grpcs' | 'pg'} kind
  * @property {string} [host]
  * @property {number} [port]
  * @property {string} [path]            // for embedded `file://`-equivalent
@@ -35,8 +35,8 @@ import { RedDBError } from './errors.js'
 
 /**
  * Parse any URI string into a normalised `ParsedUri`.
- * Accepts `red://`, `memory://`, `file://`, `grpc://` (the latter
- * three for backwards compat).
+ * Accepts `red://`, `ws(s)://`, `memory://`, `file://`, `grpc://`
+ * (the latter three for backwards compat).
  *
  * @param {string} uri
  * @returns {ParsedUri}
@@ -48,7 +48,16 @@ export function parseUri(uri) {
     )
   }
   if (uri.startsWith('red+wss://')) {
-    return parseRedWssUrl(uri)
+    return parseRedWebSocketUrl(uri, 'red+wss')
+  }
+  if (uri.startsWith('red+ws://')) {
+    return parseRedWebSocketUrl(uri, 'red+ws')
+  }
+  if (uri.startsWith('wss://')) {
+    return parseRedWebSocketUrl(uri, 'wss')
+  }
+  if (uri.startsWith('ws://')) {
+    return parseRedWebSocketUrl(uri, 'ws')
   }
   if (uri.startsWith('red://') || uri === 'red:' || uri === 'red:/') {
     return parseRedUrl(uri)
@@ -57,28 +66,35 @@ export function parseUri(uri) {
 }
 
 /**
- * Parse `red+wss://[user:pass@]host:port[?token=...]` — RedWire framing
+ * Parse `ws(s)://[user:pass@]host:port[?token=...]` — RedWire framing
  * tunneled over a binary WebSocket (the browser transport; #937, ADR
- * 0036). Resolves to a `wss://host:port/redwire` endpoint downstream.
- * Default port is 443 (the TLS edge).
+ * 0036). Resolves to a `ws(s)://host:port/redwire` endpoint downstream.
+ * TLS defaults to port 443; plaintext defaults to port 80.
  */
 export function parseRedWssUrl(uri) {
+  return parseRedWebSocketUrl(uri, 'red+wss')
+}
+
+function parseRedWebSocketUrl(uri, scheme) {
+  const tls = scheme === 'red+wss' || scheme === 'wss'
+  const prefix = `${scheme}://`
   let parsed
   try {
     // Borrow the URL parser via an `https://` authority so user / pass /
     // host / port / query all decode with the standard rules.
-    parsed = new URL('https://' + uri.slice('red+wss://'.length))
+    parsed = new URL('https://' + uri.slice(prefix.length))
   } catch (err) {
     throw new RedDBError('UNPARSEABLE_URI', `failed to parse '${uri}': ${err.message}`)
   }
   if (!parsed.hostname) {
-    throw new TypeError(`invalid red+wss:// URI: missing host in '${uri}'`)
+    throw new TypeError(`invalid ${prefix} URI: missing host in '${uri}'`)
   }
   const params = parsed.searchParams
   return {
-    kind: 'redwss',
+    kind: tls ? 'redwss' : 'redws',
     host: parsed.hostname,
-    port: parsed.port ? Number(parsed.port) : 443,
+    port: parsed.port ? Number(parsed.port) : (tls ? 443 : 80),
+    tls,
     username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
     password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
     token: params.get('token') ?? undefined,
@@ -239,7 +255,7 @@ export function parseLegacyUrl(uri) {
   }
   throw new RedDBError(
     'UNSUPPORTED_SCHEME',
-    `unsupported URI: '${uri}'. Use 'red://...' or one of memory://, file://, grpc://, http(s)://`,
+    `unsupported URI: '${uri}'. Use 'red://...' or one of memory://, file://, grpc://, http(s)://, ws(s)://`,
   )
 }
 
@@ -280,6 +296,10 @@ function defaultPortFor(kind) {
     case 'reds':
     case 'redwire':
       return 5050
+    case 'redws':
+      return 80
+    case 'redwss':
+      return 443
     case 'grpc':
       return 55055
     case 'grpcs':

--- a/drivers/js-client/src/index.browser.js
+++ b/drivers/js-client/src/index.browser.js
@@ -7,6 +7,7 @@
  *
  *   - 'http://host:port'   — HTTP JSON-RPC over `fetch`
  *   - 'https://host:port'  — HTTPS JSON-RPC over `fetch`
+ *   - 'ws(s)://host:port'  — RedWire over binary WebSocket
  *
  * Streaming is the Web-streams implementation (`./streaming-web.js`), so the
  * full transport-agnostic surface works client-side: query, execute, insert,
@@ -72,18 +73,18 @@ function browserTransportError(scheme) {
     `'${scheme}' connections are not available in the browser: the `
       + `browser sandbox exposes no raw TCP socket (red://, reds://, pg) or `
       + `HTTP/2 client (grpc://, grpcs://) to JavaScript. Connect to an `
-      + `HTTP(S) endpoint instead — e.g. 'http://host:port' / `
-      + `'https://host:port' — by running RedDB's HTTP JSON-RPC listener or `
-      + `an HTTP gateway in front of the server, then call `
-      + `connect('https://…').`,
+      + `HTTP(S) endpoint or RedWire WebSocket endpoint instead — e.g. `
+      + `'http://host:port' / 'https://host:port' / 'wss://host' — by running `
+      + `RedDB's HTTP JSON-RPC listener, its WebSocket edge, or an HTTP gateway `
+      + `in front of the server.`,
   )
 }
 
 /**
  * Connect to a remote RedDB instance from a browser.
  *
- * @param {string} uri Connection URI. Only `http(s)://` is reachable from a
- *   browser; other schemes raise `BROWSER_TRANSPORT_UNSUPPORTED`.
+ * @param {string} uri Connection URI. `http(s)://` and `ws(s)://` are
+ *   reachable from a browser; other schemes raise `BROWSER_TRANSPORT_UNSUPPORTED`.
  * @param {object} [options]
  * @param {object} [options.auth] Authentication credentials.
  * @param {string} [options.auth.token] Bearer / API-key token.
@@ -128,11 +129,12 @@ export async function connect(uri, options = {}) {
   // a WSS the sandbox can open. The TLS edge enforces the Origin allowlist
   // and WSS-only on its side; here we just open the socket and run the
   // standard RedWire handshake over it.
-  if (parsed.kind === 'redwss') {
+  if (parsed.kind === 'redws' || parsed.kind === 'redwss') {
     const merged = mergeAuthFromUri(parsed, options.auth)
     let token = merged.token
     if (!token && merged.username && merged.password) {
-      const loginUrl = merged.loginUrl ?? `https://${parsed.host}:${parsed.port}/auth/login`
+      const httpScheme = parsed.tls === false ? 'http' : 'https'
+      const loginUrl = merged.loginUrl ?? `${httpScheme}://${parsed.host}:${parsed.port}/auth/login`
       const session = await login(loginUrl, {
         username: merged.username,
         password: merged.password,
@@ -140,7 +142,8 @@ export async function connect(uri, options = {}) {
       token = session.token
     }
     const auth = token ? { kind: 'bearer', token } : { kind: 'anonymous' }
-    const url = `wss://${parsed.host}:${parsed.port}${REDWIRE_WS_PATH}`
+    const wsScheme = parsed.tls === false ? 'ws' : 'wss'
+    const url = `${wsScheme}://${parsed.host}:${parsed.port}${REDWIRE_WS_PATH}`
     const client = await connectRedwireWs({ url, auth })
     return new RedDB(client)
   }

--- a/drivers/js-client/src/redwire-ws.js
+++ b/drivers/js-client/src/redwire-ws.js
@@ -128,7 +128,7 @@ function waitOpen(ws) {
  * Open a RedWire connection over a binary WebSocket.
  *
  * @param {object} opts
- * @param {string} [opts.url] `wss://host:port/redwire` endpoint.
+ * @param {string} [opts.url] `ws(s)://host:port/redwire` endpoint.
  * @param {{ kind: 'anonymous' } | { kind: 'bearer', token: string }} [opts.auth]
  * @param {string} [opts.clientName]
  * @param {string} [opts.subprotocol] Override the advertised subprotocol.
@@ -153,10 +153,10 @@ export async function connectRedwireWs(opts = {}) {
       'no global WebSocket in this runtime; pass opts.WebSocketImpl',
     )
   }
-  if (typeof url !== 'string' || !url.startsWith('wss://')) {
+  if (typeof url !== 'string' || !(url.startsWith('wss://') || url.startsWith('ws://'))) {
     throw new RedDBError(
-      'WSS_REQUIRED',
-      `redwire websocket requires a wss:// url, got '${url}'`,
+      'WEBSOCKET_URL_REQUIRED',
+      `redwire websocket requires a ws:// or wss:// url, got '${url}'`,
     )
   }
 

--- a/drivers/js-client/test/redwire-ws.test.mjs
+++ b/drivers/js-client/test/redwire-ws.test.mjs
@@ -170,10 +170,25 @@ test('redwire-ws: multiplexes several queries over one connection', async () => 
   await client.close()
 })
 
-test('redwire-ws: requires a wss:// url', async () => {
+test('redwire-ws: accepts a ws:// url for plaintext browser/dev endpoints', async () => {
+  const ws = new MockRedWireWebSocket()
+  const client = await connectRedwireWs({
+    url: 'ws://localhost:80/redwire',
+    WebSocketImpl: function () {
+      return ws
+    },
+  })
+
+  const result = await client.call('query', { sql: 'SELECT n FROM t' })
+  assert.deepEqual(result.rows, [{ n: 42 }])
+
+  await client.close()
+})
+
+test('redwire-ws: requires a ws:// or wss:// url', async () => {
   await assert.rejects(
-    connectRedwireWs({ url: 'ws://app.example.com/redwire', WebSocketImpl: () => ({}) }),
-    (err) => err.code === 'WSS_REQUIRED',
+    connectRedwireWs({ url: 'https://app.example.com/redwire', WebSocketImpl: () => ({}) }),
+    (err) => err.code === 'WEBSOCKET_URL_REQUIRED',
   )
 })
 

--- a/drivers/js-client/test/url.test.mjs
+++ b/drivers/js-client/test/url.test.mjs
@@ -66,3 +66,37 @@ test('red:// canonical with userinfo still parses (regression lock)', () => {
   assert.equal(p.username, 'admin')
   assert.equal(p.password, 'pw')
 })
+
+test('wss:// parses as browser RedWire WebSocket with TLS defaults', () => {
+  const p = parseUri('wss://admin:s3cr%40t@mydb.db.reddb.io?token=sk-abc&api_key=ak-xyz')
+  assert.equal(p.kind, 'redwss')
+  assert.equal(p.host, 'mydb.db.reddb.io')
+  assert.equal(p.port, 443)
+  assert.equal(p.tls, true)
+  assert.equal(p.username, 'admin')
+  assert.equal(p.password, 's3cr@t')
+  assert.equal(p.token, 'sk-abc')
+  assert.equal(p.apiKey, 'ak-xyz')
+})
+
+test('ws:// parses as browser RedWire WebSocket with plaintext defaults', () => {
+  const p = parseUri('ws://localhost')
+  assert.equal(p.kind, 'redws')
+  assert.equal(p.host, 'localhost')
+  assert.equal(p.port, 80)
+  assert.equal(p.tls, false)
+})
+
+test('red+ws:// and red+wss:// remain supported aliases', () => {
+  const ws = parseUri('red+ws://dev.example:8080')
+  assert.equal(ws.kind, 'redws')
+  assert.equal(ws.host, 'dev.example')
+  assert.equal(ws.port, 8080)
+  assert.equal(ws.tls, false)
+
+  const wss = parseUri('red+wss://prod.example')
+  assert.equal(wss.kind, 'redwss')
+  assert.equal(wss.host, 'prod.example')
+  assert.equal(wss.port, 443)
+  assert.equal(wss.tls, true)
+})


### PR DESCRIPTION
## Summary
- accept raw ws:// and wss:// as first-class RedWire WebSocket URI schemes
- keep red+ws:// and red+wss:// compatible while mapping browser connect() to /redwire
- document wss:// as the browser production path and ws:// as plaintext local dev

## Verification
- cargo fmt --all
- CARGO_TARGET_DIR=/home/cyber/.cache/reddb-cargo-target cargo test -p reddb-io-wire --test parser_table
- CARGO_TARGET_DIR=/home/cyber/.cache/reddb-cargo-target cargo test -p reddb-io-wire knowledge::tests
- npm test -- --test-name-pattern "wss|ws|redwire-ws|reds|grpc|red:// canonical"
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785209859&installation_id=129708444&pr_number=1506&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1506&signature=24fe7d72f41d61b089dd3283abfed60b5c302c73612bd14aafc7eaff8b29eb67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->