### PR TITLE
merge: #1705 Reserved-field rule rejection names field, full envelope set, and rename recourse

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1327,12 +1327,24 @@ fn replace_document_fields_body(
     Ok(())
 }
 
+fn ensure_no_reserved_document_body_fields(body: &JsonValue, collection: &str) -> RedDBResult<()> {
+    if let JsonValue::Object(map) = body {
+        crate::reserved_fields::ensure_no_reserved_public_item_fields(
+            map.keys().map(String::as_str),
+            &format!("document '{collection}'"),
+        )?;
+    }
+    Ok(())
+}
+
 fn replace_document_row_body(
     row: &mut crate::storage::unified::entity::RowData,
     body: JsonValue,
+    collection: &str,
     binary: bool,
     modified_columns: &mut Vec<String>,
 ) -> RedDBResult<()> {
+    ensure_no_reserved_document_body_fields(&body, collection)?;
     let fields = row.named.get_or_insert_with(Default::default);
     replace_document_fields_body(fields, body, binary, modified_columns)?;
 
@@ -1604,7 +1616,13 @@ impl RedDBRuntime {
                     };
                     apply_patch_operations_to_json(&mut body, &document_body_ops)
                         .map_err(crate::RedDBError::Query)?;
-                    replace_document_row_body(row, body, binary_body, &mut modified_columns)?;
+                    replace_document_row_body(
+                        row,
+                        body,
+                        &collection,
+                        binary_body,
+                        &mut modified_columns,
+                    )?;
                 }
 
                 if is_document_collection && !has_patch_operations {
@@ -1617,7 +1635,13 @@ impl RedDBRuntime {
                     )?;
                     if body != previous_body {
                         context_index_dirty = true;
-                        replace_document_row_body(row, body, binary_body, &mut modified_columns)?;
+                        replace_document_row_body(
+                            row,
+                            body,
+                            &collection,
+                            binary_body,
+                            &mut modified_columns,
+                        )?;
                     }
                 }
 
@@ -1631,7 +1655,13 @@ impl RedDBRuntime {
                         let mut body = document_body_from_named(named)?;
                         apply_patch_operations_to_json(&mut body, &field_ops)
                             .map_err(crate::RedDBError::Query)?;
-                        replace_document_row_body(row, body, binary_body, &mut modified_columns)?;
+                        replace_document_row_body(
+                            row,
+                            body,
+                            &collection,
+                            binary_body,
+                            &mut modified_columns,
+                        )?;
                     } else {
                         for op in &field_ops {
                             if let Some(col) = op.path.first() {
@@ -1667,7 +1697,13 @@ impl RedDBRuntime {
                                 map.insert(key.clone(), value.clone());
                             }
                         }
-                        replace_document_row_body(row, body, binary_body, &mut modified_columns)?;
+                        replace_document_row_body(
+                            row,
+                            body,
+                            &collection,
+                            binary_body,
+                            &mut modified_columns,
+                        )?;
                     } else {
                         for (key, value) in fields {
                             modified_columns.push(key.clone());
@@ -2180,6 +2216,7 @@ impl RedDBRuntime {
                     replace_document_row_body(
                         row,
                         body,
+                        &collection,
                         self.binary_document_body_enabled(),
                         &mut modified_columns,
                     )?;
@@ -2216,6 +2253,7 @@ impl RedDBRuntime {
                         replace_document_row_body(
                             row,
                             body,
+                            &collection,
                             self.binary_document_body_enabled(),
                             &mut modified_columns,
                         )?;

--- a/crates/reddb-server/src/reserved_fields.rs
+++ b/crates/reddb-server/src/reserved_fields.rs
@@ -12,6 +12,9 @@ pub(crate) const RESERVED_PUBLIC_ITEM_FIELDS: &[&str] = &[
     crate::runtime::ai::moderation::MODERATION_STATUS_FIELD,
 ];
 
+const RESERVED_PUBLIC_ENVELOPE_FIELDS_MESSAGE: &str =
+    "rid, collection, kind, tenant, created_at, updated_at";
+
 pub(crate) fn is_reserved_public_item_field(field: &str) -> bool {
     RESERVED_PUBLIC_ITEM_FIELDS
         .iter()
@@ -20,7 +23,9 @@ pub(crate) fn is_reserved_public_item_field(field: &str) -> bool {
 
 pub(crate) fn reserved_field_error(field: &str, context: &str) -> crate::RedDBError {
     crate::RedDBError::Query(format!(
-        "reserved system field '{field}' cannot be used as a top-level user field in {context}"
+        "reserved system field '{field}' cannot be used as a top-level user field in {context}. \
+         Reserved envelope fields are: {RESERVED_PUBLIC_ENVELOPE_FIELDS_MESSAGE}. \
+         Rename the field in the payload before insert or patch."
     ))
 }
 

--- a/tests/grouped/schema_query_core/e2e_reserved_system_fields.rs
+++ b/tests/grouped/schema_query_core/e2e_reserved_system_fields.rs
@@ -4,7 +4,10 @@ mod support;
 
 use std::path::Path;
 
-use reddb::application::{CreateDocumentInput, EntityUseCases};
+use reddb::application::{
+    CreateDocumentInput, EntityUseCases, PatchEntityInput, PatchEntityOperation,
+    PatchEntityOperationType,
+};
 use reddb::json::json;
 use reddb::{PhysicalMetadataFile, RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
@@ -29,6 +32,14 @@ fn assert_reserved_error(message: &str, field: &str, context: &str) {
     );
     assert!(message.contains(field), "unexpected error: {message}");
     assert!(message.contains(context), "unexpected error: {message}");
+    assert!(
+        message.contains("rid, collection, kind, tenant, created_at, updated_at"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("Rename the field in the payload before insert or patch"),
+        "unexpected error: {message}"
+    );
 }
 
 #[test]
@@ -59,6 +70,56 @@ fn create_document_rejects_reserved_top_level_body_fields() {
         .expect_err("reserved document field should fail");
 
     assert_reserved_error(&err.to_string(), "tenant", "document 'reserved_docs'");
+}
+
+#[test]
+fn sql_document_insert_reserved_error_names_full_envelope_and_recourse() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT sql_reserved_docs")
+        .expect("document collection should be created");
+
+    let err = rt
+        .execute_query(
+            r#"INSERT INTO sql_reserved_docs DOCUMENT (body) VALUES ('{"kind":"runbook"}')"#,
+        )
+        .expect_err("reserved document field should fail");
+
+    assert_eq!(
+        err.to_string(),
+        "query error: reserved system field 'kind' cannot be used as a top-level user field in document 'sql_reserved_docs'. Reserved envelope fields are: rid, collection, kind, tenant, created_at, updated_at. Rename the field in the payload before insert or patch."
+    );
+}
+
+#[test]
+fn document_patch_rejects_reserved_top_level_body_fields() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT patch_reserved_docs")
+        .expect("document collection should be created");
+
+    let created = EntityUseCases::new(&rt)
+        .create_document(CreateDocumentInput {
+            collection: "patch_reserved_docs".to_string(),
+            body: json!({"title": "runbook"}),
+            metadata: Vec::new(),
+            node_links: Vec::new(),
+            vector_links: Vec::new(),
+        })
+        .expect("document should be created");
+
+    let err = EntityUseCases::new(&rt)
+        .patch(PatchEntityInput {
+            collection: "patch_reserved_docs".to_string(),
+            id: created.id,
+            payload: json!(null),
+            operations: vec![PatchEntityOperation {
+                op: PatchEntityOperationType::Set,
+                path: vec!["body".to_string(), "tenant".to_string()],
+                value: Some(json!("acme")),
+            }],
+        })
+        .expect_err("reserved document patch field should fail");
+
+    assert_reserved_error(&err.to_string(), "tenant", "document 'patch_reserved_docs'");
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1705. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1705

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785731863&installation_id=129708444&pr_number=1714&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1714&signature=6bf5b767b2b495e54d2e924d6655aab3a3a41e30027349a5961aea1bd450667d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added stricter validation so document updates now reject reserved top-level fields in incoming JSON bodies.
  - Improved error messages to clearly list the reserved fields and provide guidance on renaming them before insert or patch.
  - Expanded end-to-end coverage for reserved-field handling in both SQL insert and document patch flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->