### PR TITLE
concurrent claim: queue-shaped claim via QueueLifecycle

### DIFF
--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1709,6 +1709,15 @@ impl RedDBRuntime {
                 query.table
             )));
         }
+        // Queue-shaped CLAIM (ADR 0020, #1609): a CLAIM on a queue collection
+        // is a QueueLifecycle delivery acquisition, not a raw row UPDATE.
+        // Route it through the lifecycle seam before the table-shaped
+        // contract / RLS gates below (which would reject an UPDATE against a
+        // queue's declared model) so QueueLifecycle stays the sole authority
+        // for delivery state.
+        if query.claim_limit.is_some() && self.is_queue_collection(&query.table) {
+            return self.execute_queue_shaped_claim(raw_query, query);
+        }
         // CollectionContract gate (#50): runs the APPEND ONLY guard
         // (and any future contract bits) before RLS / RETURNING work
         // so the operator's immutability declaration is honoured

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -1772,9 +1772,7 @@ impl RedDBRuntime {
     pub(super) fn is_queue_collection(&self, collection: &str) -> bool {
         self.db()
             .collection_contract_arc(collection)
-            .map(|contract| {
-                contract.declared_model == crate::catalog::CollectionModel::Queue
-            })
+            .map(|contract| contract.declared_model == crate::catalog::CollectionModel::Queue)
             .unwrap_or(false)
     }
 
@@ -1824,8 +1822,7 @@ impl RedDBRuntime {
             .deliver(&txn, queue, &group, count)
             .map_err(map_qse)?;
 
-        let mut result =
-            UnifiedResult::with_columns(vec!["delivery_id".into(), "payload".into()]);
+        let mut result = UnifiedResult::with_columns(vec!["delivery_id".into(), "payload".into()]);
         for message in &delivered {
             let mut record = UnifiedRecord::new();
             record.set("delivery_id", Value::text(message.delivery_id.clone()));

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -1765,6 +1765,117 @@ impl RedDBRuntime {
                 .build(),
         );
     }
+
+    /// Whether `collection` is declared as a queue model. Used to route a
+    /// `CLAIM` through the [`QueueLifecycle`] seam instead of the raw
+    /// row-update path (#1609).
+    pub(super) fn is_queue_collection(&self, collection: &str) -> bool {
+        self.db()
+            .collection_contract_arc(collection)
+            .map(|contract| {
+                contract.declared_model == crate::catalog::CollectionModel::Queue
+            })
+            .unwrap_or(false)
+    }
+
+    /// Route a queue-collection `CLAIM` through the [`QueueLifecycle`]
+    /// delivery seam (ADR 0020, #1609).
+    ///
+    /// A `CLAIM` on a queue collection is a delivery *acquisition* — select
+    /// and lock pending messages — not a raw UPDATE of the underlying queue
+    /// rows. Dispatching here keeps the `QueueLifecycle` state machine
+    /// (ACK/NACK, retry, DLQ, pending delivery, replica replay) the sole
+    /// authority for delivery state, instead of `execute_update_inner_tracked`
+    /// mutating queue storage directly.
+    ///
+    /// Shapes the delivery seam cannot express are rejected up front with a
+    /// clear [`RedDBError::InvalidOperation`] rather than silently falling
+    /// back to raw storage mutation (see [`validate_queue_claim_shape`]).
+    pub(super) fn execute_queue_shaped_claim(
+        &self,
+        raw_query: &str,
+        query: &UpdateQuery,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        validate_queue_claim_shape(query)?;
+
+        let queue = query.table.as_str();
+        let store = self.inner.db.store();
+        ensure_queue_exists(store.as_ref(), queue)?;
+
+        // A queue-shaped CLAIM maps onto WORK-mode delivery: each message is
+        // reserved for exactly one consumer. FANOUT queues fan every message
+        // to every group, which a single-target CLAIM cannot express — those
+        // must be consumed through GROUP READ.
+        let config = load_queue_config(store.as_ref(), queue);
+        if config.mode != QueueMode::Work {
+            return Err(RedDBError::InvalidOperation(format!(
+                "CLAIM on queue '{queue}' cannot be expressed: FANOUT delivery \
+                 must be consumed through GROUP READ, not a queue-shaped CLAIM"
+            )));
+        }
+
+        // Attribute the delivery to the WORK default consumer group (the same
+        // group an unqualified `QUEUE READ` uses), so the pending locks the
+        // lifecycle records resolve for a later ACK/NACK by delivery id.
+        let group = resolve_read_group(store.as_ref(), queue, None, "", &config)?;
+        let count = query.claim_limit.unwrap_or(0) as usize;
+        let (lifecycle, _ps, txn) = runtime_lifecycle(self, queue);
+        let delivered = lifecycle
+            .deliver(&txn, queue, &group, count)
+            .map_err(map_qse)?;
+
+        let mut result =
+            UnifiedResult::with_columns(vec!["delivery_id".into(), "payload".into()]);
+        for message in &delivered {
+            let mut record = UnifiedRecord::new();
+            record.set("delivery_id", Value::text(message.delivery_id.clone()));
+            record.set("payload", message.payload.clone());
+            result.push(record);
+        }
+        let affected_rows = delivered.len() as u64;
+        if affected_rows > 0 {
+            self.invalidate_result_cache();
+        }
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "queue_claim",
+            engine: "runtime-queue",
+            result,
+            affected_rows,
+            statement_type: "update",
+            bookmark: None,
+        })
+    }
+}
+
+/// Reject `CLAIM` shapes that [`QueueLifecycle`] delivery cannot express
+/// (#1609). Queue delivery is strictly FIFO (oldest-available first) and
+/// acquires *up to* N available messages:
+///
+/// - a descending `ORDER BY` contradicts FIFO delivery order, and
+/// - `CLAIM EXACT` demands an all-or-nothing batch the delivery seam does
+///   not offer.
+///
+/// Both surface a clear [`RedDBError::InvalidOperation`] instead of a
+/// silent raw storage mutation.
+fn validate_queue_claim_shape(query: &UpdateQuery) -> RedDBResult<()> {
+    if query.order_by.iter().any(|clause| !clause.ascending) {
+        return Err(RedDBError::InvalidOperation(format!(
+            "CLAIM on queue '{}' cannot be expressed: a descending ORDER BY \
+             conflicts with FIFO queue delivery order",
+            query.table
+        )));
+    }
+    if query.claim_exact {
+        return Err(RedDBError::InvalidOperation(format!(
+            "CLAIM EXACT on queue '{}' cannot be expressed: queue delivery \
+             acquires up to N available messages, not an exact-or-nothing batch",
+            query.table
+        )));
+    }
+    Ok(())
 }
 
 fn ensure_queue_exists(store: &UnifiedStore, queue: &str) -> RedDBResult<()> {

--- a/crates/reddb-server/tests/queue_shaped_claim_lifecycle.rs
+++ b/crates/reddb-server/tests/queue_shaped_claim_lifecycle.rs
@@ -56,13 +56,19 @@ fn queue_claim_acquires_deliveries_and_locks_them() {
         .expect("queue claim succeeds");
     assert_eq!(first.affected_rows, 2, "claims up to the requested limit");
     let first_ids = delivery_ids(&first);
-    assert_eq!(first_ids.len(), 2, "each claimed message carries a delivery_id");
+    assert_eq!(
+        first_ids.len(),
+        2,
+        "each claimed message carries a delivery_id"
+    );
 
     // The first two deliveries are locked under the lifecycle, so a second
     // claim skips them and only acquires the one remaining message. A raw
     // storage mutation would not hold delivery locks this way.
     let second = rt
-        .execute_query("UPDATE qclaim SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC")
+        .execute_query(
+            "UPDATE qclaim SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC",
+        )
         .expect("second queue claim succeeds");
     assert_eq!(
         second.affected_rows, 1,
@@ -77,7 +83,9 @@ fn queue_claim_delivery_id_is_a_real_lifecycle_handle() {
     exec(&rt, "QUEUE PUSH qack 'payload-1'");
 
     let claimed = rt
-        .execute_query("UPDATE qack SET status = 'processing' CLAIM LIMIT 1 ORDER BY enqueued_at ASC")
+        .execute_query(
+            "UPDATE qack SET status = 'processing' CLAIM LIMIT 1 ORDER BY enqueued_at ASC",
+        )
         .expect("queue claim succeeds");
     assert_eq!(claimed.affected_rows, 1);
     let delivery_id = delivery_ids(&claimed)
@@ -95,7 +103,9 @@ fn queue_claim_delivery_id_is_a_real_lifecycle_handle() {
 
     // The queue is now drained: no message remains to claim.
     let empty = rt
-        .execute_query("UPDATE qack SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC")
+        .execute_query(
+            "UPDATE qack SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC",
+        )
         .expect("claim on drained queue succeeds");
     assert_eq!(empty.affected_rows, 0, "acked delivery is not re-claimable");
 }
@@ -126,7 +136,9 @@ fn queue_claim_exact_is_rejected() {
     exec(&rt, "QUEUE PUSH qexact 'job-1'");
 
     let err = rt
-        .execute_query("UPDATE qexact SET status = 'processing' CLAIM EXACT 3 ORDER BY enqueued_at ASC")
+        .execute_query(
+            "UPDATE qexact SET status = 'processing' CLAIM EXACT 3 ORDER BY enqueued_at ASC",
+        )
         .expect_err("CLAIM EXACT cannot be expressed through queue delivery");
     let msg = format!("{err:?}");
     assert!(

--- a/crates/reddb-server/tests/queue_shaped_claim_lifecycle.rs
+++ b/crates/reddb-server/tests/queue_shaped_claim_lifecycle.rs
@@ -1,0 +1,136 @@
+//! Issue #1609 — queue-shaped `CLAIM` routes through `QueueLifecycle`.
+//!
+//! A `UPDATE q CLAIM LIMIT n ...` against a *queue* collection is a
+//! delivery acquisition under the `QueueLifecycle` state machine (ADR
+//! 0020), not a raw UPDATE of the underlying queue rows. These tests
+//! exercise the runtime seam so every transport inherits the behaviour:
+//!
+//! - a queue `CLAIM` acquires up to N pending deliveries (returning the
+//!   opaque `delivery_id`) and locks them so a concurrent claim skips
+//!   them — proving the lifecycle owns delivery state, not a raw mutation;
+//! - the acquired `delivery_id` is a real lifecycle handle: `QUEUE ACK`
+//!   retires it, preserving ACK/NACK/retry/DLQ semantics;
+//! - a `CLAIM` shape the delivery seam cannot express (descending
+//!   `ORDER BY`, or `CLAIM EXACT`) returns a clear `InvalidOperation`
+//!   rather than silently mutating queue storage.
+
+use reddb_server::storage::schema::Value;
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn delivery_ids(result: &reddb_server::RuntimeQueryResult) -> Vec<String> {
+    result
+        .result
+        .records
+        .iter()
+        .map(|rec| match rec.get("delivery_id") {
+            Some(Value::Text(s)) => s.to_string(),
+            other => panic!("expected text delivery_id, got {other:?}"),
+        })
+        .collect()
+}
+
+#[test]
+fn queue_claim_acquires_deliveries_and_locks_them() {
+    let rt = runtime();
+    exec(&rt, "CREATE QUEUE qclaim");
+    exec(&rt, "QUEUE PUSH qclaim 'job-1'");
+    exec(&rt, "QUEUE PUSH qclaim 'job-2'");
+    exec(&rt, "QUEUE PUSH qclaim 'job-3'");
+
+    // Queue-shaped CLAIM: the SET / WHERE are subsumed by delivery
+    // acquisition — the lifecycle transitions the messages to pending.
+    let first = rt
+        .execute_query(
+            "UPDATE qclaim SET status = 'processing' WHERE status = 'pending' \
+             CLAIM LIMIT 2 ORDER BY enqueued_at ASC",
+        )
+        .expect("queue claim succeeds");
+    assert_eq!(first.affected_rows, 2, "claims up to the requested limit");
+    let first_ids = delivery_ids(&first);
+    assert_eq!(first_ids.len(), 2, "each claimed message carries a delivery_id");
+
+    // The first two deliveries are locked under the lifecycle, so a second
+    // claim skips them and only acquires the one remaining message. A raw
+    // storage mutation would not hold delivery locks this way.
+    let second = rt
+        .execute_query("UPDATE qclaim SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC")
+        .expect("second queue claim succeeds");
+    assert_eq!(
+        second.affected_rows, 1,
+        "the two pending deliveries stay locked; only one message is left"
+    );
+}
+
+#[test]
+fn queue_claim_delivery_id_is_a_real_lifecycle_handle() {
+    let rt = runtime();
+    exec(&rt, "CREATE QUEUE qack");
+    exec(&rt, "QUEUE PUSH qack 'payload-1'");
+
+    let claimed = rt
+        .execute_query("UPDATE qack SET status = 'processing' CLAIM LIMIT 1 ORDER BY enqueued_at ASC")
+        .expect("queue claim succeeds");
+    assert_eq!(claimed.affected_rows, 1);
+    let delivery_id = delivery_ids(&claimed)
+        .into_iter()
+        .next()
+        .expect("a delivery was acquired");
+
+    // ACK against the acquired delivery_id retires the message through the
+    // QueueLifecycle — proving the CLAIM produced a genuine delivery, and
+    // that ACK/NACK/retry/DLQ semantics stay under lifecycle authority.
+    exec(
+        &rt,
+        &format!("QUEUE ACK qack WITH delivery_id = '{delivery_id}'"),
+    );
+
+    // The queue is now drained: no message remains to claim.
+    let empty = rt
+        .execute_query("UPDATE qack SET status = 'processing' CLAIM LIMIT 5 ORDER BY enqueued_at ASC")
+        .expect("claim on drained queue succeeds");
+    assert_eq!(empty.affected_rows, 0, "acked delivery is not re-claimable");
+}
+
+#[test]
+fn queue_claim_descending_order_is_rejected() {
+    let rt = runtime();
+    exec(&rt, "CREATE QUEUE qdesc");
+    exec(&rt, "QUEUE PUSH qdesc 'job-1'");
+
+    let err = rt
+        .execute_query(
+            "UPDATE qdesc SET status = 'processing' \
+             CLAIM LIMIT 1 ORDER BY enqueued_at DESC",
+        )
+        .expect_err("descending ORDER BY conflicts with FIFO delivery");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("cannot be expressed") && msg.contains("FIFO"),
+        "expected a clear InvalidOperation about FIFO delivery order, got: {msg}"
+    );
+}
+
+#[test]
+fn queue_claim_exact_is_rejected() {
+    let rt = runtime();
+    exec(&rt, "CREATE QUEUE qexact");
+    exec(&rt, "QUEUE PUSH qexact 'job-1'");
+
+    let err = rt
+        .execute_query("UPDATE qexact SET status = 'processing' CLAIM EXACT 3 ORDER BY enqueued_at ASC")
+        .expect_err("CLAIM EXACT cannot be expressed through queue delivery");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("CLAIM EXACT") && msg.contains("cannot be expressed"),
+        "expected a clear InvalidOperation about CLAIM EXACT, got: {msg}"
+    );
+}


### PR DESCRIPTION
Queue-shaped CLAIM routes through QueueLifecycle delivery seam instead of raw storage mutation.

- Dispatch in execute_update detects queue collection and routes to execute_queue_shaped_claim
- Inexpressible shapes (DESC ORDER BY, CLAIM EXACT, FANOUT queue) return InvalidOperation
- 4 QueueLifecycle seam tests added

Closes #1609

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785465996&installation_id=129708444&pr_number=1613&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1613&signature=bf01b2bb18378d76be48f1752b7808de7c66b639975d315ea4d0d5f37e721a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->