### PR TITLE
merge: #1587 First-boot self-bootstrap (red server creates paged vault in place)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "jsonwebtoken",
  "proptest",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -2608,14 +2608,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "proptest",
  "reddb-io-types",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-server"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2723,7 +2723,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "insta",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ cast_possible_truncation = "warn"
 
 [package]
 name = "reddb-io"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 # Cargo auto-discovers every top-level `tests/*.rs` file as a separate
 # integration-test binary. This crate has 269 such files; keep discovery off

--- a/crates/reddb-client-connector/Cargo.toml
+++ b/crates/reddb-client-connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client-connector"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "Workspace-internal gRPC connector used by `reddb-server` (rpc_stdio) and `reddb-client`. Splitting it out of `reddb-client` breaks the otherwise-circular path dependency between `reddb-client[embedded]` (which pulls `reddb-server`) and `reddb-server` (which needs the connector)."

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-client"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "Official Rust client for RedDB — embedded engine, gRPC, HTTP, and RedWire transports behind one connection-string API. Also hosts the workspace-internal connector + REPL used by the `red` and `red_client` binaries."

--- a/crates/reddb-crypto/Cargo.toml
+++ b/crates/reddb-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-crypto"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB cryptographic authority: the canonical per-page encryption-at-rest envelope (AES-256-GCM), mandatory encrypt parameters, and key parsing."

--- a/crates/reddb-file/Cargo.toml
+++ b/crates/reddb-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-file"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB file artifact layer: single-file .rdb layout, WAL, snapshots, checkpoints, locks, and recovery."

--- a/crates/reddb-grpc-proto/Cargo.toml
+++ b/crates/reddb-grpc-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-grpc-proto"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "Generated gRPC protobuf types and tonic client/server stubs for RedDB. Shared across reddb-server, reddb-client, and language drivers."

--- a/crates/reddb-rql/Cargo.toml
+++ b/crates/reddb-rql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-rql"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB Query Language (RQL) front-end + conformance authority (ADR 0053). Owns the sqllogictest-format conformance suite whose truth comes from the public SQLite corpus; depends only on reddb-io-types."

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-server"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB server-side engine: storage, runtime, replication, MCP, AI, and the gRPC/HTTP/RedWire/PG-wire dispatchers. Re-exported by the umbrella `reddb` crate."

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -369,7 +369,12 @@ fn server_flags() -> Vec<FlagSchema> {
         FlagSchema::boolean("dev")
             .with_description("Alias for --no-auth (local development convenience)."),
         FlagSchema::new("bootstrap-preset")
-            .with_description("First-boot preset")
+            .with_description(
+                "First-boot preset. With --vault on a fresh --path, red server \
+                 self-bootstraps the paged vault in place (no separate `red bootstrap`) \
+                 then applies the preset and serves; a re-boot against the existing \
+                 vault just serves (idempotent — no re-bootstrap, no new certificate).",
+            )
             .with_choices(&["simple", "production", "regulated", "cloud"]),
         FlagSchema::new("bootstrap-manifest")
             .with_description("Path to first-boot bootstrap manifest JSON"),

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -395,6 +395,49 @@ impl ServerCommandConfig {
                 .insert(NO_AUTH_META.to_string(), "true".to_string());
         }
 
+        // Issue #1587 — first-boot self-bootstrap. A single distroless
+        // `red server` must be able to create the paged vault in place and
+        // serve in one process. The default embedded single-file packaging
+        // routes storage through `UnifiedStore::with_config`, which exposes no
+        // pager, so the vault gate in `build_runtime_with_bootstrap` aborts
+        // with "vault requires a paged database (persistent mode)". The
+        // separate `red bootstrap` subcommand escapes this by opening with the
+        // operational-directory packaging; compose the same storage selection
+        // here so the fresh database is paged, the vault pages exist, and the
+        // existing preset machinery (`ProceedLocal` → `apply_preset_from_config`)
+        // can mint the admins + certificate before listeners come up.
+        //
+        // Gated on (path absent AND a bootstrap intent is present AND the vault
+        // is enabled): an existing database keeps whatever packaging is already
+        // on disk (so a re-boot just serves — no re-bootstrap, no cert churn),
+        // and a fresh path with no intent keeps today's behaviour (a clear
+        // "vault requires a paged database" error rather than a silently
+        // created empty vault). `--no-auth` / `--dev` cleared `vault_enabled`
+        // above, so the development carveout never triggers first-boot either.
+        let bootstrap_intent_present = !matches!(
+            self.bootstrap.auth_bootstrap_input(),
+            crate::cluster::AuthBootstrapInput::None
+        );
+        let path_absent = self.path.as_ref().is_some_and(|path| !path.exists());
+        // Mirrors `embedded_single_file_selected`: only this profile lacks a
+        // pager, so it is the only one that needs promotion to create a vault.
+        let embedded_single_file = options.storage_profile.deploy_profile
+            == crate::storage::DeployProfile::Embedded
+            && options.storage_profile.packaging == crate::storage::StoragePackaging::SingleFile;
+        if options.auth.vault_enabled
+            && bootstrap_intent_present
+            && path_absent
+            && embedded_single_file
+        {
+            options.storage_profile.packaging =
+                crate::storage::StoragePackaging::OperationalDirectory;
+            options.create_if_missing = true;
+            tracing::info!(
+                target: "reddb::bootstrap",
+                "first-boot self-bootstrap: creating paged vault in place for a fresh database with a bootstrap intent"
+            );
+        }
+
         // Issue #652 — Control Event Ledger Compliance Mode.
         // `REDDB_COMPLIANCE_MODE=true|1|yes|on` makes the producer
         // slices (652b/c/d) fail-closed on ledger persistence

--- a/crates/reddb-types/Cargo.toml
+++ b/crates/reddb-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-types"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB logical type system: the neutral keystone vocabulary — Value, DataType, SqlTypeName, TypeModifier, TypeCategory, ValueError, Row — depended on by every authority crate and depending on none."

--- a/crates/reddb-wire/Cargo.toml
+++ b/crates/reddb-wire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reddb-io-wire"
-version = "1.18.0"
+version = "1.19.0"
 edition.workspace = true
 authors.workspace = true
 description = "RedDB wire protocol vocabulary: connection-string parser, RedWire frames, payload codecs, topology, sanitizers, and replication messages."

--- a/drivers/bun/package.json
+++ b/drivers/bun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client-bun",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "RedDB wire protocol client for Bun — ultra-fast native TCP",
   "main": "index.ts",
   "scripts": {

--- a/drivers/js-client/package.json
+++ b/drivers/js-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/client",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Thin remote-only RedDB driver. Downloads the `red_client` binary on install. Speaks RedWire/gRPC/HTTP. Embedded URIs (memory://, file://, red:///path) are rejected — use @reddb-io/sdk for those.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/js/package.json
+++ b/drivers/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/sdk",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Official embedded RedDB SDK — launches a local red binary over stdio JSON-RPC. Use @reddb-io/client for remote HTTP, gRPC, and RedWire.",
   "type": "module",
   "main": "src/index.js",

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-client",
  "reddb-io-grpc-proto",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-client-connector",
  "reddb-io-grpc-proto",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-client-connector"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-grpc-proto",
  "reddb-io-wire",
@@ -2024,14 +2024,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-crypto"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "reddb-io-file"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "blake3",
  "crc32fast",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-grpc-proto"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "prost",
  "reddb-io-wire",
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-python"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "prost",
  "pyo3",
@@ -2076,14 +2076,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-rql"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-types",
 ]
 
 [[package]]
 name = "reddb-io-server"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -2143,14 +2143,14 @@ dependencies = [
 
 [[package]]
 name = "reddb-io-types"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "reddb-io-wire"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "reddb-io-types",
  "serde_json",

--- a/drivers/python/Cargo.toml
+++ b/drivers/python/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "reddb-io-python"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2021"
 description = "Native Python driver for RedDB (compiled Rust via pyo3)"
 license = "MIT"

--- a/drivers/python/pyproject.toml
+++ b/drivers/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "reddb"
-version = "1.18.0"
+version = "1.19.0"
 description = "Official Python driver for RedDB — embedded engine and gRPC remote in one package."
 readme = "README.md"
 license = { text = "MIT" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/cli",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "CLI launcher for RedDB. The JS/TS app driver is published as @reddb-io/sdk.",
   "type": "commonjs",
   "bin": {

--- a/packages/internal-asset-fetcher/package.json
+++ b/packages/internal-asset-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-asset-fetcher",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "description": "Workspace-only deep module: download a `red`/`red_client` binary from a GitHub release with platform/arch resolution, redirect handling, and optional sha256 verification.",
   "type": "module",

--- a/packages/internal-bin-resolver/package.json
+++ b/packages/internal-bin-resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-bin-resolver",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "description": "Workspace-only deep module: locate a pinned binary inside a node_modules package, env override > local. PATH is never consulted.",
   "type": "module",

--- a/packages/internal-version-compare/package.json
+++ b/packages/internal-version-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/internal-version-compare",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "private": true,
   "description": "Workspace-only deep module: compare a package version against an installed `red --version`, return install/upgrade/skip verdict for the CLI postinstall.",
   "type": "module",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reddb-io/mcp",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Zero-install npx launcher for the RedDB MCP surface — fetches the matching red binary and spawns `red mcp` over stdio.",
   "type": "module",
   "bin": {

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -3401,7 +3401,12 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 cli::types::FlagSchema::boolean("dev")
                     .with_description("Alias for --no-auth (local development convenience)."),
                 cli::types::FlagSchema::new("bootstrap-preset")
-                    .with_description("First-boot preset")
+                    .with_description(
+                        "First-boot preset. With --vault on a fresh --path, red server \
+                         self-bootstraps the paged vault in place (no separate `red bootstrap`) \
+                         then applies the preset and serves; a re-boot against the existing \
+                         vault just serves (idempotent — no re-bootstrap, no new certificate).",
+                    )
                     .with_choices(&["simple", "production", "regulated", "cloud"]),
                 cli::types::FlagSchema::new("bootstrap-manifest")
                     .with_description("Path to first-boot bootstrap manifest JSON"),

--- a/tests/cli_first_boot.rs
+++ b/tests/cli_first_boot.rs
@@ -1,0 +1,260 @@
+//! Integration tests for #1587 — first-boot self-bootstrap.
+//!
+//! These spawn the real `red` binary via `CARGO_BIN_EXE_red` so they
+//! exercise the full `main()` boot path: a single `red server` on a
+//! fresh volume with a bootstrap intent must create the paged vault in
+//! place, apply the preset, and serve — no separate `red bootstrap` and
+//! no "vault requires a paged database" abort.
+
+#[allow(dead_code)]
+mod support;
+
+use std::fs::File;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+/// Grab an OS-assigned free TCP port, then release it so the child can
+/// bind it. Small TOCTOU window, acceptable for a test.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    listener.local_addr().expect("local_addr").port()
+}
+
+/// A spawned `red server` that is killed + reaped on drop, with its
+/// stderr captured to a file for post-mortem assertions.
+struct ServerChild {
+    child: Child,
+    stderr_path: PathBuf,
+}
+
+impl ServerChild {
+    fn stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_path).unwrap_or_default()
+    }
+}
+
+impl Drop for ServerChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Spawn `red server` with a hermetic environment. `stderr_path` receives
+/// the child's stderr so the caller can grep it after the child exits.
+fn spawn_server(args: &[&str], stderr_path: &Path) -> ServerChild {
+    let stderr_file = File::create(stderr_path).expect("create stderr file");
+    let child = Command::new(red_binary())
+        .args(args)
+        .env_remove("REDDB_CERTIFICATE")
+        .env_remove("REDDB_USERNAME")
+        .env_remove("REDDB_PASSWORD")
+        .env_remove("REDDB_USERNAME_FILE")
+        .env_remove("REDDB_PASSWORD_FILE")
+        .env_remove("REDDB_CERTIFICATE_FILE")
+        .env_remove("REDDB_BOOTSTRAP_PRESET")
+        .env_remove("REDDB_PRESET")
+        .env_remove("REDDB_BOOTSTRAP_MANIFEST")
+        .env_remove("REDDB_VAULT")
+        .env_remove("REDDB_AUTH")
+        .env_remove("REDDB_REQUIRE_AUTH")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .expect("spawn red server");
+    ServerChild {
+        child,
+        stderr_path: stderr_path.to_path_buf(),
+    }
+}
+
+/// Wait until the spawned server is serving: it is still alive AND a TCP
+/// connection to its listener succeeds (listeners bind only after the
+/// runtime + vault + preset are built, so a live connect proves the boot
+/// got past the vault gate). Returns `false` if the process exits first.
+fn wait_until_serving(server: &mut ServerChild, addr: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(Some(_status)) = server.child.try_wait() {
+            return false; // exited before serving — boot failed
+        }
+        if TcpStream::connect(addr).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    false
+}
+
+/// Wait for the process to exit, returning its exit code (or `None` on
+/// timeout). Used by the negative test where boot must fail fast.
+fn wait_for_exit(server: &mut ServerChild, timeout: Duration) -> Option<i32> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(Some(status)) = server.child.try_wait() {
+            return Some(status.code().unwrap_or(-1));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    None
+}
+
+/// The paged operational-directory layout writes a `<path>-hdr` sidecar
+/// next to the main file; the embedded single-file layout does not. Its
+/// presence is therefore a reliable marker that the paged vault was
+/// created in place.
+fn paged_layout_marker(db_path: &Path) -> PathBuf {
+    let mut name = db_path.file_name().unwrap().to_os_string();
+    name.push("-hdr");
+    db_path.with_file_name(name)
+}
+
+fn cloud_server_args<'a>(
+    db_path: &'a str,
+    http_addr: &'a str,
+    head_pw: &'a str,
+    customer_pw: &'a str,
+) -> Vec<&'a str> {
+    vec![
+        "server",
+        "--path",
+        db_path,
+        "--vault",
+        "true",
+        "--http",
+        "--http-bind",
+        http_addr,
+        "--bootstrap-preset",
+        "cloud",
+        "--cloud-head-admin",
+        "red_admin",
+        "--cloud-head-admin-password-file",
+        head_pw,
+        "--customer-admin",
+        "admin",
+        "--customer-admin-password-file",
+        customer_pw,
+    ]
+}
+
+/// First boot on a fresh volume with a `cloud` bootstrap intent creates
+/// the paged vault in place, applies the preset, and serves — and a
+/// re-boot against the now-existing vault serves again without
+/// re-bootstrapping (idempotent).
+#[test]
+fn first_boot_cloud_intent_creates_vault_then_idempotent_reboot() {
+    let dir = support::temp_data_dir("first-boot-cloud");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let head_pw = dir.join("head.pw");
+    let customer_pw = dir.join("customer.pw");
+    std::fs::write(&head_pw, "head-secret\n").unwrap();
+    std::fs::write(&customer_pw, "customer-secret\n").unwrap();
+    let head_pw_s = head_pw.to_str().unwrap();
+    let customer_pw_s = customer_pw.to_str().unwrap();
+    let port = free_port();
+    let http_addr = format!("127.0.0.1:{port}");
+    let stderr_path = dir.join("server.stderr");
+
+    // Sanity: the database does not exist yet.
+    assert!(!db_path.exists(), "fresh volume precondition");
+
+    let mut server = spawn_server(
+        &cloud_server_args(&db_path_str, &http_addr, head_pw_s, customer_pw_s),
+        &stderr_path,
+    );
+
+    let serving = wait_until_serving(&mut server, &http_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "server never came up — first boot did not serve.\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("vault requires a paged database"),
+        "first boot must NOT abort at the vault gate.\nstderr:\n{stderr}"
+    );
+    // The paged vault was created in place (operational-directory layout).
+    assert!(
+        paged_layout_marker(&db_path).exists(),
+        "expected paged vault created in place ({} missing).\nstderr:\n{stderr}",
+        paged_layout_marker(&db_path).display()
+    );
+
+    drop(server); // kill + reap
+
+    // ---- Idempotent re-boot against the now-existing paged vault. ----
+    // If the preset were re-applied, re-creating the head/customer admins
+    // would fail ("already exists") and boot would abort — so a clean
+    // second serve is itself proof that the bootstrap-completed marker
+    // short-circuited preset re-application (no re-bootstrap, no new cert).
+    let stderr_path2 = dir.join("server2.stderr");
+    let mut server2 = spawn_server(
+        &cloud_server_args(&db_path_str, &http_addr, head_pw_s, customer_pw_s),
+        &stderr_path2,
+    );
+
+    let serving2 = wait_until_serving(&mut server2, &http_addr, Duration::from_secs(30));
+    let stderr2 = server2.stderr();
+    assert!(
+        serving2,
+        "re-boot against the existing vault must serve without re-bootstrapping.\nstderr:\n{stderr2}"
+    );
+    assert!(
+        !stderr2.contains("vault requires a paged database"),
+        "re-boot must not abort at the vault gate.\nstderr:\n{stderr2}"
+    );
+}
+
+/// No bootstrap intent + non-existent path keeps today's behaviour: the
+/// vault gate aborts with a clear error rather than silently creating an
+/// empty vault. (`--vault true` with no preset/credentials = no intent.)
+#[test]
+fn no_intent_fresh_path_keeps_vault_gate_error() {
+    let dir = support::temp_data_dir("first-boot-no-intent");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let port = free_port();
+    let http_addr = format!("127.0.0.1:{port}");
+    let stderr_path = dir.join("server.stderr");
+
+    let mut server = spawn_server(
+        &[
+            "server",
+            "--path",
+            &db_path_str,
+            "--vault",
+            "true",
+            "--http",
+            "--http-bind",
+            &http_addr,
+        ],
+        &stderr_path,
+    );
+
+    // Without an intent the boot must fail fast at the vault gate — it
+    // must exit non-zero and never come up as a listener.
+    let code = wait_for_exit(&mut server, Duration::from_secs(15));
+    let stderr = server.stderr();
+    assert_eq!(
+        code,
+        Some(1),
+        "no-intent fresh-path boot must exit 1 at the vault gate; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("vault requires a paged database"),
+        "expected the clear vault-gate error; stderr:\n{stderr}"
+    );
+    // It must NOT have silently created a paged vault.
+    assert!(
+        !paged_layout_marker(&db_path).exists(),
+        "no-intent boot must not self-create a paged vault"
+    );
+}

--- a/tests/grouped/cli_transport.rs
+++ b/tests/grouped/cli_transport.rs
@@ -12,6 +12,9 @@ mod support;
 #[path = "../cli_bootstrap.rs"]
 mod cli_bootstrap;
 
+#[path = "../cli_first_boot.rs"]
+mod cli_first_boot;
+
 #[path = "cli_transport/cli_migrate_from_redis.rs"]
 mod cli_migrate_from_redis;
 


### PR DESCRIPTION
## Summary

Implements #1587 (keystone slice of PRD #1580). A single distroless `red server` on a fresh/empty volume with a bootstrap intent now creates the paged vault **in place** and serves in one process — no separate `red bootstrap`, no `vault requires a paged database (persistent mode)` abort.

## How it works

The root cause: the default embedded single-file packaging (`DeployProfile::Embedded` + `StoragePackaging::SingleFile`) builds the store via `UnifiedStore::with_config`, which exposes **no pager**, so the vault gate in `build_runtime_with_bootstrap` aborts. `red bootstrap` escapes this by opening with operational-directory packaging.

`ServerCommandConfig::to_db_options` now composes that same storage selection when **all** of:
- the vault is enabled, AND
- a bootstrap intent is present (`bootstrap.auth_bootstrap_input() != None` — preset/credentials/manifest), AND
- the `--path` is absent, AND
- the resolved profile is embedded single-file (the only one lacking a pager).

When triggered it promotes packaging to `OperationalDirectory` (+ `create_if_missing`), so the fresh DB is paged, the vault pages exist, and the **existing** preset machinery (`ProceedLocal` → `apply_preset_from_config`) mints the admins + certificate before listeners come up. No bootstrap logic is shelled out or duplicated.

## Idempotency

A re-boot finds the path present → no promotion → the on-disk operational-directory layout opens with a pager, and the `system.bootstrap.completed` marker short-circuits preset re-application (no re-bootstrap, no new certificate). `--no-auth`/`--dev` clears `vault_enabled` first, so the dev carveout never triggers first-boot.

## No-intent unchanged

No intent + absent path keeps today's behaviour: the clear vault-gate error, never a silently-created empty vault.

## Tests (`tests/cli_first_boot.rs`, grouped under `grouped_cli_transport`)

- `first_boot_cloud_intent_creates_vault_then_idempotent_reboot` — fresh path + `cloud` intent creates the paged vault (asserts the `-hdr` paged sidecar), serves, no vault-gate abort; then a re-boot serves again (a clean second serve proves idempotency — re-applying the preset would fail on duplicate admins and abort).
- `no_intent_fresh_path_keeps_vault_gate_error` — `--vault true` with no intent exits 1 with the clear error and creates no paged vault.

Help text for `--bootstrap-preset` updated in both flag-schema sites (`red server --help`).

`cargo clippy --locked --all -- -D warnings` clean; rustfmt 1.91 applied; existing `cli_bootstrap` tests still pass.

Closes #1587

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785413502&installation_id=129708444&pr_number=1593&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1593&signature=50afeca11946d7bc164af2de27d53b8d82f193faf292d33213eddd51878688f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `red server` startup behavior for fresh installs with `--vault` and a bootstrap preset: the server can now create the required vault structure in place and continue booting.

* **Bug Fixes**
  * Reboots now reuse existing vault state instead of re-bootstraping or generating a new certificate.
  * Fresh paths without bootstrap intent still fail with the expected vault requirement error, avoiding silent setup changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->