### PR TITLE
ci(testing): harden chaos workflow issue handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -65,8 +65,11 @@ jobs:
         with:
           script: |
             const title = `Nightly storage fault recovery failed: ${new Date().toISOString().slice(0, 10)}`;
+            const marker = 'nightly-storage-fault-recovery';
             const body = [
               'The scheduled storage fault recovery lane failed.',
+              '',
+              `Marker: ${marker}`,
               '',
               `Workflow run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
               '',
@@ -75,6 +78,18 @@ jobs:
               '- Find the failing `SEED=<n>` line in the test output.',
               '- Re-run `SEED=<n> make test-dst-storage` locally before closing.'
             ].join('\n');
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'release-blocker',
+              per_page: 100
+            });
+            const existing = issues.find((issue) => issue.body?.includes(`Marker: ${marker}`));
+            if (existing) {
+              core.info(`Open storage fault recovery blocker already exists: #${existing.number}`);
+              return;
+            }
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -9,6 +9,11 @@ function read(relativePath) {
   return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
+function workflowJob(workflow, name) {
+  const job = workflow.match(new RegExp(`\\n  ${name}:[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:|\\n$)`));
+  return job?.[0] ?? "";
+}
+
 test("red_client size guard is wired to a documented local and CI budget check", () => {
   const budget = read("crates/reddb-client/SIZE_BUDGET").trim();
   const sizeScript = read("scripts/check-red-client-size.sh");
@@ -135,7 +140,7 @@ test("nightly DR drill workflow uses the current-shell runner and public make ta
 
 test("changesets checkout uses the default token before release PAT handoff", () => {
   const workflow = read(".github/workflows/changesets.yml");
-  const checkoutStep = workflow.match(/- uses: actions\/checkout@v6[\s\S]*?(?=\n\n      - uses: pnpm\/action-setup@v6)/)?.[0] ?? "";
+  const checkoutStep = workflow.match(/- uses: actions\/checkout@v\d+[\s\S]*?(?=\n\n      - uses: pnpm\/action-setup@v\d+)/)?.[0] ?? "";
 
   assert.match(checkoutStep, /fetch-depth: 0/);
   assert.doesNotMatch(checkoutStep, /\n\s+token:/);
@@ -160,12 +165,53 @@ test("parser fuzz nightly installs protoc before fuzz builds", () => {
   );
 });
 
-test("per-PR parser fuzz job has enough timeout for three fixed fuzz windows", () => {
-  const workflow = read(".github/workflows/ci.yml");
-  const job = workflow.match(/\n  fuzz-parsers:[\s\S]*?(?=\n  package:)/)?.[0] ?? "";
+test("chaos and DST workflows use least-privilege GitHub token scopes", () => {
+  const ciWorkflow = read(".github/workflows/ci.yml");
+  const dstWorkflow = read(".github/workflows/dst-nightly.yml");
+  const seedSweep = workflowJob(dstWorkflow, "dst-seed-sweep");
+  const storageFaultRecovery = workflowJob(dstWorkflow, "storage-fault-recovery");
 
-  assert.match(job, /timeout-minutes: 40/);
-  assert.match(job, /cargo \+nightly fuzz run sql_parser -- -max_total_time=300/);
-  assert.match(job, /cargo \+nightly fuzz run migration_parser -- -max_total_time=300/);
-  assert.match(job, /cargo \+nightly fuzz run conn_string_parser -- -max_total_time=300/);
+  assert.match(seedSweep, /\n  dst-seed-sweep:/);
+  assert.match(storageFaultRecovery, /\n  storage-fault-recovery:/);
+  assert.match(ciWorkflow, /\npermissions:\n  contents: read\n\n/);
+  assert.match(dstWorkflow, /\npermissions:\n  contents: read\n\n/);
+  assert.doesNotMatch(seedSweep, /issues: write/);
+  assert.match(storageFaultRecovery, /\n    permissions:\n      contents: read\n      issues: write\n/);
+});
+
+test("DST storage fault issue creation deduplicates open release blockers", () => {
+  const workflow = read(".github/workflows/dst-nightly.yml");
+  const storageFaultRecovery = workflowJob(workflow, "storage-fault-recovery");
+
+  assert.match(storageFaultRecovery, /const marker = 'nightly-storage-fault-recovery';/);
+  assert.match(storageFaultRecovery, /`Marker: \$\{marker\}`/);
+  assert.match(storageFaultRecovery, /github\.paginate\(github\.rest\.issues\.listForRepo/);
+  assert.match(storageFaultRecovery, /labels: 'release-blocker'/);
+  assert.match(storageFaultRecovery, /issue\.body\?\.includes\(`Marker: \$\{marker\}`\)/);
+  assert.match(storageFaultRecovery, /github\.rest\.issues\.create/);
+
+  const existingGuard = storageFaultRecovery.indexOf("if (existing) {");
+  const existingReturn = storageFaultRecovery.indexOf("return;", existingGuard);
+  const createCall = storageFaultRecovery.indexOf("github.rest.issues.create");
+
+  assert.ok(existingGuard >= 0, "existing issue guard must be present");
+  assert.ok(existingReturn > existingGuard, "existing issue branch must return");
+  assert.ok(createCall > existingReturn, "issue creation must happen after existing issue guard");
+});
+
+test("per-PR parser fuzz matrix has bounded fixed fuzz windows", () => {
+  const workflow = read(".github/workflows/ci.yml");
+  const fuzzTargets = workflowJob(workflow, "fuzz-targets");
+  const fuzzParsers = workflowJob(workflow, "fuzz-parsers");
+
+  assert.match(fuzzTargets, /timeout-minutes: 20/);
+  for (const target of ["sql_parser", "migration_parser", "conn_string_parser", "query_with_params"]) {
+    assert.match(fuzzTargets, new RegExp(`- ${target}`));
+  }
+  assert.match(
+    fuzzTargets,
+    /cargo \+nightly fuzz run \$\{\{ matrix\.target \}\} -- -max_total_time=300 -rss_limit_mb=4096 -malloc_limit_mb=2048/,
+  );
+  assert.match(fuzzParsers, /name: Fuzz Parsers/);
+  assert.match(fuzzParsers, /needs: \[fuzz-targets\]/);
 });


### PR DESCRIPTION
## Summary
- add explicit read-only GitHub token scope to the CI workflow
- deduplicate DST storage fault release-blocker issues by a stable body marker
- lock the chaos/DST workflow contract in release_tooling_contract.test.mjs and refresh stale workflow assertions

## Verification
- git diff --check
- node --test scripts/release_tooling_contract.test.mjs
- actionlint -ignore 'label "blacksmith-[^\\"]+" is unknown' .github/workflows/ci.yml .github/workflows/dst-nightly.yml\n- CARGO_TARGET_DIR=/home/cyber/.cache/reddb-codex-chaos-target make test-dst-storage\n- CARGO_TARGET_DIR=/home/cyber/.cache/reddb-codex-chaos-target cargo test --locked --test grouped_chaos_drill_persistence --no-fail-fast\n\nAddresses CodeRabbit follow-ups from #1510.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785266071&installation_id=129708444&pr_number=1514&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1514&signature=7b38f741dc417ccaa8fb65cc57e92d7ad48a50da72f87ee8480f59d9d9071c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate blocker issues from being created when the same nightly failure is detected more than once.
  * Improved workflow behavior with tighter permissions and clearer issue-triage handling.

* **Chores**
  * Updated automated workflow checks to better enforce safe defaults and more reliable CI configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->