### PR TITLE
merge: #1641 refactor(server): migrate admin + ops/cluster legacy routes to the discovered route catalog (routing 1/3)

### DIFF
--- a/crates/reddb-server/src/server/routes/admin_ops.route.rs
+++ b/crates/reddb-server/src/server/routes/admin_ops.route.rs
@@ -4,7 +4,7 @@ use crate::server::route_catalog::{
 };
 use crate::server::routes::common::{
     ADMIN_TOKEN_MIDDLEWARE, ALL_SURFACES, PUBLIC_ADMIN_SURFACES, PUBLIC_MIDDLEWARE,
-    PUBLIC_NO_QUOTA_MIDDLEWARE,
+    PUBLIC_NO_QUOTA_MIDDLEWARE, PUBLIC_SURFACES, STANDARD_MIDDLEWARE,
 };
 
 const ADMIN_SURFACES: &[ListenerSurface] = &[ListenerSurface::Public, ListenerSurface::Admin];
@@ -66,6 +66,19 @@ const OPS_PUBLIC_PROBE: RouteGroupDefaults = RouteGroupDefaults {
     surfaces: ALL_SURFACES,
     stability: RouteStability::Stable,
     middlewares: PUBLIC_NO_QUOTA_MIDDLEWARE,
+};
+
+// Eventual-consistency per-field mutation + status endpoints. The legacy
+// dispatcher served these from the untyped `/ec/{collection}/{field}/{action}`
+// fallthrough (authenticated user, public listener only, quota-gated, no ops
+// policy); the discovered group reproduces that surface/auth/middleware shape.
+const OPS_EC_FIELD: RouteGroupDefaults = RouteGroupDefaults {
+    family: "ops",
+    audience: RouteAudience::Client,
+    auth: RouteAuth::UserRequired,
+    surfaces: PUBLIC_SURFACES,
+    stability: RouteStability::Stable,
+    middlewares: STANDARD_MIDDLEWARE,
 };
 
 const ADMIN_STATUS_ALIASES: &[RouteAlias] = &[RouteAlias::canonical(
@@ -391,6 +404,42 @@ const OPS_PUBLIC_ROUTES: &[RouteEntry] = &[
     ),
 ];
 
+const OPS_EC_FIELD_ROUTES: &[RouteEntry] = &[
+    RouteEntry::with_aliases(
+        "ops.ec.add",
+        RouteMethod::Post,
+        "/ec/:collection/:field/add",
+        ops_aliases!(RouteMethod::Post, "/v1/ops/ec/:collection/:field/add"),
+    ),
+    RouteEntry::with_aliases(
+        "ops.ec.sub",
+        RouteMethod::Post,
+        "/ec/:collection/:field/sub",
+        ops_aliases!(RouteMethod::Post, "/v1/ops/ec/:collection/:field/sub"),
+    ),
+    RouteEntry::with_aliases(
+        "ops.ec.set",
+        RouteMethod::Post,
+        "/ec/:collection/:field/set",
+        ops_aliases!(RouteMethod::Post, "/v1/ops/ec/:collection/:field/set"),
+    ),
+    RouteEntry::with_aliases(
+        "ops.ec.consolidate",
+        RouteMethod::Post,
+        "/ec/:collection/:field/consolidate",
+        ops_aliases!(
+            RouteMethod::Post,
+            "/v1/ops/ec/:collection/:field/consolidate"
+        ),
+    ),
+    RouteEntry::with_aliases(
+        "ops.ec.field_status",
+        RouteMethod::Get,
+        "/ec/:collection/:field/status",
+        ops_aliases!(RouteMethod::Get, "/v1/ops/ec/:collection/:field/status"),
+    ),
+];
+
 pub(crate) fn register(registry: &mut RouteRegistry) {
     registry.routes(ADMIN_MUTATION, ADMIN_MUTATION_ROUTES);
     registry.routes(
@@ -405,4 +454,5 @@ pub(crate) fn register(registry: &mut RouteRegistry) {
     registry.routes(OPS_READ, OPS_READ_ROUTES);
     registry.routes(OPS_PUBLIC_PROBE, OPS_PUBLIC_PROBE_ROUTES);
     registry.routes(OPS_PUBLIC, OPS_PUBLIC_ROUTES);
+    registry.routes(OPS_EC_FIELD, OPS_EC_FIELD_ROUTES);
 }

--- a/crates/reddb-server/src/server/routes/mod.rs
+++ b/crates/reddb-server/src/server/routes/mod.rs
@@ -59,6 +59,45 @@ mod tests {
     }
 
     #[test]
+    fn discovered_ec_dynamic_routes_resolve_through_catalog() {
+        let catalog = build_discovered_route_catalog().unwrap();
+
+        for (method, path, id) in [
+            (RouteMethod::Post, "/ec/orders/total/add", "ops.ec.add"),
+            (RouteMethod::Post, "/ec/orders/total/sub", "ops.ec.sub"),
+            (RouteMethod::Post, "/ec/orders/total/set", "ops.ec.set"),
+            (
+                RouteMethod::Post,
+                "/ec/orders/total/consolidate",
+                "ops.ec.consolidate",
+            ),
+            (
+                RouteMethod::Get,
+                "/ec/orders/total/status",
+                "ops.ec.field_status",
+            ),
+        ] {
+            let matched = catalog
+                .find(method, path)
+                .unwrap_or_else(|| panic!("missing EC route {path}"));
+            assert_eq!(matched.spec.id, id, "unexpected id for {path}");
+            assert_eq!(
+                matched.params.get("collection").map(String::as_str),
+                Some("orders")
+            );
+            assert_eq!(
+                matched.params.get("field").map(String::as_str),
+                Some("total")
+            );
+        }
+
+        // The global `/ec/status` exact route still wins over the dynamic
+        // `/ec/:collection/:field/status` pattern.
+        let global = catalog.find(RouteMethod::Get, "/ec/status").unwrap();
+        assert_eq!(global.spec.id, "ops.ec.status");
+    }
+
+    #[test]
     fn discovered_routes_carry_canonical_aliases() {
         let catalog = build_discovered_route_catalog().unwrap();
 

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -430,16 +430,6 @@ impl RedDBServer {
             },
             ("GET", "/grpc") => self.handle_grpc_discovery(),
 
-            // Eventual Consistency endpoints
-            ("GET", "/ec/status") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "eventual-consistency")
-                {
-                    return deny;
-                }
-                handlers_ec::handle_ec_global_status(&self.runtime)
-            }
-
             // Geo endpoints
             ("POST", "/geo/distance") => handlers_geo::handle_geo_distance(body),
             ("POST", "/geo/bearing") => handlers_geo::handle_geo_bearing(body),
@@ -455,102 +445,15 @@ impl RedDBServer {
             // Log endpoints (handled dynamically below for /logs/{name}/...)
 
             // CDC & Backup endpoints
-            ("GET", "/changes") => self.handle_cdc_poll(&query),
-            ("GET", "/backup/status") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "backup-status")
-                {
-                    return deny;
-                }
-                self.handle_backup_status()
-            }
-            ("POST", "/backup/trigger") => self.handle_backup_trigger(),
             ("GET", "/recovery/restore-points") => self.handle_restore_points(),
 
             // Replication endpoints
-            ("GET", "/replication/status") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "replication-status")
-                {
-                    return deny;
-                }
-                self.handle_replication_status()
-            }
-
-            // Topology graph (#803) — built-in `red.topology.cluster` analytics,
-            // aggregated into the PRD #794 nodes/edges/groups/metadata document.
-            ("GET", "/v1/topology/graph") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "topology-graph")
-                {
-                    return deny;
-                }
-                self.handle_topology_graph()
-            }
             ("POST", "/replication/snapshot") => self.handle_replication_snapshot(),
-            ("POST", "/admin/replication/rejoin/confirm-rewind") => {
-                self.handle_admin_replication_confirm_rewind(body)
-            }
 
-            ("POST", "/admin/shutdown") => self.handle_admin_shutdown(),
-            ("POST", "/admin/drain") => self.handle_admin_drain(),
-            // PLAN.md Phase 3.2 / 3.3 — admin restore + backup.
-            ("POST", "/admin/restore") => self.handle_admin_restore(body),
-            ("POST", "/admin/backup") => self.handle_admin_backup(&query),
-            // PLAN.md Phase 4.3 — dynamic read-only toggle.
-            ("POST", "/admin/readonly") => self.handle_admin_readonly(body),
-            // Issue #148 — Blob Cache admin maintenance endpoints
-            // (closes sweeper.rs flag #4 + the operator UX gap from #148).
-            ("POST", "/admin/blob_cache/sweep") => self.handle_admin_blob_cache_sweep(body),
-            ("POST", "/admin/blob_cache/flush_namespace") => {
-                self.handle_admin_blob_cache_flush_namespace(body)
-            }
-            // Issue #195 — optimistic-lock compare-and-set on the result cache.
-            ("POST", "/admin/cache/compare-and-set") => {
-                self.handle_admin_blob_cache_compare_and_set(body)
-            }
-            // Issue #198 — blob cache stats endpoint.
-            ("GET", "/admin/blob_cache/stats") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "blob-cache-stats")
-                {
-                    return deny;
-                }
-                self.handle_admin_blob_cache_stats(&query)
-            }
-            // PLAN.md Phase 11.6 — manual replica → primary promotion.
-            ("POST", "/admin/failover/promote") => self.handle_admin_failover_promote(body),
-            ("GET", "/admin/status") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "admin-status")
-                {
-                    return deny;
-                }
-                self.handle_admin_status()
-            }
-            // Red UI cluster status snapshot (#738) — single aggregated
-            // contract so the UI doesn't need to stitch /admin/status,
-            // /replication/status, /backup/status, /ready/* together.
-            ("GET", "/cluster/status") => {
-                if let Some(deny) =
-                    self.check_ops_http_policy(&headers, "ops:read:cluster", "cluster-status")
-                {
-                    return deny;
-                }
-                self.handle_cluster_status()
-            }
             // Red UI feature & capability discovery (#752). Two levels:
             // static/system capabilities and the effective principal
             // view. Both are on the public allowlist in `is_authorized`.
             ("GET", "/capabilities") => self.handle_capabilities(),
-            // SOC 2 / HIPAA structured audit query — JSONL/JSON over
-            // the active `.audit.log` plus rotated archives.
-            ("GET", "/admin/audit") => {
-                if let Some(deny) = self.check_ops_http_policy(&headers, "ops:admin", "audit") {
-                    return deny;
-                }
-                self.handle_admin_audit_query(&query)
-            }
 
             ("GET", "/health") => {
                 let report = self.native_use_cases().health();
@@ -637,33 +540,6 @@ impl RedDBServer {
                     503
                 };
                 json_response(status, self.health_json_with_transport(&report))
-            }
-            ("GET", "/deployment/profiles") => {
-                let profile = query
-                    .get("profile")
-                    .and_then(|value| deployment_profile_from_token(value.as_str()));
-                json_response(
-                    200,
-                    match profile {
-                        Some(profile) => {
-                            crate::presentation::deployment_json::deployment_profile_json(
-                                match profile {
-                                    DeploymentProfile::Embedded => crate::presentation::deployment_json::DeploymentProfileView::Embedded,
-                                    DeploymentProfile::Server => crate::presentation::deployment_json::DeploymentProfileView::Server,
-                                    DeploymentProfile::Serverless => crate::presentation::deployment_json::DeploymentProfileView::Serverless,
-                                },
-                            )
-                        }
-                        None => crate::presentation::deployment_json::deployment_profiles_catalog_json(
-                            &[
-                                crate::presentation::deployment_json::DeploymentProfileView::Embedded,
-                                crate::presentation::deployment_json::DeploymentProfileView::Server,
-                                crate::presentation::deployment_json::DeploymentProfileView::Serverless,
-                            ],
-                            "Use /deployment/profiles?profile=serverless to get the exact serverless contract.",
-                        ),
-                    },
-                )
             }
             ("GET", "/catalog/readiness") => {
                 let native = self.native_use_cases();
@@ -1153,90 +1029,6 @@ impl RedDBServer {
                     }
                 }
 
-                // IAM policy admin endpoints (Agent #28 lane).
-                if path == "/admin/policies" {
-                    return match method.as_str() {
-                        "GET" => self.handle_iam_policy_list(),
-                        _ => json_error(405, "method not allowed"),
-                    };
-                }
-                if path == "/admin/policies/simulate" && method == "POST" {
-                    return self.handle_iam_simulate(body);
-                }
-                if path == "/admin/policies/lint" {
-                    return match method.as_str() {
-                        "POST" => self.handle_iam_policy_lint(body),
-                        _ => json_error(405, "method not allowed"),
-                    };
-                }
-                if path == "/admin/policies/migrate-mode" {
-                    return match method.as_str() {
-                        "POST" => self.handle_iam_policy_migrate_mode(body),
-                        _ => json_error(405, "method not allowed"),
-                    };
-                }
-                if path == "/admin/policies/actions" {
-                    return match method.as_str() {
-                        "GET" => self.handle_iam_policy_actions(),
-                        _ => json_error(405, "method not allowed"),
-                    };
-                }
-                if let Some(rest) = path.strip_prefix("/admin/policies/") {
-                    let id = rest.trim_matches('/');
-                    if !id.is_empty() && !id.contains('/') {
-                        return match method.as_str() {
-                            "PUT" => self.handle_iam_policy_put(&headers, id, body),
-                            "GET" => self.handle_iam_policy_get(id),
-                            "DELETE" => self.handle_iam_policy_delete(&headers, id),
-                            _ => json_error(405, "method not allowed"),
-                        };
-                    }
-                }
-                if let Some(rest) = path.strip_prefix("/admin/users/") {
-                    // /admin/users/:user/policies/:policy_id  PUT|DELETE
-                    // /admin/users/:user/groups/:group       PUT|DELETE
-                    // /admin/users/:user/effective-permissions GET
-                    if let Some((user, tail)) = rest.split_once('/') {
-                        if tail == "effective-permissions" && method == "GET" {
-                            return self.handle_iam_effective_permissions(user, &query);
-                        }
-                        if let Some(group) = tail.strip_prefix("groups/") {
-                            let group = group.trim_matches('/');
-                            if !group.is_empty() && !group.contains('/') {
-                                return match method.as_str() {
-                                    "PUT" => self.handle_iam_add_user_group(user, group),
-                                    "DELETE" => self.handle_iam_remove_user_group(user, group),
-                                    _ => json_error(405, "method not allowed"),
-                                };
-                            }
-                        }
-                        if let Some(pid) = tail.strip_prefix("policies/") {
-                            let pid = pid.trim_matches('/');
-                            if !pid.is_empty() && !pid.contains('/') {
-                                return match method.as_str() {
-                                    "PUT" => self.handle_iam_attach_user(&headers, user, pid),
-                                    "DELETE" => self.handle_iam_detach_user(&headers, user, pid),
-                                    _ => json_error(405, "method not allowed"),
-                                };
-                            }
-                        }
-                    }
-                }
-                if let Some(rest) = path.strip_prefix("/admin/groups/") {
-                    if let Some((group, tail)) = rest.split_once('/') {
-                        if let Some(pid) = tail.strip_prefix("policies/") {
-                            let pid = pid.trim_matches('/');
-                            if !pid.is_empty() && !pid.contains('/') {
-                                return match method.as_str() {
-                                    "PUT" => self.handle_iam_attach_group(&headers, group, pid),
-                                    "DELETE" => self.handle_iam_detach_group(&headers, group, pid),
-                                    _ => json_error(405, "method not allowed"),
-                                };
-                            }
-                        }
-                    }
-                }
-
                 // Log dynamic routes: /logs/{name}/append, /logs/{name}/query, /logs/{name}/retention
                 if let Some(rest) = path.strip_prefix("/logs/") {
                     let parts: Vec<&str> = rest.split('/').collect();
@@ -1254,51 +1046,6 @@ impl RedDBServer {
                                 handlers_log::handle_log_retention(&self.runtime, log_name)
                             }
                             _ => json_error(405, "method not allowed for log endpoint"),
-                        };
-                    }
-                }
-
-                // EC dynamic routes: /ec/{collection}/{field}/{action}
-                if let Some(rest) = path.strip_prefix("/ec/") {
-                    let parts: Vec<&str> = rest.split('/').collect();
-                    if parts.len() >= 3 {
-                        let ec_collection = parts[0];
-                        let ec_field = parts[1];
-                        let ec_action = parts[2];
-                        return match (method.as_str(), ec_action) {
-                            ("POST", "add") => handlers_ec::handle_ec_mutate(
-                                &self.runtime,
-                                ec_collection,
-                                ec_field,
-                                "add",
-                                body,
-                            ),
-                            ("POST", "sub") => handlers_ec::handle_ec_mutate(
-                                &self.runtime,
-                                ec_collection,
-                                ec_field,
-                                "sub",
-                                body,
-                            ),
-                            ("POST", "set") => handlers_ec::handle_ec_mutate(
-                                &self.runtime,
-                                ec_collection,
-                                ec_field,
-                                "set",
-                                body,
-                            ),
-                            ("POST", "consolidate") => handlers_ec::handle_ec_consolidate(
-                                &self.runtime,
-                                ec_collection,
-                                ec_field,
-                            ),
-                            ("GET", "status") => handlers_ec::handle_ec_status(
-                                &self.runtime,
-                                ec_collection,
-                                ec_field,
-                                &query,
-                            ),
-                            _ => json_error(405, "method not allowed for EC endpoint"),
                         };
                     }
                 }
@@ -1919,6 +1666,41 @@ impl RedDBServer {
             "admin.status" => Some(self.handle_admin_status()),
             "admin.blob_cache.stats" => Some(self.handle_admin_blob_cache_stats(query)),
             "ops.ec.status" => Some(handlers_ec::handle_ec_global_status(&self.runtime)),
+            "ops.ec.add" | "ops.ec.sub" | "ops.ec.set" => {
+                let collection = matched.params.get("collection")?;
+                let field = matched.params.get("field")?;
+                let operation = match matched.spec.id {
+                    "ops.ec.add" => "add",
+                    "ops.ec.sub" => "sub",
+                    _ => "set",
+                };
+                Some(handlers_ec::handle_ec_mutate(
+                    &self.runtime,
+                    collection,
+                    field,
+                    operation,
+                    body.to_vec(),
+                ))
+            }
+            "ops.ec.consolidate" => {
+                let collection = matched.params.get("collection")?;
+                let field = matched.params.get("field")?;
+                Some(handlers_ec::handle_ec_consolidate(
+                    &self.runtime,
+                    collection,
+                    field,
+                ))
+            }
+            "ops.ec.field_status" => {
+                let collection = matched.params.get("collection")?;
+                let field = matched.params.get("field")?;
+                Some(handlers_ec::handle_ec_status(
+                    &self.runtime,
+                    collection,
+                    field,
+                    query,
+                ))
+            }
             "ops.backup.status" => Some(self.handle_backup_status()),
             "ops.backup.trigger" => Some(self.handle_backup_trigger()),
             "ops.recovery.restore_points" => Some(self.handle_restore_points()),


### PR DESCRIPTION
Automated AFK landing for #1641. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1641

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785606998&installation_id=129708444&pr_number=1663&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1663&signature=106fe513bab4fa2c51c7d2729c07dd870cee3e27b3171ae5f7099e7134255fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->