### PR TITLE
merge: #1707 JSON_PARSE builtin: explicit string→JSON conversion

### DIFF
--- a/crates/reddb-rql/tests/reddb_corpus/README.md
+++ b/crates/reddb-rql/tests/reddb_corpus/README.md
@@ -3,8 +3,9 @@
 Each `*.slt` file here is a [sqllogictest][slt]-format script covering a
 **RedDB-only query surface** — one with no standard-SQL counterpart and no
 external oracle: vector search, the native `GRAPH` command family, the four
-graph DSL modes (Gremlin / Cypher / SPARQL / Path), natural-language, and
-vector extensions. The harness (`tests/reddb_conformance.rs`) discovers every
+graph DSL modes (Gremlin / Cypher / SPARQL / Path), natural-language, vector
+extensions, and RedDB-specific scalar builtins. The harness
+(`tests/reddb_conformance.rs`) discovers every
 `.slt` file here automatically and runs it end-to-end against the in-server
 engine (`reddb-server`'s `RedDBRuntime::in_memory()`), one fresh runtime per
 file so state never leaks between scripts.
@@ -17,10 +18,11 @@ is the public SQLite oracle (ADR 0053).
 These surfaces are RedDB inventions, so no third-party engine can adjudicate
 them. Every expected value in a `query` block is authored from the **semantics**
 of the surface — cosine ranking, neighbourhood reachability, shortest-path hop
-counts, downstream PageRank flow — and never copied from whatever the engine
-happens to emit. The fixtures are kept deliberately small and tie-free so the
-correct answer is unambiguous (e.g. a vector fixture whose cosine similarities
-are 1.00 / 0.60 / 0.00 gives one strict ranking).
+counts, downstream PageRank flow, or explicit scalar builtin contracts — and
+never copied from whatever the engine happens to emit. The fixtures are kept
+deliberately small and tie-free so the correct answer is unambiguous (e.g. a
+vector fixture whose cosine similarities are 1.00 / 0.60 / 0.00 gives one
+strict ranking).
 
 ## Volatile columns are projected away, not pinned
 
@@ -31,9 +33,10 @@ numbers, `red_*` capability metadata, and raw distance/score floats whose exact
 value is engine-defined rather than oracle-defined. The harness projects every
 result down to a fixed allowlist of **semantic, deterministic** columns
 (`label`, `name`, `content`, `depth`, `path_found`, `hop_count`,
-`total_weight`, `nodes_visited`, `negative_cycle_detected`) in a canonical
-order. A golden therefore asserts the *meaning* of a result and stays silent
-about engine bookkeeping, so it never freezes non-determinism.
+`total_weight`, `nodes_visited`, `negative_cycle_detected`, and focused scalar
+test aliases) in a canonical order. A golden therefore asserts the *meaning* of
+a result and stays silent about engine bookkeeping, so it never freezes
+non-determinism.
 
 ## Characterization is clearly marked regression-only
 
@@ -53,6 +56,7 @@ semantic columns for it.
   `THRESHOLD`, and the `inner_product` metric extension.
 - `graph_commands.slt` — TRUTH: `GRAPH NEIGHBORHOOD` / `TRAVERSE` /
   `PROPERTIES` / `SHORTEST_PATH` / `CENTRALITY` over a directed chain.
+- `json_builtins.slt` — TRUTH: RedDB-specific JSON scalar builtin semantics.
 - `characterization_unprojected_surfaces.slt` — REGRESSION-ONLY: Gremlin,
   Cypher, SPARQL, Path, natural-language, and the `SEARCH SIMILAR … COLLECTION`
   form, each pinned with `statement ok`.

--- a/crates/reddb-rql/tests/reddb_corpus/json_builtins.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/json_builtins.slt
@@ -1,0 +1,38 @@
+# RedDB-only JSON builtin contracts.
+#
+# Truth is hand-authored from the JSON builtin semantics, not copied from engine
+# output. JSON_PARSE is the explicit string-to-JSON conversion complement to
+# JSON literals.
+
+query TT nosort
+SELECT JSON_EXTRACT(JSON_PARSE('{"user":{"name":"Ada","visits":2}}'), '$.user.name') AS json_name,
+       JSON_EXTRACT_TEXT(JSON_PARSE('{"user":{"name":"Ada","visits":2}}'), '$.user.visits') AS json_visits
+----
+"Ada" 2
+
+statement ok
+CREATE TABLE json_parse_inputs (id INTEGER, raw TEXT, suffix TEXT)
+
+statement ok
+INSERT INTO json_parse_inputs (id, raw, suffix) VALUES
+  (1, '{"user":{"name":"Ada","visits":2}}', '"Ada"}}')
+
+# Round-trip: string column -> JSON_PARSE -> dotted-path read.
+query TT nosort
+SELECT JSON_EXTRACT(JSON_PARSE(raw), '$.user.name') AS json_column_name,
+       JSON_EXTRACT_TEXT(JSON_PARSE(raw), '$.user.visits') AS json_column_visits
+FROM json_parse_inputs
+WHERE id = 1
+----
+"Ada" 2
+
+# Computed expression input is still runtime text.
+query T nosort
+SELECT JSON_EXTRACT(JSON_PARSE('{"user":{"name":' || suffix), '$.user.name') AS json_computed_name
+FROM json_parse_inputs
+WHERE id = 1
+----
+"Ada"
+
+statement error JSON_PARSE failed to parse JSON
+SELECT JSON_PARSE('{"broken":') AS json_invalid

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1741,6 +1741,7 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
         "JSON_EXTRACT_TEXT" => {
             json_extract_impl(args.first()?, args.get(1)?, /*as_text=*/ true)
         }
+        "JSON_PARSE" => json_parse_impl(args.first()?),
         "JSON_SET" => json_set_impl(args.first()?, args.get(1)?, args.get(2)?),
         "JSON_ARRAY_LENGTH" => {
             let v = value_to_json(args.first()?)?;
@@ -1818,6 +1819,16 @@ fn value_to_json(value: &Value) -> Option<crate::serde_json::Value> {
         Value::Text(s) => crate::serde_json::from_str(s).ok(),
         _ => None,
     }
+}
+
+fn json_parse_impl(input: &Value) -> Option<Value> {
+    let Value::Text(text) = input else {
+        return Some(Value::Null);
+    };
+    crate::serde_json::from_str::<crate::serde_json::Value>(text)
+        .ok()
+        .map(|json| Value::Json(json.to_string_compact().into_bytes()))
+        .or(Some(Value::Null))
 }
 
 fn value_contains(value: &Value, needle: &str) -> bool {

--- a/crates/reddb-server/src/runtime/join_filter/projection.rs
+++ b/crates/reddb-server/src/runtime/join_filter/projection.rs
@@ -18,6 +18,7 @@ pub(in crate::runtime) fn project_runtime_record(
         document_projection,
         entity_projection,
     )
+    .unwrap_or_else(|_| UnifiedRecord::new())
 }
 
 pub(in crate::runtime) fn project_runtime_record_with_db(
@@ -28,7 +29,7 @@ pub(in crate::runtime) fn project_runtime_record_with_db(
     table_alias: Option<&str>,
     document_projection: bool,
     entity_projection: bool,
-) -> UnifiedRecord {
+) -> crate::RedDBResult<UnifiedRecord> {
     let select_all = projections.is_empty()
         || projections
             .iter()
@@ -77,39 +78,59 @@ pub(in crate::runtime) fn project_runtime_record_with_db(
             Projection::Expression(filter, _) => {
                 // Route through typed evaluator; fall back to filter-boolean path for
                 // shapes the evaluator doesn't cover (CONFIG / KV / ML_* references).
-                crate::storage::query::sql_lowering::projection_to_expr(projection)
-                    .and_then(|(expr, _)| {
-                        let row = RecordRow {
-                            record: source,
-                            table_name,
-                            table_alias,
-                        };
-                        crate::storage::query::evaluator::evaluate(&expr, &row).ok()
-                    })
-                    .or_else(|| {
-                        Some(Value::Boolean(evaluate_runtime_filter_with_db(
+                if let Some((expr, _)) =
+                    crate::storage::query::sql_lowering::projection_to_expr(projection)
+                {
+                    let row = RecordRow {
+                        record: source,
+                        table_name,
+                        table_alias,
+                    };
+                    match crate::storage::query::evaluator::evaluate(&expr, &row) {
+                        Ok(value) => Some(value),
+                        Err(crate::storage::query::evaluator::EvalError::UnknownFunction {
+                            ..
+                        }) => Some(Value::Boolean(evaluate_runtime_filter_with_db(
                             db,
                             source,
                             filter,
                             table_name,
                             table_alias,
-                        )))
-                    })
+                        ))),
+                        Err(err) => return Err(crate::RedDBError::Query(err.to_string())),
+                    }
+                } else {
+                    Some(Value::Boolean(evaluate_runtime_filter_with_db(
+                        db,
+                        source,
+                        filter,
+                        table_name,
+                        table_alias,
+                    )))
+                }
             }
             Projection::Function(ref name, ref args) => {
                 // Route catalog-resolvable functions through the typed evaluator.
                 // Falls back to the legacy dispatcher for CONFIG/KV/ML_*/geo/time
                 // and any shape where argument resolution fails via evaluator.
-                crate::storage::query::sql_lowering::projection_to_expr(projection)
-                    .and_then(|(expr, _)| {
-                        let row = RecordRow {
-                            record: source,
-                            table_name,
-                            table_alias,
-                        };
-                        crate::storage::query::evaluator::evaluate(&expr, &row).ok()
-                    })
-                    .or_else(|| evaluate_scalar_function_with_db(db, name, args, source))
+                if let Some((expr, _)) =
+                    crate::storage::query::sql_lowering::projection_to_expr(projection)
+                {
+                    let row = RecordRow {
+                        record: source,
+                        table_name,
+                        table_alias,
+                    };
+                    match crate::storage::query::evaluator::evaluate(&expr, &row) {
+                        Ok(value) => Some(value),
+                        Err(crate::storage::query::evaluator::EvalError::UnknownFunction {
+                            ..
+                        }) => evaluate_scalar_function_with_db(db, name, args, source),
+                        Err(err) => return Err(crate::RedDBError::Query(err.to_string())),
+                    }
+                } else {
+                    evaluate_scalar_function_with_db(db, name, args, source)
+                }
             }
             Projection::All => None,
             // Slice 7b (#590): the window phase has already
@@ -124,7 +145,7 @@ pub(in crate::runtime) fn project_runtime_record_with_db(
         record.set_arc(std::sync::Arc::from(label), value.unwrap_or(Value::Null));
     }
 
-    record
+    Ok(record)
 }
 
 pub(in crate::runtime) fn resolve_runtime_projection_value(

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -425,7 +425,7 @@ fn project_scalar_via_evaluator(
                         None,
                         false,
                         false,
-                    )
+                    )?
                     .get(col_name.as_str())
                     .cloned()
                     .unwrap_or(Value::Null)

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -173,7 +173,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     outer_alias,
                 )?;
 
-                return Ok(records
+                return records
                     .iter()
                     .map(|record| {
                         project_runtime_record_with_db(
@@ -186,7 +186,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                             false,
                         )
                     })
-                    .collect());
+                    .collect();
             }
             other => {
                 return Err(RedDBError::Query(format!(
@@ -855,7 +855,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                             false,
                         )
                     })
-                    .collect();
+                    .collect::<crate::RedDBResult<Vec<_>>>()?;
             }
 
             return Ok(records);
@@ -1558,7 +1558,7 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 Some(context.table_name),
                 Some(context.table_alias),
             )?;
-            Ok(records
+            records
                 .iter()
                 .map(|record| {
                     project_runtime_record_with_db(
@@ -1571,7 +1571,7 @@ pub(crate) fn execute_runtime_canonical_table_node(
                         entity_projection,
                     )
                 })
-                .collect())
+                .collect()
         }
         other => Err(RedDBError::Query(format!(
             "unsupported canonical table operator {other}"

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -985,7 +985,7 @@ pub(super) fn red_query(
                     false,
                 )
             })
-            .collect();
+            .collect::<crate::RedDBResult<Vec<_>>>()?;
     }
 
     let columns = if projections.is_empty()

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -140,6 +140,8 @@ pub enum EvalError {
     /// Numeric scalar evaluation produced an undefined or non-finite
     /// float result (domain error, overflow, NaN, or infinity).
     InvalidNumericResult { function: String, reason: String },
+    /// JSON_PARSE input was not valid JSON text.
+    JsonParseFailed { reason: String },
     /// `IN (...)` against an empty value list — preserves the legacy
     /// "always false" semantic but recorded explicitly so the
     /// optimiser can fold it.
@@ -174,6 +176,9 @@ impl std::fmt::Display for EvalError {
             EvalError::DivisionByZero => write!(f, "division by zero"),
             EvalError::InvalidNumericResult { function, reason } => {
                 write!(f, "invalid numeric result in {function}: {reason}")
+            }
+            EvalError::JsonParseFailed { reason } => {
+                write!(f, "JSON_PARSE failed to parse JSON: {reason}")
             }
             EvalError::EmptyInList => write!(f, "IN list is empty"),
         }
@@ -711,6 +716,20 @@ fn dispatch_function(name: &str, args: &[Value]) -> Result<Value, EvalError> {
                 args: vec![other.data_type()],
             }),
         },
+        "CONCAT" => {
+            let mut out = String::new();
+            for arg in args {
+                let Value::Text(value) = arg else {
+                    return Err(EvalError::UnknownFunction {
+                        name: name.to_string(),
+                        args: args.iter().map(Value::data_type).collect(),
+                    });
+                };
+                out.push_str(value);
+            }
+            Ok(Value::Text(Arc::from(out)))
+        }
+        "JSON_PARSE" => json_parse_value(&args[0]),
         "JSON_EXTRACT" => Ok(json_extract_value(&args[0], &args[1], false)),
         "JSON_EXTRACT_TEXT" => Ok(json_extract_value(&args[0], &args[1], true)),
         "CONTAINS" => Ok(contains_value(&args[0], &args[1])),
@@ -911,6 +930,20 @@ fn json_extract_value(input: &Value, path: &Value, as_text: bool) -> Value {
     } else {
         Value::text(target.to_string_compact())
     }
+}
+
+fn json_parse_value(input: &Value) -> Result<Value, EvalError> {
+    let Value::Text(text) = input else {
+        return Err(EvalError::UnknownFunction {
+            name: "JSON_PARSE".to_string(),
+            args: vec![input.data_type()],
+        });
+    };
+    crate::serde_json::from_str::<crate::serde_json::Value>(text)
+        .map(|json| Value::Json(json.to_string_compact().into_bytes()))
+        .map_err(|err| EvalError::JsonParseFailed {
+            reason: err.to_string(),
+        })
 }
 
 fn contains_value(input: &Value, needle: &Value) -> Value {

--- a/crates/reddb-types/src/function_catalog.rs
+++ b/crates/reddb-types/src/function_catalog.rs
@@ -860,6 +860,16 @@ pub const FUNCTION_CATALOG: &[FunctionEntry] = &[
     // Scalar — JSON (Phase 1.4 PG parity)
     // ─────────────────────────────────────────────────────────────
     //
+    // JSON_PARSE(text) → Json
+    //   Explicit string-to-JSON conversion. Unlike JSON_VALID, invalid JSON is
+    //   a runtime error in evaluator paths that can surface errors.
+    entry(
+        "JSON_PARSE",
+        ARGS_JSON_TEXT,
+        DataType::Json,
+        FunctionKind::Scalar,
+        false,
+    ),
     // JSON_EXTRACT(json_or_text, path) → Text
     //   Returns the value at `path` serialised as JSON text. Scalar strings
     //   come back with surrounding quotes; scalar numbers/booleans come back

--- a/docs/query/maintenance.md
+++ b/docs/query/maintenance.md
@@ -78,12 +78,16 @@ JSONPath DSL parser.
 
 | Function | Returns |
 |----------|---------|
+| `json_parse(text)` | JSON value parsed from text; invalid input errors |
 | `json_extract(json, '$.path')` | Value at path, or NULL |
 | `json_set(json, '$.path', value)` | Mutated JSON with path set |
 | `json_array_length(json)` | Integer length of top-level array |
 | `json_path_query(json, path)` | Matching subtree |
 
 ```sql
+SELECT json_extract(json_parse(payload_text), '$.user.email') AS email
+FROM events;
+
 SELECT json_extract(payload, '$.user.email') AS email
 FROM events
 WHERE json_array_length(payload->'tags') > 0;

--- a/docs/query/scalar-functions.md
+++ b/docs/query/scalar-functions.md
@@ -141,6 +141,27 @@ WHERE MONEY_ASSET(balance) = 'USDT'
 
 ---
 
+## JSON Functions
+
+These functions operate on JSON values and JSON text in expression positions.
+
+| Function | Arguments | Returns | Description |
+|:---------|:----------|:--------|:------------|
+| `JSON_PARSE(text)` | Text containing valid JSON | Json | Explicit string-to-JSON conversion; invalid JSON is a runtime error |
+| `JSON_EXTRACT(json, path)` | Json or JSON text, path text | Text | Value at path, serialized as JSON text |
+| `JSON_EXTRACT_TEXT(json, path)` | Json or JSON text, path text | Text | Value at path, with scalar strings unquoted |
+| `JSON_SET(json, path, value)` | Json or JSON text, path text, value | Json | Return a new JSON value with the path set |
+| `JSON_ARRAY_LENGTH(json)` | Json or JSON text | Integer | Top-level array length, or NULL |
+| `JSON_TYPEOF(json)` | Json or JSON text | Text | JSON type name |
+| `JSON_VALID(text)` | Text | Boolean | Whether the text parses as JSON |
+
+```sql
+SELECT JSON_EXTRACT(JSON_PARSE(payload_text), '$.user.email') AS email
+FROM imported_events
+```
+
+---
+
 ## General Functions
 
 | Function | Arguments | Returns | Description |

--- a/tests/grouped/surface_contracts/rql_reddb_conformance.rs
+++ b/tests/grouped/surface_contracts/rql_reddb_conformance.rs
@@ -57,6 +57,11 @@ const KEEP: &[&str] = &[
     "total_weight",
     "nodes_visited",
     "negative_cycle_detected",
+    "json_name",
+    "json_visits",
+    "json_column_name",
+    "json_column_visits",
+    "json_computed_name",
 ];
 
 use super::support::PersistentRuntime;


### PR DESCRIPTION
Automated AFK landing for #1707. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1707

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785743104&installation_id=129708444&pr_number=1719&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1719&signature=8801fc8ce620fb878d5f93df9db276298f56035c9d23ca3655e53569890ca4f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `JSON_PARSE` in queries and expression contexts.
  * Added JSON extraction and concatenation behavior for runtime evaluation.
  * Expanded conformance coverage for JSON-related result columns.

* **Bug Fixes**
  * Improved error handling so invalid JSON now reports a parse failure instead of returning misleading results.
  * Fixed query execution paths to correctly stop on projection errors rather than silently continuing.

* **Documentation**
  * Updated JSON function docs and corpus guidance to reflect the new JSON behavior and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->