### PR TITLE
#1749 Ask synthesis intent routing (rebased onto main)

### DIFF
--- a/crates/reddb-server/src/runtime/ai/ask_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_planner.rs
@@ -620,6 +620,57 @@ mod tests {
     }
 
     #[test]
+    fn synthesis_intent_carries_the_routed_intent_for_the_rag_fallthrough() {
+        // #1749: a summarise/explain question routes to the RAG path. The
+        // routing carries the intent so the orchestrator can record it on the
+        // downstream audit row without re-classifying.
+        let route = plan_and_route(
+            "summarise the incidents from yesterday",
+            &slice(),
+            &mock_model("{\"intent\":\"synthesis\",\"query\":null,\"rationale\":\"rag\"}"),
+        )
+        .unwrap();
+        match route.routing {
+            PlanRouting::Unsupported { intent } => {
+                assert_eq!(intent, AskIntent::Synthesis);
+                assert_eq!(intent.as_str(), "synthesis");
+            }
+            other => panic!("expected Unsupported{{synthesis}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn calculation_question_routes_factual_not_synthesis() {
+        // ADR 0013 conformance boundary (#1749): a calculation-shaped question
+        // must land on the *factual* intent — a read-only aggregate the engine
+        // computes — never synthesis, where the LLM would be free to invent the
+        // number. The planner emits `factual` + a read-only aggregate SELECT;
+        // routing executes it and never falls through to RAG synthesis.
+        let route = plan_and_route(
+            "how many trips went to Lisbon?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"SELECT COUNT(*) FROM trips WHERE city = 'Lisbon'\",\"rationale\":\"aggregate count\"}",
+            ),
+        )
+        .unwrap();
+        assert_ne!(
+            route.plan.intent,
+            AskIntent::Synthesis,
+            "a calculation must never classify as synthesis (the LLM must not invent numbers)"
+        );
+        match route.routing {
+            PlanRouting::Execute { candidate } => {
+                assert!(candidate.is_read_only());
+                assert_eq!(candidate.statement_type, "select");
+            }
+            other => {
+                panic!("a calculation must route to an executable factual candidate, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
     fn how_to_intent_routes_unsupported_in_this_slice() {
         let route = plan_and_route(
             "how would I capture events into a queue?",

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1232,14 +1232,19 @@ impl RedDBRuntime {
             return self.execute_ask_as_rql(raw_query, ask);
         }
 
-        // ADR 0068 / #1747: planner-first path. When enabled, ASK runs the
-        // funnel → planner-LLM → typed plan → auto-executed read-only query
-        // → cited synthesis over the executed rows. A factual plan (or a
-        // structured mutating refusal) returns here; a non-factual intent
-        // returns `None` and falls through to the RAG synthesis path below.
+        // ADR 0068 / #1747 / #1749: planner-first path. When enabled, ASK runs
+        // the funnel → planner-LLM → typed plan → routing. A factual plan (or a
+        // structured mutating refusal) is fully handled and returns here. A
+        // synthesis/how-to intent falls through to the ADR 0013 RAG synthesis
+        // path below **unchanged**, carrying only the routed intent so the
+        // downstream audit row records the routing decision (#1749).
+        let mut routed_intent: Option<&'static str> = None;
         if !ask.explain && self.ask_planner_enabled() {
-            if let Some(result) = self.execute_ask_planner_factual(raw_query, ask)? {
-                return Ok(result);
+            match self.execute_ask_planner_prepass(raw_query, ask)? {
+                PlannerPrepass::Handled(result) => return Ok(*result),
+                PlannerPrepass::FallThrough { intent } => {
+                    routed_intent = Some(intent.as_str());
+                }
             }
         }
 
@@ -1530,7 +1535,7 @@ impl RedDBRuntime {
                             validation_ok: false,
                             retry_count,
                             errors: &errors,
-                            intent: None,
+                            intent: routed_intent,
                             plan_summary: None,
                             executed_query: None,
                         })?;
@@ -1634,7 +1639,7 @@ impl RedDBRuntime {
             validation_ok: true,
             retry_count: ask_attempt.retry_count,
             errors: &[],
-            intent: None,
+            intent: routed_intent,
             plan_summary: None,
             executed_query: None,
         })?;
@@ -1717,22 +1722,27 @@ impl RedDBRuntime {
         self.config_bool("red.config.ai.ask.planner", false)
     }
 
-    /// ADR 0068 / #1747 — the planner-first factual path, end-to-end.
+    /// ADR 0068 / #1747 / #1749 — the planner-first pre-pass, end-to-end.
     ///
     /// Funnel narrows the schema slice → planner LLM (its own model) emits a
-    /// typed plan over *only* that slice → the `query` step's read-only RQL
-    /// candidate is validated by the production parser + read-only classifier
-    /// → auto-executed under the caller's EffectiveScope → the executed rows
-    /// become `sources_flat` for a cited synthesis call.
+    /// typed plan over *only* that slice → routing:
+    ///   - **factual**: the `query` step's read-only RQL candidate is validated
+    ///     by the production parser + read-only classifier → auto-executed under
+    ///     the caller's EffectiveScope → the executed rows become `sources_flat`
+    ///     for a cited synthesis call. A mutating candidate is a structured
+    ///     refusal. Both are `PlannerPrepass::Handled`.
+    ///   - **synthesis / how-to**: `PlannerPrepass::FallThrough { intent }` so
+    ///     the caller runs the ADR 0013 RAG path unchanged (#1749). The routed
+    ///     intent rides along only for the downstream audit row — a
+    ///     calculation-shaped question never lands here, it classifies factual
+    ///     (the LLM never invents numbers, ADR 0013 conformance boundary).
     ///
-    /// Returns `Ok(None)` for a non-factual intent so the caller falls
-    /// through to the RAG path; `Ok(Some(_))` for a factual answer or a
-    /// structured mutating refusal; `Err` for a malformed/planner failure.
-    fn execute_ask_planner_factual(
+    /// `Err` for a malformed plan / planner failure.
+    fn execute_ask_planner_prepass(
         &self,
         raw_query: &str,
         ask: &crate::storage::query::ast::AskQuery,
-    ) -> RedDBResult<Option<RuntimeQueryResult>> {
+    ) -> RedDBResult<PlannerPrepass> {
         use crate::ai::{parse_provider, resolve_api_key_from_runtime};
         use crate::runtime::ai::ask_planner;
 
@@ -1840,17 +1850,23 @@ impl RedDBRuntime {
         let route = ask_planner::plan_and_route(&ask.question, &slice, &planner_closure)?;
 
         match route.routing {
-            ask_planner::PlanRouting::Unsupported { .. } => Ok(None),
+            // #1749: synthesis / how-to route to the ADR 0013 RAG path
+            // unchanged; the routed intent rides along for the audit row.
+            ask_planner::PlanRouting::Unsupported { intent } => {
+                Ok(PlannerPrepass::FallThrough { intent })
+            }
             ask_planner::PlanRouting::RefuseMutating {
                 statement_type,
                 rql,
-            } => Ok(Some(self.build_planner_refusal_result(
-                raw_query,
-                &scope,
-                &route.plan,
-                statement_type,
-                &rql,
-            )?)),
+            } => Ok(PlannerPrepass::Handled(Box::new(
+                self.build_planner_refusal_result(
+                    raw_query,
+                    &scope,
+                    &route.plan,
+                    statement_type,
+                    &rql,
+                )?,
+            ))),
             ask_planner::PlanRouting::Execute { candidate } => {
                 // The query step is budgeted too; exhausting the budget
                 // mid-plan surfaces a structured partial-with-warning.
@@ -1870,7 +1886,7 @@ impl RedDBRuntime {
                     &settings,
                     transport,
                 )?;
-                Ok(Some(executed))
+                Ok(PlannerPrepass::Handled(Box::new(executed)))
             }
         }
     }
@@ -4054,6 +4070,19 @@ fn sse_source_rows_from_sources_json(
 /// canonical pattern set. If the audit pipeline grows a separate
 /// redactor with operator-tunable patterns, swap the constructor here.
 /// A single synthesis attempt's result on the planner-first factual path.
+/// Outcome of the planner-first pre-pass (ADR 0068 / #1749).
+///
+/// Either the planner fully handled the ASK (a cited factual answer or a
+/// structured mutating refusal), or it classified a non-factual intent and
+/// the caller must run the ADR 0013 RAG path unchanged — carrying the routed
+/// intent so the downstream audit row records the routing decision.
+enum PlannerPrepass {
+    Handled(Box<RuntimeQueryResult>),
+    FallThrough {
+        intent: crate::runtime::ai::ask_planner::AskIntent,
+    },
+}
+
 struct PlannerSynthesis {
     answer: String,
     provider: crate::ai::AiProvider,

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1801,17 +1801,19 @@ impl RedDBRuntime {
             ask_planner::GroundingOutcome::NoMatchingSources => {
                 // No planner or synthesis LLM call is made — the model can
                 // never invent an answer over an empty `(none)` slice.
-                return Ok(Some(
+                return Ok(PlannerPrepass::Handled(Box::new(
                     self.build_no_matching_sources_result(raw_query, &scope, ask)?,
-                ));
+                )));
             }
             ask_planner::GroundingOutcome::Grounded { slice, refined } => {
                 if refined {
                     // The single refine_retrieval re-funnel is a plan step.
                     if let Err(exhausted) = budget.charge(ask_planner::PlanStep::RefineRetrieval) {
-                        return Ok(Some(self.build_budget_exhausted_result(
-                            raw_query, &scope, ask, &budget, &exhausted,
-                        )?));
+                        return Ok(PlannerPrepass::Handled(Box::new(
+                            self.build_budget_exhausted_result(
+                                raw_query, &scope, ask, &budget, &exhausted,
+                            )?,
+                        )));
                     }
                 }
                 slice
@@ -1871,9 +1873,11 @@ impl RedDBRuntime {
                 // The query step is budgeted too; exhausting the budget
                 // mid-plan surfaces a structured partial-with-warning.
                 if let Err(exhausted) = budget.charge(ask_planner::PlanStep::Query) {
-                    return Ok(Some(self.build_budget_exhausted_result(
-                        raw_query, &scope, ask, &budget, &exhausted,
-                    )?));
+                    return Ok(PlannerPrepass::Handled(Box::new(
+                        self.build_budget_exhausted_result(
+                            raw_query, &scope, ask, &budget, &exhausted,
+                        )?,
+                    )));
                 }
                 let executed = self.execute_planner_candidate_and_synthesize(
                     raw_query,

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -365,6 +365,97 @@ fn ungrounded_question_returns_no_matching_sources_without_inventing() {
 }
 
 // ===========================================================================
+// 7 — #1749: a synthesis question routes to the ADR 0013 RAG path unchanged;
+//     the audit row records the routed intent.
+// ===========================================================================
+
+#[test]
+fn synthesis_question_routes_to_rag_and_audit_records_intent() {
+    let _env = env_lock().lock().expect("env lock");
+
+    let stub = ScriptedStub::start(vec![
+        // Planner call → classifies the question as synthesis (no query).
+        "{\"intent\":\"synthesis\",\"query\":null,\"rationale\":\"summarise incidents\"}"
+            .to_string(),
+        // RAG synthesis call → cited answer over the retrieved sources. This
+        // is the ADR 0013 path, untouched by the planner.
+        "Two incidents were reported: an outage and a latency spike [^1]".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE incidents (id TEXT PRIMARY KEY, title TEXT, day TEXT) \
+         WITH CONTEXT INDEX ON (id, title, day)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO incidents (id, title, day) VALUES \
+           ('i1', 'checkout outage', 'yesterday'), ('i2', 'latency spike', 'yesterday')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("ASK 'summarise the incidents from yesterday' STRICT OFF LIMIT 5")
+        .expect("synthesis ASK should route to RAG and succeed");
+    let record = result
+        .result
+        .records
+        .first()
+        .expect("RAG ASK returns one canonical row");
+
+    // (contract) The result row is identical to today's RAG ASK — the routing
+    // decision lives in the audit row, never in the answer contract. The
+    // planner-only columns must NOT appear.
+    assert!(
+        record.get("intent").is_none(),
+        "RAG result contract must be unchanged: no `intent` column"
+    );
+    assert!(
+        record.get("executed_query").is_none(),
+        "RAG result contract must be unchanged: no `executed_query` column"
+    );
+    let answer = text(record, "answer").expect("answer column");
+    assert!(
+        answer.contains("incident"),
+        "RAG answer should come back over the retrieved sources, got: {answer:?}"
+    );
+    // The cited-answer contract is preserved: a citations column is present.
+    assert!(
+        record.get("citations").is_some(),
+        "RAG cited-answer contract must be preserved"
+    );
+
+    // Both the planner (classification) and the RAG synthesis LLM were called.
+    assert!(
+        stub.request_count() >= 2,
+        "planner classification + RAG synthesis calls expected, got {}",
+        stub.request_count()
+    );
+
+    // The audit row records the routed intent (#1749). No plan summary /
+    // executed query — synthesis carries only the routing decision.
+    let audit = rt
+        .execute_query("SELECT * FROM red_ask_audit")
+        .expect("read audit rows");
+    let audit_row = audit
+        .result
+        .records
+        .iter()
+        .find(|r| text(r, "intent").as_deref() == Some("synthesis"))
+        .expect("an audit row recording the routed synthesis intent");
+    assert!(
+        text(audit_row, "executed_query").is_none(),
+        "synthesis routes to RAG — no executed query is recorded"
+    );
+}
+
+// ===========================================================================
 // Scripted mock stub — sequenced chat completions + request-body capture.
 // ===========================================================================
 


### PR DESCRIPTION
Closes #1749.

Finish-from-branch landing of worker `wXDL8`'s #1749 (PRD #1744 — synthesis intent routing: planner routes summarise/explain questions to the ADR 0013 RAG path unchanged, audit records intent).

The worker's attempt hit a **merge conflict** (not a logic failure): #1748 landed the same planner e2e test file in between. Rebased onto current main; the only conflict was additive (both slices appended a distinct `#[test]` fn to `e2e_ask_planner_core.rs`) — both tests kept. `ask_planner.rs`/`impl_search.rs` rebased clean. cargo fmt applied.

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785854086&installation_id=129708444&pr_number=1759&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1759&signature=62fe4119b8fd957ca3386f7b41259fc45714332465b660996a20ce09f93a5245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->