### PR TITLE
merge: #1645 feat(tm): READ COMMITTED per-statement snapshot semantics (TM v2 2/8)

### DIFF
--- a/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
@@ -555,14 +555,21 @@ impl RedDBRuntime {
     /// Return the snapshot the current connection should use for visibility
     /// checks (Phase 2.3 PG parity).
     ///
-    /// * If the connection is inside a BEGIN-wrapped transaction, reuse
-    ///   the snapshot stored in its `TxnContext`.
+    /// * If the connection is inside a READ COMMITTED transaction, capture
+    ///   a fresh statement snapshot while preserving the transaction's xid
+    ///   and write-set lifecycle.
+    /// * If the connection is inside a SNAPSHOT transaction, reuse the
+    ///   snapshot stored in its `TxnContext`.
     /// * Otherwise (autocommit), capture a fresh snapshot tied to an
     ///   implicit xid=0 — the read path treats pre-MVCC rows as always
     ///   visible so this degrades to "see everything committed".
     pub fn current_snapshot(&self) -> crate::storage::transaction::snapshot::Snapshot {
         let conn_id = current_connection_id();
         if let Some(ctx) = self.inner.tx_contexts.read().get(&conn_id).cloned() {
+            if ctx.isolation == crate::storage::transaction::IsolationLevel::ReadCommitted {
+                let high_water = self.inner.snapshot_manager.peek_next_xid();
+                return self.inner.snapshot_manager.snapshot(high_water);
+            }
             return ctx.snapshot;
         }
         // Autocommit: take a fresh snapshot bounded by `peek_next_xid` so

--- a/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
@@ -143,7 +143,12 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
                 .map(Value::text)
                 .unwrap_or(Value::Null),
             isolation
-                .map(|_| Value::text("snapshot_isolation"))
+                .map(|level| match level {
+                    crate::storage::transaction::IsolationLevel::ReadCommitted => {
+                        Value::text("read_committed")
+                    }
+                    _ => Value::text("snapshot_isolation"),
+                })
                 .unwrap_or(Value::Null),
         ],
     )])

--- a/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
+++ b/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
@@ -94,18 +94,39 @@ fn text_cell(row: &reddb::storage::query::unified::UnifiedRecord, column: &str) 
     }
 }
 
+fn int_cell(row: &reddb::storage::query::unified::UnifiedRecord, column: &str) -> i64 {
+    match row.get(column) {
+        Some(Value::Integer(value)) => *value,
+        Some(Value::UnsignedInteger(value)) => *value as i64,
+        other => panic!("expected integer in {column}, got {other:?}"),
+    }
+}
+
 #[test]
 fn begin_isolation_level_round_trips_to_transaction_status() {
     let rt = rt();
 
-    for (offset, (sql, requested)) in [
-        ("BEGIN ISOLATION LEVEL READ UNCOMMITTED", "read_uncommitted"),
-        ("BEGIN ISOLATION LEVEL READ COMMITTED", "read_committed"),
+    for (offset, (sql, requested, effective)) in [
+        (
+            "BEGIN ISOLATION LEVEL READ UNCOMMITTED",
+            "read_uncommitted",
+            "snapshot_isolation",
+        ),
+        (
+            "BEGIN ISOLATION LEVEL READ COMMITTED",
+            "read_committed",
+            "read_committed",
+        ),
         (
             "BEGIN ISOLATION LEVEL REPEATABLE READ",
             "snapshot_isolation",
+            "snapshot_isolation",
         ),
-        ("BEGIN ISOLATION LEVEL SNAPSHOT", "snapshot_isolation"),
+        (
+            "BEGIN ISOLATION LEVEL SNAPSHOT",
+            "snapshot_isolation",
+            "snapshot_isolation",
+        ),
     ]
     .into_iter()
     .enumerate()
@@ -121,13 +142,79 @@ fn begin_isolation_level_round_trips_to_transaction_status() {
         assert_eq!(text_cell(row, "isolation_level"), requested, "{sql}");
         assert_eq!(
             text_cell(row, "effective_isolation_level"),
-            "snapshot_isolation",
+            effective,
             "{sql}"
         );
 
         try_exec(&rt, "COMMIT").expect("COMMIT should close the tx");
     }
 
+    clear_current_connection_id();
+}
+
+#[test]
+fn read_committed_refreshes_snapshot_per_statement_but_snapshot_does_not() {
+    let rt = rt();
+    set_current_connection_id(9970);
+    try_exec(&rt, "CREATE TABLE rc_statement_snap (id INT, label TEXT)").unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO rc_statement_snap (id, label) VALUES (1, 'base')",
+    )
+    .unwrap();
+
+    try_exec(&rt, "BEGIN ISOLATION LEVEL READ COMMITTED").unwrap();
+    let rc_first = select_count(&rt, "SELECT * FROM rc_statement_snap");
+    assert_eq!(rc_first, 1, "RC first statement sees initial row");
+
+    set_current_connection_id(9971);
+    try_exec(&rt, "BEGIN").unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO rc_statement_snap (id, label) VALUES (2, 'concurrent')",
+    )
+    .unwrap();
+    try_exec(&rt, "COMMIT").unwrap();
+
+    set_current_connection_id(9970);
+    let rc_second = select_count(&rt, "SELECT * FROM rc_statement_snap");
+    assert_eq!(rc_second, 2, "RC next statement sees concurrent commit");
+    try_exec(&rt, "COMMIT").unwrap();
+
+    set_current_connection_id(9972);
+    try_exec(
+        &rt,
+        "CREATE TABLE snapshot_statement_snap (id INT, label TEXT)",
+    )
+    .unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO snapshot_statement_snap (id, label) VALUES (1, 'base')",
+    )
+    .unwrap();
+    try_exec(&rt, "BEGIN ISOLATION LEVEL SNAPSHOT").unwrap();
+    let snapshot_first = select_count(&rt, "SELECT * FROM snapshot_statement_snap");
+    assert_eq!(
+        snapshot_first, 1,
+        "SNAPSHOT first statement sees initial row"
+    );
+
+    set_current_connection_id(9973);
+    try_exec(&rt, "BEGIN").unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO snapshot_statement_snap (id, label) VALUES (2, 'concurrent')",
+    )
+    .unwrap();
+    try_exec(&rt, "COMMIT").unwrap();
+
+    set_current_connection_id(9972);
+    let snapshot_second = select_count(&rt, "SELECT * FROM snapshot_statement_snap");
+    assert_eq!(
+        snapshot_second, 1,
+        "SNAPSHOT keeps the transaction-begin snapshot"
+    );
+    try_exec(&rt, "COMMIT").unwrap();
     clear_current_connection_id();
 }
 
@@ -148,6 +235,48 @@ fn writer_sees_own_uncommitted_row() {
 
     let after = select_count(&rt, "SELECT * FROM ryo WHERE id = 1");
     assert_eq!(after, 0, "rollback must hide the writer's own row");
+    clear_current_connection_id();
+}
+
+#[test]
+fn read_committed_keeps_own_writes_visible_across_statement_snapshots() {
+    let rt = rt();
+    set_current_connection_id(9980);
+    try_exec(&rt, "CREATE TABLE rc_own_writes (id INT, label TEXT)").unwrap();
+    try_exec(&rt, "BEGIN ISOLATION LEVEL READ COMMITTED").unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO rc_own_writes (id, label) VALUES (1, 'parent')",
+    )
+    .unwrap();
+    let first = rt
+        .execute_query("SELECT id FROM rc_own_writes")
+        .expect("select own write");
+    assert_eq!(first.result.records.len(), 1);
+    assert_eq!(int_cell(&first.result.records[0], "id"), 1);
+
+    set_current_connection_id(9981);
+    try_exec(&rt, "BEGIN").unwrap();
+    try_exec(
+        &rt,
+        "INSERT INTO rc_own_writes (id, label) VALUES (2, 'other')",
+    )
+    .unwrap();
+    try_exec(&rt, "COMMIT").unwrap();
+
+    set_current_connection_id(9980);
+    let second = rt
+        .execute_query("SELECT id FROM rc_own_writes")
+        .expect("select own and concurrent writes");
+    let mut ids: Vec<i64> = second
+        .result
+        .records
+        .iter()
+        .map(|row| int_cell(row, "id"))
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2]);
+    try_exec(&rt, "ROLLBACK").unwrap();
     clear_current_connection_id();
 }
 

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
@@ -241,3 +241,35 @@ fn stale_transaction_conflicts_with_autocommit_update() {
     );
     clear_current_connection_id();
 }
+
+#[test]
+fn read_committed_stale_update_conflicts_with_concurrent_commit() {
+    let rt = rt();
+    set_current_connection_id(43951);
+    exec(&rt, "CREATE TABLE fcw_rc (id INT, label TEXT)");
+    exec(&rt, "INSERT INTO fcw_rc (id, label) VALUES (1, 'base')");
+    let eid = rid(&rt, "fcw_rc", 1);
+
+    set_current_connection_id(43952);
+    exec(&rt, "BEGIN ISOLATION LEVEL READ COMMITTED");
+    assert_eq!(label_for(&rt, "fcw_rc", eid).as_deref(), Some("base"));
+
+    set_current_connection_id(43953);
+    exec(&rt, "BEGIN");
+    exec(
+        &rt,
+        &format!("UPDATE fcw_rc SET label = 'first' WHERE rid = {eid}"),
+    );
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(43952);
+    exec(
+        &rt,
+        &format!("UPDATE fcw_rc SET label = 'stale' WHERE rid = {eid}"),
+    );
+    assert_conflict(&exec_err(&rt, "COMMIT"));
+
+    set_current_connection_id(43954);
+    assert_eq!(label_for(&rt, "fcw_rc", eid).as_deref(), Some("first"));
+    clear_current_connection_id();
+}

--- a/tests/grouped/mvcc_transactions/e2e_savepoints.rs
+++ b/tests/grouped/mvcc_transactions/e2e_savepoints.rs
@@ -5,6 +5,7 @@
 //! each test pins a deterministic connection id for the duration.
 
 use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
 fn rt() -> RedDBRuntime {
@@ -18,6 +19,22 @@ fn exec(rt: &RedDBRuntime, sql: &str) {
 
 fn try_exec(rt: &RedDBRuntime, sql: &str) -> Result<(), String> {
     rt.execute_query(sql).map(|_| ()).map_err(|e| e.to_string())
+}
+
+fn ids(rt: &RedDBRuntime, sql: &str) -> Vec<i64> {
+    let result = rt.execute_query(sql).expect("select ids");
+    let mut ids: Vec<i64> = result
+        .result
+        .records
+        .iter()
+        .map(|row| match row.get("id") {
+            Some(Value::Integer(value)) => *value,
+            Some(Value::UnsignedInteger(value)) => *value as i64,
+            other => panic!("expected id integer, got {other:?}"),
+        })
+        .collect();
+    ids.sort_unstable();
+    ids
 }
 
 #[test]
@@ -78,6 +95,40 @@ fn rollback_to_savepoint_discards_inner_writes() {
         1,
         "ROLLBACK TO must discard the inner insert"
     );
+
+    clear_current_connection_id();
+}
+
+#[test]
+fn read_committed_resnapshot_preserves_savepoint_visibility() {
+    let rt = rt();
+    set_current_connection_id(1007);
+
+    exec(&rt, "CREATE TABLE sp_rc (id INT, label TEXT)");
+    exec(&rt, "INSERT INTO sp_rc (id, label) VALUES (1, 'base')");
+    exec(&rt, "BEGIN ISOLATION LEVEL READ COMMITTED");
+    exec(&rt, "SAVEPOINT sp1");
+    exec(&rt, "INSERT INTO sp_rc (id, label) VALUES (2, 'inner')");
+    assert_eq!(ids(&rt, "SELECT id FROM sp_rc"), vec![1, 2]);
+
+    set_current_connection_id(1008);
+    exec(&rt, "BEGIN");
+    exec(&rt, "INSERT INTO sp_rc (id, label) VALUES (3, 'other')");
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(1007);
+    assert_eq!(
+        ids(&rt, "SELECT id FROM sp_rc"),
+        vec![1, 2, 3],
+        "RC must see its savepoint write plus concurrent committed rows"
+    );
+    exec(&rt, "ROLLBACK TO SAVEPOINT sp1");
+    assert_eq!(
+        ids(&rt, "SELECT id FROM sp_rc"),
+        vec![1, 3],
+        "rolled-back savepoint xid stays hidden after RC re-snapshot"
+    );
+    exec(&rt, "COMMIT");
 
     clear_current_connection_id();
 }


### PR DESCRIPTION
Automated AFK landing for #1645. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1645

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785670279&installation_id=129708444&pr_number=1687&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1687&signature=1966b3a386cea60b16c2b36add37308275e285e4c2a364e64c2abdb95573768e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->