### PR TITLE
merge: #1652 feat(pgwire): wire authentication to the IAM auth store (commercial 1/6)

### DIFF
--- a/crates/reddb-server/src/runtime/authz/projection.rs
+++ b/crates/reddb-server/src/runtime/authz/projection.rs
@@ -93,6 +93,14 @@ impl RedDBRuntime {
         table: &TableQuery,
         frame: &dyn super::super::statement_frame::ReadFrame,
     ) -> RedDBResult<()> {
+        // A source-free scalar SELECT (`SELECT CURRENT_USER()`, `SELECT 1`,
+        // ...) parses to the synthetic `any` table but reads no user rows,
+        // so table-read authorization does not apply. Secret/KV/CONFIG
+        // scalars carry their own action gates enforced at execution time,
+        // so skipping the table gate here does not weaken those.
+        if super::super::query_exec::table_query_is_implicit_scalar_select(table) {
+            return Ok(());
+        }
         let Some((username, role)) = frame.identity() else {
             return Ok(());
         };

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -318,7 +318,12 @@ pub(super) fn runtime_record_has_document_capability(record: &UnifiedRecord) -> 
         .unwrap_or(false)
 }
 
-fn table_query_is_implicit_scalar_select(query: &TableQuery) -> bool {
+/// A source-free scalar SELECT (no `FROM`) parses to the synthetic `any`
+/// table with only source-free scalar projections (literals, session
+/// functions like `CURRENT_USER()`, `CONFIG(...)`, ...). It reads no user
+/// table, so table-read authorization must not gate it — the authz layer
+/// consults this to skip projection checks for such queries.
+pub(crate) fn table_query_is_implicit_scalar_select(query: &TableQuery) -> bool {
     query.table == "any"
         && query.alias.is_none()
         && query.source.is_none()
@@ -404,29 +409,67 @@ fn project_scalar_via_evaluator(
             continue;
         };
         let col_name = super::join_filter::projection_name(proj);
-        let value = match evaluator::evaluate(expr, empty_row) {
-            Ok(v) => v,
-            // Fall back for CONFIG, KV, ML_* and any other special-cased
-            // functions the evaluator does not cover yet.
-            Err(evaluator::EvalError::UnknownFunction { .. }) => {
-                super::join_filter::project_runtime_record_with_db(
-                    db,
-                    source,
-                    std::slice::from_ref(proj),
-                    None,
-                    None,
-                    false,
-                    false,
-                )
-                .get(col_name.as_str())
-                .cloned()
-                .unwrap_or(Value::Null)
+        let value = if let Some(value) = session_context_scalar_value(expr) {
+            value
+        } else {
+            match evaluator::evaluate(expr, empty_row) {
+                Ok(v) => v,
+                // Fall back for CONFIG, KV, ML_* and any other special-cased
+                // functions the evaluator does not cover yet.
+                Err(evaluator::EvalError::UnknownFunction { .. }) => {
+                    super::join_filter::project_runtime_record_with_db(
+                        db,
+                        source,
+                        std::slice::from_ref(proj),
+                        None,
+                        None,
+                        false,
+                        false,
+                    )
+                    .get(col_name.as_str())
+                    .cloned()
+                    .unwrap_or(Value::Null)
+                }
+                Err(err) => return Err(RedDBError::Query(err.to_string())),
             }
-            Err(err) => return Err(RedDBError::Query(err.to_string())),
         };
         record.set(&col_name, value);
     }
     Ok(record)
+}
+
+/// Resolve the PG session-context functions (`CURRENT_USER`, `CURRENT_ROLE`,
+/// `CURRENT_TENANT`, and their SQL aliases) against the thread-local auth
+/// identity installed by the transport layer (e.g. the PG-Wire password-auth
+/// flow). Returns `None` for any other expression so the caller falls through
+/// to the ordinary evaluator.
+fn session_context_scalar_value(expr: &Expr) -> Option<Value> {
+    let name = match expr {
+        Expr::FunctionCall { name, args, .. } if args.is_empty() => name.as_str(),
+        Expr::Column {
+            field: FieldRef::TableColumn { table, column },
+            ..
+        } if table.is_empty() => column.as_str(),
+        _ => return None,
+    };
+    match name.to_ascii_uppercase().as_str() {
+        "CURRENT_TENANT" => Some(
+            super::impl_core::current_tenant()
+                .map(Value::text)
+                .unwrap_or(Value::Null),
+        ),
+        "CURRENT_USER" | "SESSION_USER" | "USER" => Some(
+            super::impl_core::current_user_projected()
+                .map(Value::text)
+                .unwrap_or(Value::Null),
+        ),
+        "CURRENT_ROLE" => Some(
+            super::impl_core::current_role_projected()
+                .map(Value::text)
+                .unwrap_or(Value::Null),
+        ),
+        _ => None,
+    }
 }
 
 pub(super) fn evaluate_runtime_document_filter(

--- a/crates/reddb-server/src/wire/postgres/protocol.rs
+++ b/crates/reddb-server/src/wire/postgres/protocol.rs
@@ -84,7 +84,8 @@ pub enum FrontendMessage {
     Execute(ExecuteMessage),
     /// `C` — Close a prepared statement or portal.
     Close(CloseMessage),
-    /// `p` — password / SASL response. Payload is ignored for `trust` auth.
+    /// `p` — password / SASL response. Payload is the cleartext password
+    /// (NUL-terminated) when answering AuthenticationCleartextPassword.
     PasswordMessage(Vec<u8>),
     /// `X` — Terminate.
     Terminate,
@@ -157,6 +158,10 @@ impl StartupParams {
 pub enum BackendMessage {
     /// `R` — AuthenticationOk (subtype 0).
     AuthenticationOk,
+    /// `R` — AuthenticationCleartextPassword (subtype 3). Prompts the
+    /// client to reply with a `PasswordMessage` carrying the cleartext
+    /// password to verify against the auth store.
+    AuthenticationCleartextPassword,
     /// `S` — ParameterStatus (server_version, client_encoding, ...).
     ParameterStatus { name: String, value: String },
     /// `K` — BackendKeyData (cancel key).
@@ -408,6 +413,10 @@ fn encode_backend(msg: &BackendMessage) -> (u8, Vec<u8>) {
         BackendMessage::AuthenticationOk => {
             // Subtype 0 = AuthenticationOk.
             (b'R', vec![0, 0, 0, 0])
+        }
+        BackendMessage::AuthenticationCleartextPassword => {
+            // Subtype 3 = AuthenticationCleartextPassword.
+            (b'R', vec![0, 0, 0, 3])
         }
         BackendMessage::ParameterStatus { name, value } => {
             let mut buf = Vec::with_capacity(name.len() + value.len() + 2);

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -17,6 +17,7 @@ use super::protocol::{
     DescribeTarget, FrontendMessage, PgWireError, TransactionStatus,
 };
 use super::types::{pg_param_to_value, value_to_pg_wire_bytes, PgOid};
+use crate::auth::Role;
 use crate::runtime::ai::ask_response_envelope::{
     AskResult, Citation, Mode, SourceRow, Validation, ValidationError, ValidationWarning,
 };
@@ -34,6 +35,19 @@ pub struct PgWireConfig {
     /// sniff this to enable/disable features. RedDB advertises a
     /// recent-enough version to get the broadest client support.
     pub server_version: String,
+}
+
+/// The authenticated identity resolved during the PG-Wire startup
+/// handshake. Installed as the thread-local execution identity for the
+/// duration of each statement so every query dispatched over this
+/// connection flows through the same IAM/policy gates as native
+/// transports. `None` connections (loopback trust) run under the ambient
+/// embedded identity, preserving the pre-auth behaviour.
+#[derive(Debug, Clone)]
+struct PgAuthContext {
+    username: String,
+    role: Role,
+    tenant: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -89,6 +103,81 @@ fn run_runtime_blocking<T>(f: impl FnOnce() -> T) -> T {
     }
 }
 
+/// Run `f` with the authenticated PG-Wire identity installed as the
+/// thread-local execution identity, restoring the prior state afterwards.
+///
+/// The runtime's query dispatch resolves `CURRENT_USER/ROLE/TENANT` and
+/// folds RLS/IAM policies from these thread-locals, so installing them
+/// here is what makes PG-Wire statements transport-invariant with the
+/// native wire. A `None` context leaves the ambient identity untouched.
+fn execute_with_pg_auth_context<T>(
+    auth_context: Option<&PgAuthContext>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let Some(auth_context) = auth_context else {
+        return f();
+    };
+    let _guard = PgAuthContextGuard::install(auth_context);
+    f()
+}
+
+/// RAII guard that installs the PG-Wire auth identity + tenant on the
+/// current thread and restores the previous state on drop, so pooled
+/// runtime threads never leak an identity across statements.
+struct PgAuthContextGuard {
+    previous_tenant: Option<String>,
+}
+
+impl PgAuthContextGuard {
+    fn install(auth_context: &PgAuthContext) -> Self {
+        let previous_tenant = crate::runtime::execution_context::current_tenant();
+        match &auth_context.tenant {
+            Some(tenant) => crate::runtime::execution_context::set_current_tenant(tenant.clone()),
+            None => crate::runtime::execution_context::clear_current_tenant(),
+        }
+        crate::runtime::execution_context::set_current_auth_identity(
+            auth_context.username.clone(),
+            auth_context.role,
+        );
+        Self { previous_tenant }
+    }
+}
+
+impl Drop for PgAuthContextGuard {
+    fn drop(&mut self) {
+        crate::runtime::execution_context::clear_current_auth_identity();
+        match self.previous_tenant.take() {
+            Some(tenant) => crate::runtime::execution_context::set_current_tenant(tenant),
+            None => crate::runtime::execution_context::clear_current_tenant(),
+        }
+    }
+}
+
+/// Whether `bind_addr` ("host:port") resolves to a loopback host. Trust
+/// authentication survives only for loopback binds with no credentials
+/// configured; every other bind requires a verified password.
+fn is_loopback_bind(bind_addr: &str) -> bool {
+    let host = bind_addr
+        .rsplit_once(':')
+        .map(|(host, _)| host.trim_matches(['[', ']']))
+        .unwrap_or(bind_addr);
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+    host.parse::<std::net::IpAddr>()
+        .map(|addr| addr.is_loopback())
+        .unwrap_or(false)
+}
+
+/// Extract the cleartext password from a `PasswordMessage` payload (a
+/// single NUL-terminated C-string), returning `None` on malformed input.
+fn password_from_message(payload: &[u8]) -> Option<String> {
+    let nul = payload.iter().position(|&b| b == 0)?;
+    std::str::from_utf8(&payload[..nul])
+        .ok()
+        .map(|password| password.to_string())
+}
+
 /// Spawn the PG wire listener. Blocks until the listener errors out.
 /// Each connection is handled in its own tokio task.
 pub async fn start_pg_wire_listener(
@@ -96,6 +185,23 @@ pub async fn start_pg_wire_listener(
     runtime: Arc<RedDBRuntime>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind(&config.bind_addr).await?;
+    // Posture: with no auth store enabled, PG-Wire falls back to trust
+    // auth for loopback binds only (see `authenticate_startup`). Surface a
+    // startup warning whenever that fallback is active so an operator never
+    // exposes an unauthenticated listener without noticing.
+    let trust_active = runtime
+        .auth_store()
+        .map(|store| !store.is_enabled())
+        .unwrap_or(true)
+        && is_loopback_bind(&config.bind_addr);
+    if trust_active {
+        tracing::warn!(
+            transport = "pg-wire",
+            bind = %config.bind_addr,
+            "PG-Wire trust authentication is active (no auth store configured); \
+             loopback-only. Configure auth before exposing this listener."
+        );
+    }
     tracing::info!(
         transport = "pg-wire",
         bind = %config.bind_addr,
@@ -132,8 +238,9 @@ where
     // Handshake. The first frame may be SSLRequest / GSSENCRequest
     // (pre-auth negotiation) or a plain Startup. Loop once to cover
     // SSL-not-supported path: reply 'N' and expect the client to send
-    // a regular Startup next.
-    loop {
+    // a regular Startup next. On success the loop yields the connection's
+    // authenticated identity (`None` for loopback trust connections).
+    let auth_context = loop {
         match read_startup(&mut stream).await? {
             FrontendMessage::SslRequest | FrontendMessage::GssEncRequest => {
                 // 'N' = not supported — client continues in plaintext and
@@ -142,8 +249,12 @@ where
                 continue;
             }
             FrontendMessage::Startup(params) => {
-                send_auth_ok(&mut stream, &config, &params).await?;
-                break;
+                match authenticate_startup(&mut stream, &runtime, &config, &params).await? {
+                    Some(context) => break context,
+                    // Authentication failed: the error frame was already
+                    // sent and the socket must close.
+                    None => return Ok(()),
+                }
             }
             FrontendMessage::Unknown { .. } => {
                 // CancelRequest: no response expected; drop the socket.
@@ -155,7 +266,7 @@ where
                 )));
             }
         }
-    }
+    };
 
     let mut prepared: HashMap<String, PgPreparedStatement> = HashMap::new();
     let mut portals: HashMap<String, PgPortal> = HashMap::new();
@@ -170,7 +281,7 @@ where
 
         match frame {
             FrontendMessage::Query(sql) => {
-                handle_simple_query(&mut stream, &runtime, &sql).await?;
+                handle_simple_query(&mut stream, &runtime, auth_context.as_ref(), &sql).await?;
             }
             FrontendMessage::Parse(msg) => {
                 handle_parse(&mut stream, &mut prepared, msg).await?;
@@ -179,10 +290,25 @@ where
                 handle_bind(&mut stream, &prepared, &mut portals, msg).await?;
             }
             FrontendMessage::Describe(msg) => {
-                handle_describe(&mut stream, &runtime, &prepared, &mut portals, msg).await?;
+                handle_describe(
+                    &mut stream,
+                    &runtime,
+                    auth_context.as_ref(),
+                    &prepared,
+                    &mut portals,
+                    msg,
+                )
+                .await?;
             }
             FrontendMessage::Execute(msg) => {
-                handle_execute(&mut stream, &runtime, &mut portals, msg).await?;
+                handle_execute(
+                    &mut stream,
+                    &runtime,
+                    auth_context.as_ref(),
+                    &mut portals,
+                    msg,
+                )
+                .await?;
             }
             FrontendMessage::Close(msg) => {
                 handle_close(&mut stream, &mut prepared, &mut portals, msg).await?;
@@ -327,6 +453,7 @@ where
 async fn handle_describe<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     prepared: &HashMap<String, PgPreparedStatement>,
     portals: &mut HashMap<String, PgPortal>,
     msg: super::protocol::DescribeMessage,
@@ -371,7 +498,12 @@ where
                 portal.row_description_sent = true;
                 Ok(())
             } else if is_row_returning_query(&portal.sql) {
-                let result = match execute_pg_query_result(runtime, &portal.sql, &portal.params) {
+                let result = match execute_pg_query_result(
+                    runtime,
+                    auth_context,
+                    &portal.sql,
+                    &portal.params,
+                ) {
                     Ok(result) => result,
                     Err(err) => {
                         let code = classify_sqlstate(&err);
@@ -394,6 +526,7 @@ where
 async fn handle_execute<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     portals: &mut HashMap<String, PgPortal>,
     msg: super::protocol::ExecuteMessage,
 ) -> Result<(), PgWireError>
@@ -410,7 +543,7 @@ where
         return Ok(());
     };
     if portal.result.is_none() {
-        match execute_pg_query_result(runtime, &portal.sql, &portal.params) {
+        match execute_pg_query_result(runtime, auth_context, &portal.sql, &portal.params) {
             Ok(result) => {
                 portal.result = Some(result);
                 portal.row_offset = 0;
@@ -501,6 +634,7 @@ fn bind_pg_params(
 
 fn execute_pg_query_result(
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     sql: &str,
     params: &[Value],
 ) -> Result<crate::runtime::RuntimeQueryResult, String> {
@@ -519,15 +653,20 @@ fn execute_pg_query_result(
                 statement_type: "select",
                 bookmark: None,
             }),
-            Ok(None) => {
-                run_runtime_blocking(|| runtime.execute_query(sql)).map_err(|err| err.to_string())
-            }
+            Ok(None) => run_runtime_blocking(|| {
+                execute_with_pg_auth_context(auth_context, || runtime.execute_query(sql))
+            })
+            .map_err(|err| err.to_string()),
             Err(err) => Err(err.to_string()),
         };
     }
 
-    run_runtime_blocking(|| runtime.execute_query_with_params(sql, params))
-        .map_err(|err| err.to_string())
+    run_runtime_blocking(|| {
+        execute_with_pg_auth_context(auth_context, || {
+            runtime.execute_query_with_params(sql, params)
+        })
+    })
+    .map_err(|err| err.to_string())
 }
 
 fn try_execute_pg_scalar_select(
@@ -690,7 +829,77 @@ fn is_ask_query(sql: &str) -> bool {
     sql.trim_start().to_ascii_lowercase().starts_with("ask")
 }
 
-async fn send_auth_ok<S>(
+/// Drive the PG-Wire authentication handshake after a `StartupMessage`.
+///
+/// Posture:
+///   * Auth store enabled → request `AuthenticationCleartextPassword`,
+///     read the client's `PasswordMessage`, and verify it against the same
+///     auth store the native transports use. Success installs the resolved
+///     identity; failure emits `28P01` and closes the socket.
+///   * No auth store enabled + loopback bind → legacy trust: send
+///     `AuthenticationOk` with no credentials required (`None` context).
+///   * No auth store enabled + non-loopback bind → refuse with `28P01`;
+///     an unconfigured listener must never grant unauthenticated access
+///     off loopback.
+///
+/// Returns `Ok(Some(context))` once the connection is ready for queries
+/// (`context` is `None` for trust connections), or `Ok(None)` when
+/// authentication failed and the error frame has already been sent.
+///
+/// Failures give the same `28P01` "password authentication failed" for a
+/// wrong password and a missing user, so there is no user-existence oracle.
+async fn authenticate_startup<S>(
+    stream: &mut S,
+    runtime: &RedDBRuntime,
+    config: &PgWireConfig,
+    params: &super::protocol::StartupParams,
+) -> Result<Option<Option<PgAuthContext>>, PgWireError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let auth_store = runtime.auth_store().filter(|store| store.is_enabled());
+    let Some(auth_store) = auth_store else {
+        // No credentials configured: trust survives for loopback only.
+        if is_loopback_bind(&config.bind_addr) {
+            send_startup_ready(stream, config, params).await?;
+            return Ok(Some(None));
+        }
+        send_error(stream, "28P01", "password authentication failed").await?;
+        return Ok(None);
+    };
+
+    write_frame(stream, &BackendMessage::AuthenticationCleartextPassword).await?;
+    let password = match read_frame(stream).await? {
+        FrontendMessage::PasswordMessage(payload) => password_from_message(&payload),
+        // Anything other than a PasswordMessage is a protocol violation
+        // here; treat it as an auth failure rather than leaking detail.
+        _ => None,
+    };
+    let username = params.get("user").unwrap_or("");
+    let tenant = params.get("tenant");
+    let Some(password) = password else {
+        send_error(stream, "28P01", "password authentication failed").await?;
+        return Ok(None);
+    };
+    // A missing user and a wrong password both surface as the same error
+    // class below — no user-existence oracle leaks over the wire.
+    let session = match auth_store.authenticate_in_tenant(tenant, username, &password) {
+        Ok(session) => session,
+        Err(_) => {
+            send_error(stream, "28P01", "password authentication failed").await?;
+            return Ok(None);
+        }
+    };
+
+    send_startup_ready(stream, config, params).await?;
+    Ok(Some(Some(PgAuthContext {
+        username: session.username,
+        role: session.role,
+        tenant: session.tenant_id,
+    })))
+}
+
+async fn send_startup_ready<S>(
     stream: &mut S,
     config: &PgWireConfig,
     params: &super::protocol::StartupParams,
@@ -698,7 +907,7 @@ async fn send_auth_ok<S>(
 where
     S: AsyncWrite + Unpin,
 {
-    // Phase 3.1: trust auth. We always send AuthenticationOk.
+    // Authentication has succeeded (or trust applies): signal AuthenticationOk.
     write_frame(stream, &BackendMessage::AuthenticationOk).await?;
 
     // Standard ParameterStatus frames. Drivers gate capabilities on these.
@@ -747,6 +956,7 @@ where
 async fn handle_simple_query<S>(
     stream: &mut S,
     runtime: &RedDBRuntime,
+    auth_context: Option<&PgAuthContext>,
     sql: &str,
 ) -> Result<(), PgWireError>
 where
@@ -785,7 +995,9 @@ where
             statement_type: "select",
             bookmark: None,
         }),
-        Ok(None) => run_runtime_blocking(|| runtime.execute_query(sql)),
+        Ok(None) => run_runtime_blocking(|| {
+            execute_with_pg_auth_context(auth_context, || runtime.execute_query(sql))
+        }),
         Err(err) => Err(err),
     };
 
@@ -1372,10 +1584,93 @@ fn classify_sqlstate(msg: &str) -> &'static str {
 mod tests {
     use super::*;
     use crate::api::RedDBOptions;
+    use crate::auth::{AuthConfig, AuthStore};
     use crate::runtime::RuntimeQueryResult;
     use crate::storage::query::modes::QueryMode;
     use crate::storage::query::unified::UnifiedResult;
     use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn enabled_auth_store_rejects_bad_pgwire_password_with_28p01() {
+        let runtime = Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap());
+        let auth = Arc::new(AuthStore::new(AuthConfig {
+            enabled: true,
+            require_auth: true,
+            ..AuthConfig::default()
+        }));
+        auth.create_user("alice", "secret", Role::Write).unwrap();
+        runtime.set_auth_store(auth);
+
+        let config = Arc::new(PgWireConfig::default());
+        let (server_io, mut client_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            handle_connection(server_io, runtime, config).await.unwrap();
+        });
+
+        write_startup_params(&mut client_io, &[("user", "alice")]).await;
+        // Server must challenge for a cleartext password first.
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'R');
+        assert_eq!(i32::from_be_bytes(body[..4].try_into().unwrap()), 3);
+
+        write_frontend_frame(&mut client_io, b'p', cstring_body("wrong")).await;
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'E');
+        assert_eq!(error_response_field(&body, b'C'), Some("28P01"));
+
+        // The connection is closed after an auth failure.
+        let mut eof = [0u8; 1];
+        assert_eq!(client_io.read(&mut eof).await.unwrap(), 0);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pgwire_password_auth_installs_statement_identity() {
+        let runtime = Arc::new(RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap());
+        let auth = Arc::new(AuthStore::new(AuthConfig {
+            enabled: true,
+            require_auth: true,
+            ..AuthConfig::default()
+        }));
+        auth.create_user_in_tenant(Some("acme"), "alice", "secret", Role::Write)
+            .unwrap();
+        runtime.set_auth_store(auth);
+
+        let config = Arc::new(PgWireConfig::default());
+        let (server_io, mut client_io) = tokio::io::duplex(64 * 1024);
+        let server = tokio::spawn(async move {
+            handle_connection(server_io, runtime, config).await.unwrap();
+        });
+
+        write_startup_params(&mut client_io, &[("user", "alice"), ("tenant", "acme")]).await;
+        let (tag, body) = read_backend_frame(&mut client_io).await;
+        assert_eq!(tag, b'R');
+        assert_eq!(i32::from_be_bytes(body[..4].try_into().unwrap()), 3);
+        write_frontend_frame(&mut client_io, b'p', cstring_body("secret")).await;
+        read_until_ready(&mut client_io).await;
+
+        // The authenticated identity must drive CURRENT_USER/ROLE/TENANT so
+        // the simple-query path yields real rows (T,D,C,Z), transport-
+        // invariant with the native wire.
+        write_frontend_frame(
+            &mut client_io,
+            b'Q',
+            cstring_body("SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_TENANT()"),
+        )
+        .await;
+        let frames = read_until_ready(&mut client_io).await;
+        assert_eq!(
+            frames.iter().map(|(tag, _)| *tag).collect::<Vec<_>>(),
+            b"TDCZ"
+        );
+        let cells = decode_data_row(&frames[1].1);
+        assert_eq!(cells[0].as_deref(), Some(b"alice".as_slice()));
+        assert_eq!(cells[1].as_deref(), Some(b"write".as_slice()));
+        assert_eq!(cells[2].as_deref(), Some(b"acme".as_slice()));
+
+        write_frontend_frame(&mut client_io, b'X', Vec::new()).await;
+        server.await.unwrap();
+    }
 
     #[tokio::test]
     async fn extended_parse_bind_execute_returns_rows() {
@@ -1597,13 +1892,40 @@ mod tests {
     }
 
     async fn write_startup<W: AsyncWrite + Unpin>(stream: &mut W) {
+        write_startup_params(stream, &[("user", "reddb")]).await;
+    }
+
+    async fn write_startup_params<W: AsyncWrite + Unpin>(stream: &mut W, params: &[(&str, &str)]) {
         let mut payload = Vec::new();
         payload.extend_from_slice(&crate::wire::postgres::protocol::PG_PROTOCOL_V3.to_be_bytes());
-        payload.extend_from_slice(b"user\0reddb\0");
+        for (name, value) in params {
+            push_pg_cstring(&mut payload, name);
+            push_pg_cstring(&mut payload, value);
+        }
         payload.push(0);
         let len = (payload.len() + 4) as u32;
         stream.write_all(&len.to_be_bytes()).await.unwrap();
         stream.write_all(&payload).await.unwrap();
+    }
+
+    fn cstring_body(value: &str) -> Vec<u8> {
+        let mut out = Vec::new();
+        push_pg_cstring(&mut out, value);
+        out
+    }
+
+    fn error_response_field(body: &[u8], field_tag: u8) -> Option<&str> {
+        let mut pos = 0;
+        while pos < body.len() && body[pos] != 0 {
+            let tag = body[pos];
+            pos += 1;
+            let end = body[pos..].iter().position(|&b| b == 0)? + pos;
+            if tag == field_tag {
+                return std::str::from_utf8(&body[pos..end]).ok();
+            }
+            pos = end + 1;
+        }
+        None
     }
 
     async fn write_frontend_frame<W: AsyncWrite + Unpin>(

--- a/docs/api/postgres-wire.md
+++ b/docs/api/postgres-wire.md
@@ -39,6 +39,36 @@ ROLLBACK TO SAVEPOINT s1;
 COMMIT;
 ```
 
+## Authentication
+
+The PG listener verifies credentials against the same IAM auth store the
+native transports use, so a statement executed over PG-Wire flows through the
+identical policy gates — a principal denied `secret:read` by policy gets the
+same denial over PG-Wire as over RedWire.
+
+- **With an auth store configured**, the server requests a password
+  (`AuthenticationCleartextPassword`) after the startup message and verifies
+  the client's `PasswordMessage` against the store. The authenticated identity
+  (user + role + tenant) is installed per-connection and drives IAM on every
+  subsequent statement, so `CURRENT_USER()` / `CURRENT_ROLE()` /
+  `CURRENT_TENANT()` reflect the logged-in principal. Supply the password (and
+  optional `tenant`) in the connection string:
+
+  ```bash
+  psql "host=127.0.0.1 port=5432 user=alice password=secret dbname=reddb"
+  ```
+
+  A wrong password or a missing user both fail with SQLSTATE `28P01`
+  (`password authentication failed`) and the connection is closed — the error
+  is identical for both cases, so there is no user-existence oracle.
+
+- **With no auth store configured**, the listener falls back to *trust* auth
+  **for loopback binds only** (`127.0.0.1` / `::1` / `localhost`): any local
+  client connects without a password under the ambient embedded identity. A
+  startup warning is logged whenever this fallback is active. A non-loopback
+  bind with no credentials configured refuses every connection with `28P01`;
+  it never grants unauthenticated access off loopback.
+
 ## Safe Parameter Binding Status
 
 The PG listener supports PostgreSQL's extended protocol (`Parse` / `Bind` /


### PR DESCRIPTION
Automated AFK landing for #1652. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1652

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785706146&installation_id=129708444&pr_number=1698&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1698&signature=1c307f8943ee5a8951d7fe2a7a71247737f1be02215e3f7b0d847ed7689b94cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL connections now authenticate during startup when credentials are configured.
  * Session identity is now carried through queries, so user, role, and tenant-aware behavior stays consistent for a connection.
  * Cleartext password authentication is now supported for PostgreSQL clients.

* **Bug Fixes**
  * Source-free scalar `SELECT` queries now evaluate correctly without being blocked by table-level access checks.

* **Documentation**
  * Added PostgreSQL wire-protocol authentication details, including loopback-only trust fallback and connection failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->