### PR TITLE
merge: #1533 Block direct promotion of archive replicas

### DIFF
--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -73,7 +73,8 @@ pub use ownership_lease::{
     OwnerWriteMode, OwnershipLease, RangeRequest, SupervisorTerm,
 };
 pub use ownership_transition::{
-    prepare, run_transition, CatchUpEvidence, CommitWatermark, InvalidCandidateReason,
+    prepare, run_transition, validate_archive_recovery_source, ArchiveRecoveryEvidence,
+    ArchiveRecoveryRejection, CatchUpEvidence, CommitWatermark, InvalidCandidateReason,
     PreparedTransition, TransitionError, TransitionKind, TransitionOutcome, TransitionRejection,
     TransitionRequest,
 };

--- a/crates/reddb-server/src/cluster/ownership.rs
+++ b/crates/reddb-server/src/cluster/ownership.rs
@@ -829,6 +829,12 @@ impl RangeOwnership {
             RangeRole::Owner
         } else if self.replicas.iter().any(|replica| replica == node) {
             RangeRole::Replica
+        } else if self
+            .compressed_archive_replicas
+            .iter()
+            .any(|archive_replica| archive_replica == node)
+        {
+            RangeRole::ArchiveReplica
         } else {
             RangeRole::NoCopy
         }
@@ -912,6 +918,9 @@ pub enum RangeRole {
     /// rejected and routed to the owner; replicated changes still flow in via
     /// the privileged internal apply path.
     Replica,
+    /// Holds a compressed archive copy. Archive replicas are recovery sources
+    /// only after restore, checksum validation, and watermark validation.
+    ArchiveReplica,
     /// Holds no copy of the range at all.
     NoCopy,
 }
@@ -923,10 +932,15 @@ impl RangeRole {
         matches!(self, RangeRole::Owner)
     }
 
+    pub fn is_direct_promotion_candidate(self) -> bool {
+        matches!(self, RangeRole::Replica)
+    }
+
     fn label(self) -> &'static str {
         match self {
             RangeRole::Owner => "owner",
             RangeRole::Replica => "replica",
+            RangeRole::ArchiveReplica => "archive-replica",
             RangeRole::NoCopy => "no-copy",
         }
     }

--- a/crates/reddb-server/src/cluster/ownership_transition.rs
+++ b/crates/reddb-server/src/cluster/ownership_transition.rs
@@ -796,10 +796,11 @@ mod tests {
         archive_replicas: &[&str],
     ) -> (ShardOwnershipCatalog, CollectionId) {
         let (mut catalog, orders) = catalog_with(owner, replicas);
-        let archived = catalog
-            .range(&orders, RangeId::new(1))
-            .unwrap()
-            .update_archive_replicas(archive_replicas.iter().map(|r| ident(r)));
+        let range = catalog.range(&orders, RangeId::new(1)).unwrap();
+        let archived = range.update_replica_roles(
+            range.replicas().iter().cloned(),
+            archive_replicas.iter().map(|r| ident(r)),
+        );
         catalog.apply_update(archived).unwrap();
         (catalog, orders)
     }

--- a/crates/reddb-server/src/cluster/ownership_transition.rs
+++ b/crates/reddb-server/src/cluster/ownership_transition.rs
@@ -58,7 +58,7 @@
 
 use super::identity::NodeIdentity;
 use super::ownership::{
-    CatalogError, CatalogVersion, CollectionId, OwnershipEpoch, RangeId, RangeOwnership,
+    CatalogError, CatalogVersion, CollectionId, OwnershipEpoch, RangeId, RangeOwnership, RangeRole,
     ShardOwnershipCatalog,
 };
 
@@ -113,6 +113,58 @@ impl CatchUpEvidence {
         self.applied_term > watermark.term
             || (self.applied_term == watermark.term && self.applied_lsn >= watermark.lsn)
     }
+}
+
+/// Validation receipts required before a compressed archive copy may be used as
+/// a restored recovery source. This is deliberately separate from
+/// [`CatchUpEvidence`]: hot mirror promotion needs live catch-up evidence, while
+/// archive recovery must first prove restore integrity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArchiveRecoveryEvidence {
+    pub restore_validated: bool,
+    pub checksum_validated: bool,
+    pub watermark_validated: bool,
+}
+
+impl ArchiveRecoveryEvidence {
+    pub fn new(
+        restore_validated: bool,
+        checksum_validated: bool,
+        watermark_validated: bool,
+    ) -> Self {
+        Self {
+            restore_validated,
+            checksum_validated,
+            watermark_validated,
+        }
+    }
+}
+
+/// Why a compressed archive copy is not eligible to be used as a recovery
+/// source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArchiveRecoveryRejection {
+    NotArchiveReplica {
+        collection: CollectionId,
+        range_id: RangeId,
+        candidate: NodeIdentity,
+        role: RangeRole,
+    },
+    MissingRestoreValidation {
+        collection: CollectionId,
+        range_id: RangeId,
+        candidate: NodeIdentity,
+    },
+    MissingChecksumValidation {
+        collection: CollectionId,
+        range_id: RangeId,
+        candidate: NodeIdentity,
+    },
+    MissingWatermarkValidation {
+        collection: CollectionId,
+        range_id: RangeId,
+        candidate: NodeIdentity,
+    },
 }
 
 /// Whether a transition is a failover promote or a move-range handoff. Both run
@@ -224,6 +276,10 @@ pub enum InvalidCandidateReason {
     /// been receiving the range's stream can cover the commit watermark, so an
     /// arbitrary node is never a valid promotion target.
     NotAReplica,
+    /// The target is a compressed archive replica. Archive data may be a
+    /// recovery source only after restore, checksum validation, and watermark
+    /// validation prove the recovered range is safe.
+    ArchiveReplicaRequiresRestoreValidation,
     /// The target is already the current owner — a transition to the incumbent is
     /// a no-op and almost always a planner bug, so it is rejected.
     AlreadyOwner,
@@ -233,6 +289,9 @@ impl InvalidCandidateReason {
     fn label(self) -> &'static str {
         match self {
             InvalidCandidateReason::NotAReplica => "candidate is not a replica of the range",
+            InvalidCandidateReason::ArchiveReplicaRequiresRestoreValidation => {
+                "archive replica requires restore, checksum, and watermark validation"
+            }
             InvalidCandidateReason::AlreadyOwner => "candidate is already the current owner",
         }
     }
@@ -538,23 +597,35 @@ pub fn prepare(
         });
     }
 
-    // Candidate eligibility: a valid target is a current replica of the range
-    // and not the incumbent owner.
-    if request.target == *current.owner() {
-        return Err(TransitionRejection::InvalidCandidate {
-            collection: request.collection.clone(),
-            range_id: request.range_id,
-            candidate: request.target.clone(),
-            reason: InvalidCandidateReason::AlreadyOwner,
-        });
-    }
-    if !current.replicas().contains(&request.target) {
-        return Err(TransitionRejection::InvalidCandidate {
-            collection: request.collection.clone(),
-            range_id: request.range_id,
-            candidate: request.target.clone(),
-            reason: InvalidCandidateReason::NotAReplica,
-        });
+    // Candidate eligibility: a valid target is a hot replica of the range and
+    // not the incumbent owner. Compressed archive replicas are recovery sources,
+    // not direct promotion candidates.
+    match current.role_of(&request.target) {
+        RangeRole::Owner => {
+            return Err(TransitionRejection::InvalidCandidate {
+                collection: request.collection.clone(),
+                range_id: request.range_id,
+                candidate: request.target.clone(),
+                reason: InvalidCandidateReason::AlreadyOwner,
+            });
+        }
+        RangeRole::Replica => {}
+        RangeRole::ArchiveReplica => {
+            return Err(TransitionRejection::InvalidCandidate {
+                collection: request.collection.clone(),
+                range_id: request.range_id,
+                candidate: request.target.clone(),
+                reason: InvalidCandidateReason::ArchiveReplicaRequiresRestoreValidation,
+            });
+        }
+        RangeRole::NoCopy => {
+            return Err(TransitionRejection::InvalidCandidate {
+                collection: request.collection.clone(),
+                range_id: request.range_id,
+                candidate: request.target.clone(),
+                reason: InvalidCandidateReason::NotAReplica,
+            });
+        }
     }
 
     // Safety gate: evidence must exist, vouch for the target, and cover the
@@ -614,6 +685,51 @@ pub fn run_transition(
     prepared.activate(catalog).map_err(TransitionError::Catalog)
 }
 
+/// Validate that a compressed archive copy may be used as a recovery source.
+/// This never prepares a direct ownership transition; a recovered range must be
+/// restored and then enter the ordinary hot-replica path before promotion.
+pub fn validate_archive_recovery_source(
+    catalog: &ShardOwnershipCatalog,
+    collection: &CollectionId,
+    range_id: RangeId,
+    candidate: &NodeIdentity,
+    evidence: ArchiveRecoveryEvidence,
+) -> Result<(), ArchiveRecoveryRejection> {
+    let role = catalog
+        .role_at(candidate, collection, range_id)
+        .unwrap_or(RangeRole::NoCopy);
+    if role != RangeRole::ArchiveReplica {
+        return Err(ArchiveRecoveryRejection::NotArchiveReplica {
+            collection: collection.clone(),
+            range_id,
+            candidate: candidate.clone(),
+            role,
+        });
+    }
+    if !evidence.restore_validated {
+        return Err(ArchiveRecoveryRejection::MissingRestoreValidation {
+            collection: collection.clone(),
+            range_id,
+            candidate: candidate.clone(),
+        });
+    }
+    if !evidence.checksum_validated {
+        return Err(ArchiveRecoveryRejection::MissingChecksumValidation {
+            collection: collection.clone(),
+            range_id,
+            candidate: candidate.clone(),
+        });
+    }
+    if !evidence.watermark_validated {
+        return Err(ArchiveRecoveryRejection::MissingWatermarkValidation {
+            collection: collection.clone(),
+            range_id,
+            candidate: candidate.clone(),
+        });
+    }
+    Ok(())
+}
+
 /// The error of an end-to-end [`run_transition`]: either the safety gate refused
 /// the transition, or the catalog rejected the activation write.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -671,6 +787,20 @@ mod tests {
                 PlacementMetadata::with_replication_factor(3),
             ))
             .unwrap();
+        (catalog, orders)
+    }
+
+    fn catalog_with_archive(
+        owner: &str,
+        replicas: &[&str],
+        archive_replicas: &[&str],
+    ) -> (ShardOwnershipCatalog, CollectionId) {
+        let (mut catalog, orders) = catalog_with(owner, replicas);
+        let archived = catalog
+            .range(&orders, RangeId::new(1))
+            .unwrap()
+            .update_archive_replicas(archive_replicas.iter().map(|r| ident(r)));
+        catalog.apply_update(archived).unwrap();
         (catalog, orders)
     }
 
@@ -875,6 +1005,117 @@ mod tests {
             }
             other => panic!("expected InvalidCandidate(NotAReplica), got {other:?}"),
         }
+    }
+
+    #[test]
+    fn archive_replica_is_not_a_direct_promotion_candidate() {
+        let (catalog, orders) =
+            catalog_with_archive("CN=node-a", &["CN=node-b"], &["CN=archive-a"]);
+        let version = catalog.range(&orders, RangeId::new(1)).unwrap().version();
+        let req = TransitionRequest::new(
+            TransitionKind::Promote,
+            orders.clone(),
+            RangeId::new(1),
+            ident("CN=node-a"),
+            OwnershipEpoch::initial(),
+            version,
+            ident("CN=archive-a"),
+            CommitWatermark::new(1, 10),
+        )
+        .with_evidence(CatchUpEvidence::new(ident("CN=archive-a"), 1, 10));
+
+        let err = prepare(&catalog, &req).unwrap_err();
+        match err {
+            TransitionRejection::InvalidCandidate { reason, .. } => {
+                assert_eq!(
+                    reason,
+                    InvalidCandidateReason::ArchiveReplicaRequiresRestoreValidation
+                );
+            }
+            other => panic!("expected archive replica rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn archive_recovery_rejects_missing_restore_validation() {
+        let (catalog, orders) = catalog_with_archive("CN=node-a", &[], &["CN=archive-a"]);
+        let err = validate_archive_recovery_source(
+            &catalog,
+            &orders,
+            RangeId::new(1),
+            &ident("CN=archive-a"),
+            ArchiveRecoveryEvidence::new(false, true, true),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ArchiveRecoveryRejection::MissingRestoreValidation { .. }
+        ));
+    }
+
+    #[test]
+    fn archive_recovery_rejects_missing_checksum_validation() {
+        let (catalog, orders) = catalog_with_archive("CN=node-a", &[], &["CN=archive-a"]);
+        let err = validate_archive_recovery_source(
+            &catalog,
+            &orders,
+            RangeId::new(1),
+            &ident("CN=archive-a"),
+            ArchiveRecoveryEvidence::new(true, false, true),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ArchiveRecoveryRejection::MissingChecksumValidation { .. }
+        ));
+    }
+
+    #[test]
+    fn archive_recovery_rejects_missing_watermark_validation() {
+        let (catalog, orders) = catalog_with_archive("CN=node-a", &[], &["CN=archive-a"]);
+        let err = validate_archive_recovery_source(
+            &catalog,
+            &orders,
+            RangeId::new(1),
+            &ident("CN=archive-a"),
+            ArchiveRecoveryEvidence::new(true, true, false),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ArchiveRecoveryRejection::MissingWatermarkValidation { .. }
+        ));
+    }
+
+    #[test]
+    fn archive_recovery_and_hot_mirror_promotion_use_different_paths() {
+        let (mut catalog, orders) =
+            catalog_with_archive("CN=node-a", &["CN=node-b"], &["CN=archive-a"]);
+        let version = catalog.range(&orders, RangeId::new(1)).unwrap().version();
+
+        let hot_mirror = TransitionRequest::new(
+            TransitionKind::Promote,
+            orders.clone(),
+            RangeId::new(1),
+            ident("CN=node-a"),
+            OwnershipEpoch::initial(),
+            version,
+            ident("CN=node-b"),
+            CommitWatermark::new(1, 10),
+        )
+        .with_evidence(CatchUpEvidence::new(ident("CN=node-b"), 1, 10));
+        run_transition(&mut catalog, &hot_mirror).expect("hot mirror promotion succeeds");
+
+        let (catalog, orders) =
+            catalog_with_archive("CN=node-a", &["CN=node-b"], &["CN=archive-a"]);
+        validate_archive_recovery_source(
+            &catalog,
+            &orders,
+            RangeId::new(1),
+            &ident("CN=archive-a"),
+            ArchiveRecoveryEvidence::new(true, true, true),
+        )
+        .expect("archive recovery accepts only after restore integrity validation");
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1533. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1533

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785305484&installation_id=129708444&pr_number=1545&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1545&signature=750efe6e646cf0b6cb8439682f290d88f0a6f4ff0248676bf4d7d9d7d2b13dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for archive replicas in range ownership, including a distinct archive-replica role.
  * Introduced archive recovery validation so only fully verified archive sources can be used for recovery.

* **Bug Fixes**
  * Tightened ownership transition checks to prevent invalid promotion paths.
  * Improved rejection messages for unsupported or unverified candidate nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->