### PR TITLE
Array literals parse lossless; vector-vs-JSON typing resolves from target

### DIFF
--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -877,8 +877,16 @@ impl<'a> Parser<'a> {
                 Ok(Value::Null)
             }
             Token::LBracket => {
-                // Parse array literal [val1, val2, ...]
-                // For numeric arrays, produce Value::Vector; for others, produce Value::Json
+                // Parse array literal `[val1, val2, ...]` **losslessly** into a
+                // `Value::Array`, preserving each element's integer/float/other
+                // identity (issue #1708, ADR 0067). The parser deliberately does
+                // NOT decide here whether the array is a vector or a JSON array:
+                // committing to an f32 `Value::Vector` at parse time silently
+                // corrupts large integers destined for a JSON position (e.g.
+                // `[9007199254740993]`). Instead the analyzer/runtime resolves
+                // the concrete shape from the target's type — a vector-typed
+                // position coerces `Value::Array` → `Value::Vector`, a JSON
+                // position coerces it to an exact JSON array.
                 self.advance()?; // consume '['
                 let mut items = Vec::new();
                 if !self.check(&Token::RBracket) {
@@ -890,38 +898,7 @@ impl<'a> Parser<'a> {
                     }
                 }
                 self.expect(Token::RBracket)?;
-
-                // Check if all items are numeric (Integer or Float) -> Value::Vector
-                let all_numeric = items
-                    .iter()
-                    .all(|v| matches!(v, Value::Integer(_) | Value::Float(_)));
-                if all_numeric && !items.is_empty() {
-                    let floats: Vec<f32> = items
-                        .iter()
-                        .map(|v| match v {
-                            Value::Float(f) => *f as f32,
-                            Value::Integer(i) => *i as f32,
-                            _ => 0.0,
-                        })
-                        .collect();
-                    Ok(Value::Vector(floats))
-                } else {
-                    // Encode as JSON bytes
-                    let json_arr: Vec<reddb_types::json::Value> = items
-                        .iter()
-                        .map(|v| match v {
-                            Value::Null => reddb_types::json::Value::Null,
-                            Value::Boolean(b) => reddb_types::json::Value::Bool(*b),
-                            Value::Integer(i) => reddb_types::json::Value::Number(*i as f64),
-                            Value::Float(f) => reddb_types::json::Value::Number(*f),
-                            Value::Text(s) => reddb_types::json::Value::String(s.to_string()),
-                            _ => reddb_types::json::Value::Null,
-                        })
-                        .collect();
-                    let json_val = reddb_types::json::Value::Array(json_arr);
-                    let bytes = reddb_types::json::to_vec(&json_val).unwrap_or_default();
-                    Ok(Value::Json(bytes))
-                }
+                Ok(Value::Array(items))
             }
             Token::LBrace => {
                 // Parse JSON object literal {key: value, ...}
@@ -1425,16 +1402,35 @@ mod tests {
         let value = parser.parse_literal_value().expect("secret ref");
         assert!(matches!(value, Value::Json(_)));
 
+        // Array literals parse losslessly into `Value::Array`, preserving each
+        // element's integer/float identity (issue #1708). Vector-vs-JSON typing
+        // is resolved downstream from the target, not guessed at parse time.
         let mut parser = make_parser("[1, 2.5]");
         assert!(matches!(
-            parser.parse_literal_value().expect("vector"),
-            Value::Vector(values) if values == vec![1.0, 2.5]
+            parser.parse_literal_value().expect("array"),
+            Value::Array(items)
+                if items == vec![Value::Integer(1), Value::Float(2.5)]
         ));
 
         let mut parser = make_parser("['a', 2]");
         assert!(matches!(
-            parser.parse_literal_value().expect("json array"),
-            Value::Json(_)
+            parser.parse_literal_value().expect("mixed array"),
+            Value::Array(items)
+                if items == vec![Value::Text("a".into()), Value::Integer(2)]
+        ));
+
+        // A large integer that cannot survive an f32 (or even f64) round-trip
+        // keeps its exact `Value::Integer` identity through the parser.
+        let mut parser = make_parser("[1, 2, 9007199254740993]");
+        assert!(matches!(
+            parser.parse_literal_value().expect("lossless big-int array"),
+            Value::Array(items)
+                if items
+                    == vec![
+                        Value::Integer(1),
+                        Value::Integer(2),
+                        Value::Integer(9007199254740993),
+                    ]
         ));
 
         let mut parser = make_parser("{level = 'info', count: 2}");

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -929,17 +929,7 @@ impl<'a> Parser<'a> {
                         }
                         // Value: recursive
                         let val = self.parse_literal_value()?;
-                        let json_val = match val {
-                            Value::Null => reddb_types::json::Value::Null,
-                            Value::Boolean(b) => reddb_types::json::Value::Bool(b),
-                            Value::Integer(i) => reddb_types::json::Value::Number(i as f64),
-                            Value::Float(f) => reddb_types::json::Value::Number(f),
-                            Value::Text(s) => reddb_types::json::Value::String(s.to_string()),
-                            Value::Json(ref bytes) => reddb_types::json::from_slice(bytes)
-                                .unwrap_or(reddb_types::json::Value::Null),
-                            _ => reddb_types::json::Value::Null,
-                        };
-                        map.insert(key, json_val);
+                        map.insert(key, literal_value_to_json(&val));
                         if !self.consume(&Token::Comma)? {
                             break;
                         }
@@ -956,6 +946,30 @@ impl<'a> Parser<'a> {
                 self.position(),
             )),
         }
+    }
+}
+
+/// Convert a parsed literal `Value` into a `reddb_types::json::Value`.
+///
+/// Array literals now parse into `Value::Array` (issue #1708). When an array
+/// appears inside a JSON object-literal position (e.g.
+/// `{roles: ['edge', 'cache']}`) it must serialise as a JSON array rather than
+/// collapsing to `null` the way the old catch-all arm did. Recurses so nested
+/// arrays and objects round-trip.
+fn literal_value_to_json(val: &Value) -> reddb_types::json::Value {
+    match val {
+        Value::Null => reddb_types::json::Value::Null,
+        Value::Boolean(b) => reddb_types::json::Value::Bool(*b),
+        Value::Integer(i) => reddb_types::json::Value::Number(*i as f64),
+        Value::Float(f) => reddb_types::json::Value::Number(*f),
+        Value::Text(s) => reddb_types::json::Value::String(s.to_string()),
+        Value::Json(bytes) => {
+            reddb_types::json::from_slice(bytes).unwrap_or(reddb_types::json::Value::Null)
+        }
+        Value::Array(items) => {
+            reddb_types::json::Value::Array(items.iter().map(literal_value_to_json).collect())
+        }
+        _ => reddb_types::json::Value::Null,
     }
 }
 

--- a/crates/reddb-rql/src/parser/json_literal_table.rs
+++ b/crates/reddb-rql/src/parser/json_literal_table.rs
@@ -395,15 +395,16 @@ fn quoted_form_still_parses() {
 
 #[test]
 fn vector_literal_still_parses() {
-    // `[0.1, 0.2]` must keep producing a Value::Vector, not be touched
-    // by the JSON sub-mode (which only triggers on `{`).
+    // `[0.1, 0.2, 0.3]` parses losslessly into `Value::Array` (issue #1708),
+    // not the JSON sub-mode (which only triggers on `{`). The runtime coerces
+    // it to a `Value::Vector` at the vector column position.
     let q = parse(r#"INSERT INTO emb VECTOR (dense) VALUES ([0.1, 0.2, 0.3])"#)
         .unwrap()
         .query;
     let QueryExpr::Insert(ins) = q else {
         panic!("expected Insert");
     };
-    assert!(matches!(ins.values[0][0], Value::Vector(_)));
+    assert!(matches!(ins.values[0][0], Value::Array(_)));
 }
 
 #[test]

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2070,7 +2070,9 @@ fn test_parse_dml_literal_value_array_and_object_branches() {
     // preserved verbatim rather than being flattened to JSON `null`.
     let mut parser = Parser::new("[PASSWORD('pw')]").unwrap();
     let value = parser.parse_literal_value().unwrap();
-    assert!(matches!(value, Value::Array(items) if matches!(items.as_slice(), [Value::Password(_)])));
+    assert!(
+        matches!(value, Value::Array(items) if matches!(items.as_slice(), [Value::Password(_)]))
+    );
 
     let mut parser = Parser::new(
         "{'quoted': 'text', ident = 1, type: true, nested: {ok: false}, raw: {\"x\":1}, secret: SECRET('s')}",

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -1876,7 +1876,9 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
     let QueryExpr::Insert(insert) = query else {
         panic!("Expected InsertQuery");
     };
-    assert!(matches!(insert.values[0][0], Value::Json(_)));
+    // Array literals parse losslessly into `Value::Array` (issue #1708); object
+    // literals `{...}` remain `Value::Json`.
+    assert!(matches!(insert.values[0][0], Value::Array(_)));
     assert!(matches!(insert.values[0][1], Value::Json(_)));
 
     let query =
@@ -1895,10 +1897,13 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
     };
     assert_eq!(insert.ttl_ms, Some(42_000));
     assert_eq!(insert.with_metadata.len(), 4);
+    // Array-valued metadata (`empty`, `mixed`) parses losslessly into
+    // `Value::Array` (issue #1708); object-valued metadata (`nested`, `raw`)
+    // stays `Value::Json`.
     assert!(insert
         .with_metadata
         .iter()
-        .all(|(_, value)| matches!(value, Value::Json(_))));
+        .all(|(_, value)| matches!(value, Value::Json(_) | Value::Array(_))));
 
     let query =
         parse("UPDATE counters SET value = value + 1 WHERE id = 7 LIMIT 50 RETURNING id").unwrap();
@@ -2048,28 +2053,24 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
 fn test_parse_dml_literal_value_array_and_object_branches() {
     use reddb_types::types::Value;
 
+    // Array literals parse losslessly into `Value::Array` (issue #1708): the
+    // parser preserves element identity instead of guessing a vector-vs-JSON
+    // shape, so `[1, 2.5]` keeps its `Integer`/`Float` mix.
     let mut parser = Parser::new("[1, 2.5]").unwrap();
     let value = parser.parse_literal_value().unwrap();
-    assert!(matches!(value, Value::Vector(values) if values == vec![1.0, 2.5]));
+    assert!(
+        matches!(value, Value::Array(items) if items == vec![Value::Integer(1), Value::Float(2.5)])
+    );
 
     let mut parser = Parser::new("[]").unwrap();
     let value = parser.parse_literal_value().unwrap();
-    let Value::Json(bytes) = value else {
-        panic!("Expected Value::Json");
-    };
-    let parsed: reddb_types::json::Value = reddb_types::json::from_slice(&bytes).unwrap();
-    assert!(parsed.as_array().is_some_and(|items| items.is_empty()));
+    assert!(matches!(value, Value::Array(items) if items.is_empty()));
 
+    // Non-JSON-encodable elements (e.g. a `PASSWORD(...)` constructor) are
+    // preserved verbatim rather than being flattened to JSON `null`.
     let mut parser = Parser::new("[PASSWORD('pw')]").unwrap();
     let value = parser.parse_literal_value().unwrap();
-    let Value::Json(bytes) = value else {
-        panic!("Expected Value::Json");
-    };
-    let parsed: reddb_types::json::Value = reddb_types::json::from_slice(&bytes).unwrap();
-    assert_eq!(
-        parsed.as_array().and_then(|items| items.first()),
-        Some(&reddb_types::json::Value::Null)
-    );
+    assert!(matches!(value, Value::Array(items) if matches!(items.as_slice(), [Value::Password(_)])));
 
     let mut parser = Parser::new(
         "{'quoted': 'text', ident = 1, type: true, nested: {ok: false}, raw: {\"x\":1}, secret: SECRET('s')}",
@@ -3496,13 +3497,21 @@ fn test_parse_insert_vector() {
         assert_eq!(ins.entity_type, crate::ast::InsertEntityType::Vector);
         assert_eq!(ins.columns, vec!["dense", "content"]);
         assert_eq!(ins.values.len(), 1);
-        // The vector literal should be parsed as Value::Vector
+        // The array literal parses losslessly into `Value::Array` (issue
+        // #1708); the runtime coerces it to a `Value::Vector` at the
+        // vector-typed column position.
         match &ins.values[0][0] {
-            reddb_types::types::Value::Vector(v) => {
-                assert_eq!(v.len(), 3);
-                assert!((v[0] - 0.1).abs() < 0.01);
+            reddb_types::types::Value::Array(items) => {
+                assert_eq!(
+                    items,
+                    &vec![
+                        reddb_types::types::Value::Float(0.1),
+                        reddb_types::types::Value::Float(0.2),
+                        reddb_types::types::Value::Float(0.3),
+                    ]
+                );
             }
-            other => panic!("Expected Vector value, got {other:?}"),
+            other => panic!("Expected Array value, got {other:?}"),
         }
     } else {
         panic!("Expected InsertQuery with Vector entity type");
@@ -3539,14 +3548,23 @@ fn test_parse_insert_kv() {
 
 #[test]
 fn test_parse_insert_vector_array_literal() {
-    // Test array literal parsing in VALUES
+    // Integer array literals also parse losslessly into `Value::Array`; the
+    // integer identity of each element is preserved (issue #1708) and the
+    // runtime coerces to `Vec<f32>` only at the vector column.
     let query = parse("INSERT INTO emb VECTOR (dense) VALUES ([1, 2, 3])").unwrap();
     if let QueryExpr::Insert(ins) = query {
         match &ins.values[0][0] {
-            reddb_types::types::Value::Vector(v) => {
-                assert_eq!(v, &[1.0, 2.0, 3.0]);
+            reddb_types::types::Value::Array(items) => {
+                assert_eq!(
+                    items,
+                    &vec![
+                        reddb_types::types::Value::Integer(1),
+                        reddb_types::types::Value::Integer(2),
+                        reddb_types::types::Value::Integer(3),
+                    ]
+                );
             }
-            other => panic!("Expected Vector value, got {other:?}"),
+            other => panic!("Expected Array value, got {other:?}"),
         }
     } else {
         panic!("Expected InsertQuery");

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -240,6 +240,13 @@ pub fn render_value_sql(v: &Value) -> String {
         // JSON bytes are stored as canonical compact JSON; emit them raw so
         // the lexer picks them up as a JsonLiteral token on re-parse.
         Value::Json(bytes) => String::from_utf8_lossy(bytes).to_string(),
+        // Array literals render back to `[...]` so a comparison against an
+        // array literal re-parses losslessly (issue #1708) rather than
+        // collapsing to NULL.
+        Value::Array(items) => {
+            let rendered: Vec<String> = items.iter().map(render_value_sql).collect();
+            format!("[{}]", rendered.join(", "))
+        }
         _ => "NULL".to_string(),
     }
 }

--- a/crates/reddb-rql/tests/reddb_corpus/array_literal_typing.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/array_literal_typing.slt
@@ -1,0 +1,49 @@
+# RedDB-only conformance — array-literal typing (issue #1708, PRD #1703,
+# ADR 0067). HAND-AUTHORED TRUTH (ADR 0053 S3).
+#
+# A bare `[…]` literal parses LOSSLESSLY into an array; whether it becomes a
+# vector or a JSON array is resolved by the runtime from the target's type, not
+# guessed (lossily, as an f32 vector) at parse time. This file exercises both
+# resolutions plus the mixed-type array case.
+#
+# The harness projects each result to its semantic `content` column; the
+# engine-internal id/score/timestamp columns are run-varying and intentionally
+# not pinned (see tests/reddb_conformance.rs). KV/document `value`/`body`
+# positions are not among the projected semantic columns, so the JSON-target
+# cases below assert acceptance (`statement ok`) — the exact-integer round-trip
+# for those positions is pinned at the value level in
+# `crates/reddb-server/tests/issue_1708_array_literal_typing.rs`.
+
+# --- Vector target ---------------------------------------------------------
+# A numeric array at a vector-typed position resolves to a vector. Integer
+# element spellings ([1, 0]) are accepted just like float spellings and rank
+# identically against the unit query.
+statement ok
+CREATE VECTOR v DIM 2 METRIC cosine
+
+statement ok
+INSERT INTO v VECTOR (embedding, content) VALUES ([1, 0], 'near')
+
+statement ok
+INSERT INTO v VECTOR (embedding, content) VALUES ([0, 1], 'far')
+
+# Nearest-first by cosine similarity: 'near' is colinear with [1, 0], 'far' is
+# orthogonal, so the strict ranking is near, far.
+query T nosort
+VECTOR SEARCH v SIMILAR TO [1, 0] LIMIT 2
+----
+near
+far
+
+# --- JSON target -----------------------------------------------------------
+# A numeric array at a JSON/KV position stays an exact JSON array. The large
+# integer 9007199254740993 (2^53 + 1) cannot survive an f32/f64 round-trip, so
+# a parse-time vector guess would corrupt it; the lossless parse preserves it.
+statement ok
+INSERT INTO settings KV (key, value) VALUES ('nums', [1, 2, 9007199254740993])
+
+# --- Mixed-type array ------------------------------------------------------
+# A mixed array is never a vector candidate and resolves to a JSON array with
+# every element's identity preserved.
+statement ok
+INSERT INTO settings KV (key, value) VALUES ('mixed', ['a', 2, true, null])

--- a/crates/reddb-server/src/runtime/impl_dml_support.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_support.rs
@@ -226,7 +226,9 @@ pub(super) fn find_document_body_json(
             .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
         // A JSON-position array literal parses losslessly into `Value::Array`
         // (issue #1708); resolve it to a JSON array here.
-        Value::Array(_) => Ok(crate::presentation::entity_json::storage_value_to_json(&val)),
+        Value::Array(_) => Ok(crate::presentation::entity_json::storage_value_to_json(
+            &val,
+        )),
         Value::Integer(value) => crate::json::from_str(&value.to_string())
             .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
         Value::UnsignedInteger(value) => crate::json::from_str(&value.to_string())

--- a/crates/reddb-server/src/runtime/impl_dml_support.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_support.rs
@@ -224,6 +224,9 @@ pub(super) fn find_document_body_json(
         }
         Value::Text(text) => crate::json::from_str(text.as_ref())
             .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        // A JSON-position array literal parses losslessly into `Value::Array`
+        // (issue #1708); resolve it to a JSON array here.
+        Value::Array(_) => Ok(crate::presentation::entity_json::storage_value_to_json(&val)),
         Value::Integer(value) => crate::json::from_str(&value.to_string())
             .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
         Value::UnsignedInteger(value) => crate::json::from_str(&value.to_string())
@@ -374,6 +377,10 @@ pub(super) fn find_column_value_f32_opt(
 }
 
 /// Find a required column value and coerce to Vec<f32> (from Value::Vector).
+///
+/// Array literals now parse losslessly into `Value::Array` (issue #1708), so a
+/// vector-typed column position resolves that array to `Vec<f32>` here rather
+/// than the parser committing to an f32 vector before the target is known.
 pub(super) fn find_column_value_vec_f32(
     columns: &[String],
     values: &[Value],
@@ -382,6 +389,17 @@ pub(super) fn find_column_value_vec_f32(
     let val = find_column_value(columns, values, name)?;
     match val {
         Value::Vector(v) => Ok(v),
+        Value::Array(items) => items
+            .iter()
+            .map(|item| match item {
+                Value::Float(f) => Ok(*f as f32),
+                Value::Integer(n) | Value::BigInt(n) => Ok(*n as f32),
+                Value::UnsignedInteger(n) => Ok(*n as f32),
+                other => Err(RedDBError::Query(format!(
+                    "column '{name}' vector array accepts only numeric values, got {other:?}"
+                ))),
+            })
+            .collect(),
         Value::Json(bytes) => {
             // Try to parse as JSON array of numbers
             let s = std::str::from_utf8(&bytes).map_err(|_| {

--- a/crates/reddb-server/tests/issue_1708_array_literal_typing.rs
+++ b/crates/reddb-server/tests/issue_1708_array_literal_typing.rs
@@ -1,0 +1,101 @@
+//! Issue #1708 — array literals parse lossless; vector-vs-JSON typing resolves
+//! from the target (PRD #1703, ADR 0067).
+//!
+//! A bare `[…]` literal used to commit to an f32 `Value::Vector` at parse time
+//! whenever every element was numeric — silently corrupting large integers
+//! destined for a JSON position long before the target type was known. The
+//! parser now yields a lossless `Value::Array`, and the runtime resolves the
+//! concrete shape from the target: a vector-typed position coerces to a
+//! `Vec<f32>`, a JSON/KV position keeps the exact `Value::Array`.
+
+use reddb_server::storage::schema::Value;
+use reddb_server::{RedDBOptions, RedDBRuntime};
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots")
+}
+
+/// A JSON/KV position keeps every element's exact integer identity — including
+/// `9007199254740993` (2^53 + 1), which cannot survive an f32 or f64 round-trip.
+#[test]
+fn json_position_array_round_trips_with_exact_integers() {
+    let rt = runtime();
+
+    rt.execute_query(
+        "INSERT INTO settings KV (key, value) VALUES ('nums', [1, 2, 9007199254740993])",
+    )
+    .expect("insert array-valued kv pair");
+
+    let read = rt
+        .execute_query("SELECT key, value FROM settings WHERE key = 'nums'")
+        .expect("read array-valued kv pair");
+
+    let value = read.result.records[0]
+        .get("value")
+        .expect("value column present");
+
+    assert_eq!(
+        value,
+        &Value::Array(vec![
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(9_007_199_254_740_993),
+        ]),
+        "large integers must survive the round-trip intact, not collapse to f32/f64"
+    );
+}
+
+/// A mixed-type array (never a vector candidate) is preserved element-for-element
+/// rather than being flattened through a lossy JSON encode at parse time.
+#[test]
+fn json_position_mixed_type_array_round_trips() {
+    let rt = runtime();
+
+    rt.execute_query(
+        "INSERT INTO settings KV (key, value) VALUES ('mixed', ['a', 2, true, null])",
+    )
+    .expect("insert mixed-type array");
+
+    let read = rt
+        .execute_query("SELECT key, value FROM settings WHERE key = 'mixed'")
+        .expect("read mixed-type array");
+
+    let value = read.result.records[0]
+        .get("value")
+        .expect("value column present");
+
+    assert_eq!(
+        value,
+        &Value::Array(vec![
+            Value::text("a"),
+            Value::Integer(2),
+            Value::Boolean(true),
+            Value::Null,
+        ]),
+    );
+}
+
+/// A numeric array literal at a vector-typed position still resolves to a
+/// vector — existing vector-model flows stay green with unchanged syntax.
+#[test]
+fn vector_position_array_still_resolves_to_a_vector() {
+    let rt = runtime();
+
+    rt.execute_query("CREATE VECTOR v DIM 2 METRIC cosine")
+        .expect("create vector collection");
+    // Integer array literals (previously the corruption-prone case) resolve
+    // cleanly to the vector column.
+    rt.execute_query("INSERT INTO v VECTOR (embedding, content) VALUES ([1, 0], 'near')")
+        .expect("insert integer-array vector");
+    rt.execute_query("INSERT INTO v VECTOR (embedding, content) VALUES ([0, 1], 'far')")
+        .expect("insert integer-array vector");
+
+    let result = rt
+        .execute_query("VECTOR SEARCH v SIMILAR TO [1, 0] LIMIT 1")
+        .expect("vector search");
+
+    let content = result.result.records[0]
+        .get("content")
+        .expect("content column present");
+    assert_eq!(content, &Value::text("near"));
+}

--- a/crates/reddb-server/tests/issue_1708_array_literal_typing.rs
+++ b/crates/reddb-server/tests/issue_1708_array_literal_typing.rs
@@ -51,10 +51,8 @@ fn json_position_array_round_trips_with_exact_integers() {
 fn json_position_mixed_type_array_round_trips() {
     let rt = runtime();
 
-    rt.execute_query(
-        "INSERT INTO settings KV (key, value) VALUES ('mixed', ['a', 2, true, null])",
-    )
-    .expect("insert mixed-type array");
+    rt.execute_query("INSERT INTO settings KV (key, value) VALUES ('mixed', ['a', 2, true, null])")
+        .expect("insert mixed-type array");
 
     let read = rt
         .execute_query("SELECT key, value FROM settings WHERE key = 'mixed'")


### PR DESCRIPTION
Closes #1708 — PRD #1703. Rebased on MVCC fix (main).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785779378&installation_id=129708444&pr_number=1728&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1728&signature=2cf1d48a77f8780ff9eb3ceb3922ca27b25ae224f2ced3e8ef31dcf1bc1ba9ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->