### PR TITLE
ci(release): harden release provenance

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -143,6 +143,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -161,8 +164,14 @@ jobs:
               | sed 's#  \./#  #'
           ) > release/checksums.txt
           test -s release/checksums.txt
+          cp release/checksums.txt release/SHA256SUMS
           echo "---- checksums.txt ----"
           cat release/checksums.txt
+
+      - name: Attest release candidate artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS
 
       - name: Create pre-release
         uses: softprops/action-gh-release@v3
@@ -177,14 +186,16 @@ jobs:
 
             ```bash
             # Server + embedded engine
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red-linux-x86_64 -o red && chmod +x red
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red-linux-x86_64
+            chmod +x red-linux-x86_64
 
             # Thin remote-only client
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red_client-linux-x86_64 -o red_client && chmod +x red_client
+            curl -fsSLO https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/red_client-linux-x86_64
+            chmod +x red_client-linux-x86_64
 
             # Verify downloaded binaries against the aggregate checksum manifest.
-            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/checksums.txt -o checksums.txt
-            grep -E '  (red|red_client)-linux-x86_64$' checksums.txt | sha256sum -c -
+            curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ needs.plan.outputs.rc_tag }}/SHA256SUMS -o SHA256SUMS
+            grep -E '  (red|red_client)-linux-x86_64$' SHA256SUMS | sha256sum -c -
             ```
           files: release/*
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,9 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -388,8 +391,14 @@ jobs:
               | sed 's#  \./#  #'
           ) > release/checksums.txt
           test -s release/checksums.txt
+          cp release/checksums.txt release/SHA256SUMS
           echo "---- checksums.txt ----"
           cat release/checksums.txt
+
+      - name: Attest release artifacts
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release/SHA256SUMS
 
       - name: Generate changelog from commits
         uses: orhun/git-cliff-action@v4
@@ -411,6 +420,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          VERSION="${TAG#v}"
+          MINOR_TAG="${VERSION%.*}"
+          MAJOR_TAG="${VERSION%%.*}"
           CHANGELOG="$(cat release-changelog.md)"
           cat > release-body.md <<MARKDOWN
           # RedDB ${TAG}
@@ -419,7 +431,17 @@ jobs:
 
           ---
 
-          ## Install
+          ## Upgrade Notes
+
+          Review the changelog above before upgrading. Storage-format, wire-protocol, or API breaking changes must appear in the changelog as breaking changes; if none are listed, this release is intended to be a standard same-major upgrade.
+
+          ## Compatibility
+
+          - Server, CLI, client packages, crates, and container images are published from the same tag: \`${TAG}\`.
+          - Official JavaScript packages are published only after the GitHub Release carries every postinstall-required binary asset and checksum manifest.
+          - Client/transport compatibility details live in [SDK & Client Compatibility](https://github.com/${REPO}/blob/${TAG}/docs/clients/sdk-compatibility.md).
+
+          ## Installation
 
           **npm / pnpm:**
           \`\`\`bash
@@ -428,21 +450,42 @@ jobs:
           pnpm add @reddb-io/client # Thin remote-only client
           \`\`\`
 
-          **Binaries (Linux x86_64):**
+          **Prebuilt binaries:**
+
+          | Platform | Server asset | Thin client asset |
+          | --- | --- | --- |
+          | Linux x86_64 (glibc) | \`red-linux-x86_64\` | \`red_client-linux-x86_64\` |
+          | Linux x86_64 (static musl) | \`red-linux-x86_64-static\` | \`red_client-linux-x86_64-static\` |
+          | Linux aarch64 (glibc) | \`red-linux-aarch64\` | \`red_client-linux-aarch64\` |
+          | Linux aarch64 (static musl) | \`red-linux-aarch64-static\` | \`red_client-linux-aarch64-static\` |
+          | Linux armv7 | \`red-linux-armv7\` | \`red_client-linux-armv7\` |
+          | macOS Intel | \`red-macos-x86_64\` | \`red_client-macos-x86_64\` |
+          | macOS Apple Silicon | \`red-macos-aarch64\` | \`red_client-macos-aarch64\` |
+          | Windows x86_64 | \`red-windows-x86_64.exe\` | \`red_client-windows-x86_64.exe\` |
+
+          Example for Linux x86_64:
           \`\`\`bash
           # Full server + embedded engine
-          curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/red-linux-x86_64 -o red && chmod +x red
+          curl -fsSLO https://github.com/${REPO}/releases/download/${TAG}/red-linux-x86_64
+          chmod +x red-linux-x86_64
+
           # Thin remote-only client (~2 MB)
-          curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/red_client-linux-x86_64 -o red_client && chmod +x red_client
-          # Verify downloaded binaries against the aggregate checksum manifest.
-          curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/checksums.txt -o checksums.txt
-          grep -E '  (red|red_client)-linux-x86_64$' checksums.txt | sha256sum -c -
+          curl -fsSLO https://github.com/${REPO}/releases/download/${TAG}/red_client-linux-x86_64
+          chmod +x red_client-linux-x86_64
           \`\`\`
 
           **Docker:**
           \`\`\`bash
           docker run --rm ghcr.io/${REPO}:${TAG} version
           \`\`\`
+
+          Stable image tags:
+
+          - \`${TAG}\` and \`${VERSION}\` are immutable release tags.
+          - \`${VERSION}\` is also published without the leading \`v\` for Docker-native workflows.
+          - \`${MINOR_TAG}\` moves to the latest patch in this minor line.
+          - \`${MAJOR_TAG}\` moves to the latest minor in this major line.
+          - \`latest\` moves to the latest stable release.
 
           **Or via Docker (thin client, ~7 MB):**
           \`\`\`bash
@@ -453,8 +496,32 @@ jobs:
 
           \`\`\`toml
           [dependencies]
-          reddb-io = "${TAG#v}"
+          reddb-io = "${VERSION}"
           \`\`\`
+
+          ## Verification
+
+          Every stable release publishes both \`checksums.txt\` for installers and \`SHA256SUMS\` for standard manual verification. They contain the same SHA-256 manifest.
+
+          \`\`\`bash
+          curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/SHA256SUMS -o SHA256SUMS
+          grep -E '  (red|red_client)-linux-x86_64$' SHA256SUMS | sha256sum -c -
+
+          gh attestation verify red-linux-x86_64 --repo ${REPO}
+          gh attestation verify red_client-linux-x86_64 --repo ${REPO}
+          \`\`\`
+
+          Docker images are published as multi-arch GHCR images for linux/amd64 and linux/arm64 with BuildKit provenance and SBOM attestations.
+
+          \`\`\`bash
+          docker buildx imagetools inspect ghcr.io/${REPO}:${TAG}
+          docker buildx imagetools inspect ghcr.io/${REPO}-client:${TAG}
+          \`\`\`
+
+          ## Release Assets
+
+          - \`checksums.txt\` / \`SHA256SUMS\`: aggregate SHA-256 manifest for all release binaries.
+          - \`artifact-sizes.md\`: release evidence from the binary/container size gate, not an installer input.
           MARKDOWN
           echo "---- composed body ----"
           cat release-body.md
@@ -793,6 +860,8 @@ jobs:
           tags: |
             type=raw,value=${{ needs.plan.outputs.release_tag }}
             type=raw,value=${{ needs.plan.outputs.package_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.plan.outputs.release_tag }},enable=${{ needs.plan.outputs.release_channel == 'stable' }}
+            type=semver,pattern={{major}},value=${{ needs.plan.outputs.release_tag }},enable=${{ needs.plan.outputs.release_channel == 'stable' }}
             type=raw,value=latest,enable=${{ needs.plan.outputs.release_channel == 'stable' }}
             type=raw,value=next,enable=${{ needs.plan.outputs.release_channel == 'next' }}
           labels: |
@@ -809,7 +878,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+          provenance: mode=max
+          sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -875,6 +945,8 @@ jobs:
           tags: |
             type=raw,value=${{ needs.plan.outputs.release_tag }}
             type=raw,value=${{ needs.plan.outputs.package_version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.plan.outputs.release_tag }},enable=${{ needs.plan.outputs.release_channel == 'stable' }}
+            type=semver,pattern={{major}},value=${{ needs.plan.outputs.release_tag }},enable=${{ needs.plan.outputs.release_channel == 'stable' }}
             type=raw,value=latest,enable=${{ needs.plan.outputs.release_channel == 'stable' }}
             type=raw,value=next,enable=${{ needs.plan.outputs.release_channel == 'next' }}
           labels: |
@@ -891,7 +963,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          provenance: false
+          provenance: mode=max
+          sbom: true
 
   # ===========================================================================
   # publish-python — Build and upload reddb wheels to PyPI.

--- a/README.md
+++ b/README.md
@@ -626,6 +626,9 @@ gRPC stubs, and wire vocabulary live in sibling crates.
 - [npm driver package](https://www.npmjs.com/package/reddb)
 - [npm CLI launcher](https://www.npmjs.com/package/@reddb-io/cli)
 - [Releases](https://github.com/reddb-io/reddb/releases)
+- [Release Policy](./docs/release-policy.md)
+- [Support Policy](./SUPPORT.md)
+- [Security Policy](./SECURITY.md)
 - [Public Contract Matrix](./docs/reference/contract-matrix.md) — every doc'd promise mapped to a test or a planned-status note
 
 ---

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,38 @@
+# Support Policy
+
+RedDB support follows the public release stream. Use GitHub issues for bugs,
+regressions, packaging failures, and compatibility reports. Report security
+issues privately through `SECURITY.md`.
+
+## Supported Versions
+
+| Version line | Support level |
+| --- | --- |
+| Current stable minor | Bug fixes, packaging fixes, and security fixes |
+| Previous stable minor | Critical security and data-loss fixes when feasible |
+| Older stable minors | Unsupported; upgrade to a supported line |
+| Release candidates / `next` | Testing only; no production support promise |
+
+Patch releases are the preferred vehicle for fixes that do not require a
+storage-format, wire-protocol, or public API change. Minor releases may add
+capabilities and compatibility surfaces. Breaking changes require a major
+release unless a release note explicitly calls out a narrower migration.
+
+## Compatibility Reports
+
+Include:
+
+- RedDB version and install channel.
+- Server/client versions when they differ.
+- OS, architecture, and container digest when relevant.
+- Storage mode and transport used.
+- Minimal reproduction, logs, and the exact query or command.
+
+## Packaging Reports
+
+For installer or release-asset failures, include:
+
+- Release tag.
+- Asset name or package name.
+- `SHA256SUMS` / `checksums.txt` verification output.
+- `gh attestation verify <asset> --repo reddb-io/reddb` output when applicable.

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -233,6 +233,7 @@
   - [Limitations](/reference/limitations.md)
 
 - **Release Notes**
+  - [Release Policy](/release-policy.md)
   - [2026-06-20 (AI Multimodality + TigerStyle + Crate Split)](/release-notes-2026-06-20.md)
   - [2026-04-26 (RedWire + Auth)](/release-notes-2026-04-26.md)
   - [2026-04-17 (Multi-tenancy + Perf)](/release-notes-2026-04-17.md)

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,79 @@
+# Release Policy
+
+RedDB releases are tag-driven. Stable releases are built from immutable
+`vX.Y.Z` tags and all official artifacts for that version should come from the
+same commit.
+
+## Channels
+
+| Channel | Source | Intended use |
+| --- | --- | --- |
+| Stable (`vX.Y.Z`) | Immutable Git tag | Production and normal upgrades |
+| Release candidate (`vX.Y.Z-rc.N`) | Latest eligible `main` commit | Installer, packaging, and integration testing |
+| `next` | CI prerelease channel | Early validation only |
+
+Release candidates and `next` builds are not production support lines.
+
+## Versioning
+
+RedDB uses SemVer for the software version and calls out database-specific
+compatibility in release notes.
+
+- Patch releases should not intentionally change storage format, wire protocol,
+  or public API behavior.
+- Minor releases may add storage features, protocol capabilities, APIs, and
+  drivers. Existing supported clients should remain compatible unless the
+  release notes say otherwise.
+- Major releases may include breaking storage, protocol, API, or operational
+  changes.
+
+Any release that changes storage format, wire protocol compatibility, or upgrade
+requirements must include explicit upgrade notes in the GitHub Release body.
+
+## Artifact Contract
+
+Stable GitHub Releases publish:
+
+- `red-*` server binaries.
+- `red_client-*` thin-client binaries.
+- Per-asset `.sha256` files for compatibility.
+- `checksums.txt` for automatic installers.
+- `SHA256SUMS` for standard manual verification.
+- `artifact-sizes.md` as release-gate evidence.
+
+Official JavaScript package publication is gated on the GitHub Release carrying
+the postinstall-required binary assets and checksum manifests. Release artifacts
+are attested with GitHub Artifact Attestations from the aggregate checksum
+manifest.
+
+## Container Tags
+
+Stable GHCR images publish immutable and moving tags:
+
+- `vX.Y.Z` and `X.Y.Z`: immutable release tags.
+- `X.Y`: latest patch in the minor line.
+- `X`: latest minor in the major line.
+- `latest`: latest stable release.
+
+Prerelease images publish `next`.
+
+Server and thin-client images are multi-arch for `linux/amd64` and
+`linux/arm64`, with BuildKit provenance and SBOM attestations.
+
+## Verification
+
+Manual binary verification:
+
+```bash
+curl -fsSLO https://github.com/reddb-io/reddb/releases/download/vX.Y.Z/red-linux-x86_64
+curl -fsSL https://github.com/reddb-io/reddb/releases/download/vX.Y.Z/SHA256SUMS -o SHA256SUMS
+grep -E '  red-linux-x86_64$' SHA256SUMS | sha256sum -c -
+gh attestation verify red-linux-x86_64 --repo reddb-io/reddb
+```
+
+Container inspection:
+
+```bash
+docker buildx imagetools inspect ghcr.io/reddb-io/reddb:vX.Y.Z
+docker buildx imagetools inspect ghcr.io/reddb-io/reddb-client:vX.Y.Z
+```

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -344,11 +344,30 @@ The musl variant (`linux-aarch64-static`) is built but **not** part of
 the contract — it backs the thin `Dockerfile.client` image, not npm
 postinstall.
 
-Every stable release also publishes `checksums.txt`, an aggregate SHA-256
-manifest for the downloadable binaries. Automatic installers should fetch
-this manifest and verify the selected binary before execution. The per-asset
-`.sha256` files remain published for compatibility; `artifact-sizes.md` is
-release evidence for the binary/image size gate, not an installer contract.
+Every stable release also publishes two aggregate SHA-256 manifests for the
+downloadable binaries:
+
+- `checksums.txt` is the installer-facing contract. Automatic installers should
+  fetch this manifest and verify the selected binary before execution.
+- `SHA256SUMS` carries the same content under the conventional ecosystem name
+  used by manual verification and release-attestation examples.
+
+The per-asset `.sha256` files remain published for compatibility;
+`artifact-sizes.md` is release evidence for the binary/image size gate, not an
+installer contract.
+
+Stable release artifacts are also attested through GitHub Artifact
+Attestations from the aggregate checksum manifest. A downloaded binary can be
+verified back to the official workflow run with:
+
+```bash
+gh attestation verify red-linux-x86_64 --repo reddb-io/reddb
+```
+
+GHCR server and thin-client images are published as multi-arch images for
+`linux/amd64` and `linux/arm64` with BuildKit provenance and SBOM attestations.
+The release workflow publishes immutable `vX.Y.Z` and `X.Y.Z` tags, moving
+`X.Y`, `X`, and `latest` tags for stable releases, and `next` for prereleases.
 
 The release workflow enforces the contract automatically:
 
@@ -359,7 +378,8 @@ The release workflow enforces the contract automatically:
   `publish-npm` (`@reddb-io/cli`) depends on it, so a missing asset
   blocks every Node-side publish at the gate.
 - `scripts/verify-release-assets.sh` queries `gh release view --json
-  assets`, asserts each `(bin, suffix)` pair and `checksums.txt` are
+  assets`, asserts each `(bin, suffix)` pair plus `checksums.txt` and
+  `SHA256SUMS` are
   present, and exits 1 with the explicit missing list on failure. Run it
   locally against any past tag to audit:
 

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -47,6 +47,7 @@ SUFFIXES=(
 )
 EXTRA_ASSETS=(
   checksums.txt
+  SHA256SUMS
 )
 
 echo "verify-release-assets: checking ${REPO}@${TAG}"
@@ -74,7 +75,7 @@ if (( ${#MISSING[@]} > 0 )); then
     echo "ERROR: release ${TAG} is missing ${#MISSING[@]} required asset(s):"
     for m in "${MISSING[@]}"; do echo "  - $m"; done
     echo
-    echo "These assets back the SDK postinstall, checksum verification, and curl-based installer."
+    echo "These assets back the SDK postinstall, checksum verification, artifact attestations, and curl-based installer."
     echo "Do NOT publish to npm without them — see docs/release-runbook.md"
     echo "(\"Release asset contract\")."
   } >&2


### PR DESCRIPTION
## Summary

- publish both `checksums.txt` and conventional `SHA256SUMS` for stable and RC release assets
- add GitHub Artifact Attestations for release binaries from the aggregate checksum manifest
- enable GHCR BuildKit provenance/SBOM attestations and publish moving `X.Y`/`X` Docker tags for stable releases
- expand GitHub Release notes with upgrade notes, compatibility, install, verification, Docker tag policy, and release-asset sections
- add `SUPPORT.md` and `docs/release-policy.md`, with README/sidebar links

## Verification

- `git diff --check`
- Prettier parser check for edited YAML/Markdown via local `prettier` package
- `bash -n scripts/verify-release-assets.sh`
- `node scripts/gen-docs-from-matrix.mjs --check`
- `node scripts/verify-contract-matrix.mjs`
- `bash scripts/verify-release-assets.sh v1.16.0` fails as expected because the current stable release predates aggregate checksum manifests

## Notes

The stable `v1.16.0` release is unchanged. This PR upgrades the contract for the next stable/RC publish.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785270899&installation_id=129708444&pr_number=1516&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1516&signature=ba3d886b6ae53eee81cdebb6f4480420d999c5666bf75667fa99d3c4ee763cb1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->