### PR TITLE
merge: #1534 Project serving graph with Placement Authority and replica roles

### DIFF
--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -60,9 +60,9 @@ pub use ownership::{
     CatalogError, CatalogVersion, CollectionGroupAuthority, CollectionGroupId,
     CollectionGroupIdError, CollectionId, CollectionIdError, HotMirrorCandidate,
     HotMirrorPromotion, HotMirrorPromotionRefusal, OwnershipEpoch, PlacementAuthorityCatalog,
-    PlacementAuthorityError, PlacementMetadata, RangeBound, RangeBounds, RangeBoundsError, RangeId,
-    RangeOwnership, RangeRole, RangeWriteReject, ReplicaRole, ShardKeyMode, ShardOwnershipCatalog,
-    UpdateOutcome,
+    PlacementAuthorityError, PlacementAuthorityId, PlacementAuthorityIdError, PlacementMetadata,
+    RangeBound, RangeBounds, RangeBoundsError, RangeId, RangeOwnership, RangeRole,
+    RangeWriteReject, ReplicaRole, ShardKeyMode, ShardOwnershipCatalog, UpdateOutcome,
 };
 pub use ownership_force::{
     force_transition, EmptyOperatorReason, ForceDenial, ForceFailure, ForceTransitionCapability,
@@ -95,5 +95,6 @@ pub use supervisor::{
     HealthPolicy, HealthScore, MemberSignals, PlannedPromotion,
 };
 pub use topology::{
-    ClientTopology, HintOutcome, RefreshOutcome, TopologyRange, TopologySnapshot, TopologyUpdate,
+    ClientTopology, HintOutcome, RefreshOutcome, TopologyAuthority, TopologyRange,
+    TopologySnapshot, TopologyUpdate,
 };

--- a/crates/reddb-server/src/cluster/ownership.rs
+++ b/crates/reddb-server/src/cluster/ownership.rs
@@ -120,6 +120,10 @@ impl CollectionGroupId {
         Ok(Self(value.to_string()))
     }
 
+    pub fn for_collection(collection: &CollectionId) -> Self {
+        Self(collection.as_str().to_string())
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -271,6 +275,45 @@ impl PlacementAuthorityCatalog {
         self.assignments
             .values()
             .find(|assignment| assignment.collections.contains(collection))
+    }
+}
+
+/// Stable identity of the Placement Authority that publishes a collection group.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PlacementAuthorityId(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlacementAuthorityIdError;
+
+impl std::fmt::Display for PlacementAuthorityIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "placement authority id is empty")
+    }
+}
+
+impl std::error::Error for PlacementAuthorityIdError {}
+
+impl PlacementAuthorityId {
+    pub fn new(value: impl AsRef<str>) -> Result<Self, PlacementAuthorityIdError> {
+        let value = value.as_ref().trim();
+        if value.is_empty() {
+            return Err(PlacementAuthorityIdError);
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn default_global() -> Self {
+        Self("global-placement-authority".to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for PlacementAuthorityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
     }
 }
 
@@ -560,6 +603,8 @@ impl PlacementMetadata {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RangeOwnership {
     collection: CollectionId,
+    collection_group: CollectionGroupId,
+    placement_authority: PlacementAuthorityId,
     range_id: RangeId,
     shard_key_mode: ShardKeyMode,
     bounds: RangeBounds,
@@ -632,8 +677,11 @@ impl RangeOwnership {
         replicas: impl IntoIterator<Item = NodeIdentity>,
         placement: PlacementMetadata,
     ) -> Self {
+        let collection_group = CollectionGroupId::for_collection(&collection);
         Self {
             collection,
+            collection_group,
+            placement_authority: PlacementAuthorityId::default_global(),
             range_id,
             shard_key_mode,
             bounds,
@@ -648,6 +696,14 @@ impl RangeOwnership {
 
     pub fn collection(&self) -> &CollectionId {
         &self.collection
+    }
+
+    pub fn collection_group(&self) -> &CollectionGroupId {
+        &self.collection_group
+    }
+
+    pub fn placement_authority(&self) -> &PlacementAuthorityId {
+        &self.placement_authority
     }
 
     pub fn range_id(&self) -> RangeId {
@@ -699,6 +755,16 @@ impl RangeOwnership {
     /// The catalog key for this entry: `(collection, range_id)`.
     fn key(&self) -> (CollectionId, RangeId) {
         (self.collection.clone(), self.range_id)
+    }
+
+    pub fn with_collection_group(mut self, collection_group: CollectionGroupId) -> Self {
+        self.collection_group = collection_group;
+        self
+    }
+
+    pub fn with_placement_authority(mut self, placement_authority: PlacementAuthorityId) -> Self {
+        self.placement_authority = placement_authority;
+        self
     }
 
     /// A transition that moves write authority to `new_owner` with `new_replicas`.

--- a/crates/reddb-server/src/cluster/topology.rs
+++ b/crates/reddb-server/src/cluster/topology.rs
@@ -39,11 +39,19 @@ use std::collections::BTreeMap;
 
 use super::identity::NodeIdentity;
 use super::ownership::{
-    CatalogVersion, CollectionId, OwnershipEpoch, RangeBounds, RangeId, RangeOwnership,
-    ReplicaRole, ShardKeyMode, ShardOwnershipCatalog,
+    CatalogVersion, CollectionGroupId, CollectionId, OwnershipEpoch, PlacementAuthorityId,
+    RangeBounds, RangeId, RangeOwnership, ReplicaRole, ShardKeyMode, ShardOwnershipCatalog,
 };
 use super::routing::RoutingHint;
 use super::slot::hash_shard_key_to_range_key;
+
+/// What authority a topology/serving-graph projection carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TopologyAuthority {
+    /// Consumable by routers and drivers, but never sufficient to authorize a
+    /// durable write without the owner-side epoch fence.
+    RoutingMetadataOnly,
+}
 
 /// One range's routing metadata as a driver sees it.
 ///
@@ -56,6 +64,8 @@ use super::slot::hash_shard_key_to_range_key;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TopologyRange {
     collection: CollectionId,
+    collection_group: CollectionGroupId,
+    placement_authority: PlacementAuthorityId,
     range_id: RangeId,
     shard_key_mode: ShardKeyMode,
     bounds: RangeBounds,
@@ -70,6 +80,8 @@ impl TopologyRange {
     fn from_ownership(range: &RangeOwnership) -> Self {
         Self {
             collection: range.collection().clone(),
+            collection_group: range.collection_group().clone(),
+            placement_authority: range.placement_authority().clone(),
             range_id: range.range_id(),
             shard_key_mode: range.shard_key_mode(),
             bounds: range.bounds().clone(),
@@ -85,6 +97,14 @@ impl TopologyRange {
         &self.collection
     }
 
+    pub fn collection_group(&self) -> &CollectionGroupId {
+        &self.collection_group
+    }
+
+    pub fn placement_authority(&self) -> &PlacementAuthorityId {
+        &self.placement_authority
+    }
+
     pub fn range_id(&self) -> RangeId {
         self.range_id
     }
@@ -98,6 +118,10 @@ impl TopologyRange {
     }
 
     pub fn owner(&self) -> &NodeIdentity {
+        &self.owner
+    }
+
+    pub fn range_owner(&self) -> &NodeIdentity {
         &self.owner
     }
 
@@ -163,6 +187,11 @@ pub struct TopologySnapshot {
 }
 
 impl TopologySnapshot {
+    /// The authority level carried by this serving graph projection.
+    pub fn authority(&self) -> TopologyAuthority {
+        TopologyAuthority::RoutingMetadataOnly
+    }
+
     /// The snapshot generation — the high-water catalog version across its ranges.
     pub fn version(&self) -> CatalogVersion {
         self.version
@@ -576,14 +605,26 @@ mod tests {
     fn snapshot_exposes_explicit_replica_roles() {
         let orders = collection("orders");
         let catalog = catalog_with([full_range(&orders, 1, "CN=node-a", &["CN=node-b"])
+            .with_collection_group(CollectionGroupId::new("commerce").unwrap())
+            .with_placement_authority(PlacementAuthorityId::new("pa-commerce-1").unwrap())
             .with_compressed_archive_replicas([ident("CN=node-c")])]);
 
         let snapshot = catalog.topology_snapshot();
+        assert_eq!(snapshot.authority(), TopologyAuthority::RoutingMetadataOnly);
         let range = snapshot
             .route(&orders, b"any-key")
             .expect("full range covers all keys");
 
         assert_eq!(range.owner(), &ident("CN=node-a"));
+        assert_eq!(range.range_owner(), &ident("CN=node-a"));
+        assert_eq!(
+            range.collection_group(),
+            &CollectionGroupId::new("commerce").unwrap()
+        );
+        assert_eq!(
+            range.placement_authority(),
+            &PlacementAuthorityId::new("pa-commerce-1").unwrap()
+        );
         assert_eq!(range.hot_mirror_replicas(), &[ident("CN=node-b")]);
         assert_eq!(range.compressed_archive_replicas(), &[ident("CN=node-c")]);
         assert_eq!(range.promotion_candidates(), &[ident("CN=node-b")]);
@@ -594,6 +635,42 @@ mod tests {
         assert_eq!(
             range.replica_role_of(&ident("CN=node-c")),
             Some(ReplicaRole::CompressedArchive)
+        );
+    }
+
+    #[test]
+    fn serving_graph_reflects_ownership_transitions_and_replica_roles() {
+        let orders = collection("orders");
+        let range = full_range(&orders, 1, "CN=node-a", &["CN=node-b"])
+            .with_collection_group(CollectionGroupId::new("commerce").unwrap())
+            .with_placement_authority(PlacementAuthorityId::new("pa-commerce-1").unwrap())
+            .with_compressed_archive_replicas([ident("CN=node-c")]);
+        let mut catalog = catalog_with([range]);
+
+        let current = catalog.range(&orders, RangeId::new(1)).unwrap().clone();
+        catalog
+            .apply_update(current.transfer_to(ident("CN=node-b"), [ident("CN=node-a")]))
+            .unwrap();
+        let current = catalog.range(&orders, RangeId::new(1)).unwrap().clone();
+        catalog
+            .apply_update(current.update_replica_roles([ident("CN=node-a")], [ident("CN=node-d")]))
+            .unwrap();
+
+        let projected = catalog
+            .topology_snapshot()
+            .range(&orders, RangeId::new(1))
+            .unwrap()
+            .clone();
+
+        assert_eq!(projected.range_owner(), &ident("CN=node-b"));
+        assert_eq!(projected.hot_mirror_replicas(), &[ident("CN=node-a")]);
+        assert_eq!(
+            projected.compressed_archive_replicas(),
+            &[ident("CN=node-d")]
+        );
+        assert_eq!(
+            projected.placement_authority(),
+            &PlacementAuthorityId::new("pa-commerce-1").unwrap()
         );
     }
 


### PR DESCRIPTION
Automated AFK landing for #1534. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1534

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785306697&installation_id=129708444&pr_number=1546&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1546&signature=5c5420c3329a1645802e348971bebce41728c5dae0c8f0df186a680deebc8756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->