### PR TITLE
merge: #1577 H3 spatial slice 3: route SEARCH SPATIAL to H3 index

### DIFF
--- a/crates/reddb-server/src/geo/h3.rs
+++ b/crates/reddb-server/src/geo/h3.rs
@@ -60,6 +60,17 @@ pub fn grid_disk(cell: u64, k: u32) -> Vec<u64> {
     }
 }
 
+/// Average hexagon edge length, in kilometres, for an H3 resolution.
+///
+/// Sourced from h3o's per-resolution average-edge table. Used by the
+/// spatial query path to size the covering kRing for a radius search
+/// (`k ≈ radius_km / edge_km`): one grid step spans at least one edge
+/// length, so dividing the radius by the edge length over-estimates the
+/// ring count, which keeps the cover a safe superset (PRD #1574 slice 3).
+pub fn edge_length_km(res: u8) -> f64 {
+    clamp_resolution(res).edge_length_km()
+}
+
 /// Truncate `cell` to its ancestor cell at the coarser resolution
 /// `res` (hierarchical parent).
 ///
@@ -127,6 +138,18 @@ mod tests {
         assert_eq!(coarse, lat_lng_to_cell(PARIS_LAT, PARIS_LON, 5));
         // A "parent" finer than the cell's own resolution has no answer.
         assert_eq!(cell_to_parent(fine, 12), 0);
+    }
+
+    #[test]
+    fn edge_length_km_is_positive_and_shrinks_with_resolution() {
+        // Coarser resolutions have longer edges than finer ones, and the
+        // length is always a usable positive number for the cover sizing.
+        let coarse = edge_length_km(5);
+        let fine = edge_length_km(12);
+        assert!(coarse > 0.0 && fine > 0.0);
+        assert!(coarse > fine, "edge length must shrink as resolution grows");
+        // Out-of-range bytes clamp to res 15 rather than panicking.
+        assert!(edge_length_km(200) > 0.0);
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -865,12 +865,21 @@ impl RedDBRuntime {
                     ));
                 }
                 use crate::storage::unified::spatial_index::haversine_km;
-                let _ = column; // Column indicates which field holds geo data
+                // When the geo column carries an H3 index, gather candidates
+                // from a covering kRing over the disk B-tree cell ids; the
+                // ring is a provable superset of the in-radius rows, so the
+                // haversine post-filter below yields byte-identical results
+                // to the full scan. Without an H3 index, scan every row
+                // exactly as before (PRD #1574 slice 3).
+                let h3_candidates = self.h3_radius_candidate_ids(
+                    collection,
+                    column,
+                    *center_lat,
+                    *center_lon,
+                    *radius_km,
+                );
                 let store = self.inner.db.store();
-                let entities = store
-                    .get_collection(collection)
-                    .map(|m| m.query_all(|_| true))
-                    .unwrap_or_default();
+                let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
                 for entity in &entities {
@@ -920,12 +929,15 @@ impl RedDBRuntime {
                             .to_string(),
                     ));
                 }
-                let _ = column;
+                // Cover the bbox with a kRing big enough to enclose its
+                // farthest corner from the centre, scan those cells off the
+                // H3 disk index, then apply the exact bbox filter. The ring
+                // is a superset of the box, so results match the full scan.
+                let h3_candidates = self.h3_bbox_candidate_ids(
+                    collection, column, *min_lat, *min_lon, *max_lat, *max_lon,
+                );
                 let store = self.inner.db.store();
-                let entities = store
-                    .get_collection(collection)
-                    .map(|m| m.query_all(|_| true))
-                    .unwrap_or_default();
+                let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
 
                 let mut result = UnifiedResult::with_columns(vec!["entity_id".into()]);
                 let mut count = 0;
@@ -969,12 +981,16 @@ impl RedDBRuntime {
                     ));
                 }
                 use crate::storage::unified::spatial_index::haversine_km;
-                let _ = column;
+                // Expand rings outward off the H3 disk index until the K-th
+                // nearest candidate is provably closer than any unscanned
+                // cell, then post-filter exactly as the full scan does. When
+                // no H3 index covers the column (or the cover can't be
+                // proven within the ring cap), fall back to the full scan so
+                // results stay byte-identical (PRD #1574 slice 3).
+                let h3_candidates =
+                    self.h3_nearest_candidate_ids(collection, column, *lat, *lon, *k);
                 let store = self.inner.db.store();
-                let entities = store
-                    .get_collection(collection)
-                    .map(|m| m.query_all(|_| true))
-                    .unwrap_or_default();
+                let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
                 for entity in &entities {
@@ -1264,5 +1280,197 @@ fn extract_geo_from_entity(entity: &UnifiedEntity) -> Option<(f64, f64)> {
             None
         }
         _ => None,
+    }
+}
+
+/// Collect the entities a spatial post-filter runs over. With an H3 cover
+/// (`Some`), the collection scan is restricted to the candidate entity ids
+/// while preserving `query_all` order, so the downstream stable sort and
+/// early-LIMIT behaviour stay byte-identical to the full scan. Without a
+/// cover (`None`), every row is scanned exactly as before (PRD #1574 slice 3).
+fn scan_collection_with_candidates(
+    store: &std::sync::Arc<crate::storage::unified::store::UnifiedStore>,
+    collection: &str,
+    candidates: &Option<std::collections::HashSet<u64>>,
+) -> Vec<UnifiedEntity> {
+    match candidates {
+        Some(ids) => store
+            .get_collection(collection)
+            .map(|m| m.query_all(|e| ids.contains(&e.id.raw())))
+            .unwrap_or_default(),
+        None => store
+            .get_collection(collection)
+            .map(|m| m.query_all(|_| true))
+            .unwrap_or_default(),
+    }
+}
+
+/// Cells covering a disk of `radius_km` around `(lat, lon)` at `resolution`.
+///
+/// Sizes the kRing as `ceil(radius_km / edge_km) + 1`: one grid step spans
+/// at least one edge length, so the division over-estimates the ring count,
+/// and the extra ring is the boundary margin that prevents the geohash-style
+/// edge miss. Returns an empty vec — signalling the caller to fall back to
+/// the full scan — for an un-encodable coordinate or a cover so large it
+/// would be cheaper to scan the collection than to enumerate the cells.
+fn h3_cover_cells(lat: f64, lon: f64, radius_km: f64, resolution: u8) -> Vec<u64> {
+    let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
+    if cell == 0 {
+        return Vec::new();
+    }
+    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
+    // Cap the cover so a large radius over a fine resolution cannot blow up
+    // into hundreds of millions of cells; beyond it the full scan is cheaper.
+    const MAX_COVER_RING: u32 = 128;
+    let k_f = (radius_km / edge_km).ceil() + 1.0;
+    if !k_f.is_finite() || k_f > f64::from(MAX_COVER_RING) {
+        return Vec::new();
+    }
+    crate::geo::h3::grid_disk(cell, k_f as u32)
+}
+
+impl RedDBRuntime {
+    /// Resolution of the H3 index registered on `(collection, column)`, if
+    /// the column is covered by one. `None` for any other (or no) index.
+    fn h3_index_resolution(&self, collection: &str, column: &str) -> Option<u8> {
+        match self
+            .inner
+            .index_store
+            .find_index_for_column(collection, column)?
+            .method
+        {
+            super::index_store::IndexMethodKind::H3 { resolution } => Some(resolution),
+            _ => None,
+        }
+    }
+
+    /// Map a set of H3 cell ids to the entity ids stored under them in the
+    /// disk B-tree (sorted) index via per-cell point lookups. `None` when no
+    /// cells were supplied or the column has no sorted index entry.
+    fn h3_cell_candidate_ids(
+        &self,
+        collection: &str,
+        column: &str,
+        cells: &[u64],
+    ) -> Option<std::collections::HashSet<u64>> {
+        if cells.is_empty() {
+            return None;
+        }
+        let keys: Vec<_> = cells
+            .iter()
+            .filter_map(|c| {
+                crate::storage::schema::value_to_canonical_key(&Value::UnsignedInteger(*c))
+            })
+            .collect();
+        let ids = self.inner.index_store.sorted.in_lookup_limited(
+            collection,
+            column,
+            &keys,
+            usize::MAX,
+        )?;
+        Some(ids.into_iter().map(|id| id.raw()).collect())
+    }
+
+    /// Covering-kRing candidate ids for a RADIUS query, or `None` to fall
+    /// back to the full scan (no H3 index, un-encodable centre, or a cover
+    /// too large to enumerate).
+    fn h3_radius_candidate_ids(
+        &self,
+        collection: &str,
+        column: &str,
+        center_lat: f64,
+        center_lon: f64,
+        radius_km: f64,
+    ) -> Option<std::collections::HashSet<u64>> {
+        let resolution = self.h3_index_resolution(collection, column)?;
+        let cells = h3_cover_cells(center_lat, center_lon, radius_km, resolution);
+        self.h3_cell_candidate_ids(collection, column, &cells)
+    }
+
+    /// Covering-kRing candidate ids for a BBOX query: cover a disk centred on
+    /// the box whose radius reaches its farthest corner, then let the exact
+    /// bbox filter trim it. `None` falls back to the full scan.
+    fn h3_bbox_candidate_ids(
+        &self,
+        collection: &str,
+        column: &str,
+        min_lat: f64,
+        min_lon: f64,
+        max_lat: f64,
+        max_lon: f64,
+    ) -> Option<std::collections::HashSet<u64>> {
+        let resolution = self.h3_index_resolution(collection, column)?;
+        let center_lat = (min_lat + max_lat) / 2.0;
+        let center_lon = (min_lon + max_lon) / 2.0;
+        let radius_km = [
+            (min_lat, min_lon),
+            (min_lat, max_lon),
+            (max_lat, min_lon),
+            (max_lat, max_lon),
+        ]
+        .into_iter()
+        .map(|(la, lo)| crate::geo::haversine_km(center_lat, center_lon, la, lo))
+        .fold(0.0_f64, f64::max);
+        let cells = h3_cover_cells(center_lat, center_lon, radius_km, resolution);
+        self.h3_cell_candidate_ids(collection, column, &cells)
+    }
+
+    /// Ring-expansion candidate ids for a NEAREST-K query. Expands the cover
+    /// outward until the K-th nearest candidate is provably closer than any
+    /// point in an unscanned cell, returning that superset. `None` (→ full
+    /// scan) when the column has no H3 index, the centre is un-encodable, or
+    /// the proof is not reached within the ring cap (e.g. fewer than K rows).
+    fn h3_nearest_candidate_ids(
+        &self,
+        collection: &str,
+        column: &str,
+        lat: f64,
+        lon: f64,
+        k: usize,
+    ) -> Option<std::collections::HashSet<u64>> {
+        let resolution = self.h3_index_resolution(collection, column)?;
+        if k == 0 {
+            return None;
+        }
+        let center = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
+        if center == 0 {
+            return None;
+        }
+        let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
+        // Bound the expansion so an index holding fewer than K points cannot
+        // loop forever; past the cap the exact full scan takes over.
+        const MAX_RING: u32 = 64;
+        let store = self.inner.db.store();
+        for r in 0..=MAX_RING {
+            let cells = crate::geo::h3::grid_disk(center, r);
+            let Some(ids) = self.h3_cell_candidate_ids(collection, column, &cells) else {
+                continue;
+            };
+            if ids.len() < k {
+                continue;
+            }
+            let candidates = Some(ids);
+            let mut dists: Vec<f64> =
+                scan_collection_with_candidates(&store, collection, &candidates)
+                    .iter()
+                    .filter_map(|e| {
+                        extract_geo_from_entity(e)
+                            .map(|(elat, elon)| crate::geo::haversine_km(lat, lon, elat, elon))
+                    })
+                    .collect();
+            if dists.len() < k {
+                continue;
+            }
+            dists.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+            let d_k = dists[k - 1];
+            // A point in any unscanned cell (grid distance > r) lies at least
+            // `r * edge_km` from the centre — a conservative lower bound. Once
+            // that already meets or exceeds the current K-th distance, the
+            // cover is a proven superset of the true nearest-K.
+            if f64::from(r) * edge_km >= d_k {
+                return candidates;
+            }
+        }
+        None
     }
 }

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -181,3 +181,160 @@ fn h3_index_survives_restart_rebuilt_from_catalog() {
         "rehydrated H3 index must not allocate a resident R-tree"
     );
 }
+
+// ── SEARCH SPATIAL parity: H3 ring scan vs full scan (PRD #1574 slice 3) ─────
+//
+// `SEARCH SPATIAL RADIUS/BBOX/NEAREST` must return byte-identical results
+// whether the geo column carries an H3 index (covering-ring scan over the
+// disk B-tree) or no index at all (full collection scan + haversine). The
+// parity is asserted on the SAME table and the SAME runtime: the queries run
+// once with no index (full scan), then again after `CREATE INDEX … USING H3`
+// (the ring scan), so the underlying entity store — and therefore the
+// `entity_id` ordering for equidistant ties — is identical between the two
+// runs. Only the index mechanism changes.
+
+/// A geo corpus chosen to exercise cell boundaries: points cluster around
+/// central Paris in *different* res-9 cells, plus an exact duplicate of the
+/// centre (a 0-km tie that must keep its store order on both paths) and
+/// far-away outliers in other regions.
+const GEO_CORPUS: &[(i64, &str)] = &[
+    (1, "48.8566,2.3522"),     // Notre-Dame (centre)
+    (2, "48.8606,2.3376"),     // Louvre, ~1.2 km
+    (3, "48.8530,2.3499"),     // ~0.4 km
+    (4, "48.8738,2.2950"),     // Arc de Triomphe, ~4.5 km
+    (5, "48.8584,2.2945"),     // Eiffel Tower, ~4.2 km
+    (6, "48.8000,2.3000"),     // ~6.7 km
+    (7, "49.0000,2.5000"),     // ~20 km
+    (8, "48.8566,2.3522"),     // exact duplicate of the centre (0-km tie)
+    (9, "51.5074,-0.1278"),    // London, ~344 km
+    (10, "-23.5505,-46.6333"), // São Paulo, far hemisphere
+];
+
+fn seed_geo_corpus(table: &str) -> RedDBRuntime {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query(&format!("CREATE TABLE {table} (id INT, loc GEOPOINT)"))
+        .unwrap();
+    for (id, loc) in GEO_CORPUS {
+        rt.execute_query(&format!(
+            "INSERT INTO {table} (id, loc) VALUES ({id}, '{loc}')"
+        ))
+        .unwrap();
+    }
+    rt
+}
+
+/// Ordered `(entity_id, distance_km_bits)` rows for exact comparison. The
+/// distance is compared by raw bits so two haversine computations are held
+/// to byte-for-byte equality; rows without a `distance_km` column (BBOX)
+/// contribute a `0` placeholder, which is identical on both paths.
+fn spatial_rows(rt: &RedDBRuntime, query: &str) -> Vec<(u64, u64)> {
+    let res = rt.execute_query(query).expect("spatial query must execute");
+    res.result
+        .records
+        .iter()
+        .map(|r| {
+            let id = match r.get("entity_id") {
+                Some(Value::UnsignedInteger(n)) => *n,
+                other => panic!("missing entity_id: {other:?}"),
+            };
+            let dist = match r.get("distance_km") {
+                Some(Value::Float(f)) => f.to_bits(),
+                _ => 0,
+            };
+            (id, dist)
+        })
+        .collect()
+}
+
+/// For each query: run the full scan (no index), create the H3 index, run
+/// the ring scan, and assert the two are byte-identical.
+fn assert_h3_parity(create_index: &str, queries: &[String]) {
+    let rt = seed_geo_corpus("places");
+    let baseline: Vec<Vec<(u64, u64)>> = queries.iter().map(|q| spatial_rows(&rt, q)).collect();
+    rt.execute_query(create_index).unwrap();
+    for (q, expected) in queries.iter().zip(&baseline) {
+        assert_eq!(
+            &spatial_rows(&rt, q),
+            expected,
+            "H3 ring scan diverged from full scan for: {q}"
+        );
+    }
+}
+
+#[test]
+fn h3_radius_parity_with_full_scan() {
+    // Tight radii land on res-9 cell boundaries (the +1 ring margin must
+    // still find the neighbouring in-radius points); large radii exceed the
+    // cover cap and fall back to the full scan — both must match.
+    let queries: Vec<String> = [
+        (48.8566, 2.3522, 0.5),
+        (48.8566, 2.3522, 1.0),
+        (48.8566, 2.3522, 5.0),
+        (48.8584, 2.2945, 2.0),
+        (48.8566, 2.3522, 50.0),
+        (48.8566, 2.3522, 500.0),
+        (48.8566, 2.3522, 20000.0),
+    ]
+    .iter()
+    .map(|(clat, clon, r)| {
+        format!("SEARCH SPATIAL RADIUS {clat} {clon} {r} COLLECTION places COLUMN loc")
+    })
+    .collect();
+    assert_h3_parity("CREATE INDEX idx ON places (loc) USING H3", &queries);
+}
+
+#[test]
+fn h3_nearest_parity_with_full_scan() {
+    let queries: Vec<String> = [
+        (48.8566, 2.3522, 1),
+        (48.8566, 2.3522, 4),
+        (48.8566, 2.3522, 6),
+        (48.8584, 2.2945, 3),
+        // K larger than the corpus → ring expansion exhausts and the cover
+        // proof falls back to the full scan; results must still match.
+        (48.8566, 2.3522, 50),
+    ]
+    .iter()
+    .map(|(lat, lon, k)| {
+        format!("SEARCH SPATIAL NEAREST {lat} {lon} K {k} COLLECTION places COLUMN loc")
+    })
+    .collect();
+    assert_h3_parity("CREATE INDEX idx ON places (loc) USING H3 (9)", &queries);
+}
+
+#[test]
+fn h3_bbox_parity_with_full_scan() {
+    let queries: Vec<String> = [
+        (48.84, 2.33, 48.87, 2.36),   // tight box around the centre cluster
+        (48.80, 2.25, 48.90, 2.40),   // wider Paris box
+        (48.00, 2.00, 50.00, 3.00),   // region-scale box
+        (-90.0, -180.0, 90.0, 180.0), // whole globe
+    ]
+    .iter()
+    .map(|(min_lat, min_lon, max_lat, max_lon)| {
+        format!(
+            "SEARCH SPATIAL BBOX {min_lat} {min_lon} {max_lat} {max_lon} COLLECTION places COLUMN loc"
+        )
+    })
+    .collect();
+    assert_h3_parity("CREATE INDEX idx ON places (loc) USING H3", &queries);
+}
+
+#[test]
+fn h3_radius_uses_disk_btree_not_rtree() {
+    // The H3 radius path must run off the sorted disk B-tree cell index and
+    // never allocate the in-RAM rstar R-tree for the column.
+    let rt = seed_geo_corpus("places");
+    rt.execute_query("CREATE INDEX idx ON places (loc) USING H3")
+        .unwrap();
+    let _ = rt
+        .execute_query("SEARCH SPATIAL RADIUS 48.8566 2.3522 5.0 COLLECTION places COLUMN loc")
+        .unwrap();
+    assert!(
+        rt.index_store_ref()
+            .spatial
+            .index_stats("places", "loc")
+            .is_err(),
+        "an H3 radius query must not create a resident rstar R-tree"
+    );
+}


### PR DESCRIPTION
## What

PRD #1574 slice 3. Routes `SEARCH SPATIAL RADIUS/BBOX/NEAREST` over the
disk-resident H3 B-tree index (slice 2) instead of the full collection
scan, with **byte-identical** results. Grammar unchanged — execution only.

### Routing (where H3 vs full-scan dispatch happens)
`crates/reddb-server/src/runtime/impl_graph_commands.rs` — each of the three
spatial arms now asks `h3_index_resolution(collection, column)`; when an H3
index exists it gathers a candidate entity-id set from a covering kRing, then
runs the **unchanged** haversine post-filter over `query_all` filtered to that
set (so stable-sort tie order and early-LIMIT match the full scan exactly).
With no H3 index — or a cover too large to enumerate — it falls back to the
existing full scan unchanged.

- **RADIUS**: query cell -> kRing `k = ceil(radius_km / cell_edge_km) + 1`
  (the +1 ring is the boundary margin) -> B-tree IN-scan of those cells ->
  haversine <= radius -> sort asc -> LIMIT.
- **NEAREST**: expand rings outward until the K-th nearest candidate is
  provably nearer than any unscanned cell (`r * edge_km >= d_k`), then
  haversine-rank + take K; ring-cap fallback to full scan.
- **BBOX**: cover a disk reaching the box's farthest corner -> scan -> exact
  bbox filter.

`cell_edge_km` comes from h3o's per-resolution average edge length, exposed as
`geo::h3::edge_length_km`.

### Tests
`tests/grouped/schema_query_core/e2e_h3_index.rs` adds RADIUS/BBOX/NEAREST
parity tests: same table/runtime, run each query with no index (full scan),
then after `CREATE INDEX … USING H3`, asserting byte-identical ordered rows.
Covers cell-boundary clusters, a 0-km duplicate tie, and the large-radius /
K>corpus ring-cap fallback. Plus a guard that the radius path never allocates
the in-RAM rstar R-tree.

## Verification
- `cargo build -p reddb-io-server` — exit 0
- `cargo clippy -p reddb-io-server --lib` — clean
- rustfmt 1.91 applied
- `cargo nextest run -p reddb-io --test grouped_sql_core -E 'test(/h3/)'` — 8 passed (4 new parity tests)

Closes #1577

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785395494&installation_id=129708444&pr_number=1585&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1585&signature=7b3d4693ed99496761c0b6a0c746752db2386802e13cd6f79be8cf35939fd0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->