### PR TITLE
merge: #1590 cloud preset: red_admin is un-removable and its protecting policy is un-deletable

### DIFF
--- a/crates/reddb-server/src/auth/store.rs
+++ b/crates/reddb-server/src/auth/store.rs
@@ -1329,6 +1329,28 @@ impl AuthStore {
         self.check_policy_authz_with_role(actor, action, &resource, &ctx, actor_role)
     }
 
+    /// Returns `true` only when an IAM policy explicitly denies the
+    /// action on the target. `DefaultDeny` (no matching policy) is
+    /// treated as permitted, so this is safe to call after the caller
+    /// has already verified the actor's role — it only blocks protected
+    /// principals (e.g. the cloud-preset `red_admin` guardrail).
+    pub fn has_explicit_user_lifecycle_deny(
+        &self,
+        actor: &UserId,
+        actor_role: Role,
+        action: &str,
+        target: &UserId,
+    ) -> bool {
+        let resource = Self::user_lifecycle_resource(target);
+        let ctx = self.eval_context_for_principal(actor, actor_role, target.tenant.clone());
+        let pols = self.effective_policies(actor);
+        let refs: Vec<&Policy> = pols.iter().map(|p| p.as_ref()).collect();
+        matches!(
+            iam_policies::evaluate(&refs, action, &resource, &ctx),
+            iam_policies::Decision::Deny { .. }
+        )
+    }
+
     pub fn get_user(&self, tenant_id: Option<&str>, username: &str) -> Option<User> {
         let id = UserId::from_parts(tenant_id, username);
         self.get_user_cloned(&id).map(|u| User {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -11595,7 +11595,7 @@ impl RedDBRuntime {
                 AlterUserAttribute::Password(_) => "user:password:change",
                 _ => "user:update",
             };
-            if !auth_store.check_user_lifecycle_authz(&actor, grole, action, &target) {
+            if auth_store.has_explicit_user_lifecycle_deny(&actor, grole, action, &target) {
                 return Err(RedDBError::Query(format!(
                     "ALTER USER denied by IAM policy: action `{action}` resource `user:{target}`"
                 )));

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -11577,7 +11577,7 @@ impl RedDBRuntime {
             .clone()
             .ok_or_else(|| RedDBError::Query("auth store not configured".to_string()))?;
 
-        let (_gname, grole) = current_auth_identity().ok_or_else(|| {
+        let (gname, grole) = current_auth_identity().ok_or_else(|| {
             RedDBError::Query("ALTER USER requires an authenticated principal".to_string())
         })?;
         if grole != crate::auth::Role::Admin {
@@ -11587,6 +11587,20 @@ impl RedDBRuntime {
         }
 
         let target = UserId::from_parts(stmt.tenant.as_deref(), &stmt.username);
+        let actor_tenant = current_tenant();
+        let actor = UserId::from_parts(actor_tenant.as_deref(), &gname);
+        for attr in &stmt.attributes {
+            let action = match attr {
+                AlterUserAttribute::Disable => "user:disable",
+                AlterUserAttribute::Password(_) => "user:password:change",
+                _ => "user:update",
+            };
+            if !auth_store.check_user_lifecycle_authz(&actor, grole, action, &target) {
+                return Err(RedDBError::Query(format!(
+                    "ALTER USER denied by IAM policy: action `{action}` resource `user:{target}`"
+                )));
+            }
+        }
 
         // Apply attributes incrementally — each one reads the current
         // record, mutates the relevant field, writes back.

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -2596,7 +2596,7 @@ fn apply_cloud_preset(
             )
             .map_err(|err| format!("attach allow-all policy: {err}"))?;
     }
-    install_cloud_guardrails(runtime, auth_store)?;
+    install_cloud_guardrails(runtime, auth_store, &head_id)?;
     auth_store
         .attach_policy(
             PrincipalRef::User(customer_id),
@@ -2631,6 +2631,7 @@ fn install_allow_all_policy(auth_store: &Arc<AuthStore>) -> Result<(), String> {
 fn install_cloud_guardrails(
     runtime: &RedDBRuntime,
     auth_store: &Arc<AuthStore>,
+    head_admin: &crate::auth::UserId,
 ) -> Result<(), String> {
     use crate::auth::policies::Policy;
     use crate::auth::registry::EvidenceRequirement;
@@ -2647,12 +2648,23 @@ fn install_cloud_guardrails(
                 }},
                 {{
                     "effect": "deny",
+                    "actions": [
+                        "user:delete",
+                        "user:disable",
+                        "user:password:change",
+                        "user:role:update"
+                    ],
+                    "resources": ["user:{head_admin}"]
+                }},
+                {{
+                    "effect": "deny",
                     "actions": ["config:write"],
                     "resources": ["config:{cloud}.*"]
                 }}
             ]
         }}"#,
         id = CLOUD_PROTECT_MANAGED_POLICY,
+        head_admin = head_admin,
         cloud = CLOUD_CONFIG_NAMESPACE,
     ))
     .map_err(|err| format!("compile cloud guardrail policy: {err}"))?;
@@ -3994,6 +4006,71 @@ mod tests {
             crate::storage::schema::Value::Text(s) => assert_eq!(s.as_ref(), PRESET_CLOUD),
             other => panic!("expected Text(cloud), got {other:?}"),
         }
+
+        clear_preset_env();
+    }
+
+    #[test]
+    fn cloud_preset_customer_cannot_disable_head_admin_or_drop_guardrail_policy() {
+        use crate::auth::Role;
+        use crate::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
+
+        let _g = no_auth_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_preset_env();
+
+        let bootstrap = BootstrapConfig {
+            preset: Some(PRESET_CLOUD.to_string()),
+            cloud_head_admin: Some("red_admin".to_string()),
+            cloud_head_admin_password: Some("head-pass".to_string()),
+            customer_admin: Some("admin".to_string()),
+            customer_admin_password: Some("customer-pass".to_string()),
+            ..BootstrapConfig::default()
+        };
+        let (runtime, auth_store) = fresh_runtime_and_store();
+        apply_preset_from_config(&runtime, &auth_store, &bootstrap)
+            .expect("cloud preset applies cleanly");
+        runtime.set_auth_store(Arc::clone(&auth_store));
+
+        set_current_auth_identity("admin".to_string(), Role::Admin);
+        let disable_head = runtime.execute_query("ALTER USER red_admin DISABLE");
+        let drop_guardrail =
+            runtime.execute_query(&format!("DROP POLICY '{}'", CLOUD_PROTECT_MANAGED_POLICY));
+        let create_user = runtime.execute_query("CREATE USER app_user WITH PASSWORD 'p' ROLE read");
+        let disable_user = runtime.execute_query("ALTER USER app_user DISABLE");
+        clear_current_auth_identity();
+
+        let disable_head_err = disable_head.expect_err("customer admin must not disable red_admin");
+        assert!(
+            disable_head_err.to_string().contains("user:disable"),
+            "error should name the denied lifecycle action: {disable_head_err}"
+        );
+        assert!(
+            auth_store
+                .get_user(None, "red_admin")
+                .expect("red_admin should still exist")
+                .enabled,
+            "denied mutation must leave red_admin enabled"
+        );
+
+        let drop_guardrail_err =
+            drop_guardrail.expect_err("customer admin must not drop cloud guardrail policy");
+        assert!(
+            drop_guardrail_err.to_string().contains("managed policy"),
+            "error should name the managed policy guardrail: {drop_guardrail_err}"
+        );
+        assert!(auth_store
+            .get_policy(CLOUD_PROTECT_MANAGED_POLICY)
+            .is_some());
+
+        create_user.expect("customer admin should retain normal create-user authority");
+        disable_user.expect("customer admin should retain normal user-disable authority");
+        assert!(
+            !auth_store
+                .get_user(None, "app_user")
+                .expect("app_user should exist")
+                .enabled,
+            "normal capability should still apply outside the reserved head admin"
+        );
 
         clear_preset_env();
     }


### PR DESCRIPTION
Automated AFK landing for #1590. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1590

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785436488&installation_id=129708444&pr_number=1596&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1596&signature=5a9333dd3b3e64ceba4c40bdad6233d58d045f0a0c0436f159fa442bcfc0720e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened user-management safeguards by blocking unauthorized changes to critical accounts.
  * Added explicit checks that prevent disabling, deleting, changing passwords, or altering roles for protected users when not permitted.
  * Improved cloud preset protections so the main admin account and related guardrail settings can’t be removed or weakened accidentally.
  * Normal user administration actions continue to work as expected for permitted accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->