### PR TITLE
merge: #1724 /go: Iterate a MVCC concurrency fix that fixed one bug but introduced a regre

### DIFF
--- a/crates/reddb-server/src/runtime/impl_dml_update_analysis.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_update_analysis.rs
@@ -91,7 +91,41 @@ pub(super) fn resolve_update_entity_by_logical_id(
     logical_id: EntityId,
 ) -> Option<UnifiedEntity> {
     let store = runtime.inner.db.store();
-    if let Some(entity) = store.get_table_row_by_logical_id(table, logical_id) {
+
+    // Read-modify-write pre-image resolution.
+    //
+    // A compound assignment (`n = n + 1`) folds the pre-image value into the
+    // written row, so the pre-image MUST be the LATEST COMMITTED version,
+    // re-evaluated *now* — this call runs while we hold the per-row RMW lock,
+    // so every earlier same-row writer has already committed. Two failure
+    // modes must both be avoided:
+    //   * `get_table_row_by_logical_id` returns whichever physical version
+    //     currently carries `xmax == 0`, which under concurrent same-row
+    //     writes can be another transaction's still-uncommitted version —
+    //     folding a later-aborted write into committed state (dirty read).
+    //   * the pinned *statement* snapshot was captured before this statement
+    //     acquired the RMW lock, so it can miss a value a peer committed in
+    //     the meantime — every concurrent increment then reads the same stale
+    //     pre-image and overwrites its predecessor (lost update).
+    // A snapshot taken at this instant, paired with this connection's own
+    // in-flight xids, threads both: it sees the freshest committed version
+    // (no lost update) and this transaction's own writes, while hiding every
+    // other transaction's uncommitted version (no dirty read).
+    if let Some(base) = crate::runtime::impl_core::capture_current_snapshot() {
+        let snapshot = base.manager.fresh_read_snapshot();
+        let ctx = crate::runtime::impl_core::SnapshotContext {
+            snapshot,
+            manager: Arc::clone(&base.manager),
+            own_xids: base.own_xids.clone(),
+            requires_index_fallback: true,
+            serializable_reader: base.serializable_reader,
+        };
+        let resolver =
+            crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::captured(Some(ctx));
+        if let Some(entity) = resolver.resolve_logical_id(&store, table, logical_id) {
+            return Some(entity);
+        }
+    } else if let Some(entity) = store.get_table_row_by_logical_id(table, logical_id) {
         return Some(entity);
     }
     // Fallback for non-table-row entities (graph nodes/edges, etc.) where

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -189,10 +189,47 @@ impl SnapshotManager {
 
     /// Allocate a new xid and mark it active. Returns the xid for
     /// stamping onto `UnifiedEntity::xmin/xmax`.
+    ///
+    /// Allocation and the `active` insert happen together under the state
+    /// write lock. This is load-bearing for first-committer-wins: a
+    /// concurrent snapshot (state read lock) must never observe a
+    /// *lower-numbered* still-running xid as absent from `active`. Were the
+    /// `fetch_add` done outside the lock, a writer that grabbed the smaller
+    /// xid could still be mid-`begin()` while a later transaction snapshots
+    /// a larger xid — the smaller xid would be missing from `in_progress`,
+    /// yet `xmin <= snapshot.xid`, so the snapshot would treat that
+    /// concurrent (later possibly-committed) writer as visible. That both
+    /// leaks an uncommitted row into a peer's read and lets two writers on
+    /// the same row both commit. Serialising allocation under the lock
+    /// guarantees any xid smaller than a taken snapshot's xid is already in
+    /// `active` (or already finished), so `in_progress` is never short a
+    /// concurrent writer.
     pub fn begin(&self) -> Xid {
+        let mut state = self.state.write();
         let xid = self.next_xid.fetch_add(1, Ordering::Relaxed);
-        self.state.write().active.insert(xid);
+        state.active.insert(xid);
         xid
+    }
+
+    /// Capture a fresh *read-committed* snapshot at this instant: sees every
+    /// transaction that has committed so far and hides every still-active
+    /// one. Unlike [`snapshot`], the caller supplies no xid — the snapshot
+    /// id is the current allocator high-water mark, read *under the same
+    /// state lock* that [`begin`] holds while it bumps the counter and
+    /// inserts into `active`. That mutual exclusion is what makes the read
+    /// atomic: a concurrent `begin()` is either wholly visible (counter
+    /// bumped AND present in `active`, hence hidden as in-progress) or
+    /// wholly invisible (neither) — never the torn state where its xid sits
+    /// below the high-water mark yet is missing from `active`, which would
+    /// leak an uncommitted writer as visible.
+    ///
+    /// Used for RMW pre-image reads that must always observe the latest
+    /// committed row version rather than a pinned statement snapshot.
+    pub fn fresh_read_snapshot(&self) -> Snapshot {
+        let state = self.state.read();
+        let xid = self.next_xid.load(Ordering::Relaxed);
+        let in_progress: HashSet<Xid> = state.active.iter().copied().collect();
+        Snapshot { xid, in_progress }
     }
 
     /// Capture a point-in-time snapshot. Must be called after `begin()`
@@ -475,6 +512,35 @@ mod tests {
         assert!(snap.in_progress.contains(&writer));
         // A row written by `writer` with xmin=writer must be invisible.
         assert!(!snap.sees(writer, XID_NONE));
+    }
+
+    #[test]
+    fn fresh_read_snapshot_sees_latest_committed_hides_active() {
+        let m = SnapshotManager::new();
+        // A committed writer must be visible to a fresh read snapshot; an
+        // xid still active must be hidden. This is the RMW pre-image
+        // contract: latest committed, never an uncommitted sibling.
+        let committed = m.begin();
+        m.commit(committed);
+        let active = m.begin();
+
+        let snap = m.fresh_read_snapshot();
+        assert!(snap.sees(committed, XID_NONE));
+        assert!(!snap.sees(active, XID_NONE));
+        assert!(snap.in_progress.contains(&active));
+    }
+
+    #[test]
+    fn fresh_read_snapshot_refreshes_between_calls() {
+        let m = SnapshotManager::new();
+        // Value committed *after* a first read must be visible to a second
+        // fresh read — proving the snapshot is re-evaluated, not pinned.
+        let later = m.begin();
+        let first = m.fresh_read_snapshot();
+        assert!(!first.sees(later, XID_NONE));
+        m.commit(later);
+        let second = m.fresh_read_snapshot();
+        assert!(second.sees(later, XID_NONE));
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1724. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1724

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785776366&installation_id=129708444&pr_number=1725&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1725&signature=949ec0141d3895b7b2bd9e281cc939c3c1bb833de5b4c462c47e9913c5f45c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->