### PR TITLE
merge: #1748 Ask planner critique and plan budget: single refine_retrieval retry, max_plan_steps cap, STEPS N clamp, honest no-matching-sources

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -969,6 +969,10 @@ pub struct AskQuery {
     /// candidate when (and only when) it is read-only. A mutating
     /// candidate is refused for auto-execution regardless of this flag.
     pub execute: bool,
+    /// Per-query plan-step budget request (`ASK '...' STEPS N`). Clamped to
+    /// `red.config.ai.ask.max_plan_steps` at planning time and never exceeds
+    /// it; `None` falls back to the configured cap.
+    pub steps: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -718,10 +718,11 @@ impl<'a> Parser<'a> {
         let mut cache = AskCacheClause::Default;
         let mut as_rql = false;
         let mut execute = false;
+        let mut steps = None;
 
         // Parse optional clauses in any order. Loop bound = number of
         // clause kinds, so each can appear at most once.
-        for _ in 0..14 {
+        for _ in 0..15 {
             if self.consume(&Token::Using)? {
                 provider = Some(match &self.current.token {
                     Token::String(_) => self.parse_string()?,
@@ -798,6 +799,21 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 execute = true;
+            } else if self.consume_ident_ci("STEPS")? {
+                if steps.is_some() {
+                    return Err(ParseError::new(
+                        "ASK STEPS specified more than once",
+                        self.position(),
+                    ));
+                }
+                let n = self.parse_integer()?;
+                if n < 1 {
+                    return Err(ParseError::new(
+                        "ASK STEPS must be a positive integer",
+                        self.position(),
+                    ));
+                }
+                steps = Some(n as usize);
             } else {
                 break;
             }
@@ -820,6 +836,7 @@ impl<'a> Parser<'a> {
             cache,
             as_rql,
             execute,
+            steps,
         }))
     }
 
@@ -1565,6 +1582,53 @@ mod tests {
         assert_eq!(query.question, "");
         assert_eq!(query.question_param, Some(0));
         assert_eq!(query.cache, AskCacheClause::NoCache);
+    }
+
+    #[test]
+    fn ask_parses_steps_budget_clause() {
+        // Absent by default — the runtime falls back to the config cap.
+        assert_eq!(ask("ASK 'q'").steps, None);
+
+        // A positive STEPS N is captured verbatim (clamping to the config
+        // cap happens later, in the planner).
+        let query = ask("ASK 'q' STEPS 2 STRICT OFF");
+        assert_eq!(query.steps, Some(2));
+
+        // STEPS composes with the other clauses in any order.
+        let query = ask("ASK 'q' DEPTH 3 STEPS 5 LIMIT 4");
+        assert_eq!(query.steps, Some(5));
+        assert_eq!(query.depth, Some(3));
+        assert_eq!(query.limit, Some(4));
+    }
+
+    #[test]
+    fn ask_steps_clause_error_paths() {
+        let mut parser = make_parser("ASK 'q' STEPS 0");
+        let err = parser.parse_ask_query().expect_err("STEPS 0 should fail");
+        assert!(
+            err.to_string()
+                .contains("ASK STEPS must be a positive integer"),
+            "got: {err}"
+        );
+
+        let mut parser = make_parser("ASK 'q' STEPS 2 STEPS 3");
+        let err = parser
+            .parse_ask_query()
+            .expect_err("duplicate STEPS should fail");
+        assert!(
+            err.to_string()
+                .contains("ASK STEPS specified more than once"),
+            "got: {err}"
+        );
+
+        let mut parser = make_parser("ASK 'q' STEPS abc");
+        let err = parser
+            .parse_ask_query()
+            .expect_err("non-integer STEPS should fail");
+        assert!(
+            err.to_string().to_ascii_lowercase().contains("integer"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -221,6 +221,7 @@ fn ask_query_from_request(
         cache: crate::storage::query::ast::AskCacheClause::Default,
         as_rql: false,
         execute: false,
+        steps: None,
     })
 }
 

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -425,6 +425,7 @@ impl McpServer {
             },
             as_rql: false,
             execute: false,
+            steps: None,
         };
         let result = self
             .runtime

--- a/crates/reddb-server/src/runtime/ai/ask_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_planner.rs
@@ -75,6 +75,13 @@ impl NarrowedSlice {
             .map(|c| c.collection.as_str())
             .collect()
     }
+
+    /// The funnel grounded nothing: no candidate collection survived the
+    /// narrowing. An empty slice must never reach the planner LLM — grounding
+    /// failure is answered honestly, not by inventing a query over `(none)`.
+    pub fn is_empty(&self) -> bool {
+        self.collections.is_empty()
+    }
 }
 
 /// The typed plan the planner LLM emits, before candidate validation.
@@ -275,6 +282,163 @@ pub fn plan_and_route<M: PlannerModel>(
     })
 }
 
+// ===========================================================================
+// Plan budget (ADR 0068 §4, issue #1748)
+// ===========================================================================
+
+/// Default `red.config.ai.ask.max_plan_steps` cap when unset.
+pub const DEFAULT_MAX_PLAN_STEPS: usize = 3;
+
+/// A budgeted step in the executed plan. `refine_retrieval` and `query` are
+/// the steps the budget accounts for; each consumes exactly one step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanStep {
+    /// A single re-funnel with expanded tokens after grounding fails on the
+    /// first pass (ADR 0013 single-retry analogy).
+    RefineRetrieval,
+    /// The read-only RQL candidate the planner emitted.
+    Query,
+}
+
+impl PlanStep {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PlanStep::RefineRetrieval => "refine_retrieval",
+            PlanStep::Query => "query",
+        }
+    }
+}
+
+/// Resolve the effective plan-step budget: a per-query `STEPS N` request is
+/// clamped to the configured `max_plan_steps` cap and never exceeds it; an
+/// absent request falls back to the cap. The result is always at least 1.
+pub fn clamp_plan_steps(requested: Option<usize>, cap: usize) -> usize {
+    let cap = cap.max(1);
+    match requested {
+        Some(n) => n.clamp(1, cap),
+        None => cap,
+    }
+}
+
+/// The budget was exhausted mid-plan: a step was attempted after the cap was
+/// already reached. The orchestrator turns this into a structured
+/// partial-with-warning result rather than looping unbounded.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BudgetExhausted {
+    pub attempted: PlanStep,
+    pub executed_steps: usize,
+    pub max_steps: usize,
+}
+
+/// A bounded plan-step counter. Total executed steps can never exceed
+/// `max_steps` — the anti-unbounded-loop guard (ADR 0068 §4).
+#[derive(Debug, Clone)]
+pub struct PlanBudget {
+    max_steps: usize,
+    executed: Vec<PlanStep>,
+}
+
+impl PlanBudget {
+    /// Build a budget from a per-query `STEPS N` request and the config cap.
+    /// The request is clamped so it can never exceed the cap.
+    pub fn new(requested_steps: Option<usize>, cap: usize) -> Self {
+        Self {
+            max_steps: clamp_plan_steps(requested_steps, cap),
+            executed: Vec::new(),
+        }
+    }
+
+    /// The clamped ceiling on total executed steps.
+    pub fn max_steps(&self) -> usize {
+        self.max_steps
+    }
+
+    /// How many steps have executed so far.
+    pub fn executed_count(&self) -> usize {
+        self.executed.len()
+    }
+
+    /// Steps still available before the budget is exhausted.
+    pub fn remaining(&self) -> usize {
+        self.max_steps.saturating_sub(self.executed.len())
+    }
+
+    /// The executed steps, in order — surfaced to the audit row.
+    pub fn executed_steps(&self) -> &[PlanStep] {
+        &self.executed
+    }
+
+    /// Charge one plan step. Returns `Err(BudgetExhausted)` — without
+    /// recording the step — when the cap is already reached.
+    pub fn charge(&mut self, step: PlanStep) -> Result<(), BudgetExhausted> {
+        if self.executed.len() >= self.max_steps {
+            return Err(BudgetExhausted {
+                attempted: step,
+                executed_steps: self.executed.len(),
+                max_steps: self.max_steps,
+            });
+        }
+        self.executed.push(step);
+        Ok(())
+    }
+}
+
+// ===========================================================================
+// Grounding critique + single refine_retrieval retry (ADR 0068 §4)
+// ===========================================================================
+
+/// The funnel behind a closure seam so the retry/refusal logic is unit-tested
+/// without a live retrieval pass. `expanded` requests the refine_retrieval
+/// widening (expanded tokens, relaxed score floor) on the single retry.
+pub trait RetrievalFunnel {
+    fn funnel(&self, expanded: bool) -> RedDBResult<NarrowedSlice>;
+}
+
+impl<F> RetrievalFunnel for F
+where
+    F: Fn(bool) -> RedDBResult<NarrowedSlice>,
+{
+    fn funnel(&self, expanded: bool) -> RedDBResult<NarrowedSlice> {
+        self(expanded)
+    }
+}
+
+/// The outcome of the grounding critique: either a grounded slice (possibly
+/// after the single refine_retrieval retry) or an honest "no matching
+/// sources" — never an invented answer.
+#[derive(Debug, Clone, PartialEq)]
+pub enum GroundingOutcome {
+    /// A slice that grounds. `refined` is true when the single
+    /// refine_retrieval retry produced it.
+    Grounded { slice: NarrowedSlice, refined: bool },
+    /// Both the first funnel pass and the single refine_retrieval retry
+    /// grounded nothing. ASK answers honestly instead of inventing.
+    NoMatchingSources,
+}
+
+/// Fold the self-critique into grounding: run the funnel; if it grounds
+/// nothing, re-funnel **exactly once** with expanded tokens (mirroring the
+/// single citation retry of ADR 0013); if that still grounds nothing, report
+/// `NoMatchingSources` so ASK answers honestly rather than inventing.
+pub fn ground_with_refine<F: RetrievalFunnel>(funnel: &F) -> RedDBResult<GroundingOutcome> {
+    let first = funnel.funnel(false)?;
+    if !first.is_empty() {
+        return Ok(GroundingOutcome::Grounded {
+            slice: first,
+            refined: false,
+        });
+    }
+    // Exactly one refine_retrieval re-funnel with expanded tokens.
+    let refined = funnel.funnel(true)?;
+    if !refined.is_empty() {
+        return Ok(GroundingOutcome::Grounded {
+            slice: refined,
+            refined: true,
+        });
+    }
+    Ok(GroundingOutcome::NoMatchingSources)
+}
+
 /// Extract the outermost `{...}` JSON object from a model response that may
 /// carry code fences or surrounding prose.
 fn extract_json_object(raw: &str) -> Option<&str> {
@@ -469,6 +633,114 @@ mod tests {
                 intent: AskIntent::HowTo
             }
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Plan budget: STEPS clamp + bounded step counter (#1748).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn steps_clause_is_clamped_to_the_config_cap_never_exceeding_it() {
+        // Above the cap → clamped down to the cap.
+        assert_eq!(clamp_plan_steps(Some(9), 3), 3);
+        // At/below the cap → honored verbatim.
+        assert_eq!(clamp_plan_steps(Some(2), 3), 2);
+        assert_eq!(clamp_plan_steps(Some(3), 3), 3);
+        // Absent → falls back to the cap.
+        assert_eq!(clamp_plan_steps(None, 3), 3);
+        // Never below 1, even for a zero cap or a zero request.
+        assert_eq!(clamp_plan_steps(Some(0), 3), 1);
+        assert_eq!(clamp_plan_steps(None, 0), 1);
+    }
+
+    #[test]
+    fn plan_budget_charges_until_exhausted_then_refuses_more() {
+        let mut budget = PlanBudget::new(Some(2), 3);
+        assert_eq!(budget.max_steps(), 2);
+        assert_eq!(budget.remaining(), 2);
+
+        assert!(budget.charge(PlanStep::RefineRetrieval).is_ok());
+        assert_eq!(budget.remaining(), 1);
+        assert!(budget.charge(PlanStep::Query).is_ok());
+        assert_eq!(budget.remaining(), 0);
+        assert_eq!(
+            budget.executed_steps(),
+            &[PlanStep::RefineRetrieval, PlanStep::Query]
+        );
+
+        // The third step exhausts the budget — no unbounded loop.
+        let err = budget.charge(PlanStep::Query).unwrap_err();
+        assert_eq!(err.max_steps, 2);
+        assert_eq!(err.executed_steps, 2);
+        assert_eq!(err.attempted, PlanStep::Query);
+        // The refused step is not recorded.
+        assert_eq!(budget.executed_count(), 2);
+    }
+
+    #[test]
+    fn plan_budget_request_above_cap_cannot_buy_extra_steps() {
+        // STEPS 5 with a cap of 1 → only one step ever executes.
+        let mut budget = PlanBudget::new(Some(5), 1);
+        assert_eq!(budget.max_steps(), 1);
+        assert!(budget.charge(PlanStep::Query).is_ok());
+        assert!(budget.charge(PlanStep::RefineRetrieval).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // Grounding critique + single refine_retrieval retry (#1748).
+    // -----------------------------------------------------------------------
+
+    /// A funnel closure that counts calls and returns empty/non-empty per the
+    /// script `[first, refined]`.
+    fn scripted_funnel(
+        script: Vec<bool>,
+    ) -> (impl RetrievalFunnel, std::rc::Rc<std::cell::Cell<usize>>) {
+        let calls = std::rc::Rc::new(std::cell::Cell::new(0usize));
+        let calls_inner = calls.clone();
+        let funnel = move |_expanded: bool| -> RedDBResult<NarrowedSlice> {
+            let n = calls_inner.get();
+            calls_inner.set(n + 1);
+            let non_empty = script.get(n).copied().unwrap_or(false);
+            Ok(if non_empty {
+                slice()
+            } else {
+                NarrowedSlice::default()
+            })
+        };
+        (funnel, calls)
+    }
+
+    #[test]
+    fn grounding_succeeds_on_first_pass_without_refining() {
+        let (funnel, calls) = scripted_funnel(vec![true]);
+        let outcome = ground_with_refine(&funnel).unwrap();
+        assert_eq!(calls.get(), 1, "no refine when the first pass grounds");
+        match outcome {
+            GroundingOutcome::Grounded { refined, .. } => assert!(!refined),
+            other => panic!("expected Grounded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_first_pass_triggers_exactly_one_refine_retrieval() {
+        // First pass grounds nothing; the single refine retry grounds.
+        let (funnel, calls) = scripted_funnel(vec![false, true]);
+        let outcome = ground_with_refine(&funnel).unwrap();
+        assert_eq!(calls.get(), 2, "exactly one refine re-funnel");
+        match outcome {
+            GroundingOutcome::Grounded { refined, .. } => assert!(refined),
+            other => panic!("expected Grounded after refine, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn second_grounding_failure_returns_no_matching_sources_not_an_invented_answer() {
+        // Both passes ground nothing → honest no-matching-sources; the funnel
+        // is called exactly twice and never a third time.
+        let (funnel, calls) = scripted_funnel(vec![false, false]);
+        let outcome = ground_with_refine(&funnel).unwrap();
+        assert_eq!(calls.get(), 2, "exactly one refine retry, then give up");
+        assert_eq!(outcome, GroundingOutcome::NoMatchingSources);
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1747,21 +1747,66 @@ impl RedDBRuntime {
         let planner_provider = parse_provider(&planner_provider_name)?;
         crate::runtime::ai::provider_gate::enforce(self, &planner_provider)?;
 
-        // Stage 1-4 funnel: narrow the schema slice under the caller's scope.
+        // Plan budget: a per-query `STEPS N` request clamped to the config
+        // cap; total executed plan steps can never exceed it (ADR 0068 §4).
+        let max_plan_steps = self.config_u64(
+            "red.config.ai.ask.max_plan_steps",
+            ask_planner::DEFAULT_MAX_PLAN_STEPS as u64,
+        ) as usize;
+        let mut budget = ask_planner::PlanBudget::new(ask.steps, max_plan_steps);
+
+        // Stage 1-4 funnel behind a closure seam. The self-critique folds in
+        // here: when the first pass grounds nothing, exactly one
+        // refine_retrieval re-funnel runs with expanded tokens (relaxed score
+        // floor, wider row cap) before we give up — the single-retry analogy
+        // of ADR 0013. When grounding still fails, ASK answers honestly with a
+        // structured "no matching sources" outcome instead of inventing.
         let scope = self.ai_scope();
-        let row_cap = ask
+        let base_row_cap = ask
             .limit
             .unwrap_or(crate::runtime::ask_pipeline::DEFAULT_ROW_CAP);
-        let ask_context =
-            crate::runtime::ask_pipeline::AskPipeline::execute_with_limit_and_min_score(
+        let funnel = |expanded: bool| -> RedDBResult<ask_planner::NarrowedSlice> {
+            let (row_cap, min_score) = if expanded {
+                (
+                    base_row_cap
+                        .saturating_mul(2)
+                        .max(crate::runtime::ask_pipeline::DEFAULT_ROW_CAP),
+                    None,
+                )
+            } else {
+                (base_row_cap, ask.min_score)
+            };
+            let ctx = crate::runtime::ask_pipeline::AskPipeline::execute_with_limit_and_min_score(
                 self,
                 &scope,
                 &ask.question,
                 row_cap,
-                ask.min_score,
+                min_score,
                 ask.depth,
             )?;
-        let slice = narrowed_slice_from_context(&ask_context);
+            Ok(narrowed_slice_from_context(&ctx))
+        };
+
+        let slice = match ask_planner::ground_with_refine(&funnel)? {
+            ask_planner::GroundingOutcome::NoMatchingSources => {
+                // No planner or synthesis LLM call is made — the model can
+                // never invent an answer over an empty `(none)` slice.
+                return Ok(Some(
+                    self.build_no_matching_sources_result(raw_query, &scope, ask)?,
+                ));
+            }
+            ask_planner::GroundingOutcome::Grounded { slice, refined } => {
+                if refined {
+                    // The single refine_retrieval re-funnel is a plan step.
+                    if let Err(exhausted) = budget.charge(ask_planner::PlanStep::RefineRetrieval) {
+                        return Ok(Some(self.build_budget_exhausted_result(
+                            raw_query, &scope, ask, &budget, &exhausted,
+                        )?));
+                    }
+                }
+                slice
+            }
+        };
 
         // Resolve the planner model independently of the synthesis model
         // (ADR 0068 §3). Planner falls back to the general/ASK default.
@@ -1807,6 +1852,13 @@ impl RedDBRuntime {
                 &rql,
             )?)),
             ask_planner::PlanRouting::Execute { candidate } => {
+                // The query step is budgeted too; exhausting the budget
+                // mid-plan surfaces a structured partial-with-warning.
+                if let Err(exhausted) = budget.charge(ask_planner::PlanStep::Query) {
+                    return Ok(Some(self.build_budget_exhausted_result(
+                        raw_query, &scope, ask, &budget, &exhausted,
+                    )?));
+                }
                 let executed = self.execute_planner_candidate_and_synthesize(
                     raw_query,
                     ask,
@@ -2194,6 +2246,154 @@ impl RedDBRuntime {
         record.set("intent", Value::text(plan.intent.as_str().to_string()));
         record.set("candidate", Value::text(candidate_rql.to_string()));
         record.set("candidate_type", Value::text(statement_type.to_string()));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    /// Honest "no matching sources" outcome (ADR 0068 §4, #1748). Reached only
+    /// after the funnel *and* the single refine_retrieval retry both ground
+    /// nothing. No planner or synthesis LLM call is made, so the model can
+    /// never invent an answer — grounding failure is reported, not papered
+    /// over. The empty outcome is audited like any other ASK.
+    fn build_no_matching_sources_result(
+        &self,
+        raw_query: &str,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        ask: &crate::storage::query::ast::AskQuery,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let answer = "No matching sources were found for this question, even after expanding \
+                      retrieval. ASK does not answer without grounding, so no answer was \
+                      generated."
+            .to_string();
+        let plan_summary = "intent=unknown; no_matching_sources; refine_retrieval attempted";
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &ask.question,
+            source_urns: &[],
+            provider: "",
+            model: "",
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            answer: &answer,
+            citations: &[],
+            cache_hit: false,
+            effective_mode: crate::runtime::ai::strict_validator::Mode::Lenient,
+            temperature: None,
+            seed: None,
+            validation_ok: true,
+            retry_count: 0,
+            errors: &[],
+            intent: Some("no_matching_sources"),
+            plan_summary: Some(plan_summary),
+            executed_query: None,
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "answer".into(),
+            "no_matching_sources".into(),
+            "intent".into(),
+            "sources_count".into(),
+            "refined".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("answer", Value::text(answer));
+        record.set("no_matching_sources", Value::Boolean(true));
+        record.set("intent", Value::text("no_matching_sources".to_string()));
+        record.set("sources_count", Value::Integer(0));
+        record.set("refined", Value::Boolean(true));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    /// Structured partial-with-warning when the plan budget is exhausted
+    /// mid-plan (ADR 0068 §4, #1748). A step was attempted after the clamped
+    /// `max_plan_steps` cap was reached — the plan stops here rather than
+    /// looping unbounded, and the truncation is audited.
+    fn build_budget_exhausted_result(
+        &self,
+        raw_query: &str,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        ask: &crate::storage::query::ast::AskQuery,
+        budget: &crate::runtime::ai::ask_planner::PlanBudget,
+        exhausted: &crate::runtime::ai::ask_planner::BudgetExhausted,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let warning = format!(
+            "plan budget exhausted: {} step(s) executed (max_plan_steps = {}); the `{}` step \
+             was not run",
+            exhausted.executed_steps,
+            exhausted.max_steps,
+            exhausted.attempted.as_str()
+        );
+        let answer = format!(
+            "This question needed more plan steps than the budget allows, so it stopped early. {warning}."
+        );
+        let executed_labels: Vec<&str> =
+            budget.executed_steps().iter().map(|s| s.as_str()).collect();
+        let plan_summary = format!(
+            "intent=factual; budget_exhausted; executed=[{}]; max_plan_steps={}",
+            executed_labels.join(","),
+            exhausted.max_steps
+        );
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &ask.question,
+            source_urns: &[],
+            provider: "",
+            model: "",
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            answer: &answer,
+            citations: &[],
+            cache_hit: false,
+            effective_mode: crate::runtime::ai::strict_validator::Mode::Lenient,
+            temperature: None,
+            seed: None,
+            validation_ok: true,
+            retry_count: 0,
+            errors: &[],
+            intent: Some("factual"),
+            plan_summary: Some(&plan_summary),
+            executed_query: None,
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "answer".into(),
+            "budget_exhausted".into(),
+            "warning".into(),
+            "max_plan_steps".into(),
+            "executed_steps".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("answer", Value::text(answer));
+        record.set("budget_exhausted", Value::Boolean(true));
+        record.set("warning", Value::text(warning));
+        record.set("max_plan_steps", Value::Integer(exhausted.max_steps as i64));
+        record.set(
+            "executed_steps",
+            Value::Integer(exhausted.executed_steps as i64),
+        );
         result.push(record);
 
         Ok(RuntimeQueryResult {

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -304,6 +304,67 @@ fn mutating_candidate_is_refused_and_never_executed() {
 }
 
 // ===========================================================================
+// #1748 — grounding critique: a question that grounds nothing (even after the
+// single refine_retrieval re-funnel) returns the honest "no matching sources"
+// outcome and NEVER calls the LLM to invent an answer.
+// ===========================================================================
+
+#[test]
+fn ungrounded_question_returns_no_matching_sources_without_inventing() {
+    let _env = env_lock().lock().expect("env lock");
+
+    // The stub scripts no chat answers: if the planner/synthesis LLM were
+    // ever called for an ungrounded question, it would fall through to the
+    // canned filler — the test asserts that never happens.
+    let stub = ScriptedStub::start(vec![]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES ('t1', 'FDD-1', 'Alice')",
+    );
+
+    configure_planner(&rt);
+
+    // The question's tokens match no collection or column in the schema, so
+    // the funnel grounds nothing on the first pass and on the single refine
+    // re-funnel — the honest no-matching-sources path.
+    let result = rt
+        .execute_query("ASK 'quantum dragons volcano wibble' STRICT OFF")
+        .expect("ungrounded ASK is a structured outcome, not an error");
+    let record = result.result.records.first().expect("one canonical row");
+
+    assert_eq!(
+        record.get("no_matching_sources"),
+        Some(&Value::Boolean(true)),
+        "an ungrounded question must report no matching sources"
+    );
+    let answer = text(record, "answer").expect("answer column");
+    assert!(
+        answer.contains("No matching sources"),
+        "answer must honestly report the grounding failure, got: {answer:?}"
+    );
+
+    // The LLM was never called to invent an answer — grounding failure short
+    // circuits before any chat completion. (The funnel may still hit
+    // /embeddings, which is not a chat completion.)
+    assert_eq!(
+        stub.chat_bodies().len(),
+        0,
+        "no planner/synthesis chat call may be made for an ungrounded question"
+    );
+}
+
+// ===========================================================================
 // Scripted mock stub — sequenced chat completions + request-body capture.
 // ===========================================================================
 


### PR DESCRIPTION
Automated AFK landing for #1748. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1748

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785852528&installation_id=129708444&pr_number=1758&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1758&signature=11c338a70c18dcf894421664725e62f16e7adc3cece7dec0602f49e8327a0a90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `STEPS N` support for `ASK` queries to let users limit how much planning work can be done.
  * Improved `ASK` results to clearly report when no matching sources are found instead of returning a misleading answer.

* **Bug Fixes**
  * Enforced sensible limits on `STEPS` values and rejected invalid or duplicate clauses.
  * Prevented empty-source queries from triggering unnecessary follow-up processing.
  * Added clearer partial-result handling when a query exceeds its planning budget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->