### PR TITLE
ci(fuzz): shrink per-pr fuzz cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,29 +686,17 @@ jobs:
       - name: Unit tests
         run: cargo test --locked --lib
 
-  fuzz-targets:
-    # Issue #87 — short-window cargo-fuzz run on every PR.
-    # Catches panics introduced by grammar changes; the long-window
-    # nightly run lives in a separate scheduled workflow.
-    #
-    # Each parser fuzzes in its own parallel job. The aggregate
-    # required status check lives in the `fuzz-parsers` job below
-    # (name: "Fuzz Parsers"), which is what main's branch protection
-    # gates on — keep that name in lockstep with branch protection.
-    name: Fuzz ${{ matrix.target }}
+  fuzz-parsers:
+    # Required status-check name expected by main's branch protection.
+    # Keep the per-PR path as a bounded smoke window; the long exploration
+    # window lives in parser-fuzz-nightly.yml.
+    name: Fuzz Parsers
     needs: gate
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
     runs-on: blacksmith-4vcpu-ubuntu-2404
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - sql_parser
-          - migration_parser
-          - conn_string_parser
-          - query_with_params
+    timeout-minutes: 15
     env:
+      FUZZ_PR_TIME_SECONDS: 30
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
     steps:
@@ -721,18 +709,16 @@ jobs:
       - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
-          # Per-target cache key so parallel jobs don't thrash a
-          # shared cache entry.
-          shared-key: ubuntu-fuzz-nightly-${{ matrix.target }}
+          shared-key: ubuntu-fuzz-pr-smoke
           cache-on-failure: "true"
           workspaces: |
             . -> target
             fuzz -> fuzz/target
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
-      - name: Build fuzz target
-        run: cargo +nightly fuzz build ${{ matrix.target }}
-      - name: Run fuzz target (5 min)
+        run: cargo +nightly install cargo-fuzz --locked
+      - name: Build fuzz targets
+        run: cargo +nightly fuzz build --dev
+      - name: Run fuzz targets (30s each)
         # Issue #90 — conn_string_parser is a pre-auth parser, panic-
         # resistance is the only invariant; conn-string sees attacker-
         # controlled bytes before any handshake completes, so we bake
@@ -743,33 +729,20 @@ jobs:
         # as an actionable crash finding instead of a silent runner
         # OOM/timeout. scripts/fuzz-local.sh mirrors these limits (plus a
         # systemd memory cgroup) for safe fuzzing on a dev box.
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300 -rss_limit_mb=4096 -malloc_limit_mb=2048
+        run: |
+          set -euo pipefail
+          for target in sql_parser migration_parser conn_string_parser query_with_params; do
+            cargo +nightly fuzz run --dev "$target" -- -max_total_time="${FUZZ_PR_TIME_SECONDS}" -rss_limit_mb=4096 -malloc_limit_mb=2048
+          done
       - name: Upload fuzz crash artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: fuzz-crashes-${{ matrix.target }}
+          name: fuzz-crashes
           path: |
             fuzz/artifacts/
             fuzz/corpus/
           retention-days: 14
-
-  fuzz-parsers:
-    # Aggregator that preserves the EXACT required status-check name
-    # "Fuzz Parsers" expected by main's branch protection. It succeeds
-    # iff every matrix job in fuzz-targets succeeded. Do not rename.
-    name: Fuzz Parsers
-    needs: [fuzz-targets]
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Verify all fuzz targets passed
-        run: |
-          if [ "${{ needs.fuzz-targets.result }}" != "success" ]; then
-            echo "a fuzz target failed"
-            exit 1
-          fi
 
   package:
     name: cargo package dry-run

--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -28,6 +28,7 @@ jobs:
           - sql_parser
           - migration_parser
           - conn_string_parser
+          - query_with_params
     steps:
       - uses: actions/checkout@v7
 

--- a/crates/reddb-server/tests/support/parser_hardening/README.md
+++ b/crates/reddb-server/tests/support/parser_hardening/README.md
@@ -84,8 +84,8 @@ single unmasked match.
   back to `*.snap` files)
 - Fuzz smoke: `cargo fuzz run sql_parser -- -max_total_time=10`
 - Fuzz smoke (migration): `cargo fuzz run migration_parser -- -max_total_time=10`
-- Fuzz CI run: `cargo fuzz run sql_parser -- -max_total_time=300`
-  and `cargo fuzz run migration_parser -- -max_total_time=300`
+- Fuzz CI smoke: `cargo fuzz run sql_parser -- -max_total_time=30`
+  and `cargo fuzz run migration_parser -- -max_total_time=30`
 
 ## Limit defaults
 

--- a/docs/security/parser-limits.md
+++ b/docs/security/parser-limits.md
@@ -90,19 +90,22 @@ unbounded recursion and time out before reporting useful coverage.
 cargo +nightly fuzz run sql_parser -- -max_total_time=10
 ```
 
-### CI run (per-PR, 5 minutes)
+### CI run (per-PR smoke)
 
-The `Fuzz Parsers` job in `.github/workflows/ci.yml` runs the
-target with `-max_total_time=300`. A panic, ASAN finding, or
-out-of-memory abort fails the job; libFuzzer's evolved corpus is
-uploaded as an artifact for triage.
+The `Fuzz Parsers` job in `.github/workflows/ci.yml` runs every
+parser fuzz target in one required check with a `--dev` fuzz build
+and `-max_total_time=30` per target. This keeps pull-request cost
+bounded while still replaying seed corpora and catching deterministic
+panics, ASAN findings, and out-of-memory aborts. Crash artifacts are
+uploaded for triage.
 
 ### Nightly long-window run
 
-A 1-hour scheduled run lives outside the per-PR job to keep PR
-latency tight. To set up, copy `.github/workflows/ci.yml`'s
-`fuzz-parsers` job into a new scheduled workflow with
-`-max_total_time=3600` and a `cron: '0 4 * * *'` schedule.
+A 1-hour scheduled run lives in
+`.github/workflows/parser-fuzz-nightly.yml` outside the per-PR job
+to keep PR latency tight. It runs the same parser fuzz targets with
+`-max_total_time=3600` and preserves the evolved corpus between
+runs.
 
 ### Reproducing a crash
 

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -249,19 +249,33 @@ test("DST storage fault issue creation deduplicates open release blockers", () =
   assert.ok(createCall > existingReturn, "issue creation must happen after existing issue guard");
 });
 
-test("per-PR parser fuzz matrix has bounded fixed fuzz windows", () => {
+test("per-PR parser fuzz runs as one bounded required smoke check", () => {
   const workflow = read(".github/workflows/ci.yml");
-  const fuzzTargets = workflowJob(workflow, "fuzz-targets");
   const fuzzParsers = workflowJob(workflow, "fuzz-parsers");
 
-  assert.match(fuzzTargets, /timeout-minutes: 20/);
+  assert.equal(workflowJob(workflow, "fuzz-targets"), "", "per-PR fuzz must not fan out into separate runners");
+  assert.match(fuzzParsers, /name: Fuzz Parsers/);
+  assert.match(fuzzParsers, /needs: gate/);
+  assert.match(fuzzParsers, /timeout-minutes: 15/);
+  assert.match(fuzzParsers, /FUZZ_PR_TIME_SECONDS: 30/);
+  assert.match(fuzzParsers, /shared-key: ubuntu-fuzz-pr-smoke/);
+  assert.match(fuzzParsers, /cargo \+nightly fuzz build --dev/);
   for (const target of ["sql_parser", "migration_parser", "conn_string_parser", "query_with_params"]) {
-    assert.match(fuzzTargets, new RegExp(`- ${target}`));
+    assert.match(fuzzParsers, new RegExp(`for target in[\\s\\S]*${target}`));
   }
   assert.match(
-    fuzzTargets,
-    /cargo \+nightly fuzz run \$\{\{ matrix\.target \}\} -- -max_total_time=300 -rss_limit_mb=4096 -malloc_limit_mb=2048/,
+    fuzzParsers,
+    /cargo \+nightly fuzz run --dev "\$target" -- -max_total_time="\$\{FUZZ_PR_TIME_SECONDS\}" -rss_limit_mb=4096 -malloc_limit_mb=2048/,
   );
-  assert.match(fuzzParsers, /name: Fuzz Parsers/);
-  assert.match(fuzzParsers, /needs: \[fuzz-targets\]/);
+});
+
+test("nightly parser fuzz keeps the long-window coverage for every PR target", () => {
+  const workflow = read(".github/workflows/parser-fuzz-nightly.yml");
+  const fuzz = workflowJob(workflow, "fuzz");
+
+  assert.match(fuzz, /timeout-minutes: 90/);
+  for (const target of ["sql_parser", "migration_parser", "conn_string_parser", "query_with_params"]) {
+    assert.match(fuzz, new RegExp(`- ${target}`));
+  }
+  assert.match(fuzz, /cargo \+nightly fuzz run \$\{\{ matrix\.target \}\} -- -max_total_time=3600/);
 });


### PR DESCRIPTION
## Summary
- replace the four-runner per-PR cargo-fuzz matrix with one required `Fuzz Parsers` smoke job
- cap per-target PR fuzz time at 30s while preserving ASAN/RSS/malloc failure behavior
- move the long exploration responsibility to the nightly workflow and add `query_with_params` there too
- update docs and release-tooling contracts so the cost shape does not regress

## Evidence
- previous PR run #28339071936 spent ~14m30s on each of four parallel fuzz jobs before `Fuzz Parsers` could report
- new CI shape uses one 4vcpu runner, one cargo-fuzz install/cache, one required check, and 30s per target

## Verification
- node --test scripts/release_tooling_contract.test.mjs
- node --test scripts/ci-docs-shim-contract.test.mjs
- node scripts/verify-contract-matrix.mjs
- actionlint -ignore 'label "blacksmith-.*" is unknown' .github/workflows/ci.yml .github/workflows/parser-fuzz-nightly.yml\n- git diff --check\n

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785287304&installation_id=129708444&pr_number=1523&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1523&signature=c7cd0d2a3e5f010d6d4bca79b1bf75731a786fa5ff1e0d5a789b1fb55ff7489d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a quicker per-PR fuzzing smoke check that runs all parser fuzz targets in one short pass.
  * Expanded nightly fuzz coverage to include an additional parser path.

* **Bug Fixes**
  * Improved crash artifact handling so fuzz failures are collected in a single, easier-to-review output.

* **Documentation**
  * Updated security and parser hardening docs to reflect the new fuzzing time limits and nightly run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->