### PR TITLE
merge: #1535 Prove stale topology cannot create split-brain writes

### DIFF
--- a/crates/reddb-server/src/cluster/ownership_lease.rs
+++ b/crates/reddb-server/src/cluster/ownership_lease.rs
@@ -69,7 +69,8 @@
 
 use super::identity::NodeIdentity;
 use super::ownership::{
-    CollectionId, OwnershipEpoch, RangeId, RangeOwnership, RangeRole, ShardOwnershipCatalog,
+    CatalogVersion, CollectionId, OwnershipEpoch, RangeId, RangeOwnership, RangeRole,
+    ShardOwnershipCatalog,
 };
 
 /// The Cluster Supervisor term an ownership lease is granted under.
@@ -471,6 +472,8 @@ pub enum DurableWriteReject {
         range_id: RangeId,
         role: RangeRole,
         owner: NodeIdentity,
+        epoch: OwnershipEpoch,
+        version: CatalogVersion,
     },
     /// This node *is* the catalog owner, but it is self-fenced: it holds no valid
     /// lease for the range. Carries the [`FenceReason`].
@@ -503,10 +506,12 @@ impl std::fmt::Display for DurableWriteReject {
                 collection,
                 range_id,
                 owner,
+                epoch,
+                version,
                 ..
             } => write!(
                 f,
-                "this node does not own {collection}/{range_id} — route the durable write to {owner}"
+                "this node does not own {collection}/{range_id} — route the durable write to {owner} at epoch {epoch} (catalog version {version})"
             ),
             Self::Fenced {
                 collection,
@@ -576,6 +581,8 @@ pub fn admit_durable_write<'c>(
             range_id: range.range_id(),
             role,
             owner: range.owner().clone(),
+            epoch: range.epoch(),
+            version: range.version(),
         });
     }
 

--- a/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
+++ b/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
@@ -536,15 +536,17 @@ fn stale_topology_targeting_old_owner_cannot_create_split_brain_writes() {
         term,
         500,
     ) {
-        Err(DurableWriteReject::NotOwner {
-            owner,
-            epoch,
-            version,
+        Err(DurableWriteReject::StaleOwnership {
+            attempted_owner,
+            current_owner,
+            attempted_epoch,
+            current_epoch,
             ..
         }) => {
-            assert_eq!(owner, ident(NODE_B));
-            assert_eq!(epoch, new_epoch);
-            assert_eq!(version, after.version());
+            assert_eq!(attempted_owner, stale_owner);
+            assert_eq!(current_owner, ident(NODE_B));
+            assert_eq!(attempted_epoch, old_epoch);
+            assert_eq!(current_epoch, new_epoch);
         }
         other => panic!("expected stale owner durable-write rejection, got {other:?}"),
     }

--- a/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
+++ b/crates/reddb-server/tests/multi_writer_cluster_drill_e2e.rs
@@ -40,8 +40,8 @@ use reddb_server::cluster::{
     KeyTarget, LeasedOwner, MemberCapacity, MemberKind, MemberSignals, MembershipCatalog,
     NodeIdentity, OperatorReason, OwnerWriteMode, OwnershipEpoch, OwnershipLease,
     PlacementMetadata, PlacementPolicy, PlacementSignals, RangeBound, RangeBounds, RangeId,
-    RangeLoad, RangeOwnership, RangeRole, RangeWriteReject, RedirectReason, RequestOperation,
-    RouteDecision, RoutedRequest, RoutingPolicy, SeedAuthority, ShardKeyMode,
+    RangeLoad, RangeOwnership, RangeRequest, RangeRole, RangeWriteReject, RedirectReason,
+    RequestOperation, RouteDecision, RoutedRequest, RoutingPolicy, SeedAuthority, ShardKeyMode,
     ShardOwnershipCatalog, SupervisorTerm, TransitionKind, WeightedPlacementPlanner,
     WriteTransactionReject,
 };
@@ -448,6 +448,130 @@ fn stale_client_is_corrected_by_redirect_and_safe_reads_are_forwarded() {
         RouteDecision::Forward { hint } => assert_eq!(hint.owner(), &ident(NODE_B)),
         other => panic!("expected safe forward to owner, got {other:?}"),
     }
+}
+
+#[test]
+fn stale_topology_targeting_old_owner_cannot_create_split_brain_writes() {
+    let (mut catalog, orders) = ownership_two_ranges();
+    let mut client =
+        reddb_server::cluster::ClientTopology::from_snapshot(catalog.topology_snapshot());
+    let term = SupervisorTerm::genesis();
+
+    let before = catalog.range(&orders, RangeId::new(1)).unwrap().clone();
+    let old_epoch = before.epoch();
+    let old_owner_lease = OwnershipLease::grant(
+        term,
+        orders.clone(),
+        RangeId::new(1),
+        ident(NODE_A),
+        old_epoch,
+        0,
+        10_000,
+    );
+    let old_owner = LeasedOwner::with_lease(old_owner_lease);
+
+    catalog
+        .apply_update(before.transfer_to(ident(NODE_B), [ident(NODE_A), ident(NODE_C)]))
+        .expect("ownership transition applied");
+    let after = catalog.range(&orders, RangeId::new(1)).unwrap();
+    let new_epoch = after.epoch();
+    assert!(
+        new_epoch.value() > old_epoch.value(),
+        "ownership transition bumped the fencing epoch"
+    );
+
+    // The cached topology is stale and still targets the old owner.
+    let stale_owner = client
+        .resolve(&orders, &KEY_LOW)
+        .expect("stale topology resolves low key")
+        .clone();
+    assert_eq!(
+        stale_owner,
+        ident(NODE_A),
+        "stale topology targets old owner"
+    );
+
+    // Routing through the live cluster seam returns a refreshable correction.
+    let write = RoutedRequest::new(
+        orders.clone(),
+        KEY_LOW.to_vec(),
+        RequestOperation::Transaction,
+    );
+    let hint = match catalog.plan_route(&stale_owner, &write, &RoutingPolicy::forwarding()) {
+        RouteDecision::Redirect { hint, reason } => {
+            assert_eq!(reason, RedirectReason::Transaction);
+            hint
+        }
+        other => panic!("expected stale topology to redirect, got {other:?}"),
+    };
+    assert_eq!(hint.owner(), &ident(NODE_B));
+    assert_eq!(hint.epoch(), new_epoch);
+    assert_eq!(client.apply_hint(&hint), HintOutcome::Corrected);
+    assert!(client.needs_refresh(), "hint is enough to trigger refresh");
+
+    // Even if the stale topology sends the write to the old owner, the old
+    // owner's lease is behind the current epoch and fences durable writes.
+    match old_owner.admit_request(RangeRequest::DurableWrite, term, new_epoch, 500) {
+        Err(err) => match err.reason {
+            FenceReason::EpochSuperseded {
+                lease_epoch,
+                current_epoch,
+            } => {
+                assert_eq!(lease_epoch, old_epoch);
+                assert_eq!(current_epoch, new_epoch);
+            }
+            other => panic!("expected epoch fence, got {other:?}"),
+        },
+        Ok(()) => panic!("old owner accepted a durable write after epoch bump"),
+    }
+
+    // The combined durable-write gate also rejects the old owner and carries the
+    // current owner/epoch/version facts needed for safe retry.
+    match admit_durable_write(
+        &catalog,
+        &old_owner,
+        &stale_owner,
+        &orders,
+        &KEY_LOW,
+        term,
+        500,
+    ) {
+        Err(DurableWriteReject::NotOwner {
+            owner,
+            epoch,
+            version,
+            ..
+        }) => {
+            assert_eq!(owner, ident(NODE_B));
+            assert_eq!(epoch, new_epoch);
+            assert_eq!(version, after.version());
+        }
+        other => panic!("expected stale owner durable-write rejection, got {other:?}"),
+    }
+
+    // The new owner, holding a lease for the bumped epoch, is the only node that
+    // can accept the durable write.
+    let new_owner = LeasedOwner::with_lease(OwnershipLease::grant(
+        term,
+        orders.clone(),
+        RangeId::new(1),
+        ident(NODE_B),
+        new_epoch,
+        0,
+        10_000,
+    ));
+    let admitted = admit_durable_write(
+        &catalog,
+        &new_owner,
+        &ident(NODE_B),
+        &orders,
+        &KEY_LOW,
+        term,
+        500,
+    )
+    .expect("new owner accepts durable write at the bumped epoch");
+    assert_eq!(admitted.owner(), &ident(NODE_B));
+    assert_eq!(admitted.epoch(), new_epoch);
 }
 
 // --- criterion 4: failover only when commit watermark is covered --------------


### PR DESCRIPTION
Automated AFK landing for #1535. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1535

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1547"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785308314&installation_id=129708444&pr_number=1547&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1547&signature=ed46bf96ec9eeecf9805dd8592ab760e7874f793973e8a755a5773818d052182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rejection messages for writes sent to the wrong node, now showing more routing and version context to help with retries.
  * Strengthened protection against stale cluster information, preventing writes from being accepted after ownership changes.

* **Tests**
  * Added end-to-end coverage for ownership transitions and stale-client write handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->