### PR TITLE
merge: #1654 feat(pgwire): ParameterDescription + extended-protocol conformance gaps (commercial 3/6)

### DIFF
--- a/crates/reddb-server/src/wire/postgres/mod.rs
+++ b/crates/reddb-server/src/wire/postgres/mod.rs
@@ -10,12 +10,15 @@
 //! * Authentication: `trust` only (no password). Clients that send an
 //!   actual password are accepted — the password is ignored.
 //! * Simple query protocol (`Q` frames): parse → execute → stream rows.
-//! * Extended query protocol (`Parse` / `Bind` / `Describe` / `Execute`).
+//! * Extended query protocol (`Parse` / `Bind` / `Describe` / `Execute` /
+//!   `Close` / `Sync`), including prepared statements, portals,
+//!   `ParameterDescription`, and row-limited `Execute` with
+//!   `PortalSuspended`.
 //! * Minimal row description using a small OID mapping table.
 //! * ReadyForQuery + Command­Complete + ErrorResponse framing.
 //!
 //! Not in this phase (future 3.1.x):
-//! * SASL / SCRAM auth, TLS.
+//! * SASL / SCRAM auth, TLS, GSSAPI encryption.
 //! * Function-call protocol.
 //! * COPY protocol.
 //! * NOTIFY / LISTEN.

--- a/crates/reddb-server/src/wire/postgres/protocol.rs
+++ b/crates/reddb-server/src/wire/postgres/protocol.rs
@@ -177,6 +177,8 @@ pub enum BackendMessage {
     CloseComplete,
     /// `t` — ParameterDescription.
     ParameterDescription(Vec<u32>),
+    /// `s` — PortalSuspended.
+    PortalSuspended,
     /// `n` — NoData.
     NoData,
     /// `E` — ErrorResponse with severity + code + message.
@@ -474,6 +476,7 @@ fn encode_backend(msg: &BackendMessage) -> (u8, Vec<u8>) {
             }
             (b't', buf)
         }
+        BackendMessage::PortalSuspended => (b's', Vec::new()),
         BackendMessage::NoData => (b'n', Vec::new()),
         BackendMessage::ErrorResponse {
             severity,

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -49,7 +49,8 @@ struct PgPortal {
     #[allow(dead_code)]
     result_format_codes: Vec<i16>,
     row_description_sent: bool,
-    described_result: Option<crate::runtime::RuntimeQueryResult>,
+    result: Option<crate::runtime::RuntimeQueryResult>,
+    row_offset: usize,
 }
 
 impl Default for PgWireConfig {
@@ -316,7 +317,8 @@ where
             params,
             result_format_codes: msg.result_format_codes,
             row_description_sent: false,
-            described_result: None,
+            result: None,
+            row_offset: 0,
         },
     );
     write_frame(stream, &BackendMessage::BindComplete).await
@@ -379,7 +381,8 @@ where
                 };
                 emit_row_description_for_result(stream, &result).await?;
                 portal.row_description_sent = true;
-                portal.described_result = Some(result);
+                portal.result = Some(result);
+                portal.row_offset = 0;
                 Ok(())
             } else {
                 write_frame(stream, &BackendMessage::NoData).await
@@ -406,18 +409,41 @@ where
         .await?;
         return Ok(());
     };
-    let _max_rows = msg.max_rows;
-    let was_described = portal.row_description_sent || portal.described_result.is_some();
-    portal.row_description_sent = false;
-    let result = match portal.described_result.take() {
-        Some(result) => Ok(result),
-        None => execute_pg_query_result(runtime, &portal.sql, &portal.params),
-    };
-    match result {
-        Ok(result) if was_described => {
-            emit_success_result_without_row_description(stream, &result).await
+    if portal.result.is_none() {
+        match execute_pg_query_result(runtime, &portal.sql, &portal.params) {
+            Ok(result) => {
+                portal.result = Some(result);
+                portal.row_offset = 0;
+            }
+            Err(err) => {
+                let code = classify_sqlstate(&err);
+                send_error(stream, code, &err).await?;
+                return Ok(());
+            }
         }
-        Ok(result) => emit_success_result(stream, &result).await,
+    }
+
+    let result = portal.result.as_ref().expect("portal result populated");
+    match emit_portal_execution(
+        stream,
+        result,
+        portal.row_description_sent,
+        portal.row_offset,
+        msg.max_rows,
+    )
+    .await
+    {
+        Ok(PortalExecution::Complete) => {
+            portal.result = None;
+            portal.row_offset = 0;
+            portal.row_description_sent = false;
+            Ok(())
+        }
+        Ok(PortalExecution::Suspended { next_row_offset }) => {
+            portal.row_offset = next_row_offset;
+            portal.row_description_sent = true;
+            Ok(())
+        }
         Err(err) => {
             let code = classify_sqlstate(&err);
             send_error(stream, code, &err).await
@@ -864,6 +890,97 @@ where
     Ok(())
 }
 
+enum PortalExecution {
+    Complete,
+    Suspended { next_row_offset: usize },
+}
+
+async fn emit_portal_execution<S>(
+    stream: &mut S,
+    result: &crate::runtime::RuntimeQueryResult,
+    row_description_sent: bool,
+    row_offset: usize,
+    max_rows: u32,
+) -> Result<PortalExecution, String>
+where
+    S: AsyncWrite + Unpin,
+{
+    if result.statement == "ask" && row_description_sent {
+        emit_success_result_without_row_description(stream, result)
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Complete)
+    } else if result.statement == "ask" {
+        emit_success_result(stream, result)
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Complete)
+    } else if result_returns_rows(result) {
+        emit_row_returning_portal_execution(
+            stream,
+            result,
+            row_description_sent,
+            row_offset,
+            max_rows,
+        )
+        .await
+    } else if row_description_sent {
+        emit_success_result_without_row_description(stream, result)
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Complete)
+    } else {
+        emit_success_result(stream, result)
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Complete)
+    }
+}
+
+async fn emit_row_returning_portal_execution<S>(
+    stream: &mut S,
+    result: &crate::runtime::RuntimeQueryResult,
+    row_description_sent: bool,
+    row_offset: usize,
+    max_rows: u32,
+) -> Result<PortalExecution, String>
+where
+    S: AsyncWrite + Unpin,
+{
+    if !row_description_sent {
+        emit_result_row_description(stream, &result.result)
+            .await
+            .map_err(|err| err.to_string())?;
+    }
+
+    let total_rows = result.result.records.len();
+    let remaining_rows = total_rows.saturating_sub(row_offset);
+    let rows_to_emit = if max_rows == 0 {
+        remaining_rows
+    } else {
+        remaining_rows.min(max_rows as usize)
+    };
+    emit_result_data_rows_range(stream, &result.result, row_offset, rows_to_emit)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let next_row_offset = row_offset + rows_to_emit;
+    if next_row_offset < total_rows {
+        write_frame(stream, &BackendMessage::PortalSuspended)
+            .await
+            .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Suspended { next_row_offset })
+    } else {
+        write_frame(
+            stream,
+            &BackendMessage::CommandComplete(format!("SELECT {}", total_rows)),
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+        Ok(PortalExecution::Complete)
+    }
+}
+
 async fn emit_row_description_for_result<S>(
     stream: &mut S,
     result: &crate::runtime::RuntimeQueryResult,
@@ -952,6 +1069,18 @@ async fn emit_result_data_rows<S>(
 where
     S: AsyncWrite + Unpin,
 {
+    emit_result_data_rows_range(stream, result, 0, result.records.len()).await
+}
+
+async fn emit_result_data_rows_range<S>(
+    stream: &mut S,
+    result: &crate::storage::query::unified::UnifiedResult,
+    row_offset: usize,
+    row_count: usize,
+) -> Result<(), PgWireError>
+where
+    S: AsyncWrite + Unpin,
+{
     let columns: Vec<String> = if !result.columns.is_empty() {
         result.columns.clone()
     } else if let Some(first) = result.records.first() {
@@ -959,7 +1088,7 @@ where
     } else {
         Vec::new()
     };
-    for record in &result.records {
+    for record in result.records.iter().skip(row_offset).take(row_count) {
         let fields: Vec<Option<Vec<u8>>> = columns
             .iter()
             .map(|col| record_get(record, col).and_then(value_to_pg_wire_bytes))

--- a/docs/api/postgres-wire.md
+++ b/docs/api/postgres-wire.md
@@ -145,10 +145,15 @@ shape:
 | ErrorResponse (`E`) | ✅ |
 | Cleartext password auth | ✅ |
 | SSL request (rejected with `N`) | ✅ |
-| Extended query (Parse / Bind / Describe / Execute) | ✅ |
+| Extended query (Parse / Bind / Describe / Execute / Close / Sync) | ✅ |
+| Prepared statements and portals | ✅ |
+| ParameterDescription (`t`) on Describe-statement | ✅ |
+| Row-limited Execute + PortalSuspended (`s`) | ✅ |
 | SCRAM-SHA-256 auth | 🟡 Planned |
 | TLS-wrapped connection | 🟡 Planned |
+| GSSAPI encryption | 🟡 Out of scope |
 | COPY protocol | 🟡 Use `COPY FROM 'file'` instead |
+| LISTEN / NOTIFY | 🟡 Out of scope |
 
 ## Type mapping
 

--- a/tests/grouped/redwire_protocol/postgres_wire_extended.rs
+++ b/tests/grouped/redwire_protocol/postgres_wire_extended.rs
@@ -45,6 +45,101 @@ async fn postgres_extended_query_binds_and_returns_rows() {
 }
 
 #[tokio::test]
+async fn postgres_extended_describe_statement_emits_parameter_description() {
+    let (addr, _server) = start_server().await;
+    let mut stream = TcpStream::connect(addr).await.expect("connect pg wire");
+
+    write_startup(&mut stream).await;
+    read_until_ready(&mut stream).await;
+
+    write_frontend_frame(
+        &mut stream,
+        b'P',
+        parse_body(
+            "sel",
+            "SELECT $1::int, $2::text",
+            &[PgOid::Unknown.as_u32(), PgOid::Text.as_u32()],
+        ),
+    )
+    .await;
+    write_frontend_frame(&mut stream, b'D', describe_body(b'S', "sel")).await;
+    write_frontend_frame(&mut stream, b'S', Vec::new()).await;
+
+    let frames = read_until_ready(&mut stream).await;
+    assert_eq!(
+        frames.iter().map(|(tag, _)| *tag).collect::<Vec<_>>(),
+        b"1tnZ"
+    );
+    assert_eq!(
+        decode_parameter_description(&frames[1].1),
+        vec![PgOid::Int4.as_u32(), PgOid::Text.as_u32()]
+    );
+
+    write_frontend_frame(&mut stream, b'X', Vec::new()).await;
+}
+
+#[tokio::test]
+async fn postgres_extended_execute_with_max_rows_suspends_portal() {
+    let (addr, _server) = start_server().await;
+    let mut stream = TcpStream::connect(addr).await.expect("connect pg wire");
+
+    write_startup(&mut stream).await;
+    read_until_ready(&mut stream).await;
+
+    write_frontend_frame(
+        &mut stream,
+        b'Q',
+        query_body("CREATE TABLE pg_ext_cursor_items (id INT)"),
+    )
+    .await;
+    read_until_ready(&mut stream).await;
+    write_frontend_frame(
+        &mut stream,
+        b'Q',
+        query_body("INSERT INTO pg_ext_cursor_items (id) VALUES (1), (2), (3)"),
+    )
+    .await;
+    read_until_ready(&mut stream).await;
+
+    write_frontend_frame(
+        &mut stream,
+        b'P',
+        parse_body("cursor_stmt", "SELECT id FROM pg_ext_cursor_items", &[]),
+    )
+    .await;
+    write_frontend_frame(
+        &mut stream,
+        b'B',
+        bind_body("cursor", "cursor_stmt", &[], &[], &[]),
+    )
+    .await;
+    write_frontend_frame(&mut stream, b'E', execute_body("cursor", 2)).await;
+    write_frontend_frame(&mut stream, b'E', execute_body("cursor", 0)).await;
+    write_frontend_frame(&mut stream, b'S', Vec::new()).await;
+
+    let frames = read_until_ready(&mut stream).await;
+    assert_eq!(
+        frames.iter().map(|(tag, _)| *tag).collect::<Vec<_>>(),
+        b"12TDDsDCZ"
+    );
+    assert_eq!(
+        decode_data_row(&frames[3].1)[0].as_deref(),
+        Some(b"1".as_slice())
+    );
+    assert_eq!(
+        decode_data_row(&frames[4].1)[0].as_deref(),
+        Some(b"2".as_slice())
+    );
+    assert_eq!(
+        decode_data_row(&frames[6].1)[0].as_deref(),
+        Some(b"3".as_slice())
+    );
+    assert_eq!(decode_command_complete(&frames[7].1), "SELECT 3");
+
+    write_frontend_frame(&mut stream, b'X', Vec::new()).await;
+}
+
+#[tokio::test]
 async fn postgres_extended_execute_emits_row_description_without_describe() {
     let (addr, _server) = start_server().await;
     let mut stream = TcpStream::connect(addr).await.expect("connect pg wire");
@@ -461,6 +556,22 @@ fn decode_row_description(body: &[u8]) -> Vec<(String, u32)> {
         columns.push((name, type_oid));
     }
     columns
+}
+
+fn decode_parameter_description(body: &[u8]) -> Vec<u32> {
+    let count = i16::from_be_bytes([body[0], body[1]]) as usize;
+    let mut pos = 2;
+    let mut oids = Vec::with_capacity(count);
+    for _ in 0..count {
+        oids.push(u32::from_be_bytes([
+            body[pos],
+            body[pos + 1],
+            body[pos + 2],
+            body[pos + 3],
+        ]));
+        pos += 4;
+    }
+    oids
 }
 
 fn decode_command_complete(body: &[u8]) -> &str {

--- a/tests/pgwire_clients/run.sh
+++ b/tests/pgwire_clients/run.sh
@@ -58,7 +58,7 @@ docker run --rm --network host \
   -e PGPORT="$PROXY_PORT" \
   -v "$ROOT/tests/pgwire_clients:/clients:ro" \
   -w /clients \
-  golang:1.24 \
+  golang:1.25 \
   sh -lc 'export PATH=/usr/local/go/bin:$PATH; go mod download && go run pgx_client.go'
 
 docker run --rm --network host \


### PR DESCRIPTION
Automated AFK landing for #1654. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1654

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785684687&installation_id=129708444&pr_number=1694&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1694&signature=f8d9a82ceafe65286bd5159a1d071719b30d0211118f614cbf88456e0712208f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->