### PR TITLE
merge: #1655 ci(pgwire): promote the real-client conformance harness to a CI lane (commercial 4/6)

### DIFF
--- a/.github/workflows/pgwire-clients.yml
+++ b/.github/workflows/pgwire-clients.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           RED_BIN: target/debug/red
           LOG_FILE: ${{ runner.temp }}/reddb-pgwire360.log
-        run: tests/pgwire_clients/run.sh
+        run: bash tests/pgwire_clients/run.sh
 
       - name: Upload PG-Wire proxy log
         if: always()

--- a/.github/workflows/pgwire-clients.yml
+++ b/.github/workflows/pgwire-clients.yml
@@ -63,7 +63,6 @@ jobs:
 
       - name: Run real-client PG-Wire conformance
         env:
-          RED_BIN: target/debug/red
           LOG_FILE: ${{ runner.temp }}/reddb-pgwire360.log
         run: bash tests/pgwire_clients/run.sh
 

--- a/.github/workflows/pgwire-clients.yml
+++ b/.github/workflows/pgwire-clients.yml
@@ -1,0 +1,76 @@
+name: PG-Wire Client Conformance
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/pgwire-clients.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/reddb-server/**'
+      - 'src/bin/red.rs'
+      - 'tests/pgwire_clients/**'
+      - 'tests/grouped/redwire_protocol/postgres_wire_extended.rs'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '.github/workflows/pgwire-clients.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/reddb-server/**'
+      - 'src/bin/red.rs'
+      - 'tests/pgwire_clients/**'
+      - 'tests/grouped/redwire_protocol/postgres_wire_extended.rs'
+  workflow_dispatch:
+
+concurrency:
+  group: pgwire-clients-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  pgwire-clients:
+    name: PG-Wire Clients (psycopg, pgx, pgjdbc)
+    if: github.actor != 'dependabot[bot]'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@1.91.0
+
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+
+      - uses: rui314/setup-mold@v1
+
+      - uses: mozilla-actions/sccache-action@v0.0.10
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-pgwire-clients-rust-1.91.0
+          cache-on-failure: "true"
+
+      - name: Build RedDB server
+        run: cargo build --locked --bin red
+
+      - name: Run real-client PG-Wire conformance
+        env:
+          RED_BIN: target/debug/red
+          LOG_FILE: ${{ runner.temp }}/reddb-pgwire360.log
+        run: tests/pgwire_clients/run.sh
+
+      - name: Upload PG-Wire proxy log
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pgwire-client-proxy-log
+          path: ${{ runner.temp }}/reddb-pgwire360.log
+          if-no-files-found: ignore

--- a/tests/pgwire_clients/README.md
+++ b/tests/pgwire_clients/README.md
@@ -1,0 +1,30 @@
+# PG-Wire real-client conformance harness
+
+`run.sh` starts a local RedDB server with the PG listener enabled, proxies the
+PG-Wire traffic for frame auditing, and runs three real PostgreSQL clients:
+
+- `psycopg_client.py` in the pinned `PSYCOPG_IMAGE`
+- `pgx_client.go` in the pinned `PGX_IMAGE`
+- `JdbcClient.java` in the pinned `PGJDBC_IMAGE`
+
+The script ends by running `assert_extended.py` against the proxy log, so a
+green run proves that each client completed successfully and that the extended
+protocol frames were observed.
+
+Run it locally after building `red`:
+
+```sh
+cargo build --locked --bin red
+RED_BIN=target/debug/red tests/pgwire_clients/run.sh
+```
+
+## Adding a client
+
+1. Add the client source file under `tests/pgwire_clients/`.
+2. Add a digest-pinned image variable near the top of `run.sh`, following the
+   existing `*_IMAGE` defaults. Use a multi-arch manifest digest when possible.
+3. Add one `run_client "<name>" "$<IMAGE_VAR>" '<command>'` line. Keep the name
+   stable because CI failure output uses it to identify the failing client.
+4. Set a unique `application_name` in the client connection string.
+5. Add the expected statements for that application name to `assert_extended.py`.
+6. Run `tests/pgwire_clients/run.sh` and confirm the final frame audit passes.

--- a/tests/pgwire_clients/README.md
+++ b/tests/pgwire_clients/README.md
@@ -15,7 +15,7 @@ Run it locally after building `red`:
 
 ```sh
 cargo build --locked --bin red
-RED_BIN=target/debug/red bash tests/pgwire_clients/run.sh
+bash tests/pgwire_clients/run.sh
 ```
 
 ## Adding a client

--- a/tests/pgwire_clients/README.md
+++ b/tests/pgwire_clients/README.md
@@ -15,7 +15,7 @@ Run it locally after building `red`:
 
 ```sh
 cargo build --locked --bin red
-RED_BIN=target/debug/red tests/pgwire_clients/run.sh
+RED_BIN=target/debug/red bash tests/pgwire_clients/run.sh
 ```
 
 ## Adding a client
@@ -27,4 +27,4 @@ RED_BIN=target/debug/red tests/pgwire_clients/run.sh
    stable because CI failure output uses it to identify the failing client.
 4. Set a unique `application_name` in the client connection string.
 5. Add the expected statements for that application name to `assert_extended.py`.
-6. Run `tests/pgwire_clients/run.sh` and confirm the final frame audit passes.
+6. Run `bash tests/pgwire_clients/run.sh` and confirm the final frame audit passes.

--- a/tests/pgwire_clients/run.sh
+++ b/tests/pgwire_clients/run.sh
@@ -8,6 +8,9 @@ PROXY_PORT="${PROXY_PORT:-55433}"
 AI_PORT="${AI_PORT:-55436}"
 LOG_FILE="${LOG_FILE:-$(mktemp /tmp/reddb-pgwire360-log.XXXXXX)}"
 DB_PATH="${DB_PATH:-$(mktemp /tmp/reddb-pgwire360-db.XXXXXX).rdb}"
+PSYCOPG_IMAGE="${PSYCOPG_IMAGE:-python:3.12-slim@sha256:423ed6ab25b1921a477529254bfeeabf5855151dc2c3141699a1bfc852199fbf}"
+PGX_IMAGE="${PGX_IMAGE:-golang:1.25@sha256:f188e8c16ea47a8b22d2bdcf6d9bcd07b63ea7876c199749c07bf31e0ab33bad}"
+PGJDBC_IMAGE="${PGJDBC_IMAGE:-maven:3.9-eclipse-temurin-17@sha256:1ed5d1f54416b706707b4f3238f63a20bb06aab27c6d240090a2bb9ad895ed45}"
 
 cleanup() {
   if [[ -n "${PROXY_PID:-}" ]]; then kill "$PROXY_PID" 2>/dev/null || true; fi
@@ -47,25 +50,28 @@ for port in (${AI_PORT}, ${PG_PORT}, ${PROXY_PORT}):
             time.sleep(0.1)
 PY
 
-docker run --rm --network host \
-  -e PGPORT="$PROXY_PORT" \
-  -v "$ROOT/tests/pgwire_clients:/clients:ro" \
-  -w /clients \
-  python:3.12-slim \
-  sh -lc 'pip install -q "psycopg[binary]" && python psycopg_client.py'
+run_client() {
+  local name="$1"
+  local image="$2"
+  local command="$3"
 
-docker run --rm --network host \
-  -e PGPORT="$PROXY_PORT" \
-  -v "$ROOT/tests/pgwire_clients:/clients:ro" \
-  -w /clients \
-  golang:1.25 \
-  sh -lc 'export PATH=/usr/local/go/bin:$PATH; go mod download && go run pgx_client.go'
+  echo "::group::pgwire client: ${name}"
+  echo "Running ${name} with ${image}"
+  if ! docker run --rm --network host \
+    -e PGPORT="$PROXY_PORT" \
+    -v "$ROOT/tests/pgwire_clients:/clients:ro" \
+    -w /clients \
+    "$image" \
+    sh -lc "$command"; then
+    echo "::endgroup::"
+    echo "FAIL: pgwire client ${name} failed"
+    return 1
+  fi
+  echo "::endgroup::"
+}
 
-docker run --rm --network host \
-  -e PGPORT="$PROXY_PORT" \
-  -v "$ROOT/tests/pgwire_clients:/clients:ro" \
-  -w /clients \
-  maven:3.9-eclipse-temurin-17 \
-  sh -lc 'mkdir -p /tmp/pgwire360-classes && mvn -q dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=/tmp/pgwire360-deps && javac -d /tmp/pgwire360-classes -cp "/tmp/pgwire360-deps/*" JdbcClient.java && java -cp "/tmp/pgwire360-classes:/tmp/pgwire360-deps/*" JdbcClient'
+run_client "psycopg" "$PSYCOPG_IMAGE" 'pip install -q "psycopg[binary]" && python psycopg_client.py'
+run_client "pgx" "$PGX_IMAGE" 'export PATH=/usr/local/go/bin:$PATH; go mod download && go run pgx_client.go'
+run_client "pgjdbc" "$PGJDBC_IMAGE" 'mkdir -p /tmp/pgwire360-classes && mvn -q dependency:copy-dependencies -DincludeScope=runtime -DoutputDirectory=/tmp/pgwire360-deps && javac -d /tmp/pgwire360-classes -cp "/tmp/pgwire360-deps/*" JdbcClient.java && java -cp "/tmp/pgwire360-classes:/tmp/pgwire360-deps/*" JdbcClient'
 
 python3 "$ROOT/tests/pgwire_clients/assert_extended.py" "$LOG_FILE"

--- a/tests/pgwire_clients/run.sh
+++ b/tests/pgwire_clients/run.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-RED_BIN="${RED_BIN:-/home/cyber/.cache/cargo-target/debug/red}"
+if [[ -z "${RED_BIN:-}" ]]; then
+  TARGET_DIR="$(cargo metadata --no-deps --format-version 1 | python3 -c 'import json, sys; print(json.load(sys.stdin)["target_directory"])')"
+  RED_BIN="${TARGET_DIR}/debug/red"
+fi
 PG_PORT="${PG_PORT:-55432}"
 PROXY_PORT="${PROXY_PORT:-55433}"
 AI_PORT="${AI_PORT:-55436}"


### PR DESCRIPTION
Automated AFK landing for #1655. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1655

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785686346&installation_id=129708444&pr_number=1696&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1696&signature=62ac1f6a46ce0577ee98658d9246188e0eee86909f76e552b35e62f473c402ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->