### PR TITLE
ci(release): fix cargo RC publish dependency pins

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -222,12 +222,10 @@ jobs:
           node-version: '22'
 
       - name: Update crate package versions for RC
-        # sync-version.js updates dep version requirements in per-crate Cargo.toml
-        # table-format entries (e.g. [dependencies.reddb-io-*]\nversion = "...") to
-        # the RC version, which does not exist on crates.io yet and breaks cargo
-        # publish. Use a targeted Python script that touches only [package] version,
-        # leaving all dep requirements pointing to stable siblings on crates.io.
-        # cargo publish does not consult Cargo.lock, so no generate-lockfile needed.
+        # sync-version.js updates npm/package metadata too broadly for the cargo-only
+        # RC publish job. Touch only crate [package] versions here; the next step pins
+        # internal workspace dependency requirements so path package versions still
+        # satisfy Cargo's publish-time validation.
         env:
           RC_VERSION: ${{ needs.plan.outputs.rc_version }}
         run: |
@@ -246,6 +244,13 @@ jobs:
                   out.append(l)
               open(path, 'w').writelines(out)
           PYEOF
+
+      - name: Patch workspace dep version requirements for RC
+        # Cargo does not match pre-release versions against range requirements like "^1.0".
+        # Pin every internal workspace dep to the exact RC version so cargo publish resolves.
+        run: |
+          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
+          sed -i -E "s/(package = \"reddb-io-[^\"]+\", version = \")[^\"]+(\")/\1=${RC_VERSION}\2/" Cargo.toml
 
       - name: Publish workspace crates
         env:


### PR DESCRIPTION
## Summary
- pin internal workspace dependency requirements to the exact RC version in the `Publish crates @rc` job
- align cargo RC publishing with the existing RC build job behavior
- fix the tolerated `Publish crates @rc` failure seen after merging v1.16.0 versioning

## Verification
- git diff --check
- observed `Release Candidate` run 28329517359: workflow concluded success, but `Publish crates @rc` failed because path package versions were rewritten to `1.16.0-rc.83` while internal dependency requirements still resolved as `^1.0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785258423&installation_id=129708444&pr_number=1512&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1512&signature=fa8a2d2e96194b1efb2994e9a3d2657c25b64baea39ca48741cc6972e845dac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->