### PR TITLE
feat(cluster): require bounded read fanout

### DIFF
--- a/crates/reddb-server/src/cluster/cross_range.rs
+++ b/crates/reddb-server/src/cluster/cross_range.rs
@@ -20,11 +20,13 @@
 //!   involved — a clear "unsupported" contract rather than a silent partial
 //!   commit.
 //!
-//! * **Simple read fanout** ([`plan_read_fanout`]). A best-effort read may span
-//!   any number of range owners; the plan collects one [`ReadLeg`] per owner so
-//!   the caller can scatter the read and gather the results. This is explicitly
-//!   *not* a globally consistent snapshot — each leg observes its owner at
-//!   whatever point it happens to be at — and the type name says so.
+//! * **Explicit bounded read fanout** ([`plan_read_fanout`]). A best-effort read
+//!   may span range owners only when the caller opts into fanout and supplies a
+//!   budget. The plan collects one [`ReadLeg`] per owner and returns
+//!   [`ReadFanoutTrace`] metadata so the transport can expose participating
+//!   owners/ranges instead of hiding a scatter query. This is explicitly *not* a
+//!   globally consistent snapshot — each leg observes its owner at whatever point
+//!   it happens to be at — and the type name says so.
 //!
 //! * **Consistent / transactional reads** ([`plan_consistent_read`]). A read that
 //!   must look globally consistent needs a safe snapshot point that covers every
@@ -312,6 +314,117 @@ impl ReadLeg {
     }
 }
 
+/// The explicit policy a caller supplies before a read may fan out.
+///
+/// The default posture is [`SingleOwnerOnly`](Self::SingleOwnerOnly): a read that
+/// would cross owners is rejected before execution. To scatter, a caller must
+/// choose [`ExplicitFanout`](Self::ExplicitFanout) and provide a
+/// [`ReadFanoutBudget`]. That is the ADR 0055 contract in code: no hidden,
+/// unbounded fanout path for cold-cache or missing-shard-key query shapes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ReadFanoutPolicy {
+    /// Only reads that resolve to one owner are admitted.
+    #[default]
+    SingleOwnerOnly,
+    /// Cross-owner fanout is allowed, bounded, and marked with partial-result
+    /// policy for the executor/transport.
+    ExplicitFanout {
+        budget: ReadFanoutBudget,
+        allow_partial: bool,
+    },
+}
+
+impl ReadFanoutPolicy {
+    pub fn single_owner_only() -> Self {
+        Self::SingleOwnerOnly
+    }
+
+    pub fn explicit(budget: ReadFanoutBudget) -> Self {
+        Self::ExplicitFanout {
+            budget,
+            allow_partial: false,
+        }
+    }
+
+    pub fn allowing_partial(mut self) -> Self {
+        if let Self::ExplicitFanout {
+            ref mut allow_partial,
+            ..
+        } = self
+        {
+            *allow_partial = true;
+        }
+        self
+    }
+}
+
+/// Hard caps for one explicit best-effort read fanout plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadFanoutBudget {
+    max_owners: usize,
+    max_ranges: usize,
+    max_targets: usize,
+}
+
+impl ReadFanoutBudget {
+    pub fn new(max_owners: usize, max_ranges: usize, max_targets: usize) -> Self {
+        Self {
+            max_owners,
+            max_ranges,
+            max_targets,
+        }
+    }
+
+    pub fn max_owners(&self) -> usize {
+        self.max_owners
+    }
+
+    pub fn max_ranges(&self) -> usize {
+        self.max_ranges
+    }
+
+    pub fn max_targets(&self) -> usize {
+        self.max_targets
+    }
+}
+
+impl Default for ReadFanoutBudget {
+    fn default() -> Self {
+        Self {
+            max_owners: 8,
+            max_ranges: 64,
+            max_targets: 512,
+        }
+    }
+}
+
+/// Observable metadata for a best-effort fanout plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReadFanoutTrace {
+    target_count: usize,
+    owner_count: usize,
+    range_count: usize,
+    partial_allowed: bool,
+}
+
+impl ReadFanoutTrace {
+    pub fn target_count(&self) -> usize {
+        self.target_count
+    }
+
+    pub fn owner_count(&self) -> usize {
+        self.owner_count
+    }
+
+    pub fn range_count(&self) -> usize {
+        self.range_count
+    }
+
+    pub fn partial_allowed(&self) -> bool {
+        self.partial_allowed
+    }
+}
+
 /// A simple, best-effort cross-range read split into one [`ReadLeg`] per owner.
 ///
 /// **Not** a globally consistent snapshot: each leg observes its owner at
@@ -321,6 +434,7 @@ impl ReadLeg {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReadFanout {
     legs: Vec<ReadLeg>,
+    trace: ReadFanoutTrace,
 }
 
 impl ReadFanout {
@@ -329,9 +443,14 @@ impl ReadFanout {
         &self.legs
     }
 
-    /// Whether the read fans out to more than one owner.
+    /// Observable fanout metadata the executor/transport should trace.
+    pub fn trace(&self) -> ReadFanoutTrace {
+        self.trace
+    }
+
+    /// Whether the read touches more than one range.
     pub fn is_cross_range(&self) -> bool {
-        self.legs.len() > 1
+        self.trace.range_count > 1
     }
 }
 
@@ -345,6 +464,15 @@ pub enum ReadFanoutReject {
         collection: CollectionId,
         key: Vec<u8>,
     },
+    /// The read would cross owners, but the caller did not explicitly opt into
+    /// fanout.
+    FanoutNotExplicit { owners: Vec<NodeIdentity> },
+    /// The request named more targets than the fanout budget permits.
+    TargetBudgetExceeded { requested: usize, max: usize },
+    /// The plan would contact more owners than the fanout budget permits.
+    OwnerBudgetExceeded { requested: usize, max: usize },
+    /// The plan would touch more ranges than the fanout budget permits.
+    RangeBudgetExceeded { requested: usize, max: usize },
 }
 
 impl std::fmt::Display for ReadFanoutReject {
@@ -355,6 +483,32 @@ impl std::fmt::Display for ReadFanoutReject {
                 f,
                 "no range of collection {collection} covers key {} — re-resolve routing",
                 DisplayKey(key)
+            ),
+            Self::FanoutNotExplicit { owners } => {
+                write!(
+                    f,
+                    "read would fan out to {} owners but fanout was not explicit: ",
+                    owners.len()
+                )?;
+                for (i, owner) in owners.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{owner}")?;
+                }
+                Ok(())
+            }
+            Self::TargetBudgetExceeded { requested, max } => write!(
+                f,
+                "read fanout targets {requested} keys, exceeding budget {max}"
+            ),
+            Self::OwnerBudgetExceeded { requested, max } => write!(
+                f,
+                "read fanout would contact {requested} owners, exceeding budget {max}"
+            ),
+            Self::RangeBudgetExceeded { requested, max } => write!(
+                f,
+                "read fanout would touch {requested} ranges, exceeding budget {max}"
             ),
         }
     }
@@ -618,24 +772,73 @@ impl ShardOwnershipCatalog {
         }
     }
 
-    /// Plan a simple, best-effort cross-range read fanout over `targets`
-    /// (issue #1002).
+    /// Plan a simple, best-effort read over `targets` (issue #1002, ADR 0055).
     ///
-    /// Collects the resolved targets into one [`ReadLeg`] per owner so the caller
-    /// can scatter the read across every range owner and gather the results. This
-    /// is *not* a consistent snapshot — see [`ReadFanout`]. `Err` only when the
-    /// read is empty or a target routes nowhere; spanning many owners is the
-    /// expected, successful case.
-    pub fn plan_read_fanout(&self, targets: &[KeyTarget]) -> Result<ReadFanout, ReadFanoutReject> {
+    /// A read that resolves to one owner is admitted under
+    /// [`ReadFanoutPolicy::SingleOwnerOnly`]. A read that would contact multiple
+    /// owners must use [`ReadFanoutPolicy::ExplicitFanout`] and fit inside the
+    /// supplied budget. The returned [`ReadFanoutTrace`] records target, owner,
+    /// range, and partial-result policy so a later executor can surface fanout
+    /// rather than making it invisible.
+    pub fn plan_read_fanout(
+        &self,
+        targets: &[KeyTarget],
+        policy: ReadFanoutPolicy,
+    ) -> Result<ReadFanout, ReadFanoutReject> {
         if targets.is_empty() {
             return Err(ReadFanoutReject::Empty);
+        }
+        if let ReadFanoutPolicy::ExplicitFanout { budget, .. } = policy {
+            if targets.len() > budget.max_targets() {
+                return Err(ReadFanoutReject::TargetBudgetExceeded {
+                    requested: targets.len(),
+                    max: budget.max_targets(),
+                });
+            }
         }
         let resolved = self
             .resolve_targets(targets)
             .map_err(|(collection, key)| ReadFanoutReject::Unroutable { collection, key })?;
 
+        let owner_count = distinct_owner_count(&resolved);
+        let range_count = distinct_range_count(&resolved);
+        let partial_allowed = match policy {
+            ReadFanoutPolicy::SingleOwnerOnly => {
+                if owner_count > 1 {
+                    return Err(ReadFanoutReject::FanoutNotExplicit {
+                        owners: distinct_owners(&resolved),
+                    });
+                }
+                false
+            }
+            ReadFanoutPolicy::ExplicitFanout {
+                budget,
+                allow_partial,
+            } => {
+                if owner_count > budget.max_owners() {
+                    return Err(ReadFanoutReject::OwnerBudgetExceeded {
+                        requested: owner_count,
+                        max: budget.max_owners(),
+                    });
+                }
+                if range_count > budget.max_ranges() {
+                    return Err(ReadFanoutReject::RangeBudgetExceeded {
+                        requested: range_count,
+                        max: budget.max_ranges(),
+                    });
+                }
+                allow_partial
+            }
+        };
+
         Ok(ReadFanout {
             legs: group_targets_by_owner(resolved),
+            trace: ReadFanoutTrace {
+                target_count: targets.len(),
+                owner_count,
+                range_count,
+                partial_allowed,
+            },
         })
     }
 
@@ -718,6 +921,27 @@ fn group_targets_by_owner(resolved: Vec<ResolvedTarget>) -> Vec<ReadLeg> {
         .into_iter()
         .map(|(owner, targets)| ReadLeg { owner, targets })
         .collect()
+}
+
+fn distinct_owners(resolved: &[ResolvedTarget]) -> Vec<NodeIdentity> {
+    resolved
+        .iter()
+        .map(|target| target.owner().clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn distinct_owner_count(resolved: &[ResolvedTarget]) -> usize {
+    distinct_owners(resolved).len()
+}
+
+fn distinct_range_count(resolved: &[ResolvedTarget]) -> usize {
+    resolved
+        .iter()
+        .map(|target| (target.collection().clone(), target.range_id()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .len()
 }
 
 /// Group pinned targets into one [`ConsistentReadLeg`] per owner, in identity
@@ -879,17 +1103,24 @@ mod tests {
 
     // AC #3: a simple read fanout collects one leg per owner across ranges.
     #[test]
-    fn read_fanout_collects_per_owner_legs() {
+    fn explicit_read_fanout_collects_per_owner_legs() {
         let (catalog, orders) = two_range_catalog();
         let fanout = catalog
-            .plan_read_fanout(&[
-                target(&orders, b"alice"),
-                target(&orders, b"zeb"),
-                target(&orders, b"bob"),
-            ])
+            .plan_read_fanout(
+                &[
+                    target(&orders, b"alice"),
+                    target(&orders, b"zeb"),
+                    target(&orders, b"bob"),
+                ],
+                ReadFanoutPolicy::explicit(ReadFanoutBudget::default()).allowing_partial(),
+            )
             .expect("fanout planned");
         assert!(fanout.is_cross_range());
         assert_eq!(fanout.legs().len(), 2);
+        assert_eq!(fanout.trace().target_count(), 3);
+        assert_eq!(fanout.trace().owner_count(), 2);
+        assert_eq!(fanout.trace().range_count(), 2);
+        assert!(fanout.trace().partial_allowed());
         // node-a leg gets alice + bob (range 1); node-b leg gets zeb (range 2).
         let a = &fanout.legs()[0];
         assert_eq!(a.owner(), &ident("CN=node-a"));
@@ -901,20 +1132,115 @@ mod tests {
     }
 
     #[test]
+    fn cross_owner_read_requires_explicit_fanout() {
+        let (catalog, orders) = two_range_catalog();
+        match catalog.plan_read_fanout(
+            &[target(&orders, b"alice"), target(&orders, b"zeb")],
+            ReadFanoutPolicy::single_owner_only(),
+        ) {
+            Err(ReadFanoutReject::FanoutNotExplicit { owners }) => {
+                assert_eq!(owners, vec![ident("CN=node-a"), ident("CN=node-b")]);
+            }
+            other => panic!("expected FanoutNotExplicit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_read_fanout_enforces_owner_budget() {
+        let (catalog, orders) = two_range_catalog();
+        match catalog.plan_read_fanout(
+            &[target(&orders, b"alice"), target(&orders, b"zeb")],
+            ReadFanoutPolicy::explicit(ReadFanoutBudget::new(1, 2, 8)),
+        ) {
+            Err(ReadFanoutReject::OwnerBudgetExceeded { requested, max }) => {
+                assert_eq!(requested, 2);
+                assert_eq!(max, 1);
+            }
+            other => panic!("expected OwnerBudgetExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_read_fanout_enforces_range_budget() {
+        let (catalog, orders) = two_range_catalog();
+        match catalog.plan_read_fanout(
+            &[target(&orders, b"alice"), target(&orders, b"zeb")],
+            ReadFanoutPolicy::explicit(ReadFanoutBudget::new(2, 1, 8)),
+        ) {
+            Err(ReadFanoutReject::RangeBudgetExceeded { requested, max }) => {
+                assert_eq!(requested, 2);
+                assert_eq!(max, 1);
+            }
+            other => panic!("expected RangeBudgetExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_read_fanout_enforces_target_budget_before_routing() {
+        let (catalog, orders) = two_range_catalog();
+        match catalog.plan_read_fanout(
+            &[target(&orders, b"alice"), target(&orders, b"bob")],
+            ReadFanoutPolicy::explicit(ReadFanoutBudget::new(2, 2, 1)),
+        ) {
+            Err(ReadFanoutReject::TargetBudgetExceeded { requested, max }) => {
+                assert_eq!(requested, 2);
+                assert_eq!(max, 1);
+            }
+            other => panic!("expected TargetBudgetExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn single_owner_read_is_not_cross_range() {
         let (catalog, orders) = two_range_catalog();
         let fanout = catalog
-            .plan_read_fanout(&[target(&orders, b"alice"), target(&orders, b"bob")])
+            .plan_read_fanout(
+                &[target(&orders, b"alice"), target(&orders, b"bob")],
+                ReadFanoutPolicy::single_owner_only(),
+            )
             .expect("fanout planned");
         assert!(!fanout.is_cross_range());
         assert_eq!(fanout.legs().len(), 1);
+        assert_eq!(fanout.trace().owner_count(), 1);
+        assert_eq!(fanout.trace().range_count(), 1);
+        assert!(!fanout.trace().partial_allowed());
+    }
+
+    #[test]
+    fn single_owner_multi_range_read_is_cross_range_but_not_cross_owner() {
+        let orders = collection("orders");
+        let mut catalog = ShardOwnershipCatalog::new();
+        catalog
+            .apply_update(range(&orders, 1, bounds(b"a", b"m"), "CN=node-a"))
+            .unwrap();
+        catalog
+            .apply_update(range(
+                &orders,
+                2,
+                RangeBounds::new(RangeBound::key(b"m"), RangeBound::Max).unwrap(),
+                "CN=node-a",
+            ))
+            .unwrap();
+
+        let fanout = catalog
+            .plan_read_fanout(
+                &[target(&orders, b"alice"), target(&orders, b"zeb")],
+                ReadFanoutPolicy::single_owner_only(),
+            )
+            .expect("same-owner multi-range read is admitted");
+        assert!(fanout.is_cross_range());
+        assert_eq!(fanout.trace().owner_count(), 1);
+        assert_eq!(fanout.trace().range_count(), 2);
     }
 
     #[test]
     fn unroutable_read_fanout_is_rejected() {
         let catalog = ShardOwnershipCatalog::new();
         let orders = collection("orders");
-        match catalog.plan_read_fanout(&[target(&orders, b"x")]) {
+        match catalog.plan_read_fanout(
+            &[target(&orders, b"x")],
+            ReadFanoutPolicy::single_owner_only(),
+        ) {
             Err(ReadFanoutReject::Unroutable { collection, .. }) => {
                 assert_eq!(collection, orders)
             }

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -34,8 +34,9 @@ pub use control_plane::{
 };
 pub use cross_range::{
     ConsistentReadLeg, ConsistentReadPlan, ConsistentReadReject, ExactClaimPlan, ExactClaimReject,
-    GlobalReadWatermark, KeyTarget, PinnedTarget, RangeParticipant, ReadFanout, ReadFanoutReject,
-    ReadLeg, ResolvedTarget, WriteTransactionPlan, WriteTransactionReject, WriterParticipation,
+    GlobalReadWatermark, KeyTarget, PinnedTarget, RangeParticipant, ReadFanout, ReadFanoutBudget,
+    ReadFanoutPolicy, ReadFanoutReject, ReadFanoutTrace, ReadLeg, ResolvedTarget,
+    WriteTransactionPlan, WriteTransactionReject, WriterParticipation,
 };
 pub use drain::{
     drain_status, plan_drain, plan_force_remove, run_drain, run_force_remove, DrainBlock,

--- a/crates/reddb-server/src/storage/engine/btree.rs
+++ b/crates/reddb-server/src/storage/engine/btree.rs
@@ -1555,7 +1555,7 @@ mod overflow_pipeline_tests {
 
             // xorshift produces incompressible bytes deterministically
             // so the test never flakes on the codec's heuristic.
-            let mut state: u64 = 0xC0FFEE_DEAD_F00D;
+            let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
             let value: Vec<u8> = (0..5 * 1024 * 1024)
                 .map(|_| {
                     state ^= state << 13;

--- a/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
+++ b/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
@@ -764,16 +764,23 @@ fn cross_range_writes_are_rejected_and_read_fanout_spans_owners() {
     // A best-effort cross-range read fanout over the same two keys succeeds,
     // with one leg per owner.
     let fanout = catalog
-        .plan_read_fanout(&[
-            KeyTarget::new(orders.clone(), KEY_LOW.to_vec()),
-            KeyTarget::new(orders.clone(), KEY_HIGH.to_vec()),
-        ])
-        .expect("cross-range read fanout is plannable");
+        .plan_read_fanout(
+            &[
+                KeyTarget::new(orders.clone(), KEY_LOW.to_vec()),
+                KeyTarget::new(orders.clone(), KEY_HIGH.to_vec()),
+            ],
+            reddb_server::cluster::ReadFanoutPolicy::explicit(
+                reddb_server::cluster::ReadFanoutBudget::default(),
+            ),
+        )
+        .expect("explicit cross-range read fanout is plannable");
     assert!(
         fanout.is_cross_range(),
         "the read spans more than one owner"
     );
     assert_eq!(fanout.legs().len(), 2, "one leg per range owner");
+    assert_eq!(fanout.trace().owner_count(), 2);
+    assert_eq!(fanout.trace().range_count(), 2);
     let leg_owners: Vec<_> = fanout.legs().iter().map(|l| l.owner().clone()).collect();
     assert!(leg_owners.contains(&ident(NODE_A)) && leg_owners.contains(&ident(NODE_B)));
 }

--- a/docs/architecture/cluster-sharding.md
+++ b/docs/architecture/cluster-sharding.md
@@ -27,7 +27,7 @@ The implementation lives under `crates/reddb-server/src/cluster/`, especially:
 | Any-node routing decisions | Landed as pure routing decisions |
 | Public write fencing by owner epoch | Landed in the catalog model |
 | Cross-range write transaction guardrails | Landed as pure planning decisions |
-| Best-effort read fanout plan | Landed as pure planning decisions |
+| Explicit, budgeted best-effort read fanout plan | Landed as pure planning decisions |
 | Consistent cross-range read watermark contract | Landed as pure planning decisions |
 | Weighted placement and hotspot-aware rebalance plan | Landed as pure planning decisions |
 | Full transport/storage integration for cluster mode | In progress |
@@ -202,7 +202,7 @@ The current contract is deliberately conservative.
 | Single-key point read/write | Route to one range owner; may be forwarded from a non-owner when safe |
 | Write transaction touching one writer's ranges | Admitted to that writer, even if it touches several ranges owned by that writer |
 | Write transaction touching multiple writers | Rejected as unsupported; there is no hidden two-phase commit |
-| Best-effort multi-key read | Planned as one read leg per owner; not a global snapshot |
+| Best-effort multi-key read | Requires explicit fanout when it crosses owners, enforces owner/range/target budgets, and is not a global snapshot |
 | Consistent multi-key read | Requires a global safe watermark covering every touched range |
 | Distributed SQL plan, shard execution, and merge | Roadmap |
 
@@ -210,6 +210,13 @@ This means cross-writer ACID is not part of the current cluster contract. If an
 application needs a business workflow that spans writers, the first expected
 pattern is a saga or another explicit compensating workflow above RedDB, not an
 implicit distributed transaction in the engine.
+
+Best-effort fanout is deliberately not transparent magic. The planning model
+admits same-owner reads by default, but a read that would scatter across owners
+must opt into fanout and fit within caller-supplied owner, range, and target
+budgets. The plan also carries trace metadata — target count, owner count, range
+count, and whether partial results are allowed — so the transport/executor layer
+can expose scatter behavior instead of hiding it behind a normal-looking query.
 
 ## Caching
 

--- a/docs/architecture/cluster-vitess-gap-analysis.md
+++ b/docs/architecture/cluster-vitess-gap-analysis.md
@@ -68,7 +68,7 @@ policy, and overload tests.
 | Resharding/range movement | Reshard is a workflow: create, show/status, VDiff, SwitchTraffic, ReverseTraffic, cancel, complete. | `cluster/move_range.rs`, placement, split, catch-up, and cutover state machines exist as pure models. | Need an operator workflow around move/split/cutover with status, validation, rollback/reverse, and dry-run. |
 | Control/data separation | Topology is metadata/locks, not RPC/log storage or per-query dependency. | ADR 0052 explicitly keeps user writes out of the control-plane consensus log. | Preserve this; do not "fix" clustering by pushing data writes through consensus. |
 | Operator surface | vtctldclient and VTAdmin expose broad cluster inspection and mutation. | RedDB has status JSON and deployment JSON surfaces plus individual docs. | Need one cluster operator surface with topology, health, ownership, failover, and movement commands. |
-| Fanout and overload | Vitess supports scatter queries, but Slack's incident report shows broad fanout under cache churn can overload a keyspace. | ADR 0055 already says cross-shard reads must be explicit and bounded. | Need enforcement, tracing, throttling, and chaos tests for cold-cache fanout. |
+| Fanout and overload | Vitess supports scatter queries, but Slack's incident report shows broad fanout under cache churn can overload a keyspace. | ADR 0055 says cross-shard reads must be explicit and bounded; the pure planner now enforces explicit cross-owner fanout budgets and returns trace metadata. | Need executor/transport wiring, runtime metrics, throttling, and chaos tests for cold-cache fanout. |
 | Testing | Vitess documents operational behaviors and has mature workflow surfaces to exercise. | RedDB has Maelstrom-style protocol model and Jepsen-style black-box harness docs, plus chaos replication tests. | Need public workflow E2E tests: planned failover, emergency failover, stale route, move range, and interrupted move. |
 
 ## Slack Production Signal
@@ -229,16 +229,18 @@ and future dashboards.
 Slack's 2022 incident is a concrete warning for RedDB's future cross-range read
 surface: a query that is cheap under a hot cache can become a keyspace-wide
 load amplifier when cache hit rates collapse. ADR 0055 already takes the right
-position by making cross-shard reads explicit and bounded. The missing maturity
-work is enforcement and operational behavior.
+position by making cross-shard reads explicit and bounded. The pure planning
+model now enforces explicit cross-owner fanout budgets and emits trace metadata;
+the remaining maturity work is wiring that contract into executor/transport
+behavior, runtime metrics, and overload handling.
 
 Minimum contract:
 
-- reject unbounded cross-range reads by default;
-- require an explicit fanout mode or API flag when a query cannot prove a shard
-  key predicate;
-- enforce per-request shard-count, timeout, row, byte, and coordinator-memory
-  budgets;
+- wire planner rejections into public API errors;
+- require the public request surface to set explicit fanout mode when a query
+  cannot prove a shard key predicate;
+- extend current owner/range/target budgets with timeout, row, byte, and
+  coordinator-memory budgets;
 - report participating ranges, partial status, retries, and timeout causes in
   traces and response metadata;
 - expose router/server metrics for fanout count, fanout latency, rejected fanout,
@@ -306,8 +308,8 @@ attached to named cluster workflows.
    - Mark each as implemented, modeled, or roadmap to avoid overclaiming.
 
 9. **Bounded fanout and overload guardrails**
-   - Enforce explicit fanout opt-in and per-request budgets for cross-range
-     reads.
+   - Wire explicit fanout opt-in and planner budgets into the executor and
+     public APIs.
    - Add metrics/traces for fanout, partial results, retry storms, and overload
      throttling.
    - Add cold-cache fanout scenarios to the chaos harness.


### PR DESCRIPTION
## Summary
- require explicit policy for read fanout that crosses owners
- add owner/range/target fanout budgets plus trace metadata for planned scatter reads
- update the multi-writer cluster drill and architecture docs to match the bounded fanout contract

## Verification
- cargo test -p reddb-io-server cluster::cross_range --lib
- cargo test -p reddb-io-server --test multi_writer_cluster_drill_e2e cross_range_writes_are_rejected_and_read_fanout_spans_owners
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785290454&installation_id=129708444&pr_number=1526&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1526&signature=31210923a9aac033f5e9e030fe07a8fb91c942577d0bb2047ee4d3c447424c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit, budgeted cross-range read fanout with visible trace metadata for owner, range, and target counts.
  * Cross-owner reads now require an explicit fanout mode and can be limited by configurable budgets.

* **Bug Fixes**
  * Improved fanout planning to reject unsupported or over-budget reads earlier and report clearer errors.
  * Cross-range detection now uses range metadata for more accurate results.

* **Documentation**
  * Clarified cluster read behavior and the distinction between default same-owner reads and explicit multi-owner fanout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->