### PR TITLE
merge: #1656 docs: per-data-model getting-started quickstarts (commercial 5/6)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -68,10 +68,31 @@ jobs:
       - run: echo "docs-only — contract matrix unaffected"
 
   docs-matrix:
+    # Issue #1656 — the getting-started quickstarts (docs/getting-started/
+    # quickstart-*.md) are executable: tests/docs_getting_started_quickstarts.rs
+    # runs each page's RQL against an in-memory RedDB so a quickstart cannot
+    # rot. On code PRs the workspace Test Suite already runs that target; but a
+    # docs-only PR (which edits a quickstart's `.md`) skips ci.yml entirely
+    # (#1307), so this docs lane must execute the quickstarts itself. That needs
+    # the workspace to build — including reddb-grpc-proto, whose build.rs
+    # requires protoc — so this job installs the toolchain + protoc rather than
+    # echoing. It keeps the required "Docs Match Contract Matrix" context name.
     name: Docs Match Contract Matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
-      - run: echo "docs-only — covered by ci.yml on code PRs"
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-docs-quickstarts-rust-1.91.0
+          cache-on-failure: "true"
+      - name: Execute getting-started quickstarts
+        run: cargo test --locked --test docs_getting_started_quickstarts
 
   helm-chart:
     name: Helm Chart

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ name = "llms_txt_generated"
 path = "tests/llms_txt_generated.rs"
 
 [[test]]
+name = "docs_getting_started_quickstarts"
+path = "tests/docs_getting_started_quickstarts.rs"
+
+[[test]]
 name = "grouped_ai_search"
 path = "tests/grouped/ai_search.rs"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,9 @@ that data lives.
 | Time-Series | Metrics, telemetry, bucketed aggregations | `SELECT avg(value) FROM cpu_metrics GROUP BY time_bucket(5m)` |
 | Queues | Jobs, retries, consumer groups, DLQ | `QUEUE READ tasks GROUP workers CONSUMER worker1 COUNT 5` |
 
+New here? Every model has a runnable, five-minute quickstart — see
+[Quickstarts by Model](/getting-started/quickstarts.md).
+
 For the distinction between user-facing models, native persisted entity kinds, and supporting
 structures such as indexes and probabilistic sketches, see
 [Data Model Overview](/data-models/overview.md).

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,6 +6,17 @@
   - [Modes and Transports](/getting-started/modes-and-transports.md)
   - [Configuration](/getting-started/configuration.md)
   - [Docker (Quickstart + Production)](/getting-started/docker.md)
+  - [Quickstarts by Model](/getting-started/quickstarts.md)
+    - [Relational SQL](/getting-started/quickstart-relational.md)
+    - [Documents](/getting-started/quickstart-document.md)
+    - [Key-Value, Config & Vault](/getting-started/quickstart-key-value.md)
+    - [Graphs](/getting-started/quickstart-graph.md)
+    - [Vector Search](/getting-started/quickstart-vector.md)
+    - [Time-Series](/getting-started/quickstart-timeseries.md)
+    - [Queues](/getting-started/quickstart-queue.md)
+    - [Spatial Search](/getting-started/quickstart-spatial.md)
+    - [Version Control (Time-Travel)](/getting-started/quickstart-vcs.md)
+    - [ASK / RAG](/getting-started/quickstart-ask-rag.md)
 
 - **AI & LLM**
   - [ASK Command](/query/search-commands.md#ask)

--- a/docs/getting-started/quickstart-ask-rag.md
+++ b/docs/getting-started/quickstart-ask-rag.md
@@ -1,0 +1,64 @@
+# Quickstart: ASK / RAG
+
+Retrieve context from a `collection` (the universal container) and let RedDB
+answer a question with citations. **ASK** is the RAG semantic layer: it
+retrieves the most relevant items, then grounds an LLM answer in them.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Build a retrievable knowledge base
+
+ASK grounds its answers in whatever it can retrieve. Seed a small vector
+collection — real embeddings come from your model; these 2-D vectors keep the
+example runnable:
+
+```sql
+INSERT INTO kb VECTOR (dense, content) VALUES ([0.9, 0.1], 'RedDB ASK grounds answers in retrieved sources and returns citations.');
+INSERT INTO kb VECTOR (dense, content) VALUES ([0.1, 0.9], 'RedWire is the principal transport for RedDB connections.');
+INSERT INTO kb VECTOR (dense, content) VALUES ([0.8, 0.2], 'STRICT mode makes ASK refuse to answer when retrieval finds nothing.');
+```
+
+## 3. Your first meaningful result: the retrieval
+
+This is exactly the context ASK would ground its answer in — the two nearest
+sources to the query embedding:
+
+```sql
+VECTOR SEARCH kb SIMILAR TO [0.9, 0.1] LIMIT 2;
+```
+
+```text
+ content                                                              | score
+---------------------------------------------------------------------+------
+ RedDB ASK grounds answers in retrieved sources and returns citations.| 0.99
+ STRICT mode makes ASK refuse to answer when retrieval finds nothing. | 0.97
+```
+
+## 4. Ask, grounded and cited
+
+With an AI provider configured, `ASK` retrieves that same context and returns a
+source-cited answer. `[^1]` maps to `sources_flat[0]`; `validation.ok` confirms
+every citation points at a real source. This call needs a live provider, so it
+is shown here rather than run by the docs test:
+
+```sql
+-- doctest:skip
+ASK 'how does RedDB ground answers?' USING openai STRICT ON CACHE TTL '5m' LIMIT 5;
+```
+
+## Where to go next
+
+- [Vector search quickstart](/getting-started/quickstart-vector.md) — the retrieval half in depth
+- [AI policy reference](/query/ai-policy.md) — providers, STRICT mode, and caching
+- [Vectors & Embeddings](/data-models/vectors.md) — the collection ASK retrieves from

--- a/docs/getting-started/quickstart-document.md
+++ b/docs/getting-started/quickstart-document.md
@@ -1,0 +1,50 @@
+# Quickstart: Documents
+
+Store schema-free JSON and query its fields directly. The **document** model
+is a semantic layer over a `collection` (the universal container): you write
+whole JSON bodies, and RedDB lets you filter and project their fields as if
+they were columns.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Insert JSON documents
+
+Each document carries an arbitrary JSON `body`:
+
+```sql
+INSERT INTO docs DOCUMENT (body) VALUES ('{"category":"ops","slug":"guide","title":"Runbook Guide"}');
+INSERT INTO docs DOCUMENT (body) VALUES ('{"category":"db","slug":"runbook","title":"DB Runbook"}');
+```
+
+The `docs` collection is created on first write — no schema declaration needed.
+
+## 3. Your first meaningful result
+
+Query document fields by name, just like columns:
+
+```sql
+SELECT slug, title FROM docs WHERE category = 'ops' ORDER BY slug ASC;
+```
+
+```text
+ slug  | title
+-------+--------------
+ guide | Runbook Guide
+```
+
+## Where to go next
+
+- [Documents](/data-models/documents.md) — the full document model
+- [Querying nested fields](/query/select.md) — dotted-path field access
+- [INSERT reference](/query/insert.md) — `DOCUMENT` and other write forms

--- a/docs/getting-started/quickstart-graph.md
+++ b/docs/getting-started/quickstart-graph.md
@@ -1,0 +1,59 @@
+# Quickstart: Graphs
+
+Model entities and their relationships, then traverse them. The **graph**
+model is a semantic layer over a `collection` (the universal container): nodes
+and edges live in one `network` collection, and RedDB runs pathfinding over
+them.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Insert nodes
+
+The first user-inserted item in a fresh database gets `rid = 1024` (ids
+`1..1023` are reserved for internal bootstrap records), so these three nodes
+are `1024`, `1025`, and `1026`:
+
+```sql
+INSERT INTO network NODE (label, node_type, role) VALUES ('gateway', 'Host', 'gateway');
+INSERT INTO network NODE (label, node_type, role) VALUES ('app', 'Host', 'application');
+INSERT INTO network NODE (label, node_type, role) VALUES ('db', 'Host', 'database');
+```
+
+## 3. Connect them with weighted edges
+
+```sql
+INSERT INTO network EDGE (label, from, to, weight) VALUES ('connects', 1024, 1025, 1.0);
+INSERT INTO network EDGE (label, from, to, weight) VALUES ('connects', 1025, 1026, 1.0);
+INSERT INTO network EDGE (label, from, to, weight) VALUES ('connects', 1024, 1026, 5.0);
+```
+
+## 4. Your first meaningful result
+
+Find the cheapest path from the gateway to the database. Dijkstra prefers the
+two 1.0-weight hops over the single 5.0 edge:
+
+```sql
+GRAPH SHORTEST_PATH '1024' TO '1026' ALGORITHM dijkstra;
+```
+
+```text
+ hop_count | total_weight
+-----------+-------------
+ 2         | 2.0
+```
+
+## Where to go next
+
+- [Graphs](/data-models/graphs.md) — nodes, edges, and properties
+- [Graph commands](/query/graph-commands.md) — traversals and analytics

--- a/docs/getting-started/quickstart-key-value.md
+++ b/docs/getting-started/quickstart-key-value.md
@@ -1,0 +1,48 @@
+# Quickstart: Key-Value, Config & Vault
+
+The **key-value** model is the simplest semantic layer over a `collection`
+(the universal container): opaque `key -> value` pairs. The same shape powers
+config flags and, with a vault-backed collection, secrets.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Write key-value pairs
+
+```sql
+INSERT INTO settings KV (key, value) VALUES ('feature_flag', true);
+INSERT INTO settings KV (key, value) VALUES ('max_retries', 3);
+```
+
+Values keep their type — a boolean stays a boolean, a number stays a number.
+
+## 3. Your first meaningful result
+
+Read the collection back, ordered by key:
+
+```sql
+SELECT key, value FROM settings ORDER BY key ASC;
+```
+
+```text
+ key          | value
+--------------+------
+ feature_flag | true
+ max_retries  | 3
+```
+
+## Where to go next
+
+- [Key-Value](/data-models/key-value.md) — the full KV model
+- [Cache](/data-models/cache.md) — KV with TTL and invalidation
+- [Vault & secrets](/security/vault.md) — encrypted, access-controlled values

--- a/docs/getting-started/quickstart-queue.md
+++ b/docs/getting-started/quickstart-queue.md
@@ -1,0 +1,58 @@
+# Quickstart: Queues
+
+Hand work to background consumers with at-least-once delivery. The **queue**
+model is a semantic layer over a `collection` (the universal container):
+messages, consumer groups, and a dead-letter queue for poison messages.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Create a queue and a consumer group
+
+Failed messages retry up to three times before landing in `failed_tasks`:
+
+```sql
+CREATE QUEUE tasks WITH DLQ failed_tasks MAX_ATTEMPTS 3;
+QUEUE GROUP CREATE tasks workers;
+```
+
+## 3. Push work
+
+```sql
+QUEUE PUSH tasks 'job-1';
+QUEUE PUSH tasks 'job-2';
+```
+
+## 4. Your first meaningful result
+
+Check the backlog, then deliver the first job to a consumer:
+
+```sql
+QUEUE LEN tasks;
+QUEUE READ tasks GROUP workers CONSUMER worker1 COUNT 1;
+```
+
+```text
+ payload | consumer
+---------+---------
+ job-1   | worker1
+```
+
+Acknowledge the message with `QUEUE ACK tasks GROUP workers '<message_id>'`
+once the work is done, or it will be redelivered.
+
+## Where to go next
+
+- [Queues & Deques](/data-models/queues.md) — the full queue model
+- [Events](/data-models/events.md) — pub/sub over the same engine
+- [Event Workflow](/data-models/event-workflow.md) — multi-stage processing

--- a/docs/getting-started/quickstart-relational.md
+++ b/docs/getting-started/quickstart-relational.md
@@ -1,0 +1,67 @@
+# Quickstart: Relational SQL
+
+Go from an empty database to a grouped SQL report in under five minutes. The
+**relational** model gives a `collection` typed columns, constraints, and
+familiar `SELECT ... GROUP BY` — the model is the semantic layer; the
+`accounts` collection below is the universal container underneath it.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Then open a session with `red connect 127.0.0.1:55055` (or POST each statement
+to `http://127.0.0.1:5000/query`). Every statement below is plain RQL.
+
+## 2. Create a typed collection
+
+```sql
+CREATE TABLE accounts (id TEXT PRIMARY KEY, username TEXT UNIQUE, status TEXT NOT NULL DEFAULT = 'active', tier TEXT DEFAULT = 'basic', score FLOAT) WITH timestamps = true;
+```
+
+## 3. Insert rows
+
+```sql
+INSERT INTO accounts (id, username, status, score) VALUES ('u1', 'alice', 'active', 91.5);
+INSERT INTO accounts (id, username, status, tier, score) VALUES ('u2', 'bob', 'suspended', 'enterprise', 72.0);
+INSERT INTO accounts (id, username, status, tier, score) VALUES ('u3', 'carol', 'active', 'pro', 88.25);
+```
+
+## 4. Your first meaningful result
+
+Filter, project, and order like any SQL database:
+
+```sql
+SELECT username, tier FROM accounts WHERE status = 'active' ORDER BY username ASC;
+```
+
+```text
+ username | tier
+----------+------
+ alice    | basic
+ carol    | pro
+```
+
+Then aggregate:
+
+```sql
+SELECT status, count(*) AS total FROM accounts GROUP BY status ORDER BY status ASC;
+```
+
+```text
+ status    | total
+-----------+------
+ active    | 2
+ suspended | 1
+```
+
+## Where to go next
+
+- [Tables & Rows](/data-models/tables.md) — the full relational model
+- [CREATE TABLE reference](/query/create-table.md) — constraints, TTL, indexes
+- [INSERT reference](/query/insert.md) — every write form

--- a/docs/getting-started/quickstart-spatial.md
+++ b/docs/getting-started/quickstart-spatial.md
@@ -1,0 +1,56 @@
+# Quickstart: Spatial Search
+
+Index geographic points and query them by radius or nearest-neighbour. The
+**spatial** model adds an H3 index to a `collection` (the universal
+container): a `GEOPOINT` column becomes searchable by distance.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Create a collection with a geopoint and an H3 index
+
+```sql
+CREATE TABLE places (id INT, name TEXT, loc GEOPOINT);
+CREATE INDEX idx_loc ON places (loc) USING H3;
+```
+
+## 3. Insert points
+
+`GEOPOINT` values are `'latitude,longitude'` strings — three Paris landmarks:
+
+```sql
+INSERT INTO places (id, name, loc) VALUES (1, 'Louvre', '48.8606,2.3376');
+INSERT INTO places (id, name, loc) VALUES (2, 'Eiffel Tower', '48.8584,2.2945');
+INSERT INTO places (id, name, loc) VALUES (3, 'Sacre-Coeur', '48.8867,2.3431');
+```
+
+## 4. Your first meaningful result
+
+Find everything within 5 km of the city centre, then the two nearest points:
+
+```sql
+SEARCH SPATIAL RADIUS 48.8566 2.3522 5.0 COLLECTION places COLUMN loc;
+SEARCH SPATIAL NEAREST 48.8566 2.3522 K 2 COLLECTION places COLUMN loc;
+```
+
+```text
+ name         | distance_km
+--------------+------------
+ Louvre       | 1.2
+ Sacre-Coeur  | 3.4
+```
+
+## Where to go next
+
+- [CREATE INDEX reference](/query/create-index.md) — H3, R-tree, and other index kinds
+- [Data Model Overview](/data-models/overview.md) — how spatial composes with other models

--- a/docs/getting-started/quickstart-timeseries.md
+++ b/docs/getting-started/quickstart-timeseries.md
@@ -1,0 +1,58 @@
+# Quickstart: Time-Series
+
+Ingest timestamped measurements and roll them up into time buckets. The
+**time-series** model is a semantic layer over a `collection` (the universal
+container): append-heavy points with a retention window and built-in
+downsampling.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Declare the series
+
+Set a 7-day retention window and a 1h->5m average downsample rule:
+
+```sql
+CREATE TIMESERIES metrics RETENTION 7 d CHUNK_SIZE 64 DOWNSAMPLE 1h:5m:avg;
+```
+
+## 3. Ingest points
+
+Timestamps are nanoseconds; these span two 5-minute buckets:
+
+```sql
+INSERT INTO metrics (metric, value, tags, timestamp) VALUES ('cpu.usage', 10.0, '{"host":"srv-a"}', 0);
+INSERT INTO metrics (metric, value, tags, timestamp) VALUES ('cpu.usage', 20.0, '{"host":"srv-a"}', 60000000000);
+INSERT INTO metrics (metric, value, tags, timestamp) VALUES ('cpu.usage', 30.0, '{"host":"srv-b"}', 300000000000);
+```
+
+## 4. Your first meaningful result
+
+Bucket by five minutes and average each window:
+
+```sql
+SELECT time_bucket(5m) AS bucket, avg(value) AS avg_value, count(*) AS samples FROM metrics WHERE metric = 'cpu.usage' GROUP BY time_bucket(5m);
+```
+
+```text
+ bucket | avg_value | samples
+--------+-----------+--------
+ 0      | 15.0      | 2
+ 5m     | 30.0      | 1
+```
+
+## Where to go next
+
+- [Time-Series](/data-models/timeseries.md) — the full time-series model
+- [Hypertables](/data-models/hypertables.md) — partitioned time-series at scale
+- [Continuous Aggregates](/data-models/continuous-aggregates.md) — always-fresh rollups

--- a/docs/getting-started/quickstart-vcs.md
+++ b/docs/getting-started/quickstart-vcs.md
@@ -1,0 +1,70 @@
+# Quickstart: Version Control (Time-Travel)
+
+Commit a snapshot of your data, keep writing, then read the past. RedDB's
+**VCS** layer opts a `collection` (the universal container) into versioning so
+you can `CHECKPOINT` a commit and query `AS OF` any branch.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Create a versioned collection
+
+```sql
+CREATE TABLE releases (id INT, name TEXT, status TEXT);
+ALTER TABLE releases SET VERSIONED = true;
+INSERT INTO releases (id, name, status) VALUES (1, 'reddb', 'draft');
+```
+
+## 3. Commit a checkpoint
+
+`CHECKPOINT` records the current state as a commit on the `main` branch:
+
+```sql
+CHECKPOINT 'cut draft release' AUTHOR 'Release Bot <rel@reddb.io>';
+```
+
+## 4. Change the data, then time-travel
+
+Update the live row, then compare "now" against the committed snapshot:
+
+```sql
+UPDATE releases SET status = 'published' WHERE id = 1;
+SELECT name, status FROM releases;
+SELECT name, status FROM releases AS OF BRANCH 'main';
+```
+
+```text
+-- live now:
+ name  | status
+-------+----------
+ reddb | published
+
+-- AS OF BRANCH 'main' (the checkpoint):
+ name  | status
+-------+-------
+ reddb | draft
+```
+
+## 5. Your first meaningful result
+
+The commit log shows the checkpoint you just made:
+
+```sql
+SELECT message, height FROM red.commits ORDER BY height DESC LIMIT 3;
+```
+
+## Where to go next
+
+- [VCS overview](/vcs/overview.md) — branches, commits, and merges
+- [VCS commands](/vcs/commands.md) — `CHECKPOINT`, `CHECKOUT`, `MERGE`, and more
+- [VCS walkthrough](/vcs/walkthrough.md) — a longer end-to-end tour

--- a/docs/getting-started/quickstart-vector.md
+++ b/docs/getting-started/quickstart-vector.md
@@ -1,0 +1,51 @@
+# Quickstart: Vector Search
+
+Store embeddings and find the nearest ones by similarity. The **vector**
+model is a semantic layer over a `collection` (the universal container): each
+item holds a `dense` vector plus its `content`, and RedDB ranks them by
+distance to a query vector.
+
+## 1. Start RedDB
+
+```bash
+docker run --rm \
+  -p 5050:5050 \
+  -p 55055:55055 \
+  -p 5000:5000 \
+  ghcr.io/reddb-io/reddb:latest
+```
+
+Connect with `red connect 127.0.0.1:55055` (or POST to
+`http://127.0.0.1:5000/query`).
+
+## 2. Insert embeddings
+
+Real embeddings have hundreds of dimensions; these 2-D vectors keep the math
+easy to read:
+
+```sql
+INSERT INTO embeddings VECTOR (dense, content) VALUES ([1.0, 0.0], 'gateway runbook');
+INSERT INTO embeddings VECTOR (dense, content) VALUES ([0.0, 1.0], 'database manual');
+INSERT INTO embeddings VECTOR (dense, content) VALUES ([0.5, 0.5], 'shared note');
+```
+
+## 3. Your first meaningful result
+
+Ask for the vectors most similar to `[1.0, 0.0]`:
+
+```sql
+VECTOR SEARCH embeddings SIMILAR TO [1.0, 0.0] LIMIT 2;
+```
+
+```text
+ content         | score
+-----------------+------
+ gateway runbook | 1.00
+ shared note     | 0.71
+```
+
+## Where to go next
+
+- [Vectors & Embeddings](/data-models/vectors.md) — the full vector model
+- [HNSW index](/vectors/hnsw.md) — approximate search at scale
+- [ASK / RAG quickstart](/getting-started/quickstart-ask-rag.md) — grounded answers over vectors

--- a/docs/getting-started/quickstarts.md
+++ b/docs/getting-started/quickstarts.md
@@ -1,0 +1,25 @@
+# Quickstarts by Data Model
+
+One runnable quickstart per data model — each takes you from `docker run` to a
+first meaningful result in under five minutes, using only released artifacts.
+Throughout, a `collection` is the universal container and the data model is the
+semantic layer over it.
+
+Every SQL sequence on these pages is executed by the docs CI lane, so the
+examples cannot rot.
+
+| Model | Quickstart | You will |
+|-------|-----------|----------|
+| Relational SQL | [Relational](/getting-started/quickstart-relational.md) | Create typed columns and run `GROUP BY` |
+| Document | [Documents](/getting-started/quickstart-document.md) | Store JSON and query its fields |
+| Key-Value | [Key-Value, Config & Vault](/getting-started/quickstart-key-value.md) | Write and read typed `key -> value` pairs |
+| Graph | [Graphs](/getting-started/quickstart-graph.md) | Traverse nodes and edges with Dijkstra |
+| Vector | [Vector Search](/getting-started/quickstart-vector.md) | Rank embeddings by similarity |
+| Time-Series | [Time-Series](/getting-started/quickstart-timeseries.md) | Bucket and aggregate measurements |
+| Queue | [Queues](/getting-started/quickstart-queue.md) | Push and deliver work to consumers |
+| Spatial | [Spatial Search](/getting-started/quickstart-spatial.md) | Query geopoints by radius and nearest |
+| VCS | [Version Control (Time-Travel)](/getting-started/quickstart-vcs.md) | Checkpoint and read the past `AS OF` |
+| ASK / RAG | [ASK / RAG](/getting-started/quickstart-ask-rag.md) | Retrieve context for a grounded answer |
+
+New to RedDB? Start with [Quick Start](/getting-started/quick-start.md) for a
+cross-model tour, then pick the model that fits your workload above.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,6 +4,8 @@
 
 This file is generated from the engine's own authorities — do not edit by hand. See `AGENTS.md` for the human/agent overview. Each section below is emitted from source so it cannot drift from the engine.
 
+New to RedDB? Every data model has a runnable, five-minute quickstart under `docs/getting-started/` — one per model (relational, document, key-value, graph, vector, time-series, queue, spatial, VCS/time-travel, and ASK/RAG), indexed at `docs/getting-started/quickstarts.md`. Each quickstart's RQL is executed by the docs CI lane, so its examples stay runnable.
+
 <!-- BEGIN GENERATED: rql -->
 # RedDB RQL Reference
 

--- a/tests/docs_getting_started_quickstarts.rs
+++ b/tests/docs_getting_started_quickstarts.rs
@@ -1,0 +1,180 @@
+//! Executable getting-started quickstarts (issue #1656, PRD #1621 — DX slice 1).
+//!
+//! Each `docs/getting-started/quickstart-*.md` page walks a newcomer from an
+//! `docker run` / embedded open to a first meaningful result for one data
+//! model. Those pages are *executable documentation*: this test extracts the
+//! ` ```sql ` fences from every quickstart and runs them against a fresh
+//! in-memory RedDB, so a quickstart can never silently rot — a renamed keyword
+//! or dropped column fails the docs CI lane instead of a reader's terminal.
+//!
+//! Contract, per quickstart:
+//!   * every executed RQL statement must succeed (`Ok`), and
+//!   * at least one statement must return a row — the "first meaningful result"
+//!     the page promises.
+//!
+//! A ` ```sql ` fence whose first content line is `-- doctest:skip` documents a
+//! statement that cannot run headless (e.g. `ASK ... USING openai`, which needs
+//! a configured provider); it is shown to readers but not executed here.
+
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::{RedDBOptions, RedDBRuntime};
+use std::fs;
+use std::path::PathBuf;
+
+/// Every model gets exactly one runnable quickstart (issue #1656 acceptance:
+/// "Ten runnable quickstarts, one per model").
+const QUICKSTARTS: &[&str] = &[
+    "quickstart-relational.md",
+    "quickstart-document.md",
+    "quickstart-key-value.md",
+    "quickstart-graph.md",
+    "quickstart-vector.md",
+    "quickstart-timeseries.md",
+    "quickstart-queue.md",
+    "quickstart-spatial.md",
+    "quickstart-vcs.md",
+    "quickstart-ask-rag.md",
+];
+
+const SKIP_MARKER: &str = "-- doctest:skip";
+
+fn getting_started_dir() -> PathBuf {
+    // CARGO_MANIFEST_DIR is the umbrella crate root == repo root.
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("getting-started")
+}
+
+/// Extract the bodies of every ` ```sql ` fenced block, in document order.
+fn sql_fences(markdown: &str) -> Vec<String> {
+    let mut fences = Vec::new();
+    let mut in_fence = false;
+    let mut current = String::new();
+    for line in markdown.lines() {
+        let trimmed = line.trim_start();
+        if !in_fence {
+            // Open only on a bare ```sql fence — leave ```bash / ```rust /
+            // ```json (illustrative, non-executable) blocks alone.
+            if trimmed == "```sql" {
+                in_fence = true;
+                current.clear();
+            }
+            continue;
+        }
+        if trimmed.starts_with("```") {
+            fences.push(std::mem::take(&mut current));
+            in_fence = false;
+            continue;
+        }
+        current.push_str(line);
+        current.push('\n');
+    }
+    fences
+}
+
+/// Split a fence into individual RQL statements: drop whole-line `--` comments,
+/// split on `;`, and trim. Authored quickstart SQL never embeds a `;` inside a
+/// string literal, so a plain split is safe here.
+fn statements(fence: &str) -> Vec<String> {
+    let without_comments: String = fence
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    without_comments
+        .split(';')
+        .map(|stmt| stmt.trim().to_string())
+        .filter(|stmt| !stmt.is_empty())
+        .collect()
+}
+
+fn is_skipped(fence: &str) -> bool {
+    fence
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .is_some_and(|line| line.starts_with(SKIP_MARKER))
+}
+
+/// Run one quickstart's SQL end-to-end against a fresh in-memory engine and
+/// enforce the executable-docs contract.
+fn run_quickstart(file: &str) {
+    let path = getting_started_dir().join(file);
+    let markdown = fs::read_to_string(&path)
+        .unwrap_or_else(|err| panic!("missing quickstart {}: {err}", path.display()));
+
+    let fences = sql_fences(&markdown);
+    assert!(
+        !fences.is_empty(),
+        "{file}: no ```sql fences found — a quickstart must be executable"
+    );
+
+    // VCS quickstarts issue CHECKPOINT / AS OF, which resolve the committing
+    // connection from the MVCC thread-local; bind one so those verbs work.
+    let needs_connection = markdown.contains("CHECKPOINT") || markdown.contains("AS OF");
+    if needs_connection {
+        set_current_connection_id(1);
+    }
+
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory())
+        .unwrap_or_else(|err| panic!("{file}: could not open in-memory RedDB: {err}"));
+
+    let mut executed = 0usize;
+    let mut produced_row = false;
+    for fence in &fences {
+        if is_skipped(fence) {
+            continue;
+        }
+        for stmt in statements(fence) {
+            let result = rt.execute_query(&stmt).unwrap_or_else(|err| {
+                panic!("{file}: quickstart statement failed:\n  {stmt}\n-> {err:?}")
+            });
+            executed += 1;
+            if !result.result.records.is_empty() {
+                produced_row = true;
+            }
+        }
+    }
+
+    if needs_connection {
+        clear_current_connection_id();
+    }
+
+    assert!(
+        executed >= 3,
+        "{file}: only {executed} runnable statements — a quickstart should create, \
+         write, and read"
+    );
+    assert!(
+        produced_row,
+        "{file}: no statement returned a row — the quickstart never reaches its \
+         'first meaningful result'"
+    );
+}
+
+#[test]
+fn every_model_has_a_runnable_quickstart() {
+    for file in QUICKSTARTS {
+        run_quickstart(file);
+    }
+}
+
+/// The docs acceptance criterion requires a newcomer path from the docs root to
+/// every quickstart in <=2 clicks. The sidebar renders on every page, so a
+/// sidebar entry per quickstart is that path — guard it so a new quickstart is
+/// never added without wiring its navigation.
+#[test]
+fn every_quickstart_is_reachable_from_the_sidebar() {
+    let sidebar = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("docs")
+        .join("_sidebar.md");
+    let contents = fs::read_to_string(&sidebar).expect("read docs/_sidebar.md");
+    for file in QUICKSTARTS {
+        let link = format!("/getting-started/{file}");
+        assert!(
+            contents.contains(&link),
+            "docs/_sidebar.md is missing a link to {link} — the quickstart is not \
+             reachable in <=2 clicks"
+        );
+    }
+}

--- a/tests/llms_txt_generated.rs
+++ b/tests/llms_txt_generated.rs
@@ -34,6 +34,13 @@ language (RQL). RedWire (`red://` / `reds://`) is the principal transport.\n\n",
 hand. See `AGENTS.md` for the human/agent overview. Each section below is \
 emitted from source so it cannot drift from the engine.\n\n",
     );
+    out.push_str(
+        "New to RedDB? Every data model has a runnable, five-minute quickstart under \
+`docs/getting-started/` — one per model (relational, document, key-value, \
+graph, vector, time-series, queue, spatial, VCS/time-travel, and ASK/RAG), \
+indexed at `docs/getting-started/quickstarts.md`. Each quickstart's RQL is \
+executed by the docs CI lane, so its examples stay runnable.\n\n",
+    );
     out.push_str(&reddb_rql::knowledge::rql_llms_section());
     out.push_str("\n\n");
     out.push_str(&reddb_types::knowledge::type_llms_section());


### PR DESCRIPTION
Automated AFK landing for #1656. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1656

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785708172&installation_id=129708444&pr_number=1699&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1699&signature=e2dd846e46d80c3be7760bae9b473bb6850cd0381d4b445d4c763effa5365267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->