### PR TITLE
Catalog model inference for unmarked document DML; INSERT DOCUMENT as idempotent model assertion (#1710)

### DIFF
--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -105,6 +105,14 @@ impl<'a> Parser<'a> {
         // column list.
         let columns = if matches!(entity_type, InsertEntityType::Document) {
             self.parse_document_insert_columns()?
+        } else if matches!(entity_type, InsertEntityType::Row) && self.check(&Token::Values) {
+            // ADR 0067 (#1710): the bare `INSERT INTO c VALUES (…)` form
+            // carries no column list and no model marker. The model is
+            // inferred from the catalog at analysis time — an existing
+            // document collection routes to document creation — so the
+            // parser leaves the column list empty and defers the routing
+            // decision to the runtime.
+            Vec::new()
         } else {
             self.expect(Token::LParen)?;
             let columns = self.parse_ident_list()?;
@@ -1282,6 +1290,29 @@ mod tests {
             query.returning.as_deref(),
             Some([ReturningItem::All].as_slice())
         );
+    }
+
+    #[test]
+    fn unmarked_bare_values_insert_parses_with_empty_columns() {
+        // ADR 0067 (#1710): `INSERT INTO c VALUES ({…})` with no column
+        // list and no marker parses to a Row insert with an empty column
+        // list; the runtime infers the model from the catalog.
+        let query = insert("INSERT INTO events VALUES ({\"level\": \"info\"})");
+        assert_eq!(query.table, "events");
+        assert_eq!(query.entity_type, InsertEntityType::Row);
+        assert!(query.columns.is_empty());
+        assert_eq!(query.values.len(), 1);
+        assert!(matches!(query.values[0][0], Value::Json(_)));
+
+        // Multi-row bare VALUES keeps working.
+        let query = insert("INSERT INTO events VALUES ({\"a\": 1}), ({\"b\": 2})");
+        assert!(query.columns.is_empty());
+        assert_eq!(query.entity_type, InsertEntityType::Row);
+        assert_eq!(query.values.len(), 2);
+
+        // An explicit column list is still parsed positionally.
+        let query = insert("INSERT INTO t (id) VALUES (1)");
+        assert_eq!(query.columns, vec!["id"]);
     }
 
     #[test]

--- a/crates/reddb-rql/tests/reddb_corpus/document_model_inference.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/document_model_inference.slt
@@ -1,0 +1,80 @@
+# ADR 0067 (#1710) — catalog model inference for unmarked document DML.
+#
+# TRUTH is hand-authored (a RedDB-only surface with no external oracle):
+# the marker rule made real — a model marker exists only where it
+# disambiguates what the catalog cannot know.
+#
+#   * an unmarked INSERT into an existing document collection inserts a
+#     document (the model is inferred from the catalog);
+#   * the DOCUMENT marker is an explicit, idempotent model assertion —
+#     the same statement passes on the first and the thousandth run;
+#   * a marker contradicting the catalog fails with the model-contract
+#     error;
+#   * an unmarked INSERT into an unknown collection is a didactic error
+#     naming both recourses.
+#
+# Result rows are projected to the harness's semantic allowlist (`name`)
+# and compared with `rowsort`, so the golden asserts the *set* of inserted
+# documents without freezing engine-defined insertion order.
+
+# --- Unmarked INSERT into an existing document collection ----------------
+
+statement ok
+CREATE DOCUMENT events
+
+statement ok
+INSERT INTO events DOCUMENT VALUES ({"name": "alice"})
+
+# No DOCUMENT marker: the analyzer resolves the model from the catalog and
+# routes to document creation.
+statement ok
+INSERT INTO events VALUES ({"name": "bob"})
+
+query T rowsort
+SELECT name FROM events
+----
+alice
+bob
+
+# --- Marked INSERT is an idempotent model assertion ----------------------
+
+# First run bootstraps the collection as a document...
+statement ok
+INSERT INTO logs DOCUMENT VALUES ({"name": "first"})
+
+# ...and the identical statement passes again on the existing collection.
+statement ok
+INSERT INTO logs DOCUMENT VALUES ({"name": "second"})
+
+# Once the assertion has bootstrapped the model, the unmarked form infers it.
+statement ok
+INSERT INTO logs VALUES ({"name": "third"})
+
+query T rowsort
+SELECT name FROM logs
+----
+first
+second
+third
+
+# --- A marker that contradicts the catalog fails -------------------------
+
+statement ok
+CREATE TABLE accounts (id INTEGER)
+
+statement error does not allow 'document' writes
+INSERT INTO accounts DOCUMENT VALUES ({"name": "nope"})
+
+# --- Unknown collection + no marker → didactic error ---------------------
+
+statement error does not exist and the INSERT carries no model marker
+INSERT INTO ghosts VALUES ({"name": "boo"})
+
+# The error's named recourse works: the assertion form bootstraps it.
+statement ok
+INSERT INTO ghosts DOCUMENT VALUES ({"name": "boo"})
+
+query T rowsort
+SELECT name FROM ghosts
+----
+boo

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -81,6 +81,59 @@ pub(super) struct MaterializedUpdateAssignments {
 }
 
 impl RedDBRuntime {
+    /// ADR 0067 (#1710): resolve the model of an unmarked bare-VALUES
+    /// INSERT from the catalog, making the marker rule real — *a model
+    /// marker exists only where it disambiguates what the catalog cannot
+    /// know.*
+    ///
+    /// `INSERT INTO c VALUES ({…})` has no column list and no model marker,
+    /// so the parser leaves `entity_type = Row` with an empty column list.
+    /// Only that exact shape is a candidate for inference — every other
+    /// INSERT (an explicit column list, or an explicit `DOCUMENT` / `NODE`
+    /// / `VECTOR` / … marker) is returned untouched.
+    ///
+    /// * existing **document** collection → rewritten to a `DOCUMENT`
+    ///   insert so the body routes through document creation, exactly the
+    ///   path the explicit marker takes;
+    /// * existing **non-document** collection → the bare form does not
+    ///   apply; reported with a model-oriented error;
+    /// * unknown collection → didactic error naming both recourses (the
+    ///   `DOCUMENT` assertion form or `CREATE DOCUMENT` first).
+    fn infer_unmarked_document_insert(
+        &self,
+        query: &InsertQuery,
+    ) -> RedDBResult<Option<InsertQuery>> {
+        if !matches!(query.entity_type, InsertEntityType::Row) || !query.columns.is_empty() {
+            return Ok(None);
+        }
+        match self
+            .db()
+            .collection_contract_arc(&query.table)
+            .map(|contract| contract.declared_model)
+        {
+            Some(crate::catalog::CollectionModel::Document) => {
+                let mut rewritten = query.clone();
+                rewritten.entity_type = InsertEntityType::Document;
+                rewritten.columns = vec!["body".to_string()];
+                Ok(Some(rewritten))
+            }
+            Some(other) => Err(RedDBError::InvalidOperation(format!(
+                "collection '{table}' is declared as '{model}'; the bare \
+                 `INSERT INTO {table} VALUES (…)` form is the document body shorthand — \
+                 write an explicit column list (`INSERT INTO {table} (col, …) VALUES (…)`) \
+                 to insert into a {model} collection",
+                table = query.table,
+                model = crate::runtime::ddl::polymorphic_resolver::model_name(other),
+            ))),
+            None => Err(RedDBError::InvalidOperation(format!(
+                "collection '{table}' does not exist and the INSERT carries no model marker; \
+                 write `INSERT INTO {table} DOCUMENT VALUES ({{…}})` to create it as a document \
+                 (idempotent), or run `CREATE DOCUMENT {table}` first",
+                table = query.table,
+            ))),
+        }
+    }
+
     /// Execute INSERT INTO table [entity_type] (cols) VALUES (vals), ...
     ///
     /// Each row in `query.values` is zipped with `query.columns` to produce a
@@ -101,6 +154,22 @@ impl RedDBRuntime {
             &query.table,
             crate::runtime::collection_contract::MutationKind::Insert,
         )?;
+        // ADR 0067 (#1710): catalog model inference for the unmarked
+        // bare-VALUES INSERT. `INSERT INTO c VALUES ({…})` carries no
+        // column list and no model marker (parsed as a Row insert with an
+        // empty column list); resolve the model from the catalog so an
+        // existing document collection routes to document creation and an
+        // unknown collection surfaces a didactic error. Runs before tenant
+        // injection so a rewritten document insert is tenant-scoped like
+        // the explicit `DOCUMENT` marker path.
+        let inferred_owned;
+        let query = match self.infer_unmarked_document_insert(query)? {
+            Some(rewritten) => {
+                inferred_owned = rewritten;
+                &inferred_owned
+            }
+            None => query,
+        };
         // Phase 2.5.4 table-scoped tenancy: if the target table is
         // tenant-scoped and the user didn't name the tenant column,
         // auto-inject it with the thread-local `CURRENT_TENANT()`


### PR DESCRIPTION
Implements PRD #1703 slice #1710 (ADR 0067 point 4): the `DOCUMENT` marker becomes an optional idempotent model assertion, and unmarked `INSERT INTO c VALUES ({…})` infers the model from the catalog.

## Changes (3 commits, one file each, based on current `main`)
1. **`crates/reddb-rql/src/parser/dml.rs`** — bare `INSERT INTO c VALUES ({…})` (no column list, no marker) parses to a Row insert with empty columns, deferring model resolution to the runtime. + parser unit test.
2. **`crates/reddb-server/src/runtime/impl_dml.rs`** — `infer_unmarked_document_insert` resolves the model from the catalog: existing document collection → document creation; existing non-document → model-oriented error; unknown collection → didactic error naming both recourses. `DOCUMENT` stays an idempotent assertion via `create_document`'s `ensure_model` gate (create-if-absent / validate-if-present; mismatch → model-contract error).
3. **`crates/reddb-rql/tests/reddb_corpus/document_model_inference.slt`** — sqllogictest golden covering all flows incl. the unknown-collection negative fixture.

## Verification (agent-run + finish-from-branch)
- Parser unit test: pass.
- reddb-only conformance golden (builds reddb-server, runs the new `.slt`): pass — locks all 5 flows end-to-end.
- `cargo fmt --check`: clean.

## Note
Landed via manual finish-from-branch: the AFK orchestrator was killed mid-run (operator error — a live worker's worktree was repeatedly reaped during unrelated cleanup), but the inner agent committed incrementally off `origin/main` and the 3 commits are intact and coherent. CI is the gate.

Closes #1710

Claude-Session: https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785792213&installation_id=129708444&pr_number=1730&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1730&signature=8d7805fbfc14b38aa9c3e2da549472ca8c53226559e024053d5fc77dca3847c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for bare `INSERT INTO <table> VALUES (...)` statements without requiring a column list in supported cases.
  * Unmarked inserts can now be inferred for document collections, matching the existing collection model automatically.

* **Bug Fixes**
  * Improved error messages for inserts into incompatible or unknown collections.
  * Added broader test coverage for document-model inference and multi-row insert behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->