### PR TITLE
docs(embedded): rename reserved field 'kind' in doc-builder example

### DIFF
--- a/docs/api/embedded.md
+++ b/docs/api/embedded.md
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .save()?;
 
     let doc_rid = db.doc("events")
-        .field("kind", "login")
+        .field("action", "login")
         .field("user", "alice")
         .field("success", true)
         .save()?;


### PR DESCRIPTION
Follow-up from the #1713 docs audit: `docs/api/embedded.md:63` used `.field("kind", "login")` in the embedded doc-builder example, but `kind` is a reserved envelope field since #1705 — the example fails at runtime with the reserved-field error. Renamed to `action`.

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785799737&installation_id=129708444&pr_number=1740&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1740&signature=87649de3719886c3234a1f9c15dd0ae3d7e057042891cefe11fb729a8727cd23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->