### PR TITLE
#1747 Ask planner core: factual intent end-to-end

### DIFF
--- a/crates/reddb-server/src/ai.rs
+++ b/crates/reddb-server/src/ai.rs
@@ -2377,6 +2377,24 @@ pub fn resolve_defaults_from_runtime(
     (provider, model)
 }
 
+/// Resolve the ASK planner model from runtime KV (`red.config.ai.ask.planner_model`),
+/// falling back to `fallback_model` — the resolved synthesis/ASK model — when
+/// no planner model is configured (ADR 0068 §3). Lets a cheap/fast model plan
+/// while the user-chosen model synthesizes.
+pub fn resolve_ask_planner_model_from_runtime(
+    runtime: &crate::runtime::RedDBRuntime,
+    fallback_model: &str,
+) -> String {
+    use crate::application::ports::RuntimeEntityPort;
+    let kv_getter = |key: &str| -> crate::RedDBResult<Option<String>> {
+        match runtime.get_kv("red_config", key)? {
+            Some((crate::storage::schema::Value::Text(s), _)) => Ok(Some(s.to_string())),
+            _ => Ok(None),
+        }
+    };
+    resolve_ask_planner_model(&kv_getter, fallback_model)
+}
+
 /// Resolve default provider + model via RuntimeEntityPort trait (for use in QueryUseCases).
 pub fn resolve_defaults_from_runtime_port<
     P: crate::application::ports::RuntimeEntityPort + ?Sized,

--- a/crates/reddb-server/src/runtime/ai/ask_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_planner.rs
@@ -189,14 +189,14 @@ pub fn build_planner_prompt(question: &str, slice: &NarrowedSlice) -> String {
 /// Parse the planner model's output into a typed plan. Tolerates code
 /// fences and surrounding prose by extracting the outermost JSON object.
 pub fn parse_plan(raw: &str) -> RedDBResult<AskPlan> {
-    let json = extract_json_object(raw).ok_or_else(|| {
-        RedDBError::Query("ASK planner returned no JSON plan object".to_string())
+    let json = extract_json_object(raw)
+        .ok_or_else(|| RedDBError::Query("ASK planner returned no JSON plan object".to_string()))?;
+    let parsed: crate::json::Value = crate::json::from_str(json).map_err(|err| {
+        RedDBError::Query(format!("ASK planner returned invalid JSON plan: {err}"))
     })?;
-    let parsed: crate::json::Value = crate::json::from_str(json)
-        .map_err(|err| RedDBError::Query(format!("ASK planner returned invalid JSON plan: {err}")))?;
-    let obj = parsed.as_object().ok_or_else(|| {
-        RedDBError::Query("ASK planner plan must be a JSON object".to_string())
-    })?;
+    let obj = parsed
+        .as_object()
+        .ok_or_else(|| RedDBError::Query("ASK planner plan must be a JSON object".to_string()))?;
 
     let intent_raw = obj
         .get("intent")
@@ -350,7 +350,10 @@ mod tests {
     #[test]
     fn parse_plan_rejects_non_json() {
         let err = parse_plan("the answer is 42").unwrap_err();
-        assert!(err.to_string().contains("no JSON plan object"), "got: {err}");
+        assert!(
+            err.to_string().contains("no JSON plan object"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -402,9 +405,9 @@ mod tests {
         )
         .unwrap();
         match route.routing {
-            PlanRouting::RefuseMutating {
-                statement_type, ..
-            } => assert_eq!(statement_type, "delete"),
+            PlanRouting::RefuseMutating { statement_type, .. } => {
+                assert_eq!(statement_type, "delete")
+            }
             other => panic!("expected RefuseMutating, got {other:?}"),
         }
     }
@@ -414,7 +417,9 @@ mod tests {
         let err = plan_and_route(
             "who owns passport FDD-1?",
             &slice(),
-            &mock_model("{\"intent\":\"factual\",\"query\":\"this is not rql\",\"rationale\":\"x\"}"),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"this is not rql\",\"rationale\":\"x\"}",
+            ),
         )
         .unwrap_err();
         assert!(

--- a/crates/reddb-server/src/runtime/ai/ask_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_planner.rs
@@ -1,0 +1,480 @@
+//! ASK planner-first typed plan (ADR 0068, issue #1747).
+//!
+//! The planner runs *after* the deterministic AskPipeline funnel has
+//! narrowed the schema slice (candidate collections + columns + scores).
+//! The narrowed slice — never the raw catalog — is the only schema the
+//! planner LLM ever sees. The model emits a **typed plan** whose `query`
+//! step carries a read-only RQL candidate; the candidate is re-validated
+//! through the production parser and the read-only classifier
+//! ([`super::ask_rql_planner`]) before it can execute.
+//!
+//! This module is pure: it holds the plan types, the JSON plan parser, the
+//! narrowed-slice prompt builder, and the routing/refusal decision. The LLM
+//! transport, auto-execution, and synthesis live in the orchestrator
+//! ([`super::super::impl_search`]). The [`PlannerModel`] closure seam lets
+//! the routing/refusal logic be unit-tested without any HTTP round-trip.
+
+use std::collections::BTreeSet;
+
+use crate::api::{RedDBError, RedDBResult};
+
+use super::ask_rql_planner::{validate_candidate, CandidateDisposition, ValidatedCandidate};
+
+/// The intent the planner routes a question to (ADR 0068 §2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AskIntent {
+    /// "what happened to passport 123?" — generate read-only RQL over the
+    /// full read-only surface, auto-execute, synthesize over the rows.
+    Factual,
+    /// "summarise yesterday's incidents" — retrieval-RAG cited answer.
+    Synthesis,
+    /// "how would I capture events into a queue?" — suggestion envelope.
+    HowTo,
+}
+
+impl AskIntent {
+    /// Canonical lowercase label (audit / plan summary).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AskIntent::Factual => "factual",
+            AskIntent::Synthesis => "synthesis",
+            AskIntent::HowTo => "how_to",
+        }
+    }
+
+    fn parse(raw: &str) -> Option<AskIntent> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "factual" => Some(AskIntent::Factual),
+            "synthesis" => Some(AskIntent::Synthesis),
+            "how_to" | "howto" | "how-to" => Some(AskIntent::HowTo),
+            _ => None,
+        }
+    }
+}
+
+/// A single funnel-narrowed candidate collection with its retrieval score.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScoredCollection {
+    pub collection: String,
+    pub score: f32,
+    pub columns: Vec<String>,
+}
+
+/// The funnel-narrowed schema slice handed to the planner. This is the
+/// *only* schema the model sees — the raw catalog never reaches it.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct NarrowedSlice {
+    pub collections: Vec<ScoredCollection>,
+}
+
+impl NarrowedSlice {
+    /// Collection names in the slice, in narrowed order.
+    pub fn collection_names(&self) -> Vec<&str> {
+        self.collections
+            .iter()
+            .map(|c| c.collection.as_str())
+            .collect()
+    }
+}
+
+/// The typed plan the planner LLM emits, before candidate validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AskPlan {
+    pub intent: AskIntent,
+    /// The `query` step's read-only RQL candidate (factual intent).
+    pub query: Option<String>,
+    /// Model rationale / self-critique, surfaced to plan summary + audit.
+    pub rationale: String,
+}
+
+impl AskPlan {
+    /// A short, single-line plan summary for the audit row.
+    pub fn summary(&self) -> String {
+        let mut out = format!("intent={}", self.intent.as_str());
+        if let Some(query) = &self.query {
+            out.push_str("; query=");
+            out.push_str(query.trim());
+        }
+        out
+    }
+}
+
+/// A model that turns a planner prompt into a typed-plan JSON document.
+///
+/// The blanket impl over `Fn(&str) -> RedDBResult<String>` lets callers
+/// pass a closure wrapping the configured planner provider (production) or
+/// a canned string (tests / mock model) without a bespoke type — this is
+/// the closure-model seam the routing/refusal unit tests use.
+pub trait PlannerModel {
+    fn plan(&self, prompt: &str) -> RedDBResult<String>;
+}
+
+impl<F> PlannerModel for F
+where
+    F: Fn(&str) -> RedDBResult<String>,
+{
+    fn plan(&self, prompt: &str) -> RedDBResult<String> {
+        self(prompt)
+    }
+}
+
+/// How the planner routed a plan after candidate validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlanRouting {
+    /// Factual intent with a validated **read-only** candidate ready to
+    /// auto-execute under the caller's EffectiveScope.
+    Execute { candidate: ValidatedCandidate },
+    /// Factual intent whose candidate is **mutating** — a structured
+    /// refusal. Mutating candidates are never executed under any flag; the
+    /// suggestion envelope arrives in a later slice.
+    RefuseMutating {
+        statement_type: &'static str,
+        rql: String,
+    },
+    /// A non-factual intent (synthesis / how-to). This slice implements the
+    /// factual path only; the orchestrator decides the fallback.
+    Unsupported { intent: AskIntent },
+}
+
+/// A planner pass: the prompt sent, the parsed plan, and the routing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedRoute {
+    pub prompt: String,
+    pub plan: AskPlan,
+    pub routing: PlanRouting,
+}
+
+/// Assemble the planner prompt from *only* the narrowed slice. A catalog
+/// with many collections never reaches the model raw: the slice is the
+/// anti-drowning gate (ADR 0068 §1).
+pub fn build_planner_prompt(question: &str, slice: &NarrowedSlice) -> String {
+    let mut prompt = String::new();
+    prompt.push_str(
+        "You are the RedDB ASK planner. Classify the user's question intent and, for a \
+         factual question, generate a single read-only RQL SELECT candidate over the \
+         collections below.\n\
+         Respond with ONLY a JSON object, no code fences or commentary:\n\
+         {\"intent\": \"factual\"|\"synthesis\"|\"how_to\", \"query\": \"<read-only RQL or null>\", \
+         \"rationale\": \"<one sentence>\"}\n\
+         Rules: use only the collections and columns listed; never invent a collection; \
+         a factual question MUST carry a read-only SELECT (joins and the global `any` source \
+         are allowed); never emit INSERT/UPDATE/DELETE/DDL.\n\n",
+    );
+
+    if slice.collections.is_empty() {
+        prompt.push_str("Candidate collections: (none)\n");
+    } else {
+        prompt.push_str("Candidate collections (name, score, columns):\n");
+        for c in &slice.collections {
+            prompt.push_str("- ");
+            prompt.push_str(&c.collection);
+            prompt.push_str(&format!(" (score {:.4})", c.score));
+            if !c.columns.is_empty() {
+                let mut cols: BTreeSet<&str> = BTreeSet::new();
+                for col in &c.columns {
+                    cols.insert(col.as_str());
+                }
+                prompt.push_str(": ");
+                prompt.push_str(&cols.into_iter().collect::<Vec<_>>().join(", "));
+            }
+            prompt.push('\n');
+        }
+    }
+
+    prompt.push_str("\nQuestion: ");
+    prompt.push_str(question);
+    prompt
+}
+
+/// Parse the planner model's output into a typed plan. Tolerates code
+/// fences and surrounding prose by extracting the outermost JSON object.
+pub fn parse_plan(raw: &str) -> RedDBResult<AskPlan> {
+    let json = extract_json_object(raw).ok_or_else(|| {
+        RedDBError::Query("ASK planner returned no JSON plan object".to_string())
+    })?;
+    let parsed: crate::json::Value = crate::json::from_str(json)
+        .map_err(|err| RedDBError::Query(format!("ASK planner returned invalid JSON plan: {err}")))?;
+    let obj = parsed.as_object().ok_or_else(|| {
+        RedDBError::Query("ASK planner plan must be a JSON object".to_string())
+    })?;
+
+    let intent_raw = obj
+        .get("intent")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| RedDBError::Query("ASK planner plan is missing `intent`".to_string()))?;
+    let intent = AskIntent::parse(intent_raw).ok_or_else(|| {
+        RedDBError::Query(format!(
+            "ASK planner returned an unknown intent `{intent_raw}`"
+        ))
+    })?;
+
+    let query = obj
+        .get("query")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let rationale = obj
+        .get("rationale")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    Ok(AskPlan {
+        intent,
+        query,
+        rationale,
+    })
+}
+
+/// Route a parsed plan: validate the factual candidate through the parser +
+/// read-only classifier, refuse mutating candidates, and mark non-factual
+/// intents unsupported for this slice.
+pub fn route_plan(plan: &AskPlan) -> RedDBResult<PlanRouting> {
+    match plan.intent {
+        AskIntent::Factual => {
+            let rql = plan.query.as_deref().ok_or_else(|| {
+                RedDBError::Query(
+                    "ASK planner classified the question as factual but produced no query \
+                     candidate"
+                        .to_string(),
+                )
+            })?;
+            // Re-validate through the production parser; malformed candidates
+            // are rejected here and never execute.
+            let candidate = validate_candidate(rql)?;
+            match candidate.disposition {
+                CandidateDisposition::ReadOnly => Ok(PlanRouting::Execute { candidate }),
+                CandidateDisposition::Mutating => Ok(PlanRouting::RefuseMutating {
+                    statement_type: candidate.statement_type,
+                    rql: candidate.rql,
+                }),
+            }
+        }
+        other => Ok(PlanRouting::Unsupported { intent: other }),
+    }
+}
+
+/// Full planner pass: build the narrowed-slice prompt, call the model,
+/// parse the plan, and route it. The model is the closure-model seam.
+pub fn plan_and_route<M: PlannerModel>(
+    question: &str,
+    slice: &NarrowedSlice,
+    model: &M,
+) -> RedDBResult<PlannedRoute> {
+    let prompt = build_planner_prompt(question, slice);
+    let raw = model.plan(&prompt)?;
+    let plan = parse_plan(&raw)?;
+    let routing = route_plan(&plan)?;
+    Ok(PlannedRoute {
+        prompt,
+        plan,
+        routing,
+    })
+}
+
+/// Extract the outermost `{...}` JSON object from a model response that may
+/// carry code fences or surrounding prose.
+fn extract_json_object(raw: &str) -> Option<&str> {
+    let start = raw.find('{')?;
+    let end = raw.rfind('}')?;
+    if end <= start {
+        return None;
+    }
+    Some(&raw[start..=end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slice() -> NarrowedSlice {
+        NarrowedSlice {
+            collections: vec![
+                ScoredCollection {
+                    collection: "travelers".to_string(),
+                    score: 0.91,
+                    columns: vec!["passport".to_string(), "name".to_string()],
+                },
+                ScoredCollection {
+                    collection: "trips".to_string(),
+                    score: 0.44,
+                    columns: vec!["passport".to_string(), "city".to_string()],
+                },
+            ],
+        }
+    }
+
+    /// A mock planner model that returns a fixed plan JSON regardless of the
+    /// prompt — stands in for the configured planner provider.
+    fn mock_model(plan_json: &'static str) -> impl PlannerModel {
+        move |_prompt: &str| Ok(plan_json.to_string())
+    }
+
+    #[test]
+    fn prompt_contains_only_narrowed_slice() {
+        let prompt = build_planner_prompt("who owns passport FDD-1?", &slice());
+        assert!(prompt.contains("travelers"));
+        assert!(prompt.contains("trips"));
+        assert!(prompt.contains("passport"));
+        // A collection outside the narrowed slice must never appear.
+        assert!(!prompt.contains("secret_ledger"));
+    }
+
+    #[test]
+    fn parse_plan_reads_intent_and_query() {
+        let plan = parse_plan(
+            "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"lookup\"}",
+        )
+        .unwrap();
+        assert_eq!(plan.intent, AskIntent::Factual);
+        assert_eq!(
+            plan.query.as_deref(),
+            Some("SELECT * FROM travelers WHERE passport = 'FDD-1'")
+        );
+        assert_eq!(plan.rationale, "lookup");
+    }
+
+    #[test]
+    fn parse_plan_tolerates_code_fences() {
+        let plan = parse_plan(
+            "```json\n{\"intent\":\"synthesis\",\"query\":null,\"rationale\":\"summary\"}\n```",
+        )
+        .unwrap();
+        assert_eq!(plan.intent, AskIntent::Synthesis);
+        assert!(plan.query.is_none());
+    }
+
+    #[test]
+    fn parse_plan_rejects_non_json() {
+        let err = parse_plan("the answer is 42").unwrap_err();
+        assert!(err.to_string().contains("no JSON plan object"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_plan_rejects_unknown_intent() {
+        let err = parse_plan("{\"intent\":\"chitchat\",\"query\":null}").unwrap_err();
+        assert!(err.to_string().contains("unknown intent"), "got: {err}");
+    }
+
+    #[test]
+    fn factual_plan_routes_to_executable_read_only_candidate() {
+        let route = plan_and_route(
+            "who owns passport FDD-1?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"lookup\"}",
+            ),
+        )
+        .unwrap();
+        match route.routing {
+            PlanRouting::Execute { candidate } => {
+                assert!(candidate.is_read_only());
+                assert_eq!(candidate.statement_type, "select");
+            }
+            other => panic!("expected Execute, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn factual_join_candidate_is_executable() {
+        let route = plan_and_route(
+            "which cities did the owner of passport FDD-1 visit?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers JOIN trips ON travelers.passport = trips.passport WHERE travelers.passport = 'FDD-1'\",\"rationale\":\"join\"}",
+            ),
+        )
+        .unwrap();
+        assert!(matches!(route.routing, PlanRouting::Execute { .. }));
+    }
+
+    #[test]
+    fn factual_plan_with_mutating_candidate_is_refused_not_executed() {
+        let route = plan_and_route(
+            "delete traveler FDD-1",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"DELETE FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"oops\"}",
+            ),
+        )
+        .unwrap();
+        match route.routing {
+            PlanRouting::RefuseMutating {
+                statement_type, ..
+            } => assert_eq!(statement_type, "delete"),
+            other => panic!("expected RefuseMutating, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn factual_plan_with_malformed_candidate_is_rejected() {
+        let err = plan_and_route(
+            "who owns passport FDD-1?",
+            &slice(),
+            &mock_model("{\"intent\":\"factual\",\"query\":\"this is not rql\",\"rationale\":\"x\"}"),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid RQL candidate"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn factual_plan_without_query_is_rejected() {
+        let err = plan_and_route(
+            "who owns passport FDD-1?",
+            &slice(),
+            &mock_model("{\"intent\":\"factual\",\"query\":null,\"rationale\":\"x\"}"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("no query candidate"), "got: {err}");
+    }
+
+    #[test]
+    fn synthesis_intent_routes_unsupported_in_this_slice() {
+        let route = plan_and_route(
+            "summarise yesterday's incidents",
+            &slice(),
+            &mock_model("{\"intent\":\"synthesis\",\"query\":null,\"rationale\":\"rag\"}"),
+        )
+        .unwrap();
+        assert_eq!(
+            route.routing,
+            PlanRouting::Unsupported {
+                intent: AskIntent::Synthesis
+            }
+        );
+    }
+
+    #[test]
+    fn how_to_intent_routes_unsupported_in_this_slice() {
+        let route = plan_and_route(
+            "how would I capture events into a queue?",
+            &slice(),
+            &mock_model("{\"intent\":\"how_to\",\"query\":null,\"rationale\":\"guide\"}"),
+        )
+        .unwrap();
+        assert_eq!(
+            route.routing,
+            PlanRouting::Unsupported {
+                intent: AskIntent::HowTo
+            }
+        );
+    }
+
+    #[test]
+    fn plan_summary_includes_intent_and_query() {
+        let plan = AskPlan {
+            intent: AskIntent::Factual,
+            query: Some("SELECT * FROM travelers WHERE passport = 'FDD-1'".to_string()),
+            rationale: "lookup".to_string(),
+        };
+        let summary = plan.summary();
+        assert!(summary.contains("intent=factual"));
+        assert!(summary.contains("SELECT * FROM travelers"));
+    }
+}

--- a/crates/reddb-server/src/runtime/ai/audit_record_builder.rs
+++ b/crates/reddb-server/src/runtime/ai/audit_record_builder.rs
@@ -121,6 +121,12 @@ pub struct CallState<'a> {
     pub validation_ok: bool,
     pub retry_count: u32,
     pub errors: &'a [ValidationError],
+    /// Planner-first fields (ADR 0068 / #1747). `None` on the RAG path so
+    /// the row shape is unchanged; `Some` on the planner path, where the
+    /// audit row grows the routed intent, plan summary, and executed query.
+    pub intent: Option<&'a str>,
+    pub plan_summary: Option<&'a str>,
+    pub executed_query: Option<&'a str>,
 }
 
 /// Produce one audit row, ready to insert into `red_ask_audit`.
@@ -168,6 +174,17 @@ pub fn build(state: &CallState<'_>, settings: Settings) -> BTreeMap<&'static str
 
     if settings.include_answer {
         row.insert("answer", json!(state.answer));
+    }
+
+    // Planner-first fields (#1747): present only on the planner path.
+    if let Some(intent) = state.intent {
+        row.insert("intent", json!(intent));
+    }
+    if let Some(plan_summary) = state.plan_summary {
+        row.insert("plan_summary", json!(plan_summary));
+    }
+    if let Some(executed_query) = state.executed_query {
+        row.insert("executed_query", json!(executed_query));
     }
 
     row
@@ -240,7 +257,33 @@ mod tests {
             validation_ok: true,
             retry_count: 0,
             errors,
+            intent: None,
+            plan_summary: None,
+            executed_query: None,
         }
+    }
+
+    #[test]
+    fn planner_fields_present_only_when_set() {
+        let urns: Vec<String> = vec![];
+        let citations: Vec<u32> = vec![];
+        let errors: Vec<ValidationError> = vec![];
+        let mut state = base_state("q?", &urns, "answer", &citations, &errors);
+        let row = build(&state, Settings::default());
+        assert!(!row.contains_key("intent"));
+        assert!(!row.contains_key("plan_summary"));
+        assert!(!row.contains_key("executed_query"));
+
+        state.intent = Some("factual");
+        state.plan_summary = Some("intent=factual; query=SELECT * FROM t WHERE a = 'x'");
+        state.executed_query = Some("SELECT * FROM t WHERE a = 'x'");
+        let row = build(&state, Settings::default());
+        assert_eq!(row.get("intent"), Some(&json!("factual")));
+        assert_eq!(
+            row.get("executed_query"),
+            Some(&json!("SELECT * FROM t WHERE a = 'x'"))
+        );
+        assert!(row.contains_key("plan_summary"));
     }
 
     // ---- answer_hash ----------------------------------------------------

--- a/crates/reddb-server/src/runtime/ai/mod.rs
+++ b/crates/reddb-server/src/runtime/ai/mod.rs
@@ -13,6 +13,7 @@
 //! at runtime config time.
 
 pub mod answer_cache_key;
+pub mod ask_planner;
 pub mod ask_response_envelope;
 pub mod ask_rql_planner;
 pub mod audit_record_builder;

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1766,8 +1766,7 @@ impl RedDBRuntime {
         // Resolve the planner model independently of the synthesis model
         // (ADR 0068 §3). Planner falls back to the general/ASK default.
         let synth_model = ask.model.clone().unwrap_or_else(|| default_model.clone());
-        let planner_model =
-            crate::ai::resolve_ask_planner_model_from_runtime(self, &synth_model);
+        let planner_model = crate::ai::resolve_ask_planner_model_from_runtime(self, &synth_model);
 
         let settings = self.ask_cost_guard_settings();
         let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
@@ -1975,7 +1974,10 @@ impl RedDBRuntime {
         ]);
         let mut record = UnifiedRecord::new();
         record.set("answer", Value::text(synthesized.answer));
-        record.set("provider", Value::text(synthesized.provider.token().to_string()));
+        record.set(
+            "provider",
+            Value::text(synthesized.provider.token().to_string()),
+        );
         record.set("model", Value::text(synth_model.to_string()));
         record.set(
             "mode",
@@ -1984,7 +1986,10 @@ impl RedDBRuntime {
         record.set("intent", Value::text(intent_label.to_string()));
         record.set("executed_query", Value::text(candidate_rql.to_string()));
         record.set("plan_summary", Value::text(plan_summary));
-        record.set("retry_count", Value::Integer(synthesized.retry_count as i64));
+        record.set(
+            "retry_count",
+            Value::Integer(synthesized.retry_count as i64),
+        );
         record.set(
             "prompt_tokens",
             Value::Integer(synthesized.prompt_tokens as i64),
@@ -3931,8 +3936,9 @@ fn planner_value_to_json(value: &Value) -> crate::json::Value {
         Value::Float(f) => crate::json::Value::Number(*f),
         Value::Boolean(b) => crate::json::Value::Bool(*b),
         Value::Text(s) => crate::json::Value::String(s.to_string()),
-        Value::Json(bytes) => crate::json::from_slice(bytes)
-            .unwrap_or_else(|_| crate::json::Value::String(String::from_utf8_lossy(bytes).to_string())),
+        Value::Json(bytes) => crate::json::from_slice(bytes).unwrap_or_else(|_| {
+            crate::json::Value::String(String::from_utf8_lossy(bytes).to_string())
+        }),
         other => crate::json::Value::String(format!("{other:?}")),
     }
 }

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1232,6 +1232,17 @@ impl RedDBRuntime {
             return self.execute_ask_as_rql(raw_query, ask);
         }
 
+        // ADR 0068 / #1747: planner-first path. When enabled, ASK runs the
+        // funnel → planner-LLM → typed plan → auto-executed read-only query
+        // → cited synthesis over the executed rows. A factual plan (or a
+        // structured mutating refusal) returns here; a non-factual intent
+        // returns `None` and falls through to the RAG synthesis path below.
+        if !ask.explain && self.ask_planner_enabled() {
+            if let Some(result) = self.execute_ask_planner_factual(raw_query, ask)? {
+                return Ok(result);
+            }
+        }
+
         // S3 / #711: planner-level provider gate. Runs as the first
         // step — before the AskPipeline and before the credential
         // resolver — so a policy-denied query never spends cycles on
@@ -1519,6 +1530,9 @@ impl RedDBRuntime {
                             validation_ok: false,
                             retry_count,
                             errors: &errors,
+                            intent: None,
+                            plan_summary: None,
+                            executed_query: None,
                         })?;
                         let validation = validation_to_json_with_mode_warning(
                             &citation_result.warnings,
@@ -1620,6 +1634,9 @@ impl RedDBRuntime {
             validation_ok: true,
             retry_count: ask_attempt.retry_count,
             errors: &[],
+            intent: None,
+            plan_summary: None,
+            executed_query: None,
         })?;
 
         // Step 4: Build result
@@ -1679,6 +1696,499 @@ impl RedDBRuntime {
         record.set("sources_flat", Value::Json(sources_flat_bytes));
         record.set("citations", Value::Json(citations_bytes));
         record.set("validation", Value::Json(validation_bytes));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    /// ADR 0068 §1: is the planner-first ASK path enabled? Config-gated so
+    /// this slice can land the factual path without flipping the default
+    /// RAG contract (a later slice makes planner-first the default).
+    fn ask_planner_enabled(&self) -> bool {
+        self.config_bool("red.config.ai.ask.planner", false)
+    }
+
+    /// ADR 0068 / #1747 — the planner-first factual path, end-to-end.
+    ///
+    /// Funnel narrows the schema slice → planner LLM (its own model) emits a
+    /// typed plan over *only* that slice → the `query` step's read-only RQL
+    /// candidate is validated by the production parser + read-only classifier
+    /// → auto-executed under the caller's EffectiveScope → the executed rows
+    /// become `sources_flat` for a cited synthesis call.
+    ///
+    /// Returns `Ok(None)` for a non-factual intent so the caller falls
+    /// through to the RAG path; `Ok(Some(_))` for a factual answer or a
+    /// structured mutating refusal; `Err` for a malformed/planner failure.
+    fn execute_ask_planner_factual(
+        &self,
+        raw_query: &str,
+        ask: &crate::storage::query::ast::AskQuery,
+    ) -> RedDBResult<Option<RuntimeQueryResult>> {
+        use crate::ai::{parse_provider, resolve_api_key_from_runtime};
+        use crate::runtime::ai::ask_planner;
+
+        // Provider gate + failover order (mirrors the RAG path).
+        let (default_provider, default_model) = crate::ai::resolve_defaults_from_runtime(self);
+        let provider_names =
+            self.ask_provider_failover_names(ask.provider.as_deref(), &default_provider)?;
+        let planner_provider_name = provider_names
+            .first()
+            .cloned()
+            .unwrap_or_else(|| default_provider.token().to_string());
+        let planner_provider = parse_provider(&planner_provider_name)?;
+        crate::runtime::ai::provider_gate::enforce(self, &planner_provider)?;
+
+        // Stage 1-4 funnel: narrow the schema slice under the caller's scope.
+        let scope = self.ai_scope();
+        let row_cap = ask
+            .limit
+            .unwrap_or(crate::runtime::ask_pipeline::DEFAULT_ROW_CAP);
+        let ask_context =
+            crate::runtime::ask_pipeline::AskPipeline::execute_with_limit_and_min_score(
+                self,
+                &scope,
+                &ask.question,
+                row_cap,
+                ask.min_score,
+                ask.depth,
+            )?;
+        let slice = narrowed_slice_from_context(&ask_context);
+
+        // Resolve the planner model independently of the synthesis model
+        // (ADR 0068 §3). Planner falls back to the general/ASK default.
+        let synth_model = ask.model.clone().unwrap_or_else(|| default_model.clone());
+        let planner_model =
+            crate::ai::resolve_ask_planner_model_from_runtime(self, &synth_model);
+
+        let settings = self.ask_cost_guard_settings();
+        let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
+        let planner_api_key = resolve_api_key_from_runtime(&planner_provider, None, self)?;
+        let planner_api_base = planner_provider.resolve_api_base();
+
+        // The closure-model seam: the planner LLM behind a `PlannerModel`.
+        // Deterministic by default (temperature 0). The narrowed slice is
+        // the only schema that reaches the model.
+        let planner_closure = |prompt: &str| -> RedDBResult<String> {
+            let response = call_ask_llm(
+                &planner_provider,
+                transport.clone(),
+                planner_api_key.clone(),
+                planner_model.clone(),
+                prompt.to_string(),
+                planner_api_base.clone(),
+                settings.max_completion_tokens as usize,
+                Some(0.0),
+                None,
+                false,
+                None,
+            )?;
+            Ok(response.output_text)
+        };
+        let route = ask_planner::plan_and_route(&ask.question, &slice, &planner_closure)?;
+
+        match route.routing {
+            ask_planner::PlanRouting::Unsupported { .. } => Ok(None),
+            ask_planner::PlanRouting::RefuseMutating {
+                statement_type,
+                rql,
+            } => Ok(Some(self.build_planner_refusal_result(
+                raw_query,
+                &scope,
+                &route.plan,
+                statement_type,
+                &rql,
+            )?)),
+            ask_planner::PlanRouting::Execute { candidate } => {
+                let executed = self.execute_planner_candidate_and_synthesize(
+                    raw_query,
+                    ask,
+                    &scope,
+                    &route.plan,
+                    &candidate.rql,
+                    &provider_names,
+                    &synth_model,
+                    &settings,
+                    transport,
+                )?;
+                Ok(Some(executed))
+            }
+        }
+    }
+
+    /// Auto-execute the validated read-only candidate under the caller's
+    /// EffectiveScope, then synthesize a cited answer over the executed rows.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_planner_candidate_and_synthesize(
+        &self,
+        raw_query: &str,
+        ask: &crate::storage::query::ast::AskQuery,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        plan: &crate::runtime::ai::ask_planner::AskPlan,
+        candidate_rql: &str,
+        provider_names: &[String],
+        synth_model: &str,
+        settings: &crate::runtime::ai::cost_guard::Settings,
+        transport: crate::runtime::ai::transport::AiTransport,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        // Auto-execute under the ambient execution context — the same RLS /
+        // EffectiveScope the funnel ran under. An out-of-scope collection is
+        // filtered here, so it can appear in neither plan nor answer.
+        let executed = self.execute_query(candidate_rql)?;
+        let (sources_flat_json, source_urns, source_payloads) =
+            planner_sources_from_result(&executed.result);
+        let sources_flat_bytes =
+            crate::json::to_vec(&sources_flat_json).unwrap_or_else(|_| b"[]".to_vec());
+        let sources_count = source_urns.len();
+
+        let synthesis_prompt =
+            build_planner_synthesis_prompt(&ask.question, candidate_rql, &source_payloads);
+        let sources_fingerprint = format!("{}\n{}", candidate_rql, source_urns.join(","));
+
+        // Cost guard (pre-call) — unchanged machinery.
+        let now = ask_cost_guard_now();
+        let tenant_key = ask_cost_guard_tenant_key(scope.tenant.as_deref());
+        let prompt_tokens = estimate_prompt_tokens(&synthesis_prompt);
+        let planned_cost_usd = estimate_ask_cost_usd(prompt_tokens, settings.max_completion_tokens);
+        let usage = crate::runtime::ai::cost_guard::Usage {
+            prompt_tokens,
+            sources_bytes: saturating_u32(sources_flat_bytes.len()),
+            estimated_cost_usd: planned_cost_usd,
+            ..Default::default()
+        };
+        let daily_state = self.ask_daily_cost_state(&tenant_key, now);
+        if let crate::runtime::ai::cost_guard::Decision::Reject { limit, detail, .. } =
+            crate::runtime::ai::cost_guard::evaluate(&usage, &daily_state, settings, now)
+        {
+            return Err(cost_guard_rejection_to_error(limit, detail));
+        }
+
+        // Synthesis with provider failover + strict citation validation
+        // (one retry) — the same pure modules as the RAG path (criterion 6).
+        let requested_mode = if ask.strict {
+            crate::runtime::ai::strict_validator::Mode::Strict
+        } else {
+            crate::runtime::ai::strict_validator::Mode::Lenient
+        };
+        let mut failed_attempts = Vec::new();
+        let mut synthesized: Option<PlannerSynthesis> = None;
+        for provider_name in provider_names {
+            match self.synthesize_over_rows(
+                provider_name,
+                synth_model,
+                &synthesis_prompt,
+                sources_count,
+                sources_flat_bytes.len(),
+                requested_mode,
+                &sources_fingerprint,
+                ask,
+                settings,
+                &transport,
+                &tenant_key,
+            ) {
+                Ok(result) => {
+                    synthesized = Some(result);
+                    break;
+                }
+                Err(err) => {
+                    let attempt_err = ask_attempt_error_from_reddb(&err);
+                    if attempt_err.is_retryable() {
+                        failed_attempts.push((provider_name.clone(), attempt_err));
+                        continue;
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        let synthesized = synthesized.ok_or_else(|| {
+            ask_failover_exhausted_to_error(
+                crate::runtime::ai::provider_failover::FailoverExhausted {
+                    attempts: failed_attempts,
+                },
+            )
+        })?;
+
+        let citations_json =
+            citations_to_json(&synthesized.citation_result.citations, &source_urns);
+        let validation_json = validation_to_json_with_mode_warning(
+            &synthesized.citation_result.warnings,
+            &[],
+            true,
+            synthesized.mode_warning.as_ref(),
+        );
+        let citations_bytes =
+            crate::json::to_vec(&citations_json).unwrap_or_else(|_| b"[]".to_vec());
+        let validation_bytes =
+            crate::json::to_vec(&validation_json).unwrap_or_else(|_| b"{}".to_vec());
+
+        let citation_markers = citation_markers(&synthesized.citation_result.citations);
+        let intent_label = plan.intent.as_str();
+        let plan_summary = plan.summary();
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &ask.question,
+            source_urns: &source_urns,
+            provider: synthesized.provider.token(),
+            model: synth_model,
+            prompt_tokens: i64::from(synthesized.prompt_tokens),
+            completion_tokens: synthesized.completion_tokens.min(i64::MAX as u64) as i64,
+            cost_usd: synthesized.cost_usd,
+            answer: &synthesized.answer,
+            citations: &citation_markers,
+            cache_hit: false,
+            effective_mode: synthesized.effective_mode,
+            temperature: synthesized.temperature,
+            seed: synthesized.seed,
+            validation_ok: true,
+            retry_count: synthesized.retry_count,
+            errors: &[],
+            intent: Some(intent_label),
+            plan_summary: Some(&plan_summary),
+            executed_query: Some(candidate_rql),
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "answer".into(),
+            "provider".into(),
+            "model".into(),
+            "mode".into(),
+            "intent".into(),
+            "executed_query".into(),
+            "plan_summary".into(),
+            "retry_count".into(),
+            "prompt_tokens".into(),
+            "completion_tokens".into(),
+            "cost_usd".into(),
+            "cache_hit".into(),
+            "sources_count".into(),
+            "sources_flat".into(),
+            "citations".into(),
+            "validation".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("answer", Value::text(synthesized.answer));
+        record.set("provider", Value::text(synthesized.provider.token().to_string()));
+        record.set("model", Value::text(synth_model.to_string()));
+        record.set(
+            "mode",
+            Value::text(strict_mode_label(synthesized.effective_mode)),
+        );
+        record.set("intent", Value::text(intent_label.to_string()));
+        record.set("executed_query", Value::text(candidate_rql.to_string()));
+        record.set("plan_summary", Value::text(plan_summary));
+        record.set("retry_count", Value::Integer(synthesized.retry_count as i64));
+        record.set(
+            "prompt_tokens",
+            Value::Integer(synthesized.prompt_tokens as i64),
+        );
+        record.set(
+            "completion_tokens",
+            Value::Integer(synthesized.completion_tokens as i64),
+        );
+        record.set("cost_usd", Value::Float(synthesized.cost_usd));
+        record.set("cache_hit", Value::Boolean(false));
+        record.set("sources_count", Value::Integer(sources_count as i64));
+        record.set("sources_flat", Value::Json(sources_flat_bytes));
+        record.set("citations", Value::Json(citations_bytes));
+        record.set("validation", Value::Json(validation_bytes));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    /// One synthesis attempt against a single provider: cost-metered LLM
+    /// call over the executed rows, strict citation validation with one
+    /// retry. Reuses the RAG path's pure modules unchanged.
+    #[allow(clippy::too_many_arguments)]
+    fn synthesize_over_rows(
+        &self,
+        provider_name: &str,
+        model: &str,
+        base_prompt: &str,
+        sources_count: usize,
+        sources_bytes: usize,
+        requested_mode: crate::runtime::ai::strict_validator::Mode,
+        sources_fingerprint: &str,
+        ask: &crate::storage::query::ast::AskQuery,
+        settings: &crate::runtime::ai::cost_guard::Settings,
+        transport: &crate::runtime::ai::transport::AiTransport,
+        tenant_key: &str,
+    ) -> RedDBResult<PlannerSynthesis> {
+        use crate::ai::{parse_provider, resolve_api_key_from_runtime};
+
+        let provider = parse_provider(provider_name)?;
+        crate::runtime::ai::provider_gate::enforce(self, &provider)?;
+        let provider_token = provider.token().to_string();
+        let mode_outcome = self
+            .ask_provider_capability_registry(&provider_token)
+            .evaluate_mode(&provider_token, requested_mode);
+        let effective_mode = mode_outcome.effective();
+        let mode_warning = mode_outcome.warning().cloned();
+        let capabilities = self
+            .ask_provider_capability_registry(&provider_token)
+            .capabilities(&provider_token);
+        let determinism = crate::runtime::ai::determinism_decider::decide(
+            crate::runtime::ai::determinism_decider::Inputs {
+                question: &ask.question,
+                sources_fingerprint,
+            },
+            capabilities,
+            crate::runtime::ai::determinism_decider::Overrides {
+                temperature: ask.temperature,
+                seed: ask.seed,
+            },
+            crate::runtime::ai::determinism_decider::Settings {
+                default_temperature: self.config_f64("ask.default_temperature", 0.0) as f32,
+            },
+        );
+
+        let api_key = resolve_api_key_from_runtime(&provider, None, self)?;
+        let api_base = provider.resolve_api_base();
+        let mut attempt = crate::runtime::ai::strict_validator::Attempt::First;
+        let mut retry_count = 0_u32;
+        let mut prompt_for_call = base_prompt.to_string();
+        loop {
+            let response = call_ask_llm(
+                &provider,
+                transport.clone(),
+                api_key.clone(),
+                model.to_string(),
+                prompt_for_call.clone(),
+                api_base.clone(),
+                settings.max_completion_tokens as usize,
+                determinism.temperature,
+                determinism.seed,
+                false,
+                None,
+            )?;
+            let completion_tokens = response.completion_tokens.unwrap_or(0);
+            let prompt_tokens = response
+                .prompt_tokens
+                .map(u64_to_u32_saturating)
+                .unwrap_or_else(|| estimate_prompt_tokens(&prompt_for_call));
+            let completion_tokens_u32 = u64_to_u32_saturating(completion_tokens);
+            let cost_usd = estimate_ask_cost_usd(prompt_tokens, completion_tokens_u32);
+            let usage = crate::runtime::ai::cost_guard::Usage {
+                prompt_tokens,
+                sources_bytes: saturating_u32(sources_bytes),
+                completion_tokens: completion_tokens_u32,
+                estimated_cost_usd: cost_usd,
+                ..Default::default()
+            };
+            self.check_and_record_ask_daily_cost(tenant_key, &usage, settings)?;
+
+            let answer = response.output_text;
+            let citation_result =
+                crate::runtime::ai::citation_parser::parse_citations(&answer, sources_count);
+            match crate::runtime::ai::strict_validator::validate(
+                &citation_result,
+                effective_mode,
+                attempt,
+            ) {
+                crate::runtime::ai::strict_validator::Decision::Ok => {
+                    return Ok(PlannerSynthesis {
+                        answer,
+                        provider,
+                        effective_mode,
+                        mode_warning,
+                        temperature: determinism.temperature,
+                        seed: determinism.seed,
+                        retry_count,
+                        prompt_tokens,
+                        completion_tokens,
+                        cost_usd,
+                        citation_result,
+                    });
+                }
+                crate::runtime::ai::strict_validator::Decision::Retry { prompt } => {
+                    attempt = crate::runtime::ai::strict_validator::Attempt::Retry;
+                    retry_count = 1;
+                    prompt_for_call = format!("{prompt}\n\n{base_prompt}");
+                }
+                crate::runtime::ai::strict_validator::Decision::GiveUp { errors } => {
+                    let validation = validation_to_json_with_mode_warning(
+                        &citation_result.warnings,
+                        &errors,
+                        false,
+                        mode_warning.as_ref(),
+                    );
+                    return Err(RedDBError::Validation {
+                        message: "ASK citation validation failed after retry".to_string(),
+                        validation,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Structured refusal for a mutating planner candidate. The candidate is
+    /// never executed under any flag; the suggestion envelope arrives later.
+    fn build_planner_refusal_result(
+        &self,
+        raw_query: &str,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        plan: &crate::runtime::ai::ask_planner::AskPlan,
+        statement_type: &str,
+        candidate_rql: &str,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let answer = format!(
+            "This question maps to a mutating `{statement_type}` statement, which ASK never \
+             executes. No query was run."
+        );
+        let plan_summary = plan.summary();
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &plan_summary,
+            source_urns: &[],
+            provider: "",
+            model: "",
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            answer: &answer,
+            citations: &[],
+            cache_hit: false,
+            effective_mode: crate::runtime::ai::strict_validator::Mode::Lenient,
+            temperature: None,
+            seed: None,
+            validation_ok: true,
+            retry_count: 0,
+            errors: &[],
+            intent: Some(plan.intent.as_str()),
+            plan_summary: Some(&plan_summary),
+            executed_query: None,
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "answer".into(),
+            "refused".into(),
+            "intent".into(),
+            "candidate".into(),
+            "candidate_type".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("answer", Value::text(answer));
+        record.set("refused", Value::Boolean(true));
+        record.set("intent", Value::text(plan.intent.as_str().to_string()));
+        record.set("candidate", Value::text(candidate_rql.to_string()));
+        record.set("candidate_type", Value::text(statement_type.to_string()));
         result.push(record);
 
         Ok(RuntimeQueryResult {
@@ -2333,6 +2843,9 @@ impl RedDBRuntime {
             validation_ok: input.validation_ok,
             retry_count: input.retry_count,
             errors: input.errors,
+            intent: input.intent,
+            plan_summary: input.plan_summary,
+            executed_query: input.executed_query,
         };
         let row =
             crate::runtime::ai::audit_record_builder::build(&state, self.ask_audit_settings());
@@ -2714,6 +3227,57 @@ struct AskAuditInput<'a> {
     validation_ok: bool,
     retry_count: u32,
     errors: &'a [crate::runtime::ai::strict_validator::ValidationError],
+    /// Planner-first audit fields (#1747). `None` on the RAG path.
+    intent: Option<&'a str>,
+    plan_summary: Option<&'a str>,
+    executed_query: Option<&'a str>,
+}
+
+impl<'a> AskAuditInput<'a> {
+    /// Construct a RAG-path audit input with the planner-first fields unset.
+    #[allow(clippy::too_many_arguments)]
+    fn rag(
+        scope: &'a crate::runtime::statement_frame::EffectiveScope,
+        question: &'a str,
+        source_urns: &'a [String],
+        provider: &'a str,
+        model: &'a str,
+        prompt_tokens: i64,
+        completion_tokens: i64,
+        cost_usd: f64,
+        answer: &'a str,
+        citations: &'a [u32],
+        cache_hit: bool,
+        effective_mode: crate::runtime::ai::strict_validator::Mode,
+        temperature: Option<f32>,
+        seed: Option<u64>,
+        validation_ok: bool,
+        retry_count: u32,
+        errors: &'a [crate::runtime::ai::strict_validator::ValidationError],
+    ) -> Self {
+        AskAuditInput {
+            scope,
+            question,
+            source_urns,
+            provider,
+            model,
+            prompt_tokens,
+            completion_tokens,
+            cost_usd,
+            answer,
+            citations,
+            cache_hit,
+            effective_mode,
+            temperature,
+            seed,
+            validation_ok,
+            retry_count,
+            errors,
+            intent: None,
+            plan_summary: None,
+            executed_query: None,
+        }
+    }
 }
 
 fn ask_cache_mode(
@@ -3284,6 +3848,152 @@ fn sse_source_rows_from_sources_json(
 /// `prompt_template::SecretRedactor::new()` defaults, which are the
 /// canonical pattern set. If the audit pipeline grows a separate
 /// redactor with operator-tunable patterns, swap the constructor here.
+/// A single synthesis attempt's result on the planner-first factual path.
+struct PlannerSynthesis {
+    answer: String,
+    provider: crate::ai::AiProvider,
+    effective_mode: crate::runtime::ai::strict_validator::Mode,
+    mode_warning: Option<crate::runtime::ai::provider_capabilities::ModeWarning>,
+    temperature: Option<f32>,
+    seed: Option<u64>,
+    retry_count: u32,
+    prompt_tokens: u32,
+    completion_tokens: u64,
+    cost_usd: f64,
+    citation_result: crate::runtime::ai::citation_parser::CitationParseResult,
+}
+
+/// Build the planner's narrowed slice from the funnel context: candidate
+/// collections with per-collection retrieval scores and columns. Only this
+/// slice reaches the planner LLM — the raw catalog never does.
+fn narrowed_slice_from_context(
+    ctx: &crate::runtime::ask_pipeline::AskContext,
+) -> crate::runtime::ai::ask_planner::NarrowedSlice {
+    use crate::runtime::ai::ask_planner::{NarrowedSlice, ScoredCollection};
+    let mut scores: std::collections::HashMap<&str, f32> = std::collections::HashMap::new();
+    for hit in &ctx.text_hits {
+        let e = scores.entry(hit.collection.as_str()).or_insert(0.0);
+        if hit.score > *e {
+            *e = hit.score;
+        }
+    }
+    for hit in &ctx.vector_hits {
+        let e = scores.entry(hit.collection.as_str()).or_insert(0.0);
+        if hit.score > *e {
+            *e = hit.score;
+        }
+    }
+    for hit in &ctx.graph_hits {
+        let e = scores.entry(hit.collection.as_str()).or_insert(0.0);
+        if hit.score > *e {
+            *e = hit.score;
+        }
+    }
+    // A literal-matched row is the strongest funnel signal.
+    for row in &ctx.filtered_rows {
+        let e = scores.entry(row.collection.as_str()).or_insert(0.0);
+        if *e < 1.0 {
+            *e = 1.0;
+        }
+    }
+
+    let mut collections: Vec<ScoredCollection> = ctx
+        .candidates
+        .collections
+        .iter()
+        .map(|collection| ScoredCollection {
+            collection: collection.clone(),
+            score: scores.get(collection.as_str()).copied().unwrap_or(0.0),
+            columns: ctx
+                .candidates
+                .columns_by_collection
+                .get(collection)
+                .cloned()
+                .unwrap_or_default(),
+        })
+        .collect();
+    collections.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.collection.cmp(&b.collection))
+    });
+    NarrowedSlice { collections }
+}
+
+/// Convert a storage row value to the in-house JSON value for the source
+/// payload. Common scalars map directly; anything exotic stringifies.
+fn planner_value_to_json(value: &Value) -> crate::json::Value {
+    match value {
+        Value::Null => crate::json::Value::Null,
+        Value::Integer(i) => crate::json::Value::Number(*i as f64),
+        Value::UnsignedInteger(u) => crate::json::Value::Number(*u as f64),
+        Value::Float(f) => crate::json::Value::Number(*f),
+        Value::Boolean(b) => crate::json::Value::Bool(*b),
+        Value::Text(s) => crate::json::Value::String(s.to_string()),
+        Value::Json(bytes) => crate::json::from_slice(bytes)
+            .unwrap_or_else(|_| crate::json::Value::String(String::from_utf8_lossy(bytes).to_string())),
+        other => crate::json::Value::String(format!("{other:?}")),
+    }
+}
+
+/// Turn the auto-executed result rows into `sources_flat` (JSON array),
+/// their parallel URNs (aligned by index for citation resolution), and
+/// per-row payload strings for the synthesis prompt.
+fn planner_sources_from_result(
+    result: &UnifiedResult,
+) -> (crate::json::Value, Vec<String>, Vec<String>) {
+    let mut arr: Vec<crate::json::Value> = Vec::with_capacity(result.records.len());
+    let mut urns: Vec<String> = Vec::with_capacity(result.records.len());
+    let mut payloads: Vec<String> = Vec::with_capacity(result.records.len());
+    for (idx, rec) in result.records.iter().enumerate() {
+        let mut payload_obj: crate::json::Map<String, crate::json::Value> = Default::default();
+        for (key, value) in rec.iter_fields() {
+            payload_obj.insert(key.to_string(), planner_value_to_json(value));
+        }
+        let payload_json = crate::json::Value::Object(payload_obj);
+        let payload_str =
+            crate::json::to_string(&payload_json).unwrap_or_else(|_| "{}".to_string());
+        let urn = format!("urn:reddb:ask-row:{}", idx + 1);
+
+        let mut obj: crate::json::Map<String, crate::json::Value> = Default::default();
+        obj.insert(
+            "kind".to_string(),
+            crate::json::Value::String("row".to_string()),
+        );
+        obj.insert("urn".to_string(), crate::json::Value::String(urn.clone()));
+        obj.insert("payload".to_string(), payload_json);
+        arr.push(crate::json::Value::Object(obj));
+        urns.push(urn);
+        payloads.push(payload_str);
+    }
+    (crate::json::Value::Array(arr), urns, payloads)
+}
+
+/// Assemble the synthesis prompt over the executed rows: numbered sources
+/// the model must cite with `[^N]`, plus the executed query for context.
+fn build_planner_synthesis_prompt(question: &str, executed_query: &str, rows: &[String]) -> String {
+    let mut prompt = String::new();
+    prompt.push_str(
+        "You are answering a question using ONLY the executed query result rows below. \
+         Cite every claim with an inline [^N] marker where N is the 1-based row number. \
+         Do not invent facts beyond the rows.\n\n",
+    );
+    prompt.push_str("Executed query: ");
+    prompt.push_str(executed_query);
+    prompt.push_str("\n\nRows:\n");
+    if rows.is_empty() {
+        prompt.push_str("(no rows returned)\n");
+    } else {
+        for (idx, row) in rows.iter().enumerate() {
+            prompt.push_str(&format!("[^{}] {}\n", idx + 1, row));
+        }
+    }
+    prompt.push_str("\nQuestion: ");
+    prompt.push_str(question);
+    prompt
+}
+
 fn render_prompt(ctx: &crate::runtime::ask_pipeline::AskContext, question: &str) -> String {
     use crate::runtime::ai::prompt_template::{
         ContextBlock, ContextSource, PromptTemplate, ProviderTier, SecretRedactor, TemplateSlots,
@@ -4398,6 +5108,9 @@ mod citation_wedge_tests {
             validation_ok: true,
             retry_count: 0,
             errors: &errors,
+            intent: None,
+            plan_summary: None,
+            executed_query: None,
         };
         let audit_row = crate::runtime::ai::audit_record_builder::build(
             &state,
@@ -4612,6 +5325,9 @@ mod citation_wedge_tests {
                 validation_ok: true,
                 retry_count: 0,
                 errors: &errors,
+                intent: None,
+                plan_summary: None,
+                executed_query: None,
             };
             let row = crate::runtime::ai::audit_record_builder::build(
                 &state,

--- a/tests/grouped/ai_search.rs
+++ b/tests/grouped/ai_search.rs
@@ -12,6 +12,9 @@ mod support;
 #[path = "surface_contracts/compile_fail.rs"]
 mod compile_fail;
 
+#[path = "ai_search/e2e_ask_planner_core.rs"]
+mod e2e_ask_planner_core;
+
 #[path = "ai_search/e2e_ask_search_conformance.rs"]
 mod e2e_ask_search_conformance;
 

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -1,0 +1,460 @@
+//! #1747 — ASK planner core: the factual intent, end-to-end (ADR 0068).
+//!
+//! Pins the planner-first factual path with a mock OpenAI-compatible HTTP
+//! stub, fully offline. The stub returns a *scripted sequence* of chat
+//! completions (plan JSON first, then the cited synthesis) and captures
+//! every chat request body so the tests can assert what reached the model.
+//!
+//! Coverage:
+//!   1. A factual `ASK` generates → validates → executes a read-only query
+//!      and answers with citations over the executed rows.
+//!   2. The planner prompt carries only the funnel-narrowed slice — a
+//!      collection the funnel did not select never reaches the model.
+//!   3. A multi-collection question produces a global-`any` candidate that
+//!      executes across collections and grounds the answer.
+//!   4. A mutating candidate is refused and never executed under any flag.
+//!   5. The `red_ask_audit` row grows intent, plan summary, executed query.
+//!   6. `red.config.ai.ask.planner_model` selects the planner model
+//!      independently of the synthesis model.
+//!
+//! The planner routing/refusal logic itself is unit-tested without HTTP in
+//! `crates/reddb-server/src/runtime/ai/ask_planner.rs`.
+
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use super::support::env_lock;
+use super::support::PersistentRuntime;
+use reddb::storage::query::unified::UnifiedRecord;
+use reddb::storage::schema::Value;
+use reddb::RedDBRuntime;
+
+fn open_rt() -> PersistentRuntime {
+    super::support::persistent_test_runtime("ask-planner-core")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+/// Wire the runtime + env at a scripted mock stub and enable the planner.
+fn configure_planner(rt: &RedDBRuntime) {
+    rt.execute_query("SET CONFIG runtime.ai.transport_retry_max_attempts = 1")
+        .expect("disable transport retries");
+    rt.execute_query("SET CONFIG red.config.ai.ask.planner = true")
+        .expect("enable planner-first path");
+}
+
+fn text(record: &UnifiedRecord, col: &str) -> Option<String> {
+    match record.get(col)? {
+        Value::Text(s) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+// ===========================================================================
+// 1 + 2 + 5 + 6 — factual end-to-end, narrowed-slice prompt, audit, models.
+// ===========================================================================
+
+#[test]
+fn factual_ask_generates_executes_and_cites_over_executed_rows() {
+    let _env = env_lock().lock().expect("env lock");
+
+    let stub = ScriptedStub::start(vec![
+        // Planner call → typed plan with a read-only query step.
+        "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"passport lookup\"}".to_string(),
+        // Synthesis call → cited answer over the executed rows.
+        "Passport FDD-1 belongs to Alice [^1]".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES \
+           ('t1', 'FDD-1', 'Alice'), ('t2', 'FDD-2', 'Bob')",
+    );
+    // Collections the question does not touch — must never reach the planner.
+    exec(
+        &rt,
+        "CREATE TABLE orders (id TEXT PRIMARY KEY, sku TEXT) WITH CONTEXT INDEX ON (id, sku)",
+    );
+    exec(&rt, "INSERT INTO orders (id, sku) VALUES ('o1', 'WIDGET')");
+
+    configure_planner(&rt);
+    // Independent planner model (criterion 9).
+    rt.execute_query("SET CONFIG red.config.ai.ask.planner_model = 'planner-mini'")
+        .expect("set planner model");
+
+    let result = rt
+        .execute_query("ASK 'who owns passport FDD-1?' STRICT OFF LIMIT 5")
+        .expect("planner-first factual ASK should succeed");
+    let record = result
+        .result
+        .records
+        .first()
+        .expect("ASK returns one canonical row");
+
+    // (1) Cited synthesis over the executed rows.
+    let answer = text(record, "answer").expect("answer column");
+    assert!(
+        answer.contains("Alice"),
+        "answer should be grounded in the executed row, got: {answer:?}"
+    );
+    let intent = text(record, "intent").expect("intent column");
+    assert_eq!(intent, "factual");
+    let executed_query = text(record, "executed_query").expect("executed_query column");
+    assert_eq!(executed_query, "SELECT * FROM travelers WHERE passport = 'FDD-1'");
+    let sources_count = match record.get("sources_count") {
+        Some(Value::Integer(n)) => *n,
+        other => panic!("sources_count must be Integer, got {other:?}"),
+    };
+    assert_eq!(sources_count, 1, "one executed row → one source");
+
+    // Both the planner and the synthesis LLM were called.
+    assert!(
+        stub.request_count() >= 2,
+        "planner + synthesis calls expected, got {}",
+        stub.request_count()
+    );
+
+    // (2) The planner prompt carried only the funnel-narrowed slice.
+    let bodies = stub.chat_bodies();
+    let planner_body = &bodies[0];
+    assert!(
+        planner_body.contains("travelers"),
+        "planner prompt must include the narrowed collection"
+    );
+    assert!(
+        !planner_body.contains("orders"),
+        "planner prompt must NOT include a collection the funnel did not select: {planner_body}"
+    );
+
+    // (6) Planner and synthesis used distinct, independently-selected models.
+    assert!(
+        planner_body.contains("planner-mini"),
+        "planner call must use red.config.ai.ask.planner_model"
+    );
+    let synth_body = &bodies[1];
+    assert!(
+        synth_body.contains("synth-main"),
+        "synthesis call must use the synthesis model, not the planner model"
+    );
+
+    // (5) Audit row grows intent, plan summary, executed query.
+    let audit = rt
+        .execute_query("SELECT * FROM red_ask_audit")
+        .expect("read audit rows");
+    let audit_row = audit
+        .result
+        .records
+        .iter()
+        .find(|r| text(r, "intent").as_deref() == Some("factual"))
+        .expect("a factual audit row");
+    assert_eq!(
+        text(audit_row, "executed_query").as_deref(),
+        Some("SELECT * FROM travelers WHERE passport = 'FDD-1'")
+    );
+    assert!(
+        text(audit_row, "plan_summary")
+            .map(|s| s.contains("intent=factual"))
+            .unwrap_or(false),
+        "audit plan_summary must record the routed intent"
+    );
+}
+
+// ===========================================================================
+// 3 — multi-collection question → global-`any` candidate grounds the answer.
+// ===========================================================================
+
+#[test]
+fn multi_collection_question_executes_global_any_candidate() {
+    let _env = env_lock().lock().expect("env lock");
+
+    let stub = ScriptedStub::start(vec![
+        "{\"intent\":\"factual\",\"query\":\"SELECT * WHERE passport = 'FDD-9'\",\"rationale\":\"cross-collection passport lookup\"}".to_string(),
+        "The passport appears in travelers and trips [^1][^2]".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES ('t9', 'FDD-9', 'Carol')",
+    );
+    exec(
+        &rt,
+        "CREATE TABLE trips (id TEXT PRIMARY KEY, passport TEXT, city TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, city)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO trips (id, passport, city) VALUES ('tr9', 'FDD-9', 'Lisbon')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("ASK 'what records mention passport FDD-9?' STRICT OFF LIMIT 10")
+        .expect("multi-collection ASK should succeed");
+    let record = result
+        .result
+        .records
+        .first()
+        .expect("one canonical row");
+
+    let executed_query = text(record, "executed_query").expect("executed_query column");
+    assert_eq!(executed_query, "SELECT * WHERE passport = 'FDD-9'");
+    let sources_count = match record.get("sources_count") {
+        Some(Value::Integer(n)) => *n,
+        other => panic!("sources_count must be Integer, got {other:?}"),
+    };
+    assert!(
+        sources_count >= 2,
+        "global-`any` candidate should ground rows from both collections, got {sources_count}"
+    );
+    let sources_flat = match record.get("sources_flat") {
+        Some(Value::Json(bytes)) => String::from_utf8_lossy(bytes).to_string(),
+        Some(Value::Text(s)) => s.to_string(),
+        other => panic!("sources_flat must be JSON/Text, got {other:?}"),
+    };
+    assert!(
+        sources_flat.contains("Carol") && sources_flat.contains("Lisbon"),
+        "executed rows from both collections must appear in sources_flat: {sources_flat}"
+    );
+}
+
+// ===========================================================================
+// 4 — a mutating candidate is refused and never executed.
+// ===========================================================================
+
+#[test]
+fn mutating_candidate_is_refused_and_never_executed() {
+    let _env = env_lock().lock().expect("env lock");
+
+    let stub = ScriptedStub::start(vec![
+        // The planner (mis)classifies to a mutating candidate; the parser +
+        // classifier catch it and the path refuses without executing.
+        "{\"intent\":\"factual\",\"query\":\"DELETE FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"oops\"}".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES ('t1', 'FDD-1', 'Alice')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("ASK 'delete traveler passport FDD-1' STRICT OFF")
+        .expect("refusal is a structured result, not an error");
+    let record = result.result.records.first().expect("one row");
+    assert_eq!(record.get("refused"), Some(&Value::Boolean(true)));
+    assert_eq!(text(record, "candidate_type").as_deref(), Some("delete"));
+
+    // Only the planner was called; no synthesis.
+    assert_eq!(stub.request_count(), 1, "mutating plan must not synthesize");
+
+    // The row is untouched — the mutating candidate never executed.
+    let survivors = rt
+        .execute_query("SELECT * FROM travelers WHERE passport = 'FDD-1'")
+        .expect("select survivors");
+    assert_eq!(
+        survivors.result.records.len(),
+        1,
+        "the mutating candidate must never execute under any flag"
+    );
+}
+
+// ===========================================================================
+// Scripted mock stub — sequenced chat completions + request-body capture.
+// ===========================================================================
+
+struct ScriptedStub {
+    addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    requests: Arc<AtomicUsize>,
+    chat_bodies: Arc<Mutex<Vec<String>>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ScriptedStub {
+    fn start(chat_responses: Vec<String>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("stub bind");
+        listener.set_nonblocking(true).expect("nonblocking listener");
+        let addr = listener.local_addr().expect("local addr");
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let requests = Arc::new(AtomicUsize::new(0));
+        let chat_bodies = Arc::new(Mutex::new(Vec::new()));
+        let server_shutdown = Arc::clone(&shutdown);
+        let server_requests = Arc::clone(&requests);
+        let server_bodies = Arc::clone(&chat_bodies);
+        let mut queue: VecDeque<String> = chat_responses.into();
+        let mut last = "(no scripted response) [^1]".to_string();
+
+        let handle = thread::spawn(move || {
+            while !server_shutdown.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let (path, body) = read_request(&mut stream);
+                        server_requests.fetch_add(1, Ordering::Relaxed);
+                        if path.contains("/embeddings") {
+                            write_embedding_response(&mut stream);
+                        } else {
+                            server_bodies.lock().unwrap().push(body);
+                            let answer = queue.pop_front().unwrap_or_else(|| last.clone());
+                            last = answer.clone();
+                            write_chat_response(&mut stream, &answer);
+                        }
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            addr,
+            shutdown,
+            requests,
+            chat_bodies,
+            handle: Some(handle),
+        }
+    }
+
+    fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    fn request_count(&self) -> usize {
+        self.requests.load(Ordering::Relaxed)
+    }
+
+    fn chat_bodies(&self) -> Vec<String> {
+        self.chat_bodies.lock().unwrap().clone()
+    }
+}
+
+impl Drop for ScriptedStub {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(self.addr);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+/// Read a full HTTP/1.1 request; return (request-target, body).
+fn read_request(stream: &mut TcpStream) -> (String, String) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(100)));
+    let mut buffer = [0u8; 4096];
+    let mut out = Vec::new();
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(n) => {
+                out.extend_from_slice(&buffer[..n]);
+                if out.len() > 256 * 1024 {
+                    break;
+                }
+            }
+            Err(err)
+                if err.kind() == std::io::ErrorKind::WouldBlock
+                    || err.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                break;
+            }
+            Err(_) => break,
+        }
+    }
+    let text = String::from_utf8_lossy(&out).to_string();
+    let path = text
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("")
+        .to_string();
+    let body = text
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b.to_string())
+        .unwrap_or_default();
+    (path, body)
+}
+
+fn write_embedding_response(stream: &mut TcpStream) {
+    let body = r#"{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1,0.2,0.3]}],"model":"mock-embedding","usage":{"prompt_tokens":1,"total_tokens":1}}"#;
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn write_chat_response(stream: &mut TcpStream, answer: &str) {
+    let escaped = answer.replace('\\', "\\\\").replace('"', "\\\"");
+    let body = format!(
+        r#"{{"id":"chatcmpl-mock","object":"chat.completion","model":"mock-chat","choices":[{{"index":0,"message":{{"role":"assistant","content":"{escaped}"}},"finish_reason":"stop"}}],"usage":{{"prompt_tokens":4,"completion_tokens":4,"total_tokens":8}}}}"#
+    );
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var(name).ok();
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.name, value),
+            None => std::env::remove_var(self.name),
+        }
+    }
+}

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -118,7 +118,10 @@ fn factual_ask_generates_executes_and_cites_over_executed_rows() {
     let intent = text(record, "intent").expect("intent column");
     assert_eq!(intent, "factual");
     let executed_query = text(record, "executed_query").expect("executed_query column");
-    assert_eq!(executed_query, "SELECT * FROM travelers WHERE passport = 'FDD-1'");
+    assert_eq!(
+        executed_query,
+        "SELECT * FROM travelers WHERE passport = 'FDD-1'"
+    );
     let sources_count = match record.get("sources_count") {
         Some(Value::Integer(n)) => *n,
         other => panic!("sources_count must be Integer, got {other:?}"),
@@ -219,11 +222,7 @@ fn multi_collection_question_executes_global_any_candidate() {
     let result = rt
         .execute_query("ASK 'what records mention passport FDD-9?' STRICT OFF LIMIT 10")
         .expect("multi-collection ASK should succeed");
-    let record = result
-        .result
-        .records
-        .first()
-        .expect("one canonical row");
+    let record = result.result.records.first().expect("one canonical row");
 
     let executed_query = text(record, "executed_query").expect("executed_query column");
     assert_eq!(executed_query, "SELECT * WHERE passport = 'FDD-9'");
@@ -313,7 +312,9 @@ struct ScriptedStub {
 impl ScriptedStub {
     fn start(chat_responses: Vec<String>) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").expect("stub bind");
-        listener.set_nonblocking(true).expect("nonblocking listener");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking listener");
         let addr = listener.local_addr().expect("local addr");
         let shutdown = Arc::new(AtomicBool::new(false));
         let requests = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Closes #1747.

Finish-from-branch landing of worker `wYDEP`'s attempt for PRD #1744 slice #1747 (Ask planner core — factual intent end-to-end: typed plan, auto-executed read-only query, cited synthesis over executed rows).

The worker's attempt passed test/typecheck/build but bounced on the AFK lint gate (`cargo fmt --check`). Code is functionally complete (tests green); this branch is the worker tip + a single `cargo fmt` commit so it can land.

+1721 lines: `ask_planner.rs` (480), `impl_search.rs` (716), e2e test (460), plus wiring.

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785848594&installation_id=129708444&pr_number=1756&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1756&signature=15896031c263ef26f6744cf1c2eda5469762e5132acb047343a16379c25cc392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->