### PR TITLE
merge: #1578 H3 spatial slice 4: H3 default + cap/retire rstar R-tree

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -860,6 +860,12 @@ pub enum IndexMethod {
     Hash,
     Bitmap,
     RTree,
+    /// Generic spatial index request (`USING SPATIAL`) — the engine picks
+    /// the default spatial backend. As of PRD #1574 slice 4 (#1578) that
+    /// default is the disk-resident H3 index (RAM stays O(working set)),
+    /// not the unbounded in-RAM `RTree`. Use the explicit `USING RTREE`
+    /// form when the memory-capped in-RAM R-tree is specifically wanted.
+    Spatial,
     /// H3 hexagonal spatial index: the `(lat, lon)` geo column is
     /// encoded to a single H3 cell-id `u64` (at `resolution`) and stored
     /// in the existing disk-paged B-tree (PRD #1574 slice 2, #1576).
@@ -875,6 +881,7 @@ impl fmt::Display for IndexMethod {
             Self::Hash => write!(f, "HASH"),
             Self::Bitmap => write!(f, "BITMAP"),
             Self::RTree => write!(f, "RTREE"),
+            Self::Spatial => write!(f, "SPATIAL"),
             Self::H3 { .. } => write!(f, "H3"),
         }
     }
@@ -3346,6 +3353,7 @@ mod tests {
         assert_eq!(IndexMethod::Hash.to_string(), "HASH");
         assert_eq!(IndexMethod::Bitmap.to_string(), "BITMAP");
         assert_eq!(IndexMethod::RTree.to_string(), "RTREE");
+        assert_eq!(IndexMethod::Spatial.to_string(), "SPATIAL");
         assert_eq!(IndexMethod::H3 { resolution: 9 }.to_string(), "H3");
     }
 

--- a/crates/reddb-rql/src/parser/index_ddl.rs
+++ b/crates/reddb-rql/src/parser/index_ddl.rs
@@ -76,7 +76,7 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Parse index method identifier: HASH | BTREE | BITMAP | RTREE | H3.
+    /// Parse index method identifier: HASH | BTREE | BITMAP | RTREE | SPATIAL | H3.
     /// `HASH` is also a reserved keyword token, so we match both the
     /// keyword form and the ident form — otherwise `USING HASH`
     /// fails with "Unexpected token: HASH" even though the parser
@@ -106,10 +106,11 @@ impl<'a> Parser<'a> {
                     "BTREE" => IndexMethod::BTree,
                     "BITMAP" => IndexMethod::Bitmap,
                     "RTREE" => IndexMethod::RTree,
+                    "SPATIAL" => IndexMethod::Spatial,
                     _ => {
                         return Err(ParseError::new(
                             format!(
-                                "unknown index method '{}', expected HASH, BTREE, BITMAP, RTREE, or H3",
+                                "unknown index method '{}', expected HASH, BTREE, BITMAP, RTREE, SPATIAL, or H3",
                                 name
                             ),
                             self.position(),
@@ -120,7 +121,7 @@ impl<'a> Parser<'a> {
                 Ok(method)
             }
             other => Err(ParseError::expected(
-                vec!["HASH", "BTREE", "BITMAP", "RTREE", "H3"],
+                vec!["HASH", "BTREE", "BITMAP", "RTREE", "SPATIAL", "H3"],
                 &other,
                 self.position(),
             )),
@@ -303,5 +304,17 @@ mod tests {
                 .contains("expected: HASH, BTREE, BITMAP, RTREE"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn parse_create_index_using_spatial_is_generic_spatial_method() {
+        // `USING SPATIAL` is the generic spatial request; the engine maps
+        // it to the default spatial backend (H3 as of #1578). The parser
+        // only needs to surface the generic `Spatial` method here.
+        let query = parse_create_index("CREATE INDEX gix ON places (loc) USING SPATIAL");
+        assert_eq!(query.method, IndexMethod::Spatial);
+        // Lowercase ident is accepted too.
+        let query = parse_create_index("CREATE INDEX gix ON places (loc) USING spatial");
+        assert_eq!(query.method, IndexMethod::Spatial);
     }
 }

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -1432,7 +1432,11 @@ impl RedDBRuntime {
             IndexMethod::Hash => super::index_store::IndexMethodKind::Hash,
             IndexMethod::BTree => super::index_store::IndexMethodKind::BTree,
             IndexMethod::Bitmap => super::index_store::IndexMethodKind::Bitmap,
+            // Explicit opt-in to the in-RAM, memory-capped rstar R-tree.
             IndexMethod::RTree => super::index_store::IndexMethodKind::Spatial,
+            // Generic spatial request → engine default spatial backend
+            // (disk-resident H3 as of PRD #1574 slice 4, #1578).
+            IndexMethod::Spatial => super::index_store::IndexMethodKind::default_spatial(),
             IndexMethod::H3 { resolution } => {
                 super::index_store::IndexMethodKind::H3 { resolution }
             }

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1144,6 +1144,27 @@ pub enum IndexMethodKind {
     },
 }
 
+impl IndexMethodKind {
+    /// Resolve a *generic* spatial index request (RQL `USING SPATIAL`, or a
+    /// bare spatial index) to the engine's default spatial backend.
+    ///
+    /// As of PRD #1574 slice 4 (#1578) the default is the disk-resident
+    /// [`IndexMethodKind::H3`] index: `(lat, lon)` is encoded to a single
+    /// H3 cell-id `u64` and stored in the existing paged B-tree, so RAM
+    /// stays O(working set) rather than O(total points). The in-RAM
+    /// `rstar` R-tree ([`IndexMethodKind::Spatial`]) is no longer the
+    /// default — it is reachable only via the explicit `USING RTREE` opt-in
+    /// and is memory-capped (see `storage::unified::spatial_index`).
+    ///
+    /// Trade-off: R-tree = arbitrary shapes / exact small sets, held in
+    /// RAM (now capped); H3 = points at scale, on disk, the default.
+    pub fn default_spatial() -> Self {
+        IndexMethodKind::H3 {
+            resolution: DEFAULT_H3_RESOLUTION,
+        }
+    }
+}
+
 /// Default H3 resolution used when reconstructing an H3 index kind from
 /// the incremental-maintainer mirror, which does not carry the
 /// resolution. Mirrors `reddb_rql::ast::DEFAULT_H3_RESOLUTION`; the

--- a/crates/reddb-server/src/storage/unified/spatial_index.rs
+++ b/crates/reddb-server/src/storage/unified/spatial_index.rs
@@ -1,7 +1,33 @@
-//! R-Tree Spatial Index
+//! R-Tree Spatial Index (opt-in, memory-capped)
 //!
-//! Provides efficient spatial queries on GeoPoint, Latitude, and Longitude data.
-//! Uses the `rstar` crate for R-tree implementation.
+//! Provides spatial queries on GeoPoint, Latitude, and Longitude data using
+//! the `rstar` crate for an in-RAM R-tree.
+//!
+//! # Status (PRD #1574 / #1578)
+//! This in-RAM R-tree is **no longer the default spatial index**. The default
+//! spatial backend is the disk-resident H3 index (cell-id `u64` over the paged
+//! B-tree), which keeps RAM at O(working set) rather than O(total points). This
+//! R-tree is reachable only via the explicit `CREATE INDEX … USING RTREE`
+//! opt-in and is **memory-capped** so it can never silently OOM the process —
+//! inserting past the byte budget is refused with [`SpatialIndexError::CapacityExceeded`].
+//!
+//! Trade-off: prefer the R-tree for **arbitrary shapes / exact small sets**
+//! held in RAM; prefer H3 (the default) for **points at scale, on disk**.
+//!
+//! The cap is configured by `RED_SPATIAL_RTREE_MAX_BYTES` (an approximate byte
+//! budget on the resident structure); see [`DEFAULT_RTREE_MAX_BYTES`].
+//!
+//! # Migration (existing R-tree spatial indexes → H3)
+//! To move a spatial column off the in-RAM R-tree onto the disk-resident
+//! default, recreate the index with the generic spatial method (or `USING H3`):
+//! ```sql
+//! DROP INDEX <name> ON <table>;
+//! CREATE INDEX <name> ON <table> (<col>) USING SPATIAL;  -- resolves to H3
+//! ```
+//! No data migration is required — the geo column is unchanged; only the index
+//! mechanism (and its RAM profile) changes. `SEARCH SPATIAL` results are
+//! identical on both paths (haversine-exact). Keep `USING RTREE` only for
+//! small, in-RAM, shape-oriented workloads that fit under the cap.
 //!
 //! # Supported queries
 //! - **Radius search**: Find all points within X km of a center point
@@ -16,9 +42,49 @@ use rstar::{primitives::GeomWithData, RTree, AABB};
 
 use super::entity::EntityId;
 
+/// Default approximate memory budget for a single in-RAM R-tree spatial
+/// index, used when `RED_SPATIAL_RTREE_MAX_BYTES` is unset. 256 MiB at the
+/// recalc footprint (~100–150 B/point) bounds a single index to ~1.7–2.5M
+/// points — generous for the "small/shape sets" the R-tree is now reserved
+/// for, while making the unbounded-OOM-at-scale failure mode impossible.
+/// Points at scale belong on the disk-resident H3 default (PRD #1574).
+pub const DEFAULT_RTREE_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Environment override for [`DEFAULT_RTREE_MAX_BYTES`]. Mirrors the
+/// `RED_*_MAX_BYTES` convention used elsewhere (e.g. `RED_AUDIT_MAX_BYTES`).
+const RTREE_MAX_BYTES_ENV: &str = "RED_SPATIAL_RTREE_MAX_BYTES";
+
+/// Approximate resident cost of one indexed point, kept in lock-step with
+/// [`SpatialIndex::memory_bytes`]: one R-tree leaf entry plus the parallel
+/// `points` HashMap slot. Used to project the post-insert footprint when
+/// enforcing the cap.
+const PER_POINT_BYTES: usize = std::mem::size_of::<SpatialEntry>() + 32;
+
+/// Resolve the per-index R-tree byte budget from the environment, falling
+/// back to [`DEFAULT_RTREE_MAX_BYTES`].
+fn resolve_rtree_max_bytes() -> usize {
+    std::env::var(RTREE_MAX_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_RTREE_MAX_BYTES)
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum SpatialIndexError {
-    MissingIndex { collection: String, column: String },
+    MissingIndex {
+        collection: String,
+        column: String,
+    },
+    /// Inserting a *new* point would push the in-RAM R-tree past its
+    /// configured byte budget (`RED_SPATIAL_RTREE_MAX_BYTES`). The point is
+    /// NOT inserted — the structure refuses to grow rather than risk an OOM.
+    /// Use the disk-resident H3 index (the default) for points at scale.
+    CapacityExceeded {
+        collection: String,
+        column: String,
+        max_bytes: usize,
+        attempted_bytes: usize,
+    },
 }
 
 impl std::fmt::Display for SpatialIndexError {
@@ -30,11 +96,34 @@ impl std::fmt::Display for SpatialIndexError {
                     "spatial index for column '{column}' was not found in collection '{collection}'"
                 )
             }
+            Self::CapacityExceeded {
+                collection,
+                column,
+                max_bytes,
+                attempted_bytes,
+            } => {
+                write!(
+                    f,
+                    "in-RAM R-tree spatial index for column '{column}' in collection \
+                     '{collection}' is memory-capped at {max_bytes} bytes \
+                     (RED_SPATIAL_RTREE_MAX_BYTES); insert would need ~{attempted_bytes} bytes. \
+                     Use the disk-resident H3 spatial index (USING H3 / the default) for points at scale."
+                )
+            }
         }
     }
 }
 
 impl std::error::Error for SpatialIndexError {}
+
+/// Capacity-overflow signal raised by [`SpatialIndex::insert`], which does not
+/// know its own `(collection, column)` location. The owning
+/// [`SpatialIndexManager`] enriches it into [`SpatialIndexError::CapacityExceeded`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpatialCapacityError {
+    pub max_bytes: usize,
+    pub attempted_bytes: usize,
+}
 
 /// A 2D point in the R-tree, storing (lon, lat) in degrees with an associated EntityId.
 /// Note: rstar uses [x, y] convention, so we store (longitude, latitude).
@@ -65,16 +154,33 @@ pub struct SpatialIndex {
     points: HashMap<EntityId, (f64, f64)>,
     /// Column name
     pub column: String,
+    /// Approximate resident-byte budget; a *new*-point insert that would push
+    /// [`SpatialIndex::memory_bytes`] past this is refused (never silently
+    /// OOMs). Resolved from `RED_SPATIAL_RTREE_MAX_BYTES`.
+    max_bytes: usize,
 }
 
 impl SpatialIndex {
-    /// Create a new spatial index
+    /// Create a new spatial index with the environment-configured memory cap.
     pub fn new(column: impl Into<String>) -> Self {
+        Self::with_max_bytes(column, resolve_rtree_max_bytes())
+    }
+
+    /// Create a new spatial index with an explicit memory cap. Bypasses
+    /// `RED_SPATIAL_RTREE_MAX_BYTES` resolution so parallel tests don't race
+    /// on `set_var` (mirrors `AuditLogger::with_max_bytes`).
+    pub fn with_max_bytes(column: impl Into<String>, max_bytes: usize) -> Self {
         Self {
             tree: RTree::new(),
             points: HashMap::new(),
             column: column.into(),
+            max_bytes,
         }
+    }
+
+    /// The configured approximate memory budget (bytes).
+    pub fn max_bytes(&self) -> usize {
+        self.max_bytes
     }
 
     /// Bulk-load from a list of (entity_id, lat, lon)
@@ -91,17 +197,39 @@ impl SpatialIndex {
             tree: RTree::bulk_load(entries),
             points,
             column: column.into(),
+            max_bytes: resolve_rtree_max_bytes(),
         }
     }
 
-    /// Insert a point
-    pub fn insert(&mut self, entity_id: EntityId, lat: f64, lon: f64) {
-        // Remove old entry if exists
+    /// Insert a point.
+    ///
+    /// Updating an existing entity (same `entity_id`) is always allowed — it
+    /// does not grow the structure. Inserting a *new* point that would push
+    /// the index past its configured byte budget is refused with
+    /// [`SpatialCapacityError`]; the point is not inserted.
+    pub fn insert(
+        &mut self,
+        entity_id: EntityId,
+        lat: f64,
+        lon: f64,
+    ) -> Result<(), SpatialCapacityError> {
+        // Remove old entry if exists (an update never grows the footprint).
         if let Some((old_lat, old_lon)) = self.points.remove(&entity_id) {
             self.tree.remove(&make_entry(old_lat, old_lon, entity_id));
+        } else {
+            // New point: refuse if it would breach the cap.
+            let projected = self.memory_bytes() + PER_POINT_BYTES;
+            if projected > self.max_bytes {
+                // Re-insert nothing; `points` already had no entry for this id.
+                return Err(SpatialCapacityError {
+                    max_bytes: self.max_bytes,
+                    attempted_bytes: projected,
+                });
+            }
         }
         self.tree.insert(make_entry(lat, lon, entity_id));
         self.points.insert(entity_id, (lat, lon));
+        Ok(())
     }
 
     /// Remove a point
@@ -251,8 +379,14 @@ impl SpatialIndexManager {
     ) -> Result<(), SpatialIndexError> {
         let mut indices = self.indices.write();
         if let Some(index) = indices.get_mut(&(collection.to_string(), column.to_string())) {
-            index.insert(entity_id, lat, lon);
-            Ok(())
+            index
+                .insert(entity_id, lat, lon)
+                .map_err(|e| SpatialIndexError::CapacityExceeded {
+                    collection: collection.to_string(),
+                    column: column.to_string(),
+                    max_bytes: e.max_bytes,
+                    attempted_bytes: e.attempted_bytes,
+                })
         } else {
             Err(SpatialIndexError::MissingIndex {
                 collection: collection.to_string(),
@@ -395,13 +529,13 @@ mod tests {
         let mut idx = SpatialIndex::new("location");
 
         // Paris
-        idx.insert(EntityId::new(1), 48.8566, 2.3522);
+        idx.insert(EntityId::new(1), 48.8566, 2.3522).unwrap();
         // London
-        idx.insert(EntityId::new(2), 51.5074, -0.1278);
+        idx.insert(EntityId::new(2), 51.5074, -0.1278).unwrap();
         // Berlin
-        idx.insert(EntityId::new(3), 52.5200, 13.4050);
+        idx.insert(EntityId::new(3), 52.5200, 13.4050).unwrap();
         // Tokyo (far away)
-        idx.insert(EntityId::new(4), 35.6762, 139.6503);
+        idx.insert(EntityId::new(4), 35.6762, 139.6503).unwrap();
 
         // Search 500km from Paris — should find Paris + London, not Berlin or Tokyo
         let results = idx.search_radius(48.8566, 2.3522, 500.0, 10);
@@ -414,9 +548,9 @@ mod tests {
     #[test]
     fn test_spatial_bbox() {
         let mut idx = SpatialIndex::new("location");
-        idx.insert(EntityId::new(1), 48.8566, 2.3522); // Paris
-        idx.insert(EntityId::new(2), 51.5074, -0.1278); // London
-        idx.insert(EntityId::new(3), 35.6762, 139.6503); // Tokyo
+        idx.insert(EntityId::new(1), 48.8566, 2.3522).unwrap(); // Paris
+        idx.insert(EntityId::new(2), 51.5074, -0.1278).unwrap(); // London
+        idx.insert(EntityId::new(3), 35.6762, 139.6503).unwrap(); // Tokyo
 
         // Bounding box covering Europe
         let results = idx.search_bbox(40.0, -10.0, 55.0, 20.0, 10);
@@ -429,9 +563,9 @@ mod tests {
     #[test]
     fn test_spatial_nearest() {
         let mut idx = SpatialIndex::new("location");
-        idx.insert(EntityId::new(1), 48.8566, 2.3522); // Paris
-        idx.insert(EntityId::new(2), 51.5074, -0.1278); // London
-        idx.insert(EntityId::new(3), 52.5200, 13.4050); // Berlin
+        idx.insert(EntityId::new(1), 48.8566, 2.3522).unwrap(); // Paris
+        idx.insert(EntityId::new(2), 51.5074, -0.1278).unwrap(); // London
+        idx.insert(EntityId::new(3), 52.5200, 13.4050).unwrap(); // Berlin
 
         // Nearest to Brussels (50.85, 4.35)
         let results = idx.search_nearest(50.8503, 4.3517, 2);
@@ -443,8 +577,8 @@ mod tests {
     #[test]
     fn test_spatial_remove() {
         let mut idx = SpatialIndex::new("location");
-        idx.insert(EntityId::new(1), 48.8566, 2.3522);
-        idx.insert(EntityId::new(2), 51.5074, -0.1278);
+        idx.insert(EntityId::new(1), 48.8566, 2.3522).unwrap();
+        idx.insert(EntityId::new(2), 51.5074, -0.1278).unwrap();
         assert_eq!(idx.len(), 2);
 
         idx.remove(EntityId::new(1));
@@ -520,5 +654,77 @@ mod tests {
                 column: "location".to_string(),
             }
         );
+    }
+
+    /// Cap with headroom for exactly one point. The in-RAM R-tree must
+    /// refuse a *second, new* point rather than grow unbounded (PRD #1574 /
+    /// #1578) — it never silently OOMs.
+    #[test]
+    fn test_spatial_insert_refuses_new_point_past_memory_cap() {
+        let cap = std::mem::size_of::<SpatialIndex>() + PER_POINT_BYTES;
+        let mut idx = SpatialIndex::with_max_bytes("location", cap);
+
+        // First new point fits under the cap.
+        idx.insert(EntityId::new(1), 48.8566, 2.3522)
+            .expect("first point should fit under the cap");
+        assert_eq!(idx.len(), 1);
+
+        // Second *new* point would breach the cap → refused, not inserted.
+        let err = idx
+            .insert(EntityId::new(2), 51.5074, -0.1278)
+            .expect_err("second new point must be refused past the cap");
+        assert_eq!(err.max_bytes, cap);
+        assert!(err.attempted_bytes > cap, "{err:?}");
+        assert_eq!(idx.len(), 1, "refused point must not be inserted");
+
+        // Updating an *existing* entity is always allowed — it does not grow
+        // the structure, so the cap does not apply.
+        idx.insert(EntityId::new(1), 40.0, -3.0)
+            .expect("update of existing point must be allowed at the cap");
+        assert_eq!(idx.len(), 1);
+    }
+
+    /// The manager enriches the capacity overflow into a
+    /// `SpatialIndexError::CapacityExceeded` carrying `(collection, column)`.
+    #[test]
+    fn test_spatial_manager_surfaces_capacity_error() {
+        let mgr = SpatialIndexManager::new();
+        // Inject a tiny-cap index directly (the public `create_index` resolves
+        // the env-configured cap; the test wants a deterministic small one).
+        let cap = std::mem::size_of::<SpatialIndex>() + PER_POINT_BYTES;
+        mgr.indices.write().insert(
+            ("sites".to_string(), "location".to_string()),
+            SpatialIndex::with_max_bytes("location", cap),
+        );
+
+        mgr.insert("sites", "location", EntityId::new(1), 48.8566, 2.3522)
+            .expect("first point should fit");
+
+        let err = mgr
+            .insert("sites", "location", EntityId::new(2), 51.5074, -0.1278)
+            .expect_err("manager must surface the capacity overflow");
+        match err {
+            SpatialIndexError::CapacityExceeded {
+                collection,
+                column,
+                max_bytes,
+                ..
+            } => {
+                assert_eq!(collection, "sites");
+                assert_eq!(column, "location");
+                assert_eq!(max_bytes, cap);
+            }
+            other => panic!("expected CapacityExceeded, got {other:?}"),
+        }
+    }
+
+    /// A freshly constructed index always carries a finite, positive budget —
+    /// there is no unbounded-RAM default. The const default is itself bounded.
+    #[test]
+    fn test_spatial_default_cap_is_bounded() {
+        let idx = SpatialIndex::new("location");
+        assert!(idx.max_bytes() > 0);
+        assert!(DEFAULT_RTREE_MAX_BYTES > 0);
+        assert!(DEFAULT_RTREE_MAX_BYTES < usize::MAX);
     }
 }

--- a/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_rtree_unknown_method.snap
+++ b/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_rtree_unknown_method.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"CREATE INDEX gix ON sites (location) USING WRONGT
 ---
 input: "CREATE INDEX gix ON sites (location) USING WRONGTREE"
 kind:  Syntax
-error: Parse error at 1:44: unknown index method 'WRONGTREE', expected HASH, BTREE, BITMAP, RTREE, or H3
+error: Parse error at 1:44: unknown index method 'WRONGTREE', expected HASH, BTREE, BITMAP, RTREE, SPATIAL, or H3

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -320,6 +320,84 @@ fn h3_bbox_parity_with_full_scan() {
     assert_h3_parity("CREATE INDEX idx ON places (loc) USING H3", &queries);
 }
 
+// ── Slice 4 (PRD #1574 / #1578): H3 is the DEFAULT spatial index ─────────────
+//
+// A generic spatial index request (`USING SPATIAL`) resolves to the
+// disk-resident H3 index, NOT the unbounded in-RAM rstar R-tree. The R-tree is
+// reachable only via the explicit `USING RTREE` opt-in (and is memory-capped).
+
+#[test]
+fn bare_spatial_index_defaults_to_h3() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_places(&rt);
+
+    // Generic spatial request — no explicit backend named.
+    rt.execute_query("CREATE INDEX idx_loc ON places (loc) USING SPATIAL")
+        .unwrap();
+
+    // It resolves to the H3 disk index, not the rstar R-tree.
+    let (kind, entries) = show_index(&rt, "places", "idx_loc")
+        .expect("generic spatial index must appear in red.show_indexes");
+    assert_eq!(
+        kind, "H3",
+        "a bare/generic spatial index must default to H3"
+    );
+    assert_eq!(
+        entries, 3,
+        "the H3 default must build over all existing rows"
+    );
+
+    // No resident rstar R-tree is allocated for the column.
+    assert!(
+        rt.index_store_ref()
+            .spatial
+            .index_stats("places", "loc")
+            .is_err(),
+        "the default spatial index must NOT allocate an in-RAM rstar R-tree"
+    );
+
+    // SEARCH SPATIAL works unchanged against the defaulted index: a radius
+    // centred on Paris finds the Paris row (an exact 0-km hit). `entity_id`
+    // is the engine's internal id, so we assert on the zero distance of the
+    // centre point rather than the user `id` column.
+    let hits = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 48.8566 2.3522 5.0 COLLECTION places COLUMN loc",
+    );
+    assert!(
+        !hits.is_empty(),
+        "SEARCH SPATIAL must return hits through the defaulted H3 index"
+    );
+    assert!(
+        hits.iter().any(|(_, dist)| *dist == 0.0_f64.to_bits()),
+        "SEARCH SPATIAL must find the Paris centre point (0 km) via the H3 default"
+    );
+}
+
+#[test]
+fn explicit_rtree_is_opt_in_and_allocates_resident_rtree() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    seed_places(&rt);
+
+    // The in-RAM rstar R-tree is reachable ONLY via the explicit opt-in.
+    rt.execute_query("CREATE INDEX idx_r ON places (loc) USING RTREE")
+        .unwrap();
+
+    let (kind, _entries) =
+        show_index(&rt, "places", "idx_r").expect("RTREE index must appear in introspection");
+    assert_eq!(kind, "RTREE", "USING RTREE must stay the rstar R-tree");
+
+    // The opt-in path is the one (and only) path that allocates the
+    // resident rstar structure for the column.
+    assert!(
+        rt.index_store_ref()
+            .spatial
+            .index_stats("places", "loc")
+            .is_ok(),
+        "USING RTREE must allocate the resident rstar R-tree it opts into"
+    );
+}
+
 #[test]
 fn h3_radius_uses_disk_btree_not_rtree() {
     // The H3 radius path must run off the sorted disk B-tree cell index and


### PR DESCRIPTION
## What

Final slice of PRD #1574 — replace the unbounded-RAM in-RAM rstar R-tree as the **default** spatial index with the disk-resident H3 index (slices 1-3: #1575/#1576/#1577).

## Changes

**Default routing → H3**
- New generic RQL index method `USING SPATIAL` (RQL `IndexMethod::Spatial`), routed to the engine's default spatial backend through the new `IndexMethodKind::default_spatial()` helper in `runtime/index_store.rs` → `IndexMethodKind::H3 { resolution: DEFAULT_H3_RESOLUTION }`.
- `USING RTREE` is unchanged — the **explicit, opt-in** path to the in-RAM rstar R-tree.

**rstar R-tree memory cap (never silently OOM)**
- `SpatialIndex` gains a byte budget. A *new*-point insert that would push the resident footprint past the budget is **refused** with `SpatialIndexError::CapacityExceeded` — it does not grow unbounded. Updates to existing points (no growth) are always allowed.
- Knob: `RED_SPATIAL_RTREE_MAX_BYTES` (default `DEFAULT_RTREE_MAX_BYTES` = 256 MiB), following the existing `RED_*_MAX_BYTES` convention (e.g. `RED_AUDIT_MAX_BYTES`). Enforced in `storage/unified/spatial_index.rs` (`SpatialIndex::insert`), surfaced through `SpatialIndexManager::insert`.

**Docs + migration**
- Trade-off documented: R-tree = arbitrary shapes / exact small sets, in RAM, **capped**; H3 = points at scale, on disk, **default**.
- Migration note (module docs): `DROP INDEX … ; CREATE INDEX … USING SPATIAL;` — no data migration, geo column unchanged, `SEARCH SPATIAL` results identical (haversine-exact).

## ⚠️ BEHAVIOR CHANGE

The default/generic spatial index is now **H3 / disk-backed** (RAM = O(working set)). The in-RAM rstar R-tree is **opt-in only** via `USING RTREE` and is now **memory-capped** (was previously unbounded). Existing `USING RTREE` / `USING H3` DDL is unaffected.

## Tests

- `bare_spatial_index_defaults_to_h3` (grouped_sql_core): `USING SPATIAL` builds an **H3** index (introspection kind `H3`, no resident R-tree) and `SEARCH SPATIAL RADIUS` works unchanged.
- `explicit_rtree_is_opt_in_and_allocates_resident_rtree`: `USING RTREE` is the only path that allocates the rstar tree (kind `RTREE`).
- `test_spatial_insert_refuses_new_point_past_memory_cap` / `test_spatial_manager_surfaces_capacity_error` / `test_spatial_default_cap_is_bounded` (lib units): insert past a tiny cap is refused; manager surfaces `CapacityExceeded`; default budget is finite.
- RQL `parse_create_index_using_spatial_is_generic_spatial_method`; updated unknown-method error + snapshot to list `SPATIAL`.

### Local verification
- `cargo build -p reddb-io-server` — green.
- `cargo clippy -p reddb-io-server --lib` / `-p reddb-io-rql --lib` — clean.
- `cargo check -p reddb-io-server --all-targets` — 0 errors (type-checks the new lib unit tests).
- `cargo nextest run -p reddb-io --test grouped_sql_core -E 'test(/h3/)+test(/rtree/)+test(/spatial/)'` — 10/10 pass.
- `cargo nextest run -p reddb-io-server --test geo_parser_snapshots --test geo_parser` — 57/57 pass.
- `cargo nextest run -p reddb-io-rql` index_ddl — 10/10 pass.
- `cargo nextest run -p reddb-io --test llms_txt_generated` — 4/4 (no drift).

Note: the full `reddb-io-server` lib **test** binary cannot link under the local 6 GB cargo-guard (exit 137); the three new lib unit tests type-check via `cargo check --all-targets` and run in CI.

Closes #1578

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785397762&installation_id=129708444&pr_number=1586&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1586&signature=e7d1e4059919221627099133e20146bbd67496710d2bc4e889190b4fa9f5a089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating spatial indexes with `USING SPATIAL`.
  * Spatial indexes now default to the H3 backend unless a specific in-memory R-tree index is explicitly requested.

* **Bug Fixes**
  * Improved index creation and query behavior for spatial searches.
  * Added clearer handling when spatial indexing exceeds its allowed memory limit.

* **Tests**
  * Expanded coverage for spatial index creation, backend selection, and query results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->