### PR TITLE
merge: #1617 docs: surface DataType::Secret and DataType::Password as first-class column types

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -79,6 +79,7 @@
   - [Geo Types](/types/geo.md)
   - [Locale Types](/types/locale.md)
   - [Reference Types](/types/references.md)
+  - [Secret & Password Types](/types/secrets.md)
   - [Validation & Coercion](/types/validation.md)
 
 - **Storage Engine**

--- a/docs/types/overview.md
+++ b/docs/types/overview.md
@@ -127,4 +127,5 @@ See:
 - [Geo Types](/types/geo.md)
 - [Locale Types](/types/locale.md)
 - [Reference Types](/types/references.md)
+- [Secret & Password Types](/types/secrets.md)
 - [Validation & Coercion](/types/validation.md)

--- a/docs/types/secrets.md
+++ b/docs/types/secrets.md
@@ -1,0 +1,117 @@
+# Secret & Password Types
+
+RedDB has two security-native column types for storing sensitive values so
+they never sit in plaintext at rest. Both are typed literal constructors on
+`INSERT`: the parser recognises `SECRET('…')` and `PASSWORD('…')` and hands
+the plaintext to the executor, which applies the crypto transform before the
+value is written.
+
+| Type       | At rest                                   | Insert with        | Read back                          |
+| ---------- | ----------------------------------------- | ------------------ | ---------------------------------- |
+| `Secret`   | AES-256-GCM ciphertext                    | `SECRET('value')`  | decrypt/secret policy (admin) |
+| `Password` | argon2id hash                             | `PASSWORD('plain')`| never — verify instead             |
+
+## Secret
+
+`Secret` stores an AES-256-GCM ciphertext keyed by the vault's master AES key.
+Use it for API keys, tokens, and other credentials your service must be able
+to read back in full.
+
+```sql
+CREATE TABLE integrations (
+  id      Uuid NOT NULL,
+  name    Text NOT NULL,
+  api_key Secret
+)
+```
+
+Insert plaintext with the `SECRET(...)` constructor. The value is encrypted at
+write time; the plaintext never touches storage.
+
+```sql
+INSERT INTO integrations VALUES ('...', 'stripe', SECRET('sk_live_...'))
+```
+
+Reads require a decrypt/secret policy — for now, admin. When the vault is
+sealed, reads return `***` instead of the ciphertext or plaintext; the
+plaintext is only returned to an authorised reader while the vault is
+unsealed.
+
+```rust
+Value::Secret(vec![/* AES-256-GCM ciphertext bytes */])
+```
+
+## Password
+
+`Password` stores an argon2id hash. It is a write-and-verify type: the
+plaintext is hashed on insert and is **never** round-tripped back to a client.
+Use it for user login credentials.
+
+```sql
+CREATE TABLE users (
+  id       Uuid PRIMARY KEY,
+  email    Text,
+  password Password
+)
+```
+
+Insert with the `PASSWORD(...)` constructor, which hashes the plaintext with
+argon2id before storage.
+
+```sql
+INSERT INTO users VALUES ('...', 'alice@example.com', PASSWORD('hunter2'))
+```
+
+```rust
+Value::Password("$argon2id$v=19$...".to_string())
+```
+
+### VERIFY_PASSWORD
+
+Because the hash cannot be reversed, you compare a candidate against a stored
+`Password` column with the `VERIFY_PASSWORD` function rather than an equality
+check. It takes the `Password` column and a candidate `Text` value and returns
+a boolean.
+
+```
+VERIFY_PASSWORD(password_column, 'candidate')
+```
+
+Authenticate a user by filtering on the verification result:
+
+```sql
+SELECT id, email FROM users WHERE VERIFY_PASSWORD(password, 'hunter2')
+```
+
+Selecting the `password` column directly does not expose the hash as plaintext
+— it is redacted to `***`.
+
+## Worked Example
+
+A `users` table combining both types — an argon2id-hashed login password and
+an encrypted API key:
+
+```sql
+CREATE COLLECTION users (
+  id       Uuid PRIMARY KEY,
+  email    Text,
+  password Password,
+  api_key  Secret
+)
+```
+
+```sql
+INSERT INTO users VALUES ('...', 'alice@example.com', PASSWORD('hunter2'), SECRET('sk_live_...'))
+```
+
+```sql
+SELECT id, email FROM users WHERE VERIFY_PASSWORD(password, 'hunter2')
+```
+
+## See Also
+
+- [Type System Overview](/types/overview.md)
+- [Primitive Types](/types/primitives.md)
+- [Validation & Coercion](/types/validation.md)
+</content>
+</invoke>


### PR DESCRIPTION
Automated AFK landing for #1617. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1617

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785526234&installation_id=129708444&pr_number=1618&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1618&signature=b6935d362125729d972d136f5b0975e74a431dfd60759c405615940b2b8605d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->