### PR TITLE
chore(release): add release provenance changeset

### DIFF
--- a/.changeset/release-provenance-minor.md
+++ b/.changeset/release-provenance-minor.md
@@ -1,0 +1,11 @@
+---
+"@reddb-io/cli": minor
+"@reddb-io/sdk": minor
+"@reddb-io/client": minor
+"@reddb-io/client-bun": minor
+"@reddb-io/mcp": minor
+---
+
+Harden release provenance with aggregate checksum manifests, GitHub Artifact
+Attestations, GHCR provenance/SBOM attestations, expanded release verification
+notes, and public support/release policy docs.


### PR DESCRIPTION
## Summary

- add a Changesets minor entry for the release-provenance work merged in #1516
- lets the existing Changesets workflow create the Version Packages PR and tag the next stable minor

## Verification

- `git diff --check`
- `pnpm changeset status` confirms a minor bump for the fixed public package group and linked internal packages

## Notes

This PR intentionally contains only the changeset. The implementation is already merged in #1516 at `d5ca7626`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785272159&installation_id=129708444&pr_number=1517&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1517&signature=5517dce6e3a4143a1e2aba12f64dda8faf04905d2956e503d95c884d8b864f1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->