### PR TITLE
ci(release): sign container images with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,9 +534,11 @@ jobs:
 
           gh attestation verify red-linux-x86_64 --repo ${REPO}
           gh attestation verify red_client-linux-x86_64 --repo ${REPO}
+
+          cosign verify ghcr.io/${REPO}:${TAG} --certificate-identity "https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${TAG}" --certificate-oidc-issuer https://token.actions.githubusercontent.com
           \`\`\`
 
-          Docker images are published as multi-arch GHCR images for linux/amd64 and linux/arm64 with BuildKit provenance and SBOM attestations.
+          Docker images are published as multi-arch GHCR images for linux/amd64 and linux/arm64 with Cosign keyless signatures, BuildKit provenance, and SBOM attestations.
 
           \`\`\`bash
           docker buildx imagetools inspect ghcr.io/${REPO}:${TAG}
@@ -833,6 +835,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
+      id-token: write
       packages: write
     if: needs.plan.outputs.should_skip != 'true'
     steps:
@@ -869,6 +872,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -895,6 +901,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.plan.outputs.package_version }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -908,6 +915,14 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Sign published image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
+
   publish-client-image:
     # ADR 0004 — thin red_client container, parallel to publish-docker.
     # Built from the release matrix artifact so Docker publishing does not
@@ -918,6 +933,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
+      id-token: write
       packages: write
     if: needs.plan.outputs.should_skip != 'true'
     steps:
@@ -954,6 +970,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -980,6 +999,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.plan.outputs.package_version }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -990,6 +1010,14 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
+
+      - name: Sign published image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository }}-client
+        run: |
+          set -euo pipefail
+          cosign sign --yes "${IMAGE}@${DIGEST}"
 
   # ===========================================================================
   # publish-python — Build and upload reddb wheels to PyPI.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -58,7 +58,8 @@ Stable GHCR images publish immutable and moving tags:
 Prerelease images publish `next`.
 
 Server and thin-client images are multi-arch for `linux/amd64` and
-`linux/arm64`, with BuildKit provenance and SBOM attestations.
+`linux/arm64`, with Cosign keyless signatures, BuildKit provenance, and SBOM
+attestations.
 
 ## Verification
 
@@ -76,4 +77,7 @@ Container inspection:
 ```bash
 docker buildx imagetools inspect ghcr.io/reddb-io/reddb:vX.Y.Z
 docker buildx imagetools inspect ghcr.io/reddb-io/reddb-client:vX.Y.Z
+cosign verify ghcr.io/reddb-io/reddb:vX.Y.Z \
+  --certificate-identity "https://github.com/reddb-io/reddb/.github/workflows/release.yml@refs/tags/vX.Y.Z" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -365,9 +365,18 @@ gh attestation verify red-linux-x86_64 --repo reddb-io/reddb
 ```
 
 GHCR server and thin-client images are published as multi-arch images for
-`linux/amd64` and `linux/arm64` with BuildKit provenance and SBOM attestations.
-The release workflow publishes immutable `vX.Y.Z` and `X.Y.Z` tags, moving
-`X.Y`, `X`, and `latest` tags for stable releases, and `next` for prereleases.
+`linux/amd64` and `linux/arm64` with Cosign keyless signatures, BuildKit
+provenance, and SBOM attestations. The release workflow publishes immutable
+`vX.Y.Z` and `X.Y.Z` tags, moving `X.Y`, `X`, and `latest` tags for stable
+releases, and `next` for prereleases.
+
+Stable server-image signatures can be verified with:
+
+```bash
+cosign verify ghcr.io/reddb-io/reddb:vX.Y.Z \
+  --certificate-identity "https://github.com/reddb-io/reddb/.github/workflows/release.yml@refs/tags/vX.Y.Z" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
 
 The release workflow enforces the contract automatically:
 

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -60,9 +60,22 @@ test("Docker release images publish from GitHub Actions under reddb-io GHCR only
   assert.doesNotMatch(releaseWorkflow, legacyPersonalGhcrNamespace);
 
   const publishDocker = releaseWorkflow.match(/publish-docker:[\s\S]*?(?=\n  publish-client-image:)/)?.[0] ?? "";
+  const publishClient = releaseWorkflow.match(/publish-client-image:[\s\S]*?(?=\n  publish-python-wheels:)/)?.[0] ?? "";
   assert.match(publishDocker, /actions\/download-artifact@v8[\s\S]*name: linux-x86_64/);
   assert.match(publishDocker, /actions\/download-artifact@v8[\s\S]*name: linux-aarch64/);
   assert.match(publishDocker, /file: docker\/Dockerfile\.release/);
+
+  for (const [jobName, job, imagePattern] of [
+    ["publish-docker", publishDocker, /IMAGE: ghcr\.io\/\$\{\{ github\.repository \}\}/],
+    ["publish-client-image", publishClient, /IMAGE: ghcr\.io\/\$\{\{ github\.repository \}\}-client/],
+  ]) {
+    assert.match(job, /id-token: write/, `${jobName} must allow keyless signing`);
+    assert.match(job, /uses: sigstore\/cosign-installer@v4\.1\.2/, `${jobName} installs Cosign`);
+    assert.match(job, /id: build[\s\S]*uses: docker\/build-push-action@v7/, `${jobName} exposes build digest`);
+    assert.match(job, imagePattern, `${jobName} signs the expected GHCR image`);
+    assert.match(job, /DIGEST: \$\{\{ steps\.build\.outputs\.digest \}\}/, `${jobName} signs by digest`);
+    assert.match(job, /cosign sign --yes "\$\{IMAGE\}@\$\{DIGEST\}"/, `${jobName} signs with Cosign`);
+  }
 });
 
 test("release workflow uses runnable toolchain and pack commands", () => {
@@ -105,7 +118,7 @@ test("verify-release-assets gates every npm publish on the binary contract (#418
     assert.ok(assetName.includes(suffix), `asset-name.js still maps optional ${suffix}`);
   }
   assert.match(script, /BINS=\(red red_client\)/);
-  assert.match(script, /EXTRA_ASSETS=\(\s+checksums\.txt\s+\)/);
+  assert.match(script, /EXTRA_ASSETS=\(\s+checksums\.txt\s+SHA256SUMS\s+\)/);
   assert.match(script, /gh release view "\$TAG" --repo "\$REPO" --json assets/);
 
   assert.match(workflow, /verify-release-assets:/);
@@ -139,9 +152,10 @@ test("release workflows publish aggregate checksum manifests for installers", ()
     assert.match(workflow, /sha256sum/);
     assert.match(workflow, /> release\/checksums\.txt/);
     assert.match(workflow, /test -s release\/checksums\.txt/);
+    assert.match(workflow, /cp release\/checksums\.txt release\/SHA256SUMS/);
     assert.match(workflow, /files: release\/\*/);
-    assert.match(workflow, /releases\/download\/.+\/checksums\.txt/);
-    assert.match(workflow, /grep -E '  \(red\|red_client\)-linux-x86_64\$' checksums\.txt \| sha256sum -c -/);
+    assert.match(workflow, /releases\/download\/.+\/SHA256SUMS/);
+    assert.match(workflow, /grep -E '  \(red\|red_client\)-linux-x86_64\$' SHA256SUMS \| sha256sum -c -/);
   }
 });
 


### PR DESCRIPTION
## Summary

- sign the server and thin-client GHCR image digests with keyless Cosign after Docker build/push
- grant the Docker release jobs `id-token: write` for OIDC signing
- document stable-image Cosign verification in release notes, release policy, and runbook
- extend the release tooling contract test so Cosign signing and the aggregate checksum contract are guarded

## Verification

- `node --test scripts/release_tooling_contract.test.mjs`
- `ASDF_RUBY_VERSION=3.0.1 ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'release.yml ok'"`
- `actionlint -ignore 'label ".*" is unknown' -ignore 'constant expression "false"' .github/workflows/release.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785276714&installation_id=129708444&pr_number=1520&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1520&signature=60e5623485fb014fa5acb8a236649a486d1f1c0c4864990cbb7b54beb6de2022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->