### PR TITLE
ci(release): publish source SBOMs

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -147,10 +147,43 @@ jobs:
       attestations: write
       artifact-metadata: write
     steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+        with:
+          syft-version: v1.46.0
+
+      - name: Generate source SBOMs
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.plan.outputs.rc_tag }}
+          SYFT: ${{ steps.syft.outputs.cmd }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-sbom
+          VERSION="${RELEASE_TAG#v}"
+          syft_args=(
+            scan dir:.
+            --exclude './.git/**'
+            --exclude './release/**'
+            --exclude './release-sbom/**'
+            --source-name RedDB
+            --source-version "${VERSION}"
+          )
+          "${SYFT}" "${syft_args[@]}" -o spdx-json > "release-sbom/red-${RELEASE_TAG}.spdx.json"
+          "${SYFT}" "${syft_args[@]}" -o cyclonedx-json > "release-sbom/red-${RELEASE_TAG}.cyclonedx.json"
+          test -s "release-sbom/red-${RELEASE_TAG}.spdx.json"
+          test -s "release-sbom/red-${RELEASE_TAG}.cyclonedx.json"
+
       - uses: actions/download-artifact@v8
         with:
           path: release
           merge-multiple: true
+
+      - name: Add SBOMs to release assets
+        run: cp release-sbom/* release/
 
       - name: Generate checksum manifest
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,10 +374,41 @@ jobs:
         with:
           # git-cliff walks the full commit history to build the changelog.
           fetch-depth: 0
+      - name: Install Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+        with:
+          syft-version: v1.46.0
+
+      - name: Generate source SBOMs
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.plan.outputs.release_tag }}
+          SYFT: ${{ steps.syft.outputs.cmd }}
+        run: |
+          set -euo pipefail
+          mkdir -p release-sbom
+          VERSION="${RELEASE_TAG#v}"
+          syft_args=(
+            scan dir:.
+            --exclude './.git/**'
+            --exclude './release/**'
+            --exclude './release-sbom/**'
+            --source-name RedDB
+            --source-version "${VERSION}"
+          )
+          "${SYFT}" "${syft_args[@]}" -o spdx-json > "release-sbom/red-${RELEASE_TAG}.spdx.json"
+          "${SYFT}" "${syft_args[@]}" -o cyclonedx-json > "release-sbom/red-${RELEASE_TAG}.cyclonedx.json"
+          test -s "release-sbom/red-${RELEASE_TAG}.spdx.json"
+          test -s "release-sbom/red-${RELEASE_TAG}.cyclonedx.json"
+
       - uses: actions/download-artifact@v8
         with:
           path: release
           merge-multiple: true
+
+      - name: Add SBOMs to release assets
+        run: cp release-sbom/* release/
 
       - name: Generate checksum manifest
         shell: bash
@@ -532,8 +563,14 @@ jobs:
           curl -fsSL https://github.com/${REPO}/releases/download/${TAG}/SHA256SUMS -o SHA256SUMS
           grep -E '  (red|red_client)-linux-x86_64$' SHA256SUMS | sha256sum -c -
 
+          curl -fsSLO https://github.com/${REPO}/releases/download/${TAG}/red-${TAG}.spdx.json
+          curl -fsSLO https://github.com/${REPO}/releases/download/${TAG}/red-${TAG}.cyclonedx.json
+          grep -E "  red-${TAG}\\.(spdx|cyclonedx)\\.json$" SHA256SUMS | sha256sum -c -
+
           gh attestation verify red-linux-x86_64 --repo ${REPO}
           gh attestation verify red_client-linux-x86_64 --repo ${REPO}
+          gh attestation verify red-${TAG}.spdx.json --repo ${REPO}
+          gh attestation verify red-${TAG}.cyclonedx.json --repo ${REPO}
 
           cosign verify ghcr.io/${REPO}:${TAG} --certificate-identity "https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/${TAG}" --certificate-oidc-issuer https://token.actions.githubusercontent.com
           \`\`\`
@@ -547,7 +584,8 @@ jobs:
 
           ## Release Assets
 
-          - \`checksums.txt\` / \`SHA256SUMS\`: aggregate SHA-256 manifest for all release binaries.
+          - \`checksums.txt\` / \`SHA256SUMS\`: aggregate SHA-256 manifest for release binaries and SBOMs.
+          - \`red-${TAG}.spdx.json\` / \`red-${TAG}.cyclonedx.json\`: source SBOMs for the release.
           - \`artifact-sizes.md\`: release evidence from the binary/container size gate, not an installer input.
           MARKDOWN
           echo "---- composed body ----"

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -39,12 +39,13 @@ Stable GitHub Releases publish:
 - Per-asset `.sha256` files for compatibility.
 - `checksums.txt` for automatic installers.
 - `SHA256SUMS` for standard manual verification.
+- `red-vX.Y.Z.spdx.json` and `red-vX.Y.Z.cyclonedx.json` source SBOMs.
 - `artifact-sizes.md` as release-gate evidence.
 
 Official JavaScript package publication is gated on the GitHub Release carrying
 the postinstall-required binary assets and checksum manifests. Release artifacts
-are attested with GitHub Artifact Attestations from the aggregate checksum
-manifest.
+and SBOMs are attested with GitHub Artifact Attestations from the aggregate
+checksum manifest.
 
 ## Container Tags
 
@@ -70,6 +71,8 @@ curl -fsSLO https://github.com/reddb-io/reddb/releases/download/vX.Y.Z/red-linux
 curl -fsSL https://github.com/reddb-io/reddb/releases/download/vX.Y.Z/SHA256SUMS -o SHA256SUMS
 grep -E '  red-linux-x86_64$' SHA256SUMS | sha256sum -c -
 gh attestation verify red-linux-x86_64 --repo reddb-io/reddb
+gh attestation verify red-vX.Y.Z.spdx.json --repo reddb-io/reddb
+gh attestation verify red-vX.Y.Z.cyclonedx.json --repo reddb-io/reddb
 ```
 
 Container inspection:

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -345,12 +345,17 @@ the contract — it backs the thin `Dockerfile.client` image, not npm
 postinstall.
 
 Every stable release also publishes two aggregate SHA-256 manifests for the
-downloadable binaries:
+downloadable binaries and SBOMs:
 
 - `checksums.txt` is the installer-facing contract. Automatic installers should
   fetch this manifest and verify the selected binary before execution.
 - `SHA256SUMS` carries the same content under the conventional ecosystem name
   used by manual verification and release-attestation examples.
+
+Every stable release publishes source SBOMs in both SPDX JSON and CycloneDX JSON
+under `red-vX.Y.Z.spdx.json` and `red-vX.Y.Z.cyclonedx.json`. They are included
+in `SHA256SUMS`, so the same checksum and GitHub Artifact Attestation path
+applies to SBOM verification.
 
 The per-asset `.sha256` files remain published for compatibility;
 `artifact-sizes.md` is release evidence for the binary/image size gate, not an
@@ -362,6 +367,8 @@ verified back to the official workflow run with:
 
 ```bash
 gh attestation verify red-linux-x86_64 --repo reddb-io/reddb
+gh attestation verify red-vX.Y.Z.spdx.json --repo reddb-io/reddb
+gh attestation verify red-vX.Y.Z.cyclonedx.json --repo reddb-io/reddb
 ```
 
 GHCR server and thin-client images are published as multi-arch images for
@@ -387,10 +394,10 @@ The release workflow enforces the contract automatically:
   `publish-npm` (`@reddb-io/cli`) depends on it, so a missing asset
   blocks every Node-side publish at the gate.
 - `scripts/verify-release-assets.sh` queries `gh release view --json
-  assets`, asserts each `(bin, suffix)` pair plus `checksums.txt` and
-  `SHA256SUMS` are
-  present, and exits 1 with the explicit missing list on failure. Run it
-  locally against any past tag to audit:
+  assets`, asserts that each required `(bin, suffix)` asset,
+  `checksums.txt`, `SHA256SUMS`, `red-vX.Y.Z.spdx.json`, and
+  `red-vX.Y.Z.cyclonedx.json` are present, and exits 1 with the explicit
+  missing list on failure. Run it locally against any past tag to audit:
 
   ```bash
   GH_TOKEN="$(gh auth token)" scripts/verify-release-assets.sh v1.0.5

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -118,7 +118,10 @@ test("verify-release-assets gates every npm publish on the binary contract (#418
     assert.ok(assetName.includes(suffix), `asset-name.js still maps optional ${suffix}`);
   }
   assert.match(script, /BINS=\(red red_client\)/);
-  assert.match(script, /EXTRA_ASSETS=\(\s+checksums\.txt\s+SHA256SUMS\s+\)/);
+  assert.match(
+    script,
+    /EXTRA_ASSETS=\(\s+checksums\.txt\s+SHA256SUMS\s+"red-\$\{TAG\}\.spdx\.json"\s+"red-\$\{TAG\}\.cyclonedx\.json"\s+\)/,
+  );
   assert.match(script, /gh release view "\$TAG" --repo "\$REPO" --json assets/);
 
   assert.match(workflow, /verify-release-assets:/);
@@ -144,6 +147,17 @@ test("release workflows publish aggregate checksum manifests for installers", ()
 
   for (const workflow of [releaseWorkflow, rcWorkflow]) {
     assert.match(workflow, /name: Generate checksum manifest/);
+    assert.match(workflow, /uses: anchore\/sbom-action\/download-syft@v0\.24\.0/);
+    assert.match(workflow, /syft-version: v1\.46\.0/);
+    assert.match(workflow, /name: Generate source SBOMs/);
+    assert.match(workflow, /--exclude '\.\/\.git\/\*\*'/);
+    assert.match(workflow, /--exclude '\.\/release\/\*\*'/);
+    assert.match(workflow, /--exclude '\.\/release-sbom\/\*\*'/);
+    assert.match(workflow, /--source-name RedDB\s+--source-version "\$\{VERSION\}"/);
+    assert.match(workflow, /red-\$\{RELEASE_TAG\}\.spdx\.json/);
+    assert.match(workflow, /red-\$\{RELEASE_TAG\}\.cyclonedx\.json/);
+    assert.match(workflow, /name: Add SBOMs to release assets/);
+    assert.match(workflow, /cp release-sbom\/\* release\//);
     assert.match(workflow, /find \. -maxdepth 1 -type f/);
     assert.match(workflow, /-name 'red-\*'/);
     assert.match(workflow, /-name 'red_client-\*'/);

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -48,6 +48,8 @@ SUFFIXES=(
 EXTRA_ASSETS=(
   checksums.txt
   SHA256SUMS
+  "red-${TAG}.spdx.json"
+  "red-${TAG}.cyclonedx.json"
 )
 
 echo "verify-release-assets: checking ${REPO}@${TAG}"


### PR DESCRIPTION
## Summary

- generate SPDX JSON and CycloneDX JSON source SBOMs for stable and release-candidate GitHub releases
- publish `red-${TAG}.spdx.json` and `red-${TAG}.cyclonedx.json` as release assets
- include SBOMs in `SHA256SUMS`, GitHub Artifact Attestation coverage, and the release asset gate
- document SBOM verification in release policy/runbook and release notes

## Verification

- `node --test scripts/release_tooling_contract.test.mjs`
- `ASDF_RUBY_VERSION=3.0.1 ruby -e "require 'yaml'; ['.github/workflows/release.yml','.github/workflows/release-candidate.yml'].each { |f| YAML.load_file(f); puts "#{f} ok" }"`
- `actionlint -ignore 'label ".*" is unknown' -ignore 'constant expression "false"' .github/workflows/release.yml .github/workflows/release-candidate.yml`
- `git diff --check`
- downloaded Syft v1.46.0 and generated local SPDX/CycloneDX SBOMs with the same scan flags

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1521"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785278397&installation_id=129708444&pr_number=1521&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1521&signature=2f4e2b9396a38ceefdf624a614f7f7ccaa2c3ffd5188e08fafd5fde2f847c59a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->