### PR TITLE
fix(release): base notes on previous stable tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,16 +400,41 @@ jobs:
         with:
           subject-checksums: release/SHA256SUMS
 
+      - name: Resolve stable changelog range
+        id: changelog_range
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.plan.outputs.release_tag }}"
+          TARGET_REF="$TAG"
+          if ! git rev-parse -q --verify "${TAG}^{commit}" >/dev/null; then
+            TARGET_REF="HEAD"
+          fi
+
+          PREVIOUS_TAG="$(git tag --merged "$TARGET_REF" --list 'v*' --sort=-v:refname \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | grep -vx "$TAG" \
+            | head -n 1 || true)"
+
+          if [[ -n "$PREVIOUS_TAG" ]]; then
+            echo "range=${PREVIOUS_TAG}..${TARGET_REF}" >> "$GITHUB_OUTPUT"
+            echo "Release changelog range: ${PREVIOUS_TAG}..${TARGET_REF}"
+          else
+            echo "range=${TARGET_REF}" >> "$GITHUB_OUTPUT"
+            echo "Release changelog range: ${TARGET_REF}"
+          fi
+
       - name: Generate changelog from commits
         uses: orhun/git-cliff-action@v4
         id: changelog
         with:
           config: cliff.toml
-          # --unreleased: commits since the most recent tag
+          # The explicit range uses the previous stable tag, so RC tags do not
+          # become the public release-notes baseline.
           # --tag: label the rendered block with this version even though
           #        the tag isn't pushed yet (workflow_dispatch path)
           # --strip header: drop the top-level Changelog title; we wrap it
-          args: --unreleased --tag ${{ needs.plan.outputs.release_tag }} --strip header
+          args: ${{ steps.changelog_range.outputs.range }} --tag ${{ needs.plan.outputs.release_tag }} --strip header
         env:
           OUTPUT: release-changelog.md
           GITHUB_REPO: ${{ github.repository }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -60,6 +60,6 @@ commit_parsers = [
 
 protect_breaking_commits = false
 filter_commits = true
-tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
 topo_order = false
 sort_commits = "newest"


### PR DESCRIPTION
## Summary
- resolve the previous stable tag before running git-cliff for stable GitHub Releases
- ignore release-candidate tags as public release-note baselines
- anchor the git-cliff stable tag pattern so rc tags do not match by prefix

## Verification
- git diff --check
- ASDF_RUBY_VERSION=3.0.1 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml ok'"
- actionlint -ignore 'label ".*" is unknown' -ignore 'constant expression "false"' .github/workflows/release.yml
- local v1.17.0 changelog simulation resolved v1.16.0..v1.17.0 and included release provenance entries

## Notes
- Prettier is not configured in this worktree; npx prettier reports the base workflow file is already not formatted, so this PR avoids broad workflow reformatting.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785275135&installation_id=129708444&pr_number=1519&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1519&signature=841c9309e2f732da58bc224ec53a827db7d1575bd84aabc7f1ee2a2056d0bd37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->