### PR TITLE
fix(install): verify release checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
         run: node scripts/verify-contract-matrix.mjs
       - name: Contract-matrix tooling contract test
         run: node --test scripts/contract_matrix_contract.test.mjs
+      - name: Installer checksum contract test
+        run: node --test scripts/install_script_contract.test.mjs
       - name: Docs-shim ⇔ required-checks ⇔ ci.yml lock-step (#1307)
         run: node --test scripts/ci-docs-shim-contract.test.mjs
 

--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ npx @reddb-io/cli@latest server --wire-bind 127.0.0.1:5050 --http-bind 127.0.0.1
 ```bash
 # Install
 curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
+# The installer verifies the selected release asset against SHA256SUMS before install.
 
 # Start the server (wire: 5050, gRPC: 55055, HTTP: 5000)
 red server --wire-bind 127.0.0.1:5050 --grpc-bind 127.0.0.1:55055 --http-bind 127.0.0.1:5000 --path ./data.rdb

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,9 +14,11 @@ If you want the terminology first, read [Modes and Transports](/getting-started/
 
 ## Install from GitHub Releases
 
-### Recommended: installer script
+### Recommended: verified installer script
 
-The installer resolves the correct GitHub Release asset for your platform:
+The installer resolves the correct GitHub Release asset for your platform,
+downloads the release `SHA256SUMS` manifest, and refuses to install if the
+selected binary does not match the published SHA-256 checksum:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
@@ -38,6 +40,25 @@ Change the install location:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --install-dir "$HOME/.local/bin"
+```
+
+Install under a prefix:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --prefix "$HOME/.local"
+```
+
+Install only the thin remote client:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --client-only
+```
+
+Remove the selected binary:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --uninstall
+curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --client-only --uninstall
 ```
 
 Verify:

--- a/install.sh
+++ b/install.sh
@@ -5,9 +5,9 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash
 #   curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --channel next
-#   curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --version v0.1.0
+#   curl -fsSL https://raw.githubusercontent.com/reddb-io/reddb/main/install.sh | bash -s -- --version v1.17.0
 #
-set -e
+set -euo pipefail
 
 REPO="reddb-io/reddb"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
@@ -15,20 +15,53 @@ BINARY_NAME="red"
 CHANNEL="stable"
 VERSION=""
 STATIC=""
+MODE="server"
+UNINSTALL="false"
+TMP_DIR=""
+CHECKSUM_FILE=""
+
+cleanup() {
+  if [[ -n "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --channel)
+      [[ $# -ge 2 ]] || { echo "--channel requires a value"; exit 1; }
       CHANNEL="$2"
       shift 2
       ;;
     --version)
+      [[ $# -ge 2 ]] || { echo "--version requires a value"; exit 1; }
       VERSION="$2"
       shift 2
       ;;
     --install-dir)
+      [[ $# -ge 2 ]] || { echo "--install-dir requires a value"; exit 1; }
       INSTALL_DIR="$2"
       shift 2
+      ;;
+    --prefix)
+      [[ $# -ge 2 ]] || { echo "--prefix requires a value"; exit 1; }
+      INSTALL_DIR="${2%/}/bin"
+      shift 2
+      ;;
+    --client-only)
+      MODE="client"
+      BINARY_NAME="red_client"
+      shift
+      ;;
+    --server)
+      MODE="server"
+      BINARY_NAME="red"
+      shift
+      ;;
+    --uninstall)
+      UNINSTALL="true"
+      shift
       ;;
     --static)
       STATIC="true"
@@ -41,9 +74,13 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "Options:"
       echo "  --channel <stable|next|latest>  Release channel (default: stable)"
-      echo "  --version <version>             Install specific version (e.g., v0.1.0)"
+      echo "  --version <version>             Install specific version (e.g., v1.17.0)"
       echo "  --install-dir <path>            Installation directory (default: ~/.local/bin)"
-      echo "  --static                        Use static aarch64 build when available"
+      echo "  --prefix <path>                 Install into <path>/bin"
+      echo "  --client-only                   Install the thin red_client binary"
+      echo "  --server                        Install the full red server/CLI binary (default)"
+      echo "  --uninstall                     Remove the selected binary from the install dir"
+      echo "  --static                        Prefer a static Linux build when available"
       echo "  -h, --help                      Show this help message"
       exit 0
       ;;
@@ -84,7 +121,10 @@ detect_platform() {
   # a fallback for releases/arches that don't publish a static asset yet
   # (resolved in download_binary). macOS/Windows ship a single asset each.
   PLATFORM_FALLBACK=""
-  if [[ "$OS" == "linux" ]] && { [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "aarch64" ]]; }; then
+  if [[ "$OS" == "linux" ]] && [[ "$STATIC" == "true" ]]; then
+    PLATFORM="${OS}-${ARCH}-static"
+    PLATFORM_FALLBACK="${OS}-${ARCH}"
+  elif [[ "$OS" == "linux" ]] && { [[ "$ARCH" == "x86_64" ]] || [[ "$ARCH" == "aarch64" ]]; }; then
     PLATFORM="${OS}-${ARCH}-static"
     PLATFORM_FALLBACK="${OS}-${ARCH}"
   else
@@ -117,6 +157,34 @@ extract_release_tag() {
   fi
 }
 
+download_to_file() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL -o "$output" "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$output" "$url"
+  else
+    echo "curl or wget is required"
+    exit 1
+  fi
+}
+
+download_asset_to_file() {
+  local url="$1"
+  local output="$2"
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fL -o "$output" "$url"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -O "$output" "$url"
+  else
+    echo "curl or wget is required"
+    exit 1
+  fi
+}
+
 fetch_release_info() {
   local api_url
   local releases_json
@@ -129,14 +197,7 @@ fetch_release_info() {
     api_url="https://api.github.com/repos/$REPO/releases"
   fi
 
-  if command -v curl >/dev/null 2>&1; then
-    releases_json=$(curl -fsSL "$api_url" 2>/dev/null)
-  elif command -v wget >/dev/null 2>&1; then
-    releases_json=$(wget -qO- "$api_url" 2>/dev/null)
-  else
-    echo "curl or wget is required"
-    exit 1
-  fi
+  releases_json=$(download_to_file "$api_url" - 2>/dev/null || true)
 
   if [[ -z "$releases_json" ]]; then
     echo "Could not fetch release data"
@@ -160,6 +221,21 @@ fetch_release_info() {
   fi
 }
 
+download_checksum_manifest() {
+  local url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/SHA256SUMS"
+
+  CHECKSUM_FILE="${TMP_DIR}/SHA256SUMS"
+  echo "Downloading checksum manifest from ${url}"
+  if ! download_to_file "$url" "$CHECKSUM_FILE"; then
+    echo "Failed to download SHA256SUMS for ${RELEASE_TAG}"
+    exit 1
+  fi
+  if [[ ! -s "$CHECKSUM_FILE" ]]; then
+    echo "Checksum manifest is empty for ${RELEASE_TAG}"
+    exit 1
+  fi
+}
+
 download_binary() {
   local name="$1"
   local ext=""
@@ -173,13 +249,13 @@ download_binary() {
   local platform binary_name tmp_file url
   for platform in "${platforms[@]}"; do
     binary_name="${name}-${platform}${ext}"
-    tmp_file="/tmp/${binary_name}"
+    tmp_file="${TMP_DIR}/${binary_name}"
     url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${binary_name}"
     echo "Downloading ${name} from ${url}"
-    if command -v curl >/dev/null 2>&1; then
-      if curl -fL -o "$tmp_file" "$url"; then DOWNLOADED_FILES+=("${name}:${tmp_file}"); return 0; fi
-    else
-      if wget -O "$tmp_file" "$url"; then DOWNLOADED_FILES+=("${name}:${tmp_file}"); return 0; fi
+    if download_asset_to_file "$url" "$tmp_file"; then
+      verify_checksum "$tmp_file"
+      DOWNLOADED_FILES+=("${name}:${tmp_file}")
+      return 0
     fi
     if [[ -n "$PLATFORM_FALLBACK" && "$platform" != "$PLATFORM_FALLBACK" ]]; then
       echo "  ${name}-${platform} not found in ${RELEASE_TAG}; trying ${PLATFORM_FALLBACK}"
@@ -195,23 +271,20 @@ verify_checksum() {
   local actual_hash=""
   local asset_file
   asset_file="$(basename "$asset_path")"
-  local checksum_url="https://github.com/${REPO}/releases/download/${RELEASE_TAG}/${asset_file}.sha256"
-  local checksum_file="/tmp/${asset_file}.sha256"
 
-  if command -v curl >/dev/null 2>&1; then
-    if ! curl -fsSL -o "$checksum_file" "$checksum_url" 2>/dev/null; then
-      return 0
-    fi
-  else
-    if ! wget -qO "$checksum_file" "$checksum_url" 2>/dev/null; then
-      return 0
-    fi
+  if [[ ! -s "$CHECKSUM_FILE" ]]; then
+    echo "Checksum manifest is missing; refusing to install ${asset_file}"
+    exit 1
   fi
 
-  expected_hash=$(cat "$checksum_file" | awk '{print $1}' | tr -d '[:space:]')
-  rm -f "$checksum_file"
+  expected_hash=$(awk -v asset="$asset_file" '$2 == asset { print $1; found=1; exit } END { if (!found) exit 1 }' "$CHECKSUM_FILE" || true)
   if [[ -z "$expected_hash" ]]; then
-    return 0
+    echo "Checksum manifest does not contain ${asset_file}"
+    exit 1
+  fi
+  if ! printf '%s' "$expected_hash" | grep -Eq '^[[:xdigit:]]{64}$'; then
+    echo "Invalid checksum entry for ${asset_file}"
+    exit 1
   fi
 
   if command -v sha256sum >/dev/null 2>&1; then
@@ -219,13 +292,17 @@ verify_checksum() {
   elif command -v shasum >/dev/null 2>&1; then
     actual_hash=$(shasum -a 256 "$asset_path" | awk '{print $1}')
   else
-    return 0
+    echo "sha256sum or shasum is required to verify ${asset_file}"
+    exit 1
   fi
 
+  expected_hash=$(printf '%s' "$expected_hash" | tr 'A-F' 'a-f')
+  actual_hash=$(printf '%s' "$actual_hash" | tr 'A-F' 'a-f')
   if [[ "$expected_hash" != "$actual_hash" ]]; then
     echo "Checksum mismatch for ${asset_file}"
     exit 1
   fi
+  echo "Verified checksum for ${asset_file}"
 }
 
 install_file() {
@@ -241,6 +318,18 @@ install_file() {
   fi
 
   echo "Installed: ${binary_path}"
+}
+
+uninstall_file() {
+  local name="$1"
+  local binary_path="${INSTALL_DIR}/${name}"
+
+  if [[ -e "$binary_path" ]]; then
+    rm -f "$binary_path"
+    echo "Removed: ${binary_path}"
+  else
+    echo "Not installed: ${binary_path}"
+  fi
 }
 
 # The static `red` has no hard runtime deps. The one optional dep is a CA-cert
@@ -269,7 +358,15 @@ check_optional_runtime_deps() {
 
 main() {
   detect_platform
+
+  if [[ "$UNINSTALL" == "true" ]]; then
+    uninstall_file "$BINARY_NAME"
+    exit 0
+  fi
+
   fetch_release_info
+  TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/reddb-install.XXXXXX")"
+  download_checksum_manifest
 
   declare -a DOWNLOADED_FILES
 
@@ -278,15 +375,22 @@ main() {
   for entry in "${DOWNLOADED_FILES[@]}"; do
     name="${entry%%:*}"
     file="${entry#*:}"
-    verify_checksum "$file"
     install_file "$name" "$file"
   done
 
-  echo "✅ RedDB installed."
+  if [[ "$MODE" == "client" ]]; then
+    echo "✅ RedDB thin client installed."
+  else
+    echo "✅ RedDB installed."
+  fi
   check_optional_runtime_deps
   echo ""
   echo "Quick start:"
-  echo "  red --help"
+  if [[ "$MODE" == "client" ]]; then
+    echo "  red_client --help"
+  else
+    echo "  red --help"
+  fi
 }
 
 main

--- a/scripts/install_script_contract.test.mjs
+++ b/scripts/install_script_contract.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const installer = path.join(repoRoot, "install.sh");
+
+function sha256Hex(bytes) {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+function writeExecutable(file, body) {
+  fs.writeFileSync(file, body, "utf8");
+  fs.chmodSync(file, 0o755);
+}
+
+function makeFixture(t, { files, checksums }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "reddb-install-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  const releaseDir = path.join(dir, "release");
+  const binDir = path.join(dir, "bin");
+  const installDir = path.join(dir, "install");
+  const tmpDir = path.join(dir, "tmp");
+  fs.mkdirSync(releaseDir);
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(installDir);
+  fs.mkdirSync(tmpDir);
+
+  for (const [name, contents] of Object.entries(files)) {
+    fs.writeFileSync(path.join(releaseDir, name), contents);
+  }
+  fs.writeFileSync(path.join(releaseDir, "SHA256SUMS"), checksums, "utf8");
+
+  writeExecutable(
+    path.join(binDir, "curl"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+output=""
+url=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$url" ]; then
+  echo "curl fixture: missing url" >&2
+  exit 2
+fi
+
+payload=""
+case "$url" in
+  https://api.github.com/repos/reddb-io/reddb/releases/latest)
+    payload='{"tag_name":"v9.9.9"}'
+    ;;
+  https://api.github.com/repos/reddb-io/reddb/releases/tags/v9.9.9)
+    payload='{"tag_name":"v9.9.9"}'
+    ;;
+  https://github.com/reddb-io/reddb/releases/download/v9.9.9/*)
+    asset="\${url##*/}"
+    file="$FAKE_RELEASE_DIR/\${asset}"
+    if [ ! -f "$file" ]; then
+      exit 22
+    fi
+    if [ "$output" = "-" ] || [ -z "$output" ]; then
+      cat "$file"
+    else
+      cp "$file" "$output"
+    fi
+    exit 0
+    ;;
+  *)
+    echo "curl fixture: unexpected url $url" >&2
+    exit 22
+    ;;
+esac
+
+if [ "$output" = "-" ] || [ -z "$output" ]; then
+  printf '%s' "$payload"
+else
+  printf '%s' "$payload" > "$output"
+fi
+`,
+  );
+
+  return { dir, releaseDir, binDir, installDir, tmpDir };
+}
+
+function runInstaller(fixture, args) {
+  return spawnSync("bash", [installer, ...args], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      FAKE_RELEASE_DIR: fixture.releaseDir,
+      INSTALL_DIR: fixture.installDir,
+      PATH: `${fixture.binDir}:${process.env.PATH}`,
+      TMPDIR: fixture.tmpDir,
+    },
+    encoding: "utf8",
+  });
+}
+
+test("install.sh verifies SHA256SUMS before installing red", (t) => {
+  const asset = "red-linux-x86_64-static";
+  const bytes = "server-binary";
+  const fixture = makeFixture(t, {
+    files: { [asset]: bytes },
+    checksums: `${sha256Hex(bytes)}  ${asset}\n`,
+  });
+
+  const result = runInstaller(fixture, ["--install-dir", fixture.installDir]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Verified checksum for red-linux-x86_64-static/);
+  assert.equal(fs.readFileSync(path.join(fixture.installDir, "red"), "utf8"), bytes);
+});
+
+test("install.sh refuses a checksum mismatch", (t) => {
+  const asset = "red-linux-x86_64-static";
+  const fixture = makeFixture(t, {
+    files: { [asset]: "tampered-binary" },
+    checksums: `${"0".repeat(64)}  ${asset}\n`,
+  });
+
+  const result = runInstaller(fixture, ["--install-dir", fixture.installDir]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stdout + result.stderr, /Checksum mismatch for red-linux-x86_64-static/);
+  assert.equal(fs.existsSync(path.join(fixture.installDir, "red")), false);
+});
+
+test("install.sh refuses a release missing the selected asset in SHA256SUMS", (t) => {
+  const asset = "red-linux-x86_64-static";
+  const fixture = makeFixture(t, {
+    files: { [asset]: "server-binary" },
+    checksums: `${sha256Hex("other-binary")}  red-linux-x86_64\n`,
+  });
+
+  const result = runInstaller(fixture, ["--install-dir", fixture.installDir]);
+
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stdout + result.stderr,
+    /Checksum manifest does not contain red-linux-x86_64-static/,
+  );
+  assert.equal(fs.existsSync(path.join(fixture.installDir, "red")), false);
+});
+
+test("install.sh supports --client-only and --prefix", (t) => {
+  const asset = "red_client-linux-x86_64-static";
+  const bytes = "client-binary";
+  const fixture = makeFixture(t, {
+    files: { [asset]: bytes },
+    checksums: `${sha256Hex(bytes)}  ${asset}\n`,
+  });
+  const prefix = path.join(fixture.dir, "prefix");
+
+  const result = runInstaller(fixture, ["--client-only", "--prefix", prefix]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /RedDB thin client installed/);
+  assert.equal(fs.readFileSync(path.join(prefix, "bin", "red_client"), "utf8"), bytes);
+  assert.equal(fs.existsSync(path.join(prefix, "bin", "red")), false);
+});
+
+test("install.sh supports --uninstall without network access", (t) => {
+  const fixture = makeFixture(t, {
+    files: {},
+    checksums: "",
+  });
+  const prefix = path.join(fixture.dir, "prefix");
+  const bin = path.join(prefix, "bin");
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, "red_client"), "old-client");
+
+  const result = runInstaller(fixture, ["--client-only", "--prefix", prefix, "--uninstall"]);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.match(result.stdout, /Removed:/);
+  assert.equal(fs.existsSync(path.join(bin, "red_client")), false);
+});


### PR DESCRIPTION
## Summary
- make install.sh fail closed unless the selected GitHub Release asset matches SHA256SUMS
- install into a temporary file before verification and only move into place after the digest matches
- document verified install, --prefix, --client-only, and --uninstall flows
- add installer contract coverage to the existing contract-matrix CI job

## Verification
- node --test scripts/install_script_contract.test.mjs
- node --test scripts/ci-docs-shim-contract.test.mjs
- bash -n install.sh
- git diff --check
- INSTALL_DIR=$(mktemp -d)/bin bash install.sh --version v1.17.0 && red version from the temp install returned reddb 1.17.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785279909&installation_id=129708444&pr_number=1522&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1522&signature=f631306f11cc8e3e63a0f1320ca9b9a1bcad0175d2857489b886873e828012ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->