### PR TITLE
feat(rql): VCS read surface via RQL — red.commits/branches/tags/status/conflicts/versioned + diff/lca (#1569)

### DIFF
--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -460,11 +460,14 @@ impl<'a> Parser<'a> {
                 });
             }
 
-            // Qualified column: IDENT.IDENT[.IDENT …]
+            // Qualified column or dotted function: IDENT.IDENT[.IDENT …]
             if matches!(self.peek(), Token::Dot) {
                 let mut segments = vec![saved_name];
                 while self.consume(&Token::Dot)? {
                     segments.push(self.expect_ident_or_keyword()?);
+                }
+                if matches!(self.peek(), Token::LParen) {
+                    return self.parse_function_call_expr_with_name(start, segments.join("."));
                 }
                 let field = FieldRef::TableColumn {
                     table: segments.remove(0),

--- a/crates/reddb-rql/src/parser/table.rs
+++ b/crates/reddb-rql/src/parser/table.rs
@@ -156,11 +156,11 @@ impl<'a> Parser<'a> {
             // the centrality TVFs (issue #797) can name them, mapping the token
             // back to its lowercase identifier spelling.
             let ident = match self.advance()? {
-                Token::Ident(arg) => arg,
+                Token::Ident(arg) | Token::String(arg) => arg,
                 Token::MaxIterations => "max_iterations".to_string(),
                 other => {
                     return Err(ParseError::expected(
-                        vec!["table function argument identifier"],
+                        vec!["table function argument identifier or string literal"],
                         &other,
                         self.position(),
                     ));
@@ -415,33 +415,27 @@ impl<'a> Parser<'a> {
                 name
             } else {
                 let ident = self.expect_ident()?;
+                let mut name = ident;
+                while matches!(self.peek(), Token::Dot) {
+                    self.advance()?; // consume '.'
+                    let segment = self.parse_table_name_segment()?;
+                    name.push('.');
+                    name.push_str(&segment);
+                }
                 // Table-valued function call: `ident(arg, ...)` (issue #795).
                 if matches!(self.peek(), Token::LParen) {
                     self.advance()?; // consume '('
                     let (args, named_args, subquery_args) =
-                        self.parse_table_function_args(&ident)?;
+                        self.parse_table_function_args(&name)?;
                     self.expect(Token::RParen)?;
                     table_source = Some(self.build_table_function_source(
-                        ident.clone(),
+                        name.clone(),
                         args,
                         named_args,
                         subquery_args,
                     )?);
-                    ident
+                    name
                 } else {
-                    // Dotted table name, e.g. the `<graph>.<output>` analytics
-                    // virtual view `g.communities` (issue #800) or a schema-
-                    // qualified virtual table such as `red.collections`. The
-                    // dotted form is kept verbatim in `table`; the runtime
-                    // resolves a real collection of that exact name first, then
-                    // falls back to analytics-view resolution.
-                    let mut name = ident;
-                    while matches!(self.peek(), Token::Dot) {
-                        self.advance()?; // consume '.'
-                        let segment = self.parse_table_name_segment()?;
-                        name.push('.');
-                        name.push_str(&segment);
-                    }
                     name
                 }
             }

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -628,6 +628,23 @@ fn test_parse_table_function_multiple_args() {
 }
 
 #[test]
+fn test_parse_red_diff_tvf_with_string_commitish_args() {
+    use crate::ast::TableSource;
+    let query = parse("SELECT * FROM red.diff('a', 'b')").unwrap();
+    let QueryExpr::Table(tq) = query else {
+        panic!("Expected TableQuery");
+    };
+    assert_eq!(tq.table, "red.diff");
+    match tq.source {
+        Some(TableSource::Function { name, args, .. }) => {
+            assert_eq!(name, "red.diff");
+            assert_eq!(args, vec!["a".to_string(), "b".to_string()]);
+        }
+        other => panic!("expected TableSource::Function, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_parse_table_function_rejects_zero_args() {
     let err = parse("SELECT * FROM components()").unwrap_err();
     assert!(
@@ -2372,6 +2389,23 @@ fn test_parse_show_queues_including_internal_omits_internal_filter() {
         );
     } else {
         panic!("Expected Table for SHOW QUEUES INCLUDING INTERNAL");
+    }
+}
+
+#[test]
+fn test_parse_show_branches_and_tags_desugar_to_vcs_virtual_tables() {
+    let branches = parse("SHOW BRANCHES").unwrap();
+    if let QueryExpr::Table(tq) = branches {
+        assert_eq!(tq.table, "red.branches");
+    } else {
+        panic!("Expected Table for SHOW BRANCHES");
+    }
+
+    let tags = parse("SHOW TAGS").unwrap();
+    if let QueryExpr::Table(tq) = tags {
+        assert_eq!(tq.table, "red.tags");
+    } else {
+        panic!("Expected Table for SHOW TAGS");
     }
 }
 

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -3786,6 +3786,14 @@ impl<'a> Parser<'a> {
                         add_table_filter(&mut query, hide_internal);
                     }
                     Ok(SqlCommand::Select(query))
+                } else if self.consume_ident_ci("BRANCHES")? {
+                    let mut query = TableQuery::new("red.branches");
+                    self.parse_table_clauses(&mut query)?;
+                    Ok(SqlCommand::Select(query))
+                } else if self.consume_ident_ci("TAGS")? {
+                    let mut query = TableQuery::new("red.tags");
+                    self.parse_table_clauses(&mut query)?;
+                    Ok(SqlCommand::Select(query))
                 } else if self.consume(&Token::Vectors)? || self.consume_ident_ci("VECTORS")? {
                     Ok(SqlCommand::Select(parse_show_collections_by_model(
                         self, "vector",

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -3050,6 +3050,18 @@ impl<'a> Parser<'a> {
         result
     }
 
+    /// Desugar a `SHOW BRANCHES` / `SHOW TAGS` statement into a scan of the
+    /// matching VCS virtual table. Kept out of `parse_sql_command_inner` and
+    /// marked `#[inline(never)]` so its `TableQuery` locals do not inflate
+    /// that already-huge match frame, which is paid twice on the nested
+    /// `CREATE MATERIALIZED VIEW ... AS SELECT` parse path (issue #1569).
+    #[inline(never)]
+    fn parse_show_vcs_ref_table(&mut self, table: &str) -> Result<SqlCommand, ParseError> {
+        let mut query = TableQuery::new(table);
+        self.parse_table_clauses(&mut query)?;
+        Ok(SqlCommand::Select(query))
+    }
+
     fn parse_sql_command_inner(&mut self) -> Result<SqlCommand, ParseError> {
         match self.peek() {
             Token::Select => match self.parse_select_query()? {
@@ -3787,13 +3799,9 @@ impl<'a> Parser<'a> {
                     }
                     Ok(SqlCommand::Select(query))
                 } else if self.consume_ident_ci("BRANCHES")? {
-                    let mut query = TableQuery::new("red.branches");
-                    self.parse_table_clauses(&mut query)?;
-                    Ok(SqlCommand::Select(query))
+                    self.parse_show_vcs_ref_table("red.branches")
                 } else if self.consume_ident_ci("TAGS")? {
-                    let mut query = TableQuery::new("red.tags");
-                    self.parse_table_clauses(&mut query)?;
-                    Ok(SqlCommand::Select(query))
+                    self.parse_show_vcs_ref_table("red.tags")
                 } else if self.consume(&Token::Vectors)? || self.consume_ident_ci("VECTORS")? {
                     Ok(SqlCommand::Select(parse_show_collections_by_model(
                         self, "vector",

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -17,6 +17,8 @@
 //!   to Expr for scalar projection bodies.
 
 use super::join_filter::{compare_runtime_values, resolve_runtime_field};
+use std::collections::{HashMap, HashSet};
+
 use crate::storage::query::ast::{BinOp, Expr, FieldRef, UnaryOp};
 use crate::storage::query::unified::UnifiedRecord;
 use crate::storage::schema::Value;
@@ -213,6 +215,12 @@ pub(super) fn evaluate_runtime_expr_with_db(
             if matches!(upper.as_str(), "MODEL_REGISTER" | "MODEL_DROP") {
                 if let Some(db) = db {
                     return dispatch_model_function(db, &upper, &arg_values);
+                }
+                return None;
+            }
+            if upper == "RED.LCA" {
+                if let Some(db) = db {
+                    return dispatch_vcs_lca_function(db, &arg_values);
                 }
                 return None;
             }
@@ -1273,6 +1281,135 @@ fn dispatch_ca_function(db: &RedDB, name: &str, args: &[Value]) -> Option<Value>
 /// disappears.
 pub(super) fn scalar_dispatch_builtin(name: &str, args: &[Value]) -> Option<Value> {
     dispatch_builtin_function(name, args)
+}
+
+fn dispatch_vcs_lca_function(db: &RedDB, args: &[Value]) -> Option<Value> {
+    if args.len() != 2 {
+        return Some(Value::Null);
+    }
+    let a = text_arg(args.first()?)?;
+    let b = text_arg(args.get(1)?)?;
+    vcs_lca_from_store(db, a, b)
+        .map(Value::text)
+        .or(Some(Value::Null))
+}
+
+pub(super) fn dispatch_vcs_lca_function_public(db: &RedDB, args: &[Value]) -> Option<Value> {
+    dispatch_vcs_lca_function(db, args)
+}
+
+fn text_arg(value: &Value) -> Option<&str> {
+    match value {
+        Value::Text(text) => Some(text.as_ref()),
+        _ => None,
+    }
+}
+
+fn vcs_lca_from_store(db: &RedDB, a: &str, b: &str) -> Option<String> {
+    let commits = vcs_commit_index(db);
+    let mut a_ancestors = HashSet::new();
+    collect_vcs_ancestors(a, &commits, &mut a_ancestors);
+
+    let mut visited = HashSet::new();
+    let mut stack = vec![b.to_string()];
+    let mut best: Option<(u64, String)> = None;
+    while let Some(hash) = stack.pop() {
+        if !visited.insert(hash.clone()) {
+            continue;
+        }
+        if a_ancestors.contains(&hash) {
+            let height = commits.get(&hash).map(|commit| commit.height).unwrap_or(0);
+            match &best {
+                Some((best_height, _)) if *best_height >= height => {}
+                _ => best = Some((height, hash.clone())),
+            }
+            continue;
+        }
+        if let Some(commit) = commits.get(&hash) {
+            for parent in &commit.parents {
+                if !visited.contains(parent) {
+                    stack.push(parent.clone());
+                }
+            }
+        }
+    }
+    best.map(|(_, hash)| hash)
+}
+
+#[derive(Clone)]
+struct VcsCommitNode {
+    parents: Vec<String>,
+    height: u64,
+}
+
+fn vcs_commit_index(db: &RedDB) -> HashMap<String, VcsCommitNode> {
+    let Some(manager) = db
+        .store()
+        .get_collection(crate::application::vcs_collections::COMMITS)
+    else {
+        return HashMap::new();
+    };
+    manager
+        .query_all(|_| true)
+        .into_iter()
+        .filter_map(|entity| {
+            let row = entity.data.as_row()?;
+            let hash = row_text_field(row, "id")?;
+            Some((
+                hash,
+                VcsCommitNode {
+                    parents: row_string_list_field(row, "parents"),
+                    height: row_u64_field(row, "height").unwrap_or(0),
+                },
+            ))
+        })
+        .collect()
+}
+
+fn collect_vcs_ancestors(
+    hash: &str,
+    commits: &HashMap<String, VcsCommitNode>,
+    out: &mut HashSet<String>,
+) {
+    if !out.insert(hash.to_string()) {
+        return;
+    }
+    if let Some(commit) = commits.get(hash) {
+        for parent in &commit.parents {
+            collect_vcs_ancestors(parent, commits, out);
+        }
+    }
+}
+
+fn row_text_field(row: &crate::storage::unified::entity::RowData, field: &str) -> Option<String> {
+    match row.get_field(field)? {
+        Value::Text(value) => Some(value.to_string()),
+        _ => None,
+    }
+}
+
+fn row_u64_field(row: &crate::storage::unified::entity::RowData, field: &str) -> Option<u64> {
+    match row.get_field(field)? {
+        Value::UnsignedInteger(value) => Some(*value),
+        Value::Integer(value) if *value >= 0 => Some(*value as u64),
+        _ => None,
+    }
+}
+
+fn row_string_list_field(
+    row: &crate::storage::unified::entity::RowData,
+    field: &str,
+) -> Vec<String> {
+    match row.get_field(field) {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|value| match value {
+                Value::Text(text) => Some(text.to_string()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1035,6 +1035,12 @@ fn runtime_pool_lock(runtime: &RedDBRuntime) -> std::sync::MutexGuard<'_, PoolSt
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+fn json_runtime_value(value: crate::json::Value) -> Value {
+    crate::json::to_vec(&value)
+        .map(Value::Json)
+        .unwrap_or(Value::Null)
+}
+
 /// The graph-analytics table-valued functions recognized in FROM position.
 /// Both the graph-collection form and the inline `nodes => / edges =>` form
 /// (issue #799) accept these names.
@@ -7431,6 +7437,9 @@ impl RedDBRuntime {
         args: &[String],
         named_args: &[(String, f64)],
     ) -> RedDBResult<crate::storage::query::unified::UnifiedResult> {
+        if name.eq_ignore_ascii_case("red.diff") {
+            return self.execute_vcs_diff_tvf(args, named_args);
+        }
         if !is_graph_tvf_name(name) {
             return Err(RedDBError::Query(format!("unknown table function: {name}")));
         }
@@ -7448,6 +7457,67 @@ impl RedDBRuntime {
         // argument value. Materialization never mutates any store.
         let (nodes, edges) = self.materialize_whole_graph_abstract()?;
         self.dispatch_graph_algorithm(name, nodes, edges, named_args)
+    }
+
+    fn execute_vcs_diff_tvf(
+        &self,
+        args: &[String],
+        named_args: &[(String, f64)],
+    ) -> RedDBResult<crate::storage::query::unified::UnifiedResult> {
+        use crate::application::vcs::{DiffChange, DiffInput};
+        use crate::storage::query::unified::{UnifiedRecord, UnifiedResult};
+        use crate::storage::schema::Value;
+
+        if !named_args.is_empty() {
+            return Err(RedDBError::Query(
+                "red.diff takes only positional commit arguments".to_string(),
+            ));
+        }
+        if args.len() != 2 {
+            return Err(RedDBError::Query(format!(
+                "red.diff takes exactly 2 commit arguments, got {}",
+                args.len()
+            )));
+        }
+
+        let diff = self.vcs_diff(DiffInput {
+            from: args[0].clone(),
+            to: args[1].clone(),
+            collection: None,
+            summary_only: false,
+        })?;
+        let mut result = UnifiedResult::with_columns(vec![
+            "from".into(),
+            "to".into(),
+            "collection".into(),
+            "entity_id".into(),
+            "change".into(),
+            "before".into(),
+            "after".into(),
+        ]);
+        for entry in diff.entries {
+            let (change, before, after) = match entry.change {
+                DiffChange::Added { after } => ("added", Value::Null, json_runtime_value(after)),
+                DiffChange::Removed { before } => {
+                    ("removed", json_runtime_value(before), Value::Null)
+                }
+                DiffChange::Modified { before, after } => (
+                    "modified",
+                    json_runtime_value(before),
+                    json_runtime_value(after),
+                ),
+            };
+            let mut record = UnifiedRecord::new();
+            record.set("from", Value::text(diff.from.clone()));
+            record.set("to", Value::text(diff.to.clone()));
+            record.set("collection", Value::text(entry.collection));
+            record.set("entity_id", Value::text(entry.entity_id));
+            record.set("change", Value::text(change));
+            record.set("before", before);
+            record.set("after", after);
+            result.push(record);
+        }
+        Ok(result)
     }
 
     /// Dispatch an inline-graph table-valued function call in FROM position

--- a/crates/reddb-server/src/runtime/join_filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter.rs
@@ -2300,6 +2300,12 @@ pub(super) fn evaluate_scalar_function_with_db(
             &resolved,
         );
     }
+    if func_name.eq_ignore_ascii_case("red.lca") {
+        let resolved: Vec<Value> = (0..args.len())
+            .map(|i| resolve_scalar_arg(args, i, source).unwrap_or(Value::Null))
+            .collect();
+        return super::expr_eval::dispatch_vcs_lca_function_public(db?, &resolved);
+    }
     evaluate_scalar_function_legacy(name, args, source)
 }
 

--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -1320,12 +1320,10 @@ fn hash_filter(query: &TableQuery) -> Option<String> {
     fn visit(filter: &Filter) -> Option<String> {
         match filter {
             Filter::Compare {
-                field,
+                field: FieldRef::TableColumn { column, .. },
                 op: CompareOp::Eq,
                 value: Value::Text(hash),
-            } if matches!(field, FieldRef::TableColumn { column, .. } if column == "hash") => {
-                Some(hash.to_string())
-            }
+            } if column == "hash" => Some(hash.to_string()),
             Filter::And(left, right) => visit(left).or_else(|| visit(right)),
             _ => None,
         }

--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use super::*;
 use crate::auth::policies::{ActionPattern, Effect, Policy, ResourcePattern, Statement};
 use crate::catalog::{CollectionModel, SchemaMode};
+use crate::runtime::mvcc::current_connection_id;
 use crate::storage::query::ast::{CompareOp, Expr, FieldRef, Filter, PolicyAction, UnaryOp};
 use crate::storage::query::sql_lowering::{effective_table_filter, effective_table_projections};
 use crate::storage::schema::DataType;
@@ -150,6 +151,18 @@ pub(super) const HYPERTABLE_CHUNKS_INTERNAL: &str = "__red_schema_hypertable_chu
 // thread-discussion decision on #748.
 pub(super) const TIMESERIES_WRITES: &str = "red.timeseries_writes";
 pub(super) const TIMESERIES_WRITES_INTERNAL: &str = "__red_schema_timeseries_writes";
+pub(super) const COMMITS: &str = "red.commits";
+pub(super) const COMMITS_INTERNAL: &str = "__red_schema_commits";
+pub(super) const BRANCHES: &str = "red.branches";
+pub(super) const BRANCHES_INTERNAL: &str = "__red_schema_branches";
+pub(super) const TAGS: &str = "red.tags";
+pub(super) const TAGS_INTERNAL: &str = "__red_schema_tags";
+pub(super) const STATUS: &str = "red.status";
+pub(super) const STATUS_INTERNAL: &str = "__red_schema_status";
+pub(super) const CONFLICTS: &str = "red.conflicts";
+pub(super) const CONFLICTS_INTERNAL: &str = "__red_schema_conflicts";
+pub(super) const VERSIONED: &str = "red.versioned";
+pub(super) const VERSIONED_INTERNAL: &str = "__red_schema_versioned";
 pub(super) const READ_ONLY_ERROR: &str = "system schema is read-only";
 
 const COLLECTION_COLUMNS: [&str; 15] = [
@@ -539,6 +552,46 @@ const TIMESERIES_WRITES_COLUMNS: [&str; 5] = [
     "writes_count",
 ];
 
+const COMMIT_COLUMNS: [&str; 11] = [
+    "hash",
+    "root_xid",
+    "parents",
+    "height",
+    "author_name",
+    "author_email",
+    "committer_name",
+    "committer_email",
+    "message",
+    "timestamp_ms",
+    "signature",
+];
+
+const REF_COLUMNS: [&str; 4] = ["name", "kind", "target", "protected"];
+
+const STATUS_COLUMNS: [&str; 8] = [
+    "connection_id",
+    "head_ref",
+    "head_commit",
+    "detached",
+    "staged_changes",
+    "working_changes",
+    "unresolved_conflicts",
+    "merge_state_id",
+];
+
+const CONFLICT_COLUMNS: [&str; 8] = [
+    "id",
+    "collection",
+    "entity_id",
+    "base",
+    "ours",
+    "theirs",
+    "conflicting_paths",
+    "merge_state_id",
+];
+
+const VERSIONED_COLUMNS: [&str; 2] = ["collection", "versioned"];
+
 // Issue #746 — typed `red.graphs`. `supports_viewport` is the stable
 // capability indicator the Red UI graph explorer keys on (graph
 // viewport contract #744 has landed). `supports_algorithms` is a
@@ -639,6 +692,12 @@ pub(super) fn rewrite_virtual_names(query: &str) -> Option<String> {
         (HYPERTABLE_CHUNKS, HYPERTABLE_CHUNKS_INTERNAL),
         (TIMESERIES, TIMESERIES_INTERNAL),
         (METRICS, METRICS_INTERNAL),
+        (COMMITS, COMMITS_INTERNAL),
+        (BRANCHES, BRANCHES_INTERNAL),
+        (TAGS, TAGS_INTERNAL),
+        (STATUS, STATUS_INTERNAL),
+        (CONFLICTS, CONFLICTS_INTERNAL),
+        (VERSIONED, VERSIONED_INTERNAL),
     ] {
         if let Some(next) = replace_case_insensitive_outside_quotes(&rewritten, public, internal) {
             rewritten = next;
@@ -736,6 +795,18 @@ pub(super) fn is_virtual_table(table: &str) -> bool {
         || table.eq_ignore_ascii_case(HYPERTABLE_CHUNKS)
         || table.eq_ignore_ascii_case(TIMESERIES_WRITES_INTERNAL)
         || table.eq_ignore_ascii_case(TIMESERIES_WRITES)
+        || table.eq_ignore_ascii_case(COMMITS_INTERNAL)
+        || table.eq_ignore_ascii_case(COMMITS)
+        || table.eq_ignore_ascii_case(BRANCHES_INTERNAL)
+        || table.eq_ignore_ascii_case(BRANCHES)
+        || table.eq_ignore_ascii_case(TAGS_INTERNAL)
+        || table.eq_ignore_ascii_case(TAGS)
+        || table.eq_ignore_ascii_case(STATUS_INTERNAL)
+        || table.eq_ignore_ascii_case(STATUS)
+        || table.eq_ignore_ascii_case(CONFLICTS_INTERNAL)
+        || table.eq_ignore_ascii_case(CONFLICTS)
+        || table.eq_ignore_ascii_case(VERSIONED_INTERNAL)
+        || table.eq_ignore_ascii_case(VERSIONED)
 }
 
 pub(super) fn red_query(
@@ -810,6 +881,12 @@ pub(super) fn red_query(
         VirtualTableKind::TimeseriesWrites => {
             timeseries_writes_snapshot(runtime, tenant, visible_collections, query)
         }
+        VirtualTableKind::Commits => commits_snapshot(runtime, query)?,
+        VirtualTableKind::Branches => refs_snapshot(runtime, Some("refs/heads/"))?,
+        VirtualTableKind::Tags => refs_snapshot(runtime, Some("refs/tags/"))?,
+        VirtualTableKind::Status => status_snapshot(runtime)?,
+        VirtualTableKind::Conflicts => conflicts_snapshot(runtime)?,
+        VirtualTableKind::Versioned => versioned_snapshot(runtime, visible_collections)?,
     };
 
     let table_name = query.table.as_str();
@@ -938,6 +1015,12 @@ enum VirtualTableKind {
     Metrics,
     HypertableChunks,
     TimeseriesWrites,
+    Commits,
+    Branches,
+    Tags,
+    Status,
+    Conflicts,
+    Versioned,
 }
 
 impl VirtualTableKind {
@@ -977,6 +1060,11 @@ impl VirtualTableKind {
             Self::Metrics => &METRICS_COLUMNS,
             Self::HypertableChunks => &HYPERTABLE_CHUNK_COLUMNS,
             Self::TimeseriesWrites => &TIMESERIES_WRITES_COLUMNS,
+            Self::Commits => &COMMIT_COLUMNS,
+            Self::Branches | Self::Tags => &REF_COLUMNS,
+            Self::Status => &STATUS_COLUMNS,
+            Self::Conflicts => &CONFLICT_COLUMNS,
+            Self::Versioned => &VERSIONED_COLUMNS,
         }
     }
 
@@ -1016,6 +1104,12 @@ impl VirtualTableKind {
             Self::Metrics => METRICS,
             Self::HypertableChunks => HYPERTABLE_CHUNKS,
             Self::TimeseriesWrites => TIMESERIES_WRITES,
+            Self::Commits => COMMITS,
+            Self::Branches => BRANCHES,
+            Self::Tags => TAGS,
+            Self::Status => STATUS,
+            Self::Conflicts => CONFLICTS,
+            Self::Versioned => VERSIONED,
         }
     }
 }
@@ -1151,9 +1245,221 @@ fn virtual_table_kind(name: &str) -> RedDBResult<VirtualTableKind> {
     {
         return Ok(VirtualTableKind::TimeseriesWrites);
     }
+    if name.eq_ignore_ascii_case(COMMITS_INTERNAL) || name.eq_ignore_ascii_case(COMMITS) {
+        return Ok(VirtualTableKind::Commits);
+    }
+    if name.eq_ignore_ascii_case(BRANCHES_INTERNAL) || name.eq_ignore_ascii_case(BRANCHES) {
+        return Ok(VirtualTableKind::Branches);
+    }
+    if name.eq_ignore_ascii_case(TAGS_INTERNAL) || name.eq_ignore_ascii_case(TAGS) {
+        return Ok(VirtualTableKind::Tags);
+    }
+    if name.eq_ignore_ascii_case(STATUS_INTERNAL) || name.eq_ignore_ascii_case(STATUS) {
+        return Ok(VirtualTableKind::Status);
+    }
+    if name.eq_ignore_ascii_case(CONFLICTS_INTERNAL) || name.eq_ignore_ascii_case(CONFLICTS) {
+        return Ok(VirtualTableKind::Conflicts);
+    }
+    if name.eq_ignore_ascii_case(VERSIONED_INTERNAL) || name.eq_ignore_ascii_case(VERSIONED) {
+        return Ok(VirtualTableKind::Versioned);
+    }
     Err(RedDBError::Query(format!(
         "unknown system schema relation `{name}`"
     )))
+}
+
+fn commits_snapshot(runtime: &RedDBRuntime, query: &TableQuery) -> RedDBResult<Vec<UnifiedRecord>> {
+    let schema = Arc::new(
+        COMMIT_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    let hash = hash_filter(query);
+    let range = if let Some(hash) = hash.clone() {
+        crate::application::vcs::LogRange {
+            to: Some(hash),
+            limit: Some(1),
+            ..Default::default()
+        }
+    } else {
+        crate::application::vcs::LogRange::default()
+    };
+    Ok(runtime
+        .vcs_log(crate::application::vcs::LogInput {
+            connection_id: if hash.is_some() {
+                0
+            } else {
+                current_connection_id()
+            },
+            range,
+        })?
+        .into_iter()
+        .map(|commit| {
+            UnifiedRecord::with_schema(
+                Arc::clone(&schema),
+                vec![
+                    Value::text(commit.hash),
+                    Value::UnsignedInteger(commit.root_xid),
+                    Value::Array(commit.parents.into_iter().map(Value::text).collect()),
+                    Value::UnsignedInteger(commit.height),
+                    Value::text(commit.author.name),
+                    Value::text(commit.author.email),
+                    Value::text(commit.committer.name),
+                    Value::text(commit.committer.email),
+                    Value::text(commit.message),
+                    Value::TimestampMs(commit.timestamp_ms),
+                    commit.signature.map(Value::text).unwrap_or(Value::Null),
+                ],
+            )
+        })
+        .collect())
+}
+
+fn hash_filter(query: &TableQuery) -> Option<String> {
+    fn visit(filter: &Filter) -> Option<String> {
+        match filter {
+            Filter::Compare {
+                field,
+                op: CompareOp::Eq,
+                value: Value::Text(hash),
+            } if matches!(field, FieldRef::TableColumn { column, .. } if column == "hash") => {
+                Some(hash.to_string())
+            }
+            Filter::And(left, right) => visit(left).or_else(|| visit(right)),
+            _ => None,
+        }
+    }
+    effective_table_filter(query).and_then(|filter| visit(&filter))
+}
+
+fn refs_snapshot(runtime: &RedDBRuntime, prefix: Option<&str>) -> RedDBResult<Vec<UnifiedRecord>> {
+    let schema = Arc::new(
+        REF_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    Ok(runtime
+        .vcs_list_refs(prefix)?
+        .into_iter()
+        .map(|reference| {
+            UnifiedRecord::with_schema(
+                Arc::clone(&schema),
+                vec![
+                    Value::text(reference.name),
+                    Value::text(ref_kind_name(reference.kind)),
+                    Value::text(reference.target),
+                    Value::Boolean(reference.protected),
+                ],
+            )
+        })
+        .collect())
+}
+
+fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<UnifiedRecord>> {
+    let schema = Arc::new(
+        STATUS_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    let status = runtime.vcs_status(crate::application::vcs::StatusInput {
+        connection_id: current_connection_id(),
+    })?;
+    Ok(vec![UnifiedRecord::with_schema(
+        schema,
+        vec![
+            Value::UnsignedInteger(status.connection_id),
+            status.head_ref.map(Value::text).unwrap_or(Value::Null),
+            status.head_commit.map(Value::text).unwrap_or(Value::Null),
+            Value::Boolean(status.detached),
+            Value::UnsignedInteger(status.staged_changes as u64),
+            Value::UnsignedInteger(status.working_changes as u64),
+            Value::UnsignedInteger(status.unresolved_conflicts as u64),
+            status
+                .merge_state_id
+                .map(Value::text)
+                .unwrap_or(Value::Null),
+        ],
+    )])
+}
+
+fn conflicts_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<UnifiedRecord>> {
+    let schema = Arc::new(
+        CONFLICT_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    let status = runtime.vcs_status(crate::application::vcs::StatusInput {
+        connection_id: current_connection_id(),
+    })?;
+    let Some(merge_state_id) = status.merge_state_id else {
+        return Ok(Vec::new());
+    };
+    Ok(runtime
+        .vcs_conflicts_list(&merge_state_id)?
+        .into_iter()
+        .map(|conflict| {
+            UnifiedRecord::with_schema(
+                Arc::clone(&schema),
+                vec![
+                    Value::text(conflict.id),
+                    Value::text(conflict.collection),
+                    Value::text(conflict.entity_id),
+                    json_value(conflict.base),
+                    json_value(conflict.ours),
+                    json_value(conflict.theirs),
+                    Value::Array(
+                        conflict
+                            .conflicting_paths
+                            .into_iter()
+                            .map(Value::text)
+                            .collect(),
+                    ),
+                    Value::text(conflict.merge_state_id),
+                ],
+            )
+        })
+        .collect())
+}
+
+fn versioned_snapshot(
+    runtime: &RedDBRuntime,
+    visible_collections: Option<&HashSet<String>>,
+) -> RedDBResult<Vec<UnifiedRecord>> {
+    let schema = Arc::new(
+        VERSIONED_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    Ok(runtime
+        .vcs_list_versioned()?
+        .into_iter()
+        .filter(|collection| collection_is_visible(collection, visible_collections))
+        .map(|collection| {
+            UnifiedRecord::with_schema(
+                Arc::clone(&schema),
+                vec![Value::text(collection), Value::Boolean(true)],
+            )
+        })
+        .collect())
+}
+
+fn ref_kind_name(kind: crate::application::vcs::RefKind) -> &'static str {
+    match kind {
+        crate::application::vcs::RefKind::Branch => "branch",
+        crate::application::vcs::RefKind::Tag => "tag",
+        crate::application::vcs::RefKind::Head => "head",
+    }
+}
+
+fn json_value(value: crate::json::Value) -> Value {
+    crate::json::to_vec(&value)
+        .map(Value::Json)
+        .unwrap_or(Value::Null)
 }
 
 fn governance_registry_snapshot(runtime: &RedDBRuntime) -> Vec<UnifiedRecord> {

--- a/tests/grouped/general_multimodel.rs
+++ b/tests/grouped/general_multimodel.rs
@@ -87,6 +87,9 @@ mod e2e_vcs_opt_in;
 #[path = "vcs/e2e_vcs_phase5.rs"]
 mod e2e_vcs_phase5;
 
+#[path = "vcs/e2e_vcs_rql_read_surface.rs"]
+mod e2e_vcs_rql_read_surface;
+
 #[path = "ai_local_vector/integration_external_env.rs"]
 mod integration_external_env;
 

--- a/tests/grouped/vcs/e2e_vcs_rql_read_surface.rs
+++ b/tests/grouped/vcs/e2e_vcs_rql_read_surface.rs
@@ -1,0 +1,184 @@
+//! Issue #1569: VCS read surface through RQL virtual tables.
+
+use reddb::application::{
+    Author, CheckoutInput, CheckoutTarget, CreateBranchInput, CreateCommitInput, CreateTagInput,
+    VcsUseCases,
+};
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::query::unified::UnifiedRecord;
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn author() -> Author {
+    Author {
+        name: "test".to_string(),
+        email: "test@reddb.io".to_string(),
+    }
+}
+
+fn vcs(rt: &RedDBRuntime) -> VcsUseCases<'_, RedDBRuntime> {
+    VcsUseCases::new(rt)
+}
+
+fn commit(rt: &RedDBRuntime, conn: u64, msg: &str) -> String {
+    vcs(rt)
+        .commit(CreateCommitInput {
+            connection_id: conn,
+            message: msg.to_string(),
+            author: author(),
+            committer: None,
+            amend: false,
+            allow_empty: true,
+        })
+        .expect("commit")
+        .hash
+}
+
+fn text<'a>(record: &'a UnifiedRecord, field: &str) -> &'a str {
+    match record.get(field) {
+        Some(Value::Text(value)) => value.as_ref(),
+        other => panic!("expected text field {field}, got {other:?} in {record:?}"),
+    }
+}
+
+fn integer(record: &UnifiedRecord, field: &str) -> i64 {
+    match record.get(field) {
+        Some(Value::Integer(value)) => *value,
+        Some(Value::UnsignedInteger(value)) => i64::try_from(*value).expect("fits i64"),
+        other => panic!("expected integer field {field}, got {other:?} in {record:?}"),
+    }
+}
+
+#[test]
+fn rql_exposes_vcs_refs_commits_status_and_versioned_collections() {
+    let rt = rt();
+    let c1 = commit(&rt, 42, "root");
+    let c2 = commit(&rt, 42, "second");
+
+    vcs(&rt)
+        .branch_create(CreateBranchInput {
+            name: "feature".to_string(),
+            from: Some(c1.clone()),
+            connection_id: 42,
+        })
+        .expect("branch");
+    vcs(&rt)
+        .tag(CreateTagInput {
+            name: "v1".to_string(),
+            target: c1.clone(),
+            annotation: None,
+        })
+        .expect("tag");
+    rt.execute_query("CREATE TABLE versioned_docs (id INT)")
+        .expect("table");
+    vcs(&rt)
+        .set_versioned("versioned_docs", true)
+        .expect("versioned");
+    vcs(&rt)
+        .checkout(CheckoutInput {
+            connection_id: 42,
+            target: CheckoutTarget::Branch("feature".to_string()),
+            force: false,
+        })
+        .expect("checkout");
+    assert!(
+        vcs(&rt)
+            .branch_list()
+            .expect("branch list")
+            .iter()
+            .any(|reference| reference.name == "refs/heads/feature"),
+        "feature branch should exist through the port"
+    );
+
+    set_current_connection_id(42);
+    let commits = rt
+        .execute_query("SELECT hash, message, height FROM red.commits ORDER BY height DESC LIMIT 1")
+        .expect("red.commits");
+    assert_eq!(commits.result.records.len(), 1);
+    assert_eq!(text(&commits.result.records[0], "hash"), c1);
+    assert_eq!(text(&commits.result.records[0], "message"), "root");
+
+    let commit_show = rt
+        .execute_query(&format!(
+            "SELECT hash, message FROM red.commits WHERE hash = '{c2}'"
+        ))
+        .expect("red.commits hash filter");
+    assert_eq!(commit_show.result.records.len(), 1);
+    assert_eq!(text(&commit_show.result.records[0], "message"), "second");
+
+    let branches = rt
+        .execute_query("SELECT name, target FROM red.branches")
+        .expect("red.branches");
+    assert!(
+        branches
+            .result
+            .records
+            .iter()
+            .any(|record| text(record, "name") == "refs/heads/feature"
+                && text(record, "target") == c1),
+        "expected feature branch in {:?}",
+        branches.result.records
+    );
+
+    let tags = rt
+        .execute_query("SELECT name, target FROM red.tags")
+        .expect("red.tags");
+    assert!(
+        tags.result
+            .records
+            .iter()
+            .any(|record| text(record, "name") == "refs/tags/v1" && text(record, "target") == c1),
+        "expected v1 tag in {:?}",
+        tags.result.records
+    );
+
+    let status = rt
+        .execute_query("SELECT connection_id, head_ref, head_commit FROM red.status")
+        .expect("red.status");
+    assert_eq!(status.result.records.len(), 1);
+    assert_eq!(integer(&status.result.records[0], "connection_id"), 42);
+    assert_eq!(
+        text(&status.result.records[0], "head_ref"),
+        "refs/heads/feature"
+    );
+    assert_eq!(text(&status.result.records[0], "head_commit"), c1);
+
+    let versioned = rt
+        .execute_query("SELECT collection FROM red.versioned")
+        .expect("red.versioned");
+    assert_eq!(versioned.result.records.len(), 1);
+    assert_eq!(
+        text(&versioned.result.records[0], "collection"),
+        "versioned_docs"
+    );
+
+    let diff = rt
+        .execute_query(&format!("SELECT * FROM red.diff('{c1}', '{c2}')"))
+        .expect("red.diff");
+    assert_eq!(
+        diff.result.columns,
+        vec![
+            "from".to_string(),
+            "to".to_string(),
+            "collection".to_string(),
+            "entity_id".to_string(),
+            "change".to_string(),
+            "before".to_string(),
+            "after".to_string(),
+        ]
+    );
+    assert!(diff.result.records.is_empty());
+
+    let lca = rt
+        .execute_query(&format!(
+            "SELECT red.lca('{c1}', '{c2}') AS lca FROM red.status"
+        ))
+        .expect("red.lca");
+    assert_eq!(lca.result.records.len(), 1);
+    assert_eq!(text(&lca.result.records[0], "lca"), c1);
+    clear_current_connection_id();
+}


### PR DESCRIPTION
PRD #1567 slice 1 (urgent). Recovers worker wJEUQ's completed read-surface work, which bounced on the local lint gate with a single `clippy::redundant_guards` error (test/typecheck/build all passed). Merged onto current main (clean over the #1563/#1568 landings) + fixed the clippy guard in `hash_filter`.

Exposes the VCS read surface through RQL over `ReddbVcsPort` (additive — engine unchanged), `connection_id` implicit:
- `red.commits` / `red.branches` / `red.tags` / `red.status` / `red.conflicts` / `red.versioned` virtual tables (mirror `red.collections`)
- `red.diff(a,b)` TVF + `red.lca(a,b)` scalar
- e2e: `tests/grouped/vcs/e2e_vcs_rql_read_surface.rs`

`/repo/*` left intact (retired in slice 4 #1572). Slices #1570/#1571 (`req:1569`) auto-promote when this closes.

Closes #1569

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785368685&installation_id=129708444&pr_number=1573&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1573&signature=5fad5eff1b418d69ecb47d8376476842dc20a6ccf342949e353eeaad0e2fa4ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->