### PR TITLE
ship: #1555 release-blocker: parser fuzz crash in migration_parser

### DIFF
--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -12,6 +12,8 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  FUZZ_RSS_LIMIT_MB: 4096
+  FUZZ_MALLOC_LIMIT_MB: 2048
 
 jobs:
   fuzz:
@@ -61,7 +63,11 @@ jobs:
         run: python3 scripts/seed-parser-fuzz-corpus.py
 
       - name: Run ${{ matrix.target }}
-        run: cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=3600
+        run: >
+          cargo +nightly fuzz run ${{ matrix.target }} --
+          -max_total_time=3600
+          -rss_limit_mb="${FUZZ_RSS_LIMIT_MB}"
+          -malloc_limit_mb="${FUZZ_MALLOC_LIMIT_MB}"
 
       - name: Upload evolved corpus
         if: always()

--- a/scripts/report-parser-fuzz-crashes.sh
+++ b/scripts/report-parser-fuzz-crashes.sh
@@ -16,9 +16,10 @@ gh label create "release-blocker" \
 body="$(mktemp)"
 tmin_log="$(mktemp)"
 b64_file="$(mktemp)"
+title_suffix="crash"
 trap 'rm -f "${body}" "${tmin_log}" "${b64_file}"' EXIT
 {
-  echo "Nightly parser fuzz found a crash in \`${target}\`."
+  echo "Nightly parser fuzz found a failure in \`${target}\`."
   echo
   echo "- Workflow run: ${GITHUB_RUN_URL:-unknown}"
   echo "- Target: \`${target}\`"
@@ -36,6 +37,11 @@ trap 'rm -f "${body}" "${tmin_log}" "${b64_file}"' EXIT
 while IFS= read -r artifact; do
   minimized="${RUNNER_TEMP:-/tmp}/${target}-$(basename "${artifact}").min"
   cp "${artifact}" "${minimized}"
+  artifact_kind="crash"
+  if [[ "$(basename "${artifact}")" == oom-* ]]; then
+    artifact_kind="out-of-memory"
+    title_suffix="out-of-memory"
+  fi
 
   # Best effort: cargo-fuzz/libFuzzer usually leaves a small reproducer already,
   # but try tmin so the issue body carries the smallest input this runner can find.
@@ -43,6 +49,8 @@ while IFS= read -r artifact; do
 
   {
     echo "Artifact: \`${artifact}\`"
+    echo
+    echo "- Failure kind: ${artifact_kind}"
     echo
     echo "- Bytes: $(wc -c < "${minimized}")"
     echo "- Base64:"
@@ -60,6 +68,6 @@ while IFS= read -r artifact; do
 done < <(find "${artifact_dir}" -type f | sort)
 
 gh issue create \
-  --title "release-blocker: parser fuzz crash in ${target}" \
+  --title "release-blocker: parser fuzz ${title_suffix} in ${target}" \
   --label "release-blocker" \
   --body-file "${body}"

--- a/scripts/report-parser-fuzz-crashes.sh
+++ b/scripts/report-parser-fuzz-crashes.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 target="${1:?usage: report-parser-fuzz-crashes.sh <target>}"
 artifact_dir="fuzz/artifacts/${target}"
+fuzz_rss_limit_mb="${FUZZ_RSS_LIMIT_MB:-4096}"
+fuzz_malloc_limit_mb="${FUZZ_MALLOC_LIMIT_MB:-2048}"
 
 if [ ! -d "${artifact_dir}" ] || ! find "${artifact_dir}" -type f | grep -q .; then
   echo "No fuzz artifacts found for ${target}; skipping issue creation."
@@ -27,7 +29,7 @@ trap 'rm -f "${body}" "${tmin_log}" "${b64_file}"' EXIT
   echo
   echo '```bash'
   echo "cargo +nightly install cargo-fuzz --locked"
-  echo "cargo +nightly fuzz run ${target} fuzz/artifacts/${target}/<artifact>"
+  echo "cargo +nightly fuzz run ${target} fuzz/artifacts/${target}/<artifact> -- -rss_limit_mb=${fuzz_rss_limit_mb} -malloc_limit_mb=${fuzz_malloc_limit_mb}"
   echo '```'
   echo
   echo "## Minimized input"


### PR DESCRIPTION
Interactive /ship landing for #1555.

Closes #1555

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785331677&installation_id=129708444&pr_number=1560&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1560&signature=f35c08c4e28893c246f8369c2a861b38e1764d0993d7026a1bba7dc2474d20ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly parser fuzz runs with explicit memory limits to reduce runaway resource usage.
  * Crash reports now distinguish out-of-memory failures from other crash types, making issue titles and summaries clearer.
  * Added cleanup for temporary report files after fuzz crash handling completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->