### PR TITLE
feat(tm): SSI — SERIALIZABLE via rw-antidependency (#1647)

### DIFF
--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -1112,7 +1112,10 @@ mod tests {
             sql_command_result("CREATE VIEW v WITH RETENTION 1 h AS SELECT * FROM users").is_err()
         );
         assert!(sql_command_result("CREATE TABLE bad WITH ANALYTICS (centrality)").is_err());
-        assert!(sql_command_result("BEGIN ISOLATION LEVEL SERIALIZABLE").is_err());
+        assert!(matches!(
+            sql_command("BEGIN ISOLATION LEVEL SERIALIZABLE"),
+            SqlCommand::TransactionControl(TxnControl::Begin(Some(IsolationLevel::Serializable)))
+        ));
         assert!(sql_command_result("EVENTS BACKFILL STATUS users").is_err());
     }
 
@@ -1231,6 +1234,10 @@ mod tests {
             (
                 "START TRANSACTION ISOLATION LEVEL SNAPSHOT",
                 IsolationLevel::SnapshotIsolation,
+            ),
+            (
+                "BEGIN ISOLATION LEVEL SERIALIZABLE",
+                IsolationLevel::Serializable,
             ),
         ] {
             assert!(
@@ -4328,13 +4335,9 @@ impl<'a> Parser<'a> {
             // BEGIN [WORK | TRANSACTION] [ISOLATION LEVEL <mode>]
             // START TRANSACTION [ISOLATION LEVEL <mode>]
             //
-            // We only implement SNAPSHOT ISOLATION (our default). We
-            // accept READ UNCOMMITTED / READ COMMITTED / REPEATABLE
-            // READ / SNAPSHOT as PG-compatible no-ops, but reject
-            // SERIALIZABLE outright — the previous behaviour of
-            // silently degrading to snapshot made the parser
-            // dishonest. Real SSI (Serializable Snapshot Isolation)
-            // is tracked as a future milestone.
+            // SNAPSHOT ISOLATION is the default. READ UNCOMMITTED /
+            // READ COMMITTED / REPEATABLE READ are accepted for
+            // PG-compatible syntax; SERIALIZABLE requests the SSI path.
             Token::Begin | Token::Start => {
                 self.advance()?;
                 let _ = self.consume(&Token::Work)? || self.consume(&Token::Transaction)?;
@@ -4368,14 +4371,7 @@ impl<'a> Parser<'a> {
                     } else if self.consume_ident_ci("SNAPSHOT")? {
                         IsolationLevel::SnapshotIsolation
                     } else if self.consume_ident_ci("SERIALIZABLE")? {
-                        return Err(ParseError::new(
-                            "ISOLATION LEVEL SERIALIZABLE is not yet supported — reddb \
-                             currently provides SNAPSHOT ISOLATION (which PG calls \
-                             REPEATABLE READ). Use REPEATABLE READ / SNAPSHOT / \
-                             READ COMMITTED, or omit ISOLATION LEVEL for the default."
-                                .to_string(),
-                            self.position(),
-                        ));
+                        IsolationLevel::Serializable
                     } else {
                         return Err(ParseError::expected(
                             vec!["READ", "REPEATABLE", "SNAPSHOT", "SERIALIZABLE"],

--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -96,6 +96,7 @@ pub struct SnapshotContext {
     pub manager: Arc<crate::storage::transaction::snapshot::SnapshotManager>,
     pub own_xids: std::collections::HashSet<crate::storage::transaction::snapshot::Xid>,
     pub requires_index_fallback: bool,
+    pub serializable_reader: Option<crate::storage::transaction::snapshot::Xid>,
 }
 
 /// Install a connection id on the current thread for the duration of a
@@ -882,7 +883,11 @@ pub fn entity_visible_under_current_snapshot(
         let Some(ctx) = guard.as_ref() else {
             return true;
         };
-        visibility_check(ctx, entity.xmin, entity.xmax)
+        let visible = visibility_check(ctx, entity.xmin, entity.xmax);
+        if visible {
+            record_serializable_read(ctx, entity);
+        }
+        visible
     })
 }
 
@@ -1017,9 +1022,32 @@ pub fn entity_visible_with_context(
         return false;
     }
     match ctx {
-        Some(ctx) => visibility_check(ctx, entity.xmin, entity.xmax),
+        Some(ctx) => {
+            let visible = visibility_check(ctx, entity.xmin, entity.xmax);
+            if visible {
+                record_serializable_read(ctx, entity);
+            }
+            visible
+        }
         None => true,
     }
+}
+
+fn record_serializable_read(
+    ctx: &SnapshotContext,
+    entity: &crate::storage::unified::entity::UnifiedEntity,
+) {
+    let Some(reader) = ctx.serializable_reader else {
+        return;
+    };
+    if !matches!(
+        &entity.kind,
+        crate::storage::unified::entity::EntityKind::TableRow { .. }
+    ) {
+        return;
+    }
+    ctx.manager
+        .record_serializable_read(reader, entity.kind.collection(), entity.logical_id());
 }
 
 #[inline]

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1408,6 +1408,9 @@ impl RedDBRuntime {
                             requested_isolation.unwrap_or(IsolationLevel::SnapshotIsolation);
                         let mgr = Arc::clone(&self.inner.snapshot_manager);
                         let xid = mgr.begin();
+                        if isolation == IsolationLevel::Serializable {
+                            mgr.begin_serializable(xid);
+                        }
                         let snapshot = mgr.snapshot(xid);
                         let ctx = TxnContext {
                             xid,
@@ -1437,6 +1440,7 @@ impl RedDBRuntime {
                                     conn_id,
                                     &ctx.snapshot,
                                     &own_xids,
+                                    ctx.isolation,
                                 ) {
                                     for (_, sub) in &ctx.savepoints {
                                         self.inner.snapshot_manager.rollback(*sub);

--- a/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
@@ -241,6 +241,7 @@ impl RedDBRuntime {
         conn_id: u64,
         snapshot: &crate::storage::transaction::snapshot::Snapshot,
         own_xids: &std::collections::HashSet<crate::storage::transaction::snapshot::Xid>,
+        isolation: crate::storage::transaction::IsolationLevel,
     ) -> RedDBResult<()> {
         let versioned_updates = self
             .inner
@@ -257,6 +258,7 @@ impl RedDBRuntime {
             .cloned()
             .unwrap_or_default();
 
+        let mut serializable_write_set = std::collections::HashSet::new();
         let store = self.inner.db.store();
         for (collection, old_id, new_id, xid, previous_xmax) in versioned_updates {
             let Some(manager) = store.get_collection(&collection) else {
@@ -266,6 +268,7 @@ impl RedDBRuntime {
                 continue;
             };
             let logical_id = old.logical_id();
+            serializable_write_set.insert((collection.clone(), logical_id));
             if self.xid_conflicts_with_snapshot(previous_xmax, snapshot, own_xids) {
                 return Err(Self::conflict_error(&collection, logical_id, previous_xmax));
             }
@@ -289,6 +292,7 @@ impl RedDBRuntime {
                 continue;
             };
             let logical_id = entity.logical_id();
+            serializable_write_set.insert((collection.clone(), logical_id));
             if self.xid_conflicts_with_snapshot(previous_xmax, snapshot, own_xids) {
                 return Err(Self::conflict_error(&collection, logical_id, previous_xmax));
             }
@@ -298,6 +302,20 @@ impl RedDBRuntime {
                 return Err(Self::conflict_error(&collection, logical_id, entity.xmax));
             }
             self.check_logical_row_conflict(&collection, logical_id, &[id], snapshot, own_xids)?;
+        }
+
+        if isolation == crate::storage::transaction::IsolationLevel::Serializable
+            && self
+                .inner
+                .snapshot_manager
+                .serializable_commit_would_be_dangerous(
+                    *own_xids.iter().min().unwrap_or(&0),
+                    &serializable_write_set,
+                )
+        {
+            return Err(RedDBError::Query(
+                "serialization conflict: serializable transaction would complete rw-antidependency dangerous structure".to_string(),
+            ));
         }
 
         Ok(())

--- a/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
@@ -143,8 +143,15 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
                 .map(Value::text)
                 .unwrap_or(Value::Null),
             isolation
-                .map(isolation_level_name)
-                .map(Value::text)
+                .map(|level| match level {
+                    crate::storage::transaction::IsolationLevel::ReadCommitted => {
+                        Value::text("read_committed")
+                    }
+                    crate::storage::transaction::IsolationLevel::Serializable => {
+                        Value::text("serializable")
+                    }
+                    _ => Value::text("snapshot_isolation"),
+                })
                 .unwrap_or(Value::Null),
         ],
     )])

--- a/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
@@ -143,7 +143,8 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
                 .map(Value::text)
                 .unwrap_or(Value::Null),
             isolation
-                .map(|_| Value::text("snapshot_isolation"))
+                .map(isolation_level_name)
+                .map(Value::text)
                 .unwrap_or(Value::Null),
         ],
     )])

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -254,6 +254,7 @@ pub(super) struct StatementExecutionFrame {
     tx_local_tenant: Option<Option<String>>,
     snapshot: Snapshot,
     own_xids: HashSet<Xid>,
+    serializable_reader: Option<Xid>,
     cache_key: String,
     is_volatile_query: bool,
     cache_safe: bool,
@@ -312,10 +313,16 @@ impl StatementExecutionFrame {
     pub(super) fn build(runtime: &RedDBRuntime, query: &str) -> RedDBResult<Self> {
         let conn_id = current_connection_id();
         let tx_local_tenant = runtime.inner.tx_local_tenants.read().get(&conn_id).cloned();
-        let own_xids = runtime.own_transaction_xids(conn_id);
+        let tx_context = runtime.inner.tx_contexts.read().get(&conn_id).cloned();
+        let own_xids = own_transaction_xids(tx_context.as_ref());
+        let serializable_reader = tx_context
+            .as_ref()
+            .filter(|ctx| {
+                ctx.isolation == crate::storage::transaction::IsolationLevel::Serializable
+            })
+            .map(|ctx| ctx.xid);
         let (snapshot, as_of_floor) = runtime.statement_snapshot(query)?;
-        let requires_index_fallback =
-            as_of_floor.is_some() || runtime.inner.tx_contexts.read().contains_key(&conn_id);
+        let requires_index_fallback = as_of_floor.is_some() || tx_context.is_some();
         let cache_key = result_cache_key(query);
         let is_volatile_query = query_has_volatile_builtin(query) || query_is_ask_statement(query);
         let cache_safe = runtime.result_cache_safe(conn_id);
@@ -355,6 +362,7 @@ impl StatementExecutionFrame {
             tx_local_tenant,
             snapshot,
             own_xids,
+            serializable_reader,
             cache_key,
             is_volatile_query,
             cache_safe,
@@ -388,6 +396,7 @@ impl StatementExecutionFrame {
                 manager: Arc::clone(&runtime.inner.snapshot_manager),
                 own_xids: self.own_xids.clone(),
                 requires_index_fallback: self.requires_index_fallback,
+                serializable_reader: self.serializable_reader,
             }),
         }
     }
@@ -796,6 +805,22 @@ impl ReadFrame for EffectiveScope {
     }
 }
 
+fn own_transaction_xids(
+    ctx: Option<&crate::storage::transaction::snapshot::TxnContext>,
+) -> HashSet<Xid> {
+    let mut set = HashSet::new();
+    if let Some(ctx) = ctx {
+        set.insert(ctx.xid);
+        for (_, sub) in &ctx.savepoints {
+            set.insert(*sub);
+        }
+        for sub in &ctx.released_sub_xids {
+            set.insert(*sub);
+        }
+    }
+    set
+}
+
 impl RedDBRuntime {
     /// Build the AI command `EffectiveScope` from the current
     /// statement thread-locals + auth store.
@@ -905,20 +930,6 @@ pub(crate) mod test_support {
 }
 
 impl RedDBRuntime {
-    fn own_transaction_xids(&self, conn_id: u64) -> HashSet<Xid> {
-        let mut set = HashSet::new();
-        if let Some(ctx) = self.inner.tx_contexts.read().get(&conn_id) {
-            set.insert(ctx.xid);
-            for (_, sub) in &ctx.savepoints {
-                set.insert(*sub);
-            }
-            for sub in &ctx.released_sub_xids {
-                set.insert(*sub);
-            }
-        }
-        set
-    }
-
     /// Resolve the snapshot for the current statement, returning
     /// the snapshot itself and (when AS OF is in effect) the
     /// resolved xid floor. The floor is the same xid carried inside

--- a/crates/reddb-server/src/runtime/table_row_mvcc_resolver.rs
+++ b/crates/reddb-server/src/runtime/table_row_mvcc_resolver.rs
@@ -124,6 +124,7 @@ mod tests {
             manager: Arc::new(SnapshotManager::new()),
             own_xids: HashSet::new(),
             requires_index_fallback: false,
+            serializable_reader: None,
         }
     }
 

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -29,6 +29,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::IsolationLevel;
+use crate::storage::unified::entity::EntityId;
 
 /// Default autocommit-xid pool batch size. Each refill reserves this
 /// many xids in a single `fetch_add` so back-to-back autocommit inserts
@@ -143,6 +144,16 @@ pub struct SnapshotManager {
     autocommit_pool: parking_lot::Mutex<AutocommitPool>,
 }
 
+pub(crate) type LogicalRowKey = (String, EntityId);
+
+#[derive(Default)]
+struct SerializableTxnState {
+    read_set: HashSet<LogicalRowKey>,
+    incoming_rw: HashSet<Xid>,
+    outgoing_rw: HashSet<Xid>,
+    committed: bool,
+}
+
 #[derive(Default)]
 struct AutocommitPool {
     next: Xid,
@@ -162,6 +173,7 @@ struct ManagerState {
     /// to zero removes the entry. `prune_aborted` skips any xid present
     /// here so its row versions stay readable.
     pinned: HashMap<Xid, u32>,
+    serializable: HashMap<Xid, SerializableTxnState>,
 }
 
 impl SnapshotManager {
@@ -202,6 +214,10 @@ impl SnapshotManager {
         // Also clear from aborted set in case of prior rollback_to call
         // that touched this xid (defensive; normally a no-op).
         state.aborted.remove(&xid);
+        if let Some(ssi) = state.serializable.get_mut(&xid) {
+            ssi.committed = true;
+        }
+        Self::prune_serializable_state(&mut state);
     }
 
     /// Allocate an xid that is *born committed* — for autocommit
@@ -253,6 +269,80 @@ impl SnapshotManager {
         let mut state = self.state.write();
         state.active.remove(&xid);
         state.aborted.insert(xid);
+        state.serializable.remove(&xid);
+        for ssi in state.serializable.values_mut() {
+            ssi.incoming_rw.remove(&xid);
+            ssi.outgoing_rw.remove(&xid);
+        }
+        Self::prune_serializable_state(&mut state);
+    }
+
+    pub(crate) fn begin_serializable(&self, xid: Xid) {
+        self.state.write().serializable.entry(xid).or_default();
+    }
+
+    pub(crate) fn record_serializable_read(
+        &self,
+        reader: Xid,
+        collection: &str,
+        logical_id: EntityId,
+    ) {
+        let mut state = self.state.write();
+        if let Some(ssi) = state.serializable.get_mut(&reader) {
+            ssi.read_set.insert((collection.to_string(), logical_id));
+        }
+    }
+
+    pub(crate) fn serializable_commit_would_be_dangerous(
+        &self,
+        writer: Xid,
+        write_set: &HashSet<LogicalRowKey>,
+    ) -> bool {
+        if write_set.is_empty() {
+            return false;
+        }
+
+        let mut state = self.state.write();
+        if !state.serializable.contains_key(&writer) {
+            return false;
+        }
+
+        let readers: Vec<Xid> = state
+            .serializable
+            .iter()
+            .filter_map(|(&reader, ssi)| {
+                if reader != writer && !ssi.read_set.is_disjoint(write_set) {
+                    Some(reader)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        for reader in readers {
+            if let Some(reader_state) = state.serializable.get_mut(&reader) {
+                reader_state.outgoing_rw.insert(writer);
+            }
+            if let Some(writer_state) = state.serializable.get_mut(&writer) {
+                writer_state.incoming_rw.insert(reader);
+            }
+        }
+
+        let Some(writer_state) = state.serializable.get(&writer) else {
+            return false;
+        };
+        let has_incoming = !writer_state.incoming_rw.is_empty();
+        let has_outgoing_to_committed = writer_state
+            .outgoing_rw
+            .iter()
+            .any(|xid| state.serializable.get(xid).is_some_and(|ssi| ssi.committed));
+        has_incoming && has_outgoing_to_committed
+    }
+
+    fn prune_serializable_state(state: &mut ManagerState) {
+        if state.active.is_empty() {
+            state.serializable.clear();
+        }
     }
 
     /// Is this xid known to have rolled back? Called by the read path to

--- a/docs/query/transactions.md
+++ b/docs/query/transactions.md
@@ -270,8 +270,8 @@ COMMIT — xid=427 committed
 ## Isolation levels
 
 `BEGIN` / `START TRANSACTION` accepts an optional `ISOLATION LEVEL`
-clause. All accepted modes run under the same snapshot engine today
-— the level is a PG compatibility shim:
+clause. Weaker PG-compatible modes use the snapshot engine; `SERIALIZABLE`
+adds SSI rw-antidependency checks for SQL table rows:
 
 | Requested level       | Actual semantics                 |
 |-----------------------|----------------------------------|
@@ -280,15 +280,21 @@ clause. All accepted modes run under the same snapshot engine today
 | `REPEATABLE READ`     | Snapshot (PG maps RR→snapshot too) |
 | `SNAPSHOT`            | Snapshot                         |
 | _(omitted)_           | Snapshot (default)               |
-| `SERIALIZABLE`        | **Rejected** — see below         |
+| `SERIALIZABLE`        | Serializable Snapshot Isolation for table rows |
 
-`SERIALIZABLE` is rejected at parse time rather than silently
-degraded: real SSI (Serializable Snapshot Isolation with predicate
-locking) is a tracked future milestone, and quietly accepting the
-keyword while providing weaker guarantees would mislead callers
-who depend on the anomaly protection SSI provides. Switch the
-statement to `REPEATABLE READ` (or omit the clause) to use the
-current snapshot engine.
+Serializable transactions record visible SQL table-row reads by stable
+logical row id. When a concurrent serializable transaction writes a newer
+version of the same logical row, RedDB records the rw-antidependency edge.
+At commit, a transaction that would complete a dangerous structure of two
+consecutive rw-antidependency edges aborts with the existing retryable
+`serialization conflict` error class.
+
+SSI state is retained while overlapping transactions can still need it:
+read sets and rw edges are dropped when transactions commit or roll back
+and the active serializable overlap drains. This follows the same retention
+boundary as the oldest-active MVCC machinery; a long-running serializable
+transaction can therefore retain concurrent committed SSI metadata until it
+finishes.
 
 ## Limitations
 
@@ -296,8 +302,9 @@ current snapshot engine.
   Full multi-model rollout is out of scope for this slice; non-table
   models either use the shared resolver where implemented or retain
   their existing documented behavior.
-- `SERIALIZABLE` isolation and SSI are out of scope. RedDB rejects
-  `SERIALIZABLE` instead of silently downgrading it.
+- Serializable isolation currently covers SQL table rows. Predicate ranges,
+  phantom protection beyond materialized logical-row reads, and full
+  multi-model SSI are out of scope.
 - Manual `VACUUM` is supported for table-row history and tombstone GC.
   An autovacuum daemon is out of scope.
 - Current secondary indexes plus MVCC recheck/fallback provide the

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -10,7 +10,7 @@ RedDB v0.1 (Beta) has the following known limitations:
 | Automatic sharding runtime | In progress | Cluster range ownership/routing foundations exist; production automatic placement and distributed serving are not supported yet. See [Cluster Sharding](../architecture/cluster-sharding.md). |
 | Full RBAC granularity | Partial | Three roles: admin, write, read |
 | Cross-model transactions | Partial (single-node) | Transaction control can cover multiple model paths that use RedDB's shared visibility resolver, but the new history-store MVCC guarantee is table-row-first. Non-table models retain their documented behavior until each path adopts the history-store resolver. Cross-node distributed transactions are not supported. |
-| `SERIALIZABLE` isolation | Rejected at parse time | Parser accepts `READ COMMITTED` / `REPEATABLE READ` / `SNAPSHOT` (all map to snapshot). SSI is future work. |
+| Full SERIALIZABLE isolation | Partial | `BEGIN ISOLATION LEVEL SERIALIZABLE` enables SSI rw-antidependency checks for SQL table rows. Predicate ranges, phantoms beyond materialized logical-row reads, multi-model SSI, and distributed serializability are future work. |
 | Autovacuum | Not supported | Manual `VACUUM` reclaims table-row history and tombstones. There is no background autovacuum daemon. |
 | Historical secondary indexes | Not supported | Table-row correctness uses current indexes with MVCC recheck and fallback. Dedicated historical indexes are future performance work. |
 | Distributed query planner | Not supported | Local cost-based planner |

--- a/docs/reference/sql-1-0-x.md
+++ b/docs/reference/sql-1-0-x.md
@@ -238,8 +238,8 @@ columns or top-level document, KV, node, or edge properties named `rid`,
 | --- | --- | --- |
 | `BEGIN [WORK\|TRANSACTION]` | `BEGIN` | supported |
 | `START TRANSACTION` | `START TRANSACTION ISOLATION LEVEL SNAPSHOT` | supported |
-| Isolation clauses | `BEGIN ISOLATION LEVEL REPEATABLE READ` | partial: maps to snapshot isolation |
-| `SERIALIZABLE` | `BEGIN ISOLATION LEVEL SERIALIZABLE` | not yet |
+| Isolation clauses | `BEGIN ISOLATION LEVEL REPEATABLE READ` | supported: weaker modes use snapshot isolation |
+| `SERIALIZABLE` | `BEGIN ISOLATION LEVEL SERIALIZABLE` | partial: SSI for SQL table rows |
 | `COMMIT` / `ROLLBACK` | `COMMIT` | supported |
 | Savepoints | `SAVEPOINT s1`, `ROLLBACK TO s1`, `RELEASE s1` | supported |
 | SDK wrapper | `await db.transaction(async (tx) => tx.insert('t', row))` | supported |

--- a/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
+++ b/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
@@ -33,6 +33,8 @@ fn transaction_docs_name_supported_table_row_guarantees() {
         "Recovery applies only complete, valid commit batches",
         "manual `VACUUM`",
         "serialization conflict",
+        "Serializable Snapshot Isolation",
+        "rw-antidependency",
         "history store",
     ] {
         assert_contains(TRANSACTIONS_DOC, required);
@@ -43,7 +45,7 @@ fn transaction_docs_name_supported_table_row_guarantees() {
 fn transaction_docs_name_explicit_deferrals() {
     for required in [
         "Full multi-model rollout is out of scope",
-        "`SERIALIZABLE` isolation and SSI are out of scope",
+        "full\n  multi-model SSI are out of scope",
         "An autovacuum daemon is out of scope",
         "Historical secondary indexes are out\n  of scope",
         "cross-node transaction atomicity are out of scope",

--- a/tests/grouped/mvcc_transactions/e2e_cross_model_tx.rs
+++ b/tests/grouped/mvcc_transactions/e2e_cross_model_tx.rs
@@ -38,6 +38,7 @@ fn visible_entities(rt: &RedDBRuntime, collection: &str) -> usize {
         manager: rt.snapshot_manager(),
         own_xids: rt.current_txn_own_xids(),
         requires_index_fallback: false,
+        serializable_reader: None,
     };
     mgr.query_all(move |e| entity_visible_with_context(Some(&ctx), e))
         .len()
@@ -158,6 +159,7 @@ fn cross_model_atomic_rollback() {
                 manager: rt.snapshot_manager(),
                 own_xids: rt.current_txn_own_xids(),
                 requires_index_fallback: false,
+                serializable_reader: None,
             };
             mgr.query_all(move |e| {
                 matches!(e.kind, EntityKind::GraphNode(_))

--- a/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
+++ b/tests/grouped/mvcc_transactions/e2e_isolation_levels.rs
@@ -1,9 +1,6 @@
 //! Transaction isolation level acceptance tests.
 //!
-//! reddb today runs all transactions under snapshot isolation. The
-//! parser accepts READ UNCOMMITTED / READ COMMITTED / REPEATABLE
-//! READ / SNAPSHOT as PG-compatibility no-ops and rejects
-//! SERIALIZABLE explicitly rather than silently downgrading.
+//! reddb accepts PG isolation-level syntax and routes SERIALIZABLE to SSI.
 
 use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
 use reddb::storage::schema::Value;
@@ -48,19 +45,12 @@ fn begin_accepts_snapshot() {
 }
 
 #[test]
-fn begin_rejects_serializable_with_clear_message() {
+fn begin_accepts_serializable() {
     let rt = rt();
     set_current_connection_id(9904);
-    let err = try_exec(&rt, "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE").unwrap_err();
-    assert!(
-        err.contains("SERIALIZABLE"),
-        "error should mention SERIALIZABLE: {err}"
-    );
-    assert!(
-        err.to_ascii_lowercase().contains("not yet supported")
-            || err.to_ascii_lowercase().contains("not supported"),
-        "error should say unsupported: {err}"
-    );
+    try_exec(&rt, "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+        .expect("SERIALIZABLE should be accepted");
+    try_exec(&rt, "COMMIT").expect("COMMIT should close the tx");
     clear_current_connection_id();
 }
 
@@ -106,6 +96,7 @@ fn begin_isolation_level_round_trips_to_transaction_status() {
             "snapshot_isolation",
         ),
         ("BEGIN ISOLATION LEVEL SNAPSHOT", "snapshot_isolation"),
+        ("BEGIN ISOLATION LEVEL SERIALIZABLE", "serializable"),
     ]
     .into_iter()
     .enumerate()
@@ -121,7 +112,7 @@ fn begin_isolation_level_round_trips_to_transaction_status() {
         assert_eq!(text_cell(row, "isolation_level"), requested, "{sql}");
         assert_eq!(
             text_cell(row, "effective_isolation_level"),
-            "snapshot_isolation",
+            requested,
             "{sql}"
         );
 

--- a/tests/grouped/mvcc_transactions/e2e_ssi_serializable.rs
+++ b/tests/grouped/mvcc_transactions/e2e_ssi_serializable.rs
@@ -1,0 +1,234 @@
+//! Serializable Snapshot Isolation rw-antidependency litmus tests.
+
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn rt() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn exec_err(rt: &RedDBRuntime, sql: &str) -> String {
+    rt.execute_query(sql)
+        .expect_err("query should fail")
+        .to_string()
+}
+
+fn int_cell(rt: &RedDBRuntime, sql: &str, column: &str) -> i64 {
+    let result = rt
+        .execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    match result.result.records[0].get(column) {
+        Some(Value::Integer(value)) => *value,
+        Some(Value::UnsignedInteger(value)) => *value as i64,
+        other => panic!("expected integer column {column}, got {other:?}"),
+    }
+}
+
+fn assert_serialization_conflict(message: &str) {
+    assert!(
+        message.contains("serialization conflict"),
+        "expected serialization conflict, got {message}"
+    );
+}
+
+#[test]
+fn snapshot_write_skew_allows_both_commits() {
+    let rt = rt();
+    set_current_connection_id(164_701);
+    exec(
+        &rt,
+        "CREATE TABLE ssi_snapshot_accounts (id INT, balance INT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO ssi_snapshot_accounts (id, balance) VALUES (1, 100), (2, 100)",
+    );
+
+    set_current_connection_id(164_702);
+    exec(&rt, "BEGIN ISOLATION LEVEL SNAPSHOT");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_snapshot_accounts",
+            "total"
+        ),
+        200
+    );
+
+    set_current_connection_id(164_703);
+    exec(&rt, "BEGIN ISOLATION LEVEL SNAPSHOT");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_snapshot_accounts",
+            "total"
+        ),
+        200
+    );
+
+    set_current_connection_id(164_702);
+    exec(
+        &rt,
+        "UPDATE ssi_snapshot_accounts SET balance = -100 WHERE id = 1",
+    );
+    set_current_connection_id(164_703);
+    exec(
+        &rt,
+        "UPDATE ssi_snapshot_accounts SET balance = -100 WHERE id = 2",
+    );
+
+    set_current_connection_id(164_702);
+    exec(&rt, "COMMIT");
+    set_current_connection_id(164_703);
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(164_704);
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_snapshot_accounts",
+            "total"
+        ),
+        -200
+    );
+    clear_current_connection_id();
+}
+
+#[test]
+fn serializable_write_skew_aborts_one_commit() {
+    let rt = rt();
+    set_current_connection_id(164_711);
+    exec(
+        &rt,
+        "CREATE TABLE ssi_serializable_accounts (id INT, balance INT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO ssi_serializable_accounts (id, balance) VALUES (1, 100), (2, 100)",
+    );
+
+    set_current_connection_id(164_712);
+    exec(&rt, "BEGIN ISOLATION LEVEL SERIALIZABLE");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_serializable_accounts",
+            "total"
+        ),
+        200
+    );
+
+    set_current_connection_id(164_713);
+    exec(&rt, "BEGIN ISOLATION LEVEL SERIALIZABLE");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_serializable_accounts",
+            "total"
+        ),
+        200
+    );
+
+    set_current_connection_id(164_712);
+    exec(
+        &rt,
+        "UPDATE ssi_serializable_accounts SET balance = -100 WHERE id = 1",
+    );
+    set_current_connection_id(164_713);
+    exec(
+        &rt,
+        "UPDATE ssi_serializable_accounts SET balance = -100 WHERE id = 2",
+    );
+
+    set_current_connection_id(164_712);
+    exec(&rt, "COMMIT");
+    set_current_connection_id(164_713);
+    assert_serialization_conflict(&exec_err(&rt, "COMMIT"));
+
+    set_current_connection_id(164_714);
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(balance) AS total FROM ssi_serializable_accounts",
+            "total"
+        ),
+        0
+    );
+    clear_current_connection_id();
+}
+
+#[test]
+fn serializable_three_transaction_dangerous_structure_aborts_pivot() {
+    let rt = rt();
+    set_current_connection_id(164_721);
+    exec(&rt, "CREATE TABLE ssi_dangerous_chain (id INT, value INT)");
+    exec(
+        &rt,
+        "INSERT INTO ssi_dangerous_chain (id, value) VALUES (1, 10), (2, 20)",
+    );
+
+    set_current_connection_id(164_722);
+    exec(&rt, "BEGIN ISOLATION LEVEL SERIALIZABLE");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(value) AS total FROM ssi_dangerous_chain WHERE id = 1",
+            "total"
+        ),
+        10
+    );
+
+    set_current_connection_id(164_723);
+    exec(&rt, "BEGIN ISOLATION LEVEL SERIALIZABLE");
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(value) AS total FROM ssi_dangerous_chain WHERE id = 2",
+            "total"
+        ),
+        20
+    );
+
+    set_current_connection_id(164_724);
+    exec(&rt, "BEGIN ISOLATION LEVEL SERIALIZABLE");
+    exec(
+        &rt,
+        "UPDATE ssi_dangerous_chain SET value = 21 WHERE id = 2",
+    );
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(164_723);
+    exec(
+        &rt,
+        "UPDATE ssi_dangerous_chain SET value = 11 WHERE id = 1",
+    );
+    assert_serialization_conflict(&exec_err(&rt, "COMMIT"));
+
+    set_current_connection_id(164_722);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(164_725);
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(value) AS total FROM ssi_dangerous_chain WHERE id = 1",
+            "total"
+        ),
+        10
+    );
+    assert_eq!(
+        int_cell(
+            &rt,
+            "SELECT SUM(value) AS total FROM ssi_dangerous_chain WHERE id = 2",
+            "total"
+        ),
+        21
+    );
+    clear_current_connection_id();
+}

--- a/tests/grouped_mvcc_transactions.rs
+++ b/tests/grouped_mvcc_transactions.rs
@@ -36,5 +36,8 @@ mod e2e_savepoint_update_reversal;
 #[path = "grouped/mvcc_transactions/e2e_savepoints.rs"]
 mod e2e_savepoints;
 
+#[path = "grouped/mvcc_transactions/e2e_ssi_serializable.rs"]
+mod e2e_ssi_serializable;
+
 #[path = "grouped/mvcc_transactions/e2e_txcommitbatch_wal.rs"]
 mod e2e_txcommitbatch_wal;


### PR DESCRIPTION
Finish-from-branch land of #1647 (SSI). Recovered the 16-commit SSI branch after it bounced with a merge-conflict against main (READ COMMITTED #1645 landed underneath it).

Conflicts resolved:
- `vcs_views.rs`: effective_isolation_level now surfaces Serializable as a real level; ReadUncommitted/SnapshotIsolation floor to snapshot_isolation.
- `e2e_isolation_levels.rs`: SERIALIZABLE row adopted the post-#1645 3-tuple (sql, requested, effective) format.

Tests: grouped_mvcc_transactions 57/57 pass, incl. serializable_write_skew_aborts_one_commit + snapshot_write_skew_allows_both_commits.

Closes #1647.

https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785675461&installation_id=129708444&pr_number=1689&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1689&signature=1be809845e190c791606aa1a67090d7e4944fcdf319336c367614088c17c901d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->