### PR TITLE
merge: #1600 docs: surface DataType::Secret and DataType::Password as first-class column types

### DIFF
--- a/docs/query/create-table.md
+++ b/docs/query/create-table.md
@@ -29,7 +29,7 @@ CREATE TABLE hosts (
 
 ## Supported Column Types
 
-All 48 types from the [Type System](/types/overview.md) can be used as column types:
+All 50 types from the [Type System](/types/overview.md) can be used as column types:
 
 ```sql
 CREATE TABLE network_scan (
@@ -42,6 +42,11 @@ CREATE TABLE network_scan (
   metadata Json
 )
 ```
+
+For sensitive per-row data, use the `SECRET` and `PASSWORD` column types. The
+schema reference documents the write constructors, read behavior, and
+`VERIFY_PASSWORD` comparator in
+[Sensitive Column Types](/reference/schema.md#sensitive-column-types).
 
 ## Default TTL
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -38,6 +38,47 @@ Each column has:
 | `NOT NULL` | No | Reject null values |
 | `DEFAULT` | No | Default value for missing fields |
 
+## Sensitive Column Types
+
+Use `SECRET` and `PASSWORD` when the column itself stores sensitive per-row
+application data. They are schema column types, so declare them in a typed
+collection with `CREATE TABLE`.
+
+| Type | Semantics | Write syntax | Read behavior |
+|:-----|:----------|:-------------|:--------------|
+| `SECRET` | Encrypts each row value with AES-256-GCM using the vault AES key. Use it for API tokens, refresh tokens, private webhook secrets, and other values the application may need to decrypt later. | `SECRET('plaintext')` in `INSERT` or `UPDATE` | Returns ciphertext/masked output unless the runtime has the vault key and decrypts it for the read path. |
+| `PASSWORD` | Hashes each row value with Argon2id. Use it for credentials that must only be checked, never recovered. | `PASSWORD('plaintext')` in `INSERT` or `UPDATE` | Never returns the original value. Verify candidates with `VERIFY_PASSWORD(column, 'candidate')`, which returns a boolean. |
+
+Example schema-defined collection with both sensitive column types:
+
+```sql
+CREATE TABLE service_accounts (
+  id UUID NOT NULL,
+  name TEXT NOT NULL,
+  api_token SECRET NOT NULL,
+  login_password PASSWORD NOT NULL
+)
+
+INSERT INTO service_accounts (id, name, api_token, login_password)
+VALUES (
+  '550e8400-e29b-41d4-a716-446655440000',
+  'billing-sync',
+  SECRET('sk_live_service_token'),
+  PASSWORD('candidate-password')
+)
+
+SELECT
+  name,
+  VERIFY_PASSWORD(login_password, 'candidate-password') AS password_ok
+FROM service_accounts
+```
+
+`SECRET` columns and vault secrets solve different problems. Column-level
+`SECRET` values encrypt per-row application data inside user collections. Vault
+secrets, written with `SET SECRET` and referenced as `$secret.X`, store
+operator or application credentials outside row data so configuration and
+runtime integrations can resolve them explicitly.
+
 ## Describe a Collection
 
 ```bash

--- a/docs/types/primitives.md
+++ b/docs/types/primitives.md
@@ -185,6 +185,9 @@ CREATE TABLE integrations (
   name Text NOT NULL,
   api_key Secret NOT NULL
 )
+
+INSERT INTO integrations (name, api_key)
+VALUES ('stripe', SECRET('sk_live_abc'));
 ```
 
 ```rust
@@ -192,5 +195,7 @@ CREATE TABLE integrations (
 Value::Secret(ciphertext_bytes)
 ```
 
-> [!NOTE]
-> The type layer, binary format, and output masking are already in place — sealed secrets always render as `"***"`. Auto-encryption on INSERT via `SECRET('...')` is pending the runtime → vault wiring. Until then, `INSERT ... VALUES (SECRET('...'))` returns an error and pre-encrypted bytes must be inserted directly via the embedded API.
+Notes:
+- `SECRET('...')` marks plaintext for encryption on `INSERT` or `UPDATE`.
+- Encryption requires a bootstrapped vault AES key and is controlled by `red.config.secret.auto_encrypt` (default `true`).
+- Reads stay masked as `"***"` unless the runtime has the vault AES key and `red.config.secret.auto_decrypt` is enabled.

--- a/scripts/schema_secret_password_docs_contract.test.mjs
+++ b/scripts/schema_secret_password_docs_contract.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+test("schema reference documents SECRET and PASSWORD column types", () => {
+  const schema = read("docs/reference/schema.md");
+  const createTable = read("docs/query/create-table.md");
+  const runtimeTests = read("tests/grouped/multimodel_query/integration_entity_query.rs");
+
+  assert.match(schema, /## Sensitive Column Types/);
+  assert.match(schema, /\|\s+`SECRET`\s+\|[^|]*AES-256-GCM[^|]*\|[^|]*`SECRET\('plaintext'\)`/);
+  assert.match(schema, /\|\s+`PASSWORD`\s+\|[^|]*Argon2id[^|]*\|[^|]*`PASSWORD\('plaintext'\)`/);
+  assert.match(schema, /CREATE TABLE service_accounts \(/);
+  assert.match(schema, /api_token SECRET NOT NULL/);
+  assert.match(schema, /login_password PASSWORD NOT NULL/);
+  assert.match(schema, /VERIFY_PASSWORD\(login_password, 'candidate-password'\)/);
+  assert.match(schema, /\$secret\.X/);
+  assert.match(schema, /SET SECRET/);
+  assert.match(schema, /Column-level\s+`SECRET` values encrypt per-row application data/);
+
+  assert.match(createTable, /Sensitive Column Types/);
+  assert.match(createTable, /All 50 types/);
+  assert.match(createTable, /\/reference\/schema\.md#sensitive-column-types/);
+
+  assert.match(runtimeTests, /INSERT INTO creds \(name, token\) VALUES \('stripe', SECRET\('sk_live_abc'\)\)/);
+  assert.match(runtimeTests, /INSERT INTO accounts \(username, pw\) VALUES \('alice', PASSWORD\('MyP@ss123'\)\)/);
+  assert.match(runtimeTests, /SELECT VERIFY_PASSWORD\(pw, 'MyP@ss123'\) AS ok FROM accounts/);
+});


### PR DESCRIPTION
Automated AFK landing for #1600. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1600

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785443947&installation_id=129708444&pr_number=1604&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1604&signature=472540eabb19ea0ee6accef8972cfde3d6bb6d26394df18a0f501a03169e01d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->