### PR TITLE
merge: #1704 Didactic parse errors for document Postgres-isms (CREATE TABLE…DOCUMENT, GENERATED, ->/->>)

### DIFF
--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -131,6 +131,13 @@ impl<'a> Parser<'a> {
         let if_not_exists = self.match_if_not_exists()?;
         let name = self.expect_ident()?;
 
+        // Didactic (#1704): `CREATE TABLE <name> DOCUMENT (…)` is a Postgres-ism
+        // a document-model newcomer predictably tries. Teach the native form
+        // before the generic `expected (` error fires.
+        if self.check(&Token::Document) {
+            return Err(ParseError::document_create_table(self.position()));
+        }
+
         self.expect(Token::LParen)?;
         let mut columns = Vec::new();
         loop {
@@ -1217,6 +1224,12 @@ impl<'a> Parser<'a> {
                 def.unique = true;
             } else if self.match_primary_key()? {
                 def.primary_key = true;
+            } else if matches!(self.peek(), Token::Ident(name) if name.eq_ignore_ascii_case("GENERATED"))
+            {
+                // Didactic (#1704): `… GENERATED ALWAYS AS (…) STORED` is a
+                // Postgres-ism. Document body fields already auto-flatten into
+                // queryable columns, so teach that instead of the generic error.
+                return Err(ParseError::generated_column_unneeded(self.position()));
             } else {
                 break;
             }

--- a/crates/reddb-rql/src/parser/error.rs
+++ b/crates/reddb-rql/src/parser/error.rs
@@ -173,6 +173,53 @@ impl ParseError {
             kind: ParseErrorKind::ValueOutOfRange { field, constraint },
         }
     }
+
+    /// Didactic (#1704): a document-model newcomer wrote the Postgres
+    /// `CREATE TABLE <name> DOCUMENT (…)` form. Documents are schemaless
+    /// and have no column list — the native form is `CREATE DOCUMENT`.
+    pub fn document_create_table(position: Position) -> Self {
+        Self {
+            message: "documents are schemaless: write `CREATE DOCUMENT <name>` \
+                      (no column list) instead of `CREATE TABLE <name> DOCUMENT (…)` — \
+                      top-level body fields auto-flatten into queryable columns"
+                .to_string(),
+            position,
+            expected: Vec::new(),
+            kind: ParseErrorKind::Syntax,
+        }
+    }
+
+    /// Didactic (#1704): a document-model newcomer reached for a Postgres
+    /// `GENERATED ALWAYS AS (…) STORED` column. In the document model,
+    /// top-level body fields already auto-flatten into queryable columns.
+    pub fn generated_column_unneeded(position: Position) -> Self {
+        Self {
+            message: "top-level document body fields auto-flatten into queryable \
+                      columns, so no generated column is needed: drop the \
+                      `GENERATED ALWAYS AS (…) STORED` clause and query the field by \
+                      its dotted path (e.g. `body.details.ip`)"
+                .to_string(),
+            position,
+            expected: Vec::new(),
+            kind: ParseErrorKind::Syntax,
+        }
+    }
+
+    /// Didactic (#1704): a document-model newcomer used the Postgres JSON
+    /// operators `->` / `->>` in a query. The native idiom is the dotted
+    /// path. (Graph-mode `->` / `<-` traversal is parsed elsewhere and is
+    /// unaffected.)
+    pub fn json_arrow_operator(position: Position) -> Self {
+        Self {
+            message: "the `->` / `->>` JSON operators are not supported: use the \
+                      dotted-path idiom instead (e.g. `body.details.ip` rather than \
+                      `body->'details'->>'ip'`)"
+                .to_string(),
+            position,
+            expected: Vec::new(),
+            kind: ParseErrorKind::Syntax,
+        }
+    }
 }
 
 fn recognized_keyword_name(token: &Token) -> Option<String> {

--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -191,6 +191,15 @@ impl<'a> Parser<'a> {
                         continue;
                     }
                 }
+                // Didactic (#1704): `->` / `->>` are Postgres JSON operators a
+                // document-model newcomer predictably reaches for. Teach the
+                // dotted-path idiom instead of leaving a dangling `->` for the
+                // caller to reject as a generic "Unexpected token". Graph-mode
+                // traversal consumes `->` / `<-` in graph.rs before it ever
+                // reaches this scalar-expression path, so it is unaffected.
+                if matches!(self.peek(), Token::Arrow) {
+                    return Err(ParseError::json_arrow_operator(self.position()));
+                }
                 break;
             };
             if prec < min_prec {

--- a/crates/reddb-server/tests/conformance/negative/document_create_table_postgres_ism.toml
+++ b/crates/reddb-server/tests/conformance/negative/document_create_table_postgres_ism.toml
@@ -1,0 +1,5 @@
+input = "CREATE TABLE events DOCUMENT (id INT)"
+expected_error_substring = "write `CREATE DOCUMENT <name>`"
+expected_error_kind = "Syntax"
+source = "crates/reddb-rql/src/parser/error.rs:180"
+kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/generated_column_postgres_ism.toml
+++ b/crates/reddb-server/tests/conformance/negative/generated_column_postgres_ism.toml
@@ -1,0 +1,5 @@
+input = "ALTER TABLE events ADD COLUMN ip TEXT GENERATED ALWAYS AS (body) STORED"
+expected_error_substring = "no generated column is needed"
+expected_error_kind = "Syntax"
+source = "crates/reddb-rql/src/parser/error.rs:195"
+kind = "negative"

--- a/crates/reddb-server/tests/conformance/negative/json_arrow_operator_postgres_ism.toml
+++ b/crates/reddb-server/tests/conformance/negative/json_arrow_operator_postgres_ism.toml
@@ -1,0 +1,5 @@
+input = "SELECT body->'details'->>'ip' FROM events"
+expected_error_substring = "the `->` / `->>` JSON operators are not supported"
+expected_error_kind = "Syntax"
+source = "crates/reddb-rql/src/parser/error.rs:212"
+kind = "negative"


### PR DESCRIPTION
Automated AFK landing for #1704. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1704

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785739166&installation_id=129708444&pr_number=1717&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1717&signature=73e68be4506676602f40c9b3bed9388bf39c1ecc63d5d572e90110f924dcaab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer syntax errors for unsupported PostgreSQL-style table, column, and JSON expressions.
  * Parsing now fails with more specific guidance when using `CREATE TABLE ... DOCUMENT (...)`, generated columns, or JSON `->` / `->>` operators.
  * Improved negative test coverage for these invalid query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->