### PR TITLE
merge: #1646 spec(tm): TLA+ model of the FCW SI/SSI commit protocol in the TLC CI lane (TM v2 7/8)

### DIFF
--- a/.github/workflows/tla-check.yml
+++ b/.github/workflows/tla-check.yml
@@ -12,6 +12,8 @@ name: TLA+ Model Check
 #                     -- single-writer fencing, election safety, partitions,
 #                        and crash/recovery durability in one bounded model.
 #   * SafeReconfig    -- every membership change preserves quorum overlap.
+#   * CommitProtocol  -- optimistic MVCC visibility, FCW, savepoints, and
+#                        SSI dangerous-structure aborts.
 #
 # TLC exits non-zero on a violated invariant, which fails the job (and so
 # the build). The models are sized to finish in CI seconds-to-minutes.
@@ -49,6 +51,7 @@ jobs:
           - Durability
           - ReplicationSafetyEnvelope
           - SafeReconfig
+          - CommitProtocol
     name: model-check (${{ matrix.spec }})
     steps:
       - uses: actions/checkout@v7

--- a/specs/tla/CommitProtocol.cfg
+++ b/specs/tla/CommitProtocol.cfg
@@ -1,0 +1,15 @@
+\* TLC model for CommitProtocol: three transactions over two logical rows.
+\* This keeps the state space small while still exercising overlapping
+\* snapshots, FCW row conflicts, savepoint rollback/release, SSI rw edges,
+\* and a dangerous-structure abort.
+CONSTANTS
+    Txns = {t1, t2, t3}
+    Rows = {r1, r2}
+    EnabledLevels = {"SSI"}
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT SI_NoLostUpdate
+INVARIANT SI_SnapshotStability
+INVARIANT SSI_Serializable

--- a/specs/tla/CommitProtocol.tla
+++ b/specs/tla/CommitProtocol.tla
@@ -1,0 +1,333 @@
+---------------------------- MODULE CommitProtocol ----------------------------
+(***************************************************************************)
+(* RedDB optimistic transaction commit protocol (TM v2, issue #1646).      *)
+(*                                                                         *)
+(* This is the small bounded model for the live SQL commit path described  *)
+(* by ADR 0065: SnapshotManager allocates xids and captures in-progress    *)
+(* sets; the pure MVCC visibility predicate decides which row version a    *)
+(* transaction sees; commit performs first-committer-wins (FCW) checks over *)
+(* logical rows; savepoints use sub-xid frames that can be released or      *)
+(* rolled back; the SSI extension tracks rw-antidependency edges and aborts *)
+(* a commit that would admit a dangerous structure (two consecutive rw      *)
+(* edges).                                                                 *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets, Sequences
+
+Nil == "none"
+Levels == {"SI", "SSI"}
+Statuses == {"idle", "active", "committed", "aborted"}
+AbortReasons == {"fcw", "ssi"}
+
+CONSTANTS
+    Txns,
+    Rows,
+    EnabledLevels
+
+ASSUME
+    /\ Cardinality(Rows) > 0
+    /\ EnabledLevels \subseteq Levels
+    /\ EnabledLevels # {}
+
+VARIABLES
+    nextXid,        \* next xid rank to allocate
+    status,         \* transaction lifecycle
+    isolation,      \* SI or SSI for active/finished transactions
+    xidRank,        \* xid allocation order; 0 means not allocated
+    activeAtBegin,  \* SnapshotManager in-progress set captured at BEGIN
+    readSet,        \* logical rows read by each transaction
+    readFrom,       \* row -> writer xid observed by the first read
+    writeSet,       \* logical rows written by each transaction
+    savepointOpen,  \* whether a sub-xid frame is open
+    savepointWrites,\* writes stamped by the open sub-xid frame
+    subXidAllocated,\* transactions that allocated at least one sub-xid
+    rwEdges,        \* SSI rw-antidependency edges
+    abortReason     \* commit-time abort classes reached by the model
+
+vars ==
+    <<nextXid, status, isolation, xidRank, activeAtBegin, readSet, readFrom,
+      writeSet, savepointOpen, savepointWrites, subXidAllocated, rwEdges,
+      abortReason>>
+
+TypeOK ==
+    /\ nextXid \in 1..(Cardinality(Txns) + 1)
+    /\ status \in [Txns -> Statuses]
+    /\ isolation \in [Txns -> Levels \union {Nil}]
+    /\ xidRank \in [Txns -> 0..Cardinality(Txns)]
+    /\ activeAtBegin \in [Txns -> SUBSET Txns]
+    /\ readSet \in [Txns -> SUBSET Rows]
+    /\ readFrom \in [Txns -> [Rows -> Txns \union {0}]]
+    /\ writeSet \in [Txns -> SUBSET Rows]
+    /\ savepointOpen \in [Txns -> BOOLEAN]
+    /\ savepointWrites \in [Txns -> SUBSET Rows]
+    /\ subXidAllocated \subseteq Txns
+    /\ rwEdges \subseteq Txns \X Txns
+    /\ abortReason \subseteq AbortReasons
+    /\ \A t \in Txns : savepointWrites[t] \subseteq writeSet[t]
+    /\ \A <<a, b>> \in rwEdges : a # b
+
+Init ==
+    /\ nextXid = 1
+    /\ status = [t \in Txns |-> "idle"]
+    /\ isolation = [t \in Txns |-> Nil]
+    /\ xidRank = [t \in Txns |-> 0]
+    /\ activeAtBegin = [t \in Txns |-> {}]
+    /\ readSet = [t \in Txns |-> {}]
+    /\ readFrom = [t \in Txns |-> [r \in Rows |-> 0]]
+    /\ writeSet = [t \in Txns |-> {}]
+    /\ savepointOpen = [t \in Txns |-> FALSE]
+    /\ savepointWrites = [t \in Txns |-> {}]
+    /\ subXidAllocated = {}
+    /\ rwEdges = {}
+    /\ abortReason = {}
+
+CommittedWriters(row) ==
+    {t \in Txns : status[t] = "committed" /\ row \in writeSet[t]}
+
+VisibleCommittedWriters(reader, row) ==
+    {t \in CommittedWriters(row) :
+        /\ xidRank[t] <= xidRank[reader]
+        /\ t \notin activeAtBegin[reader]}
+
+VisibleWriter(reader, row) ==
+    LET candidates == VisibleCommittedWriters(reader, row) IN
+        IF candidates = {}
+        THEN 0
+        ELSE CHOOSE w \in candidates :
+            \A other \in candidates : xidRank[other] <= xidRank[w]
+
+NotVisibleTo(reader, writer) ==
+    \/ status[writer] # "committed"
+    \/ xidRank[writer] > xidRank[reader]
+    \/ writer \in activeAtBegin[reader]
+
+VisibleTo(reader, writer) ==
+    /\ status[writer] = "committed"
+    /\ xidRank[writer] <= xidRank[reader]
+    /\ writer \notin activeAtBegin[reader]
+
+ConcurrentWriters(t, row) ==
+    {c \in CommittedWriters(row) :
+        \/ xidRank[c] > xidRank[t]
+        \/ c \in activeAtBegin[t]}
+
+FCWConflictFree(t) ==
+    \A row \in writeSet[t] : ConcurrentWriters(t, row) = {}
+
+NewRwEdges(t) ==
+    {edge \in Txns \X Txns :
+        /\ edge[2] = t
+        /\ edge[1] # t
+        /\ status[edge[1]] = "committed"
+        /\ \E row \in Rows :
+            /\ row \in readSet[edge[1]]
+            /\ row \in writeSet[t]
+            /\ NotVisibleTo(edge[1], t)}
+    \union
+    {edge \in Txns \X Txns :
+        /\ edge[1] = t
+        /\ edge[2] # t
+        /\ status[edge[2]] = "committed"
+        /\ \E row \in Rows :
+            /\ row \in readSet[t]
+            /\ row \in writeSet[edge[2]]
+            /\ NotVisibleTo(t, edge[2])}
+
+Dangerous(edges) ==
+    \E a, b, c \in Txns :
+        /\ a # b
+        /\ b # c
+        /\ <<a, b>> \in edges
+        /\ <<b, c>> \in edges
+
+Begin(t, level) ==
+    /\ nextXid <= Cardinality(Txns)
+    /\ level \in EnabledLevels
+    /\ status[t] = "idle"
+    /\ status' = [status EXCEPT ![t] = "active"]
+    /\ isolation' = [isolation EXCEPT ![t] = level]
+    /\ xidRank' = [xidRank EXCEPT ![t] = nextXid]
+    /\ activeAtBegin' =
+        [activeAtBegin EXCEPT ![t] = {u \in Txns : status[u] = "active"}]
+    /\ nextXid' = nextXid + 1
+    /\ UNCHANGED
+        <<readSet, readFrom, writeSet, savepointOpen, savepointWrites,
+          subXidAllocated, rwEdges, abortReason>>
+
+Read(t, row) ==
+    /\ status[t] = "active"
+    /\ row \in Rows
+    /\ row \notin writeSet[t]
+    /\ row \notin readSet[t]
+    /\ readSet' = [readSet EXCEPT ![t] = @ \union {row}]
+    /\ readFrom' = [readFrom EXCEPT ![t][row] = VisibleWriter(t, row)]
+    /\ UNCHANGED
+        <<nextXid, status, isolation, xidRank, activeAtBegin, writeSet,
+          savepointOpen, savepointWrites, subXidAllocated, rwEdges,
+          abortReason>>
+
+Write(t, row) ==
+    /\ status[t] = "active"
+    /\ row \in Rows
+    /\ writeSet[t] = {}
+    /\ writeSet' = [writeSet EXCEPT ![t] = @ \union {row}]
+    /\ savepointWrites' =
+        [savepointWrites EXCEPT ![t] =
+            IF savepointOpen[t] THEN @ \union {row} ELSE @]
+    /\ UNCHANGED
+        <<nextXid, status, isolation, xidRank, activeAtBegin, readSet,
+          readFrom, savepointOpen, subXidAllocated, rwEdges, abortReason>>
+
+Savepoint(t) ==
+    /\ status[t] = "active"
+    /\ ~savepointOpen[t]
+    /\ subXidAllocated = {}
+    /\ savepointOpen' = [savepointOpen EXCEPT ![t] = TRUE]
+    /\ savepointWrites' = [savepointWrites EXCEPT ![t] = {}]
+    /\ subXidAllocated' = subXidAllocated \union {t}
+    /\ UNCHANGED
+        <<nextXid, status, isolation, xidRank, activeAtBegin, readSet,
+          readFrom, writeSet, rwEdges, abortReason>>
+
+ReleaseSavepoint(t) ==
+    /\ status[t] = "active"
+    /\ savepointOpen[t]
+    /\ savepointOpen' = [savepointOpen EXCEPT ![t] = FALSE]
+    /\ savepointWrites' = [savepointWrites EXCEPT ![t] = {}]
+    /\ UNCHANGED
+        <<nextXid, status, isolation, xidRank, activeAtBegin, readSet,
+          readFrom, writeSet, subXidAllocated, rwEdges, abortReason>>
+
+RollbackToSavepoint(t) ==
+    /\ status[t] = "active"
+    /\ savepointOpen[t]
+    /\ writeSet' = [writeSet EXCEPT ![t] = @ \ savepointWrites[t]]
+    /\ savepointWrites' = [savepointWrites EXCEPT ![t] = {}]
+    /\ UNCHANGED
+        <<nextXid, status, isolation, xidRank, activeAtBegin, readSet,
+          readFrom, savepointOpen, subXidAllocated, rwEdges, abortReason>>
+
+Commit(t) ==
+    /\ status[t] = "active"
+    /\ FCWConflictFree(t)
+    /\ LET newEdges == NewRwEdges(t) IN
+        /\ isolation[t] = "SI" \/ ~Dangerous(rwEdges \union newEdges)
+        /\ status' = [status EXCEPT ![t] = "committed"]
+        /\ rwEdges' = rwEdges \union newEdges
+    /\ UNCHANGED
+        <<nextXid, isolation, xidRank, activeAtBegin, readSet, readFrom,
+          writeSet, savepointOpen, savepointWrites, subXidAllocated,
+          abortReason>>
+
+AbortFCW(t) ==
+    /\ status[t] = "active"
+    /\ ~FCWConflictFree(t)
+    /\ status' = [status EXCEPT ![t] = "aborted"]
+    /\ abortReason' = abortReason \union {"fcw"}
+    /\ UNCHANGED
+        <<nextXid, isolation, xidRank, activeAtBegin, readSet, readFrom,
+          writeSet, savepointOpen, savepointWrites, subXidAllocated, rwEdges>>
+
+AbortSSI(t) ==
+    /\ status[t] = "active"
+    /\ isolation[t] = "SSI"
+    /\ FCWConflictFree(t)
+    /\ Dangerous(rwEdges \union NewRwEdges(t))
+    /\ status' = [status EXCEPT ![t] = "aborted"]
+    /\ abortReason' = abortReason \union {"ssi"}
+    /\ UNCHANGED
+        <<nextXid, isolation, xidRank, activeAtBegin, readSet, readFrom,
+          writeSet, savepointOpen, savepointWrites, subXidAllocated, rwEdges>>
+
+Next ==
+    \/ \E t \in Txns, level \in EnabledLevels : Begin(t, level)
+    \/ \E t \in Txns, row \in Rows : Read(t, row)
+    \/ \E t \in Txns, row \in Rows : Write(t, row)
+    \/ \E t \in Txns : Savepoint(t)
+    \/ \E t \in Txns : ReleaseSavepoint(t)
+    \/ \E t \in Txns : RollbackToSavepoint(t)
+    \/ \E t \in Txns : Commit(t)
+    \/ \E t \in Txns : AbortFCW(t)
+    \/ \E t \in Txns : AbortSSI(t)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* Serial oracle. A committed history is serializable when some serial      *)
+(* ordering of the admitted transactions explains every read: each read saw *)
+(* the last prior transaction in that order that wrote the row, or 0 for    *)
+(* the initial row value.                                                   *)
+(***************************************************************************)
+Orders(S) ==
+    {order \in [1..Cardinality(S) -> S] :
+        \A a, b \in 1..Cardinality(S) : order[a] = order[b] => a = b}
+
+Pos(order, t) == CHOOSE i \in DOMAIN order : order[i] = t
+
+WritersBefore(order, t, row) ==
+    {w \in DOMAIN order :
+        /\ Pos(order, order[w]) < Pos(order, t)
+        /\ row \in writeSet[order[w]]}
+
+LastWriterBefore(order, t, row) ==
+    LET writers == WritersBefore(order, t, row) IN
+        IF writers = {}
+        THEN 0
+        ELSE order[CHOOSE i \in writers : \A j \in writers : j <= i]
+
+SerializableSet(S) ==
+    \E order \in Orders(S) :
+        \A t \in S :
+            \A row \in readSet[t] :
+                readFrom[t][row] = LastWriterBefore(order, t, row)
+
+(***************************************************************************)
+(* Safety properties checked by TLC.                                        *)
+(***************************************************************************)
+
+SI_NoLostUpdate ==
+    \A a, b \in Txns :
+        /\ status[a] = "committed"
+        /\ status[b] = "committed"
+        /\ a # b
+        /\ writeSet[a] \cap writeSet[b] # {}
+        /\ ~VisibleTo(a, b)
+        /\ ~VisibleTo(b, a)
+        => FALSE
+
+SI_SnapshotStability ==
+    \A t \in Txns :
+        \A row \in readSet[t] :
+            row \notin writeSet[t] =>
+            readFrom[t][row] = VisibleWriter(t, row)
+
+SSI_Serializable ==
+    LET committed == {t \in Txns : status[t] = "committed"} IN
+        (\A t \in committed : isolation[t] = "SSI") => SerializableSet(committed)
+
+(***************************************************************************)
+(* Non-vacuity witnesses. They are included as named model predicates so    *)
+(* TLC state dumps can be searched and future dedicated witness configs can *)
+(* target them directly.                                                    *)
+(***************************************************************************)
+
+FCWConflictReached == "fcw" \in abortReason
+
+DangerousStructureReached == "ssi" \in abortReason
+
+OptimisticAdmitsMoreThan2PL ==
+    \E a, b \in Txns :
+        /\ a # b
+        /\ status[a] = "committed"
+        /\ status[b] = "committed"
+        /\ isolation[a] = "SSI"
+        /\ isolation[b] = "SSI"
+        /\ writeSet[a] \cap readSet[b] # {}
+        /\ writeSet[b] \cap readSet[a] = {}
+
+\* Negated witness predicates are useful for local reachability checks:
+\* adding any one of these as a temporary TLC invariant must fail.
+NoFCWConflictReached == ~FCWConflictReached
+NoDangerousStructureReached == ~DangerousStructureReached
+NoOptimisticAdmitsMoreThan2PL == ~OptimisticAdmitsMoreThan2PL
+
+=============================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -1,10 +1,9 @@
-# TLA+ specs for the replication consensus core
+# TLA+ specs for RedDB safety models
 
-Formal models of RedDB's term-based, quorum-gated replication safety
-(issue #841, PRD #819). Each module asserts **one** safety property and is
-model-checked by TLC in CI (`.github/workflows/tla-check.yml`). The models are
-deliberately small (3 nodes / 3 terms) so they exhaust their state space in
-seconds-to-minutes, not hours.
+Formal models of RedDB's replication and transaction safety contracts. Each
+module asserts a focused bounded safety envelope and is model-checked by TLC in
+CI (`.github/workflows/tla-check.yml`). The models are deliberately small so
+they exhaust their state space in seconds-to-minutes, not hours.
 
 The randomized executable counterpart is the
 [replication Maelstrom-style protocol model](../../docs/testing/replication-maelstrom-model.md).
@@ -16,7 +15,9 @@ Jepsen-style cluster harness.
 | --- | --- | --- |
 | [`ElectionSafety.tla`](ElectionSafety.tla) | No two nodes hold primary in the same term. | `replication/election.rs` (`Voter::consider`, `quorum_threshold`); ADR 0030 "no two primaries in a term" (#834). |
 | [`Durability.tla`](Durability.tla) | A write at/below the commit watermark is never rolled back (`CommittedNeverRolledBack` + `LeaderCompleteness`). | ADR 0030 commit-watermark / `NeverRollbackCommitted`; ADR 0032 `(term, lsn)` framing; `replication/quorum.rs`, `commit_waiter.rs`, `rollback.rs`. |
+| [`ReplicationSafetyEnvelope.tla`](ReplicationSafetyEnvelope.tla) | Single-writer fencing, election safety, partition behavior, and crash/recovery durability in one bounded model. | ADR 0030 / ADR 0032; writer fencing, quorum commit, crash/restart recovery. |
 | [`SafeReconfig.tla`](SafeReconfig.tla) | Every membership change preserves quorum overlap (old and new quorums intersect). | ADR 0030 membership rules; Raft single-server change. |
+| [`CommitProtocol.tla`](CommitProtocol.tla) | Optimistic MVCC commit safety: no lost update under FCW, stable snapshot reads, and SSI-admitted histories are serializable. | ADR 0065 TM v2; `SnapshotManager::begin` / `snapshot` / `commit`; `visibility::is_visible`; SQL table-row commit conflict checks; `TxnContext` savepoint sub-xids. |
 
 ## How the models mirror the implementation
 
@@ -41,6 +42,40 @@ Jepsen-style cluster harness.
   safe Raft rule), and TLC checks that a quorum of the pre-change config always
   intersects a quorum of the post-change config. `JumpBreaksOverlap` documents
   why a multi-member jump is unsafe, so the property is not vacuous.
+* **Commit protocol** — `Begin` abstracts `SnapshotManager::begin()` plus
+  `snapshot()`: xids are allocated monotonically, and the begin snapshot records
+  the active in-progress set. `VisibleWriter` mirrors
+  `storage::transaction::visibility::is_visible`: writers with future xids or
+  xids active in the reader's snapshot are hidden. `Commit` performs the live
+  first-committer-wins check over logical rows before admitting writes. The
+  savepoint actions model `TxnContext` sub-xid frames: `SAVEPOINT` allocates a
+  frame, `ROLLBACK TO` removes that frame's writes, and `RELEASE` keeps them for
+  parent commit. For SSI, `NewRwEdges` records rw-antidependencies and
+  `AbortSSI` rejects a commit that would create a dangerous structure. The
+  serializability invariant compares every all-SSI admitted history against a
+  serial-execution oracle on the same bounded rows.
+
+## Commit protocol non-vacuity
+
+`CommitProtocol.tla` names the witness predicates checked while developing the
+bounded model:
+
+* `FCWConflictReached` — the state space contains a commit-time FCW abort for
+  overlapping transactions that write the same logical row.
+* `DangerousStructureReached` — the state space contains an SSI abort caused by
+  two consecutive rw-antidependency edges.
+* `OptimisticAdmitsMoreThan2PL` — the state space contains an all-SSI history
+  with a read/write overlap admitted by the optimistic protocol, documenting
+  that the model is not equivalent to naive strict two-phase locking.
+
+The CI config keeps all transactions on the SSI path (`EnabledLevels = {"SSI"}`)
+because SSI includes the Snapshot Isolation visibility and FCW checks while
+making the serial-oracle property non-vacuous in a small three-transaction,
+two-row model. For local reachability checks, temporarily add
+`NoFCWConflictReached`, `NoDangerousStructureReached`, or
+`NoOptimisticAdmitsMoreThan2PL` as an invariant; TLC must reject the model with
+a counterexample reaching the corresponding witness state. These negated
+witness invariants are not in CI because their success condition is failure.
 
 ## Running locally
 
@@ -50,7 +85,7 @@ Needs a JDK (17+) and `tla2tools.jar` (pinned to `v1.8.0` in CI):
 curl -fsSL -o tla2tools.jar \
   https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
 
-# Check one module (repeat for Durability, SafeReconfig):
+# Check one module (repeat for Durability, SafeReconfig, CommitProtocol):
 java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
   -deadlock -config ElectionSafety.cfg ElectionSafety.tla
 ```


### PR DESCRIPTION
Automated AFK landing for #1646. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1646

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785669417&installation_id=129708444&pr_number=1686&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1686&signature=27cdd88cae74f42e7dc8621ec79d463e5459a09c313ca53e3838dfd54b052b3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->