### PR TITLE
chore(release): v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.18.0
+
+### Minor Changes
+
+- minor release
+
 ## 1.17.0
 
 ### Minor Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,7 +2461,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "jsonwebtoken",
  "proptest",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -2524,14 +2524,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2548,7 +2548,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -2560,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "proptest",
  "reddb-io-types",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-server"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2647,7 +2647,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "insta",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cast_possible_truncation = "warn"
 
 [package]
 name = "reddb-io"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 # Cargo auto-discovers every top-level `tests/*.rs` file as a separate
 # integration-test binary. This crate has 269 such files; keep discovery off

--- a/crates/reddb-client-connector/Cargo.toml
+++ b/crates/reddb-client-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client-connector"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "Workspace-internal gRPC connector used by `reddb-server` (rpc_stdio) and `reddb-client`. Splitting it out of `reddb-client` breaks the otherwise-circular path dependency between `reddb-client[embedded]` (which pulls `reddb-server`) and `reddb-server` (which needs the connector)."

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "Official Rust client for RedDB — embedded engine, gRPC, HTTP, and RedWire transports behind one connection-string API. Also hosts the workspace-internal connector + REPL used by the `red` and `red_client` binaries."

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-crypto"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB cryptographic authority: the canonical per-page encryption-at-rest envelope (AES-256-GCM), mandatory encrypt parameters, and key parsing."

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-file"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB file artifact layer: single-file .rdb layout, WAL, snapshots, checkpoints, locks, and recovery."

--- a/crates/reddb-grpc-proto/Cargo.toml
+++ b/crates/reddb-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-grpc-proto"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "Generated gRPC protobuf types and tonic client/server stubs for RedDB. Shared across reddb-server, reddb-client, and language drivers."

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-rql"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB Query Language (RQL) front-end + conformance authority (ADR 0053). Owns the sqllogictest-format conformance suite whose truth comes from the public SQLite corpus; depends only on reddb-io-types."

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-server"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB server-side engine: storage, runtime, replication, MCP, AI, and the gRPC/HTTP/RedWire/PG-wire dispatchers. Re-exported by the umbrella `reddb` crate."

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-types"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB logical type system: the neutral keystone vocabulary — Value, DataType, SqlTypeName, TypeModifier, TypeCategory, ValueError, Row — depended on by every authority crate and depending on none."

--- a/crates/reddb-wire/Cargo.toml
+++ b/crates/reddb-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-wire"
-version = "1.17.0"
+version = "1.18.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB wire protocol vocabulary: connection-string parser, RedWire frames, payload codecs, topology, sanitizers, and replication messages."

--- a/drivers/bun/CHANGELOG.md
+++ b/drivers/bun/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/client-bun
 
+## 1.18.0
+
 ## 1.17.0
 
 ### Minor Changes

--- a/drivers/bun/package.json
+++ b/drivers/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client-bun",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "RedDB wire protocol client for Bun — ultra-fast native TCP",
   "main": "index.ts",
   "scripts": {

--- a/drivers/js-client/CHANGELOG.md
+++ b/drivers/js-client/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/client
 
+## 1.18.0
+
 ## 1.17.0
 
 ### Minor Changes

--- a/drivers/js-client/package.json
+++ b/drivers/js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Thin remote-only RedDB driver. Downloads the `red_client` binary on install. Speaks RedWire/gRPC/HTTP. Embedded URIs (memory://, file://, red:///path) are rejected — use @reddb-io/sdk for those.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/js/CHANGELOG.md
+++ b/drivers/js/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/sdk
 
+## 1.18.0
+
 ## 1.17.0
 
 ### Minor Changes

--- a/drivers/js/package.json
+++ b/drivers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/sdk",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Official embedded RedDB SDK — launches a local red binary over stdio JSON-RPC. Use @reddb-io/client for remote HTTP, gRPC, and RedWire.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-client",
  "reddb-io-grpc-proto",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-client-connector",
  "reddb-io-grpc-proto",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -1943,14 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-python"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "prost",
  "pyo3",
@@ -1995,14 +1995,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-types",
 ]
 
 [[package]]
 name = "reddb-io-server"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2061,14 +2061,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "reddb-io-types",
  "serde_json",

--- a/drivers/python/Cargo.toml
+++ b/drivers/python/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "reddb-io-python"
-version = "1.17.0"
+version = "1.18.0"
 edition = "2021"
 description = "Native Python driver for RedDB (compiled Rust via pyo3)"
 license = "MIT"

--- a/drivers/python/pyproject.toml
+++ b/drivers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "reddb"
-version = "1.17.0"
+version = "1.18.0"
 description = "Official Python driver for RedDB — embedded engine and gRPC remote in one package."
 readme = "README.md"
 license = { text = "MIT" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/cli",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "CLI launcher for RedDB. The JS/TS app driver is published as @reddb-io/sdk.",
   "type": "commonjs",
   "bin": {

--- a/packages/internal-asset-fetcher/CHANGELOG.md
+++ b/packages/internal-asset-fetcher/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/internal-asset-fetcher
 
+## 1.18.0
+
 ## 1.17.0
 
 ## 1.16.0

--- a/packages/internal-asset-fetcher/package.json
+++ b/packages/internal-asset-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-asset-fetcher",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": true,
   "description": "Workspace-only deep module: download a `red`/`red_client` binary from a GitHub release with platform/arch resolution, redirect handling, and optional sha256 verification.",
   "type": "module",

--- a/packages/internal-bin-resolver/CHANGELOG.md
+++ b/packages/internal-bin-resolver/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/internal-bin-resolver
 
+## 1.18.0
+
 ## 1.17.0
 
 ## 1.16.0

--- a/packages/internal-bin-resolver/package.json
+++ b/packages/internal-bin-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-bin-resolver",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": true,
   "description": "Workspace-only deep module: locate a pinned binary inside a node_modules package, env override > local. PATH is never consulted.",
   "type": "module",

--- a/packages/internal-version-compare/CHANGELOG.md
+++ b/packages/internal-version-compare/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/internal-version-compare
 
+## 1.18.0
+
 ## 1.17.0
 
 ## 1.16.0

--- a/packages/internal-version-compare/package.json
+++ b/packages/internal-version-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-version-compare",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "private": true,
   "description": "Workspace-only deep module: compare a package version against an installed `red --version`, return install/upgrade/skip verdict for the CLI postinstall.",
   "type": "module",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @reddb-io/mcp
 
+## 1.18.0
+
 ## 1.17.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/mcp",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Zero-install npx launcher for the RedDB MCP surface — fetches the matching red binary and spawns `red mcp` over stdio.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump workspace/package versions to 1.18.0
- Include generated release changeset
- Sync main with the v1.18.0 release tag

## Verification
- make minor
- scripts/check-versions.sh (via make minor)

Release tag: v1.18.0
Release workflow: https://github.com/reddb-io/reddb/actions/runs/28367399203

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785323078&installation_id=129708444&pr_number=1558&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1558&signature=a0008f1aaa1e5c081d4c0c787b70d77d87c2b703ace1885338d58f7a75fffb8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the project and package versions to **1.18.0** across the repository.
  * Added matching **1.18.0** release entries to multiple changelogs.
  * No functional behavior, APIs, or dependencies were changed in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->