### PR TITLE
merge: #1538 Tie move-range cutover to Collection group Placement Authority

### DIFF
--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -85,10 +85,9 @@ pub use ownership_transition::{
     TransitionRequest,
 };
 pub use placement::{
-    AuthorityScopedPlannedMove, AuthorityScopedRebalancePlan, CollectionGroupId,
-    CollectionGroupPlacementAuthority, HotspotRange, MemberCapacity, MoveReason,
-    PlacementAuthorityCatalog, PlacementAuthorityError, PlacementPolicy, PlacementSignals,
-    PlannedMove, RangeLoad, RebalancePlan, WeightedPlacementPlanner, NEUTRAL_OPERATOR_WEIGHT,
+    AuthorityScopedPlannedMove, AuthorityScopedRebalancePlan, CollectionGroupPlacementAuthority,
+    HotspotRange, MemberCapacity, MoveReason, PlacementPolicy, PlacementSignals, PlannedMove,
+    RangeLoad, RebalancePlan, WeightedPlacementPlanner, NEUTRAL_OPERATOR_WEIGHT,
 };
 pub use routing::{
     RedirectReason, RequestOperation, RouteDecision, RoutedRequest, RoutingHint, RoutingPolicy,

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -85,8 +85,10 @@ pub use ownership_transition::{
     TransitionRequest,
 };
 pub use placement::{
-    HotspotRange, MemberCapacity, MoveReason, PlacementPolicy, PlacementSignals, PlannedMove,
-    RangeLoad, RebalancePlan, WeightedPlacementPlanner, NEUTRAL_OPERATOR_WEIGHT,
+    AuthorityScopedPlannedMove, AuthorityScopedRebalancePlan, CollectionGroupId,
+    CollectionGroupPlacementAuthority, HotspotRange, MemberCapacity, MoveReason,
+    PlacementAuthorityCatalog, PlacementAuthorityError, PlacementPolicy, PlacementSignals,
+    PlannedMove, RangeLoad, RebalancePlan, WeightedPlacementPlanner, NEUTRAL_OPERATOR_WEIGHT,
 };
 pub use routing::{
     RedirectReason, RequestOperation, RouteDecision, RoutedRequest, RoutingHint, RoutingPolicy,

--- a/crates/reddb-server/src/cluster/move_range.rs
+++ b/crates/reddb-server/src/cluster/move_range.rs
@@ -72,7 +72,7 @@ use super::ownership_transition::{
     run_transition, CatchUpEvidence, CommitWatermark, TransitionError, TransitionKind,
     TransitionOutcome, TransitionRequest,
 };
-use super::placement::RangeLoad;
+use super::placement::{CollectionGroupId, CollectionGroupPlacementAuthority, RangeLoad};
 
 /// The thresholds that decide whether a range is small enough to move whole or
 /// must be split first.
@@ -307,6 +307,9 @@ pub struct MoveRange {
     /// The target's range-indexed catch-up position over the shared WAL, once the
     /// snapshot is installed and catch-up begins.
     position: Option<RangeStreamPosition>,
+    /// The Collection group Placement Authority that scoped this movement, when
+    /// the caller uses the authority-checked workflow.
+    placement_authority: Option<CollectionGroupPlacementAuthority>,
 }
 
 impl MoveRange {
@@ -365,7 +368,25 @@ impl MoveRange {
             phase: MovePhase::CopyingSnapshot,
             snapshot_watermark: None,
             position: None,
+            placement_authority: None,
         })
+    }
+
+    /// Start a move under the Collection group Placement Authority responsible
+    /// for this range's collection. The authority scopes the operational move;
+    /// the later cutover still transitions only this range's owner and epoch.
+    pub fn begin_authorized(
+        catalog: &mut ShardOwnershipCatalog,
+        collection: CollectionId,
+        range_id: RangeId,
+        target: NodeIdentity,
+        placement_authority: CollectionGroupPlacementAuthority,
+        caller: &NodeIdentity,
+    ) -> Result<Self, MoveError> {
+        validate_placement_authority(&collection, &placement_authority, caller)?;
+        let mut movement = Self::begin(catalog, collection, range_id, target)?;
+        movement.placement_authority = Some(placement_authority);
+        Ok(movement)
     }
 
     pub fn phase(&self) -> MovePhase {
@@ -496,6 +517,25 @@ impl MoveRange {
         Ok(outcome)
     }
 
+    /// Cut over under the same Collection group Placement Authority that planned
+    /// the move. The authority check gates the workflow, then the catalog update
+    /// remains the same per-range fenced handoff as [`cut_over`](Self::cut_over).
+    pub fn cut_over_authorized(
+        &mut self,
+        catalog: &mut ShardOwnershipCatalog,
+        live: CommitWatermark,
+        caller: &NodeIdentity,
+    ) -> Result<TransitionOutcome, MoveError> {
+        let placement_authority = self.placement_authority.as_ref().ok_or_else(|| {
+            MoveError::MissingPlacementAuthority {
+                collection: self.collection.clone(),
+                range_id: self.range_id,
+            }
+        })?;
+        validate_placement_authority(&self.collection, placement_authority, caller)?;
+        self.cut_over(catalog, live)
+    }
+
     /// Abandon the move. The catalog is untouched (the old owner remains owner);
     /// the target keeps whatever copy it has but is never promoted.
     pub fn abort(&mut self) {
@@ -512,6 +552,28 @@ impl MoveRange {
             })
         }
     }
+}
+
+fn validate_placement_authority(
+    collection: &CollectionId,
+    placement_authority: &CollectionGroupPlacementAuthority,
+    caller: &NodeIdentity,
+) -> Result<(), MoveError> {
+    if !placement_authority.covers(collection) {
+        return Err(MoveError::CollectionOutsidePlacementAuthority {
+            collection: collection.clone(),
+            collection_group: placement_authority.collection_group().clone(),
+            authority: placement_authority.authority().clone(),
+        });
+    }
+    if placement_authority.authority() != caller {
+        return Err(MoveError::WrongPlacementAuthority {
+            collection_group: placement_authority.collection_group().clone(),
+            expected: placement_authority.authority().clone(),
+            actual: caller.clone(),
+        });
+    }
+    Ok(())
 }
 
 /// Resume an interrupted move and decide its fate from the target's persisted
@@ -658,6 +720,23 @@ pub enum MoveError {
         applied_term: u64,
         applied_lsn: u64,
     },
+    /// The scoped workflow was used without an authority token.
+    MissingPlacementAuthority {
+        collection: CollectionId,
+        range_id: RangeId,
+    },
+    /// The authority token does not cover this range's collection.
+    CollectionOutsidePlacementAuthority {
+        collection: CollectionId,
+        collection_group: CollectionGroupId,
+        authority: NodeIdentity,
+    },
+    /// A different Placement Authority attempted the scoped transition.
+    WrongPlacementAuthority {
+        collection_group: CollectionGroupId,
+        expected: NodeIdentity,
+        actual: NodeIdentity,
+    },
     /// A catalog write (replica enlistment) was rejected.
     Catalog(CatalogError),
     /// The fenced handoff transition was rejected (a CAS or safety failure) or the
@@ -697,6 +776,29 @@ impl std::fmt::Display for MoveError {
                 "cannot cut over {collection}/{range_id} to {target}: applied term {applied_term} lsn {applied_lsn} is behind the commit watermark term {} lsn {}",
                 watermark.term, watermark.lsn
             ),
+            Self::MissingPlacementAuthority {
+                collection,
+                range_id,
+            } => write!(
+                f,
+                "move-range {collection}/{range_id} has no collection group placement authority"
+            ),
+            Self::CollectionOutsidePlacementAuthority {
+                collection,
+                collection_group,
+                authority,
+            } => write!(
+                f,
+                "placement authority {authority} for collection group {collection_group} does not cover collection {collection}"
+            ),
+            Self::WrongPlacementAuthority {
+                collection_group,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "placement authority {actual} cannot transition collection group {collection_group}; expected {expected}"
+            ),
             Self::Catalog(err) => write!(f, "{err}"),
             Self::Transition(err) => write!(f, "{err}"),
         }
@@ -711,6 +813,7 @@ mod tests {
     use crate::cluster::ownership::{
         PlacementMetadata, RangeBound, RangeBounds, RangeRole, RangeWriteReject, ShardKeyMode,
     };
+    use crate::cluster::{CollectionGroupId, CollectionGroupPlacementAuthority};
     use crate::replication::cdc::ChangeOperation;
 
     fn collection(name: &str) -> CollectionId {
@@ -1007,6 +1110,52 @@ mod tests {
             catalog.range(&orders, RangeId::new(1)).unwrap().owner(),
             &ident("CN=node-a")
         );
+    }
+
+    #[test]
+    fn authorized_cutover_rejects_the_wrong_collection_group_authority() {
+        let (mut catalog, orders) = catalog_with("CN=node-a", &[]);
+        let authority = CollectionGroupPlacementAuthority::new(
+            CollectionGroupId::new("commerce").unwrap(),
+            ident("CN=pa-commerce"),
+            [orders.clone()],
+        )
+        .unwrap();
+        let mut mv = MoveRange::begin_authorized(
+            &mut catalog,
+            orders.clone(),
+            RangeId::new(1),
+            ident("CN=node-b"),
+            authority,
+            &ident("CN=pa-commerce"),
+        )
+        .unwrap();
+        mv.complete_snapshot(CommitWatermark::new(1, 10)).unwrap();
+        mv.record_catch_up(&[record(1, 1, 20, 1)]).unwrap();
+
+        let err = mv
+            .cut_over_authorized(
+                &mut catalog,
+                CommitWatermark::new(1, 20),
+                &ident("CN=pa-analytics"),
+            )
+            .unwrap_err();
+
+        assert!(matches!(err, MoveError::WrongPlacementAuthority { .. }));
+        assert_eq!(
+            catalog.range(&orders, RangeId::new(1)).unwrap().owner(),
+            &ident("CN=node-a")
+        );
+
+        mv.cut_over_authorized(
+            &mut catalog,
+            CommitWatermark::new(1, 20),
+            &ident("CN=pa-commerce"),
+        )
+        .unwrap();
+        let moved = catalog.range(&orders, RangeId::new(1)).unwrap();
+        assert_eq!(moved.owner(), &ident("CN=node-b"));
+        assert!(moved.epoch().value() > OwnershipEpoch::initial().value());
     }
 
     // --- split-and-move end to end ---------------------------------------

--- a/crates/reddb-server/src/cluster/move_range.rs
+++ b/crates/reddb-server/src/cluster/move_range.rs
@@ -813,7 +813,6 @@ mod tests {
     use crate::cluster::ownership::{
         PlacementMetadata, RangeBound, RangeBounds, RangeRole, RangeWriteReject, ShardKeyMode,
     };
-    use crate::cluster::{CollectionGroupId, CollectionGroupPlacementAuthority};
     use crate::replication::cdc::ChangeOperation;
 
     fn collection(name: &str) -> CollectionId {

--- a/crates/reddb-server/src/cluster/placement.rs
+++ b/crates/reddb-server/src/cluster/placement.rs
@@ -56,7 +56,7 @@
 //! balancing, and hotspot story is exercised deterministically — no disk, no
 //! clock, no network.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::identity::NodeIdentity;
 use super::membership::MembershipCatalog;
@@ -67,6 +67,153 @@ use super::ownership::{CollectionId, RangeId, ShardOwnershipCatalog};
 /// multiplier; `200` doubles a member's placement weight and `50` halves it. An
 /// operator nudges placement without lying about disk by tuning this.
 pub const NEUTRAL_OPERATOR_WEIGHT: u32 = 100;
+
+/// Authority-sharding unit for placement. Related small collections may share a
+/// group; a large collection can be isolated in its own group.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CollectionGroupId(String);
+
+impl CollectionGroupId {
+    pub fn new(value: impl Into<String>) -> Result<Self, PlacementAuthorityError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(PlacementAuthorityError::EmptyCollectionGroup);
+        }
+        Ok(Self(value))
+    }
+}
+
+impl std::fmt::Display for CollectionGroupId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The Placement Authority responsible for one Collection group and the
+/// collections whose ownership-catalog slice belongs to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CollectionGroupPlacementAuthority {
+    collection_group: CollectionGroupId,
+    authority: NodeIdentity,
+    collections: BTreeSet<CollectionId>,
+}
+
+impl CollectionGroupPlacementAuthority {
+    pub fn new(
+        collection_group: CollectionGroupId,
+        authority: NodeIdentity,
+        collections: impl IntoIterator<Item = CollectionId>,
+    ) -> Result<Self, PlacementAuthorityError> {
+        let collections: BTreeSet<_> = collections.into_iter().collect();
+        if collections.is_empty() {
+            return Err(PlacementAuthorityError::EmptyCollectionSet {
+                collection_group,
+                authority,
+            });
+        }
+        Ok(Self {
+            collection_group,
+            authority,
+            collections,
+        })
+    }
+
+    pub fn collection_group(&self) -> &CollectionGroupId {
+        &self.collection_group
+    }
+
+    pub fn authority(&self) -> &NodeIdentity {
+        &self.authority
+    }
+
+    pub fn covers(&self, collection: &CollectionId) -> bool {
+        self.collections.contains(collection)
+    }
+}
+
+/// Pure in-memory authority index used by placement planning.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PlacementAuthorityCatalog {
+    by_collection: BTreeMap<CollectionId, CollectionGroupPlacementAuthority>,
+}
+
+impl PlacementAuthorityCatalog {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(
+        &mut self,
+        authority: CollectionGroupPlacementAuthority,
+    ) -> Result<(), PlacementAuthorityError> {
+        for collection in &authority.collections {
+            if let Some(existing) = self.by_collection.get(collection) {
+                return Err(PlacementAuthorityError::OverlappingCollection {
+                    collection: collection.clone(),
+                    existing_group: existing.collection_group.clone(),
+                    new_group: authority.collection_group.clone(),
+                });
+            }
+        }
+        for collection in &authority.collections {
+            self.by_collection
+                .insert(collection.clone(), authority.clone());
+        }
+        Ok(())
+    }
+
+    pub fn authority_for(
+        &self,
+        collection: &CollectionId,
+    ) -> Option<&CollectionGroupPlacementAuthority> {
+        self.by_collection.get(collection)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlacementAuthorityError {
+    EmptyCollectionGroup,
+    EmptyCollectionSet {
+        collection_group: CollectionGroupId,
+        authority: NodeIdentity,
+    },
+    OverlappingCollection {
+        collection: CollectionId,
+        existing_group: CollectionGroupId,
+        new_group: CollectionGroupId,
+    },
+    MissingCollectionAuthority {
+        collection: CollectionId,
+    },
+}
+
+impl std::fmt::Display for PlacementAuthorityError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyCollectionGroup => write!(f, "collection group id must not be empty"),
+            Self::EmptyCollectionSet {
+                collection_group,
+                authority,
+            } => write!(
+                f,
+                "placement authority {authority} for collection group {collection_group} has no collections"
+            ),
+            Self::OverlappingCollection {
+                collection,
+                existing_group,
+                new_group,
+            } => write!(
+                f,
+                "collection {collection} is already assigned to collection group {existing_group}, cannot also assign it to {new_group}"
+            ),
+            Self::MissingCollectionAuthority { collection } => {
+                write!(f, "no placement authority for collection {collection}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PlacementAuthorityError {}
 
 /// A member's advertised placement capacity: how much usable disk it offers and
 /// the operator's weight multiplier on top of it.
@@ -235,6 +382,18 @@ pub struct RebalancePlan {
     pub hotspots: Vec<HotspotRange>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorityScopedPlannedMove {
+    pub movement: PlannedMove,
+    pub placement_authority: CollectionGroupPlacementAuthority,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AuthorityScopedRebalancePlan {
+    pub moves: Vec<AuthorityScopedPlannedMove>,
+    pub hotspots: Vec<HotspotRange>,
+}
+
 impl RebalancePlan {
     /// Nothing to schedule *and* nothing hot — a fully balanced, evenly-loaded
     /// cluster. Distinct from [`no_moves`](Self::no_moves): a balanced cluster can
@@ -339,6 +498,33 @@ impl WeightedPlacementPlanner {
         let (hotspots, hotspot_moves) = state.plan_hotspot_moves(&self.policy);
         moves.extend(hotspot_moves);
         RebalancePlan { moves, hotspots }
+    }
+
+    pub fn plan_rebalance_scoped(
+        &self,
+        membership: &MembershipCatalog,
+        ownership: &ShardOwnershipCatalog,
+        signals: &impl PlacementSignals,
+        authorities: &PlacementAuthorityCatalog,
+    ) -> Result<AuthorityScopedRebalancePlan, PlacementAuthorityError> {
+        let plan = self.plan_rebalance(membership, ownership, signals);
+        let mut moves = Vec::with_capacity(plan.moves.len());
+        for movement in plan.moves {
+            let placement_authority = authorities
+                .authority_for(&movement.collection)
+                .ok_or_else(|| PlacementAuthorityError::MissingCollectionAuthority {
+                    collection: movement.collection.clone(),
+                })?
+                .clone();
+            moves.push(AuthorityScopedPlannedMove {
+                movement,
+                placement_authority,
+            });
+        }
+        Ok(AuthorityScopedRebalancePlan {
+            moves,
+            hotspots: plan.hotspots,
+        })
     }
 }
 
@@ -825,6 +1011,40 @@ mod tests {
         let targets: std::collections::BTreeSet<_> =
             plan.capacity_moves().map(|m| m.to.clone()).collect();
         assert_eq!(targets.len(), 2);
+    }
+
+    #[test]
+    fn scoped_plan_identifies_the_collection_group_placement_authority() {
+        let planner = WeightedPlacementPlanner::default();
+        let members = membership(&["CN=node-a", "CN=node-b"]);
+        let (catalog, _orders) = catalog(&["CN=node-a", "CN=node-a", "CN=node-a"]);
+        let signals = FakeSignals::uniform(1_000, 100);
+        let mut authorities = PlacementAuthorityCatalog::new();
+        let group = CollectionGroupId::new("commerce").unwrap();
+        let authority = CollectionGroupPlacementAuthority::new(
+            group.clone(),
+            ident("CN=pa-commerce"),
+            [collection("orders"), collection("payments")],
+        )
+        .unwrap();
+        authorities.register(authority).unwrap();
+
+        let plan = planner
+            .plan_rebalance_scoped(&members, &catalog, &signals, &authorities)
+            .unwrap();
+
+        assert!(
+            !plan.moves.is_empty(),
+            "skewed ownership should plan movement"
+        );
+        for planned in &plan.moves {
+            assert_eq!(planned.placement_authority.collection_group(), &group);
+            assert_eq!(
+                planned.placement_authority.authority(),
+                &ident("CN=pa-commerce")
+            );
+            assert_eq!(planned.movement.collection, collection("orders"));
+        }
     }
 
     // --- acceptance scenario: heterogeneous disk weights -----------------


### PR DESCRIPTION
Automated AFK landing for #1538. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1538

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785315747&installation_id=129708444&pr_number=1549&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1549&signature=82261b950a2c6584cebe1ab2ba90c6ce3e3f699ed32fbbbf36baa0b7922819a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->