### PR TITLE
merge: #1591 Manifest-driven first-boot: --bootstrap-manifest JSON supplies the full intent + file secrets

### DIFF
--- a/crates/reddb-server/src/cli/bootstrap_manifest.rs
+++ b/crates/reddb-server/src/cli/bootstrap_manifest.rs
@@ -19,6 +19,7 @@ use crate::auth::store::{AuthStore, PrincipalRef};
 use crate::auth::{Role, User, UserId};
 use crate::runtime::RedDBRuntime;
 use crate::serde_json::{Map as JsonMap, Value as JsonValue};
+use crate::service_cli::BootstrapConfig;
 use crate::storage::schema::Value;
 use crate::storage::unified::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
 
@@ -35,6 +36,14 @@ pub fn apply_manifest_file(
         .map_err(|err| format!("read {MANIFEST_ENV} {}: {err}", path.display()))?;
     let manifest = BootstrapManifest::parse(&raw)?;
     manifest.apply(runtime, auth_store, registry)
+}
+
+pub(crate) fn bootstrap_config_from_manifest_file(
+    path: &Path,
+) -> Result<Option<BootstrapConfig>, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|err| format!("read {MANIFEST_ENV} {}: {err}", path.display()))?;
+    bootstrap_config_from_manifest_json(&raw)
 }
 
 pub fn rehydrate_manifest_registry(
@@ -65,6 +74,98 @@ pub fn rehydrate_manifest_registry(
             .map_err(|err| format!("restore bootstrap registry entry {idx}: {err}"))?;
     }
     Ok(())
+}
+
+fn bootstrap_config_from_manifest_json(raw: &str) -> Result<Option<BootstrapConfig>, String> {
+    let root: JsonValue =
+        crate::serde_json::from_str(raw).map_err(|err| format!("parse manifest JSON: {err}"))?;
+    let obj = root
+        .as_object()
+        .ok_or_else(|| "bootstrap manifest must be a JSON object".to_string())?;
+    let intent = obj
+        .get("bootstrap")
+        .and_then(|value| value.as_object())
+        .unwrap_or(obj);
+
+    let has_intent = intent.contains_key("preset")
+        || intent.contains_key("bootstrap_preset")
+        || intent.contains_key("admin")
+        || intent.contains_key("bootstrap_admin")
+        || intent.contains_key("cloud_head_admin")
+        || intent.contains_key("customer_admin");
+    if !has_intent {
+        return Ok(None);
+    }
+
+    let admin = parse_bootstrap_principal(intent, "admin", "bootstrap_admin")?;
+    let cloud_head = parse_bootstrap_principal(intent, "cloud_head_admin", "cloud_head_admin")?;
+    let customer = parse_bootstrap_principal(intent, "customer_admin", "customer_admin")?;
+
+    Ok(Some(BootstrapConfig {
+        preset: optional_string(intent, "preset")
+            .or_else(|| optional_string(intent, "bootstrap_preset")),
+        manifest: None,
+        admin_username: admin.as_ref().map(|principal| principal.username.clone()),
+        admin_password: admin.map(|principal| principal.password),
+        cloud_head_admin: cloud_head
+            .as_ref()
+            .map(|principal| principal.username.clone()),
+        cloud_head_admin_password: cloud_head.map(|principal| principal.password),
+        customer_admin: customer
+            .as_ref()
+            .map(|principal| principal.username.clone()),
+        customer_admin_password: customer.map(|principal| principal.password),
+    }))
+}
+
+struct BootstrapPrincipal {
+    username: String,
+    password: String,
+}
+
+fn parse_bootstrap_principal(
+    obj: &JsonMap<String, JsonValue>,
+    field: &str,
+    alias: &str,
+) -> Result<Option<BootstrapPrincipal>, String> {
+    let Some(value) = obj.get(field).or_else(|| obj.get(alias)) else {
+        return Ok(None);
+    };
+    let principal = value
+        .as_object()
+        .ok_or_else(|| format!("bootstrap manifest `{field}` must be an object"))?;
+    if principal.contains_key("password") || principal.contains_key("secret") {
+        return Err(format!(
+            "bootstrap manifest `{field}` must use password_file, not inline plaintext"
+        ));
+    }
+    let username = optional_string(principal, "username")
+        .or_else(|| optional_string(principal, "name"))
+        .ok_or_else(|| format!("bootstrap manifest `{field}` requires username"))?;
+    let password_file = optional_string(principal, "password_file")
+        .or_else(|| optional_string(principal, "password_path"))
+        .ok_or_else(|| format!("bootstrap manifest `{field}` requires password_file"))?;
+    let password = read_secret_file(&password_file, field)?;
+    Ok(Some(BootstrapPrincipal { username, password }))
+}
+
+fn read_secret_file(path: &str, field: &str) -> Result<String, String> {
+    let trimmed_path = path.trim();
+    if trimmed_path.is_empty() {
+        return Err(format!(
+            "bootstrap manifest `{field}` password_file is empty"
+        ));
+    }
+    let value = std::fs::read_to_string(trimmed_path)
+        .map_err(|err| format!("read bootstrap manifest `{field}` password_file: {err}"))?
+        .trim_end_matches(['\n', '\r'])
+        .to_string();
+    if value.is_empty() {
+        return Err(format!(
+            "bootstrap manifest `{field}` password_file produced an empty secret"
+        ));
+    }
+    Ok(value)
 }
 
 struct BootstrapManifest {
@@ -344,7 +445,16 @@ fn parse_users(values: &[JsonValue]) -> Result<Vec<ManifestUser>, String> {
         .map(|(idx, value)| {
             let obj = object_at(value, "users", idx)?;
             let username = required_string(obj, "username", "users", idx)?;
-            let password = required_string(obj, "password", "users", idx)?;
+            if obj.contains_key("password") && obj.contains_key("password_file") {
+                return Err(format!(
+                    "users[{idx}] must specify only one of password or password_file"
+                ));
+            }
+            let password = if let Some(path) = optional_string(obj, "password_file") {
+                read_secret_file(&path, "users.password_file")?
+            } else {
+                required_string(obj, "password", "users", idx)?
+            };
             if password.is_empty() {
                 return Err(format!("users[{idx}].password is required"));
             }
@@ -956,6 +1066,83 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_intent_manifest_reads_password_files() {
+        let (_runtime, _auth, path) = manifest_test_env();
+        let dir = path.parent().expect("manifest parent");
+        let head_password = dir.join(format!("head-secret-{}", std::process::id()));
+        let customer_password = dir.join(format!("customer-secret-{}", std::process::id()));
+        std::fs::write(&head_password, "head-pass\n").expect("write head secret");
+        std::fs::write(&customer_password, "customer-pass\r\n").expect("write customer secret");
+
+        write_manifest(
+            &path,
+            &format!(
+                r#"{{
+                    "bootstrap": {{
+                        "preset": "cloud",
+                        "cloud_head_admin": {{
+                            "username": "head",
+                            "password_file": "{}"
+                        }},
+                        "customer_admin": {{
+                            "username": "customer",
+                            "password_file": "{}"
+                        }}
+                    }}
+                }}"#,
+                head_password.display(),
+                customer_password.display()
+            ),
+        );
+
+        let config = super::bootstrap_config_from_manifest_file(&path)
+            .expect("parse intent manifest")
+            .expect("intent present");
+        assert_eq!(config.preset.as_deref(), Some("cloud"));
+        assert_eq!(config.cloud_head_admin.as_deref(), Some("head"));
+        assert_eq!(
+            config.cloud_head_admin_password.as_deref(),
+            Some("head-pass")
+        );
+        assert_eq!(config.customer_admin.as_deref(), Some("customer"));
+        assert_eq!(
+            config.customer_admin_password.as_deref(),
+            Some("customer-pass")
+        );
+        assert!(
+            config.manifest.is_none(),
+            "intent manifests must not recurse back into manifest apply"
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&head_password);
+        let _ = std::fs::remove_file(&customer_password);
+    }
+
+    #[test]
+    fn bootstrap_intent_manifest_rejects_inline_plaintext_secret() {
+        let (_runtime, _auth, path) = manifest_test_env();
+        write_manifest(
+            &path,
+            r#"{
+                "bootstrap": {
+                    "preset": "production",
+                    "admin": {
+                        "username": "ops",
+                        "password": "inline"
+                    }
+                }
+            }"#,
+        );
+
+        let err = super::bootstrap_config_from_manifest_file(&path)
+            .expect_err("inline manifest secret must be rejected");
+        assert!(err.contains("password_file"), "got: {err}");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
     fn owner_apply_creates_user_and_initial_config() {
         // Acceptance #1/#4: the fenced owner applies the manifest, creating the
         // initial admin and writing initial config.
@@ -982,6 +1169,35 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn owner_apply_reads_user_password_file() {
+        let (runtime, auth, path) = manifest_test_env();
+        let password_path = path.with_extension("secret");
+        std::fs::write(&password_path, "hunter2\n").expect("write secret");
+        write_manifest(
+            &path,
+            &format!(
+                r#"{{
+                    "users": [
+                        {{
+                            "username": "ops",
+                            "password_file": "{}",
+                            "role": "admin"
+                        }}
+                    ]
+                }}"#,
+                password_path.display()
+            ),
+        );
+
+        apply_manifest_file(&runtime, &auth, &runtime.config_registry(), &path).expect("apply");
+        auth.authenticate("ops", "hunter2")
+            .expect("password must come from mounted file");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&password_path);
     }
 
     #[test]

--- a/crates/reddb-server/src/cli/bootstrap_manifest.rs
+++ b/crates/reddb-server/src/cli/bootstrap_manifest.rs
@@ -115,6 +115,7 @@ fn bootstrap_config_from_manifest_json(raw: &str) -> Result<Option<BootstrapConf
             .as_ref()
             .map(|principal| principal.username.clone()),
         customer_admin_password: customer.map(|principal| principal.password),
+        ..BootstrapConfig::default()
     }))
 }
 

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -376,8 +376,9 @@ fn server_flags() -> Vec<FlagSchema> {
                  vault just serves (idempotent — no re-bootstrap, no new certificate).",
             )
             .with_choices(&["simple", "production", "regulated", "cloud"]),
-        FlagSchema::new("bootstrap-manifest")
-            .with_description("Path to first-boot bootstrap manifest JSON"),
+        FlagSchema::new("bootstrap-manifest").with_description(
+            "Path to first-boot bootstrap manifest JSON (preset/admins; secrets via password_file)",
+        ),
         FlagSchema::new("bootstrap-admin")
             .with_description("First admin username for production/cloud bootstrap"),
         FlagSchema::new("bootstrap-admin-password").with_description(

--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -371,7 +371,7 @@ impl ServerCommandConfig {
         options.storage_profile = self.storage_profile.validate()?;
 
         let no_auth = self.no_auth || env_truthy("REDDB_NO_AUTH") || env_truthy("REDDB_DEV");
-        let preset = self.bootstrap.resolved_preset();
+        let preset = self.bootstrap.resolved_preset_for_options()?;
         let preset_requires_auth = matches!(preset.as_str(), PRESET_PRODUCTION | PRESET_CLOUD);
 
         if self.auth || env_truthy("REDDB_AUTH") || preset_requires_auth {
@@ -529,6 +529,17 @@ impl BootstrapConfig {
             .map(str::to_string)
             .or_else(|| env_nonempty(BOOTSTRAP_PRESET_ENV).or_else(|| env_nonempty(PRESET_ENV)))
             .unwrap_or_else(|| PRESET_SIMPLE.to_string())
+    }
+
+    fn resolved_preset_for_options(&self) -> Result<String, String> {
+        if let Some(path) = self.selected_manifest() {
+            if let Some(manifest_bootstrap) =
+                crate::cli::bootstrap_manifest::bootstrap_config_from_manifest_file(&path)?
+            {
+                return Ok(manifest_bootstrap.resolved_preset());
+            }
+        }
+        Ok(self.resolved_preset())
     }
 
     fn selected_manifest(&self) -> Option<PathBuf> {
@@ -2432,6 +2443,12 @@ fn apply_preset_from_config(
     }
 
     if let Some(path) = bootstrap.selected_manifest() {
+        if let Some(manifest_bootstrap) =
+            crate::cli::bootstrap_manifest::bootstrap_config_from_manifest_file(&path)?
+        {
+            apply_preset_from_config(runtime, auth_store, &manifest_bootstrap)?;
+            return Ok(());
+        }
         let first_admin_id = crate::cli::bootstrap_manifest::apply_manifest_file(
             runtime,
             auth_store,
@@ -4104,6 +4121,91 @@ mod tests {
             "cloud-specific env password must not beat CLI alias"
         );
 
+        clear_preset_env();
+    }
+
+    #[test]
+    fn bootstrap_intent_manifest_matches_cloud_flag_path() {
+        let _g = no_auth_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        clear_preset_env();
+
+        let manifest_dir = std::env::current_dir()
+            .expect("current dir")
+            .join(".red/tmp/bootstrap-manifest-tests");
+        std::fs::create_dir_all(&manifest_dir).expect("create manifest test dir");
+        let unique = format!(
+            "{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis()
+        );
+        let head_password = manifest_dir.join(format!("head-{unique}.secret"));
+        let customer_password = manifest_dir.join(format!("customer-{unique}.secret"));
+        let manifest_path = manifest_dir.join(format!("intent-{unique}.json"));
+        std::fs::write(&head_password, "head-pass\n").expect("write head secret");
+        std::fs::write(&customer_password, "customer-pass\n").expect("write customer secret");
+        std::fs::write(
+            &manifest_path,
+            format!(
+                r#"{{
+                    "bootstrap": {{
+                        "preset": "cloud",
+                        "cloud_head_admin": {{
+                            "username": "head",
+                            "password_file": "{}"
+                        }},
+                        "customer_admin": {{
+                            "username": "customer",
+                            "password_file": "{}"
+                        }}
+                    }}
+                }}"#,
+                head_password.display(),
+                customer_password.display()
+            ),
+        )
+        .expect("write manifest");
+
+        let mut config = no_auth_test_config(false);
+        config.bootstrap.manifest = Some(manifest_path.clone());
+        let options = config.to_db_options().expect("manifest options");
+        assert!(options.auth.enabled);
+        assert!(options.auth.require_auth);
+        assert!(options.auth.vault_enabled);
+
+        let (runtime, auth_store) = fresh_runtime_and_store();
+        apply_preset_from_config(&runtime, &auth_store, &config.bootstrap)
+            .expect("manifest intent applies cleanly");
+
+        auth_store
+            .authenticate("head", "head-pass")
+            .expect("head password comes from file");
+        auth_store
+            .authenticate("customer", "customer-pass")
+            .expect("customer password comes from file");
+        assert!(auth_store.get_user(None, "head").is_some());
+        assert!(auth_store.get_user(None, "customer").is_some());
+        assert!(auth_store
+            .get_policy(CLOUD_PROTECT_MANAGED_POLICY)
+            .is_some());
+        match runtime
+            .db()
+            .store()
+            .get_config(BOOTSTRAP_PRESET_KEY)
+            .expect("preset key persisted")
+        {
+            crate::storage::schema::Value::Text(s) => assert_eq!(s.as_ref(), PRESET_CLOUD),
+            other => panic!("expected Text(cloud), got {other:?}"),
+        }
+
+        apply_preset_from_config(&runtime, &auth_store, &config.bootstrap)
+            .expect("second boot is idempotent");
+
+        let _ = std::fs::remove_file(&manifest_path);
+        let _ = std::fs::remove_file(&head_password);
+        let _ = std::fs::remove_file(&customer_password);
         clear_preset_env();
     }
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -71,7 +71,7 @@ red server [--grpc] [--http] [--grpc-bind 127.0.0.1:55055] [--http-bind 127.0.0.
 | `--vault` | | `false` | Enable encrypted auth/secret vault |
 | `--no-auth` | | `false` | Hard-disable auth and vault for local/dev boots |
 | `--bootstrap-preset` | | `simple` | First-boot preset: `simple`, `production`, `regulated`, `cloud` |
-| `--bootstrap-manifest` | | | First-boot manifest JSON path |
+| `--bootstrap-manifest` | | | First-boot manifest JSON path; can supply preset/admin intent with `password_file` secrets |
 | `--bootstrap-admin` | | | First admin username for production/cloud bootstrap |
 | `--bootstrap-admin-password-file` | | | File containing first admin password |
 | `--cloud-head-admin` | | | Cloud preset head/platform admin username |
@@ -96,6 +96,9 @@ red server --http --bind 0.0.0.0:5000
 
 # Primary mode with vault
 red server --path ./data/primary.rdb --role primary --vault --grpc-bind 0.0.0.0:55055 --http-bind 0.0.0.0:5000
+
+# First boot from mounted files, with no secrets on argv
+red server --path /data/reddb.rdb --bootstrap-manifest /etc/reddb/bootstrap.json
 ```
 
 ## red service

--- a/docs/deployment/first-boot.md
+++ b/docs/deployment/first-boot.md
@@ -50,6 +50,26 @@ Admin credentials are supplied per preset:
   `--customer-admin` / `REDDB_CUSTOMER_ADMIN` (each with matching password and
   `-password-file` flags). The two usernames must differ.
 
+Instead of flags or env, `red server --bootstrap-manifest <path>` can supply
+the complete first-boot intent from mounted JSON. The intent manifest uses the
+same preset path as flags, but reads secrets from files:
+
+```json
+{
+  "bootstrap": {
+    "preset": "cloud",
+    "cloud_head_admin": {
+      "username": "cloud-admin",
+      "password_file": "/run/secrets/reddb-cloud-admin-password"
+    },
+    "customer_admin": {
+      "username": "customer-admin",
+      "password_file": "/run/secrets/reddb-customer-admin-password"
+    }
+  }
+}
+```
+
 The bootstrap-complete marker makes presets idempotent: a preset applies once
 and is skipped on every later boot of the same database.
 
@@ -154,13 +174,23 @@ platform users. Protection is policy-derived:
   - `user:password:change`
   - `user:role:update`
 
-Example manifest shape:
+Policy manifests can also seed explicit users, policies, attachments, managed
+guardrails, and config. Prefer `password_file` for users so mounted manifests do
+not contain plaintext secrets:
 
 ```json
 {
   "users": [
-    { "username": "cloud-admin", "password": "from-secret", "role": "admin" },
-    { "username": "customer-admin", "password": "from-secret", "role": "admin" }
+    {
+      "username": "cloud-admin",
+      "password_file": "/run/secrets/reddb-cloud-admin-password",
+      "role": "admin"
+    },
+    {
+      "username": "customer-admin",
+      "password_file": "/run/secrets/reddb-customer-admin-password",
+      "role": "admin"
+    }
   ],
   "policies": [
     {
@@ -203,9 +233,8 @@ Example manifest shape:
 }
 ```
 
-Render real password values from the Cloud secret manager into the mounted
-manifest at deploy time. Do not commit a manifest containing production
-passwords.
+Render password files from the Cloud secret manager into mounted files at
+deploy time. Do not commit production passwords or password-bearing manifests.
 
 The engine rejects `users[].system_owned` in bootstrap manifests and rejects
 `condition.system_owned` in policies. Cloud ownership must remain explicit in

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -31,7 +31,7 @@ red server [flags]
 | `--vault` / `REDDB_VAULT=true` | | Enable encrypted auth/secret vault | `false` |
 | `--no-auth` / `REDDB_NO_AUTH=true` | | Hard-disable auth and vault for local/dev boots | `false` |
 | `--bootstrap-preset` / `REDDB_BOOTSTRAP_PRESET` | | First-boot preset: `simple`, `production`, `regulated`, `cloud` | `simple` |
-| `--bootstrap-manifest` / `REDDB_BOOTSTRAP_MANIFEST` | | First-boot manifest JSON path | |
+| `--bootstrap-manifest` / `REDDB_BOOTSTRAP_MANIFEST` | | First-boot manifest JSON path. Can supply the preset/admin intent with `password_file` secrets from mounted files. | |
 
 Recommended patterns:
 
@@ -53,6 +53,13 @@ red server \
 red server \
   --path ./data/reddb.rdb \
   --wire-bind 127.0.0.1:5051
+```
+
+```bash
+# First boot from a mounted manifest, with no secrets on argv
+red server \
+  --path /data/reddb.rdb \
+  --bootstrap-manifest /etc/reddb/bootstrap.json
 ```
 
 Rules of thumb:

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -3409,7 +3409,9 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                     )
                     .with_choices(&["simple", "production", "regulated", "cloud"]),
                 cli::types::FlagSchema::new("bootstrap-manifest")
-                    .with_description("Path to first-boot bootstrap manifest JSON"),
+                    .with_description(
+                        "Path to first-boot bootstrap manifest JSON (preset/admins; secrets via password_file)",
+                    ),
                 cli::types::FlagSchema::new("bootstrap-admin")
                     .with_description("First admin username for production/cloud bootstrap"),
                 cli::types::FlagSchema::new("bootstrap-admin-password").with_description(


### PR DESCRIPTION
Automated AFK landing for #1591. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1591

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785438575&installation_id=129708444&pr_number=1597&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1597&signature=ac61e5bd0dbae73b80a7b668041a887dae33ce00eecf90864346ea08d437f9be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->