### PR TITLE
merge: #1722 /go: Fix a real latent MVCC correctness bug in the RedDB engine — root-cause,

### DIFF
--- a/crates/reddb-server/src/runtime/impl_dml_update_analysis.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_update_analysis.rs
@@ -91,7 +91,19 @@ pub(super) fn resolve_update_entity_by_logical_id(
     logical_id: EntityId,
 ) -> Option<UnifiedEntity> {
     let store = runtime.inner.db.store();
-    if let Some(entity) = store.get_table_row_by_logical_id(table, logical_id) {
+    // Read-modify-write pre-image must be resolved through the *current
+    // statement snapshot*, not merely the latest live physical version.
+    // `get_table_row_by_logical_id` returns whichever version currently
+    // carries `xmax == 0`, which under concurrent same-row UPDATEs can be a
+    // sibling writer's still-uncommitted version. Applying a compound
+    // assignment (`value += 1`) on top of that pre-image lets a first-
+    // committer-wins winner fold a concurrent loser's (later-aborted) write
+    // into committed state — an isolation violation. Routing through the
+    // MVCC resolver reads the version this transaction is actually allowed
+    // to observe (including its own in-flight writes via `own_xids`).
+    let resolver =
+        crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
+    if let Some(entity) = resolver.resolve_logical_id(&store, table, logical_id) {
         return Some(entity);
     }
     // Fallback for non-table-row entities (graph nodes/edges, etc.) where

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -189,9 +189,25 @@ impl SnapshotManager {
 
     /// Allocate a new xid and mark it active. Returns the xid for
     /// stamping onto `UnifiedEntity::xmin/xmax`.
+    ///
+    /// Allocation and the `active` insert happen together under the state
+    /// write lock. This is load-bearing for first-committer-wins: a
+    /// concurrent `snapshot()` (state read lock) must never observe a
+    /// *lower-numbered* still-running xid as absent from `active`. Were the
+    /// `fetch_add` done outside the lock, a writer that grabbed the smaller
+    /// xid could still be mid-`begin()` while a later transaction snapshots
+    /// a larger xid — the smaller xid would be missing from `in_progress`,
+    /// yet `xmin <= snapshot.xid`, so the snapshot would treat that
+    /// concurrent (later possibly-committed) writer as visible. That both
+    /// leaks an uncommitted row into a peer's read and lets two writers on
+    /// the same row both commit. Serialising allocation under the lock
+    /// guarantees any xid smaller than a taken snapshot's xid is already in
+    /// `active` (or already finished), so `in_progress` is never short a
+    /// concurrent writer.
     pub fn begin(&self) -> Xid {
+        let mut state = self.state.write();
         let xid = self.next_xid.fetch_add(1, Ordering::Relaxed);
-        self.state.write().active.insert(xid);
+        state.active.insert(xid);
         xid
     }
 


### PR DESCRIPTION
Automated AFK landing for #1722. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1722

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785762499&installation_id=129708444&pr_number=1723&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1723&signature=cacceba9f8f3af4a4b33b6f1d919736cb6610299d7884900514d4aa40b71c417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency for concurrent updates, reducing cases where overlapping changes could incorrectly overwrite or merge each other.
  * Fixed snapshot handling so transactions see the correct in-flight changes during concurrent activity, improving visibility and conflict behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->