### PR TITLE
Remove DOCUMENTS/ROWS/KV markers from UPDATE; dotted SET gated by analyzer via catalog (#1711)

### DIFF
--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -433,7 +433,7 @@ impl<'a> DocumentClient<'a> {
         let result = self
             .db
             .query(&format!(
-                "UPDATE {collection} DOCUMENTS SET {} WHERE rid = {} RETURNING *",
+                "UPDATE {collection} SET {} WHERE rid = {} RETURNING *",
                 assignments.join(", "),
                 sql_string_literal(rid)
             ))

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -1855,15 +1855,21 @@ pub enum InsertEntityType {
     Kv,
 }
 
-/// Explicit item-kind qualifier for UPDATE statements.
+/// Item-kind qualifier for UPDATE statements.
+///
+/// The `DOCUMENTS` / `ROWS` / `KV` model markers were removed (ADR 0067,
+/// #1711): the catalog knows every existing collection's model, so an unmarked
+/// UPDATE parses to `Rows` and the runtime resolves `Documents` / `Kv`
+/// semantics from the catalog. Only `NODES` / `EDGES` remain parse-time markers
+/// — a graph collection holds both record kinds, so only the user can say which.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UpdateTarget {
-    /// Default: table/document/KV row-shaped items.
+    /// Unmarked UPDATE: parses as row-shaped, catalog-resolved at runtime.
     #[default]
     Rows,
-    /// UPDATE t DOCUMENTS SET ...
+    /// Catalog-inferred document collection (no parse-time marker).
     Documents,
-    /// UPDATE t KV SET ...
+    /// Catalog-inferred KV collection (no parse-time marker).
     Kv,
     /// UPDATE t NODES SET ...
     Nodes,

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -409,7 +409,7 @@ impl<'a> Parser<'a> {
         let mut assignment_exprs = Vec::new();
         let mut compound_assignment_ops = Vec::new();
         loop {
-            let col = self.parse_update_assignment_target(target)?;
+            let col = self.parse_update_assignment_target()?;
             let compound_op = if self.consume(&Token::Eq)? {
                 None
             } else {
@@ -539,28 +539,34 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    fn parse_update_assignment_target(
-        &mut self,
-        target: UpdateTarget,
-    ) -> Result<String, ParseError> {
+    fn parse_update_assignment_target(&mut self) -> Result<String, ParseError> {
+        // Dotted assignment targets (`SET a.b.c = …`) parse for every target
+        // (ADR 0067, #1711). Whether a nested path is legal is a model
+        // question the parser cannot answer — the analyzer resolves the
+        // collection's model from the catalog and rejects dotted targets off a
+        // document collection.
         let mut segments = vec![self.expect_column_ident()?];
-        if matches!(target, UpdateTarget::Documents) {
-            while self.consume(&Token::Dot)? {
-                segments.push(self.expect_column_ident()?);
-            }
+        while self.consume(&Token::Dot)? {
+            segments.push(self.expect_column_ident()?);
         }
         Ok(segments.join("."))
     }
 
     fn parse_update_target(&mut self) -> Result<UpdateTarget, ParseError> {
-        if self.consume(&Token::Kv)? {
-            return Ok(UpdateTarget::Kv);
+        // Model markers on UPDATE are removed (ADR 0067, #1711): the catalog
+        // already knows every existing collection's model, so `DOCUMENTS` /
+        // `ROWS` / `KV` are redundant and rejected with a didactic error that
+        // points at the unmarked form. `NODES` / `EDGES` stay — a graph
+        // collection holds both record kinds, so only the user can say which
+        // one an UPDATE targets.
+        if self.check(&Token::Kv) {
+            return Err(self.removed_update_marker_error("KV"));
         }
-        if self.consume(&Token::Rows)? {
-            return Ok(UpdateTarget::Rows);
+        if self.check(&Token::Rows) {
+            return Err(self.removed_update_marker_error("ROWS"));
         }
-        if self.consume_ident_ci("DOCUMENTS")? {
-            return Ok(UpdateTarget::Documents);
+        if matches!(self.peek(), Token::Ident(name) if name.eq_ignore_ascii_case("DOCUMENTS")) {
+            return Err(self.removed_update_marker_error("DOCUMENTS"));
         }
         if self.consume_ident_ci("NODES")? {
             return Ok(UpdateTarget::Nodes);
@@ -569,6 +575,21 @@ impl<'a> Parser<'a> {
             return Ok(UpdateTarget::Edges);
         }
         Ok(UpdateTarget::Rows)
+    }
+
+    /// Build the didactic error for a removed UPDATE model marker (ADR 0067,
+    /// #1711). The catalog knows the collection's model, so the marker is
+    /// redundant; the message names the unmarked form and the graph exception.
+    fn removed_update_marker_error(&self, marker: &str) -> ParseError {
+        ParseError::new(
+            format!(
+                "the `{marker}` UPDATE model marker has been removed; the catalog \
+                 already knows the collection's model — write `UPDATE <collection> \
+                 SET …` with no marker. (Graph updates still name `NODES` or `EDGES`, \
+                 since a graph collection holds both record kinds.)"
+            ),
+            self.position(),
+        )
     }
 
     /// Parse: DELETE FROM table [WHERE filter]
@@ -1346,13 +1367,11 @@ mod tests {
 
     #[test]
     fn update_targets_compound_assignments_order_limit_returning() {
+        // Only NODES/EDGES survive as parse-time markers (ADR 0067, #1711);
+        // an unmarked UPDATE parses to the default Rows target and the runtime
+        // resolves document/KV semantics from the catalog.
         let cases = [
-            ("UPDATE docs KV SET count = 1", UpdateTarget::Kv),
-            ("UPDATE docs ROWS SET count = 1", UpdateTarget::Rows),
-            (
-                "UPDATE docs DOCUMENTS SET count = 1",
-                UpdateTarget::Documents,
-            ),
+            ("UPDATE docs SET count = 1", UpdateTarget::Rows),
             ("UPDATE docs NODES SET count = 1", UpdateTarget::Nodes),
             ("UPDATE docs EDGES SET count = 1", UpdateTarget::Edges),
         ];
@@ -1360,13 +1379,26 @@ mod tests {
             assert_eq!(update(input).target, expected, "{input}");
         }
 
+        // The removed markers are rejected with a didactic error.
+        for marker in ["DOCUMENTS", "ROWS", "KV"] {
+            let input = format!("UPDATE docs {marker} SET count = 1");
+            let mut parser = make_parser(&input);
+            let err = parser
+                .parse_update_query()
+                .expect_err("removed update marker should fail");
+            let msg = err.to_string();
+            assert!(msg.contains(marker), "{msg}");
+            assert!(msg.contains("has been removed"), "{msg}");
+            assert!(msg.contains("with no marker"), "{msg}");
+        }
+
         let query = update(
-            "UPDATE docs DOCUMENTS SET count += 2, title = UPPER(title) \
+            "UPDATE docs SET count += 2, title = UPPER(title) \
              WHERE id = 1 WITH TTL 30 s WITH METADATA (source = 'update') \
              ORDER BY updated_at DESC LIMIT 5 RETURNING weight, title SUPPRESS EVENTS",
         );
         assert_eq!(query.table, "docs");
-        assert_eq!(query.target, UpdateTarget::Documents);
+        assert_eq!(query.target, UpdateTarget::Rows);
         assert_eq!(query.assignment_exprs.len(), 2);
         assert_eq!(query.compound_assignment_ops, vec![Some(BinOp::Add), None]);
         assert_eq!(query.assignments.len(), 0);
@@ -1393,6 +1425,21 @@ mod tests {
             )
         );
         assert!(query.suppress_events);
+    }
+
+    #[test]
+    fn update_dotted_targets_parse_unmarked_for_every_target() {
+        // Dotted assignment targets parse for the unmarked (Rows) target and
+        // for graph targets alike (ADR 0067, #1711); legality is an analyzer
+        // concern, not a parser one.
+        let unmarked = update("UPDATE docs SET profile.address.city = 'Lisbon' WHERE name = 'ada'");
+        assert_eq!(unmarked.target, UpdateTarget::Rows);
+        assert_eq!(unmarked.assignment_exprs[0].0, "profile.address.city");
+        assert_eq!(unmarked.assignments[0].0, "profile.address.city");
+
+        let graph = update("UPDATE social NODES SET meta.seen_at = 1");
+        assert_eq!(graph.target, UpdateTarget::Nodes);
+        assert_eq!(graph.assignment_exprs[0].0, "meta.seen_at");
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2118,20 +2118,10 @@ fn test_parse_update_with_where() {
 }
 
 #[test]
-fn test_parse_update_explicit_item_targets() {
+fn test_parse_update_graph_markers_stay_others_removed() {
+    // NODES/EDGES survive as parse-time markers; the document/row/KV markers
+    // were removed (ADR 0067, #1711) and reject with a didactic error.
     for (sql, expected) in [
-        (
-            "UPDATE hosts ROWS SET status = 'active'",
-            crate::ast::UpdateTarget::Rows,
-        ),
-        (
-            "UPDATE docs DOCUMENTS SET status = 'published'",
-            crate::ast::UpdateTarget::Documents,
-        ),
-        (
-            "UPDATE settings KV SET value = 'on'",
-            crate::ast::UpdateTarget::Kv,
-        ),
         (
             "UPDATE social NODES SET status = 'seen'",
             crate::ast::UpdateTarget::Nodes,
@@ -2140,6 +2130,10 @@ fn test_parse_update_explicit_item_targets() {
             "UPDATE social EDGES SET status = 'linked'",
             crate::ast::UpdateTarget::Edges,
         ),
+        (
+            "UPDATE hosts SET status = 'active'",
+            crate::ast::UpdateTarget::Rows,
+        ),
     ] {
         let query = parse(sql).unwrap();
         let QueryExpr::Update(update) = query else {
@@ -2147,17 +2141,27 @@ fn test_parse_update_explicit_item_targets() {
         };
         assert_eq!(update.target, expected, "{sql}");
     }
+
+    for marker in ["DOCUMENTS", "ROWS", "KV"] {
+        let sql = format!("UPDATE docs {marker} SET status = 'published'");
+        let err = parse(&sql).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(marker), "{msg}");
+        assert!(msg.contains("has been removed"), "{msg}");
+    }
 }
 
 #[test]
-fn test_parse_update_documents_path_target_round_trips() {
-    let sql = "UPDATE docs DOCUMENTS SET profile.address.city = 'Lisbon' WHERE name = 'ada'";
+fn test_parse_update_dotted_path_target_round_trips_unmarked() {
+    // Dotted SET targets parse for the unmarked form and render back unmarked
+    // (ADR 0067, #1711); the analyzer, not the parser, gates them by model.
+    let sql = "UPDATE docs SET profile.address.city = 'Lisbon' WHERE name = 'ada'";
     let query = parse(sql).unwrap();
     let QueryExpr::Update(update) = &query else {
         panic!("Expected UpdateQuery");
     };
 
-    assert_eq!(update.target, crate::ast::UpdateTarget::Documents);
+    assert_eq!(update.target, crate::ast::UpdateTarget::Rows);
     assert_eq!(update.assignment_exprs[0].0, "profile.address.city");
     assert_eq!(update.assignments[0].0, "profile.address.city");
     assert_eq!(crate::renderer::render(&query), sql);

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -110,9 +110,11 @@ fn render_update(uq: &UpdateQuery) -> String {
 
 fn render_update_target(target: UpdateTarget) -> Option<&'static str> {
     match target {
-        UpdateTarget::Rows => None,
-        UpdateTarget::Documents => Some("DOCUMENTS"),
-        UpdateTarget::Kv => Some("KV"),
+        // Row/document/KV updates render unmarked (ADR 0067, #1711): the model
+        // markers were removed and the catalog resolves the model. `Documents`
+        // / `Kv` only arise from runtime catalog inference, never from parsed
+        // SQL, so rendering them back to text must stay unmarked to round-trip.
+        UpdateTarget::Rows | UpdateTarget::Documents | UpdateTarget::Kv => None,
         UpdateTarget::Nodes => Some("NODES"),
         UpdateTarget::Edges => Some("EDGES"),
     }

--- a/crates/reddb-rql/tests/reddb_corpus/update_marker_removal.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/update_marker_removal.slt
@@ -1,0 +1,86 @@
+# ADR 0067 (#1711) — the UPDATE model markers (DOCUMENTS/ROWS/KV) are removed.
+#
+# TRUTH is hand-authored (a RedDB-only surface with no external oracle): the
+# marker rule made real — a model marker exists only where it disambiguates
+# what the catalog cannot know.
+#
+#   * an unmarked UPDATE on a document collection gets document semantics: the
+#     model is resolved from the catalog, exactly the routing the old
+#     `DOCUMENTS` marker forced;
+#   * the removed markers (`DOCUMENTS` / `ROWS` / `KV`) reject with a didactic
+#     error naming the unmarked form;
+#   * `NODES` / `EDGES` stay — a graph collection holds both record kinds, so
+#     only the user can name which one an UPDATE targets;
+#   * dotted `SET a.b.c = …` targets parse for every collection but are legal
+#     only on a document collection; off-model they reject with a clear error.
+#
+# Result rows are projected to the harness's semantic allowlist (`name`), so a
+# golden asserts the mutated field without freezing engine bookkeeping.
+
+# --- Unmarked UPDATE on a document collection gets document semantics ------
+
+statement ok
+CREATE DOCUMENT people
+
+statement ok
+INSERT INTO people DOCUMENT VALUES ({"name": "ada"})
+
+# No DOCUMENTS marker: the analyzer resolves the model from the catalog and
+# routes to document semantics.
+statement ok
+UPDATE people SET name = 'ada-lovelace' WHERE name = 'ada'
+
+query T rowsort
+SELECT name FROM people
+----
+ada-lovelace
+
+# --- The removed markers reject with a didactic error ---------------------
+
+statement error has been removed
+UPDATE people DOCUMENTS SET name = 'nope'
+
+statement error has been removed
+UPDATE people ROWS SET name = 'nope'
+
+statement error has been removed
+UPDATE people KV SET name = 'nope'
+
+# The mutation above never applied — the row is untouched.
+query T rowsort
+SELECT name FROM people
+----
+ada-lovelace
+
+# --- Dotted SET targets parse for every collection, gated by the model ----
+
+# On a document collection a dotted path is accepted (executor deep-merge is a
+# later slice; today's runtime behaviour is preserved).
+statement ok
+UPDATE people SET profile.address.city = 'Lisbon' WHERE name = 'ada-lovelace'
+
+# On a non-document collection the same dotted target is rejected off-model.
+statement ok
+CREATE TABLE accounts (id INTEGER)
+
+statement error only valid on document collections
+UPDATE accounts SET meta.tier = 'gold' WHERE id = 1
+
+# --- NODES / EDGES stay green ---------------------------------------------
+
+statement ok
+INSERT INTO social NODE (label, name) VALUES ('alice', 'Alice')
+
+statement ok
+INSERT INTO social NODE (label, name) VALUES ('bob', 'Bob')
+
+statement ok
+INSERT INTO social EDGE (label, from, to) VALUES ('KNOWS', 'alice', 'bob')
+
+# A NODES update on a mutable property is accepted; the graph markers survive.
+statement ok
+UPDATE social NODES SET name = 'Alicia' WHERE label = 'alice'
+
+# An EDGES update on a mutable property is accepted.
+statement ok
+UPDATE social EDGES SET name = 'befriends' WHERE label = 'KNOWS'

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -134,6 +134,47 @@ impl RedDBRuntime {
         }
     }
 
+    /// Resolve the model of an unmarked UPDATE from the catalog (ADR 0067,
+    /// #1711). The `DOCUMENTS` / `ROWS` / `KV` UPDATE markers were removed, so
+    /// an unmarked UPDATE parses to the `Rows` target; the catalog is the
+    /// single source of truth for the collection's model. An existing document
+    /// collection is rewritten to the `Documents` target (the runtime routes
+    /// body / patch semantics off the target the explicit marker used to set);
+    /// a KV collection to `Kv` so the key-immutability guard still fires. Table
+    /// and unknown collections keep the `Rows` default.
+    ///
+    /// Dotted assignment targets (`SET a.b.c = …`) parse for every target — the
+    /// model is not a parse-time fact — but they are legal only on a document
+    /// collection and rejected here with a clear model-oriented error off it.
+    fn resolve_unmarked_update_target(
+        &self,
+        query: &UpdateQuery,
+    ) -> RedDBResult<Option<UpdateQuery>> {
+        // NODES / EDGES are explicit, user-declared graph targets — never
+        // inferred. Dotted paths off a graph target are still off-model.
+        if matches!(query.target, UpdateTarget::Nodes | UpdateTarget::Edges) {
+            ensure_update_dotted_targets_allowed(query, false)?;
+            return Ok(None);
+        }
+        let declared_model = self
+            .db()
+            .collection_contract_arc(&query.table)
+            .map(|contract| contract.declared_model);
+        let is_document = matches!(
+            declared_model,
+            Some(crate::catalog::CollectionModel::Document)
+        );
+        ensure_update_dotted_targets_allowed(query, is_document)?;
+        let inferred = match declared_model {
+            Some(crate::catalog::CollectionModel::Document) => UpdateTarget::Documents,
+            Some(crate::catalog::CollectionModel::Kv) => UpdateTarget::Kv,
+            _ => return Ok(None),
+        };
+        let mut rewritten = query.clone();
+        rewritten.target = inferred;
+        Ok(Some(rewritten))
+    }
+
     /// Execute INSERT INTO table [entity_type] (cols) VALUES (vals), ...
     ///
     /// Each row in `query.values` is zipped with `query.columns` to produce a
@@ -1238,6 +1279,21 @@ impl RedDBRuntime {
         if query.claim_limit.is_some() && self.is_queue_collection(&query.table) {
             return self.execute_queue_shaped_claim(raw_query, query);
         }
+        // ADR 0067 (#1711): the DOCUMENTS / ROWS / KV UPDATE markers were
+        // removed. Resolve the model of an unmarked UPDATE from the catalog so
+        // a document collection routes to document semantics and a KV
+        // collection keeps its key-immutability guard, and gate dotted SET
+        // targets that only a document body can satisfy. Runs before the
+        // contract / RLS gates so every downstream path — the inner scan,
+        // RETURNING — observes the resolved target.
+        let inferred_owned;
+        let query = match self.resolve_unmarked_update_target(query)? {
+            Some(rewritten) => {
+                inferred_owned = rewritten;
+                &inferred_owned
+            }
+            None => query,
+        };
         // CollectionContract gate (#50): runs the APPEND ONLY guard
         // (and any future contract bits) before RLS / RETURNING work
         // so the operator's immutability declaration is honoured

--- a/crates/reddb-server/src/runtime/impl_dml_update_target.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_update_target.rs
@@ -27,6 +27,35 @@ pub(super) fn ensure_graph_identity_update_target_allowed(query: &UpdateQuery) -
     Ok(())
 }
 
+/// Reject dotted SET targets on a non-document UPDATE (ADR 0067, #1711).
+///
+/// Dotted assignment targets (`SET a.b.c = …`) parse for every UPDATE now that
+/// the model markers are gone — the model is not a parse-time fact. A nested
+/// path deep-merges into a document body; on any other model there is no nested
+/// body to address, so the parser's permissive acceptance is gated here against
+/// the catalog model with a clear, model-oriented error.
+pub(super) fn ensure_update_dotted_targets_allowed(
+    query: &UpdateQuery,
+    is_document: bool,
+) -> RedDBResult<()> {
+    if is_document {
+        return Ok(());
+    }
+    if let Some((column, _)) = query
+        .assignment_exprs
+        .iter()
+        .find(|(column, _)| column.contains('.'))
+    {
+        return Err(RedDBError::InvalidOperation(format!(
+            "dotted assignment target '{column}' addresses a nested document field, \
+             but collection '{table}' is not a document collection; nested \
+             `SET a.b.c = …` paths are only valid on document collections",
+            table = query.table,
+        )));
+    }
+    Ok(())
+}
+
 pub(super) fn ensure_kv_key_update_target_allowed(query: &UpdateQuery) -> RedDBResult<()> {
     if !matches!(query.target, UpdateTarget::Kv) {
         return Ok(());

--- a/crates/reddb-server/tests/document_btree_index_e2e.rs
+++ b/crates/reddb-server/tests/document_btree_index_e2e.rs
@@ -156,7 +156,7 @@ fn ordered_index_refreshes_on_insert_update_delete() {
 
     // UPDATE: bumping bob 10 -> 99 re-positions it to the top and makes it
     // appear in a range that previously excluded it.
-    rt.execute_query("UPDATE docs DOCUMENTS SET score = 99 WHERE name = 'bob'")
+    rt.execute_query("UPDATE docs SET score = 99 WHERE name = 'bob'")
         .expect("document update refreshes the ordered index");
     let after_update = rt
         .execute_query("SELECT name FROM docs WHERE score > 40 ORDER BY score ASC")

--- a/docs/data-models/documents.md
+++ b/docs/data-models/documents.md
@@ -242,18 +242,20 @@ return a structured envelope with `code`, `op_index`, and a JSON Pointer
 
 ### SQL UPDATE on documents
 
-Document updates use the explicit `DOCUMENTS` target. Compound assignment,
-`RETURNING`, `LIMIT`, and `ORDER BY ... LIMIT` work the same as for rows:
+Document updates are written **unmarked** — RedDB resolves the document model
+from the catalog (the `DOCUMENTS` marker was removed, ADR 0067). Compound
+assignment, `RETURNING`, `LIMIT`, and `ORDER BY ... LIMIT` work the same as for
+rows, and dotted `SET a.b.c = …` paths address nested body fields:
 
 ```sql
-UPDATE events DOCUMENTS
+UPDATE events
 SET retries += 1
 WHERE event_type = 'login' AND retries < 5
 RETURNING rid, retries
 ```
 
 ```sql
-UPDATE events DOCUMENTS
+UPDATE events
 SET attempts += 1, last_seen = NOW()
 WHERE status = 'pending'
 ORDER BY created_at ASC

--- a/docs/data-models/key-value.md
+++ b/docs/data-models/key-value.md
@@ -150,18 +150,19 @@ names are reserved and cannot be used as top-level KV payload fields.
 
 ## Updating KV with SQL
 
-KV updates use the explicit `KV` target. Compound assignment is supported on
-numeric values:
+KV updates are written **unmarked** — RedDB resolves the KV model from the
+catalog (the `KV` marker was removed, ADR 0067). Compound assignment is
+supported on numeric values:
 
 ```sql
-UPDATE config KV
+UPDATE config
 SET value += 1
 WHERE key = 'rollout.percent'
 RETURNING rid, key, value
 ```
 
 ```sql
-UPDATE config KV
+UPDATE config
 SET value = false
 WHERE key = 'feature.dark_mode'
 RETURNING key, value

--- a/docs/data-models/tables.md
+++ b/docs/data-models/tables.md
@@ -121,14 +121,14 @@ curl -X PATCH http://127.0.0.1:5000/collections/users/entities/102 \
 Or via SQL:
 
 ```sql
-UPDATE users ROWS
+UPDATE users
 SET age = 31
 WHERE name = 'Alice'
 RETURNING rid, age
 ```
 
 ```sql
-UPDATE users ROWS
+UPDATE users
 SET active = false, age += 1
 WHERE rid = 102
 RETURNING rid, active, age
@@ -137,7 +137,7 @@ RETURNING rid, active, age
 Ordered batch update with deterministic tie-breaker:
 
 ```sql
-UPDATE users ROWS
+UPDATE users
 SET touched = true
 WHERE active = true
 ORDER BY priority DESC

--- a/docs/query/update.md
+++ b/docs/query/update.md
@@ -1,8 +1,10 @@
 # UPDATE
 
-The `UPDATE` statement modifies RedDB items in a collection. The default target
-is table rows; use an explicit target for documents, KV pairs, graph nodes, or
-graph edges.
+The `UPDATE` statement modifies RedDB items in a collection. The collection's
+model is resolved from the catalog, so table, document, and KV updates are all
+written **unmarked** — RedDB knows whether a collection holds rows, documents,
+or KV pairs. Only graph updates carry a marker: a graph collection holds both
+nodes and edges, so `NODES` / `EDGES` says which record kind an update targets.
 
 Prefer positional parameters for values in `SET` and `WHERE`:
 
@@ -18,7 +20,7 @@ The parameterized-query design is tracked in
 ## Syntax
 
 ```sql
-UPDATE collection_name [ROWS|DOCUMENTS|KV|NODES|EDGES]
+UPDATE collection_name [NODES|EDGES]
 SET field1 = value1 [, field2 += value2, ...]
 [WHERE condition]
 [ORDER BY field [ASC|DESC] LIMIT n]
@@ -27,13 +29,15 @@ SET field1 = value1 [, field2 += value2, ...]
 
 Target meanings:
 
-| Target | Item kind | Notes |
+| Marker | Item kind | Notes |
 |:-------|:----------|:------|
-| omitted / `ROWS` | `row` | Default table-row update path |
-| `DOCUMENTS` | `document` | Updates top-level document body fields |
-| `KV` | `kv` | Updates `key`, `value`, and mutable KV fields |
+| _(none)_ | `row` / `document` / `kv` | Model resolved from the catalog. On a document collection, dotted `SET a.b.c = …` paths address nested body fields |
 | `NODES` | `node` | Updates mutable graph node properties |
 | `EDGES` | `edge` | Updates mutable graph edge properties; `from_rid` and `to_rid` are immutable |
+
+> The `DOCUMENTS` / `ROWS` / `KV` markers were removed (ADR 0067): the catalog
+> already knows the collection's model, so they were redundant. Writing one is
+> rejected with a didactic error pointing at the unmarked form.
 
 ## Examples
 
@@ -44,7 +48,7 @@ UPDATE users SET age = $1 WHERE name = $2
 ```
 
 ```sql
-UPDATE users ROWS
+UPDATE users
 SET active = true
 WHERE rid = $1
 RETURNING rid, name, active
@@ -52,15 +56,18 @@ RETURNING rid, name, active
 
 ### Update Documents, KV, and Graph Items
 
+Document and KV updates are unmarked — the catalog resolves the model. On a
+document collection a dotted `SET a.b.c = …` path addresses a nested body field.
+
 ```sql
-UPDATE events DOCUMENTS
+UPDATE events
 SET reviewed = true, attempts += 1
 WHERE event_type = 'login'
 RETURNING rid, kind, reviewed, attempts
 ```
 
 ```sql
-UPDATE config KV
+UPDATE config
 SET value += 1
 WHERE key = 'feature.rollout_percent'
 RETURNING rid, key, value
@@ -90,7 +97,7 @@ All right-hand sides in the same statement read the item state before the
 update starts.
 
 ```sql
-UPDATE accounts ROWS
+UPDATE accounts
 SET balance += 25, retries %= 3
 WHERE rid = $1
 RETURNING rid, balance, retries
@@ -104,7 +111,7 @@ Math functions can appear anywhere ordinary SQL expressions are accepted,
 including `SET` and `RETURNING` projections:
 
 ```sql
-UPDATE metrics ROWS
+UPDATE metrics
 SET root_score = SQRT(score), score = POWER(score, 2)
 WHERE score >= 0
 RETURNING rid, root_score, score
@@ -122,7 +129,7 @@ and `PI`.
 when `rid` is not already part of the ordering.
 
 ```sql
-UPDATE jobs ROWS
+UPDATE jobs
 SET claimed = true
 WHERE claimed = false
 ORDER BY priority DESC
@@ -130,9 +137,9 @@ LIMIT 25
 RETURNING rid, priority, claimed
 ```
 
-For `DOCUMENTS`, `KV`, `NODES`, and `EDGES`, ordered batches accept top-level
-fields only. Nested paths and computed `ORDER BY` expressions are rejected for
-multi-model updates.
+For document, KV, and graph (`NODES` / `EDGES`) updates, ordered batches accept
+top-level fields only. Nested paths and computed `ORDER BY` expressions are
+rejected for multi-model updates.
 
 ### Atomic Failure Behavior
 
@@ -159,7 +166,7 @@ curl -X PATCH http://127.0.0.1:5000/collections/users/entities/102 \
 ```bash
 curl -X POST http://127.0.0.1:5000/query \
   -H 'content-type: application/json' \
-  -d '{"query": "UPDATE users ROWS SET age = $1 WHERE rid = $2 RETURNING rid, age", "params": [31, 102]}'
+  -d '{"query": "UPDATE users SET age = $1 WHERE rid = $2 RETURNING rid, age", "params": [31, 102]}'
 ```
 
 ## Via gRPC

--- a/drivers/cpp/src/helpers.cpp
+++ b/drivers/cpp/src/helpers.cpp
@@ -562,7 +562,7 @@ JsonObject DocumentClient::patch(const std::string& collection, const std::strin
         parts << sql::identifier(k) << " = " << sql::value_literal(v);
     }
     std::ostringstream os;
-    os << "UPDATE " << sql::identifier_path(collection) << " DOCUMENTS SET "
+    os << "UPDATE " << sql::identifier_path(collection) << " SET "
        << parts.str() << " WHERE rid = $1 RETURNING *";
     std::string body = q_->query(os.str(), {rid});
     auto [row, _] = sql::first_row(body);

--- a/drivers/dart/lib/src/helpers.dart
+++ b/drivers/dart/lib/src/helpers.dart
@@ -163,7 +163,7 @@ class DocumentClient {
       parts.add('${_sqlIdentifier(field)} = ${_valueLiteral(value)}');
     });
     final body = await _q.query(
-      'UPDATE ${_sqlIdentifierPath(collection)} DOCUMENTS SET '
+      'UPDATE ${_sqlIdentifierPath(collection)} SET '
       '${parts.join(', ')} WHERE rid = \$1 RETURNING *',
       params: [rid],
     );

--- a/drivers/dotnet/src/Reddb/Helpers/Helpers.cs
+++ b/drivers/dotnet/src/Reddb/Helpers/Helpers.cs
@@ -169,7 +169,7 @@ public sealed class DocumentClient
                     "documents.patch currently accepts top-level document fields");
             parts.Add($"{Sql.Identifier(kv.Key)} = {Sql.ValueLiteral(kv.Value)}");
         }
-        string sql = $"UPDATE {Sql.IdentifierPath(collection)} DOCUMENTS SET {string.Join(", ", parts)} WHERE rid = $1 RETURNING *";
+        string sql = $"UPDATE {Sql.IdentifierPath(collection)} SET {string.Join(", ", parts)} WHERE rid = $1 RETURNING *";
         var body = await _q.QueryAsync(sql, new object?[] { rid }, ct).ConfigureAwait(false);
         var (row, _) = Sql.FirstRow(body.Span);
         if (row is null) throw new HelperException.NotFound($"document \"{rid}\" was not found");

--- a/drivers/go/helpers.go
+++ b/drivers/go/helpers.go
@@ -183,7 +183,7 @@ func (d *DocumentClient) Patch(ctx context.Context, collection, rid string, patc
 		}
 		parts = append(parts, fmt.Sprintf("%s = %s", sqlIdentifier(field), lit))
 	}
-	sql := fmt.Sprintf("UPDATE %s DOCUMENTS SET %s WHERE rid = $1 RETURNING *",
+	sql := fmt.Sprintf("UPDATE %s SET %s WHERE rid = $1 RETURNING *",
 		sqlIdentifierPath(collection), strings.Join(parts, ", "))
 	body, err := d.q.Query(ctx, sql, rid)
 	if err != nil {

--- a/drivers/java/src/main/java/dev/reddb/helpers/DocumentClient.java
+++ b/drivers/java/src/main/java/dev/reddb/helpers/DocumentClient.java
@@ -83,7 +83,7 @@ public final class DocumentClient {
             parts.add(Sql.sqlIdentifier(field) + " = " + Sql.valueLiteral(e.getValue()));
         }
         String sql = "UPDATE " + Sql.sqlIdentifierPath(collection)
-            + " DOCUMENTS SET " + String.join(", ", parts) + " WHERE rid = $1 RETURNING *";
+            + " SET " + String.join(", ", parts) + " WHERE rid = $1 RETURNING *";
         byte[] body = q.query(sql, rid);
         Object[] fr = Sql.firstRow(body);
         @SuppressWarnings("unchecked")

--- a/drivers/js-client/src/documents.js
+++ b/drivers/js-client/src/documents.js
@@ -57,7 +57,7 @@ export class DocumentClient {
       .map(([field, value]) => `${sqlIdentifier(field)} = ${sqlValueLiteral(value)}`)
       .join(', ')
     const result = await this.db.query(
-      `UPDATE ${sqlIdentifierPath(collection)} DOCUMENTS SET ${assignments} WHERE rid = $1 RETURNING *`,
+      `UPDATE ${sqlIdentifierPath(collection)} SET ${assignments} WHERE rid = $1 RETURNING *`,
       rid,
     )
     const item = result.rows?.[0]

--- a/drivers/js/src/documents.js
+++ b/drivers/js/src/documents.js
@@ -57,7 +57,7 @@ export class DocumentClient {
       .map(([field, value]) => `${sqlIdentifier(field)} = ${sqlValueLiteral(value)}`)
       .join(', ')
     const result = await this.db.query(
-      `UPDATE ${sqlIdentifierPath(collection)} DOCUMENTS SET ${assignments} WHERE rid = $1 RETURNING *`,
+      `UPDATE ${sqlIdentifierPath(collection)} SET ${assignments} WHERE rid = $1 RETURNING *`,
       rid,
     )
     const item = result.rows?.[0]

--- a/drivers/kotlin/src/main/kotlin/dev/reddb/helpers/Helpers.kt
+++ b/drivers/kotlin/src/main/kotlin/dev/reddb/helpers/Helpers.kt
@@ -109,7 +109,7 @@ public class DocumentClient internal constructor(private val q: Querier) {
             }
             "${Sql.identifier(k)} = ${Sql.valueLiteral(v)}"
         }
-        val sql = "UPDATE ${Sql.identifierPath(collection)} DOCUMENTS SET " +
+        val sql = "UPDATE ${Sql.identifierPath(collection)} SET " +
             parts.joinToString(", ") + " WHERE rid = \$1 RETURNING *"
         val body = q.query(sql, rid)
         val (row, _) = Sql.firstRow(body)

--- a/drivers/php/src/Helpers/Documents.php
+++ b/drivers/php/src/Helpers/Documents.php
@@ -81,7 +81,7 @@ final class Documents
             $parts[] = sprintf('%s = %s', Sql::identifier($field), Sql::valueLiteral($value));
         }
         $sql = sprintf(
-            'UPDATE %s DOCUMENTS SET %s WHERE rid = $1 RETURNING *',
+            'UPDATE %s SET %s WHERE rid = $1 RETURNING *',
             Sql::identifierPath($collection), implode(', ', $parts)
         );
         $body = $this->q->query($sql, [$rid]);

--- a/drivers/python-asyncio/src/reddb_asyncio/documents.py
+++ b/drivers/python-asyncio/src/reddb_asyncio/documents.py
@@ -86,7 +86,7 @@ class DocumentClient:
             for field, value in patch.items()
         )
         sql = (
-            f"UPDATE {sql_identifier_path(collection)} DOCUMENTS SET {assignments} "
+            f"UPDATE {sql_identifier_path(collection)} SET {assignments} "
             f"WHERE rid = $1 RETURNING *"
         )
         result = await self._db.query(sql, [rid])

--- a/drivers/python/src/high_level.rs
+++ b/drivers/python/src/high_level.rs
@@ -657,7 +657,7 @@ impl DocumentClient {
             ));
         }
         let sql = format!(
-            "UPDATE {collection} DOCUMENTS SET {} WHERE rid = {rid_sql} RETURNING *",
+            "UPDATE {collection} SET {} WHERE rid = {rid_sql} RETURNING *",
             assignments.join(", ")
         );
         let qr = rt.query(&sql).map_err(|e| err("QUERY_ERROR", e))?;

--- a/drivers/zig/src/helpers.zig
+++ b/drivers/zig/src/helpers.zig
@@ -189,7 +189,7 @@ pub const DocumentClient = struct {
         const id_path = try identifierPath(self.allocator, collection);
         defer self.allocator.free(id_path);
         const sql = try std.fmt.allocPrint(self.allocator,
-            "UPDATE {s} DOCUMENTS SET {s} WHERE rid = $1 RETURNING *",
+            "UPDATE {s} SET {s} WHERE rid = $1 RETURNING *",
             .{ id_path, parts.items });
         defer self.allocator.free(sql);
         const params = [_][]const u8{rid};

--- a/tests/e2e_update_conformance_pack.rs
+++ b/tests/e2e_update_conformance_pack.rs
@@ -157,23 +157,15 @@ fn explicit_targets_are_authorized_as_ordinary_updates() {
 
     as_user("alice", Role::Write, || {
         assert_eq!(
-            exec(&rt, "UPDATE auth_rows ROWS SET score += 1 WHERE id = 1").affected_rows,
+            exec(&rt, "UPDATE auth_rows SET score += 1 WHERE id = 1").affected_rows,
             1
         );
         assert_eq!(
-            exec(
-                &rt,
-                "UPDATE auth_docs DOCUMENTS SET score += 1 WHERE name = 'doc'"
-            )
-            .affected_rows,
+            exec(&rt, "UPDATE auth_docs SET score += 1 WHERE name = 'doc'").affected_rows,
             1
         );
         assert_eq!(
-            exec(
-                &rt,
-                "UPDATE auth_kv KV SET value += 1 WHERE key = 'counter'"
-            )
-            .affected_rows,
+            exec(&rt, "UPDATE auth_kv SET value += 1 WHERE key = 'counter'").affected_rows,
             1
         );
         assert_eq!(
@@ -195,7 +187,7 @@ fn explicit_targets_are_authorized_as_ordinary_updates() {
     });
 
     let denied = as_user("alice", Role::Write, || {
-        err_string(&rt, "UPDATE auth_denied ROWS SET score = 1 WHERE id = 1")
+        err_string(&rt, "UPDATE auth_denied SET score = 1 WHERE id = 1")
     });
     assert!(denied.contains("table:auth_denied"), "{denied}");
 }
@@ -225,7 +217,7 @@ fn update_returning_obeys_rls_and_column_policy() {
         set_current_tenant("acme".to_string());
         let result = exec(
             &rt,
-            "UPDATE tenant_accounts ROWS SET score += 1 RETURNING id, tenant_id, score",
+            "UPDATE tenant_accounts SET score += 1 RETURNING id, tenant_id, score",
         );
         clear_current_tenant();
         result
@@ -259,7 +251,7 @@ fn update_returning_obeys_rls_and_column_policy() {
     let denied = as_user("alice", Role::Write, || {
         err_string(
             &rt,
-            "UPDATE masked_accounts ROWS SET status = 'active' WHERE id = 1 RETURNING secret",
+            "UPDATE masked_accounts SET status = 'active' WHERE id = 1 RETURNING secret",
         )
     });
     assert!(denied.contains("column:masked_accounts.secret"), "{denied}");
@@ -446,7 +438,7 @@ fn explicit_document_update_emits_event_and_cdc_identity() {
 
     exec(
         &rt,
-        "UPDATE conformance_docs DOCUMENTS SET score += 5 WHERE name = 'doc'",
+        "UPDATE conformance_docs SET score += 5 WHERE name = 'doc'",
     );
 
     let payload = read_event_payload(&rt, "conformance_doc_events");
@@ -488,7 +480,7 @@ fn document_update_keeps_body_json_in_sync_with_promoted_column() {
 
     exec(
         &rt,
-        "UPDATE body_sync_docs DOCUMENTS SET score = 42 WHERE name = 'doc'",
+        "UPDATE body_sync_docs SET score = 42 WHERE name = 'doc'",
     );
 
     // The promoted top-level column reflects the new value.
@@ -524,7 +516,7 @@ fn document_path_update_keeps_nested_sibling_fields() {
 
     let updated = exec(
         &rt,
-        "UPDATE body_path_docs DOCUMENTS SET profile.address.city = 'Lisbon' WHERE name = 'doc'",
+        "UPDATE body_path_docs SET profile.address.city = 'Lisbon' WHERE name = 'doc'",
     );
     assert_eq!(updated.affected_rows, 1);
 
@@ -547,7 +539,7 @@ fn document_compound_update_keeps_body_json_in_sync() {
 
     exec(
         &rt,
-        "UPDATE body_compound_docs DOCUMENTS SET score += 5 WHERE name = 'doc'",
+        "UPDATE body_compound_docs SET score += 5 WHERE name = 'doc'",
     );
 
     let promoted = exec(
@@ -578,7 +570,7 @@ fn explicit_updates_recheck_changed_indexed_fields() {
         &rt,
         "CREATE INDEX idx_indexed_rows_score ON indexed_rows (score) USING HASH",
     );
-    exec(&rt, "UPDATE indexed_rows ROWS SET score = 15 WHERE id = 1");
+    exec(&rt, "UPDATE indexed_rows SET score = 15 WHERE id = 1");
     let row = exec(&rt, "SELECT id, score FROM indexed_rows WHERE score = 15");
     assert_eq!(int_field(only_record(&row), "id"), 1);
 
@@ -591,10 +583,7 @@ fn explicit_updates_recheck_changed_indexed_fields() {
         &rt,
         "CREATE INDEX idx_indexed_docs_score ON indexed_docs (score) USING HASH",
     );
-    exec(
-        &rt,
-        "UPDATE indexed_docs DOCUMENTS SET score = 15 WHERE name = 'doc'",
-    );
+    exec(&rt, "UPDATE indexed_docs SET score = 15 WHERE name = 'doc'");
     let doc = exec(&rt, "SELECT name, score FROM indexed_docs WHERE score = 15");
     assert_eq!(text_field(only_record(&doc), "name"), "doc");
 }
@@ -622,11 +611,11 @@ fn explicit_multimodel_compound_updates_survive_reopen_as_post_images() {
 
         exec(
             &rt,
-            "UPDATE recovery_docs DOCUMENTS SET score += 5 WHERE name = 'doc'",
+            "UPDATE recovery_docs SET score += 5 WHERE name = 'doc'",
         );
         exec(
             &rt,
-            "UPDATE recovery_kv KV SET value += 7 WHERE key = 'counter'",
+            "UPDATE recovery_kv SET value += 7 WHERE key = 'counter'",
         );
         exec(
             &rt,

--- a/tests/grouped/dml_updates/e2e_explicit_update_targets.rs
+++ b/tests/grouped/dml_updates/e2e_explicit_update_targets.rs
@@ -52,14 +52,15 @@ fn err_string(rt: &RedDBRuntime, sql: &str) -> String {
 }
 
 #[test]
-fn explicit_rows_documents_and_kv_targets_update_compatible_collections() {
+fn unmarked_updates_resolve_row_document_and_kv_models_from_catalog() {
+    // ADR 0067 (#1711): the DOCUMENTS/ROWS/KV markers are gone. An unmarked
+    // UPDATE resolves the collection's model from the catalog — a table gets
+    // row semantics, a document collection gets document semantics, a KV
+    // collection gets KV semantics — without any marker.
     let rt = runtime();
     exec(&rt, "CREATE TABLE accounts (id INT, status TEXT)");
     exec(&rt, "INSERT INTO accounts (id, status) VALUES (1, 'new')");
-    let rows = exec(
-        &rt,
-        "UPDATE accounts ROWS SET status = 'active' WHERE id = 1",
-    );
+    let rows = exec(&rt, "UPDATE accounts SET status = 'active' WHERE id = 1");
     assert_eq!(rows.affected_rows, 1);
     let selected_row = exec(&rt, "SELECT status FROM accounts WHERE id = 1");
     assert_eq!(text_field(only_record(&selected_row), "status"), "active");
@@ -71,7 +72,7 @@ fn explicit_rows_documents_and_kv_targets_update_compatible_collections() {
     );
     let docs = exec(
         &rt,
-        "UPDATE docs DOCUMENTS SET status = 'published' WHERE name = 'alpha'",
+        "UPDATE docs SET status = 'published' WHERE name = 'alpha'",
     );
     assert_eq!(docs.affected_rows, 1);
     let selected_doc = exec(&rt, "SELECT status FROM docs WHERE name = 'alpha'");
@@ -87,7 +88,7 @@ fn explicit_rows_documents_and_kv_targets_update_compatible_collections() {
     );
     let kv = exec(
         &rt,
-        "UPDATE settings KV SET value = 'on' WHERE key = 'feature'",
+        "UPDATE settings SET value = 'on' WHERE key = 'feature'",
     );
     assert_eq!(kv.affected_rows, 1);
     let selected_kv = exec(&rt, "SELECT value FROM settings WHERE key = 'feature'");
@@ -103,10 +104,7 @@ fn document_update_keeps_body_and_promoted_columns_in_sync() {
         r#"INSERT INTO docs_sync DOCUMENT VALUES ({"name":"orig","score":1})"#,
     );
 
-    let updated = exec(
-        &rt,
-        "UPDATE docs_sync DOCUMENTS SET score = 99 WHERE name = 'orig'",
-    );
+    let updated = exec(&rt, "UPDATE docs_sync SET score = 99 WHERE name = 'orig'");
 
     assert_eq!(updated.affected_rows, 1);
     let selected = exec(&rt, "SELECT body, score FROM docs_sync WHERE name = 'orig'");
@@ -170,10 +168,7 @@ fn implicit_dynamic_collections_accept_supported_explicit_targets() {
     );
     let node_rid = uint_field(only_record(&node), "rid");
 
-    let row_update = exec(
-        &rt,
-        "UPDATE flexible ROWS SET status = 'row-seen' WHERE id = 1",
-    );
+    let row_update = exec(&rt, "UPDATE flexible SET status = 'row-seen' WHERE id = 1");
     assert_eq!(row_update.affected_rows, 1);
     let selected_row = exec(&rt, "SELECT status FROM flexible WHERE id = 1");
     assert_eq!(text_field(only_record(&selected_row), "status"), "row-seen");
@@ -191,7 +186,12 @@ fn implicit_dynamic_collections_accept_supported_explicit_targets() {
 }
 
 #[test]
-fn explicit_update_targets_reject_incompatible_collection_models_before_mutation() {
+fn removed_document_marker_is_rejected_and_graph_marker_still_gated_by_model() {
+    // ADR 0067 (#1711): the DOCUMENTS/ROWS/KV markers are removed, so a
+    // `DOCUMENTS` marker on any collection is a didactic parse rejection — it
+    // no longer reaches the model-contract gate. NODES/EDGES survive, so a
+    // graph marker on a non-graph collection still surfaces the model-contract
+    // error before any mutation.
     let rt = runtime();
     exec(&rt, "CREATE TABLE accounts (id INT, status TEXT)");
     exec(&rt, "INSERT INTO accounts (id, status) VALUES (1, 'new')");
@@ -200,11 +200,33 @@ fn explicit_update_targets_reject_incompatible_collection_models_before_mutation
         &rt,
         "UPDATE accounts DOCUMENTS SET status = 'bad' WHERE id = 1",
     );
-    assert!(documents.contains("does not allow 'document' updates"));
+    assert!(
+        documents.contains("has been removed"),
+        "expected didactic marker-removal error, got: {documents}"
+    );
 
     let nodes = err_string(&rt, "UPDATE accounts NODES SET status = 'bad' WHERE id = 1");
     assert!(nodes.contains("does not allow 'graph' updates"));
 
     let selected = exec(&rt, "SELECT status FROM accounts WHERE id = 1");
+    assert_eq!(text_field(only_record(&selected), "status"), "new");
+}
+
+#[test]
+fn dotted_set_target_is_rejected_off_a_document_collection() {
+    // ADR 0067 (#1711): dotted assignment targets parse for every collection
+    // but are legal only on a document collection; off-model the analyzer
+    // rejects them before any mutation.
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE ledger (id INT, status TEXT)");
+    exec(&rt, "INSERT INTO ledger (id, status) VALUES (1, 'new')");
+
+    let dotted = err_string(&rt, "UPDATE ledger SET meta.tier = 'gold' WHERE id = 1");
+    assert!(
+        dotted.contains("only valid on document collections"),
+        "expected off-model dotted-target error, got: {dotted}"
+    );
+
+    let selected = exec(&rt, "SELECT status FROM ledger WHERE id = 1");
     assert_eq!(text_field(only_record(&selected), "status"), "new");
 }

--- a/tests/grouped/dml_updates/e2e_ordered_multimodel_update_batches.rs
+++ b/tests/grouped/dml_updates/e2e_ordered_multimodel_update_batches.rs
@@ -63,7 +63,7 @@ fn document_update_order_by_limit_uses_top_level_document_fields() {
 
     let updated = exec(
         &rt,
-        "UPDATE ordered_docs DOCUMENTS SET touched = 1 ORDER BY score ASC LIMIT 2",
+        "UPDATE ordered_docs SET touched = 1 ORDER BY score ASC LIMIT 2",
     );
 
     assert_eq!(updated.affected_rows, 2);
@@ -92,7 +92,7 @@ fn kv_update_order_by_limit_uses_key_value_fields() {
 
     let updated = exec(
         &rt,
-        "UPDATE ordered_kv KV SET value += 100 ORDER BY value DESC LIMIT 2",
+        "UPDATE ordered_kv SET value += 100 ORDER BY value DESC LIMIT 2",
     );
 
     assert_eq!(updated.affected_rows, 2);
@@ -180,35 +180,38 @@ fn edge_update_order_by_limit_uses_graph_edge_properties() {
 fn ordered_non_row_updates_require_limit_and_top_level_fields() {
     let rt = runtime();
 
-    for (target, collection) in [
-        ("DOCUMENTS", "ordered_docs"),
-        ("KV", "ordered_kv"),
-        ("NODES", "ordered_graph_nodes"),
-        ("EDGES", "ordered_graph_edges"),
+    // The DOCUMENTS/KV markers are removed (ADR 0067, #1711), so document and
+    // KV updates are written unmarked; NODES/EDGES stay. The ORDER-BY guards
+    // are parse-level and fire identically for every target.
+    for (marker, collection) in [
+        ("", "ordered_docs"),
+        ("", "ordered_kv"),
+        ("NODES ", "ordered_graph_nodes"),
+        ("EDGES ", "ordered_graph_edges"),
     ] {
         let without_limit = err_string(
             &rt,
-            &format!("UPDATE {collection} {target} SET touched = 1 ORDER BY score"),
+            &format!("UPDATE {collection} {marker}SET touched = 1 ORDER BY score"),
         );
         assert!(
             without_limit.contains("ORDER BY requires LIMIT"),
-            "{target}: {without_limit}"
+            "{marker}: {without_limit}"
         );
 
         let expression = err_string(
             &rt,
-            &format!("UPDATE {collection} {target} SET touched = 1 ORDER BY score + 1 LIMIT 1"),
+            &format!("UPDATE {collection} {marker}SET touched = 1 ORDER BY score + 1 LIMIT 1"),
         );
         assert!(
             expression.contains("top-level fields"),
-            "{target}: {expression}"
+            "{marker}: {expression}"
         );
 
         let nested = err_string(
             &rt,
-            &format!("UPDATE {collection} {target} SET touched = 1 ORDER BY body.score LIMIT 1"),
+            &format!("UPDATE {collection} {marker}SET touched = 1 ORDER BY body.score LIMIT 1"),
         );
-        assert!(nested.contains("top-level fields"), "{target}: {nested}");
+        assert!(nested.contains("top-level fields"), "{marker}: {nested}");
     }
 }
 
@@ -231,7 +234,7 @@ fn document_update_order_by_limit_breaks_ties_by_implicit_rid_asc() {
 
     let updated = exec(
         &rt,
-        "UPDATE ordered_doc_ties DOCUMENTS SET touched = 1 ORDER BY score ASC LIMIT 2",
+        "UPDATE ordered_doc_ties SET touched = 1 ORDER BY score ASC LIMIT 2",
     );
 
     assert_eq!(updated.affected_rows, 2);

--- a/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_kv_compound_updates.rs
@@ -76,7 +76,7 @@ fn document_claim_updates_ordered_subset_with_returning() {
 
     let claimed = exec(
         &rt,
-        "UPDATE doc_claim_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+        "UPDATE doc_claim_tasks SET status = 'claimed' WHERE status = 'ready' \
          CLAIM LIMIT 2 ORDER BY priority ASC RETURNING name, status",
     );
 
@@ -117,7 +117,7 @@ fn kv_claim_uses_key_identity_for_ordered_subset_with_returning() {
 
     let claimed = exec(
         &rt,
-        "UPDATE kv_claim_tasks KV SET value += 100 WHERE value >= 10 \
+        "UPDATE kv_claim_tasks SET value += 100 WHERE value >= 10 \
          CLAIM LIMIT 2 ORDER BY value ASC RETURNING value",
     );
 
@@ -165,7 +165,7 @@ fn document_claim_locks_skip_and_release_on_rollback() {
     exec(&rt, "BEGIN");
     let first = exec(
         &rt,
-        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+        "UPDATE doc_claim_lock_tasks SET status = 'claimed' WHERE status = 'ready' \
          CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
     );
     assert_eq!(returned_texts(&first, "name"), vec!["a"]);
@@ -173,7 +173,7 @@ fn document_claim_locks_skip_and_release_on_rollback() {
     set_current_connection_id(145402);
     let second = exec(
         &rt,
-        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+        "UPDATE doc_claim_lock_tasks SET status = 'claimed' WHERE status = 'ready' \
          CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
     );
     assert_eq!(second.affected_rows, 1);
@@ -185,7 +185,7 @@ fn document_claim_locks_skip_and_release_on_rollback() {
     set_current_connection_id(145402);
     let after_rollback = exec(
         &rt,
-        "UPDATE doc_claim_lock_tasks DOCUMENTS SET status = 'claimed' WHERE status = 'ready' \
+        "UPDATE doc_claim_lock_tasks SET status = 'claimed' WHERE status = 'ready' \
          CLAIM LIMIT 1 ORDER BY priority ASC RETURNING name",
     );
     assert_eq!(after_rollback.affected_rows, 1);
@@ -210,7 +210,7 @@ fn kv_claim_locks_skip_and_release_on_rollback_by_key() {
     exec(&rt, "BEGIN");
     let first = exec(
         &rt,
-        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+        "UPDATE kv_claim_lock_tasks SET value += 100 WHERE value >= 10 \
          CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
     );
     assert_eq!(int_field(only_record(&first), "value"), 110);
@@ -218,7 +218,7 @@ fn kv_claim_locks_skip_and_release_on_rollback_by_key() {
     set_current_connection_id(145404);
     let second = exec(
         &rt,
-        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+        "UPDATE kv_claim_lock_tasks SET value += 100 WHERE value >= 10 \
          CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
     );
     assert_eq!(second.affected_rows, 1);
@@ -235,7 +235,7 @@ fn kv_claim_locks_skip_and_release_on_rollback_by_key() {
     set_current_connection_id(145404);
     let after_rollback = exec(
         &rt,
-        "UPDATE kv_claim_lock_tasks KV SET value += 100 WHERE value >= 10 \
+        "UPDATE kv_claim_lock_tasks SET value += 100 WHERE value >= 10 \
          CLAIM LIMIT 1 ORDER BY value ASC RETURNING value",
     );
     assert_eq!(after_rollback.affected_rows, 1);
@@ -265,7 +265,7 @@ fn document_compound_update_uses_top_level_where_and_post_image_returning() {
 
     let updated = exec(
         &rt,
-        "UPDATE doc_scores DOCUMENTS SET score += 5 WHERE category = 'active' RETURNING name, score",
+        "UPDATE doc_scores SET score += 5 WHERE category = 'active' RETURNING name, score",
     );
     assert_eq!(updated.affected_rows, 1);
     let returned = only_record(&updated);
@@ -293,7 +293,7 @@ fn kv_compound_update_uses_key_where_and_post_image_returning() {
 
     let updated = exec(
         &rt,
-        "UPDATE counters KV SET value += 7 WHERE key = 'hits' RETURNING value",
+        "UPDATE counters SET value += 7 WHERE key = 'hits' RETURNING value",
     );
     assert_eq!(updated.affected_rows, 1);
     let returned = only_record(&updated);
@@ -320,7 +320,7 @@ fn document_and_kv_compound_failures_abort_without_partial_write() {
 
     let doc_err = err_string(
         &rt,
-        "UPDATE doc_invalid DOCUMENTS SET score += 1 WHERE category = 'batch'",
+        "UPDATE doc_invalid SET score += 1 WHERE category = 'batch'",
     );
     assert!(doc_err.contains("numeric field 'score'"));
     let ok_doc = exec(&rt, "SELECT score FROM doc_invalid WHERE name = 'ok'");
@@ -344,16 +344,16 @@ fn document_and_kv_compound_failures_abort_without_partial_write() {
         "INSERT INTO kv_invalid KV (key, value) VALUES ('max', 9223372036854775807)",
     );
 
-    let kv_err = err_string(&rt, "UPDATE kv_invalid KV SET value /= 0 WHERE key = 'ok'");
+    let kv_err = err_string(&rt, "UPDATE kv_invalid SET value /= 0 WHERE key = 'ok'");
     assert!(kv_err.contains("division by zero"));
-    let modulo_err = err_string(&rt, "UPDATE kv_invalid KV SET value %= 0 WHERE key = 'ok'");
+    let modulo_err = err_string(&rt, "UPDATE kv_invalid SET value %= 0 WHERE key = 'ok'");
     assert!(modulo_err.contains("modulo by zero"));
     let null_err = err_string(
         &rt,
-        "UPDATE kv_invalid KV SET value += 1 WHERE key = 'nullish'",
+        "UPDATE kv_invalid SET value += 1 WHERE key = 'nullish'",
     );
     assert!(null_err.contains("non-null numeric field 'value'"));
-    let overflow_err = err_string(&rt, "UPDATE kv_invalid KV SET value += 1 WHERE key = 'max'");
+    let overflow_err = err_string(&rt, "UPDATE kv_invalid SET value += 1 WHERE key = 'max'");
     assert!(overflow_err.contains("numeric overflow"));
     let ok_kv = exec(&rt, "SELECT value FROM kv_invalid WHERE key = 'ok'");
     assert_eq!(int_field(only_record(&ok_kv), "value"), 10);
@@ -363,10 +363,7 @@ fn document_and_kv_compound_failures_abort_without_partial_write() {
         9_223_372_036_854_775_807
     );
 
-    let missing_err = err_string(
-        &rt,
-        "UPDATE kv_invalid KV SET missing += 1 WHERE key = 'ok'",
-    );
+    let missing_err = err_string(&rt, "UPDATE kv_invalid SET missing += 1 WHERE key = 'ok'");
     assert!(missing_err.contains("existing numeric field 'missing'"));
 }
 
@@ -390,7 +387,7 @@ fn explicit_targets_keep_tenant_rls_scoped_to_matching_item_category() {
 
     let updated = exec(
         &rt,
-        "WITHIN TENANT 'acme' UPDATE tenant_docs DOCUMENTS SET score += 1 RETURNING name, score",
+        "WITHIN TENANT 'acme' UPDATE tenant_docs SET score += 1 RETURNING name, score",
     );
     assert_eq!(updated.affected_rows, 1);
     let returned = only_record(&updated);

--- a/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
+++ b/tests/grouped/docs_kv_queue/e2e_document_sql_analytics.rs
@@ -352,7 +352,7 @@ fn runtime_btree_document_path_index_refresh_on_dml() {
     // UPDATE: move svc1 from gold → aaa (aaa < bronze, drops out of range)
     exec(
         &rt,
-        "UPDATE refresh_docs DOCUMENTS SET tier = 'aaa' WHERE name = 'svc1'",
+        "UPDATE refresh_docs SET tier = 'aaa' WHERE name = 'svc1'",
     );
     let after_update = above_bronze(&rt);
     assert_eq!(

--- a/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
+++ b/tests/grouped/docs_kv_queue/e2e_documents_first_class_crud.rs
@@ -326,12 +326,12 @@ fn rql_document_update_body_replaces_full_body_by_id() {
 
     let replaced = rt
         .execute_query(&format!(
-            "UPDATE issue1366_rql_replace DOCUMENTS \
+            "UPDATE issue1366_rql_replace \
              SET body = '{{\"event_type\":\"replaced\",\"details\":{{\"ip\":\"127.0.0.1\"}}}}' \
              WHERE id = {}",
             created.id.raw()
         ))
-        .expect("UPDATE DOCUMENTS SET body should replace by id");
+        .expect("unmarked UPDATE SET body should replace by id");
     assert_eq!(replaced.affected_rows, 1);
 
     let selected = rt
@@ -553,7 +553,7 @@ fn document_crud_conformance_persists_mutation_and_delete_across_reopen() {
     assert_eq!(text_field(&initial.result.records[0], "keep"), "sibling");
     assert_eq!(text_field(&initial.result.records[0], "status"), "draft");
 
-    rt.execute_query("UPDATE conformance_docs DOCUMENTS SET score += 5 WHERE name = 'alpha'")
+    rt.execute_query("UPDATE conformance_docs SET score += 5 WHERE name = 'alpha'")
         .expect("partial update document");
     let partial = rt
         .execute_query("SELECT body FROM conformance_docs WHERE name = 'alpha'")
@@ -568,7 +568,7 @@ fn document_crud_conformance_persists_mutation_and_delete_across_reopen() {
     assert_eq!(partial_body["status"], json!("draft"));
 
     rt.execute_query(
-        "UPDATE conformance_docs DOCUMENTS \
+        "UPDATE conformance_docs \
          SET name = 'beta', score = 99, keep = 'replacement', status = 'done' \
          WHERE name = 'alpha'",
     )

--- a/tests/grouped/docs_kv_queue/e2e_issue_1363_document_where_id_and_body.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1363_document_where_id_and_body.rs
@@ -82,7 +82,7 @@ fn update_documents_where_id_matches_by_logical_id() {
     let updated = exec(
         &rt,
         &format!(
-            "UPDATE issue1363_update_id DOCUMENTS SET score += 5 \
+            "UPDATE issue1363_update_id SET score += 5 \
              WHERE id = {alpha_id} RETURNING name, score"
         ),
     );
@@ -112,7 +112,7 @@ fn update_documents_where_body_field_matches() {
 
     let updated = exec(
         &rt,
-        "UPDATE issue1363_update_body DOCUMENTS SET score += 1 \
+        "UPDATE issue1363_update_body SET score += 1 \
          WHERE body.category = 'active' RETURNING name, score",
     );
     assert_eq!(
@@ -192,7 +192,7 @@ fn no_match_reports_zero_not_error() {
 
     let update = exec(
         &rt,
-        "UPDATE issue1363_nomatch DOCUMENTS SET score += 1 WHERE id = 99999999",
+        "UPDATE issue1363_nomatch SET score += 1 WHERE id = 99999999",
     );
     assert_eq!(update.affected_rows, 0, "no id match → zero, not error");
 

--- a/tests/grouped/docs_kv_queue/e2e_issue_1402_document_binary_body.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1402_document_binary_body.rs
@@ -197,7 +197,7 @@ fn update_set_keeps_binary_body_in_sync() {
     rt.execute_query(r#"INSERT INTO users DOCUMENT VALUES ({"name":"Alice","tier":"free"})"#)
         .expect("insert");
 
-    rt.execute_query("UPDATE users DOCUMENTS SET tier = 'pro' WHERE name = 'Alice'")
+    rt.execute_query("UPDATE users SET tier = 'pro' WHERE name = 'Alice'")
         .expect("update");
 
     // Still binary on disk after the update.

--- a/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1403_document_single_source.rs
@@ -274,7 +274,7 @@ fn update_keeps_single_source_and_refreshes_index() {
     rt.execute_query("CREATE INDEX idx_score ON docs (score) USING BTREE")
         .expect("index");
 
-    rt.execute_query("UPDATE docs DOCUMENTS SET score = 80 WHERE name = 'alice'")
+    rt.execute_query("UPDATE docs SET score = 80 WHERE name = 'alice'")
         .expect("update");
 
     // Still no promoted columns after the update.
@@ -340,7 +340,7 @@ fn versioned_document_as_of_projects_the_historical_body() {
     insert(&rt, "vdocs", r#"{"name":"alice","score":1}"#);
     let p1 = commit(&rt, conn, "p1");
 
-    rt.execute_query("UPDATE vdocs DOCUMENTS SET score = 2 WHERE name = 'alice'")
+    rt.execute_query("UPDATE vdocs SET score = 2 WHERE name = 'alice'")
         .expect("update");
     let _p2 = commit(&rt, conn, "p2");
 

--- a/tests/grouped/docs_kv_queue/e2e_issue_552_documents_patch_set_intermediates.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_552_documents_patch_set_intermediates.rs
@@ -15,7 +15,7 @@
 //
 // The first three bullets are exercised through both the HTTP PATCH
 // `/collections/{name}/entities/{id}` surface (the public patch endpoint)
-// and the SQL `UPDATE … DOCUMENTS SET …` surface (which routes through
+// and the SQL `UPDATE … SET …` surface (which routes through
 // the same patch core in `apply_loaded_patch_entity_core`). Bullet 4 is
 // pinned at the document body level because that's the surface where
 // array positional paths could plausibly be requested by clients holding
@@ -241,7 +241,7 @@ fn http_patch_array_positional_path_rejected_with_clear_error() {
 }
 
 // Acceptance 3 (SQL): patch is also exposed through SQL — `UPDATE …
-// DOCUMENTS SET …` routes through the same patch core as the HTTP
+// SET …` routes through the same patch core as the HTTP
 // surface, and a SET that targets a previously-absent top-level body
 // key creates it without rewriting the rest of the body.
 #[test]
@@ -257,10 +257,10 @@ fn sql_update_documents_set_creates_missing_top_level_body_field() {
 
     let updated = rt
         .execute_query(
-            "UPDATE issue552_sql_patch DOCUMENTS SET status = 'reviewed' \
+            "UPDATE issue552_sql_patch SET status = 'reviewed' \
              WHERE event_type = 'login' RETURNING event_type, attempts, status",
         )
-        .expect("UPDATE DOCUMENTS SET should succeed");
+        .expect("UPDATE SET should succeed");
     assert_eq!(updated.affected_rows, 1);
 
     // Both the pre-existing fields and the freshly-created `status`

--- a/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
+++ b/tests/grouped/http_grpc_auth/e2e_issue_547_cross_transport_envelope.rs
@@ -305,7 +305,7 @@ async fn grpc_connector_document_update_reports_and_applies_affected_row() {
         .expect("insert document");
 
     let updated = client
-        .query_reply("UPDATE grpc_docs DOCUMENTS SET score = 42 WHERE name = 'doc'")
+        .query_reply("UPDATE grpc_docs SET score = 42 WHERE name = 'doc'")
         .await
         .expect("update document over gRPC connector");
     assert_eq!(updated.affected_rows, 1);

--- a/tests/grouped/surface_contracts/cross_transport_result_equivalence.rs
+++ b/tests/grouped/surface_contracts/cross_transport_result_equivalence.rs
@@ -375,12 +375,12 @@ fn insert_document_sql(collection: &str) -> String {
 }
 
 fn partial_update_document_sql(collection: &str) -> String {
-    format!("UPDATE {collection} DOCUMENTS SET score += 5 WHERE name = 'alpha'")
+    format!("UPDATE {collection} SET score += 5 WHERE name = 'alpha'")
 }
 
 fn replace_document_sql(collection: &str) -> String {
     format!(
-        "UPDATE {collection} DOCUMENTS \
+        "UPDATE {collection} \
          SET name = 'beta', score = 99, keep = 'replacement', status = 'done' \
          WHERE name = 'alpha'"
     )


### PR DESCRIPTION
Implements PRD #1703 slice #1711 (ADR 0067, *Model marker* clean break).

## What changed
- **Parser (`reddb-io-rql`)**: `parse_update_target` rejects `DOCUMENTS`/`ROWS`/`KV` UPDATE markers with a didactic error naming the unmarked form; `NODES`/`EDGES` graph markers stay (a graph holds both record kinds). Dotted assignment targets (`SET a.b.c`) now parse for all targets; analyzer validates them against the catalog model.
- **Runtime/analyzer**: unmarked UPDATE on document collections resolves document semantics via the catalog; dotted SET off-model rejected with a clear error. (Executor support for nested paths is the next slice — #1712; dotted targets keep today's runtime behaviour meanwhile.)
- **All drivers flipped** to emit unmarked document UPDATE (js, js-client, cpp, dart, dotnet, go, java, kotlin, php, python, python-asyncio, zig, client) — same-change per the no-deprecation policy.
- **Fixtures/conformance/docs** updated to drop the removed markers.

## Verification
Agent-run + finish-from-branch: parser negative fixtures, catalog-inference goldens, conformance pack, and driver examples updated in the same change. CI is the gate.

37 granular commits (one file each, `Refs #1711`). Landed via finish-from-branch (orchestrator died; commits intact on the branch).

Closes #1711

Claude-Session: https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785795286&installation_id=129708444&pr_number=1735&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1735&signature=5d782e3d155689a1f2ad0b62760312856cbb655e1f9553fe4dd0ddbb9e0ce9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->