### PR TITLE
ci(release): publish checksum manifest

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -149,6 +149,21 @@ jobs:
           path: release
           merge-multiple: true
 
+      - name: Generate checksum manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd release
+            find . -maxdepth 1 -type f \( -name 'red-*' -o -name 'red_client-*' \) ! -name '*.sha256' -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              | sed 's#  \./#  #'
+          ) > release/checksums.txt
+          test -s release/checksums.txt
+          echo "---- checksums.txt ----"
+          cat release/checksums.txt
+
       - name: Create pre-release
         uses: softprops/action-gh-release@v3
         with:
@@ -166,6 +181,10 @@ jobs:
 
             # Thin remote-only client
             curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red_client-linux-x86_64 -o red_client && chmod +x red_client
+
+            # Verify downloaded binaries against the aggregate checksum manifest.
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/checksums.txt -o checksums.txt
+            grep -E '  (red|red_client)-linux-x86_64$' checksums.txt | sha256sum -c -
             ```
           files: release/*
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,21 @@ jobs:
           path: release
           merge-multiple: true
 
+      - name: Generate checksum manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          (
+            cd release
+            find . -maxdepth 1 -type f \( -name 'red-*' -o -name 'red_client-*' \) ! -name '*.sha256' -print0 \
+              | sort -z \
+              | xargs -0 sha256sum \
+              | sed 's#  \./#  #'
+          ) > release/checksums.txt
+          test -s release/checksums.txt
+          echo "---- checksums.txt ----"
+          cat release/checksums.txt
+
       - name: Generate changelog from commits
         uses: orhun/git-cliff-action@v4
         id: changelog
@@ -419,6 +434,9 @@ jobs:
           curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/red-linux-x86_64 -o red && chmod +x red
           # Thin remote-only client (~2 MB)
           curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/red_client-linux-x86_64 -o red_client && chmod +x red_client
+          # Verify downloaded binaries against the aggregate checksum manifest.
+          curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/checksums.txt -o checksums.txt
+          grep -E '  (red|red_client)-linux-x86_64$' checksums.txt | sha256sum -c -
           \`\`\`
 
           **Docker:**

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -344,6 +344,12 @@ The musl variant (`linux-aarch64-static`) is built but **not** part of
 the contract — it backs the thin `Dockerfile.client` image, not npm
 postinstall.
 
+Every stable release also publishes `checksums.txt`, an aggregate SHA-256
+manifest for the downloadable binaries. Automatic installers should fetch
+this manifest and verify the selected binary before execution. The per-asset
+`.sha256` files remain published for compatibility; `artifact-sizes.md` is
+release evidence for the binary/image size gate, not an installer contract.
+
 The release workflow enforces the contract automatically:
 
 - `.github/workflows/release.yml` → job `verify-release-assets` runs
@@ -353,9 +359,9 @@ The release workflow enforces the contract automatically:
   `publish-npm` (`@reddb-io/cli`) depends on it, so a missing asset
   blocks every Node-side publish at the gate.
 - `scripts/verify-release-assets.sh` queries `gh release view --json
-  assets`, asserts each `(bin, suffix)` pair is present, and exits 1
-  with the explicit missing list on failure. Run it locally against any
-  past tag to audit:
+  assets`, asserts each `(bin, suffix)` pair and `checksums.txt` are
+  present, and exits 1 with the explicit missing list on failure. Run it
+  locally against any past tag to audit:
 
   ```bash
   GH_TOKEN="$(gh auth token)" scripts/verify-release-assets.sh v1.0.5

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -105,6 +105,7 @@ test("verify-release-assets gates every npm publish on the binary contract (#418
     assert.ok(assetName.includes(suffix), `asset-name.js still maps optional ${suffix}`);
   }
   assert.match(script, /BINS=\(red red_client\)/);
+  assert.match(script, /EXTRA_ASSETS=\(\s+checksums\.txt\s+\)/);
   assert.match(script, /gh release view "\$TAG" --repo "\$REPO" --json assets/);
 
   assert.match(workflow, /verify-release-assets:/);
@@ -120,7 +121,28 @@ test("verify-release-assets gates every npm publish on the binary contract (#418
   }
 
   assert.match(runbook, /Release asset contract/);
+  assert.match(runbook, /checksums\.txt/);
   assert.match(runbook, /verify-release-assets\.sh/);
+});
+
+test("release workflows publish aggregate checksum manifests for installers", () => {
+  const releaseWorkflow = read(".github/workflows/release.yml");
+  const rcWorkflow = read(".github/workflows/release-candidate.yml");
+
+  for (const workflow of [releaseWorkflow, rcWorkflow]) {
+    assert.match(workflow, /name: Generate checksum manifest/);
+    assert.match(workflow, /find \. -maxdepth 1 -type f/);
+    assert.match(workflow, /-name 'red-\*'/);
+    assert.match(workflow, /-name 'red_client-\*'/);
+    assert.match(workflow, /! -name '\*\.sha256'/);
+    assert.match(workflow, /sort -z/);
+    assert.match(workflow, /sha256sum/);
+    assert.match(workflow, /> release\/checksums\.txt/);
+    assert.match(workflow, /test -s release\/checksums\.txt/);
+    assert.match(workflow, /files: release\/\*/);
+    assert.match(workflow, /releases\/download\/.+\/checksums\.txt/);
+    assert.match(workflow, /grep -E '  \(red\|red_client\)-linux-x86_64\$' checksums\.txt \| sha256sum -c -/);
+  }
 });
 
 test("nightly DR drill workflow uses the current-shell runner and public make target", () => {

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -45,6 +45,9 @@ SUFFIXES=(
   linux-armv7
   windows-x86_64.exe
 )
+EXTRA_ASSETS=(
+  checksums.txt
+)
 
 echo "verify-release-assets: checking ${REPO}@${TAG}"
 ASSETS_JSON="$(gh release view "$TAG" --repo "$REPO" --json assets --jq '[.assets[].name]')"
@@ -59,6 +62,11 @@ for bin in "${BINS[@]}"; do
     fi
   done
 done
+for name in "${EXTRA_ASSETS[@]}"; do
+  if ! jq -e --arg n "$name" 'index($n)' <<<"$ASSETS_JSON" >/dev/null; then
+    MISSING+=("$name")
+  fi
+done
 
 if (( ${#MISSING[@]} > 0 )); then
   {
@@ -66,7 +74,7 @@ if (( ${#MISSING[@]} > 0 )); then
     echo "ERROR: release ${TAG} is missing ${#MISSING[@]} required asset(s):"
     for m in "${MISSING[@]}"; do echo "  - $m"; done
     echo
-    echo "These assets back the SDK postinstall and curl-based installer."
+    echo "These assets back the SDK postinstall, checksum verification, and curl-based installer."
     echo "Do NOT publish to npm without them — see docs/release-runbook.md"
     echo "(\"Release asset contract\")."
   } >&2


### PR DESCRIPTION
## Summary
- generate a deterministic `checksums.txt` from release binaries for stable releases and release candidates
- require `checksums.txt` in `verify-release-assets.sh` before npm publishing continues
- document `artifact-sizes.md` as size-gate evidence and `checksums.txt` as the installer-facing checksum contract

## Verification
- `git diff --check`
- `node --test scripts/release_tooling_contract.test.mjs`
- `actionlint -ignore 'label "blacksmith-[^"]+" is unknown' -ignore 'constant expression "false" in condition' -ignore 'label "macos-13" is unknown' .github/workflows/release.yml .github/workflows/release-candidate.yml`\n- local checksum manifest smoke test with `sha256sum -c -` for `red` and `red_client` linux x86_64 samples

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785268538&installation_id=129708444&pr_number=1515&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1515&signature=0bab9088418af8757451a8b514fc5f2e74cc0e6cd88b53732e69b46e075ff51a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->