### PR TITLE
merge: #1589 first-boot --bootstrap-cert-out (write unseal cert to a file)

### DIFF
--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -397,6 +397,12 @@ fn server_flags() -> Vec<FlagSchema> {
             .with_description("Cloud preset customer admin password (DEV ONLY; prefer file flag)"),
         FlagSchema::new("customer-admin-password-file")
             .with_description("File containing cloud customer admin password"),
+        FlagSchema::new("bootstrap-cert-out").with_description(
+            "Write the first-boot unseal certificate to this file (e.g. /run/reddb/cert.pem) \
+             in addition to stderr, so a distroless init can read it back for the next boot's \
+             REDDB_CERTIFICATE_FILE unseal. Written only on the bootstrap-creating boot; a \
+             re-boot against the existing vault does not rewrite it.",
+        ),
         FlagSchema::new("log-dir").with_description(
             "Directory for rotating log files (defaults to the parent of --path / ./logs)",
         ),

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -173,6 +173,15 @@ pub struct BootstrapConfig {
     pub cloud_head_admin_password: Option<String>,
     pub customer_admin: Option<String>,
     pub customer_admin_password: Option<String>,
+    /// `--bootstrap-cert-out <path>` (issue #1589). When set and the
+    /// first-boot self-bootstrap mints an unseal certificate, that
+    /// certificate hex is written to this file (in addition to the
+    /// stdout/stderr emission) so a distroless single-machine init can
+    /// read it back for the subsequent unseal via `REDDB_CERTIFICATE_FILE`
+    /// without scraping machine logs. Written only on the
+    /// bootstrap-creating boot; a re-boot against an existing vault does
+    /// not rewrite it.
+    pub cert_out: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -526,6 +535,16 @@ impl BootstrapConfig {
         self.manifest.clone().or_else(|| {
             env_nonempty(crate::cli::bootstrap_manifest::MANIFEST_ENV).map(PathBuf::from)
         })
+    }
+
+    /// Resolve the `--bootstrap-cert-out` target (issue #1589): the CLI
+    /// flag wins, else the `REDDB_BOOTSTRAP_CERT_OUT` env (with its
+    /// `_FILE` companion) — matching the flag/env pattern used by the
+    /// other bootstrap inputs.
+    fn selected_cert_out(&self) -> Option<PathBuf> {
+        self.cert_out
+            .clone()
+            .or_else(|| env_nonempty(BOOTSTRAP_CERT_OUT_ENV).map(PathBuf::from))
     }
 
     /// Classify the auth bootstrap this config would perform, for the
@@ -2350,6 +2369,9 @@ pub(crate) const BOOTSTRAP_FIRST_ADMIN_KEY: &str = "system.bootstrap.first_admin
 /// is canonical; `REDDB_PRESET` remains accepted for compatibility.
 pub(crate) const BOOTSTRAP_PRESET_ENV: &str = "REDDB_BOOTSTRAP_PRESET";
 pub(crate) const PRESET_ENV: &str = "REDDB_PRESET";
+/// Env equivalent of `--bootstrap-cert-out` (issue #1589). Honours the
+/// `_FILE` companion via [`env_nonempty`].
+pub(crate) const BOOTSTRAP_CERT_OUT_ENV: &str = "REDDB_BOOTSTRAP_CERT_OUT";
 pub(crate) const PRESET_SIMPLE: &str = "simple";
 pub(crate) const PRESET_PRODUCTION: &str = "production";
 pub(crate) const PRESET_REGULATED: &str = "regulated";
@@ -2421,18 +2443,24 @@ fn apply_preset_from_config(
         return Ok(());
     }
 
-    let first_admin_id = match preset.as_str() {
+    let (first_admin_id, certificate) = match preset.as_str() {
         PRESET_SIMPLE => {
             // `simple` is the default low-friction preset. Auth knobs
             // remain whatever the CLI/env set; we only persist the
             // bootstrap state so subsequent boots are idempotent.
-            None
+            (None, None)
         }
-        PRESET_PRODUCTION => Some(apply_production_preset_from_config(auth_store, bootstrap)?),
-        PRESET_CLOUD => Some(apply_cloud_preset(runtime, auth_store, bootstrap)?),
+        PRESET_PRODUCTION => {
+            let (id, cert) = apply_production_preset_from_config(auth_store, bootstrap)?;
+            (Some(id), cert)
+        }
+        PRESET_CLOUD => {
+            let (id, cert) = apply_cloud_preset(runtime, auth_store, bootstrap)?;
+            (Some(id), cert)
+        }
         PRESET_REGULATED => {
             apply_regulated_preset(runtime, auth_store)?;
-            None
+            (None, None)
         }
         other => {
             return Err(format!(
@@ -2441,15 +2469,45 @@ fn apply_preset_from_config(
         }
     };
 
+    // Issue #1589 — write the freshly minted unseal certificate to the
+    // caller-specified file so a distroless single-machine init can read
+    // it back for the next boot's `REDDB_CERTIFICATE_FILE` unseal. This
+    // path runs only on the bootstrap-creating boot (the completion
+    // marker short-circuits above before any cert is minted), so the file
+    // is written exactly once and a re-boot never churns it.
+    if let Some(cert) = certificate.as_deref() {
+        write_bootstrap_certificate(bootstrap, cert)?;
+    }
+
     persist_bootstrap_state(runtime, &preset, first_admin_id.as_deref());
     tracing::info!(preset = %preset, "bootstrap preset applied");
+    Ok(())
+}
+
+/// Write the unseal certificate to `--bootstrap-cert-out` when that
+/// target is set (issue #1589). No-op when the flag/env is absent, so
+/// the certificate is still emitted on stderr by the preset as before.
+fn write_bootstrap_certificate(
+    bootstrap: &BootstrapConfig,
+    certificate_hex: &str,
+) -> Result<(), String> {
+    let Some(path) = bootstrap.selected_cert_out() else {
+        return Ok(());
+    };
+    std::fs::write(&path, certificate_hex)
+        .map_err(|err| format!("write --bootstrap-cert-out {}: {err}", path.display()))?;
+    tracing::info!(
+        target: "reddb::bootstrap",
+        path = %path.display(),
+        "first-boot self-bootstrap: wrote unseal certificate to --bootstrap-cert-out (consume via REDDB_CERTIFICATE_FILE on the next boot)"
+    );
     Ok(())
 }
 
 fn apply_production_preset_from_config(
     auth_store: &Arc<AuthStore>,
     bootstrap: &BootstrapConfig,
-) -> Result<String, String> {
+) -> Result<(String, Option<String>), String> {
     use crate::auth::store::PrincipalRef;
     use crate::auth::UserId;
 
@@ -2468,7 +2526,8 @@ fn apply_production_preset_from_config(
     let result = auth_store
         .bootstrap(&username, &password)
         .map_err(|err| format!("bootstrap first admin: {err}"))?;
-    if let Some(cert) = result.certificate.as_deref() {
+    let certificate = result.certificate.clone();
+    if let Some(cert) = certificate.as_deref() {
         eprintln!("[reddb] CERTIFICATE: {}", cert);
         tracing::warn!(
             "vault certificate issued by REDDB_PRESET=production -- save it and update the runtime secret before restart"
@@ -2487,14 +2546,14 @@ fn apply_production_preset_from_config(
         )
         .map_err(|err| format!("attach allow-all policy: {err}"))?;
 
-    Ok(first_admin.to_string())
+    Ok((first_admin.to_string(), certificate))
 }
 
 fn apply_cloud_preset(
     runtime: &RedDBRuntime,
     auth_store: &Arc<AuthStore>,
     bootstrap: &BootstrapConfig,
-) -> Result<String, String> {
+) -> Result<(String, Option<String>), String> {
     use crate::auth::store::PrincipalRef;
     use crate::auth::{Role, UserId};
 
@@ -2520,6 +2579,7 @@ fn apply_cloud_preset(
     let head = auth_store
         .bootstrap_system_admin(&head_username, &head_password)
         .map_err(|err| format!("bootstrap cloud head admin: {err}"))?;
+    let certificate = head.certificate.clone();
     let head_id = UserId::platform(head.user.username.clone());
 
     auth_store
@@ -2544,7 +2604,7 @@ fn apply_cloud_preset(
         )
         .map_err(|err| format!("attach cloud guardrail policy: {err}"))?;
 
-    Ok(head_id.to_string())
+    Ok((head_id.to_string(), certificate))
 }
 
 fn install_allow_all_policy(auth_store: &Arc<AuthStore>) -> Result<(), String> {

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -3431,6 +3431,13 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 ),
                 cli::types::FlagSchema::new("customer-admin-password-file")
                     .with_description("File containing cloud customer admin password"),
+                cli::types::FlagSchema::new("bootstrap-cert-out").with_description(
+                    "Write the first-boot unseal certificate to this file (e.g. \
+                     /run/reddb/cert.pem) in addition to stderr, so a distroless init \
+                     can read it back for the next boot's REDDB_CERTIFICATE_FILE unseal. \
+                     Written only on the bootstrap-creating boot; a re-boot against the \
+                     existing vault does not rewrite it.",
+                ),
                 cli::types::FlagSchema::boolean("ui").with_description(
                     "Serve the pinned red-ui bundle as static assets on the HTTP surface \
                      (reach is governed by the bind address; default localhost)",
@@ -4117,6 +4124,10 @@ fn build_bootstrap_config(flags: &HashMap<String, FlagValue>) -> Result<Bootstra
             "customer-admin-password",
             "customer-admin-password-file",
         )?,
+        cert_out: flag_string(flags, "bootstrap-cert-out")
+            .filter(|value| !value.is_empty())
+            .or_else(|| env_string("REDDB_BOOTSTRAP_CERT_OUT"))
+            .map(PathBuf::from),
     })
 }
 

--- a/tests/cli_first_boot.rs
+++ b/tests/cli_first_boot.rs
@@ -61,6 +61,38 @@ fn spawn_server(args: &[&str], stderr_path: &Path) -> ServerChild {
         .env_remove("REDDB_BOOTSTRAP_PRESET")
         .env_remove("REDDB_PRESET")
         .env_remove("REDDB_BOOTSTRAP_MANIFEST")
+        .env_remove("REDDB_BOOTSTRAP_CERT_OUT")
+        .env_remove("REDDB_VAULT")
+        .env_remove("REDDB_AUTH")
+        .env_remove("REDDB_REQUIRE_AUTH")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::from(stderr_file))
+        .spawn()
+        .expect("spawn red server");
+    ServerChild {
+        child,
+        stderr_path: stderr_path.to_path_buf(),
+    }
+}
+
+/// Spawn `red server` like [`spawn_server`], but with `REDDB_CERTIFICATE_FILE`
+/// pointed at `cert_file` so a reboot can unseal the existing vault from the
+/// certificate written by an earlier `--bootstrap-cert-out` boot (issue #1589).
+fn spawn_server_with_cert_file(args: &[&str], stderr_path: &Path, cert_file: &Path) -> ServerChild {
+    let stderr_file = File::create(stderr_path).expect("create stderr file");
+    let child = Command::new(red_binary())
+        .args(args)
+        .env_remove("REDDB_CERTIFICATE")
+        .env_remove("REDDB_USERNAME")
+        .env_remove("REDDB_PASSWORD")
+        .env_remove("REDDB_USERNAME_FILE")
+        .env_remove("REDDB_PASSWORD_FILE")
+        .env("REDDB_CERTIFICATE_FILE", cert_file)
+        .env_remove("REDDB_BOOTSTRAP_PRESET")
+        .env_remove("REDDB_PRESET")
+        .env_remove("REDDB_BOOTSTRAP_MANIFEST")
+        .env_remove("REDDB_BOOTSTRAP_CERT_OUT")
         .env_remove("REDDB_VAULT")
         .env_remove("REDDB_AUTH")
         .env_remove("REDDB_REQUIRE_AUTH")
@@ -91,6 +123,41 @@ fn wait_until_serving(server: &mut ServerChild, addr: &str, timeout: Duration) -
         std::thread::sleep(Duration::from_millis(150));
     }
     false
+}
+
+/// Poll until `path` exists (the spawned server is still alive), or the
+/// process exits / the timeout elapses. Returns `true` only when the file
+/// appeared while the server was running. More robust than a bare TCP
+/// probe: it ties the wait to the artifact under test and cannot be fooled
+/// by a stale listener on the same ephemeral port.
+fn wait_for_file(server: &mut ServerChild, path: &Path, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if path.exists() {
+            return true;
+        }
+        if let Ok(Some(_status)) = server.child.try_wait() {
+            return path.exists(); // exited — accept only if the file landed
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    path.exists()
+}
+
+/// Poll the server's stderr until it contains `needle` (proof the boot
+/// reached that log line), the process exits, or the timeout elapses.
+fn wait_for_stderr_contains(server: &mut ServerChild, needle: &str, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if server.stderr().contains(needle) {
+            return true;
+        }
+        if let Ok(Some(_status)) = server.child.try_wait() {
+            return server.stderr().contains(needle);
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    server.stderr().contains(needle)
 }
 
 /// Wait for the process to exit, returning its exit code (or `None` on
@@ -256,5 +323,150 @@ fn no_intent_fresh_path_keeps_vault_gate_error() {
     assert!(
         !paged_layout_marker(&db_path).exists(),
         "no-intent boot must not self-create a paged vault"
+    );
+}
+
+/// Issue #1589 — first boot with `--bootstrap-cert-out <path>` writes the
+/// freshly minted unseal certificate to `<path>` (in addition to the
+/// stdout/stderr emission). The written file is consumable via
+/// `REDDB_CERTIFICATE_FILE` to unseal on a subsequent boot, and a re-boot
+/// against the existing vault does not rewrite/churn the file.
+#[test]
+fn first_boot_cert_out_writes_cert_then_unseal_roundtrip_no_churn() {
+    let dir = support::temp_data_dir("first-boot-cert-out");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let head_pw = dir.join("head.pw");
+    let customer_pw = dir.join("customer.pw");
+    std::fs::write(&head_pw, "head-secret\n").unwrap();
+    std::fs::write(&customer_pw, "customer-secret\n").unwrap();
+    let head_pw_s = head_pw.to_str().unwrap();
+    let customer_pw_s = customer_pw.to_str().unwrap();
+    let cert_out = dir.join("cert.pem");
+    let cert_out_s = cert_out.to_str().unwrap();
+    let port = free_port();
+    let http_addr = format!("127.0.0.1:{port}");
+
+    assert!(!db_path.exists(), "fresh volume precondition");
+    assert!(
+        !cert_out.exists(),
+        "cert-out must not exist before first boot"
+    );
+
+    let mut cloud_with_cert_out =
+        cloud_server_args(&db_path_str, &http_addr, head_pw_s, customer_pw_s);
+    cloud_with_cert_out.push("--bootstrap-cert-out");
+    cloud_with_cert_out.push(cert_out_s);
+
+    // ---- First boot: mint the vault + write the certificate file. ----
+    let stderr_path = dir.join("server.stderr");
+    let mut server = spawn_server(&cloud_with_cert_out, &stderr_path);
+    // The cert file is written during preset application, before listeners
+    // come up; poll for it directly rather than probing the port.
+    let wrote_cert = wait_for_file(&mut server, &cert_out, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        wrote_cert,
+        "--bootstrap-cert-out file was not written.\nstderr:\n{stderr}"
+    );
+    assert!(
+        paged_layout_marker(&db_path).exists(),
+        "first boot must create the paged vault in place.\nstderr:\n{stderr}"
+    );
+    drop(server); // kill + reap
+
+    // The certificate holds a usable 32-byte (64 hex chars) unseal cert.
+    let cert_first = std::fs::read_to_string(&cert_out).expect("read cert-out");
+    let cert_trimmed = cert_first.trim();
+    assert_eq!(
+        cert_trimmed.len(),
+        64,
+        "expected a 64-hex-char certificate, got {:?}",
+        cert_trimmed
+    );
+    assert!(
+        cert_trimmed.bytes().all(|b| b.is_ascii_hexdigit()),
+        "certificate must be hex, got {:?}",
+        cert_trimmed
+    );
+    let mtime_first = std::fs::metadata(&cert_out)
+        .and_then(|m| m.modified())
+        .expect("cert-out mtime");
+
+    // ---- Round-trip: a fresh boot with NO bootstrap intent unseals the
+    // existing vault from the written file via REDDB_CERTIFICATE_FILE. The
+    // bootstrapped operational-directory vault requires the certificate on
+    // every subsequent boot, so a clean serve here proves the file we wrote
+    // is a usable unseal certificate. ----
+    let stderr_path2 = dir.join("server2.stderr");
+    let mut server2 = spawn_server_with_cert_file(
+        &[
+            "server",
+            "--path",
+            &db_path_str,
+            "--vault",
+            "true",
+            "--http",
+            "--http-bind",
+            &http_addr,
+        ],
+        &stderr_path2,
+        &cert_out,
+    );
+    let serving2 =
+        wait_for_stderr_contains(&mut server2, "listener online", Duration::from_secs(30));
+    let stderr2 = server2.stderr();
+    assert!(
+        serving2,
+        "the written certificate must unseal via REDDB_CERTIFICATE_FILE on a subsequent boot.\nstderr:\n{stderr2}"
+    );
+    drop(server2);
+
+    // ---- No churn: a re-boot against the existing vault — even with the
+    // bootstrap intent and `--bootstrap-cert-out` re-passed — must NOT
+    // rewrite the certificate file. The completion marker short-circuits
+    // preset re-application before any cert is minted or written. The cert
+    // env unseals the existing vault so the boot reaches that point. ----
+    let stderr_path3 = dir.join("server3.stderr");
+    let mut server3 = spawn_server_with_cert_file(&cloud_with_cert_out, &stderr_path3, &cert_out);
+    let rebooted =
+        wait_for_stderr_contains(&mut server3, "listener online", Duration::from_secs(30));
+    let stderr3 = server3.stderr();
+    assert!(
+        rebooted,
+        "re-boot against the existing vault must serve.\nstderr:\n{stderr3}"
+    );
+    drop(server3);
+
+    let cert_second = std::fs::read_to_string(&cert_out).expect("read cert-out after reboot");
+    assert_eq!(
+        cert_first, cert_second,
+        "re-boot must not rewrite the cert-out file (content churned)"
+    );
+    let mtime_second = std::fs::metadata(&cert_out)
+        .and_then(|m| m.modified())
+        .expect("cert-out mtime after reboot");
+    assert_eq!(
+        mtime_first, mtime_second,
+        "re-boot must not rewrite the cert-out file (mtime churned)"
+    );
+}
+
+/// Issue #1589 — `--bootstrap-cert-out` is documented in `red server --help`.
+#[test]
+fn server_help_documents_bootstrap_cert_out() {
+    let output = Command::new(red_binary())
+        .args(["server", "--help"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("run red server --help");
+    let help = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        help.contains("--bootstrap-cert-out"),
+        "red server --help must document --bootstrap-cert-out.\nhelp:\n{help}"
     );
 }


### PR DESCRIPTION
## What

Adds `--bootstrap-cert-out <path>` (and the matching `REDDB_BOOTSTRAP_CERT_OUT` env, honouring the `_FILE` companion) so the first-boot self-bootstrap (#1587) writes the unseal certificate to a caller-specified file (e.g. `/run/reddb/cert.pem`), in addition to today's stderr emission.

On a distroless single-machine init there is no way to capture bootstrap stdout/stderr for the subsequent unseal. The written file is consumable via the existing `REDDB_CERTIFICATE_FILE` on the next boot — removing the log-scraping.

## How

- The write hooks `apply_preset_from_config` after the production/cloud presets mint the certificate (the production/cloud preset fns now return the cert alongside the first-admin id).
- **Idempotent for free**: `apply_preset_from_config` early-returns on the `system.bootstrap.completed` marker before any cert is minted, so a re-boot against an existing vault never re-mints, re-writes, or churns the file.
- Flag wired in both flag-schema sites (`src/bin/red.rs`, `crates/reddb-server/src/cli/commands.rs`) with help text.
- Behaviour with the flag absent is unchanged.

## Tests

New e2e in `tests/cli_first_boot.rs` (grouped `grouped_cli_transport` binary): first-boot writes a valid 64-hex cert; `REDDB_CERTIFICATE_FILE` round-trip unseals the existing vault and serves; re-boot does not rewrite the file (content + mtime unchanged). Plus a `red server --help` documentation assertion. The new test uses filesystem/stderr-based waits (not a bare port probe) to avoid the stale-listener false positives noted on #1587/#1588.

Local: `cargo build -p reddb-io-server` + `--bin red` green; `cargo fmt --all -- --check` clean; `cargo clippy --locked --all -- -D warnings` clean; the new e2e + the existing first-boot e2e pass.

### Note for reviewer
While testing I found the pre-existing #1587 `first_boot_cloud_intent_creates_vault_then_idempotent_reboot` test's idempotent-reboot leg only passes spuriously via its TCP port probe: a real reboot of a bootstrapped operational-directory vault **requires** the certificate (`Vault::open` returns `NoKey` without `REDDB_CERTIFICATE`). That is exactly the gap this flag closes. Left that test untouched (out of scope), flagging it here.

Closes #1589

https://claude.ai/code/session_01SUkMZLTmcWd8yGiRgj3z49

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785421084&installation_id=129708444&pr_number=1595&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1595&signature=23cfd9be1c5835f7e2845f70ab775d21cf94d1996d1be05d57ccc7381c11c932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new bootstrap option to write the first-boot unseal certificate to a file, with support for environment-based configuration.
  * Help text now documents the new certificate output setting.

* **Bug Fixes**
  * First-boot certificate output is now written only during initial bootstrap, avoiding unnecessary rewrites on later restarts.
  * Existing bootstrapped systems can now use the saved certificate to unseal successfully on restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->