### PR TITLE
merge: #1652 feat(pgwire): wire authentication to the IAM auth store (commercial 1/6)

### DIFF
--- a/crates/reddb-server/src/wire/postgres/protocol.rs
+++ b/crates/reddb-server/src/wire/postgres/protocol.rs
@@ -1,7 +1,7 @@
 //! PostgreSQL v3 wire protocol message framing (Phase 3.1 PG parity).
 //!
 //! Implements the bits of the PG v3 protocol RedDB needs for simple
-//! query support: startup negotiation, authentication (trust), the
+//! query support: startup negotiation, cleartext password authentication, the
 //! simple query flow (`Q` → `T`/`D`*/`C`/`Z`), and error reporting.
 //!
 //! The full PG reference lives at:
@@ -84,7 +84,7 @@ pub enum FrontendMessage {
     Execute(ExecuteMessage),
     /// `C` — Close a prepared statement or portal.
     Close(CloseMessage),
-    /// `p` — password / SASL response. Payload is ignored for `trust` auth.
+    /// `p` — password / SASL response.
     PasswordMessage(Vec<u8>),
     /// `X` — Terminate.
     Terminate,
@@ -157,6 +157,8 @@ impl StartupParams {
 pub enum BackendMessage {
     /// `R` — AuthenticationOk (subtype 0).
     AuthenticationOk,
+    /// `R` — AuthenticationCleartextPassword (subtype 3).
+    AuthenticationCleartextPassword,
     /// `S` — ParameterStatus (server_version, client_encoding, ...).
     ParameterStatus { name: String, value: String },
     /// `K` — BackendKeyData (cancel key).
@@ -406,6 +408,10 @@ fn encode_backend(msg: &BackendMessage) -> (u8, Vec<u8>) {
         BackendMessage::AuthenticationOk => {
             // Subtype 0 = AuthenticationOk.
             (b'R', vec![0, 0, 0, 0])
+        }
+        BackendMessage::AuthenticationCleartextPassword => {
+            // Subtype 3 = AuthenticationCleartextPassword.
+            (b'R', vec![0, 0, 0, 3])
         }
         BackendMessage::ParameterStatus { name, value } => {
             let mut buf = Vec::with_capacity(name.len() + value.len() + 2);

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -17,6 +17,7 @@ use super::protocol::{
     DescribeTarget, FrontendMessage, PgWireError, TransactionStatus,
 };
 use super::types::{pg_param_to_value, value_to_pg_wire_bytes, PgOid};
+use crate::auth::Role;
 use crate::runtime::ai::ask_response_envelope::{
     AskResult, Citation, Mode, SourceRow, Validation, ValidationError, ValidationWarning,
 };
@@ -34,6 +35,13 @@ pub struct PgWireConfig {
     /// sniff this to enable/disable features. RedDB advertises a
     /// recent-enough version to get the broadest client support.
     pub server_version: String,
+}
+
+#[derive(Debug, Clone)]
+struct PgAuthContext {
+    username: String,
+    role: Role,
+    tenant: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -88,6 +96,67 @@ fn run_runtime_blocking<T>(f: impl FnOnce() -> T) -> T {
     }
 }
 
+fn execute_with_pg_auth_context<T>(
+    _runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let Some(auth_context) = auth_context else {
+        return f();
+    };
+    let _guard = PgAuthContextGuard::install(auth_context);
+    f()
+}
+
+struct PgAuthContextGuard {
+    previous_tenant: Option<String>,
+}
+
+impl PgAuthContextGuard {
+    fn install(auth_context: &PgAuthContext) -> Self {
+        let previous_tenant = crate::runtime::mvcc::current_tenant();
+        match &auth_context.tenant {
+            Some(tenant) => crate::runtime::mvcc::set_current_tenant(tenant.clone()),
+            None => crate::runtime::mvcc::clear_current_tenant(),
+        }
+        crate::runtime::mvcc::set_current_auth_identity(
+            auth_context.username.clone(),
+            auth_context.role,
+        );
+        Self { previous_tenant }
+    }
+}
+
+impl Drop for PgAuthContextGuard {
+    fn drop(&mut self) {
+        crate::runtime::mvcc::clear_current_auth_identity();
+        match self.previous_tenant.take() {
+            Some(tenant) => crate::runtime::mvcc::set_current_tenant(tenant),
+            None => crate::runtime::mvcc::clear_current_tenant(),
+        }
+    }
+}
+
+fn is_loopback_bind(bind_addr: &str) -> bool {
+    let host = bind_addr
+        .rsplit_once(':')
+        .map(|(host, _)| host.trim_matches(['[', ']']))
+        .unwrap_or(bind_addr);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false)
+}
+
+fn password_from_message(payload: &[u8]) -> Option<String> {
+    let nul = payload.iter().position(|&b| b == 0)?;
+    std::str::from_utf8(&payload[..nul])
+        .ok()
+        .map(|password| password.to_string())
+}
+
 /// Spawn the PG wire listener. Blocks until the listener errors out.
 /// Each connection is handled in its own tokio task.
 pub async fn start_pg_wire_listener(
@@ -95,6 +164,18 @@ pub async fn start_pg_wire_listener(
     runtime: Arc<RedDBRuntime>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(&config.bind_addr).await?;
+    if runtime
+        .auth_store()
+        .map(|store| !store.is_enabled())
+        .unwrap_or(true)
+        && is_loopback_bind(&config.bind_addr)
+    {
+        tracing::warn!(
+            transport = "pg-wire",
+            bind = %config.bind_addr,
+            "PG-Wire trust authentication is active; configure auth before exposing this listener"
+        );
+    }
     tracing::info!(
         transport = "pg-wire",
         bind = %config.bind_addr,
@@ -132,7 +213,7 @@ where
     // (pre-auth negotiation) or a plain Startup. Loop once to cover
     // SSL-not-supported path: reply 'N' and expect the client to send
     // a regular Startup next.
-    loop {
+    let auth_context = loop {
         match read_startup(&mut stream).await? {
             FrontendMessage::SslRequest | FrontendMessage::GssEncRequest => {
                 // 'N' = not supported — client continues in plaintext and
@@ -141,8 +222,12 @@ where
                 continue;
             }
             FrontendMessage::Startup(params) => {
-                send_auth_ok(&mut stream, &config, &params).await?;
-                break;
+                let context =
+                    match authenticate_startup(&mut stream, &runtime, &config, &params).await? {
+                        Some(context) => context,
+                        None => return Ok(()),
+                    };
+                break context;
             }
             FrontendMessage::Unknown { .. } => {
                 // CancelRequest: no response expected; drop the socket.
@@ -154,7 +239,7 @@ where
                 )));
             }
         }
-    }
+    };
 
     let mut prepared: HashMap<String, PgPreparedStatement> = HashMap::new();
     let mut portals: HashMap<String, PgPortal> = HashMap::new();
@@ -169,7 +254,7 @@ where
 
         match frame {
             FrontendMessage::Query(sql) => {
-                handle_simple_query(&mut stream, &runtime, &sql).await?;
+                handle_simple_query(&mut stream, &runtime, auth_context.as_ref(), &sql).await?;
             }
             FrontendMessage::Parse(msg) => {
                 handle_parse(&mut stream, &mut prepared, msg).await?;
@@ -178,10 +263,25 @@ where
                 handle_bind(&mut stream, &prepared, &mut portals, msg).await?;
             }
             FrontendMessage::Describe(msg) => {
-                handle_describe(&mut stream, &runtime, &prepared, &mut portals, msg).await?;
+                handle_describe(
+                    &mut stream,
+                    &runtime,
+                    auth_context.as_ref(),
+                    &prepared,
+                    &mut portals,
+                    msg,
+                )
+                .await?;
             }
             FrontendMessage::Execute(msg) => {
-                handle_execute(&mut stream, &runtime, &mut portals, msg).await?;
+                handle_execute(
+                    &mut stream,
+                    &runtime,
+                    auth_context.as_ref(),
+                    &mut portals,
+                    msg,
+                )
+                .await?;
             }
             FrontendMessage::Close(msg) => {
                 handle_close(&mut stream, &mut prepared, &mut portals, msg).await?;
@@ -325,6 +425,7 @@ where
 async fn handle_describe<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     prepared: &HashMap<String, PgPreparedStatement>,
     portals: &mut HashMap<String, PgPortal>,
     msg: super::protocol::DescribeMessage,
@@ -369,7 +470,12 @@ where
                 portal.row_description_sent = true;
                 Ok(())
             } else if is_row_returning_query(&portal.sql) {
-                let result = match execute_pg_query_result(runtime, &portal.sql, &portal.params) {
+                let result = match execute_pg_query_result(
+                    runtime,
+                    auth_context,
+                    &portal.sql,
+                    &portal.params,
+                ) {
                     Ok(result) => result,
                     Err(err) => {
                         let code = classify_sqlstate(&err);
@@ -391,6 +497,7 @@ where
 async fn handle_execute<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     portals: &mut HashMap<String, PgPortal>,
     msg: super::protocol::ExecuteMessage,
 ) -> Result<(), PgWireError>
@@ -411,7 +518,7 @@ where
     portal.row_description_sent = false;
     let result = match portal.described_result.take() {
         Some(result) => Ok(result),
-        None => execute_pg_query_result(runtime, &portal.sql, &portal.params),
+        None => execute_pg_query_result(runtime, auth_context, &portal.sql, &portal.params),
     };
     match result {
         Ok(result) if was_described => {
@@ -475,6 +582,7 @@ fn bind_pg_params(
 
 fn execute_pg_query_result(
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     sql: &str,
     params: &[Value],
 ) -> Result<crate::runtime::RuntimeQueryResult, String> {
@@ -493,15 +601,20 @@ fn execute_pg_query_result(
                 statement_type: "select",
                 bookmark: None,
             }),
-            Ok(None) => {
-                run_runtime_blocking(|| runtime.execute_query(sql)).map_err(|err| err.to_string())
-            }
+            Ok(None) => run_runtime_blocking(|| {
+                execute_with_pg_auth_context(runtime, auth_context, || runtime.execute_query(sql))
+            })
+            .map_err(|err| err.to_string()),
             Err(err) => Err(err.to_string()),
         };
     }
 
-    run_runtime_blocking(|| runtime.execute_query_with_params(sql, params))
-        .map_err(|err| err.to_string())
+    run_runtime_blocking(|| {
+        execute_with_pg_auth_context(runtime, auth_context, || {
+            runtime.execute_query_with_params(sql, params)
+        })
+    })
+    .map_err(|err| err.to_string())
 }
 
 fn try_execute_pg_scalar_select(
@@ -664,7 +777,54 @@ fn is_ask_query(sql: &str) -> bool {
     sql.trim_start().to_ascii_lowercase().starts_with("ask")
 }
 
-async fn send_auth_ok<S>(
+async fn authenticate_startup<S>(
+    stream: &mut S,
+    runtime: &RedDBRuntime,
+    config: &PgWireConfig,
+    params: &super::protocol::StartupParams,
+) -> Result<Option<Option<PgAuthContext>>, PgWireError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let auth_store = runtime.auth_store().filter(|store| store.is_enabled());
+    let trust_allowed = auth_store.is_none() && is_loopback_bind(&config.bind_addr);
+    let Some(auth_store) = auth_store else {
+        if trust_allowed {
+            send_startup_ready(stream, config, params).await?;
+            return Ok(Some(None));
+        }
+        send_error(stream, "28P01", "password authentication failed").await?;
+        return Ok(None);
+    };
+
+    write_frame(stream, &BackendMessage::AuthenticationCleartextPassword).await?;
+    let password = match read_frame(stream).await? {
+        FrontendMessage::PasswordMessage(payload) => password_from_message(&payload),
+        _ => None,
+    };
+    let username = params.get("user").unwrap_or("");
+    let tenant = params.get("tenant");
+    let Some(password) = password else {
+        send_error(stream, "28P01", "password authentication failed").await?;
+        return Ok(None);
+    };
+    let session = match auth_store.authenticate_in_tenant(tenant, username, &password) {
+        Ok(session) => session,
+        Err(_) => {
+            send_error(stream, "28P01", "password authentication failed").await?;
+            return Ok(None);
+        }
+    };
+
+    send_startup_ready(stream, config, params).await?;
+    Ok(Some(Some(PgAuthContext {
+        username: session.username,
+        role: session.role,
+        tenant: session.tenant_id,
+    })))
+}
+
+async fn send_startup_ready<S>(
     stream: &mut S,
     config: &PgWireConfig,
     params: &super::protocol::StartupParams,
@@ -672,7 +832,6 @@ async fn send_auth_ok<S>(
 where
     S: AsyncWrite + Unpin,
 {
-    // Phase 3.1: trust auth. We always send AuthenticationOk.
     write_frame(stream, &BackendMessage::AuthenticationOk).await?;
 
     // Standard ParameterStatus frames. Drivers gate capabilities on these.
@@ -721,6 +880,7 @@ where
 async fn handle_simple_query<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     sql: &str,
 ) -> Result<(), PgWireError>
 where
@@ -759,7 +919,9 @@ where
             statement_type: "select",
             bookmark: None,
         }),
-        Ok(None) => run_runtime_blocking(|| runtime.execute_query(sql)),
+        Ok(None) => run_runtime_blocking(|| {
+            execute_with_pg_auth_context(runtime, auth_context, || runtime.execute_query(sql))
+        }),
         Err(err) => Err(err),
     };
 
@@ -1243,6 +1405,7 @@ fn classify_sqlstate(msg: &str) -> &'static str {
 mod tests {
     use super::*;
     use crate::api::RedDBOptions;
+    use crate::auth::{AuthConfig, AuthStore, Role};
     use crate::runtime::RuntimeQueryResult;
     use crate::storage::query::modes::QueryMode;
     use crate::storage::query::unified::UnifiedResult;
@@ -1287,6 +1450,83 @@ mod tests {
         assert_eq!(cells.len(), 1);
         assert_eq!(cells[0].as_deref(), Some(b"42".as_slice()));
         assert_eq!(decode_command_complete(&frames[4].1), "SELECT 1");
+
+        write_frontend_frame(&mut client_io, b'X', Vec::new()).await;
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn enabled_auth_store_rejects_bad_pgwire_password_with_28p01() {
+        let runtime = Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap());
+        let auth = Arc::new(AuthStore::new(AuthConfig {
+            enabled: true,
+            require_auth: true,
+            ..AuthConfig::default()
+        }));
+        auth.create_user("alice", "secret", Role::Write).unwrap();
+        runtime.set_auth_store(auth);
+
+        let config = Arc::new(PgWireConfig::default());
+        let (server_io, mut client_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            handle_connection(server_io, runtime, config).await.unwrap();
+        });
+
+        write_startup_params(&mut client_io, &[("user", "alice")]).await;
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'R');
+        assert_eq!(i32::from_be_bytes(body[..4].try_into().unwrap()), 3);
+
+        write_frontend_frame(&mut client_io, b'p', cstring_body("wrong")).await;
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'E');
+        assert_eq!(error_response_field(&body, b'C'), Some("28P01"));
+
+        let mut eof = [0u8; 1];
+        assert_eq!(client_io.read(&mut eof).await.unwrap(), 0);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pgwire_password_auth_installs_statement_identity() {
+        let runtime = Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap());
+        let auth = Arc::new(AuthStore::new(AuthConfig {
+            enabled: true,
+            require_auth: true,
+            ..AuthConfig::default()
+        }));
+        auth.create_user_in_tenant(Some("acme"), "alice", "secret", Role::Write)
+            .unwrap();
+        runtime.set_auth_store(auth);
+
+        let config = Arc::new(PgWireConfig::default());
+        let (server_io, mut client_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            handle_connection(server_io, runtime, config).await.unwrap();
+        });
+
+        write_startup_params(&mut client_io, &[("user", "alice"), ("tenant", "acme")]).await;
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'R');
+        assert_eq!(i32::from_be_bytes(body[..4].try_into().unwrap()), 3);
+        write_frontend_frame(&mut client_io, b'p', cstring_body("secret")).await;
+        read_until_ready(&mut client_io).await;
+
+        write_frontend_frame(
+            &mut client_io,
+            b'Q',
+            cstring_body("SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_TENANT()"),
+        )
+        .await;
+        let frames = read_until_ready(&mut client_io).await;
+        assert_eq!(
+            frames.iter().map(|(tag, _)| *tag).collect::<Vec<_>>(),
+            b"TDCZ"
+        );
+        let cells = decode_data_row(&frames[1].1);
+        assert_eq!(cells[0].as_deref(), Some(b"alice".as_slice()));
+        assert_eq!(cells[1].as_deref(), Some(b"write".as_slice()));
+        assert_eq!(cells[2].as_deref(), Some(b"acme".as_slice()));
 
         write_frontend_frame(&mut client_io, b'X', Vec::new()).await;
         server.await.unwrap();
@@ -1468,9 +1708,16 @@ mod tests {
     }
 
     async fn write_startup<W: AsyncWrite + Unpin>(stream: &mut W) {
+        write_startup_params(stream, &[("user", "reddb")]).await;
+    }
+
+    async fn write_startup_params<W: AsyncWrite + Unpin>(stream: &mut W, params: &[(&str, &str)]) {
         let mut payload = Vec::new();
         payload.extend_from_slice(&crate::wire::postgres::protocol::PG_PROTOCOL_V3.to_be_bytes());
-        payload.extend_from_slice(b"user\0reddb\0");
+        for (name, value) in params {
+            push_pg_cstring(&mut payload, name);
+            push_pg_cstring(&mut payload, value);
+        }
         payload.push(0);
         let len = (payload.len() + 4) as u32;
         stream.write_all(&len.to_be_bytes()).await.unwrap();
@@ -1566,6 +1813,26 @@ mod tests {
         push_pg_cstring(&mut out, portal);
         out.extend_from_slice(&max_rows.to_be_bytes());
         out
+    }
+
+    fn cstring_body(value: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_pg_cstring(&mut out, value);
+        out
+    }
+
+    fn error_response_field(body: &[u8], field_tag: u8) -> Option<&str> {
+        let mut pos = 0;
+        while pos < body.len() && body[pos] != 0 {
+            let tag = body[pos];
+            pos += 1;
+            let end = body[pos..].iter().position(|&b| b == 0)? + pos;
+            if tag == field_tag {
+                return std::str::from_utf8(&body[pos..end]).ok();
+            }
+            pos = end + 1;
+        }
+        None
     }
 
     fn push_pg_cstring(out: &mut Vec<u8>, value: &str) {

--- a/docs/api/postgres-wire.md
+++ b/docs/api/postgres-wire.md
@@ -25,6 +25,17 @@ red server \
 psql -h 127.0.0.1 -p 5432 -U reddb reddb
 ```
 
+When RedDB auth is enabled, PG-wire requests a cleartext password during
+startup and verifies it against the same auth store used by native transports:
+
+```bash
+PGPASSWORD=s3cret psql -h 127.0.0.1 -p 5432 -U reddb reddb
+```
+
+The legacy trust behavior is only for loopback binds with no auth store
+configured. If PG-wire is bound to a non-loopback address, configure auth before
+exposing the listener.
+
 Then any supported SQL:
 
 ```sql
@@ -69,7 +80,7 @@ path; parameterized calls use the extended protocol.
 
 ```rust
 let (client, conn) = tokio_postgres::connect(
-    "host=localhost port=5432 user=reddb",
+    "host=localhost port=5432 user=reddb password=s3cret",
     tokio_postgres::NoTls,
 ).await?;
 tokio::spawn(async move { conn.await.unwrap() });
@@ -82,7 +93,7 @@ let rows = client
 ### Go (`pgx`)
 
 ```go
-conn, err := pgx.Connect(ctx, "postgres://reddb@localhost:5432/reddb")
+conn, err := pgx.Connect(ctx, "postgres://reddb:s3cret@localhost:5432/reddb")
 rows, err := conn.Query(ctx, "SELECT id, email FROM users WHERE id = $1", 42)
 ask, err := conn.Query(ctx, "ASK $1::text STRICT OFF LIMIT 5", "why did login fail?")
 ```
@@ -91,7 +102,7 @@ ask, err := conn.Query(ctx, "ASK $1::text STRICT OFF LIMIT 5", "why did login fa
 
 ```python
 import psycopg
-with psycopg.connect("host=localhost port=5432 user=reddb") as conn:
+with psycopg.connect("host=localhost port=5432 user=reddb password=s3cret") as conn:
     with conn.cursor() as cur:
         cur.execute("SELECT id, email FROM users WHERE id = %s", (42,))
         for row in cur.fetchall():

--- a/tests/pgwire_clients/JdbcClient.java
+++ b/tests/pgwire_clients/JdbcClient.java
@@ -8,10 +8,18 @@ import java.sql.Statement;
 public final class JdbcClient {
     public static void main(String[] args) throws Exception {
         String port = System.getenv("PGPORT");
+        String user = System.getenv("PGUSER");
+        if (user == null || user.isEmpty()) {
+            user = "reddb";
+        }
+        String password = System.getenv("PGPASSWORD");
+        if (password == null) {
+            password = "";
+        }
         String url = "jdbc:postgresql://127.0.0.1:" + port + "/reddb"
                 + "?sslmode=disable&preferQueryMode=extended&prepareThreshold=1"
                 + "&ApplicationName=pgwire360-jdbc";
-        try (Connection conn = DriverManager.getConnection(url, "reddb", "")) {
+        try (Connection conn = DriverManager.getConnection(url, user, password)) {
             conn.setAutoCommit(true);
             try (Statement st = conn.createStatement()) {
                 st.execute("CREATE TABLE jdbc_items (id INT, name TEXT)");

--- a/tests/pgwire_clients/pgx_client.go
+++ b/tests/pgwire_clients/pgx_client.go
@@ -12,10 +12,15 @@ import (
 func main() {
 	ctx := context.Background()
 	port := os.Getenv("PGPORT")
-	cfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://reddb@127.0.0.1:%s/reddb?sslmode=disable", port))
+	user := os.Getenv("PGUSER")
+	if user == "" {
+		user = "reddb"
+	}
+	cfg, err := pgx.ParseConfig(fmt.Sprintf("postgres://%s@127.0.0.1:%s/reddb?sslmode=disable", user, port))
 	if err != nil {
 		panic(err)
 	}
+	cfg.Password = os.Getenv("PGPASSWORD")
 	cfg.RuntimeParams["application_name"] = "pgwire360-pgx"
 	conn, err := pgx.ConnectConfig(ctx, cfg)
 	if err != nil {

--- a/tests/pgwire_clients/psycopg_client.py
+++ b/tests/pgwire_clients/psycopg_client.py
@@ -4,8 +4,10 @@ import psycopg
 
 
 port = os.environ["PGPORT"]
+user = os.environ.get("PGUSER", "reddb")
+password = os.environ.get("PGPASSWORD", "")
 conn = psycopg.connect(
-    f"host=127.0.0.1 port={port} user=reddb dbname=reddb sslmode=disable application_name=pgwire360-psycopg",
+    f"host=127.0.0.1 port={port} user={user} password={password} dbname=reddb sslmode=disable application_name=pgwire360-psycopg",
     autocommit=True,
 )
 cur = conn.cursor()

--- a/tests/pgwire_clients/run.sh
+++ b/tests/pgwire_clients/run.sh
@@ -8,6 +8,8 @@ PROXY_PORT="${PROXY_PORT:-55433}"
 AI_PORT="${AI_PORT:-55436}"
 LOG_FILE="${LOG_FILE:-$(mktemp /tmp/reddb-pgwire360-log.XXXXXX)}"
 DB_PATH="${DB_PATH:-$(mktemp /tmp/reddb-pgwire360-db.XXXXXX).rdb}"
+PGUSER="${PGUSER:-reddb}"
+PGPASSWORD="${PGPASSWORD:-}"
 
 cleanup() {
   if [[ -n "${PROXY_PID:-}" ]]; then kill "$PROXY_PID" 2>/dev/null || true; fi
@@ -20,11 +22,15 @@ python3 "$ROOT/tests/pgwire_clients/mock_ai.py" \
   --listen "127.0.0.1:${AI_PORT}" &
 AI_PID=$!
 
+SERVER_ARGS=(server --pg-bind "127.0.0.1:${PG_PORT}" --path "$DB_PATH" --no-log-file)
+if [[ -n "$PGPASSWORD" ]]; then
+  SERVER_ARGS+=(--auth --require-auth --bootstrap-admin "$PGUSER" --bootstrap-admin-password "$PGPASSWORD")
+fi
 REDDB_AI_PROVIDER=openai \
 REDDB_OPENAI_API_KEY=test-key \
 REDDB_OPENAI_API_BASE="http://127.0.0.1:${AI_PORT}/v1" \
 REDDB_OPENAI_PROMPT_MODEL=mock-chat \
-"$RED_BIN" server --pg-bind "127.0.0.1:${PG_PORT}" --path "$DB_PATH" --no-log-file &
+"$RED_BIN" "${SERVER_ARGS[@]}" &
 SERVER_PID=$!
 
 python3 "$ROOT/tests/pgwire_clients/proxy.py" \
@@ -49,6 +55,8 @@ PY
 
 docker run --rm --network host \
   -e PGPORT="$PROXY_PORT" \
+  -e PGUSER="$PGUSER" \
+  -e PGPASSWORD="$PGPASSWORD" \
   -v "$ROOT/tests/pgwire_clients:/clients:ro" \
   -w /clients \
   python:3.12-slim \
@@ -56,6 +64,8 @@ docker run --rm --network host \
 
 docker run --rm --network host \
   -e PGPORT="$PROXY_PORT" \
+  -e PGUSER="$PGUSER" \
+  -e PGPASSWORD="$PGPASSWORD" \
   -v "$ROOT/tests/pgwire_clients:/clients:ro" \
   -w /clients \
   golang:1.24 \
@@ -63,6 +73,8 @@ docker run --rm --network host \
 
 docker run --rm --network host \
   -e PGPORT="$PROXY_PORT" \
+  -e PGUSER="$PGUSER" \
+  -e PGPASSWORD="$PGPASSWORD" \
   -v "$ROOT/tests/pgwire_clients:/clients:ro" \
   -w /clients \
   maven:3.9-eclipse-temurin-17 \


### PR DESCRIPTION
Automated AFK landing for #1652. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1652

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785683373&installation_id=129708444&pr_number=1693&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1693&signature=aab4d177892d8557e33cb232a929f5d5e1eb2ad6aefed9b4321b61f8813dd904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL wire connections now support password-based authentication and preserve the signed-in identity during queries.
  * User, role, and tenant values are now available consistently after login.

* **Bug Fixes**
  * Rejected invalid credentials with a proper authentication error instead of continuing the startup flow.
  * Updated client test tools to read connection credentials from environment variables, improving auth-enabled and passwordless setups.

* **Documentation**
  * Refreshed PostgreSQL wire docs and examples to match the current authentication flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->