### PR TITLE
chore(tm): retire the dormant transaction coordinator (#1649)

### DIFF
--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -107,10 +107,9 @@ pub(crate) const MAX_CURSOR_BATCH_SIZE: usize = 10_000;
 // Isolation model: `read_committed_deferred`. Reads inside a transaction
 // observe the latest *committed* state; they do **not** see writes the
 // same session has buffered via `insert` / `delete` / `bulk_insert`.
-// Atomicity is best-effort — a global commit lock serializes replays, but
-// auto-committed writes from other sessions may interleave between
-// commits. Strict atomicity requires funnelling every write through a
-// single session.
+// Commit replay opens a real engine transaction and relies on the live
+// SnapshotManager xid/FCW path for ordering and rollback. Reads before
+// commit still do not see this session's buffered writes.
 
 /// Per-connection session that tracks the currently open transaction
 /// and any active streaming cursors.
@@ -478,10 +477,9 @@ fn dispatch_method(
 
             // Drive the replay through a real engine transaction so
             // failures roll back the buffered write_set atomically.
-            // Replaces the legacy `commit_lock`-serialised replay:
-            // cross-session ordering is now provided by the
-            // snapshot-manager's xid allocation, which is what the
-            // SQL `BEGIN`/`COMMIT` path has used since #31.
+            // Cross-session ordering is provided by the same
+            // SnapshotManager xid allocation used by SQL
+            // `BEGIN`/`COMMIT`.
             let replay: Result<(u64, usize), (usize, String)> = (|| {
                 runtime
                     .execute_query("BEGIN")

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1053,7 +1053,7 @@ struct RuntimeInner {
     /// and wired through DML/DDL dispatch in later P1 tasks.
     /// Dormant until P1.T3 flips the read path to `(Global,IS) →
     /// (Collection,IS)` and P1.T4/T5 pick up writes/DDL.
-    lock_manager: Arc<crate::storage::transaction::lock::LockManager>,
+    lock_manager: Arc<crate::runtime::lock_manager::LockManager>,
     /// Perf-parity env-var overrides (`REDDB_<UP_DOTTED_KEY>`).
     /// Populated once at boot, read by every config getter; takes
     /// precedence over the persisted red_config value so operators
@@ -1432,6 +1432,7 @@ pub mod lease_lifecycle;
 pub mod lease_loop;
 pub mod lease_timer_wheel;
 pub mod lifecycle;
+pub mod lock_manager;
 pub mod locking;
 pub(crate) mod materialization_limit;
 pub(crate) mod metric_descriptor_catalog;

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -177,10 +177,10 @@ pub(super) fn query_is_ask_statement(sql: &str) -> bool {
 pub(super) fn intent_lock_modes_for(
     expr: &QueryExpr,
 ) -> Option<(
-    crate::storage::transaction::lock::LockMode,
-    crate::storage::transaction::lock::LockMode,
+    crate::runtime::lock_manager::LockMode,
+    crate::runtime::lock_manager::LockMode,
 )> {
-    use crate::storage::transaction::lock::LockMode::{Exclusive, IntentExclusive, IntentShared};
+    use crate::runtime::lock_manager::LockMode::{Exclusive, IntentExclusive, IntentShared};
 
     match expr {
         // Reads — IS / IS.
@@ -1404,8 +1404,9 @@ impl RedDBRuntime {
 
                 let (kind, msg) = match ctl {
                     TxnControl::Begin(requested_isolation) => {
-                        let isolation =
-                            requested_isolation.unwrap_or(IsolationLevel::SnapshotIsolation);
+                        let isolation = requested_isolation
+                            .map(IsolationLevel::from)
+                            .unwrap_or(IsolationLevel::SnapshotIsolation);
                         let mgr = Arc::clone(&self.inner.snapshot_manager);
                         let xid = mgr.begin();
                         let snapshot = mgr.snapshot(xid);

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -123,7 +123,7 @@ impl RedDBRuntime {
     /// Handle to the intent-lock manager for tests + introspection.
     /// Production code acquires via `LockerGuard::new(rt.lock_manager())`
     /// rather than touching the manager directly.
-    pub fn lock_manager(&self) -> std::sync::Arc<crate::storage::transaction::lock::LockManager> {
+    pub fn lock_manager(&self) -> std::sync::Arc<crate::runtime::lock_manager::LockManager> {
         self.inner.lock_manager.clone()
     }
 
@@ -282,11 +282,11 @@ impl RedDBRuntime {
                                 _ => 5000,
                             }
                         });
-                    let cfg = crate::storage::transaction::lock::LockConfig {
+                    let cfg = crate::runtime::lock_manager::LockConfig {
                         default_timeout: std::time::Duration::from_millis(timeout_ms),
                         ..Default::default()
                     };
-                    crate::storage::transaction::lock::LockManager::new(cfg)
+                    crate::runtime::lock_manager::LockManager::new(cfg)
                 }),
                 rls_policies: parking_lot::RwLock::new(HashMap::new()),
                 rls_enabled_tables: parking_lot::RwLock::new(HashSet::new()),

--- a/crates/reddb-server/src/runtime/lock_manager.rs
+++ b/crates/reddb-server/src/runtime/lock_manager.rs
@@ -1,0 +1,750 @@
+//! Intent lock management for runtime dispatch.
+//!
+//! This is the live runtime lock manager used by dispatch-time
+//! collection and DDL locking. It is deliberately separate from the
+//! retired transaction coordinator modules described by ADR 0065.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{
+    Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, WaitTimeoutResult,
+};
+use std::time::{Duration, Instant};
+
+/// Transaction ID type
+pub type TxnId = u64;
+
+fn read_unpoisoned<'a, T>(lock: &'a RwLock<T>) -> RwLockReadGuard<'a, T> {
+    match lock.read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn write_unpoisoned<'a, T>(lock: &'a RwLock<T>) -> RwLockWriteGuard<'a, T> {
+    match lock.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn mutex_unpoisoned<'a, T>(lock: &'a Mutex<T>) -> MutexGuard<'a, T> {
+    match lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn wait_timeout_unpoisoned<'a, T>(
+    condvar: &Condvar,
+    guard: MutexGuard<'a, T>,
+    timeout: Duration,
+) -> (MutexGuard<'a, T>, WaitTimeoutResult) {
+    match condvar.wait_timeout(guard, timeout) {
+        Ok(result) => result,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+/// Lock modes
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LockMode {
+    /// Shared lock (read)
+    Shared,
+    /// Exclusive lock (write)
+    Exclusive,
+    /// Intent shared (for hierarchical locking)
+    IntentShared,
+    /// Intent exclusive (for hierarchical locking)
+    IntentExclusive,
+    /// Shared + Intent exclusive
+    SharedIntentExclusive,
+}
+
+impl LockMode {
+    /// Check if this mode is compatible with another
+    pub fn is_compatible(&self, other: &LockMode) -> bool {
+        use LockMode::*;
+        matches!(
+            (self, other),
+            (Shared, Shared)
+                | (Shared, IntentShared)
+                | (IntentShared, Shared)
+                | (IntentShared, IntentShared)
+                | (IntentShared, IntentExclusive)
+                | (IntentExclusive, IntentShared)
+                | (IntentExclusive, IntentExclusive)
+        )
+    }
+
+    /// Check if this mode can be upgraded to another
+    pub fn can_upgrade_to(&self, target: &LockMode) -> bool {
+        use LockMode::*;
+        matches!(
+            (self, target),
+            (Shared, Exclusive)
+                | (IntentShared, IntentExclusive)
+                | (IntentShared, SharedIntentExclusive)
+                | (Shared, SharedIntentExclusive)
+        )
+    }
+}
+
+/// Lock request result
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LockResult {
+    /// Lock granted immediately
+    Granted,
+    /// Lock request is waiting
+    Waiting,
+    /// Deadlock detected, request denied (contains cycle of transaction IDs)
+    Deadlock(Vec<TxnId>),
+    /// Timeout waiting for lock
+    Timeout,
+    /// Lock upgrade granted
+    Upgraded,
+    /// Lock already held
+    AlreadyHeld,
+    /// Transaction not found
+    TxnNotFound,
+    /// Lock limit exceeded for transaction
+    LockLimitExceeded,
+}
+
+/// Lock waiter information
+#[derive(Debug, Clone)]
+pub struct LockWaiter {
+    /// Transaction ID
+    pub txn_id: TxnId,
+    /// Requested lock mode
+    pub mode: LockMode,
+    /// When the wait started
+    pub start_time: Instant,
+    /// Maximum wait time
+    pub timeout: Duration,
+}
+
+impl LockWaiter {
+    /// Create new waiter
+    pub fn new(txn_id: TxnId, mode: LockMode, timeout: Duration) -> Self {
+        Self {
+            txn_id,
+            mode,
+            start_time: Instant::now(),
+            timeout,
+        }
+    }
+
+    /// Check if wait has timed out
+    pub fn is_timed_out(&self) -> bool {
+        self.start_time.elapsed() > self.timeout
+    }
+}
+
+/// A single lock on a resource
+#[derive(Debug)]
+struct Lock {
+    /// Resource being locked
+    resource: Vec<u8>,
+    /// Current lock holders (txn_id -> mode)
+    holders: HashMap<TxnId, LockMode>,
+    /// Waiting requests
+    waiters: VecDeque<LockWaiter>,
+}
+
+impl Lock {
+    fn new(resource: Vec<u8>) -> Self {
+        Self {
+            resource,
+            holders: HashMap::new(),
+            waiters: VecDeque::new(),
+        }
+    }
+
+    /// Check if a mode can be granted given current holders
+    fn can_grant(&self, txn_id: TxnId, mode: LockMode) -> bool {
+        // If we already hold it, check upgrade
+        if let Some(held_mode) = self.holders.get(&txn_id) {
+            if *held_mode == mode {
+                return true; // Already have it
+            }
+            // Check if upgrade is possible
+            if held_mode.can_upgrade_to(&mode) {
+                // Can only upgrade if we're the only holder or others are compatible
+                return self
+                    .holders
+                    .iter()
+                    .all(|(id, m)| *id == txn_id || mode.is_compatible(m));
+            }
+            return false;
+        }
+
+        // Check compatibility with all holders
+        self.holders.values().all(|m| mode.is_compatible(m))
+    }
+
+    /// Grant lock to transaction
+    fn grant(&mut self, txn_id: TxnId, mode: LockMode) {
+        self.holders.insert(txn_id, mode);
+    }
+
+    /// Release lock from transaction
+    fn release(&mut self, txn_id: TxnId) -> Option<LockMode> {
+        self.holders.remove(&txn_id)
+    }
+
+    /// Add waiter
+    fn add_waiter(&mut self, waiter: LockWaiter) {
+        self.waiters.push_back(waiter);
+    }
+
+    /// Process waiters after a release
+    fn process_waiters(&mut self) -> Vec<TxnId> {
+        let mut granted = Vec::new();
+
+        // Remove timed out waiters
+        self.waiters.retain(|w| !w.is_timed_out());
+
+        // Try to grant waiting requests
+        let mut i = 0;
+        while i < self.waiters.len() {
+            let waiter = &self.waiters[i];
+            if self.can_grant(waiter.txn_id, waiter.mode) {
+                if let Some(waiter) = self.waiters.remove(i) {
+                    self.grant(waiter.txn_id, waiter.mode);
+                    granted.push(waiter.txn_id);
+                }
+            } else {
+                i += 1;
+            }
+        }
+
+        granted
+    }
+}
+
+/// Lock manager configuration
+#[derive(Debug, Clone)]
+pub struct LockConfig {
+    /// Default lock timeout
+    pub default_timeout: Duration,
+    /// Enable deadlock detection
+    pub deadlock_detection: bool,
+    /// Deadlock detection interval
+    pub detection_interval: Duration,
+    /// Maximum locks per transaction
+    pub max_locks_per_txn: usize,
+}
+
+impl Default for LockConfig {
+    fn default() -> Self {
+        Self {
+            default_timeout: Duration::from_secs(30),
+            deadlock_detection: true,
+            detection_interval: Duration::from_millis(100),
+            max_locks_per_txn: 10000,
+        }
+    }
+}
+
+/// Lock manager statistics
+#[derive(Debug, Clone, Default)]
+pub struct LockStats {
+    /// Total lock requests
+    pub requests: u64,
+    /// Immediately granted
+    pub granted: u64,
+    /// Had to wait
+    pub waited: u64,
+    /// Deadlocks detected
+    pub deadlocks: u64,
+    /// Timeouts
+    pub timeouts: u64,
+    /// Current active locks
+    pub active_locks: u64,
+    /// Current waiting requests
+    pub waiting: u64,
+}
+
+/// Lock manager for coordinating transaction locks
+pub struct LockManager {
+    /// Configuration
+    config: LockConfig,
+    /// Lock table: resource -> Lock
+    locks: RwLock<HashMap<Vec<u8>, Lock>>,
+    /// Transaction locks: txn_id -> resources held
+    txn_locks: RwLock<HashMap<TxnId, HashSet<Vec<u8>>>>,
+    /// Wait-for graph: txn_id -> txns it's waiting for
+    wait_graph: RwLock<HashMap<TxnId, HashSet<TxnId>>>,
+    /// Condition variable for waiters
+    waiter_cv: Condvar,
+    /// Mutex for condition variable
+    waiter_mutex: Mutex<()>,
+    /// Statistics
+    stats: RwLock<LockStats>,
+}
+
+impl LockManager {
+    /// Create new lock manager
+    pub fn new(config: LockConfig) -> Self {
+        Self {
+            config,
+            locks: RwLock::new(HashMap::new()),
+            txn_locks: RwLock::new(HashMap::new()),
+            wait_graph: RwLock::new(HashMap::new()),
+            waiter_cv: Condvar::new(),
+            waiter_mutex: Mutex::new(()),
+            stats: RwLock::new(LockStats::default()),
+        }
+    }
+
+    /// Create with default config
+    pub fn with_defaults() -> Self {
+        Self::new(LockConfig::default())
+    }
+
+    /// Acquire a lock
+    pub fn acquire(&self, txn_id: TxnId, resource: &[u8], mode: LockMode) -> LockResult {
+        self.acquire_with_timeout(txn_id, resource, mode, self.config.default_timeout)
+    }
+
+    /// Acquire lock with custom timeout
+    pub fn acquire_with_timeout(
+        &self,
+        txn_id: TxnId,
+        resource: &[u8],
+        mode: LockMode,
+        timeout: Duration,
+    ) -> LockResult {
+        // Update stats
+        {
+            let mut stats = write_unpoisoned(&self.stats);
+            stats.requests += 1;
+        }
+
+        let resource_key = resource.to_vec();
+
+        // Check lock limit
+        {
+            let txn_locks = read_unpoisoned(&self.txn_locks);
+            if let Some(locks) = txn_locks.get(&txn_id) {
+                if locks.len() >= self.config.max_locks_per_txn && !locks.contains(&resource_key) {
+                    return LockResult::LockLimitExceeded;
+                }
+            }
+        }
+
+        // Try to acquire immediately
+        {
+            let mut locks = write_unpoisoned(&self.locks);
+            let lock = locks
+                .entry(resource_key.clone())
+                .or_insert_with(|| Lock::new(resource_key.clone()));
+
+            if lock.can_grant(txn_id, mode) {
+                let already_held = lock.holders.contains_key(&txn_id);
+                lock.grant(txn_id, mode);
+
+                // Track in txn_locks
+                let mut txn_locks = write_unpoisoned(&self.txn_locks);
+                txn_locks.entry(txn_id).or_default().insert(resource_key);
+
+                let mut stats = write_unpoisoned(&self.stats);
+                stats.granted += 1;
+                stats.active_locks = locks.values().map(|l| l.holders.len() as u64).sum();
+
+                return if already_held {
+                    LockResult::Upgraded
+                } else {
+                    LockResult::Granted
+                };
+            }
+
+            // Can't grant immediately, need to wait
+            let waiting_for: HashSet<TxnId> = lock.holders.keys().copied().collect();
+
+            if self.config.deadlock_detection {
+                let mut wait_graph = Self::build_wait_graph_from_locks(&locks);
+                wait_graph
+                    .entry(txn_id)
+                    .or_default()
+                    .extend(waiting_for.iter().copied());
+
+                if self.detect_deadlock_inner(txn_id, &wait_graph) {
+                    let cycle: Vec<TxnId> = waiting_for.iter().copied().collect();
+                    let mut stats = write_unpoisoned(&self.stats);
+                    stats.deadlocks += 1;
+                    return LockResult::Deadlock(cycle);
+                }
+
+                *write_unpoisoned(&self.wait_graph) = wait_graph;
+            }
+
+            // Add to wait queue
+            if let Some(lock) = locks.get_mut(&resource_key) {
+                lock.add_waiter(LockWaiter::new(txn_id, mode, timeout));
+            }
+
+            let mut stats = write_unpoisoned(&self.stats);
+            stats.waited += 1;
+            stats.waiting += 1;
+        }
+
+        // Wait for lock
+        let start = Instant::now();
+        loop {
+            // Wait on condition variable
+            let guard = mutex_unpoisoned(&self.waiter_mutex);
+            let (_guard, _wait_result) =
+                wait_timeout_unpoisoned(&self.waiter_cv, guard, Duration::from_millis(10));
+
+            // Check if we got the lock
+            let holders: Option<HashSet<TxnId>> = {
+                let locks = read_unpoisoned(&self.locks);
+                if let Some(lock) = locks.get(&resource_key) {
+                    if lock.holders.contains_key(&txn_id) {
+                        // Remove from wait graph
+                        if self.config.deadlock_detection {
+                            let mut wait_graph = write_unpoisoned(&self.wait_graph);
+                            wait_graph.remove(&txn_id);
+                        }
+
+                        let mut stats = write_unpoisoned(&self.stats);
+                        stats.waiting -= 1;
+
+                        return LockResult::Granted;
+                    }
+
+                    Some(lock.holders.keys().copied().collect())
+                } else {
+                    None
+                }
+            };
+
+            if self.config.deadlock_detection {
+                let locks = read_unpoisoned(&self.locks);
+                let wait_graph = Self::build_wait_graph_from_locks(&locks);
+                drop(locks);
+
+                if self.detect_deadlock_inner(txn_id, &wait_graph) {
+                    let mut stats = write_unpoisoned(&self.stats);
+                    stats.deadlocks += 1;
+                    stats.waiting -= 1;
+                    return LockResult::Deadlock(holders.unwrap_or_default().into_iter().collect());
+                }
+
+                *write_unpoisoned(&self.wait_graph) = wait_graph;
+            }
+
+            // Check timeout
+            if start.elapsed() > timeout {
+                // Remove from wait queue
+                {
+                    let mut locks = write_unpoisoned(&self.locks);
+                    if let Some(lock) = locks.get_mut(&resource_key) {
+                        lock.waiters.retain(|w| w.txn_id != txn_id);
+                    }
+                }
+
+                // Remove from wait graph
+                if self.config.deadlock_detection {
+                    let mut wait_graph = write_unpoisoned(&self.wait_graph);
+                    wait_graph.remove(&txn_id);
+                }
+
+                let mut stats = write_unpoisoned(&self.stats);
+                stats.timeouts += 1;
+                stats.waiting -= 1;
+
+                return LockResult::Timeout;
+            }
+        }
+    }
+
+    /// Release a lock
+    pub fn release(&self, txn_id: TxnId, resource: &[u8]) -> bool {
+        let resource_key = resource.to_vec();
+
+        let granted = {
+            let mut locks = write_unpoisoned(&self.locks);
+
+            if let Some(lock) = locks.get_mut(&resource_key) {
+                if lock.release(txn_id).is_some() {
+                    // Remove from txn_locks
+                    let mut txn_locks = write_unpoisoned(&self.txn_locks);
+                    if let Some(resources) = txn_locks.get_mut(&txn_id) {
+                        resources.remove(&resource_key);
+                    }
+
+                    // Process waiters
+                    let granted = lock.process_waiters();
+
+                    // Update wait graph for granted transactions
+                    if self.config.deadlock_detection && !granted.is_empty() {
+                        let mut wait_graph = write_unpoisoned(&self.wait_graph);
+                        for txn in &granted {
+                            wait_graph.remove(txn);
+                        }
+                    }
+
+                    // Clean up empty lock
+                    if lock.holders.is_empty() && lock.waiters.is_empty() {
+                        locks.remove(&resource_key);
+                    }
+
+                    // Notify waiters
+                    self.waiter_cv.notify_all();
+
+                    return true;
+                }
+            }
+
+            false
+        };
+
+        granted
+    }
+
+    /// Release all locks for a transaction
+    pub fn release_all(&self, txn_id: TxnId) -> usize {
+        let resources: Vec<Vec<u8>> = {
+            let txn_locks = read_unpoisoned(&self.txn_locks);
+            txn_locks
+                .get(&txn_id)
+                .map(|r| r.iter().cloned().collect())
+                .unwrap_or_default()
+        };
+
+        let count = resources.len();
+
+        for resource in resources {
+            self.release(txn_id, &resource);
+        }
+
+        // Clean up txn_locks entry
+        {
+            let mut txn_locks = write_unpoisoned(&self.txn_locks);
+            txn_locks.remove(&txn_id);
+        }
+
+        // Clean up wait graph
+        if self.config.deadlock_detection {
+            let mut wait_graph = write_unpoisoned(&self.wait_graph);
+            wait_graph.remove(&txn_id);
+        }
+
+        count
+    }
+
+    /// Check if transaction holds lock on resource
+    pub fn holds_lock(&self, txn_id: TxnId, resource: &[u8]) -> Option<LockMode> {
+        let locks = read_unpoisoned(&self.locks);
+        locks
+            .get(resource)
+            .and_then(|lock| lock.holders.get(&txn_id).copied())
+    }
+
+    /// Get all locks held by transaction
+    pub fn get_locks(&self, txn_id: TxnId) -> Vec<(Vec<u8>, LockMode)> {
+        let txn_locks = read_unpoisoned(&self.txn_locks);
+        let locks = read_unpoisoned(&self.locks);
+
+        txn_locks
+            .get(&txn_id)
+            .map(|resources| {
+                resources
+                    .iter()
+                    .filter_map(|r| {
+                        locks
+                            .get(r)
+                            .and_then(|l| l.holders.get(&txn_id).map(|m| (r.clone(), *m)))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Detect deadlock using DFS on wait-for graph
+    fn detect_deadlock_inner(
+        &self,
+        start: TxnId,
+        wait_graph: &HashMap<TxnId, HashSet<TxnId>>,
+    ) -> bool {
+        let mut visited = HashSet::new();
+        let mut stack = HashSet::new();
+
+        Self::dfs_cycle(start, &mut visited, &mut stack, wait_graph)
+    }
+
+    fn build_wait_graph_from_locks(
+        locks: &HashMap<Vec<u8>, Lock>,
+    ) -> HashMap<TxnId, HashSet<TxnId>> {
+        let mut graph: HashMap<TxnId, HashSet<TxnId>> = HashMap::new();
+
+        for lock in locks.values() {
+            if lock.holders.is_empty() {
+                continue;
+            }
+            let holders: HashSet<TxnId> = lock.holders.keys().copied().collect();
+            for waiter in &lock.waiters {
+                graph
+                    .entry(waiter.txn_id)
+                    .or_default()
+                    .extend(holders.iter().copied());
+            }
+        }
+
+        graph
+    }
+
+    fn dfs_cycle(
+        node: TxnId,
+        visited: &mut HashSet<TxnId>,
+        stack: &mut HashSet<TxnId>,
+        wait_graph: &HashMap<TxnId, HashSet<TxnId>>,
+    ) -> bool {
+        if stack.contains(&node) {
+            return true; // Cycle found
+        }
+        if visited.contains(&node) {
+            return false; // Already processed
+        }
+
+        visited.insert(node);
+        stack.insert(node);
+
+        if let Some(waiting_for) = wait_graph.get(&node) {
+            for &next in waiting_for {
+                if Self::dfs_cycle(next, visited, stack, wait_graph) {
+                    return true;
+                }
+            }
+        }
+
+        stack.remove(&node);
+        false
+    }
+
+    /// Get statistics
+    pub fn stats(&self) -> LockStats {
+        read_unpoisoned(&self.stats).clone()
+    }
+
+    /// Get configuration
+    pub fn config(&self) -> &LockConfig {
+        &self.config
+    }
+}
+
+impl Default for LockManager {
+    fn default() -> Self {
+        Self::with_defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lock_mode_compatibility() {
+        assert!(LockMode::Shared.is_compatible(&LockMode::Shared));
+        assert!(!LockMode::Shared.is_compatible(&LockMode::Exclusive));
+        assert!(!LockMode::Exclusive.is_compatible(&LockMode::Exclusive));
+        assert!(LockMode::IntentShared.is_compatible(&LockMode::IntentShared));
+    }
+
+    #[test]
+    fn test_lock_acquire_release() {
+        let lm = LockManager::with_defaults();
+
+        // Acquire shared lock
+        let result = lm.acquire(1, b"resource1", LockMode::Shared);
+        assert_eq!(result, LockResult::Granted);
+
+        // Another transaction can get shared lock
+        let result = lm.acquire(2, b"resource1", LockMode::Shared);
+        assert_eq!(result, LockResult::Granted);
+
+        // Release locks
+        assert!(lm.release(1, b"resource1"));
+        assert!(lm.release(2, b"resource1"));
+    }
+
+    #[test]
+    fn test_exclusive_lock() {
+        let lm = LockManager::with_defaults();
+
+        // Acquire exclusive lock
+        let result = lm.acquire(1, b"resource1", LockMode::Exclusive);
+        assert_eq!(result, LockResult::Granted);
+
+        // Check held
+        assert_eq!(lm.holds_lock(1, b"resource1"), Some(LockMode::Exclusive));
+
+        // Release
+        lm.release_all(1);
+        assert_eq!(lm.holds_lock(1, b"resource1"), None);
+    }
+
+    #[test]
+    fn test_release_all() {
+        let lm = LockManager::with_defaults();
+
+        // Acquire multiple locks
+        lm.acquire(1, b"r1", LockMode::Shared);
+        lm.acquire(1, b"r2", LockMode::Exclusive);
+        lm.acquire(1, b"r3", LockMode::Shared);
+
+        // Release all
+        let count = lm.release_all(1);
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_lock_limit_exceeded() {
+        let config = LockConfig {
+            max_locks_per_txn: 1,
+            ..LockConfig::default()
+        };
+        let lm = LockManager::new(config);
+
+        let result = lm.acquire(1, b"r1", LockMode::Shared);
+        assert_eq!(result, LockResult::Granted);
+
+        let result = lm.acquire(1, b"r2", LockMode::Shared);
+        assert_eq!(result, LockResult::LockLimitExceeded);
+    }
+
+    #[test]
+    fn test_lock_limit_allows_upgrade() {
+        let config = LockConfig {
+            max_locks_per_txn: 1,
+            ..LockConfig::default()
+        };
+        let lm = LockManager::new(config);
+
+        let result = lm.acquire(1, b"r1", LockMode::Shared);
+        assert_eq!(result, LockResult::Granted);
+
+        let result = lm.acquire(1, b"r1", LockMode::Exclusive);
+        assert_eq!(result, LockResult::Upgraded);
+    }
+
+    #[test]
+    fn test_get_locks() {
+        let lm = LockManager::with_defaults();
+
+        lm.acquire(1, b"r1", LockMode::Shared);
+        lm.acquire(1, b"r2", LockMode::Exclusive);
+
+        let locks = lm.get_locks(1);
+        assert_eq!(locks.len(), 2);
+    }
+
+    #[test]
+    fn test_waiter_timeout() {
+        let waiter = LockWaiter::new(1, LockMode::Shared, Duration::from_millis(1));
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(waiter.is_timed_out());
+    }
+}

--- a/crates/reddb-server/src/runtime/locking.rs
+++ b/crates/reddb-server/src/runtime/locking.rs
@@ -1,6 +1,6 @@
 //! Intent-lock hierarchy adapter — `Resource` naming + `LockerGuard` RAII.
 //!
-//! Thin layer over `crate::storage::transaction::lock::LockManager`
+//! Thin layer over `crate::runtime::lock_manager::LockManager`
 //! that gives the runtime dispatch paths a typed API:
 //!
 //! - Read dispatch: `(Global, IS) → (Collection, IS)`
@@ -26,7 +26,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use crate::storage::transaction::lock::{LockManager, LockMode, LockResult, TxnId};
+use crate::runtime::lock_manager::{LockManager, LockMode, LockResult, TxnId};
 
 /// Hierarchical resources the runtime locks on. The byte-key encoding
 /// prefixes each level with a discriminator so `Collection("global")`

--- a/crates/reddb-server/src/storage/transaction/README.md
+++ b/crates/reddb-server/src/storage/transaction/README.md
@@ -1,119 +1,88 @@
-# `storage/transaction` — Transaction coordinator (DORMANT)
+# `storage/transaction` — live snapshot and visibility support
 
-> **⚠️ Read this first.** The `TransactionManager` / `MvccCoordinator` defined
-> in this module is **not wired** to any production write path. It is
-> architectural scaffolding that exists for future MVCC work but **does
-> not** participate in any reddb operation today.
->
-> The active transaction manager is `src/storage/wal/transaction.rs`,
-> instantiated in `src/storage/engine/database.rs:230`. **That** is the one
-> backing real durability and the stdio `tx.*` JSON-RPC methods.
+This module is the live home for transaction isolation types, snapshot
+allocation, and MVCC visibility. It is not the retired transaction
+coordinator.
 
 ## Module layout
 
-- `coordinator.rs` — `TransactionManager` (dormant), 4 isolation levels,
-  savepoints, lock manager, conflict detection
-- `lock.rs` — `LockManager`, lock modes, wait-for graph
-- `mod.rs` — re-exports
+- `mod.rs` — live `IsolationLevel` plus exports for snapshot and visibility.
+- `snapshot.rs` — `SnapshotManager`, xid allocation, transaction contexts,
+  savepoint sub-xids, commit/abort bookkeeping.
+- `visibility.rs` — pure MVCC visibility predicate used by the runtime.
+- `coordinator.rs`, `lock.rs`, `savepoint.rs`, `log.rs` — retired
+  scaffolding, gated out of the normal build with notes pointing at ADR 0065.
 
 ## Invariants
 
-### 1. This module is dormant. Do not use it from production code paths.
+### 1. SnapshotManager is the live transaction authority
 
-`coordinator::TransactionManager::new` (`coordinator.rs:334`) is called
-**only** in test code under that file. No write path, no read path, no
-runtime instantiation references it.
+The SQL runtime creates `TxnContext` values from `SnapshotManager`. That
+manager allocates transaction xids, publishes snapshots, records committed
+and aborted xids, and tracks the savepoint sub-xids attached to an open
+transaction.
 
-The dormancy is intentional: this scaffolding lets us prototype real MVCC
-without touching the runtime. **Wiring it into production requires a
-coordinated change** — see `PLAN.md` § Post-MVP for the full plan
-(MVCC row headers + WAL-first + lock manager promotion).
+Runtime transaction control flows through `QueryExpr::TransactionControl` in
+`src/runtime/impl_core.rs`; production code must not instantiate the retired
+`coordinator::TransactionManager`.
 
-If you need transactional behavior right now, go through the active path:
+### 2. IsolationLevel lives with the live transaction module
 
-```rust
-// src/storage/wal/transaction.rs
-use crate::storage::wal::transaction::TransactionManager as ActiveTM;
-```
+`storage::transaction::IsolationLevel` is the runtime isolation enum. The SQL
+parser still produces the RQL AST enum inside `BEGIN ISOLATION LEVEL ...`;
+runtime dispatch converts that parsed value into the live enum before storing
+it in `TxnContext`.
 
-### 2. Active XIDs come from a single `AtomicU64`, not from this module
+### 3. Commit conflicts are optimistic first-committer-wins checks
 
-`src/storage/wal/transaction.rs:34-40` defines the production XID
-allocator:
+The live engine does not promote the retired pessimistic coordinator. Writes
+are checked at commit time by runtime FCW conflict checks such as
+`check_table_row_write_conflicts`, and retryable serialization conflicts are
+reported from that path.
 
-```rust
-static NEXT_TX_ID: AtomicU64 = AtomicU64::new(1);
-fn next_transaction_id() -> u64 {
-    NEXT_TX_ID.fetch_add(1, Ordering::SeqCst)
-}
-```
+Because the transaction protocol is optimistic, it has no transaction lock
+waits and no transaction deadlock detector. The dispatch-time intent-lock
+adapter under `runtime::locking` is separate runtime infrastructure for
+collection/DDL coordination, not the TM coordinator described by ADR 0065.
 
-`coordinator::TransactionManager` has its own `next_id: AtomicU64`
-(`coordinator.rs:319`). **The two are not coordinated.** Mixing them gives
-you two non-overlapping XID spaces and breaks visibility checks.
+### 4. Savepoints are sub-xids
 
-When (not if) we promote `coordinator` to production, the active allocator
-must be retired or both must funnel through a single shared atomic. Until
-then, do **not** call `coordinator::TransactionManager` outside its tests.
+`SAVEPOINT`, `RELEASE SAVEPOINT`, and `ROLLBACK TO SAVEPOINT` are live. A
+savepoint allocates a sub-xid under the current `TxnContext`; rolling back to
+a savepoint aborts that sub-xid and any nested sub-xids, then revives their
+tombstones. Releasing a savepoint pops it without aborting its writes.
 
-### 3. MVCC visibility lives in the btree version chain, not in row headers
+### 5. Autocommit statements still use the live runtime path
 
-The btree at `src/storage/btree/node.rs:300` carries:
+Statements outside an explicit transaction behave as autocommit operations.
+They use the same runtime execution machinery and conflict/durability
+boundaries as explicit transactions; they do not route through the retired
+coordinator.
 
-```rust
-pub struct LeafEntry<K, V> {
-    pub key: K,
-    pub versions: VersionChain<V>,
-}
-```
+## Retired scaffolding
 
-This is the **only** MVCC source for in-memory tables today. Rows in the
-unified store (`src/storage/unified/entity.rs`) carry no `xmin`/`xmax`
-header bytes.
+ADR 0065 retires, but does not delete, the older coordinator stack:
 
-If you add a row-header MVCC field, you are also signing up for a format
-migration and a coordinator wiring. **Don't do it as a side effect of
-another change** — open a PR titled "MVCC row headers" so reviewers know.
+- `coordinator.rs` — dormant `TransactionManager` / `MvccCoordinator`.
+- `lock.rs` — transaction lock manager with wait-for graph and deadlock
+  detection.
+- `savepoint.rs` — duplicate coordinator savepoint manager.
+- `log.rs` — duplicate coordinator transaction log.
 
-### 4. `wal.sync()` on commit/rollback is the durability boundary
-
-`src/storage/wal/transaction.rs:207, 242` — the active TM calls
-`wal.sync()` on `commit()` and `rollback()`. That is the moment durability
-is guaranteed.
-
-Sub-transaction operations (intermediate inserts, savepoints in the
-dormant coordinator) **do not** offer durability. Drivers and callers
-should treat any state between begin and commit as volatile.
-
-The stdio `tx.commit` flow (`src/rpc_stdio.rs`) inherits this boundary:
-`with_commit_lock { for op in write_set { execute_query(op) } }` →
-underlying execute_query path eventually calls `wal.sync()` per
-auto-committed sub-statement. Strict atomicity across all buffered ops is
-**not** guaranteed today (documented in `rpc_stdio.rs::Session`).
-
-### 5. Lock manager is dormant alongside the coordinator
-
-`lock.rs::LockManager` exists with wait-for graph + deadlock detection,
-but is only used by `coordinator::TransactionManager`. The active path has
-exactly **one** synchronization primitive: `RuntimeInner.commit_lock:
-Mutex<()>`, used by `tx.commit` to serialize replays.
-
-A multi-granularity lock manager (intent locks, row/page/table hierarchy)
-is post-MVP. Adding row locks here without first promoting `coordinator`
-is a no-op at best and a performance regression at worst.
+Those files are excluded from the normal build in `mod.rs`. Their embedded
+tests retire with them.
 
 ## Anti-patterns to avoid
 
-- **Importing `coordinator::TransactionManager` from runtime code** — you
-  will silently use a dormant manager that is not synchronized with anything.
-- **Allocating XIDs from `coordinator::TransactionManager::next_id`** —
-  see invariant 2.
-- **Adding row headers to `RowData`** without a coordinated MVCC migration
-  PR.
+- Importing or ungating `coordinator::TransactionManager` for production
+  runtime work.
+- Reintroducing a transaction lock manager to implement isolation semantics
+  without reopening ADR 0065.
+- Adding another xid allocator for live MVCC state. Use `SnapshotManager`.
 
 ## See also
 
-- Active TM: `src/storage/wal/transaction.rs`
-- BTree version chain: `src/storage/btree/node.rs:300`, `src/storage/btree/version.rs`
-- Stdio commit flow: `src/rpc_stdio.rs::Session`
-- Future plan: `PLAN.md` § Post-MVP — MVCC row headers
+- ADR 0065: `.red/adr/0065-transaction-manager-v2-rewrite.md`
+- Live runtime transaction control: `src/runtime/impl_core.rs`
+- Live snapshot context lifecycle: `src/runtime/mvcc_lifecycle.rs`
+- Visibility predicate: `src/storage/transaction/visibility.rs`

--- a/crates/reddb-server/src/storage/transaction/coordinator.rs
+++ b/crates/reddb-server/src/storage/transaction/coordinator.rs
@@ -1,3 +1,9 @@
+//! Retired transaction coordinator scaffolding.
+//!
+//! ADR 0065 keeps this file for historical reference but gates it out of
+//! the normal build. The live engine uses optimistic SnapshotManager +
+//! first-committer-wins checks, not this pessimistic coordinator.
+//!
 //! Transaction Coordinator
 //!
 //! Central coordinator for transaction lifecycle management.

--- a/crates/reddb-server/src/storage/transaction/lock.rs
+++ b/crates/reddb-server/src/storage/transaction/lock.rs
@@ -1,3 +1,9 @@
+//! Retired transaction lock-manager scaffolding.
+//!
+//! ADR 0065 keeps this file for historical reference but gates it out of
+//! the normal build. The live transaction engine is optimistic and has no
+//! transaction lock waits or deadlock detection machinery.
+//!
 //! Lock Management for Transactions
 //!
 //! Provides pessimistic concurrency control with deadlock detection.

--- a/crates/reddb-server/src/storage/transaction/log.rs
+++ b/crates/reddb-server/src/storage/transaction/log.rs
@@ -1,3 +1,9 @@
+//! Retired coordinator transaction-log scaffolding.
+//!
+//! ADR 0065 keeps this file for historical reference but gates it out of
+//! the normal build. Live durability is handled by the WAL/page transaction
+//! path, while live MVCC commit ordering comes from SnapshotManager xids.
+//!
 //! Write-Ahead Log (WAL) for Transaction Durability
 //!
 //! Provides crash recovery through sequential logging.

--- a/crates/reddb-server/src/storage/transaction/mod.rs
+++ b/crates/reddb-server/src/storage/transaction/mod.rs
@@ -1,25 +1,8 @@
-//! Transaction Management
+//! Live transaction snapshot and visibility support.
 //!
-//! Provides ACID transaction guarantees with WAL-based durability.
-//!
-//! # Architecture
-//!
-//! ```text
-//! ┌─────────────────────────────────────────────────────────────────┐
-//! │                    Transaction Manager                           │
-//! ├─────────────────────────────────────────────────────────────────┤
-//! │  begin() → TxnHandle                                            │
-//! │  commit(TxnHandle) → Result<(), Error>                         │
-//! │  abort(TxnHandle)                                               │
-//! └─────────────────────────────────────────────────────────────────┘
-//!                              │
-//!          ┌──────────────────┼──────────────────┐
-//!          ▼                  ▼                  ▼
-//!     ┌─────────┐       ┌─────────┐       ┌─────────┐
-//!     │   WAL   │       │  MVCC   │       │  Lock   │
-//!     │  Logger │       │  Store  │       │ Manager │
-//!     └─────────┘       └─────────┘       └─────────┘
-//! ```
+//! The live engine is optimistic MVCC: `SnapshotManager` allocates xids,
+//! `visibility` decides snapshot reads, and commit-time first-committer-wins
+//! checks live in the runtime.
 //!
 //! # Isolation Levels
 //!
@@ -27,17 +10,54 @@
 //! - **Snapshot Isolation**: See consistent snapshot from transaction start
 //! - **Serializable**: Full serializability (not yet implemented)
 
+// ADR 0065 retires these dormant transaction-coordinator scaffolding modules
+// from the normal build. The live engine chose optimistic FCW; it does not
+// promote the lock/deadlock/savepoint/log coordinator stack.
+#[cfg(any())]
 pub mod coordinator;
+#[cfg(any())]
 pub mod lock;
+#[cfg(any())]
 pub mod log;
+#[cfg(any())]
 pub mod savepoint;
 pub mod snapshot;
 pub mod visibility;
 
-pub use crate::storage::query::ast::IsolationLevel;
+/// Isolation level requested by `BEGIN ISOLATION LEVEL ...`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum IsolationLevel {
+    /// `READ UNCOMMITTED`
+    ReadUncommitted,
+    /// `READ COMMITTED`
+    ReadCommitted,
+    /// `REPEATABLE READ` / `SNAPSHOT`
+    #[default]
+    SnapshotIsolation,
+    /// `SERIALIZABLE`
+    Serializable,
+}
+
+impl From<crate::storage::query::ast::IsolationLevel> for IsolationLevel {
+    fn from(level: crate::storage::query::ast::IsolationLevel) -> Self {
+        match level {
+            crate::storage::query::ast::IsolationLevel::ReadUncommitted => Self::ReadUncommitted,
+            crate::storage::query::ast::IsolationLevel::ReadCommitted => Self::ReadCommitted,
+            crate::storage::query::ast::IsolationLevel::SnapshotIsolation => {
+                Self::SnapshotIsolation
+            }
+            crate::storage::query::ast::IsolationLevel::Serializable => Self::Serializable,
+        }
+    }
+}
+
+#[cfg(any())]
 pub use coordinator::{Transaction, TransactionManager, TxnConfig, TxnError, TxnHandle, TxnState};
+#[cfg(any())]
 pub use lock::{LockManager, LockMode, LockResult, LockWaiter};
+#[cfg(any())]
 pub use log::{LogEntry, LogEntryType, TransactionLog, WalConfig};
+#[cfg(any())]
 pub use savepoint::{Savepoint, SavepointManager};
 pub use snapshot::{Snapshot, SnapshotManager, TxnContext, Xid, XID_NONE};
 pub use visibility::is_visible;

--- a/crates/reddb-server/src/storage/transaction/savepoint.rs
+++ b/crates/reddb-server/src/storage/transaction/savepoint.rs
@@ -1,3 +1,8 @@
+//! Retired coordinator savepoint-manager scaffolding.
+//!
+//! ADR 0065 keeps this file for historical reference but gates it out of
+//! the normal build. Live savepoints are implemented by TxnContext sub-xids.
+//!
 //! Savepoint Management
 //!
 //! Enables partial rollback within transactions.

--- a/tests/grouped/locking_concurrency/unit_locking.rs
+++ b/tests/grouped/locking_concurrency/unit_locking.rs
@@ -6,8 +6,8 @@
 use std::sync::Arc;
 use std::thread;
 
+use reddb::runtime::lock_manager::{LockManager, LockMode};
 use reddb::runtime::locking::{AcquireError, LockerGuard, Resource};
-use reddb::storage::transaction::lock::{LockManager, LockMode};
 
 fn mgr() -> Arc<LockManager> {
     Arc::new(LockManager::with_defaults())

--- a/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
+++ b/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
@@ -4,6 +4,9 @@
 //! table-row guarantee to every RedDB model.
 
 const TRANSACTIONS_DOC: &str = include_str!("../../../docs/query/transactions.md");
+const TRANSACTION_MODULE_README: &str =
+    include_str!("../../../crates/reddb-server/src/storage/transaction/README.md");
+const RPC_STDIO: &str = include_str!("../../../crates/reddb-server/src/rpc_stdio.rs");
 const LIMITATIONS_DOC: &str = include_str!("../../../docs/reference/limitations.md");
 
 fn assert_contains(haystack: &str, needle: &str) {
@@ -87,4 +90,17 @@ fn docs_do_not_claim_history_store_mvcc_for_every_model() {
         LIMITATIONS_DOC,
         "Non-table models retain their documented behavior until each path adopts the history-store resolver",
     );
+}
+
+#[test]
+fn internal_transaction_docs_do_not_name_retired_commit_lock() {
+    for haystack in [TRANSACTION_MODULE_README, RPC_STDIO] {
+        assert_not_contains(haystack, "commit_lock");
+        assert_not_contains(haystack, "global commit lock");
+    }
+
+    assert_contains(TRANSACTION_MODULE_README, "SnapshotManager");
+    assert_contains(TRANSACTION_MODULE_README, "first-committer-wins");
+    assert_contains(TRANSACTION_MODULE_README, "sub-xid");
+    assert_contains(TRANSACTION_MODULE_README, "autocommit");
 }


### PR DESCRIPTION
Finish-from-branch land of #1649 after it bounced with a merge-conflict (its README diverged from main once #1648 landed underneath it).

Conflict: `storage/transaction/README.md` — #1649 fully rewrites the doc (retitle DORMANT→live snapshot support, coordinator retired) which subsumes #1648's incremental Section-2 edit. Took #1649's rewrite wholesale; the essential #1648 fact (SnapshotManager is the single XID authority) is preserved.

Tests: grouped_mvcc_transactions 58/58 pass.

Closes #1649.

https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785677515&installation_id=129708444&pr_number=1690&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1690&signature=8b247696d78a91a189f29cd92721ee691986472bdc4ec66d1b8c891c9493c29f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->