### PR TITLE
merge: #1746 AI config schema clean break: ask block, per-provider modality models, inference/embeddings task pointers

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -1918,7 +1918,9 @@ pub struct InsertQuery {
 pub struct AutoEmbedConfig {
     /// Fields to extract text from for embedding
     pub fields: Vec<String>,
-    /// AI provider (e.g. "openai")
+    /// AI provider from an explicit `USING <provider>`. Empty when none was
+    /// given — the runtime then resolves it via the embeddings task pointer
+    /// `red.config.ai.embeddings.provider` (ADR-0068 §5).
     pub provider: String,
     /// Optional model override
     pub model: Option<String>,

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -310,10 +310,13 @@ impl<'a> Parser<'a> {
                 // `consume_ident_ci` would never match. Use the typed
                 // consumer instead. See bug #108 (mirrors the #92 fix
                 // for migration `DEPENDS ON`).
+                // Empty means "no explicit provider" — the runtime resolves
+                // it via the embeddings task pointer (ADR-0068 §5). Only an
+                // explicit `USING` names a provider here.
                 let provider = if self.consume(&Token::Using)? {
                     self.expect_ident()?
                 } else {
-                    "openai".to_string()
+                    String::new()
                 };
                 let model = if self.consume_ident_ci("MODEL")? {
                     Some(self.parse_string()?)

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -1866,7 +1866,9 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
         panic!("Expected InsertQuery");
     };
     let auto_embed = insert.auto_embed.expect("auto embed config");
-    assert_eq!(auto_embed.provider, "openai");
+    // No `USING` → empty provider; runtime resolves via the embeddings task
+    // pointer (ADR-0068 §5) rather than a hardcoded default.
+    assert_eq!(auto_embed.provider, "");
     assert_eq!(auto_embed.model, None);
 
     let query = parse(

--- a/crates/reddb-server/src/ai.rs
+++ b/crates/reddb-server/src/ai.rs
@@ -1652,14 +1652,198 @@ mod tests {
 
     #[test]
     fn resolve_default_provider_honors_mode_key() {
+        // The wire-protocol mode selector still wins over the task pointer.
         let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
             match key {
                 "red.config.ai.provider" => Ok(Some("anthropic-native".to_string())),
-                "red.config.ai.default.provider" => Ok(Some("groq".to_string())),
+                "red.config.ai.inference.provider" => Ok(Some("groq".to_string())),
                 _ => Ok(None),
             }
         };
         assert_eq!(resolve_default_provider(&kv), AiProvider::Anthropic);
+    }
+
+    // ---- ADR-0068 §5 config schema (issue #1746) --------------------------
+
+    #[test]
+    fn inference_provider_ask_specific_beats_task_pointer() {
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.ask.provider" => Ok(Some("groq".to_string())),
+                "red.config.ai.inference.provider" => Ok(Some("deepseek".to_string())),
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(resolve_default_provider(&kv), AiProvider::Groq);
+    }
+
+    #[test]
+    fn inference_provider_falls_through_to_task_pointer_then_default() {
+        let pointer = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.inference.provider" => Ok(Some("deepseek".to_string())),
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(resolve_default_provider(&pointer), AiProvider::DeepSeek);
+
+        let empty = |_: &str| -> crate::RedDBResult<Option<String>> { Ok(None) };
+        assert_eq!(resolve_default_provider(&empty), AiProvider::OpenAi);
+    }
+
+    #[test]
+    fn inference_model_ask_specific_beats_models_block_beats_builtin() {
+        let ask = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.ask.model" => Ok(Some("gpt-ask".to_string())),
+                "red.config.ai.providers.openai.models.inference" => {
+                    Ok(Some("gpt-block".to_string()))
+                }
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(resolve_default_model(&AiProvider::OpenAi, &ask), "gpt-ask");
+
+        let block = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.providers.openai.models.inference" => {
+                    Ok(Some("gpt-block".to_string()))
+                }
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(
+            resolve_default_model(&AiProvider::OpenAi, &block),
+            "gpt-block"
+        );
+
+        let empty = |_: &str| -> crate::RedDBResult<Option<String>> { Ok(None) };
+        assert_eq!(
+            resolve_default_model(&AiProvider::OpenAi, &empty),
+            AiProvider::OpenAi.default_prompt_model()
+        );
+    }
+
+    #[test]
+    fn embeddings_provider_follows_task_pointer() {
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.embeddings.provider" => Ok(Some("ollama".to_string())),
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(
+            resolve_embeddings_provider(&kv).unwrap(),
+            AiProvider::Ollama
+        );
+
+        let empty = |_: &str| -> crate::RedDBResult<Option<String>> { Ok(None) };
+        assert_eq!(
+            resolve_embeddings_provider(&empty).unwrap(),
+            AiProvider::OpenAi
+        );
+    }
+
+    #[test]
+    fn embeddings_provider_rejects_modality_incapable_pointer() {
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.embeddings.provider" => Ok(Some("anthropic".to_string())),
+                _ => Ok(None),
+            }
+        };
+        let err = resolve_embeddings_provider(&kv).unwrap_err().to_string();
+        assert!(
+            err.contains("red.config.ai.embeddings.provider"),
+            "error must name the pointer to fix: {err}"
+        );
+        assert!(
+            err.contains("openai") && err.contains("no embeddings API"),
+            "error must name capable alternatives: {err}"
+        );
+    }
+
+    #[test]
+    fn embeddings_model_block_beats_builtin() {
+        let block = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.providers.openai.models.embeddings" => {
+                    Ok(Some("text-embedding-custom".to_string()))
+                }
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(
+            resolve_embeddings_model(&AiProvider::OpenAi, &block),
+            "text-embedding-custom"
+        );
+
+        let empty = |_: &str| -> crate::RedDBResult<Option<String>> { Ok(None) };
+        assert_eq!(
+            resolve_embeddings_model(&AiProvider::Ollama, &empty),
+            AiProvider::Ollama.default_embedding_model()
+        );
+    }
+
+    #[test]
+    fn base_url_reads_provider_block_key() {
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            if key == "red.config.ai.providers.openai.base_url" {
+                Ok(Some("https://proxy.example/v1".to_string()))
+            } else {
+                Ok(None)
+            }
+        };
+        assert_eq!(
+            AiProvider::OpenAi.resolve_api_base_with_kv("default", &kv),
+            "https://proxy.example/v1"
+        );
+    }
+
+    #[test]
+    fn removed_config_keys_rejected_naming_replacements() {
+        let err = validate_ai_config_key_on_write("red.config.ai.default.provider")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("red.config.ai.inference.provider"), "{err}");
+
+        let err = validate_ai_config_key_on_write("red.config.ai.default.model")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("red.config.ai.providers.<provider>.models.inference"),
+            "{err}"
+        );
+
+        let err = validate_ai_config_key_on_write("red.config.ai.openai.default.base_url")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("red.config.ai.providers.<provider>.base_url"),
+            "{err}"
+        );
+
+        // New-schema keys and unrelated keys are accepted.
+        assert!(validate_ai_config_key_on_write("red.config.ai.inference.provider").is_ok());
+        assert!(validate_ai_config_key_on_write("red.config.ai.providers.openai.base_url").is_ok());
+        assert!(validate_ai_config_key_on_write("acme.some.other.key").is_ok());
+    }
+
+    #[test]
+    fn ask_planner_model_and_effort_resolve() {
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.ask.planner_model" => Ok(Some("planner-x".to_string())),
+                "red.config.ai.ask.effort" => Ok(Some("high".to_string())),
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(resolve_ask_planner_model(&kv, "fallback"), "planner-x");
+        assert_eq!(resolve_ask_effort(&kv), Some("high".to_string()));
+
+        let empty = |_: &str| -> crate::RedDBResult<Option<String>> { Ok(None) };
+        assert_eq!(resolve_ask_planner_model(&empty, "fallback"), "fallback");
+        assert_eq!(resolve_ask_effort(&empty), None);
     }
 
     #[tokio::test]
@@ -1793,8 +1977,12 @@ impl AiProvider {
         self.default_api_base().to_string()
     }
 
-    /// Resolve API base URL checking KV store too (for custom base_url config).
-    pub fn resolve_api_base_with_kv<F>(&self, alias: &str, kv_getter: &F) -> String
+    /// Resolve API base URL checking KV store too (for custom base_url
+    /// config). ADR-0068 §5 clean break: the base URL now lives at
+    /// `red.config.ai.providers.<provider>.base_url` (per provider, no
+    /// credential alias). The old `red.config.ai.<provider>.<alias>.base_url`
+    /// shape is rejected on write; see [`validate_ai_config_key_on_write`].
+    pub fn resolve_api_base_with_kv<F>(&self, _alias: &str, kv_getter: &F) -> String
     where
         F: Fn(&str) -> crate::RedDBResult<Option<String>>,
     {
@@ -1805,9 +1993,8 @@ impl AiProvider {
                 return value;
             }
         }
-        // 2. KV store: {provider}/{alias}/base_url
-        let kv_key = format!("red.config.ai.{}.{alias}.base_url", self.token());
-        if let Ok(Some(value)) = kv_getter(&kv_key) {
+        // 2. Provider block: red.config.ai.providers.<provider>.base_url
+        if let Ok(Some(value)) = kv_getter(&provider_base_url_key(self)) {
             let value = value.trim().to_string();
             if !value.is_empty() {
                 return value;
@@ -1835,6 +2022,14 @@ impl AiProvider {
     /// Whether this provider requires an API key (Ollama/Local don't).
     pub fn requires_api_key(&self) -> bool {
         !matches!(self, Self::Ollama | Self::Local)
+    }
+
+    /// Whether this provider offers an embeddings API. Anthropic famously
+    /// does not; every other provider RedDB speaks does (Local embeds
+    /// in-process). Used to fail an embeddings task pointer loudly rather
+    /// than silently re-routing to a different provider (ADR-0068 §5).
+    pub fn supports_embeddings(&self) -> bool {
+        !matches!(self, Self::Anthropic)
     }
 }
 
@@ -1866,16 +2061,90 @@ pub fn parse_provider(name: &str) -> crate::RedDBResult<AiProvider> {
     }
 }
 
-/// Resolve the default AI provider. Checks:
-/// 1. `REDDB_AI_PROVIDER` env var
-/// 2. `red_config` KV key `red.config.ai.default.provider`
-/// 3. Falls back to OpenAI
+// ============================================================================
+// AI config schema (ADR-0068 §5) — clean break
+//
+//   red.config.ai.ask.{provider,model,planner_model,effort,max_plan_steps}
+//   red.config.ai.providers.<provider>.base_url
+//   red.config.ai.providers.<provider>.models.{inference,embeddings}
+//   red.config.ai.inference.provider   # task pointer: who generates
+//   red.config.ai.embeddings.provider  # task pointer: who embeds
+//
+// Resolution order for any AI call:
+//   ASK-specific config -> task pointer -> pointed provider's models block
+//   -> provider built-in default.
+//
+// The old flat keys (`red.config.ai.default.provider|model` and the old
+// per-alias `red.config.ai.<provider>.<alias>.base_url` base-URL shape)
+// are removed and rejected on write; there is no deprecation window.
+// ============================================================================
+
+/// Providers that can serve embeddings, listed for didactic errors.
+pub const EMBEDDING_CAPABLE_PROVIDERS: &str =
+    "openai, groq, ollama, openrouter, together, venice, deepseek, minimax, huggingface, local";
+
+/// KV key for a provider's base URL under the new schema.
+pub fn provider_base_url_key(provider: &AiProvider) -> String {
+    format!("red.config.ai.providers.{}.base_url", provider.token())
+}
+
+/// KV key for a provider's per-modality model under the new schema.
+/// `modality` is `"inference"` or `"embeddings"`.
+pub fn provider_models_key(provider: &AiProvider, modality: &str) -> String {
+    format!(
+        "red.config.ai.providers.{}.models.{modality}",
+        provider.token()
+    )
+}
+
+/// Reject an AI config key that was removed in the ADR-0068 clean break,
+/// naming the replacement key. Called from the `SET CONFIG` write path so
+/// operators cannot silently persist a key nothing reads. Returns `Ok(())`
+/// for every key that is still valid (including non-AI keys).
+pub fn validate_ai_config_key_on_write(key: &str) -> crate::RedDBResult<()> {
+    let key = key.trim();
+    if key == "red.config.ai.default.provider" {
+        return Err(crate::RedDBError::Query(
+            "AI config key 'red.config.ai.default.provider' was removed in the ADR-0068 \
+             clean break; set the task pointer 'red.config.ai.inference.provider' (or \
+             'red.config.ai.ask.provider' for the ASK planner) instead"
+                .to_string(),
+        ));
+    }
+    if key == "red.config.ai.default.model" {
+        return Err(crate::RedDBError::Query(
+            "AI config key 'red.config.ai.default.model' was removed in the ADR-0068 clean \
+             break; set 'red.config.ai.ask.model' or \
+             'red.config.ai.providers.<provider>.models.inference' instead"
+                .to_string(),
+        ));
+    }
+    // Old per-alias base-URL shape: red.config.ai.<provider>.<alias>.base_url
+    // (anything under red.config.ai.* ending in .base_url that is NOT the
+    // new red.config.ai.providers.<provider>.base_url form).
+    if key.starts_with("red.config.ai.")
+        && key.ends_with(".base_url")
+        && !key.starts_with("red.config.ai.providers.")
+    {
+        return Err(crate::RedDBError::Query(format!(
+            "AI config key '{key}' uses the removed per-credential base-URL shape; set \
+             'red.config.ai.providers.<provider>.base_url' instead (ADR-0068 clean break)"
+        )));
+    }
+    Ok(())
+}
+
+/// Resolve the inference (generation) provider. Precedence:
+/// 0. Wire-protocol mode selector (`red.config.ai.provider`) when set.
+/// 1. `REDDB_AI_PROVIDER` env var.
+/// 2. ASK-specific config `red.config.ai.ask.provider`.
+/// 3. Inference task pointer `red.config.ai.inference.provider`.
+/// 4. Falls back to OpenAI.
 pub fn resolve_default_provider<F>(kv_getter: &F) -> AiProvider
 where
     F: Fn(&str) -> crate::RedDBResult<Option<String>>,
 {
-    // 0. New mode selector (red.config.ai.provider) takes precedence
-    //    when explicitly set — it picks the wire-protocol family.
+    // 0. Wire-protocol mode selector takes precedence when explicitly set.
     if let Some(mode) = resolve_provider_mode(kv_getter) {
         return provider_mode_to_provider(mode);
     }
@@ -1888,22 +2157,29 @@ where
             }
         }
     }
-    // 2. KV store
-    if let Ok(Some(value)) = kv_getter("red.config.ai.default.provider") {
-        let value = value.trim().to_string();
-        if !value.is_empty() {
-            if let Ok(provider) = parse_provider(&value) {
-                return provider;
+    // 2. ASK-specific config, then 3. inference task pointer.
+    for key in [
+        "red.config.ai.ask.provider",
+        "red.config.ai.inference.provider",
+    ] {
+        if let Ok(Some(value)) = kv_getter(key) {
+            let value = value.trim().to_string();
+            if !value.is_empty() {
+                if let Ok(provider) = parse_provider(&value) {
+                    return provider;
+                }
             }
         }
     }
     AiProvider::OpenAi
 }
 
-/// Resolve the default AI model. Checks:
-/// 1. `REDDB_AI_MODEL` env var
-/// 2. `red_config` KV key `red.config.ai.default.model`
-/// 3. Falls back to provider's default
+/// Resolve the inference (generation) model for `provider`. Precedence:
+/// 1. `REDDB_AI_MODEL` env var.
+/// 2. Provider-specific prompt-model env var.
+/// 3. ASK-specific config `red.config.ai.ask.model`.
+/// 4. Provider models block `…providers.<p>.models.inference`.
+/// 5. Provider built-in default prompt model.
 pub fn resolve_default_model<F>(provider: &AiProvider, kv_getter: &F) -> String
 where
     F: Fn(&str) -> crate::RedDBResult<Option<String>>,
@@ -1922,14 +2198,124 @@ where
             return value;
         }
     }
-    // 3. KV store
-    if let Ok(Some(value)) = kv_getter("red.config.ai.default.model") {
+    // 3. ASK-specific config, then 4. provider models block.
+    for key in [
+        "red.config.ai.ask.model".to_string(),
+        provider_models_key(provider, "inference"),
+    ] {
+        if let Ok(Some(value)) = kv_getter(&key) {
+            let value = value.trim().to_string();
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+    provider.default_prompt_model().to_string()
+}
+
+/// Resolve the embeddings provider from the embeddings task pointer
+/// (`red.config.ai.embeddings.provider`), falling back to OpenAI. Fails
+/// with a didactic error — naming the pointer and the capable providers —
+/// when the pointer names a provider that has no embeddings API, rather
+/// than silently re-routing (ADR-0068 §5; the Anthropic case generalized).
+///
+/// `REDDB_AI_EMBEDDINGS_PROVIDER` keeps env precedence over config.
+pub fn resolve_embeddings_provider<F>(kv_getter: &F) -> crate::RedDBResult<AiProvider>
+where
+    F: Fn(&str) -> crate::RedDBResult<Option<String>>,
+{
+    let mut provider = AiProvider::OpenAi;
+    if let Ok(value) = std::env::var("REDDB_AI_EMBEDDINGS_PROVIDER") {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            provider = parse_provider(&value)?;
+        }
+    } else if let Ok(Some(value)) = kv_getter("red.config.ai.embeddings.provider") {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            provider = parse_provider(&value)?;
+        }
+    }
+    ensure_provider_supports_embeddings(&provider)?;
+    Ok(provider)
+}
+
+/// Fail with a didactic error when `provider` cannot serve embeddings.
+pub fn ensure_provider_supports_embeddings(provider: &AiProvider) -> crate::RedDBResult<()> {
+    if provider.supports_embeddings() {
+        return Ok(());
+    }
+    Err(crate::RedDBError::Query(format!(
+        "the embeddings task pointer 'red.config.ai.embeddings.provider' names '{}', which \
+         has no embeddings API. Point it at a capable provider ({}) — RedDB never silently \
+         re-routes embeddings to a different provider than the one you named.",
+        provider.token(),
+        EMBEDDING_CAPABLE_PROVIDERS
+    )))
+}
+
+/// Resolve the embeddings model for `provider`. Precedence:
+/// 1. Provider-specific `REDDB_<P>_EMBEDDING_MODEL` env var.
+/// 2. `REDDB_OPENAI_EMBEDDING_MODEL` env var (legacy shared override).
+/// 3. Provider models block `…providers.<p>.models.embeddings`.
+/// 4. Provider built-in default embedding model.
+pub fn resolve_embeddings_model<F>(provider: &AiProvider, kv_getter: &F) -> String
+where
+    F: Fn(&str) -> crate::RedDBResult<Option<String>>,
+{
+    if let Ok(value) = std::env::var(format!(
+        "REDDB_{}_EMBEDDING_MODEL",
+        provider.token().to_ascii_uppercase()
+    )) {
         let value = value.trim().to_string();
         if !value.is_empty() {
             return value;
         }
     }
-    provider.default_prompt_model().to_string()
+    if let Ok(value) = std::env::var("REDDB_OPENAI_EMBEDDING_MODEL") {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    if let Ok(Some(value)) = kv_getter(&provider_models_key(provider, "embeddings")) {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    provider.default_embedding_model().to_string()
+}
+
+/// Resolve the ASK planner model (`red.config.ai.ask.planner_model`),
+/// falling back to `fallback_model` (typically the resolved ASK model).
+/// Inert until the ASK planner slice consumes it.
+pub fn resolve_ask_planner_model<F>(kv_getter: &F, fallback_model: &str) -> String
+where
+    F: Fn(&str) -> crate::RedDBResult<Option<String>>,
+{
+    if let Ok(Some(value)) = kv_getter("red.config.ai.ask.planner_model") {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    fallback_model.to_string()
+}
+
+/// Resolve the ASK planner effort (`red.config.ai.ask.effort`) if set.
+/// Inert until the ASK planner slice consumes it.
+pub fn resolve_ask_effort<F>(kv_getter: &F) -> Option<String>
+where
+    F: Fn(&str) -> crate::RedDBResult<Option<String>>,
+{
+    if let Ok(Some(value)) = kv_getter("red.config.ai.ask.effort") {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            return Some(value);
+        }
+    }
+    None
 }
 
 /// Resolve default provider + model from runtime KV store.
@@ -1963,6 +2349,53 @@ pub fn resolve_defaults_from_runtime_port<
     let provider = resolve_default_provider(&kv_getter);
     let model = resolve_default_model(&provider, &kv_getter);
     (provider, model)
+}
+
+/// Resolve the embeddings provider for an AUTO EMBED / embeddings call from
+/// a runtime port. `explicit` is the `USING <provider>` override (empty when
+/// none was given); when empty the embeddings task pointer drives selection.
+/// A modality-incapable provider fails didactically (ADR-0068 §5).
+pub fn resolve_embeddings_provider_from_runtime<
+    P: crate::application::ports::RuntimeEntityPort + ?Sized,
+>(
+    runtime: &P,
+    explicit: &str,
+) -> crate::RedDBResult<AiProvider> {
+    let explicit = explicit.trim();
+    if !explicit.is_empty() {
+        let provider = parse_provider(explicit)?;
+        ensure_provider_supports_embeddings(&provider)?;
+        return Ok(provider);
+    }
+    let kv_getter = |key: &str| -> crate::RedDBResult<Option<String>> {
+        match runtime.get_kv("red_config", key)? {
+            Some((crate::storage::schema::Value::Text(s), _)) => Ok(Some(s.to_string())),
+            _ => Ok(None),
+        }
+    };
+    resolve_embeddings_provider(&kv_getter)
+}
+
+/// Resolve the embeddings model for `provider` from a runtime port,
+/// honouring an explicit `MODEL '<name>'` override before the config
+/// resolution order (env → provider models block → built-in default).
+pub fn resolve_embeddings_model_from_runtime<
+    P: crate::application::ports::RuntimeEntityPort + ?Sized,
+>(
+    runtime: &P,
+    provider: &AiProvider,
+    explicit: Option<&str>,
+) -> String {
+    if let Some(model) = explicit.map(str::trim).filter(|m| !m.is_empty()) {
+        return model.to_string();
+    }
+    let kv_getter = |key: &str| -> crate::RedDBResult<Option<String>> {
+        match runtime.get_kv("red_config", key)? {
+            Some((crate::storage::schema::Value::Text(s), _)) => Ok(Some(s.to_string())),
+            _ => Ok(None),
+        }
+    };
+    resolve_embeddings_model(provider, &kv_getter)
 }
 
 /// Resolve an API key for a provider, **preferring the encrypted vault
@@ -2555,13 +2988,17 @@ pub fn grpc_embeddings(
     runtime: &crate::runtime::RedDBRuntime,
     payload: &JsonValue,
 ) -> crate::RedDBResult<JsonValue> {
-    let provider_name = payload
+    // An explicit `provider` is honoured verbatim; when absent, the
+    // embeddings task pointer drives selection (ADR-0068 §5).
+    let provider = match payload
         .get("provider")
         .and_then(|v| v.as_str())
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .unwrap_or("openai");
-    let provider = parse_provider(provider_name)?;
+    {
+        Some(name) => parse_provider(name)?,
+        None => resolve_embeddings_provider_from_runtime(runtime, "")?,
+    };
     // Routing matrix mirrors `handle_ai_embeddings`. See that function
     // for the rationale; in short: HuggingFace gets its own wire
     // shape, Anthropic fails fast (no embeddings product), and Local
@@ -2586,22 +3023,8 @@ pub fn grpc_embeddings(
 
     let inputs: Vec<String> = grpc_collect_embedding_inputs(runtime, payload)?;
 
-    let model = payload
-        .get("model")
-        .and_then(|v| v.as_str())
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_string)
-        .or_else(|| {
-            std::env::var(format!(
-                "REDDB_{}_EMBEDDING_MODEL",
-                provider.token().to_ascii_uppercase()
-            ))
-            .ok()
-        })
-        .or_else(|| std::env::var("REDDB_OPENAI_EMBEDDING_MODEL").ok())
-        .filter(|v| !v.trim().is_empty())
-        .unwrap_or_else(|| provider.default_embedding_model().to_string());
+    let explicit_model = payload.get("model").and_then(|v| v.as_str());
+    let model = resolve_embeddings_model_from_runtime(runtime, &provider, explicit_model);
 
     let credential = payload
         .get("credential")

--- a/crates/reddb-server/src/ai.rs
+++ b/crates/reddb-server/src/ai.rs
@@ -1764,6 +1764,25 @@ mod tests {
     }
 
     #[test]
+    fn embeddings_provider_falls_back_to_default_provider_chain() {
+        // With no embeddings-specific override, the embeddings provider
+        // follows the general default-provider chain (here the inference
+        // task pointer). This keeps a single-global-config deployment
+        // routing embeddings through the one provider it named — the
+        // regression the local-vector text-search tests guard against.
+        let kv = |key: &str| -> crate::RedDBResult<Option<String>> {
+            match key {
+                "red.config.ai.inference.provider" => Ok(Some("ollama".to_string())),
+                _ => Ok(None),
+            }
+        };
+        assert_eq!(
+            resolve_embeddings_provider(&kv).unwrap(),
+            AiProvider::Ollama
+        );
+    }
+
+    #[test]
     fn embeddings_model_block_beats_builtin() {
         let block = |key: &str| -> crate::RedDBResult<Option<String>> {
             match key {
@@ -2213,29 +2232,40 @@ where
     provider.default_prompt_model().to_string()
 }
 
-/// Resolve the embeddings provider from the embeddings task pointer
-/// (`red.config.ai.embeddings.provider`), falling back to OpenAI. Fails
-/// with a didactic error — naming the pointer and the capable providers —
-/// when the pointer names a provider that has no embeddings API, rather
-/// than silently re-routing (ADR-0068 §5; the Anthropic case generalized).
+/// Resolve the embeddings provider. Precedence:
+/// 1. `REDDB_AI_EMBEDDINGS_PROVIDER` env var (embeddings-specific override).
+/// 2. `red.config.ai.embeddings.provider` task pointer.
+/// 3. Fall back to the general default provider — [`resolve_default_provider`]
+///    honours `REDDB_AI_PROVIDER`, the wire-protocol mode selector, and the
+///    ASK/inference chain — so a deployment that only sets a single global
+///    provider (e.g. `REDDB_AI_PROVIDER=local`) still embeds through it.
 ///
-/// `REDDB_AI_EMBEDDINGS_PROVIDER` keeps env precedence over config.
+/// Fails with a didactic error — naming the embeddings pointer and the capable
+/// providers — when the resolved provider has no embeddings API, rather than
+/// silently re-routing (ADR-0068 §5; the Anthropic case generalized).
 pub fn resolve_embeddings_provider<F>(kv_getter: &F) -> crate::RedDBResult<AiProvider>
 where
     F: Fn(&str) -> crate::RedDBResult<Option<String>>,
 {
-    let mut provider = AiProvider::OpenAi;
-    if let Ok(value) = std::env::var("REDDB_AI_EMBEDDINGS_PROVIDER") {
-        let value = value.trim().to_string();
-        if !value.is_empty() {
-            provider = parse_provider(&value)?;
-        }
-    } else if let Ok(Some(value)) = kv_getter("red.config.ai.embeddings.provider") {
-        let value = value.trim().to_string();
-        if !value.is_empty() {
-            provider = parse_provider(&value)?;
-        }
-    }
+    let provider = if let Some(value) = std::env::var("REDDB_AI_EMBEDDINGS_PROVIDER")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+    {
+        parse_provider(&value)?
+    } else if let Some(value) = kv_getter("red.config.ai.embeddings.provider")
+        .ok()
+        .flatten()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+    {
+        parse_provider(&value)?
+    } else {
+        // No embeddings-specific override: follow the general default
+        // provider so the historical global `REDDB_AI_PROVIDER` selector
+        // keeps driving embeddings when the task pointer is unset.
+        resolve_default_provider(kv_getter)
+    };
     ensure_provider_supports_embeddings(&provider)?;
     Ok(provider)
 }
@@ -2258,7 +2288,14 @@ pub fn ensure_provider_supports_embeddings(provider: &AiProvider) -> crate::RedD
 /// 1. Provider-specific `REDDB_<P>_EMBEDDING_MODEL` env var.
 /// 2. `REDDB_OPENAI_EMBEDDING_MODEL` env var (legacy shared override).
 /// 3. Provider models block `…providers.<p>.models.embeddings`.
-/// 4. Provider built-in default embedding model.
+/// 4. General `REDDB_AI_MODEL` env var (historical global model selector).
+/// 5. Provider built-in default embedding model.
+///
+/// The embeddings-specific sources (1–3) outrank the general `REDDB_AI_MODEL`
+/// selector so an explicit embeddings model always wins; `REDDB_AI_MODEL`
+/// only fills in for the built-in default, which is what keeps a
+/// single-global-config deployment (`REDDB_AI_PROVIDER`+`REDDB_AI_MODEL`)
+/// routing text embeddings through the named model.
 pub fn resolve_embeddings_model<F>(provider: &AiProvider, kv_getter: &F) -> String
 where
     F: Fn(&str) -> crate::RedDBResult<Option<String>>,
@@ -2279,6 +2316,12 @@ where
         }
     }
     if let Ok(Some(value)) = kv_getter(&provider_models_key(provider, "embeddings")) {
+        let value = value.trim().to_string();
+        if !value.is_empty() {
+            return value;
+        }
+    }
+    if let Ok(value) = std::env::var("REDDB_AI_MODEL") {
         let value = value.trim().to_string();
         if !value.is_empty() {
             return value;

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -717,9 +717,11 @@ fn embed_text(db: &RedDB, text: &str, provider_hint: Option<&str>) -> Option<Val
             }),
         )
     };
+    // Embeddings follow the embeddings task pointer (ADR-0068 §5), not the
+    // inference/ASK provider, when no explicit hint is supplied.
     let provider = match provider_hint {
         Some(name) => crate::ai::parse_provider(name).ok()?,
-        None => crate::ai::resolve_default_provider(&kv_getter),
+        None => crate::ai::resolve_embeddings_provider(&kv_getter).ok()?,
     };
     if !provider.is_openai_compatible() {
         // Anthropic / providers without embedding parity fall out —
@@ -738,7 +740,7 @@ fn embed_text(db: &RedDB, text: &str, provider_hint: Option<&str>) -> Option<Val
     .ok()?;
 
     let api_base = provider.resolve_api_base_with_kv("default", &kv_getter);
-    let model = provider.default_embedding_model().to_string();
+    let model = crate::ai::resolve_embeddings_model(&provider, &kv_getter);
 
     let transport = crate::runtime::ai::transport::AiTransport::new(
         crate::runtime::ai::transport::AiTransportConfig::default(),

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1071,6 +1071,10 @@ impl RedDBRuntime {
                         "red.secrets.* is reserved for vault secrets; use SET SECRET".to_string(),
                     ));
                 }
+                // ADR-0068 §5 clean break: reject the removed AI config keys
+                // (old `default.*` provider/model and per-alias base_url shape)
+                // with a didactic error naming the replacement key.
+                crate::ai::validate_ai_config_key_on_write(key)?;
                 match self.check_managed_config_write_for_set_config(key) {
                     Err(err) => Err(err),
                     Ok(()) => {

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -229,7 +229,11 @@ impl RedDBRuntime {
         };
         self.check_insert_column_policy(query)?;
         if let Some(ref embed_config) = query.auto_embed {
-            let provider = crate::ai::parse_provider(&embed_config.provider)?;
+            // Empty provider → resolve via the embeddings task pointer
+            // (ADR-0068 §5); an explicit `USING` overrides it. A modality-
+            // incapable provider fails didactically here.
+            let provider =
+                crate::ai::resolve_embeddings_provider_from_runtime(self, &embed_config.provider)?;
             // S3 / #711: planner-level provider gate. Runs before the
             // local-model preflight and the API-key resolver so neither
             // side-effect fires when policy denies.
@@ -946,7 +950,8 @@ impl RedDBRuntime {
         // Auto-embed pipeline: batch-embed fields across all inserted rows via AiBatchClient.
         if let Some(ref embed_config) = query.auto_embed {
             let store = self.inner.db.store();
-            let provider = crate::ai::parse_provider(&embed_config.provider)?;
+            let provider =
+                crate::ai::resolve_embeddings_provider_from_runtime(self, &embed_config.provider)?;
             let is_local_provider = matches!(provider, crate::ai::AiProvider::Local);
             // Local provider runs in-process — no API key path applies.
             // The pre-flight above already required `MODEL '<name>'`
@@ -957,11 +962,13 @@ impl RedDBRuntime {
             } else {
                 crate::ai::resolve_api_key_from_runtime(&provider, None, self)?
             };
-            let model = embed_config.model.clone().unwrap_or_else(|| {
-                std::env::var("REDDB_OPENAI_EMBEDDING_MODEL")
-                    .ok()
-                    .unwrap_or_else(|| crate::ai::DEFAULT_OPENAI_EMBEDDING_MODEL.to_string())
-            });
+            // Explicit `MODEL '<name>'` wins; otherwise resolve via the
+            // provider models block then the built-in default (ADR-0068 §5).
+            let model = crate::ai::resolve_embeddings_model_from_runtime(
+                self,
+                &provider,
+                embed_config.model.as_deref(),
+            );
 
             // Collect the just-inserted rows (most-recently appended, reversed back to insert order).
             let manager = store

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -523,19 +523,29 @@ impl RedDBRuntime {
                 }
                 // If text provided, generate embedding first (semantic search)
                 let search_vector = if let Some(query_text) = text {
-                    let (default_provider, _) = crate::ai::resolve_defaults_from_runtime(self);
+                    // Embeddings follow the embeddings task pointer (ADR-0068
+                    // §5); an explicit `USING` overrides it for this query.
+                    use crate::application::ports::RuntimeEntityPort;
+                    let kv_getter = |key: &str| -> RedDBResult<Option<String>> {
+                        match self.get_kv("red_config", key)? {
+                            Some((Value::Text(s), _)) => Ok(Some(s.to_string())),
+                            _ => Ok(None),
+                        }
+                    };
                     let provider = match provider.as_deref() {
-                        Some(p) => crate::ai::parse_provider(p)?,
-                        None => default_provider,
+                        Some(p) => {
+                            let provider = crate::ai::parse_provider(p)?;
+                            crate::ai::ensure_provider_supports_embeddings(&provider)?;
+                            provider
+                        }
+                        None => crate::ai::resolve_embeddings_provider(&kv_getter)?,
                     };
                     // S3 / #711: planner-level provider gate. Runs
                     // before the credential resolver so the resolver
                     // audit event is not emitted when policy denies.
                     crate::runtime::ai::provider_gate::enforce(self, &provider)?;
                     let api_key = crate::ai::resolve_api_key_from_runtime(&provider, None, self)?;
-                    let model = std::env::var("REDDB_OPENAI_EMBEDDING_MODEL")
-                        .ok()
-                        .unwrap_or_else(|| provider.default_embedding_model().to_string());
+                    let model = crate::ai::resolve_embeddings_model(&provider, &kv_getter);
                     let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
                     let request = crate::ai::OpenAiEmbeddingRequest {
                         api_key,

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -1474,8 +1474,10 @@ fn embed_runtime_vector_text(db: &RedDB, text: &str) -> RedDBResult<Vec<f32>> {
         }
     };
 
-    let provider = crate::ai::resolve_default_provider(&kv_getter);
-    let model = crate::ai::resolve_default_model(&provider, &kv_getter);
+    // Embeddings follow the embeddings task pointer (ADR-0068 §5), not the
+    // inference/ASK provider — a modality-incapable pointer fails loudly.
+    let provider = crate::ai::resolve_embeddings_provider(&kv_getter)?;
+    let model = crate::ai::resolve_embeddings_model(&provider, &kv_getter);
 
     // Issue #681 — when the default provider is `local`, route through
     // the registered local-model backend (registry from #678, cache from

--- a/crates/reddb-server/src/server/handlers_ai.rs
+++ b/crates/reddb-server/src/server/handlers_ai.rs
@@ -450,9 +450,18 @@ impl RedDBServer {
             Err(response) => return response,
         };
 
-        let provider = match parse_ai_provider(&payload) {
-            Ok(provider) => provider,
-            Err(err) => return json_error(400, err),
+        // An explicit `provider` is honoured verbatim; when absent, the
+        // embeddings task pointer drives selection (ADR-0068 §5).
+        let provider = if json_string_field(&payload, "provider").is_some() {
+            match parse_ai_provider(&payload) {
+                Ok(provider) => provider,
+                Err(err) => return json_error(400, err),
+            }
+        } else {
+            match crate::ai::resolve_embeddings_provider_from_runtime(&self.runtime, "") {
+                Ok(provider) => provider,
+                Err(err) => return json_error(400, err.to_string()),
+            }
         };
         // Provider routing for embeddings:
         //
@@ -492,19 +501,13 @@ impl RedDBServer {
             _ => {}
         }
 
-        let model = json_string_field(&payload, "model").unwrap_or_else(|| {
-            // Provider-specific embedding model env var first, then generic
-            // fallback, then the provider's compiled-in default.
-            std::env::var(format!(
-                "REDDB_{}_EMBEDDING_MODEL",
-                provider.token().to_ascii_uppercase()
-            ))
-            .ok()
-            .or_else(|| std::env::var("REDDB_OPENAI_EMBEDDING_MODEL").ok())
-            .map(|v| v.trim().to_string())
-            .filter(|v| !v.is_empty())
-            .unwrap_or_else(|| provider.default_embedding_model().to_string())
-        });
+        // Explicit `model` wins; otherwise resolve via env → provider models
+        // block → built-in default (ADR-0068 §5).
+        let model = crate::ai::resolve_embeddings_model_from_runtime(
+            &self.runtime,
+            &provider,
+            json_string_field(&payload, "model").as_deref(),
+        );
         let dimensions = match payload
             .get("dimensions")
             .and_then(JsonValue::as_i64)
@@ -1163,9 +1166,9 @@ impl RedDBServer {
             }
         }
 
-        // Save API base URL
+        // Save API base URL (ADR-0068 §5: per-provider, no credential alias).
         if let Some(api_base) = &api_base {
-            let base_key = format!("red.config.ai.{}.{}.base_url", provider.token(), alias);
+            let base_key = crate::ai::provider_base_url_key(&provider);
             let _ = self
                 .entity_use_cases()
                 .delete_kv(RED_CONFIG_COLLECTION, &base_key);
@@ -1217,27 +1220,41 @@ impl RedDBServer {
             .and_then(JsonValue::as_bool)
             .unwrap_or(false);
         if is_default {
-            let _ = self
-                .entity_use_cases()
-                .delete_kv(RED_CONFIG_COLLECTION, "red.config.ai.default.provider");
-            let _ = self.entity_use_cases().create_kv(CreateKvInput {
-                collection: RED_CONFIG_COLLECTION.to_string(),
-                key: "red.config.ai.default.provider".to_string(),
-                value: Value::text(provider.token().to_string()),
-                metadata: Vec::new(),
-            });
+            // ADR-0068 §5 clean break: point the inference task pointer at
+            // this provider and pin its inference model in the provider
+            // models block. When the provider can embed, aim the embeddings
+            // task pointer at it too so it becomes the default for both
+            // modalities; otherwise leave the embeddings pointer untouched.
+            let set_pointer = |key: String, value: String| {
+                let _ = self
+                    .entity_use_cases()
+                    .delete_kv(RED_CONFIG_COLLECTION, &key);
+                let _ = self.entity_use_cases().create_kv(CreateKvInput {
+                    collection: RED_CONFIG_COLLECTION.to_string(),
+                    key,
+                    value: Value::text(value),
+                    metadata: Vec::new(),
+                });
+            };
+
+            set_pointer(
+                "red.config.ai.inference.provider".to_string(),
+                provider.token().to_string(),
+            );
 
             let model = json_string_field(&payload, "model")
                 .unwrap_or_else(|| provider.default_prompt_model().to_string());
-            let _ = self
-                .entity_use_cases()
-                .delete_kv(RED_CONFIG_COLLECTION, "red.config.ai.default.model");
-            let _ = self.entity_use_cases().create_kv(CreateKvInput {
-                collection: RED_CONFIG_COLLECTION.to_string(),
-                key: "red.config.ai.default.model".to_string(),
-                value: Value::text(model.clone()),
-                metadata: Vec::new(),
-            });
+            set_pointer(
+                crate::ai::provider_models_key(&provider, "inference"),
+                model.clone(),
+            );
+
+            if provider.supports_embeddings() {
+                set_pointer(
+                    "red.config.ai.embeddings.provider".to_string(),
+                    provider.token().to_string(),
+                );
+            }
 
             object.insert("is_default".to_string(), JsonValue::Bool(true));
             object.insert("default_model".to_string(), JsonValue::String(model));

--- a/crates/reddb-server/tests/vector_search_snapshots.rs
+++ b/crates/reddb-server/tests/vector_search_snapshots.rs
@@ -345,14 +345,14 @@ fn happy_hybrid_from_fusion_rrf_with_k() {
 
 #[test]
 fn happy_insert_auto_embed_default_provider() {
-    // Default provider is "openai" (per dml.rs L196). USING is
-    // omitted on purpose to pin the default-provider path.
+    // No `USING` → empty provider; the runtime resolves it via the
+    // embeddings task pointer (ADR-0068 §5) rather than a hardcoded default.
     let q = parse_query("INSERT INTO docs (id, body) VALUES (1, 'hello') WITH AUTO EMBED (body)");
     match q {
         QueryExpr::Insert(i) => {
             let cfg = i.auto_embed.as_ref().expect("auto_embed must be set");
             assert_eq!(cfg.fields, vec!["body".to_string()]);
-            assert_eq!(cfg.provider, "openai");
+            assert_eq!(cfg.provider, "");
             assert!(cfg.model.is_none());
         }
         other => panic!("expected QueryExpr::Insert, got {other:?}"),

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -243,9 +243,9 @@ curl http://127.0.0.1:5000/config
 # Import from JSON file
 curl -X POST http://127.0.0.1:5000/config -d @examples/config.json
 
-# Override specific values
+# Override specific values (new AI schema — ADR 0068 §5)
 curl -X POST http://127.0.0.1:5000/config \
-  -d '{"red":{"ai":{"default":{"provider":"ollama","model":"llama3"}}}}'
+  -d '{"red":{"config":{"ai":{"inference":{"provider":"ollama"},"embeddings":{"provider":"ollama"},"providers":{"ollama":{"models":{"inference":"llama3","embeddings":"nomic-embed-text"}}}}}}}'
 ```
 
 See [`examples/config.json`](https://github.com/reddb-io/reddb/blob/main/examples/config.json) for a complete example with all defaults.
@@ -256,7 +256,7 @@ You can read and write configuration directly from the query engine:
 
 ```sql
 -- Set a config value
-SET CONFIG red.ai.default.provider = 'groq'
+SET CONFIG red.config.ai.inference.provider = 'groq'
 SET CONFIG red.storage.hnsw.ef_search = 100
 
 -- Show all config
@@ -273,15 +273,15 @@ Read, write, or delete a single config key via HTTP:
 
 ```bash
 # Read a key or subtree
-curl http://127.0.0.1:5000/config/red.ai.default.provider
+curl http://127.0.0.1:5000/config/red.config.ai.inference.provider
 
 # Set a key
-curl -X PUT http://127.0.0.1:5000/config/red.ai.default.provider \
+curl -X PUT http://127.0.0.1:5000/config/red.config.ai.inference.provider \
   -H 'content-type: application/json' \
   -d '{"value": "groq"}'
 
 # Delete a key
-curl -X DELETE http://127.0.0.1:5000/config/red.ai.default.model
+curl -X DELETE http://127.0.0.1:5000/config/red.config.ai.ask.model
 ```
 
 ### Resolution Order
@@ -289,21 +289,48 @@ curl -X DELETE http://127.0.0.1:5000/config/red.ai.default.model
 For any setting, RedDB checks in order:
 
 1. **Environment variable** (e.g., `REDDB_AI_PROVIDER`)
-2. **`red_config` KV store** (e.g., `red.ai.default.provider`)
+2. **`red_config` KV store** (e.g., `red.config.ai.inference.provider`)
 3. **Hardcoded default**
 
-### AI & LLM (`red.ai.*`)
+### AI & LLM (`red.config.ai.*`)
+
+The AI namespace splits **inference** (generation, ASK) from **embeddings**
+(AUTO EMBED, SEARCH SIMILAR TEXT). Each task has a *pointer* naming which
+provider serves it, and each provider has a **models block** naming the
+model to use for each modality. For any AI call the resolution order is:
+
+**ASK-specific config → task pointer → the pointed provider's `models`
+block → the provider's built-in default.**
+
+`ASK … USING <provider>` overrides the **inference** side only; embeddings
+keep following the embeddings task pointer. A task pointer aimed at a
+provider that lacks the modality (e.g. Anthropic has no embeddings API)
+fails with a didactic error naming the pointer to fix — RedDB never
+silently re-routes to a different provider.
 
 | Key | Default | Description |
 |:----|:--------|:------------|
-| `red.ai.default.provider` | `openai` | Default provider for ASK, SEARCH SIMILAR TEXT, AUTO EMBED |
-| `red.ai.default.model` | provider default | Default model |
-| `red.ai.{provider}.{alias}.key` | — | API key (e.g., `red.ai.groq.default.key`) |
-| `red.ai.{provider}.{alias}.base_url` | — | Custom API base URL |
-| `red.ai.max_embedding_inputs` | `256` | Max inputs per embedding batch |
-| `red.ai.max_prompt_batch` | `256` | Max prompts per batch |
-| `red.ai.timeout.connect_secs` | `10` | API connection timeout |
-| `red.ai.timeout.read_secs` | `90` | API read timeout |
+| `red.config.ai.ask.provider` | — | ASK planner provider (wins over the inference pointer) |
+| `red.config.ai.ask.model` | inference model | ASK model (wins over the provider models block) |
+| `red.config.ai.ask.planner_model` | ASK model | Planner model for the ASK planner |
+| `red.config.ai.ask.effort` | — | Planner effort hint (e.g. `low`/`medium`/`high`) |
+| `red.config.ai.ask.max_plan_steps` | — | Max ASK planner steps |
+| `red.config.ai.inference.provider` | `openai` | Task pointer: which provider generates |
+| `red.config.ai.embeddings.provider` | `openai` | Task pointer: which provider embeds |
+| `red.config.ai.providers.{provider}.base_url` | — | Custom API base URL for a provider |
+| `red.config.ai.providers.{provider}.models.inference` | provider default | Inference model for that provider |
+| `red.config.ai.providers.{provider}.models.embeddings` | provider default | Embeddings model for that provider |
+| `red.config.ai.{provider}.{alias}.key` | — | API key (e.g., `red.config.ai.groq.default.key`) |
+| `red.config.ai.max_embedding_inputs` | `256` | Max inputs per embedding batch |
+| `red.config.ai.max_prompt_batch` | `256` | Max prompts per batch |
+| `red.config.ai.timeout.connect_secs` | `10` | API connection timeout |
+| `red.config.ai.timeout.read_secs` | `90` | API read timeout |
+
+> **Clean break (ADR 0068 §5):** the old keys `red.config.ai.default.provider`,
+> `red.config.ai.default.model`, and the per-credential base-URL shape
+> `red.config.ai.{provider}.{alias}.base_url` were **removed** — writing any
+> of them is rejected with a didactic error naming the replacement key.
+> There is no deprecation window.
 
 ### Server (`red.server.*`)
 

--- a/docs/guides/ai-providers.md
+++ b/docs/guides/ai-providers.md
@@ -126,18 +126,48 @@ compiled in: fail fast rather than silently demote.
 
 ## Setting a default provider
 
+The AI config namespace (ADR 0068 §5) splits **inference** (generation,
+ASK) from **embeddings** (AUTO EMBED, SEARCH SIMILAR TEXT). Two task
+pointers say which provider serves each modality:
+
+```sql
+-- Task pointers: who generates, who embeds
+SET CONFIG red.config.ai.inference.provider  = 'groq'
+SET CONFIG red.config.ai.embeddings.provider = 'openai'
+
+-- Per-provider model + base URL live in the provider block
+SET CONFIG red.config.ai.providers.groq.models.inference     = 'llama-3.3-70b-versatile'
+SET CONFIG red.config.ai.providers.openai.models.embeddings  = 'text-embedding-3-small'
+SET CONFIG red.config.ai.providers.groq.base_url             = 'https://api.groq.com/openai/v1'
+```
+
+Posting a credential with `"default": true` sets these pointers for you
+(the embeddings pointer only when the provider can embed):
+
 ```bash
-# Set default provider — drops `USING` from every query
 curl -X POST http://127.0.0.1:5000/ai/credentials \
   -d '{"provider":"groq","api_key":"gsk_xxx","default":true}'
 ```
 
 ```sql
--- ASK uses the default provider when USING is omitted
+-- ASK uses the inference pointer when USING is omitted
 ASK 'what changed in the last 24 hours?'
 ```
 
-Default provider can be overridden per-call with `USING <provider>`.
+**Resolution order for any AI call:** ASK-specific config
+(`red.config.ai.ask.*`) → task pointer → the pointed provider's `models`
+block → the provider's built-in default.
+
+`ASK … USING <provider>` overrides the **inference** side only —
+embeddings still resolve through the embeddings task pointer. A task
+pointer aimed at a provider that lacks the modality (Anthropic has no
+embeddings API) fails with a didactic error naming the pointer to fix;
+there is no silent re-route.
+
+> **Clean break:** `red.config.ai.default.provider`,
+> `red.config.ai.default.model`, and the old
+> `red.config.ai.{provider}.{alias}.base_url` base-URL shape were removed.
+> Writing any of them is rejected with an error naming the new key.
 
 ---
 

--- a/examples/config.json
+++ b/examples/config.json
@@ -1,9 +1,22 @@
 {
   "red": {
     "ai": {
-      "default": {
-        "provider": "openai",
+      "inference": {
+        "provider": "openai"
+      },
+      "embeddings": {
+        "provider": "openai"
+      },
+      "ask": {
         "model": "gpt-4.1-mini"
+      },
+      "providers": {
+        "openai": {
+          "models": {
+            "inference": "gpt-4.1-mini",
+            "embeddings": "text-embedding-3-small"
+          }
+        }
       },
       "openai": {
         "default": {


### PR DESCRIPTION
Automated AFK landing for #1746. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1746

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785843594&installation_id=129708444&pr_number=1755&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1755&signature=58e26246fcf00758fc092a7e367e50ab84fdf7926fa2c5a28c3b9824109bece6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->