### PR TITLE
merge: #1599 security: block red.secret.* from $secret.X resolver and SHOW SECRETS

### DIFF
--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -343,15 +343,20 @@ pub(crate) fn current_secret_value(path: &str) -> Option<String> {
                 .map(|store| store.vault_kv_snapshot());
         }
         let values = resolver.values.as_ref()?;
-        values.get(&key).cloned().or_else(|| {
+        secret_value_from_snapshot(values, &key).or_else(|| {
             key.strip_prefix("red.vault/").and_then(|rest| {
-                values
-                    .get(rest)
-                    .cloned()
-                    .or_else(|| values.get(&format!("red.secret.{rest}")).cloned())
+                secret_value_from_snapshot(values, rest)
+                    .or_else(|| secret_value_from_snapshot(values, &format!("red.secret.{rest}")))
             })
         })
     })
+}
+
+fn secret_value_from_snapshot(values: &HashMap<String, String>, key: &str) -> Option<String> {
+    if key.starts_with("red.secret.") {
+        return None;
+    }
+    values.get(key).cloned()
 }
 
 struct SecretResolver {
@@ -436,6 +441,53 @@ pub(crate) fn update_current_secret_value(path: &str, value: Option<String>) {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_secret_values<T>(values: HashMap<String, String>, f: impl FnOnce() -> T) -> T {
+        CURRENT_SECRET_RESOLVER.with(|cell| {
+            cell.replace(Some(SecretResolver {
+                store: None,
+                values: Some(values),
+            }));
+        });
+        let result = f();
+        CURRENT_SECRET_RESOLVER.with(|cell| {
+            cell.replace(None);
+        });
+        result
+    }
+
+    #[test]
+    fn current_secret_value_does_not_fall_back_to_reserved_red_secret_namespace() {
+        let values = HashMap::from([
+            (
+                "red.secret.aes_key".to_string(),
+                "vault-aes-key".to_string(),
+            ),
+            (
+                "red.secret.ai.anthropic.default.api_key".to_string(),
+                "provider-key".to_string(),
+            ),
+            ("acme.key".to_string(), "user-value".to_string()),
+        ]);
+
+        with_secret_values(values, || {
+            assert_eq!(current_secret_value("red.vault/aes_key"), None);
+            assert_eq!(current_secret_value("red.vault/red.secret.aes_key"), None);
+            assert_eq!(
+                current_secret_value("red.vault/ai.anthropic.default.api_key"),
+                None
+            );
+            assert_eq!(
+                current_secret_value("red.vault/acme.key").as_deref(),
+                Some("user-value")
+            );
+        });
+    }
 }
 
 fn latest_config_snapshot(db: &RedDB) -> HashMap<String, Value> {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -54,6 +54,10 @@ struct RankedHeadEntry {
     record: crate::storage::query::unified::UnifiedRecord,
 }
 
+fn show_secrets_allows_key(key: &str) -> bool {
+    !key.starts_with("red.secret.") && !key.starts_with("red.config.")
+}
+
 fn secret_sql_value_to_string(value: &Value) -> RedDBResult<String> {
     match value {
         Value::Text(s) => Ok(s.to_string()),
@@ -73,6 +77,21 @@ fn secret_sql_value_to_string(value: &Value) -> RedDBResult<String> {
             "SET SECRET does not support value type {:?} yet",
             value.data_type()
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn show_secrets_allows_only_user_managed_keys() {
+        assert!(!show_secrets_allows_key("red.secret.aes_key"));
+        assert!(!show_secrets_allows_key(
+            "red.secret.ai.anthropic.default.api_key"
+        ));
+        assert!(!show_secrets_allows_key("red.config.ai.default.provider"));
+        assert!(show_secrets_allows_key("acme.key"));
     }
 }
 
@@ -5564,6 +5583,9 @@ impl RedDBRuntime {
                     "status".into(),
                 ]);
                 for key in keys {
+                    if !show_secrets_allows_key(&key) {
+                        continue;
+                    }
                     if let Some(ref pfx) = prefix {
                         if !key.starts_with(pfx) {
                             continue;

--- a/tests/grouped/config_tier/e2e_secret_sql.rs
+++ b/tests/grouped/config_tier/e2e_secret_sql.rs
@@ -72,9 +72,19 @@ fn set_secret_persists_to_vault_and_show_masks_value() {
         "vault keys after SET SECRET: {:?}",
         auth.vault_kv_keys()
     );
+    auth.vault_kv_try_set(
+        "red.secret.aes_key".to_string(),
+        "vault-aes-key".to_string(),
+    )
+    .expect("seed internal red.secret key");
+    auth.vault_kv_try_set(
+        "red.config.ai.default.provider".to_string(),
+        "anthropic".to_string(),
+    )
+    .expect("seed internal red.config key");
 
     let result = rt
-        .execute_query("SHOW SECRET mycompany.stripe")
+        .execute_query("SHOW SECRETS")
         .expect("SHOW SECRET should succeed");
     assert_eq!(result.result.records.len(), 1);
     let record = &result.result.records[0];
@@ -272,67 +282,58 @@ fn dollar_secret_reference_masks_projection_and_resolves_in_filter() {
 }
 
 #[test]
-fn dollar_red_secret_reference_uses_full_red_secret_path() {
-    let (_path, rt, _auth) = open_runtime_with_vault("secret_sql_dollar_red_ref");
+fn dollar_secret_reference_does_not_resolve_reserved_red_secret_namespace() {
+    let (_path, rt, auth) = open_runtime_with_vault("secret_sql_dollar_reserved_red_ref");
 
     rt.execute_query("CREATE TABLE tokens (id INT, token TEXT)")
         .expect("create table");
-    rt.execute_query("INSERT INTO tokens (id, token) VALUES (1, 'red-match'), (2, 'other')")
+    rt.execute_query("INSERT INTO tokens (id, token) VALUES (1, 'user-match'), (2, 'other')")
         .expect("insert rows");
-    rt.execute_query("SET SECRET red.secret.tokens.active = 'red-match'")
-        .expect("set red secret");
+    rt.execute_query("SET SECRET acme.key = 'user-match'")
+        .expect("set user secret");
+    auth.vault_kv_try_set(
+        "red.secret.aes_key".to_string(),
+        "vault-aes-key".to_string(),
+    )
+    .expect("seed internal AES key");
+    auth.vault_kv_try_set(
+        "red.secret.ai.anthropic.default.api_key".to_string(),
+        "provider-key".to_string(),
+    )
+    .expect("seed internal provider key");
+
+    let aes_alias = rt
+        .execute_query("SELECT $secret.aes_key AS secret_value FROM tokens LIMIT 1")
+        .expect("project AES alias");
+    assert_eq!(
+        aes_alias.result.records[0].get("secret_value"),
+        Some(&Value::Null)
+    );
+    let explicit_reserved = rt
+        .execute_query("SELECT $secret.red.secret.aes_key AS secret_value FROM tokens LIMIT 1")
+        .expect("project explicit reserved secret");
+    assert_eq!(
+        explicit_reserved.result.records[0].get("secret_value"),
+        Some(&Value::Null)
+    );
+    let provider_key = rt
+        .execute_query(
+            "SELECT $secret.ai.anthropic.default.api_key AS secret_value FROM tokens LIMIT 1",
+        )
+        .expect("project provider secret");
+    assert_eq!(
+        provider_key.result.records[0].get("secret_value"),
+        Some(&Value::Null)
+    );
 
     let filtered = rt
-        .execute_query("SELECT id FROM tokens WHERE token = $red.secret.tokens.active")
-        .expect("filter by red secret");
+        .execute_query("SELECT id FROM tokens WHERE token = $secret.acme.key")
+        .expect("filter by user secret");
     assert_eq!(filtered.result.records.len(), 1);
     assert_eq!(
         filtered.result.records[0].get("id"),
         Some(&Value::Integer(1))
     );
-}
-
-#[test]
-fn red_secrets_plural_alias_normalizes_to_red_secret() {
-    let (_path, rt, auth) = open_runtime_with_vault("secret_sql_red_secrets_plural");
-
-    rt.execute_query("CREATE TABLE tokens (id INT, token TEXT)")
-        .expect("create table");
-    rt.execute_query("INSERT INTO tokens (id, token) VALUES (1, 'plural-match'), (2, 'other')")
-        .expect("insert rows");
-    rt.execute_query("SET SECRET red.secrets.tokens.active = 'plural-match'")
-        .expect("set plural red secret");
-
-    assert_eq!(
-        auth.vault_kv_get("red.secret.tokens.active").as_deref(),
-        Some("plural-match")
-    );
-    assert!(
-        auth.vault_kv_get("red.secrets.tokens.active").is_none(),
-        "plural alias should not create a second physical namespace"
-    );
-
-    let shown = rt
-        .execute_query("SHOW SECRETS red.secrets.tokens")
-        .expect("show plural red secrets");
-    assert_eq!(shown.result.records.len(), 1);
-    assert_eq!(
-        shown.result.records[0].get("key"),
-        Some(&Value::Text("red.secret.tokens.active".into()))
-    );
-
-    let filtered = rt
-        .execute_query("SELECT id FROM tokens WHERE token = $red.secrets.tokens.active")
-        .expect("filter by plural red secret");
-    assert_eq!(filtered.result.records.len(), 1);
-    assert_eq!(
-        filtered.result.records[0].get("id"),
-        Some(&Value::Integer(1))
-    );
-
-    rt.execute_query("DELETE SECRET red.secrets.tokens.active")
-        .expect("delete plural red secret");
-    assert!(auth.vault_kv_get("red.secret.tokens.active").is_none());
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1599. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1599

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785443411&installation_id=129708444&pr_number=1603&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1603&signature=5d1ea573d2300245b1baa5314eb4225d9ac2f14dbf2e155660ec357112b2e155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->