### PR TITLE
ci(release): skip cargo release-candidate publish

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -204,13 +204,12 @@ jobs:
           done
 
   publish-cargo:
-    name: Publish crates @rc
+    name: Skip crates @rc
     needs: [plan, build-linux]
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    # Cargo workspace pre-release publishing is best-effort: cargo resolves path
-    # deps locally and rejects RC versions against range requirements (^1.0 excludes
-    # pre-release). Failures here do not block the GitHub binary or npm @rc publish.
-    continue-on-error: true
+    # Cargo pre-release publishing is intentionally skipped. The Rust workspace has
+    # internal path dependency cycles (notably wire <-> grpc-proto) that make exact
+    # RC version rewriting unsafe; stable release publishing remains authoritative.
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.91.0
@@ -221,67 +220,7 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Update crate package versions for RC
-        # sync-version.js updates npm/package metadata too broadly for the cargo-only
-        # RC publish job. Touch only crate [package] versions here; the next step pins
-        # internal workspace dependency requirements so path package versions still
-        # satisfy Cargo's publish-time validation.
-        env:
-          RC_VERSION: ${{ needs.plan.outputs.rc_version }}
+      - name: Skip crates.io RC publish
         run: |
-          python3 - << 'PYEOF'
-          import os, re, glob
-          rc = os.environ['RC_VERSION']
-          for path in ['Cargo.toml'] + glob.glob('crates/*/Cargo.toml'):
-              lines = open(path).readlines()
-              in_pkg, replaced, out = False, False, []
-              for l in lines:
-                  if l.strip() == '[package]': in_pkg = True
-                  elif l.startswith('[') and l.strip() != '[package]': in_pkg = False
-                  if in_pkg and not replaced and re.match(r'^\s*version\s*=\s*"', l):
-                      l = re.sub(r'(version\s*=\s*")[^"]*"', f'\\g<1>{rc}"', l, count=1)
-                      replaced = True
-                  out.append(l)
-              open(path, 'w').writelines(out)
-          PYEOF
-
-      - name: Patch workspace dep version requirements for RC
-        # Cargo does not match pre-release versions against range requirements like "^1.0".
-        # Pin every internal workspace dep to the exact RC version so cargo publish resolves.
-        run: |
-          RC_VERSION="${{ needs.plan.outputs.rc_version }}"
-          sed -i -E "s/(package = \"reddb-io-[^\"]+\", version = \")[^\"]+(\")/\1=${RC_VERSION}\2/" Cargo.toml
-
-      - name: Publish workspace crates
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
-            echo "::warning::CARGO_REGISTRY_TOKEN not set — skipping crates.io @rc publish."
-            exit 0
-          fi
-
-          publish_one() {
-            local crate="$1"
-            echo "==> publish ${crate}@${{ needs.plan.outputs.rc_version }}"
-            local out
-            out=$(cargo publish --allow-dirty --no-verify -p "$crate" 2>&1) && { echo "$out"; return 0; }
-            if echo "$out" | grep -qE "already uploaded|already exists"; then
-              echo "  ${crate} already on crates.io — skipping"
-            else
-              echo "$out" >&2
-              return 1
-            fi
-          }
-
-          publish_one reddb-io-types
-          publish_one reddb-io-crypto
-          publish_one reddb-io-file
-          publish_one reddb-io-rql
-          publish_one reddb-io-wire
-          publish_one reddb-io-grpc-proto
-          publish_one reddb-io-client-connector
-          publish_one reddb-io-server
-          publish_one reddb-io-client
-          publish_one reddb-io
+          echo "::notice::Skipping crates.io @rc publish for ${{ needs.plan.outputs.rc_version }}."
+          echo "::notice::Stable release publishing is still verified by the Release workflow."


### PR DESCRIPTION
## Summary
- stop attempting crates.io `@rc` publishing for Rust crates in the Release Candidate workflow
- document why: internal path dependency cycles make exact RC rewriting unsafe for Cargo
- keep stable Release workflow as the authoritative crates.io publisher

## Verification
- git diff --check
- observed RC run 28330146876: the prior pin fix let acyclic crates publish, then `reddb-io-wire` still failed because `wire` and `grpc-proto` form a local path dependency cycle under RC version rewriting
- main CI run 28330146866 completed successfully

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785260033&installation_id=129708444&pr_number=1513&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1513&signature=ee7cf02d941eb94fc002548c3abb4ebda77b790a5ea09599eff92a1f3074d6ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->