### PR TITLE
merge: #1648 fix(tm): unify the WAL page-TM and SnapshotManager XID spaces (TM v2 4/8)

### DIFF
--- a/crates/reddb-server/src/storage/engine/database.rs
+++ b/crates/reddb-server/src/storage/engine/database.rs
@@ -45,6 +45,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use super::{Page, PageType, Pager, PagerConfig};
+use crate::storage::transaction::snapshot::SnapshotManager;
 use crate::storage::wal::{
     CheckpointError, CheckpointMode, CheckpointResult, Checkpointer, Transaction,
     TransactionManager, TxError,
@@ -225,10 +226,12 @@ impl Database {
         let pager =
             Pager::open(&path, pager_config).map_err(|e| DatabaseError::Pager(e.to_string()))?;
         let pager = Arc::new(pager);
+        let snapshot_manager = Arc::new(SnapshotManager::new());
 
         // Perform crash recovery if WAL exists
         if wal_path.exists() && !config.read_only {
             let recovery_result = Checkpointer::recover(&pager, &wal_path)?;
+            snapshot_manager.observe_committed_xid(recovery_result.max_transaction_id);
             if recovery_result.pages_checkpointed > 0 {
                 tracing::info!(
                     transactions = recovery_result.transactions_processed,
@@ -240,7 +243,12 @@ impl Database {
 
         // Create transaction manager
         let tx_manager = Arc::new(
-            TransactionManager::new(Arc::clone(&pager), &wal_path).map_err(DatabaseError::Io)?,
+            TransactionManager::new_with_snapshot_manager(
+                Arc::clone(&pager),
+                &wal_path,
+                snapshot_manager,
+            )
+            .map_err(DatabaseError::Io)?,
         );
 
         // P6.T1 — bgwriter wiring is gated behind `REDDB_BGWRITER=1`

--- a/crates/reddb-server/src/storage/transaction/README.md
+++ b/crates/reddb-server/src/storage/transaction/README.md
@@ -36,25 +36,30 @@ If you need transactional behavior right now, go through the active path:
 use crate::storage::wal::transaction::TransactionManager as ActiveTM;
 ```
 
-### 2. Active XIDs come from a single `AtomicU64`, not from this module
+### 2. Active XIDs come from `SnapshotManager`, not from this module
 
-`src/storage/wal/transaction.rs:34-40` defines the production XID
-allocator:
+The production XID allocator is
+`storage::transaction::snapshot::SnapshotManager`. The active page-level
+WAL transaction manager (`src/storage/wal/transaction.rs`) receives an
+`Arc<SnapshotManager>` and calls `begin()` / `commit()` / `rollback()` on
+that shared authority for its WAL `tx_id`s. Row MVCC xids, savepoint
+sub-xids, autocommit born-committed xids, and page-WAL transaction ids
+therefore live in one monotonic space.
 
-```rust
-static NEXT_TX_ID: AtomicU64 = AtomicU64::new(1);
-fn next_transaction_id() -> u64 {
-    NEXT_TX_ID.fetch_add(1, Ordering::SeqCst)
-}
-```
+On startup, runtime MVCC rehydrates the floor by scanning persisted
+`xmin` / `xmax` values, while page-WAL recovery reports the highest WAL
+transaction id it observed so the snapshot manager can advance past any
+replayed WAL ids before new transactions begin.
 
 `coordinator::TransactionManager` has its own `next_id: AtomicU64`
-(`coordinator.rs:319`). **The two are not coordinated.** Mixing them gives
-you two non-overlapping XID spaces and breaks visibility checks.
+(`coordinator.rs:319`) because this module is still dormant test
+scaffolding. **Do not use that allocator for production xids.** Mixing it
+with the active snapshot manager gives you a second XID space and breaks
+cross-layer correlation.
 
-When (not if) we promote `coordinator` to production, the active allocator
-must be retired or both must funnel through a single shared atomic. Until
-then, do **not** call `coordinator::TransactionManager` outside its tests.
+When (not if) we promote `coordinator` to production, its allocator must
+be retired or changed to delegate to `SnapshotManager`. Until then, do
+**not** call `coordinator::TransactionManager` outside its tests.
 
 ### 3. MVCC visibility lives in the btree version chain, not in row headers
 

--- a/crates/reddb-server/src/storage/wal/checkpoint.rs
+++ b/crates/reddb-server/src/storage/wal/checkpoint.rs
@@ -45,6 +45,8 @@ pub enum CheckpointMode {
 pub struct CheckpointResult {
     /// Number of transactions processed
     pub transactions_processed: u64,
+    /// Highest transaction id observed while scanning the WAL.
+    pub max_transaction_id: u64,
     /// Number of pages checkpointed
     pub pages_checkpointed: u64,
     /// Number of records processed
@@ -104,6 +106,10 @@ struct PendingWrite {
     lsn: u64,
 }
 
+fn result_observe_tx_id(max_transaction_id: &mut u64, tx_id: u64) {
+    *max_transaction_id = (*max_transaction_id).max(tx_id);
+}
+
 /// Checkpoint manager
 ///
 /// Responsible for transferring committed transactions from the WAL to the main database file.
@@ -155,6 +161,7 @@ impl Checkpointer {
         let mut pending_writes: Vec<PendingWrite> = Vec::new();
         let mut records_processed: u64 = 0;
         let mut last_lsn: u64 = 0;
+        let mut max_transaction_id: u64 = 0;
 
         for record_result in wal_reader.iter() {
             let (lsn, record) = record_result.map_err(CheckpointError::Io)?;
@@ -163,12 +170,15 @@ impl Checkpointer {
 
             match record {
                 WalRecord::Begin { tx_id } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     tx_states.insert(tx_id, TxState::Active);
                 }
                 WalRecord::Commit { tx_id } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     tx_states.insert(tx_id, TxState::Committed);
                 }
                 WalRecord::Rollback { tx_id } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     tx_states.insert(tx_id, TxState::Aborted);
                 }
                 WalRecord::PageWrite {
@@ -176,6 +186,7 @@ impl Checkpointer {
                     page_id,
                     data,
                 } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     pending_writes.push(PendingWrite {
                         tx_id,
                         page_id,
@@ -189,7 +200,8 @@ impl Checkpointer {
                     // Checkpoint marker - we can skip records before this LSN
                     // For now, we process everything
                 }
-                WalRecord::TxCommitBatch { .. } => {
+                WalRecord::TxCommitBatch { tx_id, .. } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     // Store-level logical commit batches are replayed by
                     // UnifiedStore, not by the pager page checkpoint path.
                 }
@@ -201,7 +213,8 @@ impl Checkpointer {
                         crate::runtime::turbo_crash_inject::InjectionPoint::MidCheckpoint,
                     );
                 }
-                WalRecord::FullPageImage { .. } => {
+                WalRecord::FullPageImage { tx_id, .. } => {
+                    result_observe_tx_id(&mut max_transaction_id, tx_id);
                     // FPI records (gh-478) are consumed by the pager
                     // recovery path before redo, not by checkpoint
                     // accounting.
@@ -290,6 +303,7 @@ impl Checkpointer {
 
         Ok(CheckpointResult {
             transactions_processed: committed_txs.len() as u64,
+            max_transaction_id,
             pages_checkpointed,
             records_processed,
             checkpoint_lsn: last_lsn,
@@ -546,6 +560,7 @@ mod tests {
 
         // Only committed transactions (1 and 3) should be processed
         assert_eq!(result.transactions_processed, 2);
+        assert_eq!(result.max_transaction_id, 3);
         assert_eq!(result.pages_checkpointed, 2);
 
         // Verify pages

--- a/crates/reddb-server/src/storage/wal/transaction.rs
+++ b/crates/reddb-server/src/storage/wal/transaction.rs
@@ -24,7 +24,6 @@
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use parking_lot::{Mutex, MutexGuard};
@@ -33,14 +32,7 @@ use super::append_coordinator::WalAppendCoordinator;
 use super::record::WalRecord;
 use super::writer::WalWriter;
 use crate::storage::engine::{Page, Pager, PAGE_SIZE};
-
-/// Global transaction ID counter
-static NEXT_TX_ID: AtomicU64 = AtomicU64::new(1);
-
-/// Generate a new unique transaction ID
-fn next_transaction_id() -> u64 {
-    NEXT_TX_ID.fetch_add(1, Ordering::SeqCst)
-}
+use crate::storage::transaction::snapshot::SnapshotManager;
 
 /// Transaction state
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -206,6 +198,7 @@ impl Transaction {
         if self.write_set.is_empty() {
             self.state = TxState::Committed;
             self.manager.unregister_transaction(self.id);
+            self.manager.snapshot_manager.commit(self.id);
             return Ok(());
         }
 
@@ -260,6 +253,7 @@ impl Transaction {
 
         // Unregister from manager
         self.manager.unregister_transaction(self.id);
+        self.manager.snapshot_manager.commit(self.id);
 
         Ok(())
     }
@@ -293,6 +287,7 @@ impl Transaction {
 
         // Unregister from manager
         self.manager.unregister_transaction(self.id);
+        self.manager.snapshot_manager.rollback(self.id);
 
         Ok(())
     }
@@ -315,6 +310,7 @@ impl Drop for Transaction {
                 .coordinator
                 .commit_at_least(target, &self.manager.wal);
             self.manager.unregister_transaction(self.id);
+            self.manager.snapshot_manager.rollback(self.id);
         }
     }
 }
@@ -334,6 +330,8 @@ pub struct TransactionManager {
     wal_path: PathBuf,
     /// Active transaction IDs
     active_transactions: RwLock<Vec<u64>>,
+    /// Shared XID authority used by row MVCC and page-level WAL transactions.
+    snapshot_manager: Arc<SnapshotManager>,
     /// Lock-free append coordinator. Replaces the per-commit
     /// `wal.lock()` that used to serialise 16 concurrent writers
     /// (Roadmap #2 / issue #157). Writers reserve an LSN range via
@@ -353,6 +351,15 @@ impl TransactionManager {
     /// * `pager` - The pager to use for page I/O
     /// * `wal_path` - Path to the WAL file
     pub fn new(pager: Arc<Pager>, wal_path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::new_with_snapshot_manager(pager, wal_path, Arc::new(SnapshotManager::new()))
+    }
+
+    /// Create a transaction manager using the provided snapshot/XID manager.
+    pub fn new_with_snapshot_manager(
+        pager: Arc<Pager>,
+        wal_path: impl AsRef<Path>,
+        snapshot_manager: Arc<SnapshotManager>,
+    ) -> io::Result<Self> {
         let wal_path = wal_path.as_ref().to_path_buf();
         let wal = WalWriter::open(&wal_path)?;
         let initial_current = wal.current_lsn();
@@ -363,6 +370,7 @@ impl TransactionManager {
             wal: Mutex::new(wal),
             wal_path,
             active_transactions: RwLock::new(Vec::new()),
+            snapshot_manager,
             coordinator: WalAppendCoordinator::new(initial_current, initial_durable),
         })
     }
@@ -391,7 +399,7 @@ impl TransactionManager {
 
     /// Begin a new transaction
     pub fn begin(self: &Arc<Self>) -> Result<Transaction, TxError> {
-        let tx_id = next_transaction_id();
+        let tx_id = self.snapshot_manager.begin();
 
         // Route the Begin record through the coordinator (same
         // ordering guarantees as commit/rollback). Begin is not
@@ -710,6 +718,36 @@ mod tests {
 
         tx2.rollback().expect("rollback() should succeed");
         assert!(!tm.has_active_transactions());
+
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn page_wal_transactions_allocate_from_snapshot_manager() {
+        let dir = temp_dir();
+        let _ = fs::create_dir_all(&dir);
+        let db_path = dir.join("test.db");
+        let wal_path = temp_wal_path(&dir, "snapshot-xid");
+
+        let pager = Arc::new(Pager::open_default(&db_path).expect("open_default() should succeed"));
+        let snapshot_manager =
+            Arc::new(crate::storage::transaction::snapshot::SnapshotManager::new());
+        let row_xid = snapshot_manager.begin();
+        snapshot_manager.commit(row_xid);
+
+        let tm = Arc::new(
+            TransactionManager::new_with_snapshot_manager(
+                Arc::clone(&pager),
+                &wal_path,
+                Arc::clone(&snapshot_manager),
+            )
+            .expect("new() should succeed"),
+        );
+
+        let tx = tm.begin().expect("begin() should succeed");
+        assert_eq!(tx.id(), row_xid + 1);
+        tx.commit().expect("commit() should succeed");
+        assert_eq!(snapshot_manager.peek_next_xid(), row_xid + 2);
 
         cleanup(&dir);
     }


### PR DESCRIPTION
Automated AFK landing for #1648. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1648

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785675271&installation_id=129708444&pr_number=1688&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1688&signature=ba55451ca4d7fd6ebc5d4a402735df9ec9c4b9ed3a032ed58dd4a955fef749f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->