### PR TITLE
ci(testing): add DST storage fault recovery lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,10 +561,8 @@ jobs:
         with:
           shared-key: ubuntu-rust-1.91.0
           cache-on-failure: "true"
-      - name: Run chaos tests
-        run: cargo test --locked --test grouped_chaos --no-fail-fast
-      - name: Run drill tests
-        run: cargo test --locked --test grouped_pitr_drills --no-fail-fast
+      - name: Run chaos, drill, and persistence tests
+        run: cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast
 
   chaos-floci:
     # PLAN.md Phase 8.4 — chaos suite against an S3-compatible
@@ -629,7 +627,7 @@ jobs:
             docker logs reddb-ci-floci || true
             exit 1
           fi
-      - run: cargo test --locked --test grouped_chaos --no-fail-fast
+      - run: cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast chaos_
       - name: Stop Floci
         if: always()
         run: docker rm -f reddb-ci-floci || true

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,12 +28,15 @@ jobs:
           shared-key: dst-nightly-rust-1.91.0
           cache-on-failure: "true"
       - name: Run DST heavy seed sweep
-        run: cargo test --locked -p reddb-server replication::dst::tests::dst_seed_sweep -- --ignored
+        run: cargo test --locked -p reddb-io-server replication::dst::tests::dst_seed_sweep -- --ignored
 
   storage-fault-recovery:
     name: Storage fault recovery
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.91.0

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -5,6 +5,14 @@ on:
     - cron: "23 7 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
 jobs:
   dst-seed-sweep:
     name: DST seed sweep
@@ -22,3 +30,53 @@ jobs:
           cache-on-failure: "true"
       - name: Run DST heavy seed sweep
         run: cargo test --locked -p reddb-server replication::dst::tests::dst_seed_sweep -- --ignored
+
+  storage-fault-recovery:
+    name: Storage fault recovery
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: "28.3"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: dst-storage-rust-1.91.0
+          cache-on-failure: "true"
+      - name: Run storage fault recovery tests
+        id: storage_faults
+        run: |
+          mkdir -p target/dst-storage
+          set -o pipefail
+          make test-dst-storage 2>&1 | tee target/dst-storage/test-dst-storage.log
+      - name: Upload storage fault report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dst-storage-fault-report
+          path: target/dst-storage/test-dst-storage.log
+      - name: Open issue on storage fault failure
+        if: failure()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const title = `Nightly storage fault recovery failed: ${new Date().toISOString().slice(0, 10)}`;
+            const body = [
+              'The scheduled storage fault recovery lane failed.',
+              '',
+              `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              '',
+              'Triage checklist:',
+              '- Inspect the `dst-storage-fault-report` artifact.',
+              '- Find the failing `SEED=<n>` line in the test output.',
+              '- Re-run `SEED=<n> make test-dst-storage` locally before closing.'
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['release-blocker']
+            });

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-fast release warm test test-fast test-full test-nextest test-nextest-lib test-nextest-e2e test-persistent test-persistent-grimms drill-nightly clean run run-grpc install fmt lint check check-helm check-driver-rust check-driver-python timings cold-start-bench binary-size image-size artifact-size link unlink dev which patch minor major release-push package-check docs publish publish-dry-run env-up env-down env-logs test-env test-env-shell test-env-rust perf-bench
+.PHONY: help build build-fast release warm test test-fast test-full test-nextest test-nextest-lib test-nextest-e2e test-persistent test-persistent-grimms test-dst-storage drill-nightly clean run run-grpc install fmt lint check check-helm check-driver-rust check-driver-python timings cold-start-bench binary-size image-size artifact-size link unlink dev which patch minor major release-push package-check docs publish publish-dry-run env-up env-down env-logs test-env test-env-shell test-env-rust perf-bench
 
 # Paths
 LOCAL_BIN := $(HOME)/.local/bin
@@ -22,6 +22,7 @@ help:
 	@echo "  make test-nextest-e2e - Run the e2e (integration) lane under cargo-nextest"
 	@echo "  make test-persistent - Run the persistent multimodel integration layer"
 	@echo "  make test-persistent-grimms - Run the Grimms-scale persistent storage fixture"
+	@echo "  make test-dst-storage - Run seeded storage fault recovery tests"
 	@echo "  make drill-nightly - Run backup/restore drill tests and append drill history"
 	@echo "  make test-env PROFILE=replica - Bring up a dedicated test environment and run shell + Rust external-env tests"
 	@echo "  make test-env-shell PROFILE=replica - Bring up a dedicated test environment and run shell checks only"
@@ -99,6 +100,9 @@ test-persistent:
 
 test-persistent-grimms:
 	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test grouped_runtime_persistence integration_persistent_grimms_scale -- --ignored --nocapture
+
+test-dst-storage:
+	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery
 
 drill-nightly:
 	@./scripts/drill-nightly.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-fast release warm test test-fast test-full test-nextest test-nextest-lib test-nextest-e2e test-persistent test-persistent-grimms test-dst-storage drill-nightly clean run run-grpc install fmt lint check check-helm check-driver-rust check-driver-python timings cold-start-bench binary-size image-size artifact-size link unlink dev which patch minor major release-push package-check docs publish publish-dry-run env-up env-down env-logs test-env test-env-shell test-env-rust perf-bench
+.PHONY: help build build-fast release warm test test-fast test-full test-nextest test-nextest-lib test-nextest-e2e test-persistent test-persistent-grimms test-chaos test-chaos-drills test-chaos-replication test-chaos-all test-dst-storage test-dst-sweep drill-nightly clean run run-grpc install fmt lint check check-helm check-driver-rust check-driver-python timings cold-start-bench binary-size image-size artifact-size link unlink dev which patch minor major release-push package-check docs publish publish-dry-run env-up env-down env-logs test-env test-env-shell test-env-rust perf-bench
 
 # Paths
 LOCAL_BIN := $(HOME)/.local/bin
@@ -22,7 +22,10 @@ help:
 	@echo "  make test-nextest-e2e - Run the e2e (integration) lane under cargo-nextest"
 	@echo "  make test-persistent - Run the persistent multimodel integration layer"
 	@echo "  make test-persistent-grimms - Run the Grimms-scale persistent storage fixture"
+	@echo "  make test-chaos    - Run local chaos tests"
+	@echo "  make test-chaos-all - Run local chaos, drill, replication harness, and storage fault tests"
 	@echo "  make test-dst-storage - Run seeded storage fault recovery tests"
+	@echo "  make test-dst-sweep - Run ignored DST replication seed sweep"
 	@echo "  make drill-nightly - Run backup/restore drill tests and append drill history"
 	@echo "  make test-env PROFILE=replica - Bring up a dedicated test environment and run shell + Rust external-env tests"
 	@echo "  make test-env-shell PROFILE=replica - Bring up a dedicated test environment and run shell checks only"
@@ -101,8 +104,25 @@ test-persistent:
 test-persistent-grimms:
 	CARGO_TARGET_DIR=$${CARGO_TARGET_DIR:-target/persistent-tests} cargo test --locked --test grouped_runtime_persistence integration_persistent_grimms_scale -- --ignored --nocapture
 
+test-chaos:
+	cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast chaos_
+
+test-chaos-drills:
+	cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast drill_
+
+test-chaos-replication:
+	cargo test --locked --test grouped_replication jepsen_black_box_harness_self_test_exercises_replay_artifacts_and_checkers
+
+test-chaos-all:
+	cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast
+	$(MAKE) test-chaos-replication
+	$(MAKE) test-dst-storage
+
 test-dst-storage:
 	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery
+
+test-dst-sweep:
+	cargo test --locked -p reddb-io-server replication::dst::tests::dst_seed_sweep -- --ignored
 
 drill-nightly:
 	@./scripts/drill-nightly.sh

--- a/docs/testing/chaos-test-lanes.md
+++ b/docs/testing/chaos-test-lanes.md
@@ -1,0 +1,76 @@
+# Chaos Test Lanes
+
+RedDB's local chaos coverage is split by fault layer so failures stay easy to
+reproduce.
+
+## Fast Local Matrix
+
+Run the normal local chaos bundle:
+
+```bash
+make test-chaos-all
+```
+
+That target runs:
+
+- `grouped_chaos_drill_persistence`: the consolidated local chaos, drill, and
+  persistence binary.
+- `make test-chaos-replication`: the Jepsen-style harness self-test and checker
+  replay contract.
+- `make test-dst-storage`: seeded storage fault recovery through
+  `unreliable-libc` and `SimVfs`.
+
+For a narrower rerun, call the failing target directly:
+
+```bash
+make test-chaos
+make test-chaos-drills
+make test-chaos-replication
+```
+
+Storage faults also support seed reproduction:
+
+```bash
+SEED=<n> make test-dst-storage
+```
+
+## Nightly And Heavy Lanes
+
+The ignored replication DST sweep is heavier and is wired to the nightly DST
+workflow:
+
+```bash
+make test-dst-sweep
+```
+
+To exercise the scheduled workflow manually from GitHub:
+
+```bash
+gh workflow run dst-nightly.yml
+```
+
+The full CI chaos jobs, including the Floci S3 backend chaos lane, run only on
+manual full CI dispatch because they need extra runtime and Docker services:
+
+```bash
+gh workflow run ci.yml -f full_ci=true
+```
+
+## Black-Box Process Harness
+
+The Jepsen-style black-box harness can run as a self-test without booting RedDB:
+
+```bash
+make test-chaos-replication
+```
+
+To run the real process-level harness, build `red` first and keep artifacts for
+replay:
+
+```bash
+cargo build --bin red
+python3 scripts/jepsen_black_box_cluster.py --seed 0x5eed --red-bin target/debug/red --keep-artifacts
+```
+
+The harness records `history.jsonl`, `schedule.json`, per-node logs, and
+`repro.json` under `target/jepsen-blackbox/` when artifacts are kept.

--- a/docs/testing/dst-storage-fault-lane.md
+++ b/docs/testing/dst-storage-fault-lane.md
@@ -1,0 +1,39 @@
+# DST Storage Fault Recovery Lane
+
+The storage fault lane promotes the existing `unreliable-libc` crash-recovery
+suites into an explicit local and nightly signal. It is the first RedDB maturity
+step toward Turso-style deterministic simulation testing for durability bugs:
+exercise seeded storage faults now, then grow the simulator surface over time.
+
+## Running Locally
+
+```bash
+make test-dst-storage
+```
+
+To reproduce a specific failing interleaving from CI:
+
+```bash
+SEED=<n> make test-dst-storage
+```
+
+The lane currently runs these suites:
+
+- `sim_power_cut_recovery`: in-process `SimVfs` coverage for torn writes,
+  dropped or reordered fsync, ENOSPC, partial rename, and seeded power cuts.
+- `value_equivalence_recovery`: typed-value crash recovery, asserting recovered
+  committed values match the model's committed prefix.
+- `power_cut_recovery`: Linux `LD_PRELOAD` shim coverage for real process kills,
+  short writes, and injected I/O failures around the WAL workload.
+
+## CI Signal
+
+`.github/workflows/dst-nightly.yml` runs this lane as the `Storage fault
+recovery` job. The job uploads `dst-storage-fault-report` with the captured test
+log on every run. On failure it opens a `release-blocker` issue with the
+workflow link and reproduction checklist.
+
+This is intentionally narrower than a full deterministic cluster simulator. It
+keeps the first gate cheap and reproducible while covering the storage
+invariants most likely to be violated by power cuts or broken filesystem
+behavior.

--- a/scripts/drill-nightly.sh
+++ b/scripts/drill-nightly.sh
@@ -18,7 +18,7 @@ if [[ ! -f "$HISTORY" ]]; then
   } > "$HISTORY"
 fi
 
-CMD="cargo test --locked --test grouped_pitr_drills --no-fail-fast"
+CMD="cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast drill_"
 START="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 # Keep the runner log out of the `reddb-*` temp namespace: the drills
 # intentionally clean that namespace while checking for leaked DB files.

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -124,7 +124,7 @@ test("nightly DR drill workflow uses the current-shell runner and public make ta
   const workflow = read(".github/workflows/drill-nightly.yml");
 
   assert.match(makefile, /\ndrill-nightly:\n\t@\.\/scripts\/drill-nightly\.sh/);
-  assert.match(script, /CMD="cargo test --locked --test grouped_pitr_drills --no-fail-fast"/);
+  assert.match(script, /CMD="cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast drill_"/);
   assert.match(script, /mktemp -t drill-nightly\.XXXXXX\.log/);
   assert.doesNotMatch(script, /mktemp -t reddb-drill-nightly/);
   assert.match(script, /eval "\$CMD" >"\$LOG" 2>&1/);


### PR DESCRIPTION
## Summary
- add `make test-dst-storage` for the existing `unreliable-libc` crash-recovery suites
- run the storage fault lane from `dst-nightly.yml`, upload the captured log, and open a `release-blocker` issue on failure
- document local and `SEED=<n>` reproduction in `docs/testing/dst-storage-fault-lane.md`
- add `make test-chaos-all` plus narrower chaos/drill/replication targets and document the chaos test lanes
- fix stale chaos/DST workflow commands to use the current grouped test target and `reddb-io-server` package id
- scope `issues: write` to only the `storage-fault-recovery` job, addressing CodeRabbit

## Verification
- `make test-chaos-all`
- `make test-chaos`
- `make test-chaos-drills`
- `make test-dst-storage`
- `node --test --test-name-pattern "nightly DR drill workflow" scripts/release_tooling_contract.test.mjs`
- `git diff --check`
- PyYAML parse/structure check for `.github/workflows/dst-nightly.yml` and `.github/workflows/ci.yml`

## Notes
- `make test-dst-sweep` now resolves the correct package id and entered `reddb-io-server` compilation locally, but I interrupted the local run after a long compile. It remains the heavy/nightly lane.
- `actionlint` still flags the repo's existing custom Blacksmith runner labels as unknown; no new non-runner-label lint remained.
- Full `node --test scripts/release_tooling_contract.test.mjs` still has unrelated pre-existing failures in the changesets checkout and parser fuzz timeout checks.