### PR TITLE
fix(dml): extend concurrent claim to document and kv collections

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -2146,6 +2146,13 @@ impl RedDBRuntime {
             .collection_contract(&collection)
             .map(|contract| contract.declared_model == crate::catalog::CollectionModel::Document)
             .unwrap_or(false);
+        let kv_key = if row.get_field("value").is_some() || row.columns.len() >= 2 {
+            row.get_field("key")
+                .cloned()
+                .or_else(|| row.columns.first().cloned())
+        } else {
+            None
+        };
         if is_document_collection {
             // #1366: when a SET assigns to `body`, treat it as a FULL REPLACE of
             // the stored document — drop other column assignments, the new body
@@ -2211,6 +2218,9 @@ impl RedDBRuntime {
             let mut all_assignments: Vec<(String, Value)> = static_field_assignments.to_vec();
             all_assignments.extend(dynamic_field_assignments);
             apply_row_field_assignments_raw(row, all_assignments);
+            if let Some(key) = kv_key {
+                set_row_field(row, "key", key);
+            }
         }
 
         for (key, value) in static_metadata_assignments

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1720,6 +1720,7 @@ impl RedDBRuntime {
             crate::runtime::collection_contract::MutationKind::Update,
         )?;
         ensure_update_target_contract(self, &query.table, query.target)?;
+        ensure_kv_key_update_target_allowed(query)?;
         ensure_graph_identity_update_target_allowed(query)?;
 
         // Apply RLS augmentation first so every downstream path — plain
@@ -1795,7 +1796,7 @@ impl RedDBRuntime {
             let (mut response, touched_ids) =
                 self.execute_update_inner_tracked(raw_query, &inner_query)?;
 
-            let snapshots = if matches!(
+            let mut snapshots = if matches!(
                 effective_query.target,
                 UpdateTarget::Nodes | UpdateTarget::Edges
             ) {
@@ -1804,6 +1805,14 @@ impl RedDBRuntime {
                 super::dml_target_scan::DmlTargetScan::new(self, &effective_query.table, None, None)
                     .row_snapshots(&touched_ids)
             };
+            if matches!(effective_query.target, UpdateTarget::Kv) {
+                restore_kv_returning_keys(
+                    self,
+                    &effective_query.table,
+                    &touched_ids,
+                    &mut snapshots,
+                );
+            }
 
             response.result = build_returning_result(&items, &snapshots, None);
             response.engine = "runtime-dml-returning";
@@ -1962,7 +1971,7 @@ impl RedDBRuntime {
                 let assignments =
                     self.materialize_update_assignments_for_entity(query, &entity, &compiled_plan)?;
                 let applied = self.apply_materialized_update_for_entity(
-                    query.table.clone(),
+                    query,
                     entity,
                     &compiled_plan,
                     assignments,
@@ -2082,7 +2091,7 @@ impl RedDBRuntime {
             let assignments =
                 self.materialize_update_assignments_for_entity(query, &entity, compiled_plan)?;
             let applied = self.apply_materialized_update_for_entity(
-                query.table.clone(),
+                query,
                 entity,
                 compiled_plan,
                 assignments,
@@ -2299,14 +2308,32 @@ impl RedDBRuntime {
 
     fn apply_materialized_update_for_entity(
         &self,
-        collection: String,
+        query: &UpdateQuery,
         entity: UnifiedEntity,
         compiled_plan: &CompiledUpdatePlan,
-        assignments: MaterializedUpdateAssignments,
+        mut assignments: MaterializedUpdateAssignments,
     ) -> RedDBResult<AppliedEntityMutation> {
+        if matches!(query.target, UpdateTarget::Kv)
+            && !compiled_plan
+                .static_field_assignments
+                .iter()
+                .any(|(column, _)| column.eq_ignore_ascii_case("key"))
+            && !assignments
+                .dynamic_field_assignments
+                .iter()
+                .any(|(column, _)| column.eq_ignore_ascii_case("key"))
+        {
+            if let Some(key) = runtime_any_record_from_entity_ref(&entity)
+                .and_then(|record| record.get("key").cloned())
+            {
+                assignments
+                    .dynamic_field_assignments
+                    .push(("key".to_string(), key));
+            }
+        }
         if matches!(entity.data, EntityData::Row(_)) {
             return self.apply_loaded_sql_update_row_core(
-                collection,
+                query.table.clone(),
                 entity,
                 &compiled_plan.static_field_assignments,
                 assignments.dynamic_field_assignments,
@@ -2326,7 +2353,7 @@ impl RedDBRuntime {
             assignments,
         );
         self.apply_loaded_patch_entity_core(
-            collection,
+            query.table.clone(),
             entity,
             crate::json::Value::Null,
             operations,
@@ -2507,6 +2534,20 @@ fn ensure_graph_identity_update_target_allowed(query: &UpdateQuery) -> RedDBResu
             return Err(RedDBError::Query(format!(
                 "immutable graph field '{column}' cannot be updated"
             )));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_kv_key_update_target_allowed(query: &UpdateQuery) -> RedDBResult<()> {
+    if !matches!(query.target, UpdateTarget::Kv) {
+        return Ok(());
+    }
+    for (column, _) in &query.assignment_exprs {
+        if column.eq_ignore_ascii_case("key") {
+            return Err(RedDBError::Query(
+                "KV key cannot be updated; delete and insert a new key instead".to_string(),
+            ));
         }
     }
     Ok(())
@@ -2904,6 +2945,46 @@ fn graph_update_returning_snapshots(
                 .collect()
         })
         .collect()
+}
+
+fn restore_kv_returning_keys(
+    runtime: &RedDBRuntime,
+    collection: &str,
+    ids: &[EntityId],
+    snapshots: &mut [Vec<(String, Value)>],
+) {
+    if ids.is_empty() || snapshots.is_empty() {
+        return;
+    }
+
+    let store = runtime.db().store();
+    for (idx, id) in ids.iter().enumerate() {
+        let Some(snapshot) = snapshots.get_mut(idx) else {
+            continue;
+        };
+        if snapshot.iter().any(|(name, _)| name == "key") {
+            continue;
+        }
+        let Some(entity) = store.get(collection, *id) else {
+            continue;
+        };
+        let logical_id = entity.logical_id();
+        let key = store
+            .table_row_versions_by_logical_id(collection, logical_id)
+            .into_iter()
+            .find_map(kv_key_value_from_entity)
+            .or_else(|| kv_key_value_from_entity(entity));
+        if let Some(key) = key {
+            snapshot.push(("key".to_string(), key));
+        }
+    }
+}
+
+fn kv_key_value_from_entity(entity: UnifiedEntity) -> Option<Value> {
+    let row = entity.data.as_row()?;
+    row.get_field("key")
+        .cloned()
+        .or_else(|| row.columns.first().cloned())
 }
 
 fn ensure_update_target_contract(

--- a/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
@@ -1,3 +1,4 @@
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
 use reddb::storage::query::unified::UnifiedRecord;
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
@@ -36,10 +37,207 @@ fn text_field(record: &UnifiedRecord, field: &str) -> String {
     }
 }
 
+fn returned_texts(result: &reddb::runtime::RuntimeQueryResult, field: &str) -> Vec<String> {
+    result
+        .result
+        .records
+        .iter()
+        .map(|record| text_field(record, field))
+        .collect()
+}
+
 fn err_string(rt: &RedDBRuntime, sql: &str) -> String {
     rt.execute_query(sql)
         .expect_err("query should fail")
         .to_string()
+}
+
+#[test]
+fn document_claim_updates_ordered_subset_with_returning() {
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT doc_claim_tasks");
+    exec(
+        &rt,
+        r#"INSERT INTO doc_claim_tasks DOCUMENT (body) VALUES ('{"name":"slow","priority":30,"status":"ready"}')"#,
+    );
+    exec(
+        &rt,
+        r#"INSERT INTO doc_claim_tasks DOCUMENT (body) VALUES ('{"name":"fast","priority":10,"status":"ready"}')"#,
+    );
+    exec(
+        &rt,
+        r#"INSERT INTO doc_claim_tasks DOCUMENT (body) VALUES ('{"name":"middle","priority":20,"status":"ready"}')"#,
+    );
+
+    let claimed = exec(
+        &rt,
+        "UPDATE doc_claim_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 2 ORDER BY priority ASC RETURNING name, status",
+    );
+
+    assert_eq!(claimed.affected_rows, 2);
+    assert_eq!(returned_texts(&claimed, "name"), vec!["fast", "middle"]);
+    assert_eq!(
+        returned_texts(&claimed, "status"),
+        vec!["claimed", "claimed"]
+    );
+    let remaining = exec(
+        &rt,
+        "SELECT name FROM doc_claim_tasks WHERE status = 'ready' ORDER BY priority ASC",
+    );
+    assert_eq!(returned_texts(&remaining, "name"), vec!["slow"]);
+}
+
+#[test]
+fn kv_claim_uses_key_identity_for_ordered_subset_with_returning() {
+    let rt = runtime();
+    exec(&rt, "CREATE KV kv_claim_tasks");
+    exec(
+        &rt,
+        "INSERT INTO kv_claim_tasks KV (key, value) VALUES ('slow', 30)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO kv_claim_tasks KV (key, value) VALUES ('fast', 10)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO kv_claim_tasks KV (key, value) VALUES ('middle', 20)",
+    );
+    let inserted = exec(&rt, "SELECT key FROM kv_claim_tasks ORDER BY value ASC");
+    assert_eq!(
+        returned_texts(&inserted, "key"),
+        vec!["fast", "middle", "slow"]
+    );
+
+    let claimed = exec(
+        &rt,
+        "UPDATE kv_claim_tasks KV SET value += 100 WHERE value >= 10 \
+         CLAIM LIMIT 2 ORDER BY value ASC RETURNING value",
+    );
+
+    assert_eq!(claimed.affected_rows, 2);
+    let values = claimed
+        .result
+        .records
+        .iter()
+        .map(|record| int_field(record, "value"))
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![110, 120]);
+    let updated = exec(
+        &rt,
+        "SELECT key FROM kv_claim_tasks WHERE value >= 100 ORDER BY value ASC",
+    );
+    let mut updated_keys = returned_texts(&updated, "key");
+    updated_keys.sort();
+    assert_eq!(updated_keys, vec!["fast", "middle"]);
+    let remaining = exec(
+        &rt,
+        "SELECT key FROM kv_claim_tasks WHERE value < 100 ORDER BY value ASC",
+    );
+    assert_eq!(returned_texts(&remaining, "key"), vec!["slow"]);
+}
+
+#[test]
+fn document_claim_locks_skip_and_release_on_rollback() {
+    let rt = runtime();
+    set_current_connection_id(145401);
+    exec(&rt, "CREATE DOCUMENT doc_claim_lock_tasks");
+    exec(
+        &rt,
+        r#"INSERT INTO doc_claim_lock_tasks DOCUMENT (body) VALUES ('{"name":"a","priority":10,"status":"ready"}')"#,
+    );
+    exec(
+        &rt,
+        r#"INSERT INTO doc_claim_lock_tasks DOCUMENT (body) VALUES ('{"name":"b","priority":20,"status":"ready"}')"#,
+    );
+
+    exec(&rt, "BEGIN");
+    let first = exec(
+        &rt,
+        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
+    );
+    assert_eq!(returned_texts(&first, "name"), vec!["a"]);
+
+    set_current_connection_id(145402);
+    let second = exec(
+        &rt,
+        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
+    );
+    assert_eq!(second.affected_rows, 1);
+    assert_eq!(returned_texts(&second, "name"), vec!["b"]);
+
+    set_current_connection_id(145401);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(145402);
+    let after_rollback = exec(
+        &rt,
+        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+         CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
+    );
+    assert_eq!(after_rollback.affected_rows, 1);
+    assert_eq!(returned_texts(&after_rollback, "name"), vec!["a"]);
+    clear_current_connection_id();
+}
+
+#[test]
+fn kv_claim_locks_skip_and_release_on_rollback_by_key() {
+    let rt = runtime();
+    set_current_connection_id(145403);
+    exec(&rt, "CREATE KV kv_claim_lock_tasks");
+    exec(
+        &rt,
+        "INSERT INTO kv_claim_lock_tasks KV (key, value) VALUES ('a', 10)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO kv_claim_lock_tasks KV (key, value) VALUES ('b', 20)",
+    );
+
+    exec(&rt, "BEGIN");
+    let first = exec(
+        &rt,
+        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+         CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
+    );
+    assert_eq!(int_field(only_record(&first), "value"), 110);
+
+    set_current_connection_id(145404);
+    let second = exec(
+        &rt,
+        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+         CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
+    );
+    assert_eq!(second.affected_rows, 1);
+    assert_eq!(int_field(only_record(&second), "value"), 120);
+    let visible_claimed = exec(
+        &rt,
+        "SELECT key FROM kv_claim_lock_tasks WHERE value >= 100 ORDER BY value ASC",
+    );
+    assert_eq!(returned_texts(&visible_claimed, "key"), vec!["b"]);
+
+    set_current_connection_id(145403);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(145404);
+    let after_rollback = exec(
+        &rt,
+        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+         CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
+    );
+    assert_eq!(after_rollback.affected_rows, 1);
+    assert_eq!(int_field(only_record(&after_rollback), "value"), 110);
+    let claimed_after_rollback = exec(
+        &rt,
+        "SELECT key FROM kv_claim_lock_tasks WHERE value >= 100 ORDER BY value ASC",
+    );
+    let mut claimed_after_rollback_keys = returned_texts(&claimed_after_rollback, "key");
+    claimed_after_rollback_keys.sort();
+    assert_eq!(claimed_after_rollback_keys, vec!["a", "b"]);
+    clear_current_connection_id();
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve KV key identity across row updates
- keep DML claim identity stable for document/KV updates
- add grouped document/KV claim coverage

Refs #1454

## Verification
- cargo test --test grouped_documents_kv_queues -- e2e_document_kv_compound_updates --nocapture
- cargo check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785340802&installation_id=129708444&pr_number=1562&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1562&signature=0b742c43228dfaada3df261fdf1845129ead55aee045120d6887931b3e4e5984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL `UPDATE` behavior for KV data so the key is preserved in returned results.
  * Prevented changes to the KV key field during updates, helping avoid accidental key mutations.
  * Returned rows now consistently include the key when using `RETURNING` with KV updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->