### PR TITLE
merge: #1650 test(tm): concurrent multi-writer harness + concurrent-commit Criterion bench (TM v2 6/8)

### DIFF
--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -191,6 +191,10 @@ harness = false
 name = "cache_ring_contention_bench"
 harness = false
 
+[[bench]]
+name = "concurrent_commit_bench"
+harness = false
+
 [dev-dependencies]
 # Criterion benchmark harness for blob_cache_bench (#190).
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/reddb-server/benches/concurrent_commit_bench.rs
+++ b/crates/reddb-server/benches/concurrent_commit_bench.rs
@@ -1,0 +1,124 @@
+//! Concurrent commit throughput benchmark (issue #1650).
+//!
+//! Run:
+//!   cargo bench -p reddb-io-server --bench concurrent_commit_bench
+//!
+//! Scenarios cover 1/2/4/8 concurrent SQL transactions on one runtime at low
+//! conflict (one row per writer) and high conflict (all writers share one row).
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use reddb_server::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+use std::hint::black_box;
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn target_row(writer: usize, conflict_rows: usize) -> usize {
+    (writer % conflict_rows) + 1
+}
+
+fn selected_u64(rt: &RedDBRuntime, sql: &str, column: &str) -> u64 {
+    let result = rt.execute_query(sql).expect("select");
+    let row = result.result.records.first().expect("one row");
+    match row.get(column) {
+        Some(reddb_server::storage::schema::Value::UnsignedInteger(value)) => *value,
+        Some(reddb_server::storage::schema::Value::Integer(value)) => *value as u64,
+        other => panic!("expected integer column {column}, got {other:?}"),
+    }
+}
+
+fn run_workload(connections: usize, conflict_rows: usize) -> usize {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE bench_concurrent_commit (id INT, value INT, marker TEXT)",
+    );
+    for id in 1..=conflict_rows {
+        exec(
+            &rt,
+            &format!(
+                "INSERT INTO bench_concurrent_commit (id, value, marker) VALUES ({id}, 0, 'seed')"
+            ),
+        );
+    }
+    let row_rids: Vec<u64> = (1..=conflict_rows)
+        .map(|id| {
+            selected_u64(
+                &rt,
+                &format!("SELECT rid FROM bench_concurrent_commit WHERE id = {id}"),
+                "rid",
+            )
+        })
+        .collect();
+
+    let rt = Arc::new(rt);
+    let begin_barrier = Arc::new(Barrier::new(connections));
+    let update_barrier = Arc::new(Barrier::new(connections));
+    let mut handles = Vec::with_capacity(connections);
+
+    for writer in 0..connections {
+        let rt = Arc::clone(&rt);
+        let begin_barrier = Arc::clone(&begin_barrier);
+        let update_barrier = Arc::clone(&update_barrier);
+        let row_id = target_row(writer, conflict_rows);
+        let row_rid = row_rids[row_id - 1];
+        handles.push(thread::spawn(move || {
+            set_current_connection_id(1650_500 + writer as u64);
+            exec(&rt, "BEGIN");
+            begin_barrier.wait();
+            let update = rt
+                .execute_query(&format!(
+                    "UPDATE bench_concurrent_commit SET value += 1 WHERE rid = {row_rid}"
+                ))
+                .map(|_| ())
+                .map_err(|err| err.to_string());
+            update_barrier.wait();
+            let committed = update.is_ok() && rt.execute_query("COMMIT").is_ok();
+            if !committed {
+                let _ = rt.execute_query("ROLLBACK");
+            }
+            clear_current_connection_id();
+            committed
+        }));
+    }
+
+    handles
+        .into_iter()
+        .map(|handle| handle.join().expect("writer thread should not panic"))
+        .filter(|committed| *committed)
+        .count()
+}
+
+fn bench_concurrent_commit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tm_concurrent_commit");
+    for connections in [1usize, 2, 4, 8] {
+        for (label, conflict_rows) in [("low_conflict", connections), ("high_conflict", 1usize)] {
+            group.throughput(Throughput::Elements(connections as u64));
+            group.bench_with_input(
+                BenchmarkId::new(label, connections),
+                &(connections, conflict_rows),
+                |b, &(connections, conflict_rows)| {
+                    b.iter(|| {
+                        black_box(run_workload(
+                            black_box(connections),
+                            black_box(conflict_rows),
+                        ))
+                    });
+                },
+            );
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_concurrent_commit);
+criterion_main!(benches);

--- a/docs/guides/benchmarks.md
+++ b/docs/guides/benchmarks.md
@@ -36,23 +36,26 @@ If you pick the wrong path, the numbers can still "look valid" while measuring t
 
 The current Cargo bench targets are:
 
-- `bench_embedded`
-- `bench_insert`
-- `perf_sweep`
+- `blob_cache_bench`
+- `cache_ring_contention_bench`
+- `concurrent_commit_bench`
+- `row_id_intersection_bench`
 
 Run them like this:
 
 ```bash
-cargo bench --bench bench_embedded
-cargo bench --bench bench_insert
-cargo bench --bench perf_sweep
+cargo bench -p reddb-io-server --bench blob_cache_bench
+cargo bench -p reddb-io-server --bench cache_ring_contention_bench
+cargo bench -p reddb-io-server --bench concurrent_commit_bench
+cargo bench -p reddb-io-server --bench row_id_intersection_bench
 ```
 
 What each one is for:
 
-- `bench_embedded`: macro-style embedded runtime benchmarks across rows, docs, graph, vector, KV, and query paths
-- `bench_insert`: persistent bulk insert benchmark
-- `perf_sweep`: microbenchmarks for hot-path primitives such as filter execution and WAL behavior
+- `blob_cache_bench`: blob cache L1/L2 behavior and Redis comparison cells
+- `cache_ring_contention_bench`: cache ring contention microbenchmarks
+- `concurrent_commit_bench`: TM concurrent commit throughput at 1/2/4/8 connections under low and high row-conflict rates
+- `row_id_intersection_bench`: row-id intersection strategy microbenchmarks
 
 Criterion outputs usually land under:
 
@@ -135,7 +138,7 @@ cargo bench --bench bench_embedded
 Or for a focused run:
 
 ```bash
-cargo bench --bench perf_sweep
+cargo bench -p reddb-io-server --bench concurrent_commit_bench
 ```
 
 Use this when you want:

--- a/tests/grouped/mvcc_transactions/e2e_concurrent_multi_writer_harness.rs
+++ b/tests/grouped/mvcc_transactions/e2e_concurrent_multi_writer_harness.rs
@@ -1,0 +1,258 @@
+//! Concurrent multi-writer MVCC harness.
+//!
+//! The workload opens N independent SQL transactions on one in-memory runtime,
+//! maps them deterministically onto a bounded set of logical rows, then releases
+//! them to update concurrently before committing in a deterministic order. A row
+//! can have at most one successful first-committer-wins update from transactions
+//! that share the same snapshot.
+
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+use std::collections::BTreeSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+#[derive(Clone, Copy)]
+struct HarnessConfig {
+    connections: usize,
+    transactions_per_connection: usize,
+    conflict_rows: usize,
+    seed: u64,
+}
+
+#[derive(Debug)]
+struct WriterOutcome {
+    row_id: usize,
+    committed: bool,
+    error: Option<String>,
+}
+
+fn rt() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn selected_i64(rt: &RedDBRuntime, sql: &str, column: &str) -> i64 {
+    let result = rt.execute_query(sql).expect("select");
+    let Some(row) = result.result.records.first() else {
+        panic!("expected one row for {sql}");
+    };
+    match row.get(column) {
+        Some(Value::Integer(value)) => *value,
+        Some(Value::UnsignedInteger(value)) => *value as i64,
+        other => panic!("expected integer column {column}, got {other:?}"),
+    }
+}
+
+fn target_row(seed: u64, writer: usize, rows: usize) -> usize {
+    if rows == 1 {
+        return 1;
+    }
+    let offset = seed as usize % rows;
+    ((writer + offset) % rows) + 1
+}
+
+fn run_harness(config: HarnessConfig) {
+    assert!(config.connections > 0);
+    assert!(config.transactions_per_connection > 0);
+    assert!(config.conflict_rows > 0);
+    assert!(config.conflict_rows <= config.connections);
+
+    let rt = rt();
+    exec(
+        &rt,
+        "CREATE TABLE tm_multi_writer (id INT, value INT, marker TEXT)",
+    );
+    for id in 1..=config.conflict_rows {
+        exec(
+            &rt,
+            &format!("INSERT INTO tm_multi_writer (id, value, marker) VALUES ({id}, 0, 'seed')"),
+        );
+    }
+    let row_rids: Vec<u64> = (1..=config.conflict_rows)
+        .map(|id| {
+            selected_i64(
+                &rt,
+                &format!("SELECT rid FROM tm_multi_writer WHERE id = {id}"),
+                "rid",
+            ) as u64
+        })
+        .collect();
+
+    let next_xid_before = rt.snapshot_manager().peek_next_xid();
+    let expected_rows: BTreeSet<usize> = (0..config.connections)
+        .map(|writer| target_row(config.seed, writer, config.conflict_rows))
+        .collect();
+
+    let rt = Arc::new(rt);
+    let mut outcomes = Vec::with_capacity(config.connections * config.transactions_per_connection);
+
+    for transaction_index in 0..config.transactions_per_connection {
+        let begin_barrier = Arc::new(Barrier::new(config.connections));
+        let update_barrier = Arc::new(Barrier::new(config.connections));
+        let commit_turn = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(config.connections);
+
+        for writer in 0..config.connections {
+            let rt = Arc::clone(&rt);
+            let begin_barrier = Arc::clone(&begin_barrier);
+            let update_barrier = Arc::clone(&update_barrier);
+            let commit_turn = Arc::clone(&commit_turn);
+            let row_id = target_row(config.seed, writer, config.conflict_rows);
+            let row_rid = row_rids[row_id - 1];
+            handles.push(thread::spawn(move || {
+                set_current_connection_id(
+                    1650_000 + (transaction_index as u64 * 100) + writer as u64,
+                );
+                exec(&rt, "BEGIN");
+                begin_barrier.wait();
+
+                let update = rt
+                    .execute_query(&format!(
+                        "UPDATE tm_multi_writer SET value += 1 WHERE rid = {row_rid}"
+                    ))
+                    .map(|_| ())
+                    .map_err(|err| err.to_string());
+                update_barrier.wait();
+                while commit_turn.load(Ordering::Acquire) != writer {
+                    thread::yield_now();
+                }
+
+                let outcome = match update {
+                    Ok(()) => match rt.execute_query("COMMIT") {
+                        Ok(_) => WriterOutcome {
+                            row_id,
+                            committed: true,
+                            error: None,
+                        },
+                        Err(err) => WriterOutcome {
+                            row_id,
+                            committed: false,
+                            error: {
+                                let message = err.to_string();
+                                let _ = rt.execute_query("ROLLBACK");
+                                Some(message)
+                            },
+                        },
+                    },
+                    Err(err) => {
+                        let _ = rt.execute_query("ROLLBACK");
+                        WriterOutcome {
+                            row_id,
+                            committed: false,
+                            error: Some(err),
+                        }
+                    }
+                };
+
+                commit_turn.fetch_add(1, Ordering::Release);
+                clear_current_connection_id();
+                outcome
+            }));
+        }
+
+        outcomes.extend(
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("writer thread should not panic")),
+        );
+    }
+
+    let committed = outcomes.iter().filter(|outcome| outcome.committed).count();
+    let aborted = outcomes.len() - committed;
+    let expected_commits = expected_rows.len() * config.transactions_per_connection;
+
+    assert_eq!(
+        committed, expected_commits,
+        "one writer per contended logical row should commit: {outcomes:?}"
+    );
+    assert_eq!(
+        aborted,
+        outcomes.len() - expected_commits,
+        "abort count should follow the conflict dial: {outcomes:?}"
+    );
+    for outcome in outcomes.iter().filter(|outcome| !outcome.committed) {
+        let message = outcome.error.as_deref().unwrap_or("");
+        assert!(
+            message.contains("serialization conflict"),
+            "expected serialization conflict for row {}, got {message}",
+            outcome.row_id
+        );
+    }
+
+    set_current_connection_id(1650_999);
+    let visible_sum = selected_i64(
+        &rt,
+        "SELECT SUM(value) AS total FROM tm_multi_writer",
+        "total",
+    );
+    assert_eq!(
+        visible_sum, committed as i64,
+        "every successful commit's effect must be observable"
+    );
+    let changed_rows = selected_i64(
+        &rt,
+        "SELECT COUNT(*) AS row_count FROM tm_multi_writer WHERE value > 0",
+        "row_count",
+    );
+    assert_eq!(
+        changed_rows,
+        expected_rows.len() as i64,
+        "each round should update the same deterministic logical row set"
+    );
+
+    exec(&rt, "VACUUM tm_multi_writer");
+    let snapshot_manager = rt.snapshot_manager();
+    assert_eq!(
+        snapshot_manager.oldest_active_xid(),
+        None,
+        "writer transactions must not leak active xids"
+    );
+    assert_eq!(
+        snapshot_manager.oldest_pinned_xid(),
+        None,
+        "harness should leave no pinned snapshots"
+    );
+    assert!(
+        snapshot_manager.peek_next_xid() > next_xid_before,
+        "commits/aborts should advance the MVCC xid floor"
+    );
+    clear_current_connection_id();
+}
+
+#[test]
+fn concurrent_multi_writer_harness_low_conflict_ci() {
+    run_harness(HarnessConfig {
+        connections: 4,
+        transactions_per_connection: 2,
+        conflict_rows: 4,
+        seed: 0x1650_0001,
+    });
+}
+
+#[test]
+fn concurrent_multi_writer_harness_high_conflict_ci() {
+    run_harness(HarnessConfig {
+        connections: 2,
+        transactions_per_connection: 1,
+        conflict_rows: 1,
+        seed: 0x1650_0002,
+    });
+}
+
+#[test]
+#[ignore = "larger local/soak parametrization for TM commit concurrency"]
+fn concurrent_multi_writer_soak_harness() {
+    run_harness(HarnessConfig {
+        connections: 16,
+        transactions_per_connection: 4,
+        conflict_rows: 16,
+        seed: 0x1650_5000,
+    });
+}

--- a/tests/grouped_mvcc_transactions.rs
+++ b/tests/grouped_mvcc_transactions.rs
@@ -18,6 +18,9 @@ mod e2e_mvcc_dml_target_scans;
 #[path = "grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs"]
 mod e2e_mvcc_first_committer_wins;
 
+#[path = "grouped/mvcc_transactions/e2e_concurrent_multi_writer_harness.rs"]
+mod e2e_concurrent_multi_writer_harness;
+
 #[path = "grouped/mvcc_transactions/e2e_mvcc_index_recheck.rs"]
 mod e2e_mvcc_index_recheck;
 


### PR DESCRIPTION
Automated AFK landing for #1650. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1650

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785678067&installation_id=129708444&pr_number=1691&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1691&signature=c685d024578370f9539923e9027902c1092e177e2a3b06bd96aa6c0169533899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->