### PR TITLE
concurrent claim: planner index-gate for CLAIM ORDER BY

### DIFF
--- a/crates/reddb-rql/src/planner/claim_gate.rs
+++ b/crates/reddb-rql/src/planner/claim_gate.rs
@@ -1,0 +1,186 @@
+//! Concurrent-claim ORDER BY index-gate (ADR 0063, #1607).
+//!
+//! ADR 0063 requires a concurrent `CLAIM` to order its candidates through a
+//! compatible index: "Without an explicit order, or with an order the planner
+//! cannot serve through an index, the statement is rejected rather than relying
+//! on physical layout, incidental scan order, or a broad write-path sort." The
+//! parser already enforces that `CLAIM LIMIT n` / `CLAIM EXACT n` carries an
+//! `ORDER BY`; this module supplies the semantic half — verifying that the
+//! ordering maps to an index on the target collection.
+//!
+//! The check is intentionally storage-agnostic: it consumes the ordered column
+//! list of every index already registered on the claim collection (looked up by
+//! the catalog-bound runtime) and reasons purely over column names. That keeps
+//! the crate graph acyclic — no `reddb-io-rql -> reddb-server` back-edge — while
+//! the runtime owns the index catalog and turns a rejection into its planner
+//! error variant.
+
+use crate::ast::{FieldRef, OrderByClause, UpdateQuery};
+
+/// The single indexable column a claim ORDER BY clause references, if any.
+///
+/// Expression sort keys (`ORDER BY <expr>`) have no single indexable column,
+/// and non-column field references (node/edge properties, node ids) are not
+/// table columns, so neither participates in the prefix check.
+fn claim_order_column(clause: &OrderByClause) -> Option<&str> {
+    if clause.expr.is_some() {
+        return None;
+    }
+    match &clause.field {
+        FieldRef::TableColumn { table, column } if table.is_empty() => Some(column.as_str()),
+        _ => None,
+    }
+}
+
+/// The user-facing ORDER BY columns a claim needs an index to serve.
+///
+/// The implicit `rid` tie-breaker the parser appends is the model's stable
+/// claim identity (ADR 0063) — it is intrinsically ordered and always
+/// available, so it is never index-gated and is filtered out here.
+pub fn claim_order_columns(query: &UpdateQuery) -> Vec<String> {
+    query
+        .order_by
+        .iter()
+        .filter_map(claim_order_column)
+        .filter(|column| !column.eq_ignore_ascii_case("rid"))
+        .map(|column| column.to_string())
+        .collect()
+}
+
+/// Whether some index in `available_indexes` (each an ordered column list)
+/// covers `order_columns` as a leading prefix.
+///
+/// A compatible index covers the ORDER BY when the ordered claim columns are a
+/// prefix of the index's columns — a single-column index on `col` covers
+/// `ORDER BY col`, and a compound `(col_a, col_b)` index covers both
+/// `ORDER BY col_a` and `ORDER BY col_a, col_b`. Column matching is
+/// case-insensitive, matching the rest of the planner.
+pub fn claim_order_is_index_backed(
+    order_columns: &[String],
+    available_indexes: &[Vec<String>],
+) -> bool {
+    if order_columns.is_empty() {
+        return true;
+    }
+    available_indexes.iter().any(|index_columns| {
+        order_columns.len() <= index_columns.len()
+            && order_columns
+                .iter()
+                .zip(index_columns.iter())
+                .all(|(want, have)| have.eq_ignore_ascii_case(want))
+    })
+}
+
+/// Reject a concurrent `CLAIM ... ORDER BY` whose ordering cannot be served by
+/// any compatible index on the target collection (ADR 0063).
+///
+/// `available_indexes` is the ordered column list of every index registered on
+/// the claim collection. Returns `Ok(())` when the statement carries no claim,
+/// orders only by the intrinsic claim identity, or a compatible index exists;
+/// otherwise returns an error message naming the uncovered ORDER BY column(s)
+/// so the operator knows which index to create.
+pub fn check_claim_order_by_index_gate(
+    query: &UpdateQuery,
+    available_indexes: &[Vec<String>],
+) -> Result<(), String> {
+    if query.claim_limit.is_none() {
+        return Ok(());
+    }
+    let order_columns = claim_order_columns(query);
+    if claim_order_is_index_backed(&order_columns, available_indexes) {
+        return Ok(());
+    }
+    Err(format!(
+        "concurrent CLAIM on '{table}' requires an index covering ORDER BY column(s) {columns}; \
+         create a compatible index (e.g. CREATE INDEX ON {table} ({columns}))",
+        table = query.table,
+        columns = order_columns.join(", "),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::QueryExpr;
+    use crate::parser::Parser;
+
+    fn update_query(sql: &str) -> UpdateQuery {
+        let mut parser = Parser::new(sql).expect("lexer");
+        match parser.parse().expect("parse should succeed") {
+            QueryExpr::Update(query) => query,
+            other => panic!("expected UPDATE, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_claim_order_by_without_covering_index() {
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 2 ORDER BY rank ASC",
+        );
+        let err = check_claim_order_by_index_gate(&query, &[])
+            .expect_err("claim without a covering index should be rejected");
+        assert!(err.contains("rank"), "message should name the column: {err}");
+        assert!(err.contains("tasks"), "message should name the collection: {err}");
+    }
+
+    #[test]
+    fn accepts_claim_order_by_with_single_column_index() {
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 2 ORDER BY rank ASC",
+        );
+        let indexes = vec![vec!["rank".to_string()]];
+        assert!(check_claim_order_by_index_gate(&query, &indexes).is_ok());
+    }
+
+    #[test]
+    fn claim_exact_follows_the_same_gate() {
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM EXACT 2 ORDER BY rank ASC",
+        );
+        assert!(check_claim_order_by_index_gate(&query, &[]).is_err());
+        let indexes = vec![vec!["rank".to_string()]];
+        assert!(check_claim_order_by_index_gate(&query, &indexes).is_ok());
+    }
+
+    #[test]
+    fn compound_index_covers_leading_order_column() {
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 1 ORDER BY rank ASC",
+        );
+        // A compound `(rank, created_at)` index still covers `ORDER BY rank`.
+        let indexes = vec![vec!["rank".to_string(), "created_at".to_string()]];
+        assert!(check_claim_order_by_index_gate(&query, &indexes).is_ok());
+    }
+
+    #[test]
+    fn implicit_rid_tiebreaker_is_not_index_gated() {
+        // The parser appends `rid` as the stable claim-identity tie-breaker;
+        // ordering only by `rid` needs no secondary index.
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 1 ORDER BY rid ASC",
+        );
+        assert!(claim_order_columns(&query).is_empty());
+        assert!(check_claim_order_by_index_gate(&query, &[]).is_ok());
+    }
+
+    #[test]
+    fn non_claim_update_is_never_gated() {
+        let query = update_query("UPDATE tasks SET status = 'done' ORDER BY rank ASC LIMIT 5");
+        assert!(check_claim_order_by_index_gate(&query, &[]).is_ok());
+    }
+
+    #[test]
+    fn column_matching_is_case_insensitive() {
+        let query = update_query(
+            "UPDATE tasks SET status = 'claimed' WHERE status = 'ready' \
+             CLAIM LIMIT 1 ORDER BY Rank ASC",
+        );
+        let indexes = vec![vec!["rank".to_string()]];
+        assert!(check_claim_order_by_index_gate(&query, &indexes).is_ok());
+    }
+}

--- a/crates/reddb-rql/src/planner/claim_gate.rs
+++ b/crates/reddb-rql/src/planner/claim_gate.rs
@@ -120,8 +120,14 @@ mod tests {
         );
         let err = check_claim_order_by_index_gate(&query, &[])
             .expect_err("claim without a covering index should be rejected");
-        assert!(err.contains("rank"), "message should name the column: {err}");
-        assert!(err.contains("tasks"), "message should name the collection: {err}");
+        assert!(
+            err.contains("rank"),
+            "message should name the column: {err}"
+        );
+        assert!(
+            err.contains("tasks"),
+            "message should name the collection: {err}"
+        );
     }
 
     #[test]

--- a/crates/reddb-rql/src/planner/mod.rs
+++ b/crates/reddb-rql/src/planner/mod.rs
@@ -17,10 +17,14 @@
 //! ([`reddb_types`], ADR 0052), so the crate graph stays acyclic — no
 //! `reddb-io-rql -> reddb-server` back-edge.
 
+pub mod claim_gate;
 pub mod optimizer;
 pub mod pathkeys;
 pub mod projections;
 pub mod rewriter;
 
+pub use claim_gate::{
+    check_claim_order_by_index_gate, claim_order_columns, claim_order_is_index_backed,
+};
 pub use optimizer::{OptimizationPass, QueryOptimizer};
 pub use rewriter::{QueryRewriter, RewriteContext, RewriteRule};

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1832,11 +1832,36 @@ impl RedDBRuntime {
             .map(|(res, _)| res)
     }
 
+    /// Enforce the concurrent-claim ORDER BY index-gate (ADR 0063, #1607).
+    ///
+    /// A `CLAIM LIMIT n` / `CLAIM EXACT n` on a logical-identity model (tables
+    /// and documents) must order its candidates through a compatible index; the
+    /// planner rejects an ordering no index on the collection can serve rather
+    /// than falling back to a broad write-path sort. KV (key identity) and graph
+    /// nodes/edges are exempt — their claim identity is intrinsic, not a user
+    /// ORDER BY column that needs a secondary index.
+    fn enforce_claim_order_by_index_gate(&self, query: &UpdateQuery) -> RedDBResult<()> {
+        if query.claim_limit.is_none()
+            || !matches!(query.target, UpdateTarget::Rows | UpdateTarget::Documents)
+        {
+            return Ok(());
+        }
+        let available_indexes: Vec<Vec<String>> = self
+            .index_store_ref()
+            .list_indices(&query.table)
+            .into_iter()
+            .map(|index| index.columns)
+            .collect();
+        reddb_rql::planner::check_claim_order_by_index_gate(query, &available_indexes)
+            .map_err(RedDBError::InvalidOperation)
+    }
+
     fn execute_update_inner_tracked(
         &self,
         raw_query: &str,
         query: &UpdateQuery,
     ) -> RedDBResult<(RuntimeQueryResult, Vec<EntityId>)> {
+        self.enforce_claim_order_by_index_gate(query)?;
         let store = self.inner.db.store();
         let effective_filter = effective_update_filter(query);
         let compiled_plan = self.compile_update_plan(query)?;
@@ -5004,6 +5029,9 @@ mod tests {
         let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
         rt.execute_query("CREATE TABLE claim_metric_locked (id INT, rank INT, status TEXT)")
             .expect("create table");
+        // ADR 0063: index-backed claim ordering on `rank`.
+        rt.execute_query("CREATE INDEX idx_claim_metric_locked_rank ON claim_metric_locked (rank)")
+            .expect("create index");
         rt.execute_query(
             "INSERT INTO claim_metric_locked (id, rank, status) VALUES \
              (1, 10, 'ready'), (2, 20, 'ready')",

--- a/docs/query/transactions.md
+++ b/docs/query/transactions.md
@@ -70,6 +70,10 @@ CREATE TABLE inventory_units (
   reservation_key TEXT
 );
 
+-- A concurrent CLAIM must order candidates through a compatible index
+-- (ADR 0063). The reservation below claims `ORDER BY unit_id`, so index it.
+CREATE INDEX idx_inventory_units_unit_id ON inventory_units (unit_id);
+
 CREATE TABLE reservation_idempotency (
   idempotency_key TEXT PRIMARY KEY,
   reservation_id TEXT,

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -276,7 +276,10 @@ fn claim_candidate_selection_requires_read_visibility() {
     );
     // ADR 0063: a concurrent CLAIM must order candidates through a compatible
     // index; `ORDER BY rank` requires an index on `rank`.
-    exec(&rt, "CREATE INDEX idx_claim_read_rank ON claim_read_tasks (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_claim_read_rank ON claim_read_tasks (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO claim_read_tasks (id, tenant_id, rank, status) VALUES \

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -274,6 +274,9 @@ fn claim_candidate_selection_requires_read_visibility() {
         &rt,
         "CREATE TABLE claim_read_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
     );
+    // ADR 0063: a concurrent CLAIM must order candidates through a compatible
+    // index; `ORDER BY rank` requires an index on `rank`.
+    exec(&rt, "CREATE INDEX idx_claim_read_rank ON claim_read_tasks (rank)");
     exec(
         &rt,
         "INSERT INTO claim_read_tasks (id, tenant_id, rank, status) VALUES \
@@ -320,6 +323,11 @@ fn claim_exact_miss_counts_only_read_visible_candidates() {
     exec(
         &rt,
         "CREATE TABLE claim_exact_read_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
+    );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(
+        &rt,
+        "CREATE INDEX idx_claim_exact_read_rank ON claim_exact_read_tasks (rank)",
     );
     exec(
         &rt,
@@ -375,6 +383,11 @@ fn claim_state_transition_requires_update_policy() {
     exec(
         &rt,
         "CREATE TABLE claim_update_tasks (id INT, tenant_id TEXT, rank INT, status TEXT)",
+    );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(
+        &rt,
+        "CREATE INDEX idx_claim_update_rank ON claim_update_tasks (rank)",
     );
     exec(
         &rt,

--- a/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
+++ b/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
@@ -79,7 +79,10 @@ fn claim_exact_updates_requested_cardinality_when_available() {
         "CREATE TABLE exact_claim_success (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_exact_claim_success_rank ON exact_claim_success (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_exact_claim_success_rank ON exact_claim_success (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO exact_claim_success (id, rank, status) VALUES \
@@ -108,7 +111,10 @@ fn claim_exact_miss_reports_zero_and_applies_no_partial_write() {
         "CREATE TABLE exact_claim_miss (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_exact_claim_miss_rank ON exact_claim_miss (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_exact_claim_miss_rank ON exact_claim_miss (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO exact_claim_miss (id, rank, status) VALUES \
@@ -135,7 +141,10 @@ fn claim_inside_transaction_publishes_on_commit() {
         "CREATE TABLE tx_claim_commit (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_tx_claim_commit_rank ON tx_claim_commit (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_tx_claim_commit_rank ON tx_claim_commit (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO tx_claim_commit (id, rank, status) VALUES \
@@ -171,7 +180,10 @@ fn claim_inside_transaction_releases_on_rollback() {
         "CREATE TABLE tx_claim_rollback (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_tx_claim_rollback_rank ON tx_claim_rollback (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_tx_claim_rollback_rank ON tx_claim_rollback (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO tx_claim_rollback (id, rank, status) VALUES \
@@ -209,7 +221,10 @@ fn competing_claim_skips_uncommitted_claim_lock() {
         "CREATE TABLE tx_claim_skip (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_tx_claim_skip_rank ON tx_claim_skip (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_tx_claim_skip_rank ON tx_claim_skip (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO tx_claim_skip (id, rank, status) VALUES \
@@ -250,7 +265,10 @@ fn ordinary_dml_against_claimed_row_keeps_mvcc_conflict_behavior() {
         "CREATE TABLE tx_claim_dml (id INT, rank INT, status TEXT, note TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_tx_claim_dml_rank ON tx_claim_dml (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_tx_claim_dml_rank ON tx_claim_dml (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO tx_claim_dml (id, rank, status, note) VALUES \
@@ -291,7 +309,10 @@ fn claim_metrics_increment_for_success_and_miss_with_bounded_labels() {
         "CREATE TABLE claim_metric_jobs (id INT, rank INT, status TEXT)",
     );
     // ADR 0063: index-backed claim ordering on `rank`.
-    exec(&rt, "CREATE INDEX idx_claim_metric_jobs_rank ON claim_metric_jobs (rank)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_claim_metric_jobs_rank ON claim_metric_jobs (rank)",
+    );
     exec(
         &rt,
         "INSERT INTO claim_metric_jobs (id, rank, status) VALUES \

--- a/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
+++ b/tests/grouped/dml_updates/e2e_ordered_row_update_batches.rs
@@ -78,6 +78,8 @@ fn claim_exact_updates_requested_cardinality_when_available() {
         &rt,
         "CREATE TABLE exact_claim_success (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_exact_claim_success_rank ON exact_claim_success (rank)");
     exec(
         &rt,
         "INSERT INTO exact_claim_success (id, rank, status) VALUES \
@@ -105,6 +107,8 @@ fn claim_exact_miss_reports_zero_and_applies_no_partial_write() {
         &rt,
         "CREATE TABLE exact_claim_miss (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_exact_claim_miss_rank ON exact_claim_miss (rank)");
     exec(
         &rt,
         "INSERT INTO exact_claim_miss (id, rank, status) VALUES \
@@ -130,6 +134,8 @@ fn claim_inside_transaction_publishes_on_commit() {
         &rt,
         "CREATE TABLE tx_claim_commit (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_tx_claim_commit_rank ON tx_claim_commit (rank)");
     exec(
         &rt,
         "INSERT INTO tx_claim_commit (id, rank, status) VALUES \
@@ -164,6 +170,8 @@ fn claim_inside_transaction_releases_on_rollback() {
         &rt,
         "CREATE TABLE tx_claim_rollback (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_tx_claim_rollback_rank ON tx_claim_rollback (rank)");
     exec(
         &rt,
         "INSERT INTO tx_claim_rollback (id, rank, status) VALUES \
@@ -200,6 +208,8 @@ fn competing_claim_skips_uncommitted_claim_lock() {
         &rt,
         "CREATE TABLE tx_claim_skip (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_tx_claim_skip_rank ON tx_claim_skip (rank)");
     exec(
         &rt,
         "INSERT INTO tx_claim_skip (id, rank, status) VALUES \
@@ -239,6 +249,8 @@ fn ordinary_dml_against_claimed_row_keeps_mvcc_conflict_behavior() {
         &rt,
         "CREATE TABLE tx_claim_dml (id INT, rank INT, status TEXT, note TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_tx_claim_dml_rank ON tx_claim_dml (rank)");
     exec(
         &rt,
         "INSERT INTO tx_claim_dml (id, rank, status, note) VALUES \
@@ -278,6 +290,8 @@ fn claim_metrics_increment_for_success_and_miss_with_bounded_labels() {
         &rt,
         "CREATE TABLE claim_metric_jobs (id INT, rank INT, status TEXT)",
     );
+    // ADR 0063: index-backed claim ordering on `rank`.
+    exec(&rt, "CREATE INDEX idx_claim_metric_jobs_rank ON claim_metric_jobs (rank)");
     exec(
         &rt,
         "INSERT INTO claim_metric_jobs (id, rank, status) VALUES \

--- a/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
@@ -56,6 +56,8 @@ fn err_string(rt: &RedDBRuntime, sql: &str) -> String {
 fn document_claim_updates_ordered_subset_with_returning() {
     let rt = runtime();
     exec(&rt, "CREATE DOCUMENT doc_claim_tasks");
+    // ADR 0063: a concurrent CLAIM orders candidates through a compatible index.
+    exec(&rt, "CREATE INDEX idx_doc_claim_tasks_priority ON doc_claim_tasks (priority)");
     exec(
         &rt,
         r#"INSERT INTO doc_claim_tasks DOCUMENT (body) VALUES ('{"name":"slow","priority":30,"status":"ready"}')"#,
@@ -143,6 +145,11 @@ fn document_claim_locks_skip_and_release_on_rollback() {
     let rt = runtime();
     set_current_connection_id(145401);
     exec(&rt, "CREATE DOCUMENT doc_claim_lock_tasks");
+    // ADR 0063: a concurrent CLAIM orders candidates through a compatible index.
+    exec(
+        &rt,
+        "CREATE INDEX idx_doc_claim_lock_priority ON doc_claim_lock_tasks (priority)",
+    );
     exec(
         &rt,
         r#"INSERT INTO doc_claim_lock_tasks DOCUMENT (body) VALUES ('{"name":"a","priority":10,"status":"ready"}')"#,

--- a/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
@@ -57,7 +57,10 @@ fn document_claim_updates_ordered_subset_with_returning() {
     let rt = runtime();
     exec(&rt, "CREATE DOCUMENT doc_claim_tasks");
     // ADR 0063: a concurrent CLAIM orders candidates through a compatible index.
-    exec(&rt, "CREATE INDEX idx_doc_claim_tasks_priority ON doc_claim_tasks (priority)");
+    exec(
+        &rt,
+        "CREATE INDEX idx_doc_claim_tasks_priority ON doc_claim_tasks (priority)",
+    );
     exec(
         &rt,
         r#"INSERT INTO doc_claim_tasks DOCUMENT (body) VALUES ('{"name":"slow","priority":30,"status":"ready"}')"#,

--- a/tests/grouped/mvcc_transactions/e2e_transactional_reservation_recipe.rs
+++ b/tests/grouped/mvcc_transactions/e2e_transactional_reservation_recipe.rs
@@ -54,6 +54,12 @@ fn setup_reservation_schema(rt: &RedDBRuntime) {
         "CREATE TABLE inventory_units \
          (sku TEXT, unit_id INT PRIMARY KEY, status TEXT, reservation_key TEXT)",
     );
+    // ADR 0063: the reservation claim orders by `unit_id`, which must be
+    // served through a compatible index.
+    exec(
+        rt,
+        "CREATE INDEX idx_inventory_units_unit_id ON inventory_units (unit_id)",
+    );
     exec(
         rt,
         "CREATE TABLE reservation_idempotency \

--- a/tests/grouped/replication/e2e_issue_813_replica_repull_idempotent.rs
+++ b/tests/grouped/replication/e2e_issue_813_replica_repull_idempotent.rs
@@ -286,6 +286,8 @@ fn claim_update_replay_applies_primary_winner_not_replica_candidate() {
         "claim_jobs",
         &[
             "CREATE TABLE claim_jobs (id INTEGER, rank INTEGER, status TEXT)",
+            // ADR 0063: index-backed claim ordering on `rank`.
+            "CREATE INDEX idx_claim_jobs_rank ON claim_jobs (rank)",
             "INSERT INTO claim_jobs (id, rank, status) VALUES (1, 10, 'ready')",
             "INSERT INTO claim_jobs (id, rank, status) VALUES (2, 20, 'ready')",
             "UPDATE claim_jobs SET status = 'claimed' WHERE status = 'ready' \


### PR DESCRIPTION
Closes #1607

## Summary
- Adds planner index-gate for `CLAIM ORDER BY` (ADR 0063)
- Validates `ORDER BY` columns have backing indexes before executing `CLAIM LIMIT n` / `CLAIM EXACT n`

## Changes
AFK worker `wO5DK` implementation. Fixed `cargo fmt` formatting in a follow-up commit.

https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785458772&installation_id=129708444&pr_number=1611&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1611&signature=64b2b755d6d48751f9a7724e365a0fb83062b6675a0030ccac7168f8f6ef31c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->