### PR TITLE
merge: #1644 feat(tm): thread ISOLATION LEVEL from parser to runtime TxnContext (TM v2 1/8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,10 @@ name = "grouped_materialized_views_events_config_audit"
 path = "tests/grouped/materialized_views_events_config_audit.rs"
 
 [[test]]
+name = "grouped_mvcc_transactions"
+path = "tests/grouped_mvcc_transactions.rs"
+
+[[test]]
 name = "grouped_probabilistic"
 path = "tests/grouped_probabilistic.rs"
 

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -642,7 +642,7 @@ pub struct DropSequenceQuery {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TxnControl {
     /// `BEGIN [WORK | TRANSACTION]`, `START TRANSACTION`
-    Begin,
+    Begin(Option<IsolationLevel>),
     /// `COMMIT [WORK | TRANSACTION]`, `END`
     Commit,
     /// `ROLLBACK [WORK | TRANSACTION]`
@@ -653,6 +653,20 @@ pub enum TxnControl {
     ReleaseSavepoint(String),
     /// `ROLLBACK TO [SAVEPOINT] name`
     RollbackToSavepoint(String),
+}
+
+/// Transaction isolation level requested by `BEGIN ISOLATION LEVEL ...`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IsolationLevel {
+    /// `READ UNCOMMITTED`
+    ReadUncommitted,
+    /// `READ COMMITTED`
+    ReadCommitted,
+    /// `REPEATABLE READ` / `SNAPSHOT`
+    #[default]
+    SnapshotIsolation,
+    /// `SERIALIZABLE`
+    Serializable,
 }
 
 /// Maintenance command variants. See [`QueryExpr::MaintenanceCommand`].

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -5877,22 +5877,22 @@ fn test_parse_transaction_control() {
     // BEGIN (bare)
     assert!(matches!(
         parse("BEGIN").unwrap(),
-        QueryExpr::TransactionControl(TxnControl::Begin)
+        QueryExpr::TransactionControl(TxnControl::Begin(None))
     ));
     // BEGIN WORK
     assert!(matches!(
         parse("BEGIN WORK").unwrap(),
-        QueryExpr::TransactionControl(TxnControl::Begin)
+        QueryExpr::TransactionControl(TxnControl::Begin(None))
     ));
     // BEGIN TRANSACTION
     assert!(matches!(
         parse("BEGIN TRANSACTION").unwrap(),
-        QueryExpr::TransactionControl(TxnControl::Begin)
+        QueryExpr::TransactionControl(TxnControl::Begin(None))
     ));
     // START TRANSACTION
     assert!(matches!(
         parse("START TRANSACTION").unwrap(),
-        QueryExpr::TransactionControl(TxnControl::Begin)
+        QueryExpr::TransactionControl(TxnControl::Begin(None))
     ));
 
     // COMMIT + COMMIT WORK + COMMIT TRANSACTION

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -10,8 +10,8 @@ use crate::ast::{
     DropTableQuery, DropTimeSeriesQuery, DropTreeQuery, DropVcsRefQuery, DropVectorQuery,
     DropViewQuery, EventsBackfillQuery, ExplainAlterQuery, ExplainMigrationQuery, Expr, FieldRef,
     Filter, ForeignColumnDef, GrantStmt, GraphCommand, GraphQuery, HybridQuery, InsertQuery,
-    JoinQuery, KvCommand, MaintenanceCommand, PathQuery, PolicyAction, ProbabilisticCommand,
-    QueryExpr, QueueCommand, QueueSelectQuery, RankOfQuery, RankRangeQuery,
+    IsolationLevel, JoinQuery, KvCommand, MaintenanceCommand, PathQuery, PolicyAction,
+    ProbabilisticCommand, QueryExpr, QueueCommand, QueueSelectQuery, RankOfQuery, RankRangeQuery,
     RefreshMaterializedViewQuery, RevokeStmt, RollbackMigrationQuery, SearchCommand, Span,
     TableQuery, TreeCommand, TruncateQuery, TxnControl, UpdateQuery, VcsCommand,
     VcsConflictResolution, VcsRefKind, VcsResetMode, VectorQuery,
@@ -363,7 +363,9 @@ mod tests {
         assert!(matches!(expr("SHOW TENANT"), QueryExpr::ShowTenant));
         assert!(matches!(
             expr("BEGIN ISOLATION LEVEL SNAPSHOT"),
-            QueryExpr::TransactionControl(TxnControl::Begin)
+            QueryExpr::TransactionControl(TxnControl::Begin(Some(
+                IsolationLevel::SnapshotIsolation
+            )))
         ));
         assert!(matches!(
             expr("ROLLBACK TO SAVEPOINT sp1"),
@@ -1213,16 +1215,29 @@ mod tests {
 
     #[test]
     fn parse_sql_command_covers_transaction_isolation_edges() {
-        for input in [
-            "BEGIN ISOLATION LEVEL READ UNCOMMITTED",
-            "BEGIN ISOLATION LEVEL READ COMMITTED",
-            "BEGIN ISOLATION LEVEL REPEATABLE READ",
-            "START TRANSACTION ISOLATION LEVEL SNAPSHOT",
+        for (input, expected) in [
+            (
+                "BEGIN ISOLATION LEVEL READ UNCOMMITTED",
+                IsolationLevel::ReadUncommitted,
+            ),
+            (
+                "BEGIN ISOLATION LEVEL READ COMMITTED",
+                IsolationLevel::ReadCommitted,
+            ),
+            (
+                "BEGIN ISOLATION LEVEL REPEATABLE READ",
+                IsolationLevel::SnapshotIsolation,
+            ),
+            (
+                "START TRANSACTION ISOLATION LEVEL SNAPSHOT",
+                IsolationLevel::SnapshotIsolation,
+            ),
         ] {
             assert!(
                 matches!(
                     sql_command(input),
-                    SqlCommand::TransactionControl(TxnControl::Begin)
+                    SqlCommand::TransactionControl(TxnControl::Begin(Some(level)))
+                        if level == expected
                 ),
                 "{input}"
             );
@@ -4329,13 +4344,11 @@ impl<'a> Parser<'a> {
                     // The level identifier can span multiple words
                     // (READ UNCOMMITTED / READ COMMITTED / REPEATABLE
                     // READ). Collect them case-insensitively.
-                    let mut parts: Vec<String> = Vec::new();
-                    if self.consume_ident_ci("READ")? {
-                        parts.push("READ".to_string());
+                    let isolation = if self.consume_ident_ci("READ")? {
                         if self.consume_ident_ci("UNCOMMITTED")? {
-                            parts.push("UNCOMMITTED".to_string());
+                            IsolationLevel::ReadUncommitted
                         } else if self.consume_ident_ci("COMMITTED")? {
-                            parts.push("COMMITTED".to_string());
+                            IsolationLevel::ReadCommitted
                         } else {
                             return Err(ParseError::expected(
                                 vec!["UNCOMMITTED", "COMMITTED"],
@@ -4344,7 +4357,6 @@ impl<'a> Parser<'a> {
                             ));
                         }
                     } else if self.consume_ident_ci("REPEATABLE")? {
-                        parts.push("REPEATABLE".to_string());
                         if !self.consume_ident_ci("READ")? {
                             return Err(ParseError::expected(
                                 vec!["READ"],
@@ -4352,9 +4364,9 @@ impl<'a> Parser<'a> {
                                 self.position(),
                             ));
                         }
-                        parts.push("READ".to_string());
+                        IsolationLevel::SnapshotIsolation
                     } else if self.consume_ident_ci("SNAPSHOT")? {
-                        parts.push("SNAPSHOT".to_string());
+                        IsolationLevel::SnapshotIsolation
                     } else if self.consume_ident_ci("SERIALIZABLE")? {
                         return Err(ParseError::new(
                             "ISOLATION LEVEL SERIALIZABLE is not yet supported — reddb \
@@ -4370,11 +4382,13 @@ impl<'a> Parser<'a> {
                             self.peek(),
                             self.position(),
                         ));
-                    }
-                    // All accepted modes map to our snapshot engine today.
-                    let _ = parts;
+                    };
+                    Ok(SqlCommand::TransactionControl(TxnControl::Begin(Some(
+                        isolation,
+                    ))))
+                } else {
+                    Ok(SqlCommand::TransactionControl(TxnControl::Begin(None)))
                 }
-                Ok(SqlCommand::TransactionControl(TxnControl::Begin))
             }
             // COMMIT [WORK | TRANSACTION]
             Token::Commit => {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1403,13 +1403,15 @@ impl RedDBRuntime {
                 let conn_id = current_connection_id();
 
                 let (kind, msg) = match ctl {
-                    TxnControl::Begin => {
+                    TxnControl::Begin(requested_isolation) => {
+                        let isolation =
+                            requested_isolation.unwrap_or(IsolationLevel::SnapshotIsolation);
                         let mgr = Arc::clone(&self.inner.snapshot_manager);
                         let xid = mgr.begin();
                         let snapshot = mgr.snapshot(xid);
                         let ctx = TxnContext {
                             xid,
-                            isolation: IsolationLevel::SnapshotIsolation,
+                            isolation,
                             snapshot,
                             savepoints: Vec::new(),
                             released_sub_xids: Vec::new(),

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -568,7 +568,7 @@ const COMMIT_COLUMNS: [&str; 11] = [
 
 const REF_COLUMNS: [&str; 4] = ["name", "kind", "target", "protected"];
 
-const STATUS_COLUMNS: [&str; 8] = [
+const STATUS_COLUMNS: [&str; 10] = [
     "connection_id",
     "head_ref",
     "head_commit",
@@ -577,6 +577,8 @@ const STATUS_COLUMNS: [&str; 8] = [
     "working_changes",
     "unresolved_conflicts",
     "merge_state_id",
+    "isolation_level",
+    "effective_isolation_level",
 ];
 
 const CONFLICT_COLUMNS: [&str; 8] = [

--- a/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
@@ -7,6 +7,15 @@
 use super::helpers::*;
 use super::*;
 
+fn isolation_level_name(level: crate::storage::transaction::IsolationLevel) -> &'static str {
+    match level {
+        crate::storage::transaction::IsolationLevel::ReadUncommitted => "read_uncommitted",
+        crate::storage::transaction::IsolationLevel::ReadCommitted => "read_committed",
+        crate::storage::transaction::IsolationLevel::SnapshotIsolation => "snapshot_isolation",
+        crate::storage::transaction::IsolationLevel::Serializable => "serializable",
+    }
+}
+
 pub(super) fn commits_snapshot(
     runtime: &RedDBRuntime,
     query: &TableQuery,
@@ -107,9 +116,14 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
             .map(|name| Arc::<str>::from(*name))
             .collect::<Vec<_>>(),
     );
-    let status = runtime.vcs_status(crate::application::vcs::StatusInput {
-        connection_id: current_connection_id(),
-    })?;
+    let connection_id = current_connection_id();
+    let status = runtime.vcs_status(crate::application::vcs::StatusInput { connection_id })?;
+    let isolation = runtime
+        .inner
+        .tx_contexts
+        .read()
+        .get(&connection_id)
+        .map(|ctx| ctx.isolation);
     Ok(vec![UnifiedRecord::with_schema(
         schema,
         vec![
@@ -123,6 +137,13 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
             status
                 .merge_state_id
                 .map(Value::text)
+                .unwrap_or(Value::Null),
+            isolation
+                .map(isolation_level_name)
+                .map(Value::text)
+                .unwrap_or(Value::Null),
+            isolation
+                .map(|_| Value::text("snapshot_isolation"))
                 .unwrap_or(Value::Null),
         ],
     )])

--- a/crates/reddb-server/src/storage/transaction/coordinator.rs
+++ b/crates/reddb-server/src/storage/transaction/coordinator.rs
@@ -10,6 +10,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant};
 
+use crate::storage::query::ast::IsolationLevel;
+
 /// Transaction ID
 pub type TxnId = u64;
 
@@ -129,20 +131,6 @@ pub enum TxnState {
     Committed,
     /// Aborted
     Aborted,
-}
-
-/// Isolation level
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum IsolationLevel {
-    /// Read uncommitted (no isolation)
-    ReadUncommitted,
-    /// Read committed (see committed values)
-    ReadCommitted,
-    /// Repeatable read / Snapshot isolation
-    #[default]
-    SnapshotIsolation,
-    /// Serializable (full isolation)
-    Serializable,
 }
 
 /// Transaction configuration

--- a/crates/reddb-server/src/storage/transaction/mod.rs
+++ b/crates/reddb-server/src/storage/transaction/mod.rs
@@ -34,9 +34,8 @@ pub mod savepoint;
 pub mod snapshot;
 pub mod visibility;
 
-pub use coordinator::{
-    IsolationLevel, Transaction, TransactionManager, TxnConfig, TxnError, TxnHandle, TxnState,
-};
+pub use crate::storage::query::ast::IsolationLevel;
+pub use coordinator::{Transaction, TransactionManager, TxnConfig, TxnError, TxnHandle, TxnState};
 pub use lock::{LockManager, LockMode, LockResult, LockWaiter};
 pub use log::{LogEntry, LogEntryType, TransactionLog, WalConfig};
 pub use savepoint::{Savepoint, SavepointManager};

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -28,7 +28,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::coordinator::IsolationLevel;
+use super::IsolationLevel;
 
 /// Default autocommit-xid pool batch size. Each refill reserves this
 /// many xids in a single `fetch_add` so back-to-back autocommit inserts

--- a/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
+++ b/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
@@ -87,6 +87,50 @@ fn select_count(rt: &RedDBRuntime, sql: &str) -> usize {
     rt.execute_query(sql).expect("select").result.records.len()
 }
 
+fn text_cell(row: &reddb::storage::query::unified::UnifiedRecord, column: &str) -> String {
+    match row.get(column) {
+        Some(Value::Text(value)) => value.to_string(),
+        other => panic!("expected text in {column}, got {other:?}"),
+    }
+}
+
+#[test]
+fn begin_isolation_level_round_trips_to_transaction_status() {
+    let rt = rt();
+
+    for (offset, (sql, requested)) in [
+        ("BEGIN ISOLATION LEVEL READ UNCOMMITTED", "read_uncommitted"),
+        ("BEGIN ISOLATION LEVEL READ COMMITTED", "read_committed"),
+        (
+            "BEGIN ISOLATION LEVEL REPEATABLE READ",
+            "snapshot_isolation",
+        ),
+        ("BEGIN ISOLATION LEVEL SNAPSHOT", "snapshot_isolation"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        set_current_connection_id(9960 + offset as u64);
+        try_exec(&rt, sql).expect("BEGIN with isolation level should be accepted");
+
+        let status = rt
+            .execute_query("SELECT isolation_level, effective_isolation_level FROM red.status")
+            .expect("red.status should expose transaction isolation");
+        assert_eq!(status.result.records.len(), 1, "one red.status row");
+        let row = &status.result.records[0];
+        assert_eq!(text_cell(row, "isolation_level"), requested, "{sql}");
+        assert_eq!(
+            text_cell(row, "effective_isolation_level"),
+            "snapshot_isolation",
+            "{sql}"
+        );
+
+        try_exec(&rt, "COMMIT").expect("COMMIT should close the tx");
+    }
+
+    clear_current_connection_id();
+}
+
 #[test]
 fn writer_sees_own_uncommitted_row() {
     // Read-your-own-writes inside a single transaction. The writer's


### PR DESCRIPTION
Automated AFK landing for #1644. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1644

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785667304&installation_id=129708444&pr_number=1685&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1685&signature=c8d6fe22f64217e9676f9e06b8fdb893a01a9a2c5e139ba390fca0bbf4dd7dc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying transaction isolation levels when starting a transaction.
  * The status view now reports both the requested and effective isolation level for active transactions.

* **Bug Fixes**
  * Transaction start behavior now consistently defaults to snapshot isolation when no level is provided.
  * Isolation level values are now reflected correctly in transaction status output.

* **Tests**
  * Added end-to-end coverage for multiple transaction isolation level forms and status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->