### PR TITLE
merge: #1391 fix(tests): eliminate remaining TMPDIR leak families — make Test Suite leak-guard green on main

### DIFF
--- a/crates/reddb-server/src/storage/cache/spill.rs
+++ b/crates/reddb-server/src/storage/cache/spill.rs
@@ -761,27 +761,27 @@ impl<G> SpillableGraph<G> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
 
-    fn test_config() -> SpillConfig {
+    fn test_manager() -> (tempfile::TempDir, SpillManager) {
         use std::sync::atomic::{AtomicU64, Ordering};
         static COUNTER: AtomicU64 = AtomicU64::new(0);
         let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-        SpillConfig::new()
+        let dir = tempfile::Builder::new()
+            .prefix(&format!("reddb-spill-test-{}-{id}-", std::process::id()))
+            .tempdir()
+            .unwrap();
+        let config = SpillConfig::new()
             .max_memory(1024 * 1024) // 1MB for testing
             .spill_threshold(0.5)
             .target_after_spill(0.3)
             .min_spill_size(100)
-            .spill_dir(env::temp_dir().join(format!(
-                "reddb-spill-test-{}-{}",
-                std::process::id(),
-                id
-            )))
+            .spill_dir(dir.path());
+        (dir, SpillManager::new(config))
     }
 
     #[test]
     fn test_register_segment() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         manager.register_segment("seg2", 200_000);
@@ -794,7 +794,7 @@ mod tests {
 
     #[test]
     fn test_update_size() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         assert_eq!(manager.memory_usage(), 100_000);
@@ -808,7 +808,7 @@ mod tests {
 
     #[test]
     fn test_needs_spill() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         // Below threshold
         manager.register_segment("seg1", 400_000); // 40%
@@ -830,7 +830,7 @@ mod tests {
 
     #[test]
     fn test_spill_and_reload() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("test_seg", 1000);
 
@@ -848,7 +848,7 @@ mod tests {
 
     #[test]
     fn test_checksum_validation() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         // Use unique segment name to avoid conflicts
         manager.register_segment("checksum_test_seg", 100);
@@ -864,7 +864,7 @@ mod tests {
 
     #[test]
     fn test_list_segments() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("alpha", 1000);
         manager.register_segment("beta", 2000);
@@ -881,7 +881,7 @@ mod tests {
 
     #[test]
     fn test_unregister_segment() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("seg1", 100_000);
         manager.register_segment("seg2", 200_000);
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_cleanup() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
 
         manager.register_segment("seg1", 100);
         manager.spill("seg1", b"test data").unwrap();
@@ -921,7 +921,7 @@ mod tests {
 
     #[test]
     fn test_v2_round_trip() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
         manager.register_segment("rt_seg", 100);
         let data: Vec<u8> = (0u8..=127).collect();
         manager.spill("rt_seg", &data).unwrap();
@@ -931,7 +931,7 @@ mod tests {
 
     #[test]
     fn test_single_byte_mutation_detected() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
         manager.register_segment("mut_seg", 100);
         let data = b"hello world mutation test data!!";
         let path = manager.spill("mut_seg", data).unwrap();
@@ -953,7 +953,7 @@ mod tests {
     fn test_byte_permutation_detected() {
         // The old fold checksum is commutative — swapping two bytes leaves the
         // sum unchanged. CRC-32 is not commutative, so v2 catches this.
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
         manager.register_segment("perm_seg", 100);
         let data = b"abcdefghij"; // all distinct bytes
         let path = manager.spill("perm_seg", data).unwrap();
@@ -976,7 +976,7 @@ mod tests {
 
     #[test]
     fn test_path_traversal_rejected() {
-        let manager = SpillManager::new(test_config());
+        let (_dir, manager) = test_manager();
         for bad_name in &["../foo", "/etc/passwd", "a/b"] {
             manager.register_segment(bad_name, 100);
             let result = manager.spill(bad_name, b"data");

--- a/crates/reddb-server/src/storage/engine/database.rs
+++ b/crates/reddb-server/src/storage/engine/database.rs
@@ -461,18 +461,43 @@ mod tests {
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    fn temp_db_path() -> PathBuf {
+    struct TempDbPath(PathBuf);
+
+    impl std::ops::Deref for TempDbPath {
+        type Target = PathBuf;
+
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+
+    impl AsRef<Path> for TempDbPath {
+        fn as_ref(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDbPath {
+        fn drop(&mut self) {
+            cleanup(&self.0);
+        }
+    }
+
+    fn temp_db_path() -> TempDbPath {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("reddb_engine_test_{}.rdb", timestamp))
+        TempDbPath(std::env::temp_dir().join(format!("reddb_engine_test_{}.rdb", timestamp)))
     }
 
     fn cleanup(path: &Path) {
         let _ = fs::remove_file(path);
         let wal_path = reddb_file::layout::engine_wal_path(path);
         let _ = fs::remove_file(wal_path);
+        for sidecar in reddb_file::layout::pager_shadow_sidecar_paths(path) {
+            let _ = fs::remove_file(sidecar);
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/engine/turboquant/extent.rs
+++ b/crates/reddb-server/src/storage/engine/turboquant/extent.rs
@@ -104,10 +104,36 @@ mod tests {
     use super::*;
     use crate::storage::engine::PagerConfig;
 
+    struct TempPagerPath(std::path::PathBuf);
+
+    impl std::ops::Deref for TempPagerPath {
+        type Target = std::path::PathBuf;
+
+        fn deref(&self) -> &std::path::PathBuf {
+            &self.0
+        }
+    }
+
+    impl AsRef<std::path::Path> for TempPagerPath {
+        fn as_ref(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempPagerPath {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+            for sidecar in reddb_file::layout::pager_shadow_sidecar_paths(&self.0) {
+                let _ = std::fs::remove_file(sidecar);
+            }
+        }
+    }
+
     #[test]
     fn turbo_extent_reads_across_page_boundaries() {
-        let path =
-            std::env::temp_dir().join(format!("reddb-turbo-extent-{}.db", std::process::id()));
+        let path = TempPagerPath(
+            std::env::temp_dir().join(format!("reddb-turbo-extent-{}.db", std::process::id())),
+        );
         let _ = std::fs::remove_file(&path);
         let pager = Arc::new(Pager::open(&path, PagerConfig::default()).unwrap());
         let mut extent = TurboExtent::new(pager).unwrap();
@@ -115,6 +141,5 @@ mod tests {
         extent.ensure_capacity(PAYLOAD_BYTES_PER_PAGE + 2).unwrap();
         let offset = extent.append(&[1, 2, 3, 4]).unwrap();
         assert_eq!(extent.read(offset, 4).unwrap(), vec![1, 2, 3, 4]);
-        let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/reddb-server/src/storage/keyring.rs
+++ b/crates/reddb-server/src/storage/keyring.rs
@@ -239,22 +239,53 @@ fn generate_nonce() -> [u8; 12] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard};
 
     // Serialize keyring tests that touch the shared on-disk keyring file.
     // Under nextest each test runs in its OWN PROCESS, so an in-process Mutex
     // cannot stop concurrent processes from racing on the fixed
     // `$XDG_CONFIG_HOME/reddb/keyring.enc` path (the source of the flaky
-    // `test_keyring_save_and_retrieve`). On first lock, lazily point
-    // XDG_CONFIG_HOME at a process-unique temp dir so every test process gets
-    // its own keyring file; the Mutex still serializes the in-process case for
-    // a plain `cargo test` run.
-    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> = std::sync::LazyLock::new(|| {
-        let dir = std::env::temp_dir().join(format!("reddb-keyring-test-{}", std::process::id()));
-        let _ = std::fs::create_dir_all(&dir);
-        std::env::set_var("XDG_CONFIG_HOME", dir);
-        Mutex::new(())
-    });
+    // `test_keyring_save_and_retrieve`). The Mutex still serializes the
+    // in-process case for a plain `cargo test` run; the guard also points
+    // XDG_CONFIG_HOME at a removable temp dir for the current test.
+    static KEYRING_TEST_LOCK: std::sync::LazyLock<Mutex<()>> =
+        std::sync::LazyLock::new(|| Mutex::new(()));
+
+    struct KeyringTestGuard {
+        _lock: MutexGuard<'static, ()>,
+        dir: PathBuf,
+        previous_config_home: Option<OsString>,
+    }
+
+    impl Drop for KeyringTestGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous_config_home {
+                std::env::set_var("XDG_CONFIG_HOME", value);
+            } else {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    fn keyring_test_guard() -> KeyringTestGuard {
+        let lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "reddb-keyring-test-{}-{}",
+            std::process::id(),
+            crate::utils::now_unix_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let previous_config_home = std::env::var_os("XDG_CONFIG_HOME");
+        std::env::set_var("XDG_CONFIG_HOME", &dir);
+        KeyringTestGuard {
+            _lock: lock,
+            dir,
+            previous_config_home,
+        }
+    }
 
     #[test]
     fn test_password_source_is_encrypted() {
@@ -327,7 +358,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_empty_flag() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 
@@ -338,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_env_var() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         let _ = clear_keyring();
 
         std::env::set_var("REDDB_KEY", "env_test_password");
@@ -362,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_keyring_save_and_retrieve() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
 
         // Clear any existing keyring
         let _ = clear_keyring();
@@ -382,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_keyring_has_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
 
         let _ = clear_keyring();
         assert!(!has_keyring_password());
@@ -396,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_clear_keyring_nonexistent() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
 
         // Should not error if keyring doesn't exist
         let _ = clear_keyring();
@@ -406,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_keyring_special_characters() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         let _ = clear_keyring();
 
         // Test password with special characters
@@ -422,7 +453,7 @@ mod tests {
 
     #[test]
     fn test_keyring_unicode_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         let _ = clear_keyring();
 
         // Test password with unicode characters
@@ -438,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_keyring_empty_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         let _ = clear_keyring();
 
         // Even empty password should work
@@ -453,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_keyring_long_password() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         let _ = clear_keyring();
 
         // Test very long password
@@ -469,7 +500,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_keyring_integration() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 
@@ -488,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_resolve_password_none_when_empty() {
-        let _lock = KEYRING_TEST_LOCK.lock().unwrap();
+        let _guard = keyring_test_guard();
         std::env::remove_var("REDDB_KEY");
         let _ = clear_keyring();
 

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -1281,6 +1281,9 @@ mod ephemeral_cleanup_tests {
         let path = options.data_path.as_ref().expect("in-memory data path");
 
         assert!(should_cleanup_ephemeral_data_path(&options, path));
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::remove_dir_all(parent);
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/telemetry/admin_intent_log.rs
+++ b/crates/reddb-server/src/telemetry/admin_intent_log.rs
@@ -599,7 +599,29 @@ mod tests {
     use super::*;
     use crate::json::Value as JsonValue;
 
-    fn tmp_path(label: &str) -> PathBuf {
+    struct TempLogPath(PathBuf);
+
+    impl std::ops::Deref for TempLogPath {
+        type Target = PathBuf;
+
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+
+    impl AsRef<Path> for TempLogPath {
+        fn as_ref(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempLogPath {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.0);
+        }
+    }
+
+    fn tmp_path(label: &str) -> TempLogPath {
         let mut p = std::env::temp_dir();
         p.push(format!(
             "reddb-intent-{}-{}-{}.log",
@@ -607,7 +629,7 @@ mod tests {
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        p
+        TempLogPath(p)
     }
 
     fn last_line_json(path: &Path) -> JsonValue {

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -536,9 +536,32 @@ mod tests {
     use super::*;
     use crate::runtime::audit_log::AuditLogger;
 
-    fn make_logger() -> (AuditLogger, std::path::PathBuf) {
-        let mut dir = std::env::temp_dir();
-        dir.push(format!(
+    struct TempAuditPath(std::path::PathBuf);
+
+    impl std::ops::Deref for TempAuditPath {
+        type Target = std::path::PathBuf;
+
+        fn deref(&self) -> &std::path::PathBuf {
+            &self.0
+        }
+    }
+
+    impl AsRef<std::path::Path> for TempAuditPath {
+        fn as_ref(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempAuditPath {
+        fn drop(&mut self) {
+            if let Some(parent) = self.0.parent() {
+                let _ = std::fs::remove_dir_all(parent);
+            }
+        }
+    }
+
+    fn make_logger() -> (AuditLogger, TempAuditPath) {
+        let dir = std::env::temp_dir().join(format!(
             "reddb-op-event-{}-{}",
             std::process::id(),
             crate::utils::now_unix_nanos()
@@ -546,7 +569,7 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         let path = dir.join(".audit.log");
         let logger = AuditLogger::with_path(path.clone());
-        (logger, path)
+        (logger, TempAuditPath(path))
     }
 
     fn drain(logger: &AuditLogger) {

--- a/crates/reddb-server/src/telemetry/slow_query_logger.rs
+++ b/crates/reddb-server/src/telemetry/slow_query_logger.rs
@@ -268,19 +268,41 @@ mod tests {
     use crate::runtime::EffectiveScope;
     use crate::storage::transaction::snapshot::Snapshot;
 
-    fn tmp_dir() -> PathBuf {
+    struct TempSlowDir(PathBuf);
+
+    impl std::ops::Deref for TempSlowDir {
+        type Target = PathBuf;
+
+        fn deref(&self) -> &PathBuf {
+            &self.0
+        }
+    }
+
+    impl AsRef<std::path::Path> for TempSlowDir {
+        fn as_ref(&self) -> &std::path::Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempSlowDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn tmp_dir() -> TempSlowDir {
         let mut d = std::env::temp_dir();
         d.push(format!(
             "reddb-slow-{}-{}",
             std::process::id(),
             crate::utils::now_unix_nanos()
         ));
-        d
+        TempSlowDir(d)
     }
 
-    fn logger(dir: &PathBuf, threshold_ms: u64, sample_pct: u8) -> Arc<SlowQueryLogger> {
+    fn logger(dir: &TempSlowDir, threshold_ms: u64, sample_pct: u8) -> Arc<SlowQueryLogger> {
         SlowQueryLogger::new(SlowQueryOpts {
-            log_dir: dir.clone(),
+            log_dir: dir.0.clone(),
             threshold_ms,
             sample_pct,
         })
@@ -304,7 +326,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(50));
     }
 
-    fn read_log_lines(dir: &PathBuf) -> Vec<crate::json::Value> {
+    fn read_log_lines(dir: &TempSlowDir) -> Vec<crate::json::Value> {
         let path = reddb_file::layout::legacy_slow_query_log_path(dir);
         let body = std::fs::read_to_string(&path).unwrap_or_default();
         body.lines()


### PR DESCRIPTION
Automated AFK landing for #1391. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785334598&installation_id=129708444&pr_number=1561&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1561&signature=7c89330f8b27eff4beb1bf85fbadf4fbfce3c2820b230ba780bfb9afffdd0e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->