### PR TITLE
test(tm): DST commit-path fault-injection campaign (#1651)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-chaos-all:
 	$(MAKE) test-dst-storage
 
 test-dst-storage:
-	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery
+	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery --test tm_commit_path_recovery
 
 test-dst-sweep:
 	cargo test --locked -p reddb-io-server replication::dst::tests::dst_seed_sweep -- --ignored

--- a/crates/unreliable-libc/Cargo.toml
+++ b/crates/unreliable-libc/Cargo.toml
@@ -31,6 +31,12 @@ path = "src/bin/wal_workload.rs"
 name = "typed_workload"
 path = "src/bin/typed_workload.rs"
 
+# The seeded TM commit-path workload (#1651), driven under the shim so a real
+# power-cut can crash each commit-path scenario mid-write.
+[[bin]]
+name = "tm_commit_path_workload"
+path = "src/bin/tm_commit_path_workload.rs"
+
 [dependencies]
 reddb-file = { workspace = true }
 reddb-types = { workspace = true }

--- a/crates/unreliable-libc/src/bin/tm_commit_path_workload.rs
+++ b/crates/unreliable-libc/src/bin/tm_commit_path_workload.rs
@@ -1,0 +1,64 @@
+//! Seeded TM commit-path workload binary, driven under `unreliable-libc`.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+use unreliable_libc::{run_tm_commit_path_workload, TmCommitPathScenario};
+
+fn main() -> ExitCode {
+    let seed = resolve_seed();
+    let scenario = match std::env::args().nth(2).as_deref() {
+        Some("fcw_before_wal_append") => TmCommitPathScenario::FcwBeforeWalAppend,
+        Some("wal_append_before_finalize") => TmCommitPathScenario::WalAppendBeforeFinalize,
+        Some("savepoint_release_rollback") => TmCommitPathScenario::SavepointReleaseRollback,
+        Some("concurrent_writers") => TmCommitPathScenario::ConcurrentWriters,
+        Some(other) => {
+            eprintln!("unknown TM commit-path scenario: {other}");
+            return ExitCode::from(2);
+        }
+        None => TmCommitPathScenario::WalAppendBeforeFinalize,
+    };
+
+    println!("SEED={seed} scenario={}", scenario.name());
+
+    let dir = match std::env::var_os("UNRELIABLE_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => {
+            eprintln!("UNRELIABLE_DIR is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    match run_tm_commit_path_workload(&dir, seed, scenario) {
+        Ok(model) => {
+            println!(
+                "OK scenario={} committed={} wal_len={}",
+                scenario.name(),
+                model.txs.len(),
+                model.wal_len
+            );
+            ExitCode::SUCCESS
+        }
+        Err(err) => {
+            eprintln!("workload stopped on durability error: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn resolve_seed() -> u64 {
+    if let Some(arg) = std::env::args().nth(1) {
+        if let Ok(seed) = arg.parse::<u64>() {
+            return seed;
+        }
+    }
+    for key in ["SEED", "UNRELIABLE_SEED"] {
+        if let Ok(raw) = std::env::var(key) {
+            if let Ok(seed) = raw.parse::<u64>() {
+                return seed;
+            }
+        }
+    }
+    0
+}

--- a/crates/unreliable-libc/src/lib.rs
+++ b/crates/unreliable-libc/src/lib.rs
@@ -15,6 +15,9 @@
 //!   persists **typed values spanning every supported [`reddb_types::Value`]
 //!   variant** and asserts the recovered committed values equal exactly the
 //!   pre-crash committed state, layered on top of the structural `oracle`.
+//! * [`tm_commit_path`] — TM v2 slice 8 (#1651): commit-path fault-injection
+//!   scenarios for FCW-before-WAL, WAL-append-before-finalize, savepoints, and
+//!   concurrent writers, layered on the same WAL oracle.
 //! * [`vfs`] — the in-process counterpart to the shim (DST Fatia, #1355): a
 //!   minimal `Vfs` / `VfsFile` durable-I/O trait pair with a production-default
 //!   [`StdVfs`](vfs::StdVfs) and a seed-driven, fault-injecting
@@ -34,12 +37,18 @@
 pub mod oracle;
 pub mod prng;
 pub mod superblock;
+pub mod tm_commit_path;
 pub mod value_equivalence;
 pub mod vfs;
 pub mod wal_workload;
 
 pub use oracle::{recover_and_check, RecoveryError, RecoveryReport};
 pub use prng::SplitMix64;
+pub use tm_commit_path::{
+    assert_tm_recovery_matches, recover_tm_commit_path, run_tm_commit_path_workload,
+    run_tm_commit_path_workload_on, tm_commit_path_scenarios, TmCommitPathModel,
+    TmCommitPathScenario, TmCommittedTx, TmRecoveredTx, TmWrite,
+};
 pub use value_equivalence::{
     canonical_value_corpus, recover_committed_values, run_typed_workload, CommittedTx,
     EquivalenceError, RecoveredTx, TypedModel,

--- a/crates/unreliable-libc/src/tm_commit_path.rs
+++ b/crates/unreliable-libc/src/tm_commit_path.rs
@@ -1,0 +1,441 @@
+//! TM commit-path DST workload (#1651).
+//!
+//! This campaign stays in the existing `unreliable-libc` lane: each scenario
+//! writes real RedDB WAL frames through the same `Vfs` abstraction as the
+//! storage-fault suites, then recovery first runs the shared structural oracle
+//! and finally checks TM-specific commit semantics against the recovered prefix.
+
+use crate::prng::SplitMix64;
+use crate::vfs::{OpenMode, StdVfs, Vfs, VfsFile};
+use crate::wal_workload::WAL_FILE_NAME;
+use reddb_file::wal_header::{
+    decode_wal_file_header, encode_wal_file_header, WAL_FILE_HEADER_BYTES,
+};
+use reddb_file::wal_record::{
+    decode_main_wal_record_frame, encode_main_wal_record_frame, MainWalRecordFrame,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{self, Cursor};
+use std::path::Path;
+
+const WORKLOAD_TERM: u64 = 1;
+
+/// Commit-path scenario families required by #1651.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TmCommitPathScenario {
+    FcwBeforeWalAppend,
+    WalAppendBeforeFinalize,
+    SavepointReleaseRollback,
+    ConcurrentWriters,
+}
+
+impl TmCommitPathScenario {
+    pub fn all() -> [Self; 4] {
+        [
+            Self::FcwBeforeWalAppend,
+            Self::WalAppendBeforeFinalize,
+            Self::SavepointReleaseRollback,
+            Self::ConcurrentWriters,
+        ]
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::FcwBeforeWalAppend => "fcw_before_wal_append",
+            Self::WalAppendBeforeFinalize => "wal_append_before_finalize",
+            Self::SavepointReleaseRollback => "savepoint_release_rollback",
+            Self::ConcurrentWriters => "concurrent_writers",
+        }
+    }
+}
+
+/// Stable scenario names for docs/tests.
+pub fn tm_commit_path_scenarios() -> [&'static str; 4] {
+    TmCommitPathScenario::all().map(TmCommitPathScenario::name)
+}
+
+/// Fault-free model for one scenario/seed. `cut`-based tests use the recorded
+/// commit offsets to decide whether a transaction should be present or absent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmCommitPathModel {
+    pub scenario: TmCommitPathScenario,
+    pub txs: Vec<TmCommittedTx>,
+    pub wal_len: u64,
+}
+
+impl TmCommitPathModel {
+    pub fn committed_through(&self, surviving_bytes: u64) -> Vec<TmRecoveredTx> {
+        self.txs
+            .iter()
+            .filter(|tx| tx.commit_end_offset <= surviving_bytes)
+            .map(|tx| TmRecoveredTx {
+                tx_id: tx.tx_id,
+                writes: tx.visible_writes.clone(),
+            })
+            .collect()
+    }
+
+    pub fn all_committed(&self) -> Vec<TmRecoveredTx> {
+        self.committed_through(u64::MAX)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmCommittedTx {
+    pub tx_id: u64,
+    pub visible_writes: Vec<TmWrite>,
+    pub commit_end_offset: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TmRecoveredTx {
+    pub tx_id: u64,
+    pub writes: Vec<TmWrite>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct TmWrite {
+    pub key: u64,
+    pub value: u64,
+    pub sub_xid: u64,
+}
+
+/// Drive the TM workload on the real filesystem.
+pub fn run_tm_commit_path_workload(
+    dir: &Path,
+    seed: u64,
+    scenario: TmCommitPathScenario,
+) -> io::Result<TmCommitPathModel> {
+    run_tm_commit_path_workload_on(&StdVfs, dir, seed, scenario)
+}
+
+/// Drive one commit-path scenario through the supplied durable-I/O backend.
+pub fn run_tm_commit_path_workload_on<V: Vfs>(
+    vfs: &V,
+    dir: &Path,
+    seed: u64,
+    scenario: TmCommitPathScenario,
+) -> io::Result<TmCommitPathModel> {
+    let wal_path = dir.join(WAL_FILE_NAME);
+    let mut wal = vfs.open(&wal_path, OpenMode::create_truncate())?;
+    wal.write_all(&encode_wal_file_header())?;
+    wal.sync_all()?;
+
+    if scenario == TmCommitPathScenario::FcwBeforeWalAppend {
+        return Ok(TmCommitPathModel {
+            scenario,
+            txs: Vec::new(),
+            wal_len: WAL_FILE_HEADER_BYTES as u64,
+        });
+    }
+
+    let mut rng = SplitMix64::new(seed ^ 0x544d_5f43_4d54_5f50); // "TM_CMT_P"
+    let mut offset = WAL_FILE_HEADER_BYTES as u64;
+    let txs = match scenario {
+        TmCommitPathScenario::FcwBeforeWalAppend => unreachable!(),
+        TmCommitPathScenario::WalAppendBeforeFinalize => {
+            let tx_id = 1;
+            let writes = vec![
+                TmWrite {
+                    key: 10,
+                    value: 1 + rng.below(1000),
+                    sub_xid: 0,
+                },
+                TmWrite {
+                    key: 11,
+                    value: 1 + rng.below(1000),
+                    sub_xid: 0,
+                },
+            ];
+            vec![append_tm_tx(&mut wal, &mut offset, tx_id, &writes, &[])?]
+        }
+        TmCommitPathScenario::SavepointReleaseRollback => {
+            let tx_id = 1;
+            let kept_sub = 101;
+            let rolled_back_sub = 102;
+            let all_writes = vec![
+                TmWrite {
+                    key: 20,
+                    value: 1 + rng.below(1000),
+                    sub_xid: 0,
+                },
+                TmWrite {
+                    key: 21,
+                    value: 1 + rng.below(1000),
+                    sub_xid: kept_sub,
+                },
+                TmWrite {
+                    key: 22,
+                    value: 1 + rng.below(1000),
+                    sub_xid: rolled_back_sub,
+                },
+            ];
+            let control = [
+                tm_action_release_sub(kept_sub),
+                tm_action_rollback_sub(rolled_back_sub),
+            ];
+            vec![append_tm_tx(
+                &mut wal,
+                &mut offset,
+                tx_id,
+                &all_writes,
+                &control,
+            )?]
+        }
+        TmCommitPathScenario::ConcurrentWriters => {
+            let tx1 = vec![TmWrite {
+                key: 30,
+                value: 1 + rng.below(1000),
+                sub_xid: 0,
+            }];
+            let tx2 = vec![TmWrite {
+                key: 31,
+                value: 1 + rng.below(1000),
+                sub_xid: 0,
+            }];
+            vec![
+                append_tm_tx(&mut wal, &mut offset, 1, &tx1, &[])?,
+                append_tm_tx(&mut wal, &mut offset, 2, &tx2, &[])?,
+            ]
+        }
+    };
+
+    Ok(TmCommitPathModel {
+        scenario,
+        txs,
+        wal_len: offset,
+    })
+}
+
+fn append_tm_tx<F: VfsFile>(
+    wal: &mut F,
+    offset: &mut u64,
+    tx_id: u64,
+    writes: &[TmWrite],
+    control: &[Vec<u8>],
+) -> io::Result<TmCommittedTx> {
+    append_frame(wal, offset, &MainWalRecordFrame::Begin { tx_id })?;
+    for write in writes {
+        append_frame(
+            wal,
+            offset,
+            &MainWalRecordFrame::PageWrite {
+                tx_id,
+                page_id: u32::try_from(write.key).unwrap_or(u32::MAX),
+                data: tm_action_write(write),
+            },
+        )?;
+    }
+    for action in control {
+        append_frame(
+            wal,
+            offset,
+            &MainWalRecordFrame::TxCommitBatch {
+                tx_id,
+                actions: vec![action.clone()],
+            },
+        )?;
+    }
+    append_frame(wal, offset, &MainWalRecordFrame::Commit { tx_id })?;
+    wal.sync_all()?;
+    let commit_end_offset = *offset;
+
+    let rolled_back: BTreeSet<u64> = control
+        .iter()
+        .filter_map(|action| parse_control_sub(action, b"rollback-sub:"))
+        .collect();
+    let visible_writes = writes
+        .iter()
+        .filter(|write| !rolled_back.contains(&write.sub_xid))
+        .cloned()
+        .collect();
+
+    Ok(TmCommittedTx {
+        tx_id,
+        visible_writes,
+        commit_end_offset,
+    })
+}
+
+fn append_frame<F: VfsFile>(
+    wal: &mut F,
+    offset: &mut u64,
+    frame: &MainWalRecordFrame,
+) -> io::Result<()> {
+    let bytes = encode_main_wal_record_frame(frame, WORKLOAD_TERM)?;
+    wal.write_all(&bytes)?;
+    *offset += bytes.len() as u64;
+    Ok(())
+}
+
+fn tm_action_write(write: &TmWrite) -> Vec<u8> {
+    format!("tm-write:{}:{}:{}", write.key, write.value, write.sub_xid).into_bytes()
+}
+
+fn tm_action_release_sub(sub_xid: u64) -> Vec<u8> {
+    format!("release-sub:{sub_xid}").into_bytes()
+}
+
+fn tm_action_rollback_sub(sub_xid: u64) -> Vec<u8> {
+    format!("rollback-sub:{sub_xid}").into_bytes()
+}
+
+fn parse_write(bytes: &[u8]) -> Option<TmWrite> {
+    let raw = std::str::from_utf8(bytes).ok()?;
+    let rest = raw.strip_prefix("tm-write:")?;
+    let mut fields = rest.split(':');
+    Some(TmWrite {
+        key: fields.next()?.parse().ok()?,
+        value: fields.next()?.parse().ok()?,
+        sub_xid: fields.next()?.parse().ok()?,
+    })
+}
+
+fn parse_control_sub(bytes: &[u8], prefix: &[u8]) -> Option<u64> {
+    bytes
+        .strip_prefix(prefix)
+        .and_then(|raw| std::str::from_utf8(raw).ok())
+        .and_then(|raw| raw.parse().ok())
+}
+
+/// Recover committed TM writes from the longest valid WAL prefix.
+pub fn recover_tm_commit_path(dir: &Path) -> io::Result<Vec<TmRecoveredTx>> {
+    let bytes = match std::fs::read(dir.join(WAL_FILE_NAME)) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Vec::new(),
+        Err(err) => return Err(err),
+    };
+    if bytes.len() < WAL_FILE_HEADER_BYTES {
+        return Ok(Vec::new());
+    }
+    let mut header = [0u8; WAL_FILE_HEADER_BYTES];
+    header.copy_from_slice(&bytes[..WAL_FILE_HEADER_BYTES]);
+    let version = match decode_wal_file_header(&header) {
+        Ok(header) => header.version,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut cursor = Cursor::new(bytes);
+    cursor.set_position(WAL_FILE_HEADER_BYTES as u64);
+    let mut open: BTreeMap<u64, TxBuilder> = BTreeMap::new();
+    let mut committed = Vec::new();
+
+    loop {
+        let frame = match decode_main_wal_record_frame(&mut cursor, version, WORKLOAD_TERM) {
+            Ok(Some((_term, frame))) => frame,
+            Ok(None) | Err(_) => break,
+        };
+        match frame {
+            MainWalRecordFrame::Begin { tx_id } => {
+                open.insert(tx_id, TxBuilder::default());
+            }
+            MainWalRecordFrame::PageWrite { tx_id, data, .. } => {
+                if let Some(write) = parse_write(&data) {
+                    open.entry(tx_id).or_default().writes.push(write);
+                }
+            }
+            MainWalRecordFrame::TxCommitBatch { tx_id, actions } => {
+                let tx = open.entry(tx_id).or_default();
+                for action in actions {
+                    if let Some(sub_xid) = parse_control_sub(&action, b"release-sub:") {
+                        tx.released_sub_xids.insert(sub_xid);
+                    }
+                    if let Some(sub_xid) = parse_control_sub(&action, b"rollback-sub:") {
+                        tx.rolled_back_sub_xids.insert(sub_xid);
+                    }
+                }
+            }
+            MainWalRecordFrame::Commit { tx_id } => {
+                if let Some(tx) = open.remove(&tx_id) {
+                    let writes = tx.visible_writes();
+                    committed.push(TmRecoveredTx { tx_id, writes });
+                }
+            }
+            MainWalRecordFrame::Rollback { tx_id } => {
+                open.remove(&tx_id);
+            }
+            MainWalRecordFrame::Checkpoint { .. }
+            | MainWalRecordFrame::FullPageImage { .. }
+            | MainWalRecordFrame::VectorInsert { .. } => {}
+        }
+    }
+
+    Ok(committed)
+}
+
+#[derive(Debug, Default)]
+struct TxBuilder {
+    writes: Vec<TmWrite>,
+    released_sub_xids: BTreeSet<u64>,
+    rolled_back_sub_xids: BTreeSet<u64>,
+}
+
+impl TxBuilder {
+    fn visible_writes(self) -> Vec<TmWrite> {
+        self.writes
+            .into_iter()
+            .filter(|write| {
+                write.sub_xid == 0
+                    || (self.released_sub_xids.contains(&write.sub_xid)
+                        && !self.rolled_back_sub_xids.contains(&write.sub_xid))
+            })
+            .collect()
+    }
+}
+
+/// Assert recovered state is one of the valid all-or-nothing commit outcomes
+/// for this scenario/seed, and that savepoint sub-xids are not orphan-visible.
+pub fn assert_tm_recovery_matches(
+    seed: u64,
+    model: &TmCommitPathModel,
+    recovered: &[TmRecoveredTx],
+) {
+    let valid_states = valid_recovered_states(model);
+    assert!(
+        valid_states
+            .iter()
+            .any(|valid| valid.as_slice() == recovered),
+        "SEED={seed} scenario={} recovered half-finalized TM state: {recovered:?}; \
+         expected one of {valid_states:?}",
+        model.scenario.name()
+    );
+
+    for tx in recovered {
+        for write in &tx.writes {
+            assert!(
+                write.sub_xid == 0
+                    || model
+                        .txs
+                        .iter()
+                        .find(|expected_tx| expected_tx.tx_id == tx.tx_id)
+                        .is_some_and(|expected_tx| expected_tx.visible_writes.contains(write)),
+                "SEED={seed} scenario={} exposed orphan savepoint sub-xid {} in tx {}",
+                model.scenario.name(),
+                write.sub_xid,
+                tx.tx_id
+            );
+        }
+    }
+}
+
+fn valid_recovered_states(model: &TmCommitPathModel) -> Vec<Vec<TmRecoveredTx>> {
+    if model.scenario == TmCommitPathScenario::ConcurrentWriters {
+        let mut states = vec![Vec::new()];
+        for tx in &model.txs {
+            let mut next = states.last().cloned().unwrap_or_default();
+            next.push(TmRecoveredTx {
+                tx_id: tx.tx_id,
+                writes: tx.visible_writes.clone(),
+            });
+            states.push(next);
+        }
+        states
+    } else {
+        let full = model.all_committed();
+        if full.is_empty() {
+            vec![Vec::new()]
+        } else {
+            vec![Vec::new(), full]
+        }
+    }
+}

--- a/crates/unreliable-libc/src/tm_commit_path.rs
+++ b/crates/unreliable-libc/src/tm_commit_path.rs
@@ -320,11 +320,9 @@ pub fn recover_tm_commit_path(dir: &Path) -> io::Result<Vec<TmRecoveredTx>> {
     let mut open: BTreeMap<u64, TxBuilder> = BTreeMap::new();
     let mut committed = Vec::new();
 
-    loop {
-        let frame = match decode_main_wal_record_frame(&mut cursor, version, WORKLOAD_TERM) {
-            Ok(Some((_term, frame))) => frame,
-            Ok(None) | Err(_) => break,
-        };
+    while let Ok(Some((_term, frame))) =
+        decode_main_wal_record_frame(&mut cursor, version, WORKLOAD_TERM)
+    {
         match frame {
             MainWalRecordFrame::Begin { tx_id } => {
                 open.insert(tx_id, TxBuilder::default());

--- a/crates/unreliable-libc/tests/tm_commit_path_recovery.rs
+++ b/crates/unreliable-libc/tests/tm_commit_path_recovery.rs
@@ -1,0 +1,204 @@
+//! Transaction-manager commit-path fault-injection campaign (#1651).
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use unreliable_libc::vfs::POWER_CUT_MESSAGE;
+use unreliable_libc::{
+    assert_tm_recovery_matches, recover_and_check, recover_tm_commit_path,
+    run_tm_commit_path_workload, run_tm_commit_path_workload_on, SimFaultConfig, SimVfs,
+    TmCommitPathScenario,
+};
+
+/// How many seeds to enumerate when `SEED` is not pinned.
+const SEED_COUNT: u64 = 16;
+const SIM_DIR: &str = "/db";
+
+#[test]
+fn tm_commit_path_campaign_enumerates_required_scenario_families() {
+    let scenarios = unreliable_libc::tm_commit_path_scenarios();
+    assert_eq!(
+        scenarios,
+        [
+            "fcw_before_wal_append",
+            "wal_append_before_finalize",
+            "savepoint_release_rollback",
+            "concurrent_writers",
+        ]
+    );
+}
+
+#[test]
+fn deterministic_crash_offsets_preserve_tm_commit_atomicity() {
+    for seed in seeds() {
+        for scenario in TmCommitPathScenario::all() {
+            let dir = tempfile::tempdir().unwrap();
+            let model = run_tm_commit_path_workload(dir.path(), seed, scenario).unwrap();
+            let wal = std::fs::read(dir.path().join("wal.log")).unwrap();
+
+            for cut in crash_offsets(&model, wal.len()) {
+                let crash_dir = tempfile::tempdir().unwrap();
+                std::fs::write(crash_dir.path().join("wal.log"), &wal[..cut]).unwrap();
+                recover_and_check(crash_dir.path()).unwrap_or_else(|err| {
+                    panic!(
+                        "structural oracle failed for SEED={seed} scenario={} cut={cut}: {err}",
+                        scenario.name()
+                    )
+                });
+                let recovered = recover_tm_commit_path(crash_dir.path()).unwrap();
+                assert_tm_recovery_matches(seed, &model, &recovered);
+            }
+        }
+    }
+}
+
+#[test]
+fn simvfs_power_cuts_preserve_tm_commit_atomicity() {
+    for seed in seeds() {
+        for scenario in TmCommitPathScenario::all() {
+            let model_dir = tempfile::tempdir().unwrap();
+            let model = run_tm_commit_path_workload(model_dir.path(), seed, scenario).unwrap();
+
+            let cfg = SimFaultConfig {
+                power_cut_after: Some(power_cut_budget(scenario, seed)),
+                ..SimFaultConfig::none()
+            };
+            let vfs = SimVfs::new(seed, cfg);
+            match run_tm_commit_path_workload_on(&vfs, Path::new(SIM_DIR), seed, scenario) {
+                Ok(_) => {}
+                Err(err) => assert!(
+                    err.to_string().contains(POWER_CUT_MESSAGE),
+                    "SEED={seed} scenario={} unexpected workload error: {err}",
+                    scenario.name()
+                ),
+            }
+
+            let crash_dir = tempfile::tempdir().unwrap();
+            vfs.materialize(crash_dir.path()).unwrap();
+            recover_and_check(crash_dir.path()).unwrap_or_else(|err| {
+                panic!(
+                    "structural oracle failed for SEED={seed} scenario={}: {err}",
+                    scenario.name()
+                )
+            });
+            let recovered = recover_tm_commit_path(crash_dir.path()).unwrap();
+            assert_tm_recovery_matches(seed, &model, &recovered);
+        }
+    }
+}
+
+#[test]
+fn fault_free_run_recovers_the_full_tm_model() {
+    for seed in seeds() {
+        for scenario in TmCommitPathScenario::all() {
+            let dir = tempfile::tempdir().unwrap();
+            let model = run_tm_commit_path_workload(dir.path(), seed, scenario).unwrap();
+            recover_and_check(dir.path()).unwrap();
+            let recovered = recover_tm_commit_path(dir.path()).unwrap();
+            assert_eq!(
+                recovered,
+                model.all_committed(),
+                "SEED={seed} scenario={} did not recover the full model",
+                scenario.name()
+            );
+        }
+    }
+}
+
+fn crash_offsets(model: &unreliable_libc::TmCommitPathModel, wal_len: usize) -> Vec<usize> {
+    let mut offsets = vec![0, reddb_file::wal_header::WAL_FILE_HEADER_BYTES, wal_len];
+    for tx in &model.txs {
+        let end = usize::try_from(tx.commit_end_offset).unwrap();
+        offsets.push(end);
+        if end > 0 {
+            offsets.push(end - 1);
+        }
+    }
+    offsets.sort_unstable();
+    offsets.dedup();
+    offsets
+}
+
+fn power_cut_budget(scenario: TmCommitPathScenario, seed: u64) -> u64 {
+    match scenario {
+        TmCommitPathScenario::FcwBeforeWalAppend => 2,
+        TmCommitPathScenario::WalAppendBeforeFinalize => 5 + seed % 4,
+        TmCommitPathScenario::SavepointReleaseRollback => 6 + seed % 6,
+        TmCommitPathScenario::ConcurrentWriters => 5 + seed % 7,
+    }
+}
+
+/// Seeds to enumerate: a single pinned seed when `SEED` is set (reproduction),
+/// otherwise the documented sweep.
+fn seeds() -> Vec<u64> {
+    match std::env::var("SEED") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(seed) => vec![seed],
+            Err(_) => documented_seeds(),
+        },
+        Err(_) => documented_seeds(),
+    }
+}
+
+fn documented_seeds() -> Vec<u64> {
+    (0..SEED_COUNT).collect()
+}
+
+// ----- Real power-cut under the LD_PRELOAD shim (Linux/glibc only) ---------
+
+#[cfg(target_os = "linux")]
+mod powercut {
+    use super::*;
+    use std::process::{Command, Stdio};
+
+    /// Absolute path to the shim `.so`, baked in by `build.rs`.
+    const SHIM_SO: &str = env!("UNRELIABLE_LIBC_SO");
+    /// The TM commit-path workload binary, provided by cargo.
+    const WORKLOAD_BIN: &str = env!("CARGO_BIN_EXE_tm_commit_path_workload");
+
+    #[test]
+    fn ld_preload_power_cut_preserves_tm_commit_atomicity() {
+        for seed in seeds() {
+            for scenario in TmCommitPathScenario::all() {
+                let model_dir = tempfile::tempdir().unwrap();
+                let model = run_tm_commit_path_workload(model_dir.path(), seed, scenario).unwrap();
+
+                let crashed = tempfile::tempdir().unwrap();
+                let _status = spawn_powercut(seed, scenario, crashed.path());
+                recover_and_check(crashed.path()).unwrap_or_else(|err| {
+                    panic!(
+                        "structural oracle failed for SEED={seed} scenario={}: {err}",
+                        scenario.name()
+                    )
+                });
+                let recovered = recover_tm_commit_path(crashed.path()).unwrap();
+                assert_tm_recovery_matches(seed, &model, &recovered);
+            }
+        }
+    }
+
+    fn spawn_powercut(
+        seed: u64,
+        scenario: TmCommitPathScenario,
+        dir: &Path,
+    ) -> std::process::ExitStatus {
+        Command::new(WORKLOAD_BIN)
+            .arg(seed.to_string())
+            .arg(scenario.name())
+            .env("LD_PRELOAD", SHIM_SO)
+            .env("UNRELIABLE_SEED", seed.to_string())
+            .env("UNRELIABLE_DIR", dir)
+            .env("UNRELIABLE_POWERCUT", "1")
+            .env("UNRELIABLE_SHORT_PPM", "200000")
+            .env("UNRELIABLE_MAX_SYSCALLS", "48")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .unwrap_or_else(|e| {
+                panic!(
+                    "failed to spawn tm_commit_path_workload for SEED={seed} scenario={}: {e}",
+                    scenario.name()
+                )
+            })
+    }
+}

--- a/docs/testing/dst-storage-fault-lane.md
+++ b/docs/testing/dst-storage-fault-lane.md
@@ -25,6 +25,26 @@ The lane currently runs these suites:
   committed values match the model's committed prefix.
 - `power_cut_recovery`: Linux `LD_PRELOAD` shim coverage for real process kills,
   short writes, and injected I/O failures around the WAL workload.
+- `tm_commit_path_recovery`: TM v2 commit-path campaign for the four #1651
+  scenario families:
+  `fcw_before_wal_append`, `wal_append_before_finalize`,
+  `savepoint_release_rollback`, and `concurrent_writers`.
+
+## Documented Seeds
+
+The TM commit-path campaign sweeps seeds `0..15` by default. `SEED=<n>` pins a
+single reproduction seed across all four scenario families:
+
+```bash
+SEED=7 cargo test --locked -p unreliable-libc --test tm_commit_path_recovery
+```
+
+Each scenario runs as a seeded workload, injects a crash through deterministic
+WAL truncation, the in-process `SimVfs` power-cut path, and on Linux the
+`LD_PRELOAD` power-cut shim. Restart first runs the shared WAL recovery oracle,
+then asserts the TM-specific invariant: single-transaction scenarios recover as
+fully absent or fully committed, the concurrent-writer scenario recovers only a
+transaction prefix, and savepoint sub-xids are never orphan-visible.
 
 ## CI Signal
 


### PR DESCRIPTION
Finish-from-branch land of #1651 after it bounced with blocked:validation. The inner agent completed (DONE) and all gates passed EXCEPT one clippy nit (`while_let_loop` in `unreliable-libc/src/tm_commit_path.rs`). Fixed the loop→while-let; clippy now clean.

test/typecheck/build were already green; this only clears the lint gate.

Closes #1651.

https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785680291&installation_id=129708444&pr_number=1692&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1692&signature=c0dcdf76ca03dcad4c6d2030fd16a01c6793dd58b5770da6ff9c1993cb5c7cd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->