### PR TITLE
fix(#1721): strict runtime string→JSON coercion + remaining driver flips

### DIFF
--- a/.red/adr/0067-document-dml-surface-clean-break.md
+++ b/.red/adr/0067-document-dml-surface-clean-break.md
@@ -70,6 +70,16 @@ found the DML surface accreted rather than designed:
    user data, matched exactly everywhere. The schemaless typo hazard
    (`userid` vs `UserId` → empty result) is a documentation concern,
    not a semantics lever.
+9. **No runtime string→JSON coercion (follow-up [#1721]).** Point 1
+   rejects the quoted-string body at *parse* time; the same strictness
+   applies to the *runtime* positions the parser cannot see. A
+   parameter-bound document body (`DOCUMENT VALUES ($1)` with a string
+   argument) and a bare string bound to a JSON-typed table column are
+   **not silently coerced** — they error, pointing at the inline literal
+   or `JSON_PARSE(<expr>)`. An inline literal already arrives as a JSON
+   value and never reaches these coercion points.
+
+[#1721]: https://github.com/reddb-io/reddb/issues/1721
 
 ## Consequences
 

--- a/crates/reddb-rql/src/sql_lowering.rs
+++ b/crates/reddb-rql/src/sql_lowering.rs
@@ -738,6 +738,27 @@ pub fn fold_expr_to_value(expr: Expr) -> Result<Value, String> {
                     Value::Secret(format!("@@plain@@{plaintext}").into_bytes())
                 });
             }
+            // ADR 0067 (#1721): `JSON_PARSE('{…}')` is the sanctioned escape
+            // hatch for writing JSON from a runtime string. Fold a literal
+            // string argument to a `Value::Json` here so it is accepted in
+            // INSERT VALUES positions, using the same parse+canonicalize
+            // pipeline as an inline JSON literal.
+            if name.eq_ignore_ascii_case("JSON_PARSE") && args.len() == 1 {
+                let raw = match fold_expr_to_value(args.into_iter().next().unwrap())? {
+                    Value::Text(text) => text,
+                    other => {
+                        return Err(format!(
+                            "JSON_PARSE() expects a string literal argument, got {other:?}"
+                        ))
+                    }
+                };
+                let parsed = reddb_types::utils::json::parse_json(raw.as_ref())
+                    .map_err(|err| format!("JSON_PARSE failed to parse JSON: {err}"))?;
+                let canonical = reddb_types::serde_json::Value::from(parsed);
+                let bytes = reddb_types::json::to_vec(&canonical)
+                    .map_err(|err| format!("JSON_PARSE failed to encode JSON: {err}"))?;
+                return Ok(Value::Json(bytes));
+            }
             Err(format!(
                 "expression is not a foldable literal: FunctionCall({name})"
             ))

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -974,7 +974,15 @@ fn coerce_contract_literal(
     let target = column.data_type;
     match target {
         DataType::Blob => Ok(Value::Blob(raw.as_bytes().to_vec())),
-        DataType::Json => Ok(Value::Json(raw.as_bytes().to_vec())),
+        // ADR 0067 (#1721): a JSON value is written as an inline strict-JSON
+        // literal — a bare string is not silently wrapped as JSON. Wrap a
+        // runtime string with `JSON_PARSE(<expr>)`. (An inline literal already
+        // arrives as `Value::Json` and never reaches this coercion.)
+        DataType::Json => Err(crate::RedDBError::Query(format!(
+            "column '{column_name}' in collection '{collection}' requires an inline strict-JSON \
+             literal (e.g. `{{\"k\": \"v\"}}`) or `JSON_PARSE(<expr>)`; a bare string is not \
+             coerced to JSON (ADR 0067)"
+        ))),
         DataType::Timestamp => raw.parse::<i64>().map(Value::Timestamp).map_err(|err| {
             crate::RedDBError::Query(format!(
                 "failed to coerce column '{}' in collection '{}' to '{}': {}",

--- a/crates/reddb-server/src/runtime/impl_dml_support.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_support.rs
@@ -222,21 +222,23 @@ pub(super) fn find_document_body_json(
                     .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}")))
             }
         }
-        Value::Text(text) => crate::json::from_str(text.as_ref())
-            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
         // A JSON-position array literal parses losslessly into `Value::Array`
         // (issue #1708); resolve it to a JSON array here.
         Value::Array(_) => Ok(crate::presentation::entity_json::storage_value_to_json(
             &val,
         )),
-        Value::Integer(value) => crate::json::from_str(&value.to_string())
-            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
-        Value::UnsignedInteger(value) => crate::json::from_str(&value.to_string())
-            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
-        Value::Float(value) => crate::json::from_str(&value.to_string())
-            .map_err(|err| RedDBError::Query(format!("invalid JSON body: {err}"))),
+        // ADR 0067 (#1721): a document body is an inline strict-JSON literal.
+        // A runtime string bound through a parameter (`DOCUMENT VALUES ($1)`)
+        // is no longer silently coerced — wrap it with `JSON_PARSE(<expr>)`.
+        Value::Text(_) => Err(RedDBError::Query(
+            "document body must be an inline strict-JSON literal \
+             (e.g. `DOCUMENT VALUES ({\"level\": \"info\"})`); wrap a runtime \
+             string with `JSON_PARSE(<expr>)` (ADR 0067)"
+                .to_string(),
+        )),
         other => Err(RedDBError::Query(format!(
-            "column 'body' expected JSON body, got {other:?}"
+            "document body must be an inline strict-JSON literal or `JSON_PARSE(<expr>)`, \
+             got {other:?} (ADR 0067)"
         ))),
     }
 }

--- a/drivers/cpp/include/reddb/helpers.hpp
+++ b/drivers/cpp/include/reddb/helpers.hpp
@@ -250,6 +250,7 @@ std::string kv_tag_literal(const std::string& tag);
 std::string queue_value_literal(const JsonValue& value);
 std::string value_literal(const JsonValue& value);
 std::string json_literal(const JsonValue& value);
+std::string json_inline_literal(const JsonValue& value);
 std::string identifier(const std::string& value);
 std::string identifier_path(const std::string& value);
 void        assert_identifier(const std::string& value, const std::string& label);

--- a/drivers/cpp/src/helpers.cpp
+++ b/drivers/cpp/src/helpers.cpp
@@ -339,6 +339,12 @@ std::string json_literal(const JsonValue& v) {
     return "'" + replace_all(enc, "'", "''") + "'";
 }
 
+// ADR 0067 (#1709): a document body is written as an inline strict-JSON
+// literal (no surrounding quotes) — the quoted-string coercion is removed.
+std::string json_inline_literal(const JsonValue& v) {
+    return json_encode(v);
+}
+
 std::string identifier(const std::string& value) {
     if (!value.empty() && all_ident_chars(value)) return value;
     return "\"" + replace_all(value, "\"", "\"\"") + "\"";
@@ -498,7 +504,7 @@ InsertResult DocumentClient::insert(const std::string& collection,
     JsonValue doc = JsonValue::make_object(document);
     std::ostringstream os;
     os << "INSERT INTO " << sql::identifier_path(collection)
-       << " DOCUMENT (body) VALUES (" << sql::json_literal(doc) << ") RETURNING *";
+       << " DOCUMENT VALUES (" << sql::json_inline_literal(doc) << ") RETURNING *";
     std::string body = q_->query(os.str(), {});
     auto [row, affected] = sql::first_row(body);
     if (!row) {

--- a/drivers/dart/lib/src/helpers.dart
+++ b/drivers/dart/lib/src/helpers.dart
@@ -100,8 +100,8 @@ class DocumentClient {
   ) async {
     await _ensureCollection(collection);
     final body = await _q.query(
-      'INSERT INTO ${_sqlIdentifierPath(collection)} DOCUMENT (body) '
-      'VALUES (${_jsonLiteral(document)}) RETURNING *',
+      'INSERT INTO ${_sqlIdentifierPath(collection)} DOCUMENT '
+      'VALUES (${_jsonInlineLiteral(document)}) RETURNING *',
     );
     final (row, declared) = _firstRow(body);
     if (row == null || row['rid'] == null) {
@@ -195,8 +195,8 @@ class DocumentClient {
     final rids = <String>[];
     for (final p in payloads) {
       final body = await _q.query(
-        'INSERT INTO ${_sqlIdentifierPath(collection)} DOCUMENT (body) '
-        'VALUES (${_jsonLiteral(p)}) RETURNING *',
+        'INSERT INTO ${_sqlIdentifierPath(collection)} DOCUMENT '
+        'VALUES (${_jsonInlineLiteral(p)}) RETURNING *',
       );
       final (row, _) = _firstRow(body);
       if (row == null || row['rid'] == null) {
@@ -523,10 +523,9 @@ String _queueValueLiteral(Object? value) {
 
 String _valueLiteral(Object? value) => _kvValueLiteral(value);
 
-String _jsonLiteral(Object? value) {
-  final s = jsonEncode(value);
-  return "'${s.replaceAll("'", "''")}'";
-}
+/// ADR 0067 (#1709): a document body is written as an inline strict-JSON
+/// literal (no surrounding quotes) — the quoted-string coercion is removed.
+String _jsonInlineLiteral(Object? value) => jsonEncode(value);
 
 String _sqlIdentifier(String value) {
   if (value.isNotEmpty && _allIdentChars(value)) return value;

--- a/drivers/dotnet/src/Reddb/Helpers/Helpers.cs
+++ b/drivers/dotnet/src/Reddb/Helpers/Helpers.cs
@@ -122,7 +122,7 @@ public sealed class DocumentClient
         if (document is null)
             throw new HelperException.InvalidArgument("documents.insert document must be an object");
         await EnsureCollectionAsync(collection, ct).ConfigureAwait(false);
-        string sql = $"INSERT INTO {Sql.IdentifierPath(collection)} DOCUMENT (body) VALUES ({Sql.JsonLiteral(document)}) RETURNING *";
+        string sql = $"INSERT INTO {Sql.IdentifierPath(collection)} DOCUMENT VALUES ({Sql.JsonInlineLiteral(document)}) RETURNING *";
         var body = await _q.QueryAsync(sql, Array.Empty<object?>(), ct).ConfigureAwait(false);
         var (row, affected) = Sql.FirstRow(body.Span);
         if (row is null || !row.TryGetValue("rid", out var rid) || rid is null)
@@ -545,8 +545,13 @@ internal static class Sql
 
     public static string ValueLiteral(object? value) => KvValueLiteral(value);
 
-    public static string JsonLiteral(object? value)
-        => "'" + JsonSerializer.Serialize(value, JsonOpts).Replace("'", "''") + "'";
+    /// <summary>
+    /// Returns the raw JSON encoding of <paramref name="value"/> with no
+    /// surrounding quotes and no SQL escaping, for use where the RQL lexer
+    /// parses an inline JSON literal directly (e.g. <c>DOCUMENT VALUES (...)</c>).
+    /// </summary>
+    public static string JsonInlineLiteral(object? value)
+        => JsonSerializer.Serialize(value, JsonOpts);
 
     public static string Identifier(string value)
         => !string.IsNullOrEmpty(value) && AllIdentChars(value)

--- a/drivers/go/helpers.go
+++ b/drivers/go/helpers.go
@@ -97,11 +97,11 @@ func (d *DocumentClient) Insert(ctx context.Context, collection string, document
 	if err := d.ensureCollection(ctx, collection); err != nil {
 		return nil, err
 	}
-	jsonLit, err := jsonLiteral(document)
+	jsonLit, err := jsonInlineLiteral(document)
 	if err != nil {
 		return nil, err
 	}
-	sql := fmt.Sprintf("INSERT INTO %s DOCUMENT (body) VALUES (%s) RETURNING *",
+	sql := fmt.Sprintf("INSERT INTO %s DOCUMENT VALUES (%s) RETURNING *",
 		sqlIdentifierPath(collection), jsonLit)
 	body, err := d.q.Query(ctx, sql)
 	if err != nil {
@@ -708,12 +708,15 @@ func valueLiteral(value any) (string, error) {
 	return kvValueLiteral(value)
 }
 
-func jsonLiteral(value any) (string, error) {
+// jsonInlineLiteral returns the raw JSON encoding of value with no
+// surrounding quotes and no SQL escaping, for use where the RQL lexer
+// parses an inline JSON literal directly (e.g. DOCUMENT VALUES (...)).
+func jsonInlineLiteral(value any) (string, error) {
 	bs, err := json.Marshal(value)
 	if err != nil {
 		return "", NewError(CodeInvalidArgument, err.Error())
 	}
-	return "'" + strings.ReplaceAll(string(bs), "'", "''") + "'", nil
+	return string(bs), nil
 }
 
 func sqlIdentifier(value string) string {

--- a/drivers/java/src/main/java/dev/reddb/helpers/DocumentClient.java
+++ b/drivers/java/src/main/java/dev/reddb/helpers/DocumentClient.java
@@ -27,7 +27,7 @@ public final class DocumentClient {
         }
         ensureCollection(collection);
         String sql = "INSERT INTO " + Sql.sqlIdentifierPath(collection)
-            + " DOCUMENT (body) VALUES (" + Sql.jsonLiteral(document) + ") RETURNING *";
+            + " DOCUMENT VALUES (" + Sql.jsonInlineLiteral(document) + ") RETURNING *";
         byte[] body = q.query(sql);
         Object[] fr = Sql.firstRow(body);
         @SuppressWarnings("unchecked")

--- a/drivers/java/src/main/java/dev/reddb/helpers/Sql.java
+++ b/drivers/java/src/main/java/dev/reddb/helpers/Sql.java
@@ -72,6 +72,15 @@ final class Sql {
         }
     }
 
+    /** Raw inline JSON literal (no surrounding quotes, no SQL escaping) for RQL's inline JSON body form. */
+    static String jsonInlineLiteral(Object value) {
+        try {
+            return JSON.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new HelperException.InvalidArgument(e.getMessage());
+        }
+    }
+
     static String sqlIdentifier(String value) {
         if (!value.isEmpty() && allIdentChars(value)) return value;
         return "\"" + value.replace("\"", "\"\"") + "\"";

--- a/drivers/kotlin/src/main/kotlin/dev/reddb/helpers/Helpers.kt
+++ b/drivers/kotlin/src/main/kotlin/dev/reddb/helpers/Helpers.kt
@@ -69,8 +69,8 @@ public class DocumentClient internal constructor(private val q: Querier) {
             throw HelperException.InvalidArgument("documents.insert document must be an object")
         }
         ensureCollection(collection)
-        val sql = "INSERT INTO ${Sql.identifierPath(collection)} DOCUMENT (body) VALUES " +
-            "(${Sql.jsonLiteral(document)}) RETURNING *"
+        val sql = "INSERT INTO ${Sql.identifierPath(collection)} DOCUMENT VALUES " +
+            "(${Sql.jsonInlineLiteral(document)}) RETURNING *"
         val body = q.query(sql)
         val (row, affectedRaw) = Sql.firstRow(body)
         if (row == null || row["rid"] == null) {
@@ -330,8 +330,9 @@ internal object Sql {
 
     fun valueLiteral(value: Any?): String = kvValueLiteral(value)
 
-    fun jsonLiteral(value: Any?): String =
-        "'" + mapper.writeValueAsString(value).replace("'", "''") + "'"
+    // ADR 0067 (#1709): a document body is written as an inline strict-JSON
+    // literal (no surrounding quotes) — the quoted-string coercion is removed.
+    fun jsonInlineLiteral(value: Any?): String = mapper.writeValueAsString(value)
 
     fun identifier(value: String): String =
         if (value.isNotEmpty() && allIdentChars(value)) value

--- a/drivers/zig/src/helpers.zig
+++ b/drivers/zig/src/helpers.zig
@@ -117,12 +117,12 @@ pub const DocumentClient = struct {
 
     pub fn insert(self: DocumentClient, collection: []const u8, document: json.Value) !InsertResult {
         try self.ensureCollection(collection);
-        const lit = try jsonLiteral(self.allocator, document);
+        const lit = try jsonInlineLiteral(self.allocator, document);
         defer self.allocator.free(lit);
         const id_path = try identifierPath(self.allocator, collection);
         defer self.allocator.free(id_path);
         const sql = try std.fmt.allocPrint(self.allocator,
-            "INSERT INTO {s} DOCUMENT (body) VALUES ({s}) RETURNING *",
+            "INSERT INTO {s} DOCUMENT VALUES ({s}) RETURNING *",
             .{ id_path, lit });
         defer self.allocator.free(sql);
         const body = try self.q.query(self.allocator, sql, &.{});
@@ -596,10 +596,11 @@ pub fn valueLiteral(allocator: Allocator, value: json.Value) ![]u8 {
     return kvValueLiteral(allocator, value);
 }
 
-pub fn jsonLiteral(allocator: Allocator, value: json.Value) ![]u8 {
-    const enc = try jsonEncode(allocator, value);
-    defer allocator.free(enc);
-    return try quoteWith(allocator, enc, '\'');
+// jsonInlineLiteral returns the raw JSON encoding of value with no
+// surrounding quotes and no SQL escaping, for use where the RQL lexer
+// parses an inline JSON literal directly (e.g. DOCUMENT VALUES (...)).
+pub fn jsonInlineLiteral(allocator: Allocator, value: json.Value) ![]u8 {
+    return try jsonEncode(allocator, value);
 }
 
 fn quoteWith(allocator: Allocator, value: []const u8, quote: u8) ![]u8 {

--- a/tests/grouped/docs_kv_queue/e2e_issue_1721_strict_json_coercion.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1721_strict_json_coercion.rs
@@ -1,0 +1,80 @@
+// Regression coverage for issue #1721 — ADR 0067 point 9: no runtime
+// string→JSON coercion. The parser already rejects a quoted-string document
+// body literal; these tests pin the two *runtime* positions the parser cannot
+// see — a parameter-bound document body and a bare string bound to a
+// JSON-typed table column — and prove `JSON_PARSE(<expr>)` is the sanctioned
+// escape hatch for both.
+
+#[path = "../../support/mod.rs"]
+mod support;
+
+use reddb::storage::schema::Value;
+use reddb::RedDBRuntime;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::in_memory().expect("runtime")
+}
+
+// --- Document body via parameter -------------------------------------------
+
+#[test]
+fn document_body_param_bound_string_is_rejected() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT issue1721_events")
+        .expect("create document");
+
+    let err = rt
+        .execute_query_with_params(
+            "INSERT INTO issue1721_events DOCUMENT VALUES ($1)",
+            &[Value::Text(r#"{"level":"info"}"#.into())],
+        )
+        .expect_err("a parameter-bound string body must be rejected, not coerced");
+    let message = err.to_string();
+    assert!(
+        message.contains("JSON_PARSE"),
+        "error should point at JSON_PARSE, got: {message}"
+    );
+}
+
+#[test]
+fn document_body_via_json_parse_is_accepted() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT issue1721_events_ok")
+        .expect("create document");
+
+    // The sanctioned escape hatch: wrap the runtime string in JSON_PARSE.
+    rt.execute_query(
+        "INSERT INTO issue1721_events_ok DOCUMENT VALUES (JSON_PARSE('{\"level\":\"warn\"}'))",
+    )
+    .expect("JSON_PARSE-wrapped body must be accepted");
+}
+
+// --- JSON-typed table column ------------------------------------------------
+
+#[test]
+fn json_column_string_literal_is_rejected() {
+    let rt = runtime();
+    rt.execute_query("CREATE TABLE issue1721_things (id INTEGER, payload JSON)")
+        .expect("create table");
+
+    let err = rt
+        .execute_query("INSERT INTO issue1721_things (id, payload) VALUES (1, '{\"a\":1}')")
+        .expect_err("a bare string bound to a JSON column must be rejected, not coerced");
+    let message = err.to_string();
+    assert!(
+        message.contains("JSON_PARSE"),
+        "error should point at JSON_PARSE, got: {message}"
+    );
+}
+
+#[test]
+fn json_column_via_json_parse_is_accepted() {
+    let rt = runtime();
+    rt.execute_query("CREATE TABLE issue1721_things_ok (id INTEGER, payload JSON)")
+        .expect("create table");
+
+    rt.execute_query(
+        "INSERT INTO issue1721_things_ok (id, payload) VALUES (1, JSON_PARSE('{\"a\":1}'))",
+    )
+    .expect("JSON_PARSE-wrapped JSON column value must be accepted");
+}

--- a/tests/grouped/documents_kv_queues.rs
+++ b/tests/grouped/documents_kv_queues.rs
@@ -21,6 +21,9 @@ mod e2e_issue_535_red_queues_virtual_table;
 #[path = "docs_kv_queue/e2e_issue_540_documents_basics.rs"]
 mod e2e_issue_540_documents_basics;
 
+#[path = "docs_kv_queue/e2e_issue_1721_strict_json_coercion.rs"]
+mod e2e_issue_1721_strict_json_coercion;
+
 #[path = "docs_kv_queue/e2e_issue_1402_document_binary_body.rs"]
 mod e2e_issue_1402_document_binary_body;
 

--- a/tests/grouped/events_retention/e2e_events_foundation.rs
+++ b/tests/grouped/events_retention/e2e_events_foundation.rs
@@ -295,7 +295,7 @@ fn redact_nested_dotted_path() {
 
     exec(
         &rt,
-        r#"INSERT INTO docs (id, body) VALUES (1, '{"user":{"email":"secret@example.com","name":"Bob"},"title":"hello"}')"#,
+        r#"INSERT INTO docs (id, body) VALUES (1, {"user":{"email":"secret@example.com","name":"Bob"},"title":"hello"})"#,
     );
 
     let payload = read_event_payload(&rt, "docs_events");
@@ -328,7 +328,7 @@ fn redact_wildcard_nested_path() {
 
     exec(
         &rt,
-        r#"INSERT INTO events_log (id, body) VALUES (1, '{"sender":{"email":"a@x.com","name":"A"},"recipient":{"email":"b@x.com","name":"B"}}')"#,
+        r#"INSERT INTO events_log (id, body) VALUES (1, {"sender":{"email":"a@x.com","name":"A"},"recipient":{"email":"b@x.com","name":"B"}})"#,
     );
 
     let payload = read_event_payload(&rt, "events_log_events");


### PR DESCRIPTION
Closes #1721. ADR 0067 audit follow-up to #1709.

## What
Closes the remaining runtime string→JSON coercion positions the parse-time rejection couldn't see, makes `JSON_PARSE` a real escape hatch in INSERT, and flips the last 7 drivers to the inline strict-JSON body form.

## Server (strict — ADR 0067 point 9)
- `find_document_body_json`: a **parameter-bound string** document body (`DOCUMENT VALUES ($1)`) is now **rejected**, not silently coerced — points at `JSON_PARSE(<expr>)`.
- `coerce_contract_literal`: a **bare string bound to a JSON-typed column** is rejected instead of being wrapped as *unvalidated* JSON (latent bug).
- `sql_lowering::fold_expr_to_value`: `JSON_PARSE('<literal>')` now **folds to `Value::Json`**, so it's accepted in INSERT VALUES positions (same parse+canonicalize pipeline as an inline literal). This makes the #1709 didactic guidance actually work.

## Drivers
Flipped `DOCUMENT (body) VALUES ('{…}')` → `DOCUMENT VALUES ({…})` (inline strict-JSON), matching the JS reference: **go, java, kotlin, dotnet, dart, cpp, zig**.

## Already done before this PR (verified)
- `JSON_PARSE` builtin — implemented via #1707.
- Python sync driver — already flipped.

## Tests
- New `e2e_issue_1721_strict_json_coercion`: reject param body / reject JSON-column string / accept both via `JSON_PARSE`.
- Full `grouped_documents_kv_queues` + `grouped_sql_core` + `grouped_general_multimodel` + `reddb-io-rql`: **120 passed, 0 failed** locally.
- Go/Java/C++ driver suites built & passed locally; dotnet/dart/zig/kotlin toolchains validated in CI.

## Acceptance (#1721)
- [x] `JSON_PARSE(<expr>)` implemented (+ now foldable in INSERT)
- [x] Param-bound body + JSON-column coercion decision made & enforced (strict) & documented (ADR 0067 pt 9)
- [x] Remaining drivers flipped

https://claude.ai/code/session_013JEckoBHyRAqwuPyVjGr8e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785813734&installation_id=129708444&pr_number=1752&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1752&signature=91e2030cec82e5d1944a5150cfc981df51278e255f8f406574732ac7f142f762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for inserting document payloads using inline strict JSON values across supported SDKs.
  * Enhanced `JSON_PARSE(<expr>)` to accept JSON from string expressions (when provided as a string literal).

* **Bug Fixes**
  * Tightened JSON coercion: bare strings are no longer silently treated as JSON.
  * Updated guidance/errors to require inline strict JSON literals or `JSON_PARSE(<expr>)`.

* **Tests**
  * Added end-to-end regression coverage for strict JSON coercion acceptance and rejection cases.

* **Documentation**
  * Updated the JSON quoting/coercion contract to clarify parse-time and runtime strictness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->