### PR TITLE
merge: #1588 fix --wire-tls-bind vs default-router port collision

### DIFF
--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -1292,6 +1292,7 @@ pub fn run_server_with_large_stack(config: ServerCommandConfig) -> Result<(), St
         || config.grpc_bind_addr.is_some()
         || config.http_bind_addr.is_some()
         || config.wire_bind_addr.is_some()
+        || config.wire_tls_bind_addr.is_some()
         || config.pg_bind_addr.is_some();
     if !has_any {
         return Err("at least one server bind address must be configured".into());
@@ -1307,6 +1308,7 @@ pub fn run_server_with_large_stack(config: ServerCommandConfig) -> Result<(), St
             (true, false) => "red-server-grpc",
             (false, true) => "red-server-http",
             (false, false) if config.wire_bind_addr.is_some() => "red-server-wire",
+            (false, false) if config.wire_tls_bind_addr.is_some() => "red-server-wire-tls",
             (false, false) => "red-server-pg-wire",
         }
     };
@@ -1377,6 +1379,8 @@ fn run_configured_servers(config: ServerCommandConfig) -> Result<(), String> {
         (None, None) => {
             if let Some(wire_addr) = config.wire_bind_addr.clone() {
                 run_wire_only_server(config, wire_addr)
+            } else if let Some(wire_tls_addr) = config.wire_tls_bind_addr.clone() {
+                run_wire_tls_only_server(config, wire_tls_addr)
             } else if let Some(pg_addr) = config.pg_bind_addr.clone() {
                 run_pg_only_server(config, pg_addr)
             } else {
@@ -2018,6 +2022,47 @@ fn run_wire_only_server(config: ServerCommandConfig, wire_addr: String) -> Resul
         crate::wire::redwire::listener::start_redwire_listener_on(listener, wire_rt)
             .await
             .map_err(|e| e.to_string())
+    })
+}
+
+/// Serve only the TLS RedWire listener (`--wire-tls-bind` with no
+/// explicit plaintext `--wire-bind`, gRPC, or HTTP bind).
+///
+/// Issue #1588: the default router is suppressed whenever
+/// `--wire-tls-bind` is set (see `build_server_config`), so a
+/// TLS-only wire deployment lands here instead of colliding with the
+/// router on port 5050. The TLS listener owns the bind directly.
+#[inline(never)]
+fn run_wire_tls_only_server(
+    config: ServerCommandConfig,
+    wire_tls_addr: String,
+) -> Result<(), String> {
+    let rt_config = detect_runtime_config();
+    let workers = config.workers.unwrap_or(rt_config.suggested_workers);
+    let db_options = config.to_db_options()?;
+    // Resolve TLS material up front so a bad cert/key (or a failed
+    // auto-generation) fails the explicit bind before we open the
+    // runtime.
+    let tls_cfg = resolve_wire_tls_config(&config)?;
+
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(workers)
+        .thread_stack_size(rt_config.stack_size)
+        .build()
+        .map_err(|err| format!("tokio runtime: {err}"))?;
+
+    let (runtime, _auth_store, _telemetry_guard) =
+        build_runtime_and_auth_store(&config, db_options.clone())?;
+    let _backup_tasks = spawn_backup_tasks_if_configured(&db_options, &runtime);
+    let signal_runtime = runtime.clone();
+    tokio_runtime.block_on(async move {
+        spawn_lifecycle_signal_handler(signal_runtime).await;
+        spawn_pg_listener(&config, &runtime);
+        let wire_rt = Arc::new(runtime);
+        crate::wire::start_redwire_tls_listener(&wire_tls_addr, wire_rt, &tls_cfg)
+            .await
+            .map_err(|e| format!("explicit wire-tls listener bind {wire_tls_addr}: {e}"))
     })
 }
 

--- a/tests/grouped/cli_transport.rs
+++ b/tests/grouped/cli_transport.rs
@@ -21,6 +21,9 @@ mod cli_migrate_from_redis;
 #[path = "cli_transport/cli_query_param.rs"]
 mod cli_query_param;
 
+#[path = "cli_transport/e2e_issue_1588_wire_tls_bind.rs"]
+mod e2e_issue_1588_wire_tls_bind;
+
 #[path = "surface_contracts/cross_binary_smoke.rs"]
 mod cross_binary_smoke;
 

--- a/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
@@ -1,0 +1,167 @@
+//! Regression coverage for issue #1588.
+//!
+//! `red server --wire-tls-bind <addr>` with no explicit plaintext
+//! `--wire-bind` (and no gRPC/HTTP bind) must bring the RedWire-over-TLS
+//! listener online. Before the fix the default router still claimed
+//! port 5050 / the wire-TLS-only config had no runner at all, so the
+//! TLS listener never bound — the process either collided with the
+//! router (`Address already in use`) or aborted with
+//! "at least one server bind address must be configured".
+//!
+//! These spawn the real `red` binary via `CARGO_BIN_EXE_red` so the
+//! whole `build_server_config` → `run_configured_servers` boot path is
+//! exercised end-to-end, and assert against process liveness (not a
+//! bare port probe) so a stray listener cannot mask a failed boot.
+
+#[path = "../../support/mod.rs"]
+mod support;
+
+use std::fs::File;
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+/// Grab an OS-assigned free TCP port, then release it so the child can
+/// bind it. Small TOCTOU window, acceptable for a test.
+fn free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    listener.local_addr().expect("local_addr").port()
+}
+
+fn port_is_free(port: u16) -> bool {
+    TcpListener::bind(("127.0.0.1", port)).is_ok()
+}
+
+/// A spawned `red server` that is killed + reaped on drop, with its
+/// stderr captured to a file for post-mortem assertions.
+struct ServerChild {
+    child: Child,
+    stderr_path: PathBuf,
+}
+
+impl ServerChild {
+    fn stderr(&self) -> String {
+        std::fs::read_to_string(&self.stderr_path).unwrap_or_default()
+    }
+}
+
+impl Drop for ServerChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_server(args: &[&str], stderr_path: &Path) -> ServerChild {
+    let stderr_file = File::create(stderr_path).expect("create stderr file");
+    let child = Command::new(red_binary())
+        .args(args)
+        .env_remove("REDDB_USERNAME")
+        .env_remove("REDDB_PASSWORD")
+        .env_remove("REDDB_VAULT")
+        .env_remove("REDDB_AUTH")
+        .env_remove("REDDB_REQUIRE_AUTH")
+        .env_remove("REDDB_WIRE_BIND_ADDR")
+        .env_remove("REDDB_BIND_ADDR")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .expect("spawn red server");
+    ServerChild {
+        child,
+        stderr_path: stderr_path.to_path_buf(),
+    }
+}
+
+/// Wait until the spawned server is serving: it is still alive AND a TCP
+/// connection to its listener succeeds. Returns `false` if the process
+/// exits first (boot failed) — process liveness guards against a stray
+/// listener masking a failed boot.
+fn wait_until_serving(server: &mut ServerChild, addr: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(Some(_status)) = server.child.try_wait() {
+            return false; // exited before serving — boot failed
+        }
+        if TcpStream::connect(addr).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    false
+}
+
+/// `--wire-tls-bind` with no explicit `--wire-bind` brings the
+/// RedWire-over-TLS listener online — no router collision, no
+/// "at least one server bind address must be configured" abort.
+/// The TLS cert/key are auto-generated next to the data dir.
+#[test]
+fn wire_tls_only_serves_without_router_collision() {
+    let dir = support::temp_data_dir("issue-1588-wire-tls-only");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let port = free_port();
+    let wire_tls_addr = format!("127.0.0.1:{port}");
+    let stderr_path = dir.join("server.stderr");
+
+    let mut server = spawn_server(
+        &[
+            "server",
+            "--path",
+            &db_path_str,
+            "--wire-tls-bind",
+            &wire_tls_addr,
+            "--no-auth",
+        ],
+        &stderr_path,
+    );
+
+    let serving = wait_until_serving(&mut server, &wire_tls_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "wire-tls-only server never came up on {wire_tls_addr}.\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Address already in use"),
+        "wire-tls listener must not collide with the default router.\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("at least one server bind address must be configured"),
+        "wire-tls-bind alone must be a valid server configuration.\nstderr:\n{stderr}"
+    );
+}
+
+/// Default-router behaviour with NO `--wire-tls-bind` is unchanged: a
+/// flagless `red server` still claims the default router port (5050).
+/// Skipped when 5050 is already occupied on the host so environmental
+/// contention can never produce a false failure.
+#[test]
+fn default_router_unchanged_without_wire_tls() {
+    if !port_is_free(5050) {
+        eprintln!("skipping: default router port 5050 is busy on this host");
+        return;
+    }
+    let dir = support::temp_data_dir("issue-1588-default-router");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let stderr_path = dir.join("server.stderr");
+
+    let mut server = spawn_server(
+        &["server", "--path", &db_path_str, "--no-auth"],
+        &stderr_path,
+    );
+
+    let serving = wait_until_serving(&mut server, "127.0.0.1:5050", Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "default-router server never came up on 127.0.0.1:5050.\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary
`red server --wire-tls-bind <addr>` with no explicit plaintext `--wire-bind` (and no gRPC/HTTP bind) never brought the RedWire-over-TLS listener online. The default-router decision in `build_server_config` already suppresses the router on that port when `--wire-tls-bind` is set, but the downstream boot path had no runner for a wire-TLS-only config: `has_any` didn't count `wire_tls_bind_addr`, and `run_configured_servers` had no branch for it, so boot aborted with `at least one server bind address must be configured`.

## Changes
- Count `wire_tls_bind_addr` in the `has_any` bind check (`run_server_with_large_stack`).
- Route the wire-TLS-only config to a new `run_wire_tls_only_server` that resolves TLS material up front, opens the runtime, and serves the TLS listener directly — no router, no plaintext-wire collision.
- Name the server thread `red-server-wire-tls` for that case.

No behaviour change when `--wire-tls-bind` is absent (the new branch is gated on `wire_tls_bind_addr.is_some()`).

## Tests
New e2e regression `tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs` (registered in the active `grouped_cli_transport` harness):
- `wire_tls_only_serves_without_router_collision` — spawns the real `red` binary with `--wire-tls-bind` only; asserts the TLS listener accepts connections, the process stays alive, and stderr has no `Address already in use` / `at least one server bind address` abort.
- `default_router_unchanged_without_wire_tls` — a flagless `red server` still claims the default router port 5050 (skips cleanly if 5050 is busy on the host).

Both pass; `cargo clippy --locked --all -- -D warnings` and `cargo fmt --all -- --check` clean.

Closes #1588

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785415886&installation_id=129708444&pr_number=1594&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1594&signature=cbc685cb4f13008ae59bdf83ea7c9adff2fb279087fc0958e3d697be8724bf05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->