### PR TITLE
merge: #1706 Fix reserved-name example payloads in Documents docs and #1668 reply

### DIFF
--- a/docs/data-models/documents.md
+++ b/docs/data-models/documents.md
@@ -65,9 +65,9 @@ CREATE DOCUMENT IF NOT EXISTS events
 > - `CREATE TABLE events DOCUMENT (id UUID PRIMARY KEY, body JSONB NOT NULL, ...)`
 >   → use `CREATE DOCUMENT events` instead.
 > - Generated columns such as
->   `ALTER TABLE events ADD COLUMN kind TEXT GENERATED ALWAYS AS (body->>'kind') STORED`
+>   `ALTER TABLE events ADD COLUMN event_type TEXT GENERATED ALWAYS AS (body->>'event_type') STORED`
 >   → unnecessary. RedDB automatically flattens top-level fields of each
->   document `body` into queryable columns, so `SELECT kind FROM events` works
+>   document `body` into queryable columns, so `SELECT event_type FROM events` works
 >   with no generated column. See [SQL First](#sql-first) above.
 
 ## Creating Documents
@@ -152,6 +152,19 @@ Returned document items also include the public envelope fields `rid`,
 `collection`, `kind`, `tenant`, `created_at`, and `updated_at`, with
 `kind = 'document'`. Those envelope names are reserved; top-level document body
 fields cannot use them.
+
+## Reserved field names
+
+The public RedDB item envelope reserves these top-level names in user data:
+`rid`, `collection`, `kind`, `tenant`, `created_at`, and `updated_at`.
+Document writes that include one of those names as a top-level `body` field are
+rejected at write time.
+
+If your source JSON uses one of those names, rename that field before inserting
+it, for example from `kind` to `event_type`. This is the permanent collision
+rule from [ADR 0066](../../.red/adr/0066-reserved-envelope-fields-user-pays.md):
+the envelope vocabulary stays unprefixed and user data pays for top-level
+collisions.
 
 ## Querying Documents
 

--- a/tests/grouped/docs_kv_queue/e2e_issue_540_documents_basics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_540_documents_basics.rs
@@ -241,3 +241,88 @@ fn readme_documents_example_runs_end_to_end() {
     assert_eq!(text_field(&selected.result.records[0], "level"), "info");
     assert_eq!(text_field(&selected.result.records[0], "msg"), "login");
 }
+
+#[test]
+fn issue_1706_documents_docs_do_not_teach_reserved_body_field_names() {
+    let docs = [
+        (
+            "docs/data-models/documents.md",
+            include_str!("../../../docs/data-models/documents.md"),
+        ),
+        (
+            "docs/getting-started/quickstart-document.md",
+            include_str!("../../../docs/getting-started/quickstart-document.md"),
+        ),
+        (
+            "docs/data-models/overview.md",
+            include_str!("../../../docs/data-models/overview.md"),
+        ),
+    ];
+
+    for (path, content) in docs {
+        assert!(
+            !content.contains(r#"{"kind":"signup""#),
+            "{path} must not use reserved `kind` as a top-level document body field",
+        );
+        assert!(
+            !content.contains("body->>'kind'"),
+            "{path} must not teach generated columns over reserved `kind`",
+        );
+        assert!(
+            !content.contains("SELECT kind FROM events"),
+            "{path} must not teach collection-scoped projection of reserved `kind` as user data",
+        );
+    }
+
+    let documents_walkthrough = docs[0].1;
+    assert!(
+        documents_walkthrough.contains("## Reserved field names"),
+        "Documents walkthrough must have a reserved field names section",
+    );
+    assert!(
+        documents_walkthrough
+            .contains("`rid`, `collection`, `kind`, `tenant`, `created_at`, and `updated_at`"),
+        "Documents walkthrough must name the reserved envelope set",
+    );
+    assert!(
+        documents_walkthrough.contains("rejected at write time"),
+        "Documents walkthrough must document write-time rejection",
+    );
+    assert!(
+        documents_walkthrough.contains("ADR 0066"),
+        "Documents walkthrough must point to ADR 0066",
+    );
+}
+
+#[test]
+fn issue_1706_corrected_signup_example_runs_over_http_query() {
+    let (_db, _rt, addr) = spawn_http_server();
+    let statements = [
+        "CREATE DOCUMENT issue1706_events",
+        r#"INSERT INTO issue1706_events DOCUMENT (body)
+           VALUES ('{"event_type":"signup","user_id":"u_abc123"}')"#,
+        "SELECT event_type, user_id FROM issue1706_events WHERE event_type = 'signup'",
+    ];
+
+    let mut last = json!(null);
+    for statement in statements {
+        let (status, body) =
+            http_request(&addr, "POST", "/query", Some(json!({ "query": statement })));
+        assert_eq!(status, 200, "statement failed: {statement}; body={body}");
+        last = body;
+    }
+
+    let records = last["data"]["records"]
+        .as_array()
+        .or_else(|| last["result"]["records"].as_array())
+        .expect("query response should contain records");
+    assert_eq!(records.len(), 1, "last={last}");
+    let values = records[0].get("values").unwrap_or_else(|| {
+        panic!(
+            "query response record should contain values: {}",
+            records[0]
+        )
+    });
+    assert_eq!(values["event_type"], json!("signup"));
+    assert_eq!(values["user_id"], json!("u_abc123"));
+}


### PR DESCRIPTION
Automated AFK landing for #1706. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1706

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785732805&installation_id=129708444&pr_number=1715&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1715&signature=df21df00d92c9c8b74d6ebd60cf58b3f3691267db95bc6d5c3bbc9ade88cb76f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->