### PR TITLE
merge: #1745 AI vault token path clean break: red.secret.ai.providers.$provider.tokens.$alias, legacy plaintext path removed

### DIFF
--- a/crates/reddb-server/src/ai.rs
+++ b/crates/reddb-server/src/ai.rs
@@ -1088,17 +1088,18 @@ mod tests {
     }
 
     #[test]
-    fn resolve_api_key_prefers_vault_secret_over_legacy_config() {
+    fn resolve_api_key_prefers_new_vault_path_over_removed_paths() {
         let provider = AiProvider::OpenAi;
         let alias = "vault_unit_alias";
         let secret_path = ai_api_secret_path(&provider, alias);
-        let legacy_key = ai_api_legacy_config_key(&provider, alias);
+        let removed_legacy = removed_plaintext_config_key(&provider, alias);
+        let removed_vault = removed_vault_api_key_path(&provider, alias);
 
         let resolved = resolve_api_key(&provider, Some(alias), |key| {
             if key == secret_path {
                 Ok(Some("vault-key".to_string()))
-            } else if key == legacy_key {
-                Ok(Some("legacy-key".to_string()))
+            } else if key == removed_legacy || key == removed_vault {
+                Ok(Some("stale-key".to_string()))
             } else {
                 Ok(None)
             }
@@ -1106,6 +1107,81 @@ mod tests {
         .expect("resolve");
 
         assert_eq!(resolved, "vault-key");
+    }
+
+    #[test]
+    fn resolve_api_key_rejects_removed_plaintext_config_path() {
+        let provider = AiProvider::Custom("cred1745legacy".to_string());
+        let alias = "prod";
+        let removed_legacy = removed_plaintext_config_key(&provider, alias);
+        let new_path = ai_api_secret_path(&provider, alias);
+
+        // Only the removed plaintext config path holds a value: resolution
+        // must reject didactically, naming the new vault path.
+        let err = resolve_api_key(&provider, Some(alias), |key| {
+            if key == removed_legacy {
+                Ok(Some("stale-plaintext-key".to_string()))
+            } else {
+                Ok(None)
+            }
+        })
+        .expect_err("must reject removed path");
+        let msg = err.to_string();
+        assert!(msg.contains(&removed_legacy), "names removed path: {msg}");
+        assert!(msg.contains(&new_path), "names new vault path: {msg}");
+    }
+
+    #[test]
+    fn resolve_api_key_rejects_removed_vault_api_key_path() {
+        let provider = AiProvider::Custom("cred1745oldvault".to_string());
+        let removed_vault = removed_vault_api_key_path(&provider, "default");
+        let new_path = ai_api_secret_path(&provider, "default");
+
+        let err = resolve_api_key(&provider, None, |key| {
+            if key == removed_vault {
+                Ok(Some("stale-vault-key".to_string()))
+            } else {
+                Ok(None)
+            }
+        })
+        .expect_err("must reject removed vault path");
+        let msg = err.to_string();
+        assert!(msg.contains(&removed_vault), "names removed path: {msg}");
+        assert!(msg.contains(&new_path), "names new vault path: {msg}");
+    }
+
+    #[test]
+    fn resolve_api_key_alias_token_overrides_default_per_request() {
+        let provider = AiProvider::OpenAi;
+        let default_path = ai_api_secret_path(&provider, "default");
+        let prod_path = ai_api_secret_path(&provider, "prod");
+        let getter = |key: &str| {
+            if key == default_path {
+                Ok(Some("default-token".to_string()))
+            } else if key == prod_path {
+                Ok(Some("prod-token".to_string()))
+            } else {
+                Ok(None)
+            }
+        };
+        // A request naming the `prod` alias resolves the tenant token; a
+        // request naming no credential resolves the implicit `default`.
+        assert_eq!(
+            resolve_api_key(&provider, Some("prod"), getter).expect("prod"),
+            "prod-token"
+        );
+        assert_eq!(
+            resolve_api_key(&provider, None, getter).expect("default"),
+            "default-token"
+        );
+    }
+
+    #[test]
+    fn ai_api_secret_path_uses_providers_tokens_shape() {
+        let path = ai_api_secret_path(&AiProvider::OpenAi, "default");
+        assert_eq!(path, "red.secret.ai.providers.openai.tokens.default");
+        let aliased = ai_api_secret_path(&AiProvider::OpenAi, "Prod");
+        assert_eq!(aliased, "red.secret.ai.providers.openai.tokens.prod");
     }
 
     #[test]
@@ -1894,21 +1970,23 @@ pub fn resolve_defaults_from_runtime_port<
 /// bootstrap fallback so a fresh deployment can talk to a provider
 /// before any key has been written to the vault.
 ///
-/// Aliased lookup (`credential_alias = Some(..)`):
-/// 1. Vault secret path: `red.secret.ai.<provider>.<alias>.api_key`
-/// 2. Vault secret indirected via `red.config.ai.<provider>.<alias>.secret_ref`
-/// 3. Env fallback with alias: `REDDB_<PROVIDER>_API_KEY_{ALIAS}`
-/// 4. Legacy KV config: `red.config.ai.<provider>.<alias>.key`
+/// Resolution order (issue #1745 — clean break, no deprecation window):
+/// 1. Vault token path: `red.secret.ai.providers.<provider>.tokens.<alias>`
+/// 2. Vault token indirected via
+///    `red.config.ai.providers.<provider>.tokens.<alias>.secret_ref`
+/// 3. Env fallback: `REDDB_<PROVIDER>_API_KEY[_<ALIAS>]`
 ///
-/// Default lookup (`credential_alias = None`):
-/// 1. Vault secret path: `red.secret.ai.<provider>.default.api_key`
-/// 2. Vault secret indirected via `secret_ref`
-/// 3. Env fallback: `REDDB_<PROVIDER>_API_KEY`
-/// 4. Legacy KV config (`red.config.ai.<provider>.default.key` and the
-///    short `<provider>/default` form)
+/// The alias `default` is implicit when `credential_alias = None`. First
+/// non-empty source wins per request.
+///
+/// The old vault path shape (`red.secret.ai.<provider>.<alias>.api_key`)
+/// and the legacy plaintext config path (`red.config.ai.<provider>.<alias>.key`)
+/// are **removed**: a credential still sitting at either is rejected with a
+/// didactic error naming the new vault path to populate — never silently
+/// read.
 ///
 /// `kv_getter` receives either a `red.secret.*` path (routed to the
-/// encrypted vault by [`resolve_api_key_from_runtime`]) or a legacy
+/// encrypted vault by [`resolve_api_key_from_runtime`]) or a
 /// `red.config.*` key and returns the value if found. Vault-stored keys
 /// are therefore encrypted at rest and rotatable via the existing vault
 /// KV path; the env vars carry no such guarantees, which is why they are
@@ -1934,13 +2012,13 @@ where
     }
 
     if let Some(alias) = credential_alias.map(str::trim).filter(|a| !a.is_empty()) {
-        // 1. Vault secret path (managed, encrypted at rest).
+        // 1. Vault token path (managed, encrypted at rest).
         if let Some(key) = kv_getter(&ai_api_secret_path(provider, alias))? {
             if !key.trim().is_empty() {
                 return Ok(key);
             }
         }
-        // 2. Vault secret reachable through a configured indirection ref.
+        // 2. Vault token reachable through a configured indirection ref.
         if let Some(secret_ref) = kv_getter(&ai_api_secret_ref_config_key(provider, alias))? {
             if let Some(key) = kv_getter(secret_ref.trim())? {
                 if !key.trim().is_empty() {
@@ -1952,26 +2030,24 @@ where
         if let Some(key) = resolve_key_from_env_alias(provider, alias) {
             return Ok(key);
         }
-        let legacy_key = ai_api_legacy_config_key(provider, alias);
-        if let Some(key) = kv_getter(&legacy_key)? {
-            if !key.trim().is_empty() {
-                return Ok(key);
-            }
-        }
+        // Clean break: a credential still sitting at a removed path is
+        // rejected didactically, never silently read (issue #1745).
+        reject_removed_credential_paths(provider, alias, &kv_getter)?;
         return Err(crate::RedDBError::Query(format!(
-            "credential '{alias}' not found for {}. Set env {} or store it in the vault",
+            "credential '{alias}' not found for {}. Set env {} or store it in the vault at '{}'",
             provider.token(),
-            provider.alias_key_env_name(alias)
+            provider.alias_key_env_name(alias),
+            ai_api_secret_path(provider, alias),
         )));
     }
 
-    // 1. Vault secret path (managed, encrypted at rest).
+    // 1. Vault token path (managed, encrypted at rest).
     if let Some(key) = kv_getter(&ai_api_secret_path(provider, "default"))? {
         if !key.trim().is_empty() {
             return Ok(key);
         }
     }
-    // 2. Vault secret reachable through a configured indirection ref.
+    // 2. Vault token reachable through a configured indirection ref.
     if let Some(secret_ref) = kv_getter(&ai_api_secret_ref_config_key(provider, "default"))? {
         if let Some(key) = kv_getter(secret_ref.trim())? {
             if !key.trim().is_empty() {
@@ -1988,27 +2064,40 @@ where
         }
     }
 
-    if let Some(key) = kv_getter(&ai_api_legacy_config_key(provider, "default"))? {
-        if !key.trim().is_empty() {
-            return Ok(key);
-        }
-    }
-
-    let legacy_short_key = format!("{}/default", provider.token());
-    if let Some(key) = kv_getter(&legacy_short_key)? {
-        if !key.trim().is_empty() {
-            return Ok(key);
-        }
-    }
+    // Clean break: reject a credential still sitting at a removed path
+    // instead of silently reading it (issue #1745).
+    reject_removed_credential_paths(provider, "default", &kv_getter)?;
 
     Err(crate::RedDBError::Query(format!(
-        "missing {} API key. Set {} or provide credential alias",
+        "missing {} API key. Set {} or store it in the vault at '{}'",
         provider.token(),
-        provider.default_key_env_name()
+        provider.default_key_env_name(),
+        ai_api_secret_path(provider, "default"),
     )))
 }
 
+/// Vault token path (issue #1745): the sole credential source in the vault.
 pub fn ai_api_secret_path(provider: &AiProvider, alias: &str) -> String {
+    format!(
+        "red.secret.ai.providers.{}.tokens.{}",
+        provider.token(),
+        normalize_credential_alias_path(alias)
+    )
+}
+
+/// Config key holding a vault indirection ref for the token (issue #1745).
+pub fn ai_api_secret_ref_config_key(provider: &AiProvider, alias: &str) -> String {
+    format!(
+        "red.config.ai.providers.{}.tokens.{}.secret_ref",
+        provider.token(),
+        normalize_credential_alias_path(alias)
+    )
+}
+
+/// Removed vault path shape (`red.secret.ai.<provider>.<alias>.api_key`,
+/// issue #1745). Probed ONLY to reject with a migration error — never read
+/// as a credential source.
+fn removed_vault_api_key_path(provider: &AiProvider, alias: &str) -> String {
     format!(
         "red.secret.ai.{}.{}.api_key",
         provider.token(),
@@ -2016,20 +2105,43 @@ pub fn ai_api_secret_path(provider: &AiProvider, alias: &str) -> String {
     )
 }
 
-pub fn ai_api_secret_ref_config_key(provider: &AiProvider, alias: &str) -> String {
-    format!(
-        "red.config.ai.{}.{}.secret_ref",
-        provider.token(),
-        normalize_credential_alias_path(alias)
-    )
-}
-
-pub fn ai_api_legacy_config_key(provider: &AiProvider, alias: &str) -> String {
+/// Removed plaintext config path (`red.config.ai.<provider>.<alias>.key`,
+/// issue #1745). Probed ONLY to reject with a migration error.
+fn removed_plaintext_config_key(provider: &AiProvider, alias: &str) -> String {
     format!(
         "red.config.ai.{}.{}.key",
         provider.token(),
         normalize_credential_alias_path(alias)
     )
+}
+
+/// Fail with a didactic error if a credential is still parked at either of
+/// the removed paths (old vault shape or legacy plaintext config). The
+/// clean break forbids silently falling back to them (issue #1745).
+fn reject_removed_credential_paths<F>(
+    provider: &AiProvider,
+    alias: &str,
+    kv_getter: &F,
+) -> crate::RedDBResult<()>
+where
+    F: Fn(&str) -> crate::RedDBResult<Option<String>>,
+{
+    let new_path = ai_api_secret_path(provider, alias);
+    for removed in [
+        removed_vault_api_key_path(provider, alias),
+        removed_plaintext_config_key(provider, alias),
+    ] {
+        if let Some(value) = kv_getter(&removed)? {
+            if !value.trim().is_empty() {
+                return Err(crate::RedDBError::Query(format!(
+                    "AI credential found at removed path '{removed}'. The AI credential vault \
+                     path changed (issue #1745): store the token at '{new_path}' instead. The \
+                     old vault path shape and the legacy plaintext config path are no longer read."
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn normalize_credential_alias_path(alias: &str) -> String {
@@ -2067,7 +2179,8 @@ fn normalize_alias_token(alias: &str) -> String {
 /// Convenience: resolve API key using a RedDBRuntime's KV store.
 ///
 /// Emits an `ai.credential.resolve` audit event so operators can answer
-/// "which principal caused us to read `red.secret.ai.<provider>.*`?"
+/// "which principal caused us to read
+/// `red.secret.ai.providers.<provider>.tokens.*`?"
 /// even though the read itself is performed as system (the AI subsystem
 /// must always be able to fetch the key the query needs — denying it
 /// would be denying the query at the wrong layer). The audit record

--- a/crates/reddb-server/src/auth/policies.rs
+++ b/crates/reddb-server/src/auth/policies.rs
@@ -1620,6 +1620,26 @@ mod tests {
     }
 
     #[test]
+    fn glob_ai_credential_alias_paths_are_separable_per_alias() {
+        // Policy separability (#1745): a vault grant scoped to a tenant
+        // alias's token sub-path must NOT reach the `default` alias token.
+        // The new path shape `red.secret.ai.providers.<p>.tokens.<alias>`
+        // puts the alias in a distinct trailing segment, so an alias-scoped
+        // glob cannot match another alias.
+        let prod = compile_glob("vault:red.vault/red.secret.ai.providers.openai.tokens.prod*");
+        assert!(glob_matches(
+            &prod,
+            "vault:red.vault/red.secret.ai.providers.openai.tokens.prod"
+        ));
+        // Granting write on the `prod` alias sub-path grants no read of the
+        // `default` alias token.
+        assert!(!glob_matches(
+            &prod,
+            "vault:red.vault/red.secret.ai.providers.openai.tokens.default"
+        ));
+    }
+
+    #[test]
     fn action_match_exact() {
         assert!(action_matches(&compile_action("select"), "select"));
         assert!(!action_matches(&compile_action("select"), "selectall"));

--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -650,7 +650,7 @@ mod tests {
                 "vault-aes-key".to_string(),
             ),
             (
-                "red.secret.ai.anthropic.default.api_key".to_string(),
+                "red.secret.ai.providers.anthropic.tokens.default".to_string(),
                 "provider-key".to_string(),
             ),
             ("acme.key".to_string(), "user-value".to_string()),
@@ -659,8 +659,14 @@ mod tests {
         with_secret_values(values, || {
             assert_eq!(current_secret_value("red.vault/aes_key"), None);
             assert_eq!(current_secret_value("red.vault/red.secret.aes_key"), None);
+            // The AI provider-token namespace is hard-blocked from `$secret`
+            // regardless of role, on the new path shape (#1745).
             assert_eq!(
-                current_secret_value("red.vault/ai.anthropic.default.api_key"),
+                current_secret_value("red.vault/ai.providers.anthropic.tokens.default"),
+                None
+            );
+            assert_eq!(
+                current_secret_value("red.vault/red.secret.ai.providers.anthropic.tokens.default"),
                 None
             );
             assert_eq!(

--- a/crates/reddb-server/src/runtime/impl_config_secret.rs
+++ b/crates/reddb-server/src/runtime/impl_config_secret.rs
@@ -64,7 +64,7 @@ mod tests {
     fn show_secrets_allows_only_user_managed_keys() {
         assert!(!show_secrets_allows_key("red.secret.aes_key"));
         assert!(!show_secrets_allows_key(
-            "red.secret.ai.anthropic.default.api_key"
+            "red.secret.ai.providers.anthropic.tokens.default"
         ));
         assert!(!show_secrets_allows_key("red.config.ai.default.provider"));
         assert!(show_secrets_allows_key("acme.key"));

--- a/crates/reddb-server/src/server/handlers_ai.rs
+++ b/crates/reddb-server/src/server/handlers_ai.rs
@@ -1152,10 +1152,6 @@ impl RedDBServer {
             let _ = self
                 .entity_use_cases()
                 .delete_kv(RED_CONFIG_COLLECTION, &key_name);
-            let legacy_key = crate::ai::ai_api_legacy_config_key(&provider, alias);
-            let _ = self
-                .entity_use_cases()
-                .delete_kv(RED_CONFIG_COLLECTION, &legacy_key);
             match self.entity_use_cases().create_kv(CreateKvInput {
                 collection: RED_CONFIG_COLLECTION.to_string(),
                 key: key_name.clone(),
@@ -1802,9 +1798,10 @@ struct LocalAiModelSpec {
     pull_policy: String,
     trust_policy: String,
     /// Vault alias used to resolve provider credentials for the pull
-    /// (currently HuggingFace). Resolves via `red.secret.ai.{provider}.{alias}`
-    /// per the shared `resolve_api_key` contract. Plaintext secrets are
-    /// never accepted at this boundary.
+    /// (currently HuggingFace). Resolves via
+    /// `red.secret.ai.providers.{provider}.tokens.{alias}` per the shared
+    /// `resolve_api_key` contract. Plaintext secrets are never accepted at
+    /// this boundary.
     credential_alias: Option<String>,
 }
 
@@ -1817,7 +1814,7 @@ impl LocalAiModelSpec {
                 return Err(format!(
                     "field '{field}' is rejected: registered models must not store plaintext \
                      provider credentials. Use 'credential_alias' and store the secret in the \
-                     vault at 'red.secret.ai.{{provider}}.{{alias}}' instead."
+                     vault at 'red.secret.ai.providers.{{provider}}.tokens.{{alias}}' instead."
                 ));
             }
         }
@@ -2432,11 +2429,11 @@ mod tests {
             .0;
         assert_eq!(ref_value, Value::Text(secret_path.clone().into()));
 
-        let legacy_key = crate::ai::ai_api_legacy_config_key(&AiProvider::OpenAi, &alias);
+        let removed_legacy = format!("red.config.ai.openai.{alias}.key");
         assert!(
             server
                 .entity_use_cases()
-                .get_kv(RED_CONFIG_COLLECTION, &legacy_key)
+                .get_kv(RED_CONFIG_COLLECTION, &removed_legacy)
                 .expect("read legacy")
                 .is_none(),
             "legacy plaintext config key must not be written"
@@ -3152,9 +3149,9 @@ mod tests {
 
     #[test]
     fn pull_with_unset_credential_alias_errors_with_vault_remediation() {
-        // The model entry has credential_alias=hf_prod but no secret
-        // has been stored at red.secret.ai.huggingface.hf_prod, so the
-        // pull must fail before touching the cache and the error must
+        // The model entry has credential_alias=hf_prod but no secret has
+        // been stored at red.secret.ai.providers.huggingface.tokens.hf_prod,
+        // so the pull must fail before touching the cache and the error must
         // point the operator at the vault path.
         let (server, path) = make_server("pull_alias_unset");
         let resp =
@@ -3167,7 +3164,8 @@ mod tests {
         assert_eq!(resp.status, 400, "expected 400 missing-credential");
         let body = String::from_utf8_lossy(&resp.body);
         assert!(
-            body.contains("hf_prod") && body.contains("red.secret.ai.huggingface.hf_prod"),
+            body.contains("hf_prod")
+                && body.contains("red.secret.ai.providers.huggingface.tokens.hf_prod"),
             "vault remediation missing: {body}"
         );
         let _ = std::fs::remove_file(path);
@@ -3182,28 +3180,18 @@ mod tests {
         let resp =
             register_local_model_with(&server, "mini", 4, r#", "credential_alias":"hf_prod""#);
         assert_eq!(resp.status, 201);
-        // Stage the credential via the legacy config KV path. The
-        // resolver walks vault (red.secret.*) → env → legacy
-        // (red.config.*.key), so a value here is the simplest stand-in
-        // for a real vault that does not need an AuthStore set up.
-        let legacy_key =
-            crate::ai::ai_api_legacy_config_key(&crate::ai::AiProvider::HuggingFace, "hf_prod");
-        server
-            .entity_use_cases()
-            .create_kv(CreateKvInput {
-                collection: RED_CONFIG_COLLECTION.to_string(),
-                key: legacy_key,
-                value: Value::text("hf_real_token"),
-                metadata: Vec::new(),
-            })
-            .expect("stage credential");
-        std::env::remove_var("REDDB_HUGGINGFACE_API_KEY_HF_PROD");
+        // Stage the credential via the env fallback (the resolution order is
+        // vault → secret_ref → env). Env is the simplest stand-in that does
+        // not need an AuthStore-backed vault set up in this unit test. The
+        // removed legacy plaintext config path is no longer read (#1745).
+        std::env::set_var("REDDB_HUGGINGFACE_API_KEY_HF_PROD", "hf_real_token");
         std::env::remove_var("REDDB_HUGGINGFACE_API_KEY");
 
         // No fixture_dir → the fixture stage fails. We assert the
         // error is the fixture-stage error, proving credential
         // resolution passed.
         let resp = server.handle_ai_model_pull("mini", Vec::new());
+        std::env::remove_var("REDDB_HUGGINGFACE_API_KEY_HF_PROD");
         assert_eq!(resp.status, 400);
         let body = String::from_utf8_lossy(&resp.body);
         assert!(

--- a/crates/reddb-server/src/server/handlers_ai_model_cache.rs
+++ b/crates/reddb-server/src/server/handlers_ai_model_cache.rs
@@ -88,7 +88,8 @@ impl RedDBServer {
                     400,
                     format!(
                         "field '{field}' is rejected: pull must not accept plaintext credentials. \
-                         Store the secret in the vault at 'red.secret.ai.huggingface.{{alias}}' and \
+                         Store the secret in the vault at \
+                         'red.secret.ai.providers.huggingface.tokens.{{alias}}' and \
                          reference it via the model's 'credential_alias' or pass 'credential_alias' \
                          on the pull request."
                     ),
@@ -307,14 +308,16 @@ impl RedDBServer {
                 400,
                 format!(
                     "credential_alias '{alias}' resolved to an empty secret; store the \
-                     HuggingFace token at 'red.secret.ai.huggingface.{alias}' before pulling"
+                     HuggingFace token at \
+                     'red.secret.ai.providers.huggingface.tokens.{alias}' before pulling"
                 ),
             )),
             Err(err) => Err((
                 400,
                 format!(
                     "failed to resolve HuggingFace credentials for alias '{alias}': {err}. \
-                     Store the token at 'red.secret.ai.huggingface.{alias}' in the vault."
+                     Store the token at \
+                     'red.secret.ai.providers.huggingface.tokens.{alias}' in the vault."
                 ),
             )),
         }

--- a/crates/reddb-server/src/server/handlers_query.rs
+++ b/crates/reddb-server/src/server/handlers_query.rs
@@ -2554,10 +2554,8 @@ mod tests {
             .runtime
             .execute_query("SET CONFIG runtime.ai.transport_retry_max_attempts = 1")
             .expect("disable retries");
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.openai.default.key = 'sk-test'")
-            .expect("set api key");
+        // Legacy plaintext config path removed (#1745); provision via env.
+        std::env::set_var("REDDB_OPENAI_API_KEY", "sk-test");
 
         let r = server.handle_query(br#"{"query": "ASK 'why did login fail?'"}"#.to_vec());
 
@@ -2583,10 +2581,8 @@ mod tests {
             .runtime
             .execute_query("SET CONFIG runtime.ai.transport_retry_max_attempts = 1")
             .expect("disable retries");
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.openai.default.key = 'sk-test'")
-            .expect("set api key");
+        // Legacy plaintext config path removed (#1745); provision via env.
+        std::env::set_var("REDDB_OPENAI_API_KEY", "sk-test");
 
         let r = server.handle_query(br#"{"query": "ASK 'why did login fail?'"}"#.to_vec());
 
@@ -2966,10 +2962,8 @@ mod tests {
 
         let server = make_server();
         configure_ask_stub_runtime(&server);
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.groq.default.key = 'sk-groq'")
-            .expect("set groq api key");
+        // Legacy plaintext config path removed (#1745); provision via env.
+        std::env::set_var("REDDB_GROQ_API_KEY", "sk-groq");
 
         let r = server.handle_query(
             br#"{"query": "ASK 'why did login fail?' USING 'groq,openai' TEMPERATURE 0.7 SEED 42"}"#.to_vec(),
@@ -3019,10 +3013,8 @@ mod tests {
 
         let server = make_server();
         configure_ask_stub_runtime(&server);
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.groq.default.key = 'sk-groq'")
-            .expect("set groq api key");
+        // Legacy plaintext config path removed (#1745); provision via env.
+        std::env::set_var("REDDB_GROQ_API_KEY", "sk-groq");
         server
             .runtime
             .execute_query("SET CONFIG ask.providers.fallback = 'groq,openai'")
@@ -3054,10 +3046,8 @@ mod tests {
 
         let server = make_server();
         configure_ask_stub_runtime(&server);
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.groq.default.key = 'sk-groq'")
-            .expect("set groq api key");
+        // Legacy plaintext config path removed (#1745); provision via env.
+        std::env::set_var("REDDB_GROQ_API_KEY", "sk-groq");
 
         let r = server.handle_query(
             br#"{"query": "ASK 'why did login fail?' USING 'groq,openai'"}"#.to_vec(),
@@ -3341,10 +3331,10 @@ mod tests {
             .runtime
             .execute_query("SET CONFIG runtime.ai.transport_retry_max_attempts = 1")
             .expect("disable transport retries");
-        server
-            .runtime
-            .execute_query("SET CONFIG red.config.ai.openai.default.key = 'sk-test'")
-            .expect("set api key");
+        // Provision the credential via the env fallback. The legacy plaintext
+        // config path was removed (#1745); callers hold ASK_ENV_LOCK and an
+        // EnvVarGuard for this var, so the value is scoped to the test.
+        std::env::set_var("REDDB_OPENAI_API_KEY", "sk-test");
     }
 
     fn ask_audit_rows(server: &RedDBServer) -> Vec<BTreeMap<String, crate::json::Value>> {

--- a/docs/guides/ai-providers.md
+++ b/docs/guides/ai-providers.md
@@ -155,7 +155,7 @@ the primary source.
 **Canonical vault path:**
 
 ```
-red.secret.ai.<provider>.<alias>.api_key
+red.secret.ai.providers.<provider>.tokens.<alias>
 ```
 
 - `<provider>` matches the **Token** column of the capability matrix
@@ -167,9 +167,9 @@ red.secret.ai.<provider>.<alias>.api_key
 **Stage a key** (after `CREATE VAULT secrets` + `VAULT UNSEAL`):
 
 ```bash
-reddb-cli vault set red.secret.ai.openai.default.api_key "sk-..."
-reddb-cli vault set red.secret.ai.huggingface.default.api_key "hf_..."
-reddb-cli vault set red.secret.ai.openai.prod.api_key "sk-prod-..."
+reddb-cli vault set red.secret.ai.providers.openai.tokens.default "sk-..."
+reddb-cli vault set red.secret.ai.providers.huggingface.tokens.default "hf_..."
+reddb-cli vault set red.secret.ai.providers.openai.tokens.prod "sk-prod-..."
 ```
 
 Vault setup itself is covered in [Security → Vault](/security/vault.md).
@@ -177,14 +177,21 @@ Vault setup itself is covered in [Security → Vault](/security/vault.md).
 **Resolution order** (first non-empty wins, per request — vault first, env as a
 bootstrap fallback):
 
-1. Vault secret: `red.secret.ai.<provider>.<alias>.api_key`
-2. Vault indirection: `red.config.ai.<provider>.<alias>.secret_ref` points at another vault path
+1. Vault token: `red.secret.ai.providers.<provider>.tokens.<alias>`
+2. Vault indirection: `red.config.ai.providers.<provider>.tokens.<alias>.secret_ref` points at another vault path
 3. Env var `REDDB_<PROVIDER>_API_KEY_<ALIAS>` (or `REDDB_<PROVIDER>_API_KEY` for the default alias)
-4. Legacy plaintext config: `red.config.ai.<provider>.<alias>.key` (deprecated — do not use for new deployments)
 
 For the **default** alias (no `"credential"` in the request), the vault path is
-`red.secret.ai.<provider>.default.api_key` and the env fallback is
+`red.secret.ai.providers.<provider>.tokens.default` and the env fallback is
 `REDDB_<PROVIDER>_API_KEY`.
+
+> **Clean break (issue #1745).** The old vault path shape
+> (`red.secret.ai.<provider>.<alias>.api_key`) and the deprecated plaintext
+> config path (`red.config.ai.<provider>.<alias>.key`) are **removed** — there
+> is no deprecation window. A credential still parked at either is rejected
+> with a didactic error naming the new vault path to populate; it is never
+> silently read. Migrate any staged keys to the `providers.<provider>.tokens.<alias>`
+> shape.
 
 A missing key surfaces as a `400` with the exact path the operator
 should populate. There is no silent fallback to a different alias or
@@ -193,7 +200,7 @@ provider.
 **Use the staged key from SQL or HTTP:**
 
 ```sql
--- uses red.secret.ai.openai.default.api_key (default alias is implicit)
+-- uses red.secret.ai.providers.openai.tokens.default (default alias is implicit)
 INSERT INTO docs (body) VALUES ('hello')
   WITH AUTO EMBED (body) USING openai;
 
@@ -220,7 +227,7 @@ namespace off-limits — even from admin:
 
 ```json
 {"effect":"deny","actions":["vault:read","vault:write"],
- "resources":["vault:red.vault/red.secret.ai.custom.*"]}
+ "resources":["vault:red.vault/red.secret.ai.providers.custom.*"]}
 ```
 
 See [Security → Vault](/security/vault.md#locking-down-secrets-by-path-with-policies)

--- a/docs/guides/local-embeddings.md
+++ b/docs/guides/local-embeddings.md
@@ -156,10 +156,10 @@ The pull endpoint:
 1. Looks up the model in the registry (404 if missing).
 2. Rejects any plaintext-credential field on the request body. Tokens
    must already be in the vault and referenced via `credential_alias`.
-3. Resolves provider credentials when `credential_alias` is set (env →
-   vault `red.secret.ai.huggingface.{alias}.api_key` → legacy config).
-   Empty / missing resolutions are a 400 — the operator either staged
-   the secret or did not, no silent fallback.
+3. Resolves provider credentials when `credential_alias` is set (vault
+   `red.secret.ai.providers.huggingface.tokens.{alias}` → `secret_ref`
+   indirection → env fallback). Empty / missing resolutions are a 400 —
+   the operator either staged the secret or did not, no silent fallback.
 4. Locates the artifact source. Today RedDB pulls from a local fixture
    directory (`fixture_dir` on the request, or
    `red.config.ai.local.fixture_dir` in `red_config`). Live HuggingFace
@@ -255,7 +255,7 @@ gated / private repos:
 1. Stage the token in the vault under the canonical AI secret path:
 
    ```bash
-   reddb-cli vault set red.secret.ai.huggingface.{alias}.api_key "hf_xxx"
+   reddb-cli vault set red.secret.ai.providers.huggingface.tokens.{alias} "hf_xxx"
    ```
 
 2. Reference it from the model:
@@ -271,11 +271,14 @@ gated / private repos:
         -d '{"fixture_dir":"...", "credential_alias":"{alias}"}'
    ```
 
-The resolution order at pull time is env (`REDDB_HUGGINGFACE_API_KEY_{ALIAS}`)
-→ vault (`red.secret.ai.huggingface.{alias}.api_key`) → legacy config
-(`red.config.ai.huggingface.{alias}.key`). A non-empty resolution is
-required when `credential_alias` is set — RedDB does not silently fall
-back to "no auth" if the operator named an alias.
+The resolution order at pull time is vault
+(`red.secret.ai.providers.huggingface.tokens.{alias}`) → `secret_ref`
+indirection → env fallback (`REDDB_HUGGINGFACE_API_KEY_{ALIAS}`). A non-empty
+resolution is required when `credential_alias` is set — RedDB does not silently
+fall back to "no auth" if the operator named an alias. The old
+`red.secret.ai.huggingface.{alias}.api_key` vault shape and the legacy plaintext
+`red.config.ai.huggingface.{alias}.key` path were removed in the same release
+(issue #1745, no deprecation window).
 
 **The boundary never accepts plaintext.** Both the model-register
 endpoint and the pull endpoint reject `api_key`, `token`, `hf_token`,

--- a/docs/security/config-secrets-vault-design.md
+++ b/docs/security/config-secrets-vault-design.md
@@ -62,7 +62,7 @@ SET CONFIG mycompany.C.Z.W = NULL; -- delete
 Secret writes:
 
 ```sql
-SET SECRET red.secret.ai.openai.default.api_key = 'sk_...';
+SET SECRET red.secret.ai.providers.openai.tokens.default = 'sk_...';
 SET SECRET mycompany.payments.stripe.key = 'sk_...';
 DELETE SECRET mycompany.payments.stripe.key;
 SET SECRET mycompany.payments.stripe.key = NULL; -- delete
@@ -81,7 +81,7 @@ Variable reads:
 SELECT $red.config.backup.enabled;
 SELECT $config.mycompany.C.Z.W;
 
-SELECT $red.secret.ai.openai.default.api_key; -- returns ***
+SELECT $red.secret.ai.providers.openai.tokens.default; -- returns ***
 SELECT $secret.mycompany.payments.stripe.key; -- returns ***
 ```
 
@@ -363,8 +363,8 @@ Initial consumers:
 AI credential storage contract:
 
 ```text
-red.secret.ai.<provider>.<alias>.api_key
-red.config.ai.<provider>.<alias>.api_key = &red.secret.ai.<provider>.<alias>.api_key
+red.secret.ai.providers.<provider>.tokens.<alias>
+red.config.ai.providers.<provider>.tokens.<alias>.secret_ref = 'red.secret.ai.providers.<provider>.tokens.<alias>'
 red.config.ai.<provider>.<alias>.base_url = 'https://...'
 red.config.ai.default.provider = 'openai'
 red.config.ai.default.model = '...'
@@ -625,7 +625,7 @@ for efficiency:
 CLI must support safe secret input without shell history:
 
 ```bash
-red secret set red.secret.ai.openai.default.api_key --stdin
+red secret set red.secret.ai.providers.openai.tokens.default --stdin
 red secret set red.secret.mtls.private_key --file /run/secrets/tls.key
 red secret list
 red secret delete mycompany.payments.stripe.key
@@ -648,9 +648,13 @@ Config file import may include secret references, not secret values:
   "red": {
     "config": {
       "ai": {
-        "openai": {
-          "default": {
-            "api_key": {"$secret": "red.secret.ai.openai.default.api_key"}
+        "providers": {
+          "openai": {
+            "tokens": {
+              "default": {
+                "secret_ref": {"$secret": "red.secret.ai.providers.openai.tokens.default"}
+              }
+            }
           }
         }
       }

--- a/docs/security/vault.md
+++ b/docs/security/vault.md
@@ -329,7 +329,7 @@ SHOW CONFIG red.secret.stripe;
 
 Vault actions are policy-evaluable per resource path. The resource is
 `vault:<collection>/<key>` and supports segment globbing, so a single
-policy can cover an entire prefix like `red.secret.ai.*`.
+policy can cover an entire prefix like `red.secret.ai.providers.*`.
 
 | Action | Gates |
 |:---|:---|
@@ -351,7 +351,7 @@ admin) can read or rotate it:**
       "sid": "no-read-ai-custom",
       "effect": "deny",
       "actions": ["vault:read", "vault:read_metadata", "vault:write"],
-      "resources": ["vault:red.vault/red.secret.ai.custom.*"]
+      "resources": ["vault:red.vault/red.secret.ai.providers.custom.*"]
     }
   ]
 }
@@ -371,7 +371,7 @@ everyone else:**
       "sid": "allow-keeper",
       "effect": "allow",
       "actions": ["vault:read"],
-      "resources": ["vault:red.vault/red.secret.ai.openai.*"]
+      "resources": ["vault:red.vault/red.secret.ai.providers.openai.*"]
     }
   ]
 }


### PR DESCRIPTION
Automated AFK landing for #1745. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1745

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785816649&installation_id=129708444&pr_number=1753&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1753&signature=9f93d0135ccb437185722c6d35245b51f3665cfb364020d3f4e86bc636bed637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->