### PR TITLE
merge: #1576 H3 spatial slice 2: CREATE INDEX USING H3 over disk B-tree

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -848,6 +848,11 @@ pub enum ProbabilisticCommand {
     },
 }
 
+/// Default H3 resolution for `CREATE INDEX ... USING H3` when no
+/// explicit resolution is supplied. Resolution 9 ≈ ~150 m hex edge
+/// (PRD #1574 slice 2, #1576).
+pub const DEFAULT_H3_RESOLUTION: u8 = 9;
+
 /// Index type for CREATE INDEX ... USING <type>
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IndexMethod {
@@ -855,6 +860,12 @@ pub enum IndexMethod {
     Hash,
     Bitmap,
     RTree,
+    /// H3 hexagonal spatial index: the `(lat, lon)` geo column is
+    /// encoded to a single H3 cell-id `u64` (at `resolution`) and stored
+    /// in the existing disk-paged B-tree (PRD #1574 slice 2, #1576).
+    H3 {
+        resolution: u8,
+    },
 }
 
 impl fmt::Display for IndexMethod {
@@ -864,6 +875,7 @@ impl fmt::Display for IndexMethod {
             Self::Hash => write!(f, "HASH"),
             Self::Bitmap => write!(f, "BITMAP"),
             Self::RTree => write!(f, "RTREE"),
+            Self::H3 { .. } => write!(f, "H3"),
         }
     }
 }
@@ -3334,6 +3346,7 @@ mod tests {
         assert_eq!(IndexMethod::Hash.to_string(), "HASH");
         assert_eq!(IndexMethod::Bitmap.to_string(), "BITMAP");
         assert_eq!(IndexMethod::RTree.to_string(), "RTREE");
+        assert_eq!(IndexMethod::H3 { resolution: 9 }.to_string(), "H3");
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/index_ddl.rs
+++ b/crates/reddb-rql/src/parser/index_ddl.rs
@@ -2,7 +2,7 @@
 
 use super::error::ParseError;
 use super::Parser;
-use crate::ast::{CreateIndexQuery, DropIndexQuery, IndexMethod, QueryExpr};
+use crate::ast::{CreateIndexQuery, DropIndexQuery, IndexMethod, QueryExpr, DEFAULT_H3_RESOLUTION};
 use crate::lexer::Token;
 
 impl<'a> Parser<'a> {
@@ -76,11 +76,17 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Parse index method identifier: HASH | BTREE | BITMAP | RTREE.
+    /// Parse index method identifier: HASH | BTREE | BITMAP | RTREE | H3.
     /// `HASH` is also a reserved keyword token, so we match both the
     /// keyword form and the ident form — otherwise `USING HASH`
     /// fails with "Unexpected token: HASH" even though the parser
     /// lists HASH as an expected option.
+    ///
+    /// `H3` additionally accepts an optional parenthesised resolution
+    /// (`USING H3 (12)`); when omitted it defaults to
+    /// [`DEFAULT_H3_RESOLUTION`]. The column list is already consumed
+    /// before `USING`, so the trailing `(...)` is unambiguously the
+    /// resolution argument.
     fn parse_index_method(&mut self) -> Result<IndexMethod, ParseError> {
         let peeked = self.peek().clone();
         if matches!(peeked, Token::Hash) {
@@ -89,7 +95,13 @@ impl<'a> Parser<'a> {
         }
         match peeked {
             Token::Ident(ref name) => {
-                let method = match name.to_ascii_uppercase().as_str() {
+                let upper = name.to_ascii_uppercase();
+                if upper == "H3" {
+                    self.advance()?;
+                    let resolution = self.parse_h3_resolution_opt()?;
+                    return Ok(IndexMethod::H3 { resolution });
+                }
+                let method = match upper.as_str() {
                     "HASH" => IndexMethod::Hash,
                     "BTREE" => IndexMethod::BTree,
                     "BITMAP" => IndexMethod::Bitmap,
@@ -97,7 +109,7 @@ impl<'a> Parser<'a> {
                     _ => {
                         return Err(ParseError::new(
                             format!(
-                                "unknown index method '{}', expected HASH, BTREE, BITMAP, or RTREE",
+                                "unknown index method '{}', expected HASH, BTREE, BITMAP, RTREE, or H3",
                                 name
                             ),
                             self.position(),
@@ -108,11 +120,34 @@ impl<'a> Parser<'a> {
                 Ok(method)
             }
             other => Err(ParseError::expected(
-                vec!["HASH", "BTREE", "BITMAP", "RTREE"],
+                vec!["HASH", "BTREE", "BITMAP", "RTREE", "H3"],
                 &other,
                 self.position(),
             )),
         }
+    }
+
+    /// Parse the optional `(resolution)` argument that follows `USING H3`.
+    /// Resolution must be an integer in H3's valid `0..=15` range; absence
+    /// of the parenthesised argument yields [`DEFAULT_H3_RESOLUTION`].
+    fn parse_h3_resolution_opt(&mut self) -> Result<u8, ParseError> {
+        if !self.consume(&Token::LParen)? {
+            return Ok(DEFAULT_H3_RESOLUTION);
+        }
+        let resolution = match self.peek().clone() {
+            Token::Integer(n) if (0..=15).contains(&n) => {
+                self.advance()?;
+                n as u8
+            }
+            other => {
+                return Err(ParseError::new(
+                    format!("H3 resolution must be an integer 0..=15, got {other:?}"),
+                    self.position(),
+                ));
+            }
+        };
+        self.expect(Token::RParen)?;
+        Ok(resolution)
     }
 
     fn parse_index_column_path(&mut self) -> Result<String, ParseError> {
@@ -202,6 +237,41 @@ mod tests {
             ));
             assert_eq!(query.method, expected);
         }
+    }
+
+    #[test]
+    fn parse_create_index_using_h3_defaults_resolution() {
+        let query = parse_create_index("CREATE INDEX idx_loc ON places (loc) USING H3");
+        assert_eq!(query.name, "idx_loc");
+        assert_eq!(query.table, "places");
+        assert_eq!(query.columns, vec!["loc"]);
+        assert_eq!(
+            query.method,
+            IndexMethod::H3 {
+                resolution: DEFAULT_H3_RESOLUTION
+            }
+        );
+    }
+
+    #[test]
+    fn parse_create_index_using_h3_explicit_resolution() {
+        let query = parse_create_index("CREATE INDEX idx_loc ON places (loc) USING H3 (12)");
+        assert_eq!(query.method, IndexMethod::H3 { resolution: 12 });
+
+        // Lowercase method ident is accepted too.
+        let query = parse_create_index("CREATE INDEX idx_loc ON places (loc) USING h3 (0)");
+        assert_eq!(query.method, IndexMethod::H3 { resolution: 0 });
+    }
+
+    #[test]
+    fn parse_create_index_using_h3_rejects_out_of_range_resolution() {
+        let mut p = parser("CREATE INDEX idx ON places (loc) USING H3 (16)");
+        p.expect(Token::Create).expect("CREATE");
+        let err = p.parse_create_index_query().unwrap_err();
+        assert!(
+            err.to_string().contains("H3 resolution must be an integer"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1022,21 +1022,47 @@ fn named_bool(
     }
 }
 
+fn named_i64(
+    named: &std::collections::HashMap<String, crate::storage::schema::Value>,
+    key: &str,
+) -> Option<i64> {
+    match named.get(key) {
+        Some(crate::storage::schema::Value::Integer(value)) => Some(*value),
+        _ => None,
+    }
+}
+
 fn index_method_kind_as_str(method: super::index_store::IndexMethodKind) -> &'static str {
     match method {
         super::index_store::IndexMethodKind::Hash => "hash",
         super::index_store::IndexMethodKind::Bitmap => "bitmap",
         super::index_store::IndexMethodKind::Spatial => "spatial",
         super::index_store::IndexMethodKind::BTree => "btree",
+        // The H3 resolution rides in a sibling `resolution` column of the
+        // persisted descriptor; the method tag itself is just "h3".
+        super::index_store::IndexMethodKind::H3 { .. } => "h3",
     }
 }
 
-fn index_method_kind_from_str(raw: &str) -> Option<super::index_store::IndexMethodKind> {
+/// The H3 resolution to persist for an index. Non-H3 kinds persist `0`,
+/// which the rehydrate path ignores.
+fn index_method_kind_resolution(method: super::index_store::IndexMethodKind) -> u8 {
+    match method {
+        super::index_store::IndexMethodKind::H3 { resolution } => resolution,
+        _ => 0,
+    }
+}
+
+fn index_method_kind_from_str(
+    raw: &str,
+    resolution: u8,
+) -> Option<super::index_store::IndexMethodKind> {
     match raw {
         "hash" => Some(super::index_store::IndexMethodKind::Hash),
         "bitmap" => Some(super::index_store::IndexMethodKind::Bitmap),
         "spatial" | "rtree" => Some(super::index_store::IndexMethodKind::Spatial),
         "btree" => Some(super::index_store::IndexMethodKind::BTree),
+        "h3" => Some(super::index_store::IndexMethodKind::H3 { resolution }),
         _ => None,
     }
 }
@@ -9613,6 +9639,12 @@ impl RedDBRuntime {
                             )),
                         ),
                         (
+                            "resolution".to_string(),
+                            crate::storage::schema::Value::Integer(i64::from(
+                                index_method_kind_resolution(index.method),
+                            )),
+                        ),
+                        (
                             "unique".to_string(),
                             crate::storage::schema::Value::Boolean(index.unique),
                         ),
@@ -9714,8 +9746,11 @@ impl RedDBRuntime {
                         .collect::<Vec<_>>()
                 })
                 .unwrap_or_default();
-            let Some(method) =
-                named_text(named, "method").and_then(|raw| index_method_kind_from_str(&raw))
+            let resolution = named_i64(named, "resolution")
+                .and_then(|v| u8::try_from(v).ok())
+                .unwrap_or(0);
+            let Some(method) = named_text(named, "method")
+                .and_then(|raw| index_method_kind_from_str(&raw, resolution))
             else {
                 continue;
             };

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -1433,6 +1433,9 @@ impl RedDBRuntime {
             IndexMethod::BTree => super::index_store::IndexMethodKind::BTree,
             IndexMethod::Bitmap => super::index_store::IndexMethodKind::Bitmap,
             IndexMethod::RTree => super::index_store::IndexMethodKind::Spatial,
+            IndexMethod::H3 { resolution } => {
+                super::index_store::IndexMethodKind::H3 { resolution }
+            }
         };
 
         // Extract fields from existing entities for indexing. Row

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1120,7 +1120,7 @@ impl RegisteredIndex {
         match self.method {
             IndexMethodKind::Hash => std::borrow::Cow::Borrowed(self.name.as_str()),
             IndexMethodKind::BTree => std::borrow::Cow::Owned(format!("{}_hash", self.name)),
-            IndexMethodKind::Bitmap | IndexMethodKind::Spatial => {
+            IndexMethodKind::Bitmap | IndexMethodKind::Spatial | IndexMethodKind::H3 { .. } => {
                 std::borrow::Cow::Borrowed(self.name.as_str())
             }
         }
@@ -1133,7 +1133,23 @@ pub enum IndexMethodKind {
     Bitmap,
     Spatial,
     BTree,
+    /// H3 spatial index: the geo column's `(lat, lon)` is encoded to a
+    /// single H3 cell-id and stored in the sorted (disk-paged B-tree)
+    /// index, exactly like a single-column `BTree` index but with an
+    /// integer cell key in place of the raw column value. `resolution`
+    /// is the H3 grid level (0..=15). RAM stays O(working set), not
+    /// O(points) — no separate resident structure (PRD #1574, #1576).
+    H3 {
+        resolution: u8,
+    },
 }
+
+/// Default H3 resolution used when reconstructing an H3 index kind from
+/// the incremental-maintainer mirror, which does not carry the
+/// resolution. Mirrors `reddb_rql::ast::DEFAULT_H3_RESOLUTION`; the
+/// authoritative resolution is always persisted in the index registry,
+/// so this default is only a structural placeholder.
+pub(crate) const DEFAULT_H3_RESOLUTION: u8 = 9;
 
 /// Unified index store aggregating all secondary index managers.
 pub struct IndexStore {
@@ -1217,6 +1233,16 @@ impl IndexStore {
                 // Spatial indexing happens via insert with lat/lon
                 Ok(0)
             }
+            IndexMethodKind::H3 { resolution } => {
+                // Encode each existing row's geo column to its H3 cell-id
+                // and build a sorted (disk-paged B-tree) index over those
+                // u64 keys — identical machinery to a single-column BTree,
+                // only the stored key is the cell-id rather than the raw
+                // GeoPoint. No resident HashMap / R-tree is allocated.
+                let cell_entities = derive_h3_cell_entities(entities, col, resolution);
+                let count = self.sorted.build_index(collection, col, &cell_entities);
+                Ok(count)
+            }
             IndexMethodKind::BTree => {
                 // Multi-column BTree → composite sorted index.
                 // `CREATE INDEX idx_cc ON users (city, age) USING BTREE`
@@ -1274,7 +1300,10 @@ impl IndexStore {
                     let col = info.columns.first().map(|s| s.as_str()).unwrap_or("");
                     self.spatial.drop_index(collection, col)
                 }
-                IndexMethodKind::BTree => false,
+                // Sorted-backed indexes (BTree / H3) are removed from the
+                // registry above; the sorted manager has no per-index drop
+                // (mirrors the pre-existing BTree behaviour).
+                IndexMethodKind::BTree | IndexMethodKind::H3 { .. } => false,
             };
             true
         } else {
@@ -1362,10 +1391,11 @@ impl IndexStore {
                 .index_stats(&index.collection, &index.name)
                 .map(|stats| stats.total_entries as u64)
                 .unwrap_or(0),
-            IndexMethodKind::BTree => self
-                .sorted
-                .entry_count(&index.collection, &index.columns)
-                .unwrap_or(0) as u64,
+            IndexMethodKind::BTree | IndexMethodKind::H3 { .. } => {
+                self.sorted
+                    .entry_count(&index.collection, &index.columns)
+                    .unwrap_or(0) as u64
+            }
             IndexMethodKind::Bitmap => index
                 .columns
                 .first()
@@ -1504,6 +1534,11 @@ impl IndexStore {
                                 .insert(collection, hash_name, key, *entity_id)
                                 .map_err(|err| err.to_string())?;
                         }
+                        IndexMethodKind::H3 { resolution } => {
+                            if let Some(cell) = h3_cell_value(value.as_ref(), resolution) {
+                                self.sorted.insert_one(collection, col, &cell, *entity_id);
+                            }
+                        }
                         IndexMethodKind::Spatial => {}
                     }
                 }
@@ -1562,6 +1597,16 @@ impl IndexStore {
                             .insert(collection, &format!("{}_hash", idx.name), key, entity_id)
                             .map_err(|err| err.to_string())?;
                     }
+                    IndexMethodKind::H3 { resolution } => {
+                        if !self.sorted.has_index(collection, col) {
+                            return Err(format!(
+                                "sorted index for collection '{collection}' column '{col}' was not found"
+                            ));
+                        }
+                        if let Some(cell) = h3_cell_value(value.as_ref(), resolution) {
+                            self.sorted.insert_one(collection, col, &cell, entity_id);
+                        }
+                    }
                     IndexMethodKind::Spatial => {}
                 }
             }
@@ -1619,6 +1664,11 @@ impl IndexStore {
                             &key,
                             entity_id,
                         );
+                    }
+                    IndexMethodKind::H3 { resolution } => {
+                        if let Some(cell) = h3_cell_value(value.as_ref(), resolution) {
+                            self.sorted.delete_one(collection, col, &cell, entity_id);
+                        }
                     }
                     IndexMethodKind::Spatial => {}
                 }
@@ -1772,6 +1822,9 @@ impl From<IndexMethodKind> for IncMethodKind {
             IndexMethodKind::Bitmap => IncMethodKind::Bitmap,
             IndexMethodKind::Spatial => IncMethodKind::Spatial,
             IndexMethodKind::BTree => IncMethodKind::BTree,
+            // The maintainer mirror doesn't carry the H3 resolution; the
+            // sorted half is maintained via `index_entity_insert`.
+            IndexMethodKind::H3 { .. } => IncMethodKind::H3,
         }
     }
 }
@@ -1783,6 +1836,11 @@ impl From<IncMethodKind> for IndexMethodKind {
             IncMethodKind::Bitmap => IndexMethodKind::Bitmap,
             IncMethodKind::Spatial => IndexMethodKind::Spatial,
             IncMethodKind::BTree => IndexMethodKind::BTree,
+            // Resolution isn't carried by the mirror — placeholder only;
+            // the authoritative resolution lives in the index registry.
+            IncMethodKind::H3 => IndexMethodKind::H3 {
+                resolution: DEFAULT_H3_RESOLUTION,
+            },
         }
     }
 }
@@ -1821,7 +1879,10 @@ impl SecondaryIndexBackend for IndexStore {
                     .insert(collection, &aux, key.to_vec(), row_id)
                     .map_err(|e| e.to_string())
             }
-            IncMethodKind::Spatial => Ok(()),
+            // H3 has no auxiliary hash side-pocket; its sorted half is
+            // maintained by `index_entity_insert` (which has the raw
+            // GeoPoint Value + resolution). Spatial is likewise a no-op.
+            IncMethodKind::Spatial | IncMethodKind::H3 => Ok(()),
         }
     }
 
@@ -1844,7 +1905,7 @@ impl SecondaryIndexBackend for IndexStore {
                 let aux = format!("{}_hash", idx.name);
                 let _ = self.hash.remove(collection, &aux, key, row_id);
             }
-            IncMethodKind::Spatial => {}
+            IncMethodKind::Spatial | IncMethodKind::H3 => {}
         }
     }
 }
@@ -1928,6 +1989,51 @@ fn derive_index_entities_for_column(
         .collect()
 }
 
+/// Encode a geo column value to its H3 cell-id at `resolution`, wrapped
+/// as a `Value::UnsignedInteger` so it stores and range-scans through the
+/// ordinary sorted-index machinery. Mirrors the `H3_INDEX` RQL scalar
+/// (slice 1), which also yields an `UnsignedInteger`, so the index key
+/// family matches the query side.
+///
+/// Returns `None` when the value is not a `GeoPoint`, or when the
+/// coordinate fails to encode (`lat_lng_to_cell` returns the `0`
+/// sentinel) — those rows are simply absent from the index, exactly as
+/// an `Unsupported` value is absent from a BTree index.
+fn h3_cell_value(value: &Value, resolution: u8) -> Option<Value> {
+    let (lat, lon) = match value {
+        Value::GeoPoint(lat_micro, lon_micro) => (
+            crate::geo::micro_to_deg(*lat_micro),
+            crate::geo::micro_to_deg(*lon_micro),
+        ),
+        _ => return None,
+    };
+    let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
+    if cell == 0 {
+        return None;
+    }
+    Some(Value::UnsignedInteger(cell))
+}
+
+/// Build the `(entity, [(column, cell-id)])` rows for an H3 index from a
+/// collection's existing entities: resolve each row's geo column, encode
+/// it to its cell-id, and skip rows whose column is absent or not a geo
+/// point. The resulting rows feed `SortedIndexManager::build_index`
+/// unchanged.
+fn derive_h3_cell_entities(
+    entities: &[(EntityId, Vec<(String, Value)>)],
+    column: &str,
+    resolution: u8,
+) -> Vec<(EntityId, Vec<(String, Value)>)> {
+    entities
+        .iter()
+        .filter_map(|(entity_id, fields)| {
+            let value = index_field_value(fields, column)?;
+            let cell = h3_cell_value(value.as_ref(), resolution)?;
+            Some((*entity_id, vec![(column.to_string(), cell)]))
+        })
+        .collect()
+}
+
 /// Convert a Value to bytes for index key
 fn value_to_bytes(value: &Value) -> Vec<u8> {
     match value {
@@ -1946,6 +2052,64 @@ mod tests {
 
     fn ids(values: &[EntityId]) -> Vec<u64> {
         values.iter().map(|id| id.raw()).collect()
+    }
+
+    #[test]
+    fn h3_cell_value_encodes_geopoint_to_unsigned_cell() {
+        // Paris (Notre-Dame). i32 micro-degrees.
+        let paris = Value::GeoPoint(48_856_600, 2_352_200);
+        let cell = h3_cell_value(&paris, 9).expect("geopoint must encode to a cell");
+        match cell {
+            Value::UnsignedInteger(n) => {
+                assert_ne!(n, 0, "valid coordinate must not yield the 0 sentinel");
+                assert_eq!(
+                    n,
+                    crate::geo::h3::lat_lng_to_cell(48.8566, 2.3522, 9),
+                    "index key must match the slice-1 encode of the same point"
+                );
+            }
+            other => panic!("expected UnsignedInteger cell, got {other:?}"),
+        }
+
+        // Finer resolution yields a different (child) cell id.
+        let fine = h3_cell_value(&paris, 12).unwrap();
+        assert_ne!(
+            fine, cell,
+            "a finer resolution must produce a distinct cell"
+        );
+    }
+
+    #[test]
+    fn h3_cell_value_rejects_non_geopoint() {
+        assert!(h3_cell_value(&Value::Integer(5), 9).is_none());
+        assert!(h3_cell_value(&Value::text("48.8,2.3".to_string()), 9).is_none());
+    }
+
+    #[test]
+    fn derive_h3_cell_entities_skips_missing_and_non_geo_rows() {
+        let entities = vec![
+            (
+                EntityId::new(1),
+                vec![("loc".to_string(), Value::GeoPoint(48_856_600, 2_352_200))],
+            ),
+            // No `loc` column — skipped.
+            (
+                EntityId::new(2),
+                vec![("id".to_string(), Value::Integer(2))],
+            ),
+            // `loc` present but not a geo point — skipped.
+            (
+                EntityId::new(3),
+                vec![("loc".to_string(), Value::Integer(0))],
+            ),
+        ];
+        let derived = derive_h3_cell_entities(&entities, "loc", 9);
+        assert_eq!(derived.len(), 1, "only the valid geo row is indexed");
+        assert_eq!(derived[0].0, EntityId::new(1));
+        assert!(matches!(
+            derived[0].1.first(),
+            Some((c, Value::UnsignedInteger(_))) if c == "loc"
+        ));
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/red_schema.rs
+++ b/crates/reddb-server/src/runtime/red_schema.rs
@@ -2161,6 +2161,7 @@ fn index_method_kind_name(kind: super::index_store::IndexMethodKind) -> &'static
         super::index_store::IndexMethodKind::BTree => "btree",
         super::index_store::IndexMethodKind::Bitmap => "bitmap",
         super::index_store::IndexMethodKind::Spatial => "spatial.rtree",
+        super::index_store::IndexMethodKind::H3 { .. } => "spatial.h3",
     }
 }
 
@@ -2415,6 +2416,7 @@ fn render_index_method_for_ddl(method: super::index_store::IndexMethodKind) -> &
         super::index_store::IndexMethodKind::BTree => "BTREE",
         super::index_store::IndexMethodKind::Bitmap => "BITMAP",
         super::index_store::IndexMethodKind::Spatial => "RTREE",
+        super::index_store::IndexMethodKind::H3 { .. } => "H3",
     }
 }
 

--- a/crates/reddb-server/src/storage/unified/index/incremental.rs
+++ b/crates/reddb-server/src/storage/unified/index/incremental.rs
@@ -63,6 +63,11 @@ pub enum IndexMethodKind {
     Bitmap,
     Spatial,
     BTree,
+    /// H3 spatial index (cell-id `u64` stored in the sorted B-tree).
+    /// The maintainer mirror does not carry the resolution — the
+    /// sorted half is maintained through `index_entity_insert`, which
+    /// reads the resolution from the runtime `IndexMethodKind::H3`.
+    H3,
 }
 
 /// One incremental change to a single secondary index.

--- a/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_rtree_unknown_method.snap
+++ b/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_rtree_unknown_method.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"CREATE INDEX gix ON sites (location) USING WRONGT
 ---
 input: "CREATE INDEX gix ON sites (location) USING WRONGTREE"
 kind:  Syntax
-error: Parse error at 1:44: unknown index method 'WRONGTREE', expected HASH, BTREE, BITMAP, or RTREE
+error: Parse error at 1:44: unknown index method 'WRONGTREE', expected HASH, BTREE, BITMAP, RTREE, or H3

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -1,0 +1,183 @@
+//! H3 spatial index (PRD #1574 slice 2, #1576).
+//!
+//! `CREATE INDEX … USING H3 (col [, resolution])` encodes a GeoPoint
+//! column to its H3 cell-id `u64` and stores it in the existing
+//! disk-paged sorted (B-tree) index — NOT the in-RAM rstar R-tree.
+//! These tests assert:
+//!   1. the index builds from existing rows and surfaces through normal
+//!      index introspection (`red.show_indexes`),
+//!   2. it survives a restart, rebuilt from the catalog like any other
+//!      B-tree index,
+//!   3. the write path (insert / update) maintains the sorted index
+//!      with no per-point resident structure — the rstar R-tree is never
+//!      touched, and a point move is a single B-tree key update.
+
+#[allow(dead_code)]
+#[path = "../../support/mod.rs"]
+mod support;
+
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+/// Pull a single index row from `red.show_indexes` for `table` + `name`.
+/// Returns `(kind, entries_indexed)`.
+fn show_index(rt: &RedDBRuntime, table: &str, name: &str) -> Option<(String, u64)> {
+    let res = rt
+        .execute_query("SELECT name, table, kind, entries_indexed FROM red.show_indexes")
+        .expect("red.show_indexes must be queryable");
+    res.result.records.iter().find_map(|r| {
+        let r_name = match r.get("name") {
+            Some(Value::Text(t)) => t.to_string(),
+            _ => return None,
+        };
+        let r_table = match r.get("table") {
+            Some(Value::Text(t)) => t.to_string(),
+            _ => return None,
+        };
+        if r_name != name || r_table != table {
+            return None;
+        }
+        let kind = match r.get("kind") {
+            Some(Value::Text(t)) => t.to_string(),
+            _ => return None,
+        };
+        let entries = match r.get("entries_indexed") {
+            Some(Value::UnsignedInteger(n)) => *n,
+            Some(Value::Integer(n)) => *n as u64,
+            _ => return None,
+        };
+        Some((kind, entries))
+    })
+}
+
+fn seed_places(rt: &RedDBRuntime) {
+    rt.execute_query("CREATE TABLE places (id INT, loc GEOPOINT)")
+        .unwrap();
+    // Paris, São Paulo, London.
+    for (id, loc) in [
+        (1, "48.8566,2.3522"),
+        (2, "-23.550520,-46.633308"),
+        (3, "51.5074,-0.1278"),
+    ] {
+        rt.execute_query(&format!(
+            "INSERT INTO places (id, loc) VALUES ({id}, '{loc}')"
+        ))
+        .unwrap();
+    }
+}
+
+#[test]
+fn h3_index_builds_and_surfaces_in_introspection() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_places(&rt);
+
+    rt.execute_query("CREATE INDEX idx_loc ON places (loc) USING H3")
+        .unwrap();
+
+    // Introspection: the index shows up as an H3 kind over all 3 rows.
+    let (kind, entries) =
+        show_index(&rt, "places", "idx_loc").expect("idx_loc must appear in red.show_indexes");
+    assert_eq!(kind, "H3", "index kind must render as H3");
+    assert_eq!(entries, 3, "H3 index must cover all 3 existing geo rows");
+
+    // It is the disk B-tree (sorted) index — the in-RAM rstar R-tree is
+    // never touched by an H3 index (that is slice 4's concern).
+    let store = rt.index_store_ref();
+    assert!(
+        store.spatial.index_stats("places", "loc").is_err(),
+        "H3 index must NOT create a resident rstar R-tree for the column"
+    );
+}
+
+#[test]
+fn h3_index_accepts_explicit_resolution() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_places(&rt);
+
+    rt.execute_query("CREATE INDEX idx_loc12 ON places (loc) USING H3 (12)")
+        .unwrap();
+
+    let (kind, entries) =
+        show_index(&rt, "places", "idx_loc12").expect("idx_loc12 must appear in introspection");
+    assert_eq!(kind, "H3");
+    assert_eq!(entries, 3);
+}
+
+#[test]
+fn h3_index_write_path_is_single_btree_key_update() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_places(&rt);
+    rt.execute_query("CREATE INDEX idx_loc ON places (loc) USING H3")
+        .unwrap();
+
+    // Insert a new point — index grows by exactly one key.
+    rt.execute_query("INSERT INTO places (id, loc) VALUES (4, '40.7128,-74.0060')")
+        .unwrap();
+    let (_, after_insert) = show_index(&rt, "places", "idx_loc").unwrap();
+    assert_eq!(after_insert, 4, "insert must add exactly one B-tree key");
+
+    // Move an existing point — a single key re-key (delete old cell +
+    // insert new cell), NOT growth. The entry count is unchanged, which
+    // is the "writes are single-integer B-tree updates, no per-point RAM
+    // growth" acceptance. (DELETE-driven index cleanup is deferred to
+    // MVCC vacuum engine-wide, so we assert the move, not a raw delete.)
+    rt.execute_query("UPDATE places SET loc = '35.6895,139.6917' WHERE id = 1")
+        .unwrap();
+    let (_, after_update) = show_index(&rt, "places", "idx_loc").unwrap();
+    assert_eq!(
+        after_update, 4,
+        "a point move is a single B-tree key update — no per-point growth"
+    );
+
+    assert!(
+        rt.index_store_ref()
+            .spatial
+            .index_stats("places", "loc")
+            .is_err(),
+        "no resident rstar R-tree may be allocated by the H3 write path"
+    );
+}
+
+#[test]
+fn h3_index_survives_restart_rebuilt_from_catalog() {
+    let dir = support::temp_data_dir("e2e-h3-index-replay");
+    let path = dir.join("data.rdb");
+    {
+        let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).unwrap();
+        seed_places(&rt);
+        rt.execute_query("CREATE INDEX idx_loc ON places (loc) USING H3 (10)")
+            .unwrap();
+        let (kind, entries) = show_index(&rt, "places", "idx_loc").unwrap();
+        assert_eq!(kind, "H3");
+        assert_eq!(entries, 3, "pre-restart sanity");
+    }
+
+    // Reopen the same path: the H3 index must be rebuilt from the
+    // persisted catalog descriptor (including its resolution), exactly
+    // like any other B-tree index — not lost, not a separate map.
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).unwrap();
+
+    let total = rt.execute_query("SELECT * FROM places").unwrap();
+    assert_eq!(
+        total.result.records.len(),
+        3,
+        "table data must survive restart"
+    );
+
+    let (kind, entries) = show_index(&rt, "places", "idx_loc")
+        .expect("H3 index must be rehydrated into introspection after restart");
+    assert_eq!(kind, "H3", "rehydrated index must still be H3 kind");
+    assert_eq!(
+        entries, 3,
+        "rehydrated H3 index must be rebuilt over all 3 rows from the catalog"
+    );
+
+    // Still purely a disk B-tree after rehydrate — no rstar R-tree.
+    assert!(
+        rt.index_store_ref()
+            .spatial
+            .index_stats("places", "loc")
+            .is_err(),
+        "rehydrated H3 index must not allocate a resident R-tree"
+    );
+}

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -15,6 +15,9 @@ mod e2e_composite_index;
 #[path = "mvcc_transactions/e2e_cross_model_tx.rs"]
 mod e2e_cross_model_tx;
 
+#[path = "schema_query_core/e2e_h3_index.rs"]
+mod e2e_h3_index;
+
 #[path = "locking_concurrency/e2e_ddl_concurrency.rs"]
 mod e2e_ddl_concurrency;
 


### PR DESCRIPTION
## What

PRD #1574 slice 2 (#1576): an **H3 spatial index** that stores the H3 cell-id `u64` in reddb's **existing disk-paged sorted B-tree** — no new in-RAM structure. RAM stays O(working set), not O(points); the in-RAM rstar R-tree is untouched (that is slice 4, #1578).

## Changes

- **Parser** (`reddb-rql`): `CREATE INDEX … USING H3 [(resolution)]`, default resolution 9 (`DEFAULT_H3_RESOLUTION`, ~150 m). New `IndexMethod::H3 { resolution }`. `H3` is parsed as a method ident (like BTREE/BITMAP/RTREE), not a new lexer keyword.
- **Catalog + runtime** (`index_store`): new `IndexMethodKind::H3 { resolution }` that **reuses the single-column BTree machinery** (`SortedIndexManager::build_index`/`insert_one`/`delete_one`). The stored key is the cell-id computed from the row's `GeoPoint` column via `geo::h3::lat_lng_to_cell`, wrapped as `Value::UnsignedInteger` to match the slice-1 `H3_INDEX` scalar key family. Write path hooked in `create_index`, `index_entity_insert`(+batch), `index_entity_delete`, and `index_entity_update` (re-key).
- **Persistence**: resolution persisted in the runtime index registry (`resolution` column); the H3 index is **rebuilt from the catalog on open** like any other B-tree index.
- **Introspection**: surfaces in `red.show_indexes` (kind `H3`) and `red.indexes` (`spatial.h3`).

## How it reuses existing machinery

Mirrors the **single-column `BTree`** index path: H3 differs only in transforming the geo `Value` into a `UnsignedInteger` cell-id before handing it to the same sorted-index store (and it carries no `{name}_hash` aux side-pocket).

## Tests

- `reddb-io-rql` parser unit tests (default/explicit/out-of-range resolution) — 805/805 pass.
- `index_store` unit tests for the cell encoder + entity derivation.
- e2e in `grouped_sql_core` (`e2e_h3_index`): build + introspection, explicit resolution, write-path re-key with no per-point growth and no resident R-tree, restart rebuild from catalog — **4/4 pass**.
- `llms_txt_generated` 4/4 (no drift); clippy clean on `reddb-io-server` + `reddb-io-rql`; rustfmt 1.91.

Does **not** touch `storage/unified/spatial_index.rs` (rstar) — that is slice 4 (#1578).

Closes #1576

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785392942&installation_id=129708444&pr_number=1584&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1584&signature=6322b7ed77539a1b9fe45f4398447f97b8194d5cf0f2a3d383451c9bfa8c9370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and introspecting H3 spatial indexes.
  * H3 indexes now accept an optional resolution value, with a default applied when omitted.
  * `SHOW CREATE TABLE` and related index reporting now display H3 indexes consistently.

* **Bug Fixes**
  * H3 index data now persists correctly across restarts.
  * Inserts, updates, and deletes keep H3 index entries in sync with table changes.

* **Tests**
  * Added end-to-end coverage for H3 index creation, querying, updates, and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->