### PR TITLE
#1750 Ask how-to intent: suggestion envelope (rebased onto main)

### DIFF
--- a/crates/reddb-server/src/runtime/ai/ask_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_planner.rs
@@ -84,12 +84,44 @@ impl NarrowedSlice {
     }
 }
 
+/// A raw suggested statement the planner emitted for a how-to question,
+/// before parser validation. `rql` is the candidate statement text exactly as
+/// the model produced it; it is never trusted until it passes the parser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawSuggestion {
+    pub rql: String,
+    pub rationale: String,
+}
+
+/// A parser-validated suggested statement in the how-to envelope. It carries
+/// the `mutating` flag and canonical statement kind and is **advisory only**:
+/// suggested statements — including mutating/DDL ones — are NEVER executed by
+/// ASK. A future apply-command consumes this envelope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SuggestedStatement {
+    /// The candidate RQL, trimmed, exactly as it parsed.
+    pub rql: String,
+    /// True when the statement writes / drops / alters / otherwise mutates
+    /// state (or is any non-read-only kind). Advisory — never a licence to run.
+    pub mutating: bool,
+    /// Canonical statement-type label (`select`, `insert`, `create_queue`, …).
+    pub statement_type: &'static str,
+    /// Why the planner suggested this statement.
+    pub rationale: String,
+}
+
 /// The typed plan the planner LLM emits, before candidate validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AskPlan {
     pub intent: AskIntent,
     /// The `query` step's read-only RQL candidate (factual intent).
     pub query: Option<String>,
+    /// The natural-language answer explaining the approach (how-to intent).
+    /// Empty for the factual/synthesis paths, which synthesize their answer.
+    pub answer: String,
+    /// The how-to suggestion: raw statements before parser validation. Each is
+    /// re-validated through the production parser by [`route_plan`].
+    pub suggestion: Vec<RawSuggestion>,
     /// Model rationale / self-critique, surfaced to plan summary + audit.
     pub rationale: String,
 }
@@ -104,6 +136,28 @@ impl AskPlan {
         }
         out
     }
+}
+
+/// Validate each suggested statement through the production parser, **dropping**
+/// any that do not parse (unparseable model output is never returned raw), and
+/// flag each read-only vs mutating. Mutating/DDL statements are kept in the
+/// envelope — so a future apply-command can consume them — but ASK never runs
+/// them; this function only classifies, it never executes.
+pub fn validate_suggestions(raw: &[RawSuggestion]) -> Vec<SuggestedStatement> {
+    let mut out = Vec::new();
+    for item in raw {
+        // A candidate that fails the production parser is dropped, never
+        // returned raw. The suggestion is advisory regardless of disposition.
+        if let Ok(candidate) = validate_candidate(&item.rql) {
+            out.push(SuggestedStatement {
+                mutating: !candidate.is_read_only(),
+                statement_type: candidate.statement_type,
+                rql: candidate.rql,
+                rationale: item.rationale.clone(),
+            });
+        }
+    }
+    out
 }
 
 /// A model that turns a planner prompt into a typed-plan JSON document.
@@ -138,8 +192,17 @@ pub enum PlanRouting {
         statement_type: &'static str,
         rql: String,
     },
-    /// A non-factual intent (synthesis / how-to). This slice implements the
-    /// factual path only; the orchestrator decides the fallback.
+    /// How-to intent: an advisory suggestion envelope. `answer` explains the
+    /// approach in natural language; `suggestion` carries the parser-validated
+    /// statements, each flagged `mutating`, plus their rationale. Suggested
+    /// statements — including mutating/DDL ones — are NEVER executed; a future
+    /// apply-command consumes this envelope.
+    Suggest {
+        answer: String,
+        suggestion: Vec<SuggestedStatement>,
+    },
+    /// A remaining non-factual intent (synthesis). The orchestrator decides
+    /// the fallback (retrieval-RAG cited answer).
     Unsupported { intent: AskIntent },
 }
 
@@ -222,6 +285,19 @@ pub fn parse_plan(raw: &str) -> RedDBResult<AskPlan> {
         .filter(|s| !s.is_empty())
         .map(str::to_string);
 
+    let answer = obj
+        .get("answer")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    let suggestion = obj
+        .get("suggestion")
+        .and_then(|v| v.as_array())
+        .map(parse_suggestions)
+        .unwrap_or_default();
+
     let rationale = obj
         .get("rationale")
         .and_then(|v| v.as_str())
@@ -232,8 +308,48 @@ pub fn parse_plan(raw: &str) -> RedDBResult<AskPlan> {
     Ok(AskPlan {
         intent,
         query,
+        answer,
+        suggestion,
         rationale,
     })
+}
+
+/// Read the `suggestion` array of a how-to plan into raw statements. Each item
+/// may be a bare RQL string or a `{ "rql": "...", "rationale": "..." }` object;
+/// items without any statement text are skipped. Parser validation happens
+/// later in [`validate_suggestions`], not here.
+fn parse_suggestions(items: &[crate::json::Value]) -> Vec<RawSuggestion> {
+    let mut out = Vec::new();
+    for item in items {
+        if let Some(rql) = item.as_str() {
+            let rql = rql.trim();
+            if !rql.is_empty() {
+                out.push(RawSuggestion {
+                    rql: rql.to_string(),
+                    rationale: String::new(),
+                });
+            }
+        } else if let Some(obj) = item.as_object() {
+            let rql = obj
+                .get("rql")
+                .or_else(|| obj.get("statement"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            if rql.is_empty() {
+                continue;
+            }
+            let rationale = obj
+                .get("rationale")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .trim()
+                .to_string();
+            out.push(RawSuggestion { rql, rationale });
+        }
+    }
+    out
 }
 
 /// Route a parsed plan: validate the factual candidate through the parser +
@@ -259,6 +375,16 @@ pub fn route_plan(plan: &AskPlan) -> RedDBResult<PlanRouting> {
                     rql: candidate.rql,
                 }),
             }
+        }
+        AskIntent::HowTo => {
+            // Parser-validate every suggested statement; unparseable ones are
+            // dropped. Mutating/DDL statements survive in the envelope but are
+            // never executed — the suggestion is advisory.
+            let suggestion = validate_suggestions(&plan.suggestion);
+            Ok(PlanRouting::Suggest {
+                answer: plan.answer.clone(),
+                suggestion,
+            })
         }
         other => Ok(PlanRouting::Unsupported { intent: other }),
     }
@@ -671,19 +797,97 @@ mod tests {
     }
 
     #[test]
-    fn how_to_intent_routes_unsupported_in_this_slice() {
+    fn how_to_intent_routes_to_a_validated_suggestion_envelope() {
+        // A how-to plan carries a natural-language answer plus a suggestion of
+        // parser-validated statements — a read-only SELECT, a mutating DDL
+        // CREATE QUEUE, and a mutating EVENTS BACKFILL.
         let route = plan_and_route(
-            "how would I capture events into a queue?",
+            "how would I capture events from orders into a queue?",
             &slice(),
-            &mock_model("{\"intent\":\"how_to\",\"query\":null,\"rationale\":\"guide\"}"),
+            &mock_model(
+                "{\"intent\":\"how_to\",\"answer\":\"Create a queue and backfill events into it.\",\
+                  \"suggestion\":[\
+                    {\"rql\":\"CREATE QUEUE events_q WORK\",\"rationale\":\"the sink queue\"},\
+                    {\"rql\":\"EVENTS BACKFILL orders TO events_q\",\"rationale\":\"seed history\"},\
+                    {\"rql\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"inspect\"}\
+                  ],\"rationale\":\"guide\"}",
+            ),
         )
         .unwrap();
-        assert_eq!(
-            route.routing,
-            PlanRouting::Unsupported {
-                intent: AskIntent::HowTo
+        match route.routing {
+            PlanRouting::Suggest { answer, suggestion } => {
+                assert!(answer.contains("Create a queue"));
+                assert_eq!(suggestion.len(), 3);
+                // DDL / mutating statements are present and flagged mutating,
+                // and are NEVER executed — this envelope is advisory only.
+                assert!(suggestion[0].mutating, "CREATE QUEUE is mutating DDL");
+                assert!(suggestion[1].mutating, "EVENTS BACKFILL is mutating");
+                assert!(!suggestion[2].mutating, "the SELECT is read-only");
+                assert_eq!(suggestion[2].statement_type, "select");
+                assert_eq!(suggestion[0].rationale, "the sink queue");
             }
-        );
+            other => panic!("expected Suggest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn how_to_suggestion_drops_unparseable_statements_never_returns_them_raw() {
+        // The middle statement is not valid RQL; it is dropped, and only the
+        // two parser-valid statements survive in the envelope.
+        let route = plan_and_route(
+            "how do I list travelers?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"how_to\",\"answer\":\"Select from the collection.\",\
+                  \"suggestion\":[\
+                    {\"rql\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\"},\
+                    {\"rql\":\"this is not rql at all\"},\
+                    \"DELETE FROM travelers WHERE passport = 'FDD-1'\"\
+                  ]}",
+            ),
+        )
+        .unwrap();
+        match route.routing {
+            PlanRouting::Suggest { suggestion, .. } => {
+                assert_eq!(suggestion.len(), 2, "the unparseable statement is dropped");
+                assert_eq!(suggestion[0].statement_type, "select");
+                // A bare-string suggestion item is accepted and validated too.
+                assert_eq!(suggestion[1].statement_type, "delete");
+                assert!(suggestion[1].mutating);
+                for s in &suggestion {
+                    assert!(
+                        !s.rql.contains("not rql"),
+                        "raw unparseable text must never survive"
+                    );
+                }
+            }
+            other => panic!("expected Suggest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn routing_distinguishes_how_to_from_factual_at_the_closure_model_seam() {
+        // Same slice + question, only the model's intent classification differs
+        // — the closure-model seam is what routes factual vs how-to.
+        let factual = plan_and_route(
+            "how would I capture events into a queue?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"x\"}",
+            ),
+        )
+        .unwrap();
+        assert!(matches!(factual.routing, PlanRouting::Execute { .. }));
+
+        let how_to = plan_and_route(
+            "how would I capture events into a queue?",
+            &slice(),
+            &mock_model(
+                "{\"intent\":\"how_to\",\"answer\":\"Use a queue.\",\"suggestion\":[\"CREATE QUEUE events_q WORK\"],\"rationale\":\"x\"}",
+            ),
+        )
+        .unwrap();
+        assert!(matches!(how_to.routing, PlanRouting::Suggest { .. }));
     }
 
     // -----------------------------------------------------------------------
@@ -799,6 +1003,8 @@ mod tests {
         let plan = AskPlan {
             intent: AskIntent::Factual,
             query: Some("SELECT * FROM travelers WHERE passport = 'FDD-1'".to_string()),
+            answer: String::new(),
+            suggestion: Vec::new(),
             rationale: "lookup".to_string(),
         };
         let summary = plan.summary();

--- a/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
@@ -300,6 +300,15 @@ fn classify(query: &QueryExpr) -> (CandidateDisposition, &'static str) {
         QueryExpr::Update(_) => (Mutating, "update"),
         QueryExpr::Delete(_) => (Mutating, "delete"),
         QueryExpr::Truncate(_) => (Mutating, "truncate"),
+        // Common DDL / streaming statements get distinct kind labels so the
+        // how-to suggestion envelope and its audit row record what was
+        // proposed. They remain `Mutating` — kept advisory, never executed.
+        QueryExpr::CreateTable(_) => (Mutating, "create_table"),
+        QueryExpr::CreateCollection(_) => (Mutating, "create_collection"),
+        QueryExpr::CreateQueue(_) => (Mutating, "create_queue"),
+        QueryExpr::CreateIndex(_) => (Mutating, "create_index"),
+        QueryExpr::AlterTable(_) => (Mutating, "alter_table"),
+        QueryExpr::EventsBackfill(_) => (Mutating, "events_backfill"),
         _ => (Mutating, "mutating"),
     }
 }

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1857,6 +1857,17 @@ impl RedDBRuntime {
             ask_planner::PlanRouting::Unsupported { intent } => {
                 Ok(PlannerPrepass::FallThrough { intent })
             }
+            ask_planner::PlanRouting::Suggest { answer, suggestion } => {
+                Ok(PlannerPrepass::Handled(Box::new(
+                    self.build_suggestion_envelope_result(
+                        raw_query,
+                        &scope,
+                        &route.plan,
+                        &answer,
+                        &suggestion,
+                    )?,
+                )))
+            }
             ask_planner::PlanRouting::RefuseMutating {
                 statement_type,
                 rql,
@@ -2266,6 +2277,121 @@ impl RedDBRuntime {
         record.set("intent", Value::text(plan.intent.as_str().to_string()));
         record.set("candidate", Value::text(candidate_rql.to_string()));
         record.set("candidate_type", Value::text(statement_type.to_string()));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
+    /// How-to suggestion envelope (ADR 0068, #1750). The question is meta-
+    /// language about the database ("how would I capture events into a
+    /// queue?"); the planner routed to the how-to intent. The envelope carries
+    /// a natural-language `answer` plus a `suggestion` of parser-validated
+    /// statements, each flagged `mutating` with its rationale. Suggested
+    /// statements — including mutating/DDL ones — are returned but NEVER
+    /// executed: ASK stays free of write side-effects, so no query runs here
+    /// (a future apply-command consumes this envelope). The audit row records
+    /// the how-to intent and the suggested statement kinds.
+    fn build_suggestion_envelope_result(
+        &self,
+        raw_query: &str,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        plan: &crate::runtime::ai::ask_planner::AskPlan,
+        answer: &str,
+        suggestion: &[crate::runtime::ai::ask_planner::SuggestedStatement],
+    ) -> RedDBResult<RuntimeQueryResult> {
+        let answer = if answer.is_empty() {
+            "Here is how you could approach this. The suggested statements below are advisory \
+             and are not executed."
+                .to_string()
+        } else {
+            answer.to_string()
+        };
+
+        // Structured suggestion array: one object per validated statement,
+        // carrying the mutating flag, canonical kind, and rationale.
+        let suggestion_json = crate::json::Value::Array(
+            suggestion
+                .iter()
+                .map(|s| {
+                    let mut obj = crate::json::Map::new();
+                    obj.insert("rql".to_string(), crate::json::Value::String(s.rql.clone()));
+                    obj.insert("mutating".to_string(), crate::json::Value::Bool(s.mutating));
+                    obj.insert(
+                        "statement_type".to_string(),
+                        crate::json::Value::String(s.statement_type.to_string()),
+                    );
+                    obj.insert(
+                        "rationale".to_string(),
+                        crate::json::Value::String(s.rationale.clone()),
+                    );
+                    crate::json::Value::Object(obj)
+                })
+                .collect(),
+        );
+        let suggestion_bytes =
+            crate::json::to_vec(&suggestion_json).unwrap_or_else(|_| b"[]".to_vec());
+
+        // The audit row records the how-to intent and the suggested statement
+        // kinds (never the raw statements — only their canonical kinds).
+        let kinds: Vec<&str> = suggestion.iter().map(|s| s.statement_type).collect();
+        let mutating_count = suggestion.iter().filter(|s| s.mutating).count();
+        let plan_summary = format!(
+            "intent=how_to; suggested=[{}]; mutating={}/{}",
+            kinds.join(","),
+            mutating_count,
+            suggestion.len()
+        );
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &plan_summary,
+            source_urns: &[],
+            provider: "",
+            model: "",
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            answer: &answer,
+            citations: &[],
+            cache_hit: false,
+            effective_mode: crate::runtime::ai::strict_validator::Mode::Lenient,
+            temperature: None,
+            seed: None,
+            validation_ok: true,
+            retry_count: 0,
+            errors: &[],
+            intent: Some(plan.intent.as_str()),
+            plan_summary: Some(&plan_summary),
+            executed_query: None,
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "answer".into(),
+            "intent".into(),
+            "suggestion".into(),
+            "suggestion_count".into(),
+            "mutating_count".into(),
+            "advisory".into(),
+            "executed".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("answer", Value::text(answer));
+        record.set("intent", Value::text(plan.intent.as_str().to_string()));
+        record.set("suggestion", Value::Json(suggestion_bytes));
+        record.set("suggestion_count", Value::Integer(suggestion.len() as i64));
+        record.set("mutating_count", Value::Integer(mutating_count as i64));
+        // The suggestion is advisory and nothing was executed — ASK never
+        // writes on a how-to question.
+        record.set("advisory", Value::Boolean(true));
+        record.set("executed", Value::Boolean(false));
         result.push(record);
 
         Ok(RuntimeQueryResult {

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1857,17 +1857,15 @@ impl RedDBRuntime {
             ask_planner::PlanRouting::Unsupported { intent } => {
                 Ok(PlannerPrepass::FallThrough { intent })
             }
-            ask_planner::PlanRouting::Suggest { answer, suggestion } => {
-                Ok(PlannerPrepass::Handled(Box::new(
-                    self.build_suggestion_envelope_result(
-                        raw_query,
-                        &scope,
-                        &route.plan,
-                        &answer,
-                        &suggestion,
-                    )?,
-                )))
-            }
+            ask_planner::PlanRouting::Suggest { answer, suggestion } => Ok(
+                PlannerPrepass::Handled(Box::new(self.build_suggestion_envelope_result(
+                    raw_query,
+                    &scope,
+                    &route.plan,
+                    &answer,
+                    &suggestion,
+                )?)),
+            ),
             ask_planner::PlanRouting::RefuseMutating {
                 statement_type,
                 rql,

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -456,6 +456,143 @@ fn synthesis_question_routes_to_rag_and_audit_records_intent() {
 }
 
 // ===========================================================================
+// #1750 — how-to intent: the suggestion envelope. A meta-language question
+// ("how would I capture events into a queue?") routes to the how-to intent.
+// The answer explains the approach in natural language and the envelope
+// carries parser-validated statements, each flagged mutating, plus rationale.
+// Mutating/DDL statements appear but are NEVER executed — no write side-effect.
+// ===========================================================================
+
+#[test]
+fn how_to_question_returns_answer_plus_validated_suggestion_never_executed() {
+    let _env = env_lock().lock().expect("env lock");
+
+    // A single scripted chat completion: the planner's how-to plan. It carries
+    // the natural-language answer and a suggestion of four statements — a
+    // read-only SELECT, a DDL CREATE QUEUE, a mutating EVENTS BACKFILL, and one
+    // unparseable string that must be dropped. No synthesis call follows.
+    let plan_json = "{\"intent\":\"how_to\",\
+        \"answer\":\"To capture events from orders into a queue, create a work queue and backfill the existing rows into it.\",\
+        \"suggestion\":[\
+          {\"rql\":\"CREATE QUEUE events_q WORK\",\"rationale\":\"the sink queue\"},\
+          {\"rql\":\"EVENTS BACKFILL orders TO events_q\",\"rationale\":\"seed history\"},\
+          {\"rql\":\"SELECT * FROM orders WHERE sku = 'WIDGET'\",\"rationale\":\"inspect source rows\"},\
+          {\"rql\":\"capture the orders somehow into the queue please\",\"rationale\":\"unparseable\"}\
+        ],\"rationale\":\"how-to guide\"}";
+    let stub = ScriptedStub::start(vec![plan_json.to_string()]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE orders (id TEXT PRIMARY KEY, sku TEXT) WITH CONTEXT INDEX ON (id, sku)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO orders (id, sku) VALUES ('o1', 'WIDGET'), ('o2', 'GADGET')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("ASK 'how would I capture events from orders into a queue?' STRICT OFF")
+        .expect("how-to ASK returns a structured suggestion envelope, not an error");
+    let record = result.result.records.first().expect("one canonical row");
+
+    // A natural-language answer explaining the approach.
+    let answer = text(record, "answer").expect("answer column");
+    assert!(
+        answer.contains("queue"),
+        "answer should explain the how-to approach, got: {answer:?}"
+    );
+    // Routed to the how-to intent.
+    assert_eq!(text(record, "intent").as_deref(), Some("how_to"));
+    // Nothing was executed and the suggestion is advisory.
+    assert_eq!(record.get("executed"), Some(&Value::Boolean(false)));
+    assert_eq!(record.get("advisory"), Some(&Value::Boolean(true)));
+
+    // The suggestion carries only the parser-validated statements — the
+    // unparseable one is dropped and never returned raw.
+    let suggestion = match record.get("suggestion") {
+        Some(Value::Json(bytes)) => String::from_utf8_lossy(bytes).to_string(),
+        Some(Value::Text(s)) => s.to_string(),
+        other => panic!("suggestion must be JSON/Text, got {other:?}"),
+    };
+    assert_eq!(record.get("suggestion_count"), Some(&Value::Integer(3)));
+    assert_eq!(record.get("mutating_count"), Some(&Value::Integer(2)));
+    // Mutating/DDL statements appear in the envelope, flagged mutating.
+    assert!(
+        suggestion.contains("CREATE QUEUE events_q WORK") && suggestion.contains("create_queue"),
+        "the DDL CREATE QUEUE must appear in the suggestion: {suggestion}"
+    );
+    assert!(
+        suggestion.contains("EVENTS BACKFILL orders TO events_q")
+            && suggestion.contains("events_backfill"),
+        "the mutating EVENTS BACKFILL must appear in the suggestion: {suggestion}"
+    );
+    assert!(
+        suggestion.contains("\"mutating\":true"),
+        "mutating statements must be flagged: {suggestion}"
+    );
+    assert!(
+        suggestion.contains("\"mutating\":false") && suggestion.contains("select"),
+        "the read-only SELECT must be flagged non-mutating: {suggestion}"
+    );
+    // Unparseable model output is never returned raw.
+    assert!(
+        !suggestion.contains("capture the orders somehow"),
+        "unparseable statement text must never survive: {suggestion}"
+    );
+
+    // Exactly one chat completion — the planner. No synthesis, no execution.
+    assert_eq!(
+        stub.chat_bodies().len(),
+        1,
+        "a how-to question makes only the planner call, never a synthesis call"
+    );
+
+    // Conformance pin: no write occurred during the how-to ASK. The source
+    // rows are untouched and the suggested CREATE QUEUE never materialized.
+    let orders = rt
+        .execute_query("SELECT * FROM orders")
+        .expect("select orders");
+    assert_eq!(
+        orders.result.records.len(),
+        2,
+        "the how-to ASK must not write — source rows are untouched"
+    );
+    assert!(
+        rt.execute_query("QUEUE LEN events_q").is_err(),
+        "the suggested CREATE QUEUE must never execute — the queue does not exist"
+    );
+
+    // The audit row records the how-to intent and the suggested statement kinds.
+    let audit = rt
+        .execute_query("SELECT * FROM red_ask_audit")
+        .expect("read audit rows");
+    let audit_row = audit
+        .result
+        .records
+        .iter()
+        .find(|r| text(r, "intent").as_deref() == Some("how_to"))
+        .expect("a how_to audit row");
+    let plan_summary = text(audit_row, "plan_summary").expect("plan_summary column");
+    assert!(
+        plan_summary.contains("intent=how_to"),
+        "audit plan_summary must record the how-to intent: {plan_summary}"
+    );
+    assert!(
+        plan_summary.contains("create_queue")
+            && plan_summary.contains("events_backfill")
+            && plan_summary.contains("select"),
+        "audit plan_summary must record the suggested statement kinds: {plan_summary}"
+    );
+}
+
+// ===========================================================================
 // Scripted mock stub — sequenced chat completions + request-body capture.
 // ===========================================================================
 


### PR DESCRIPTION
Closes #1750.

Finish-from-branch landing of worker `wXDL8`'s #1750 (PRD #1744 — how-to intent: parser-validated suggestion envelope, mutating flags, never executed).

Hit a **merge conflict** after #1749 landed. Rebased onto current main and resolved three conflicts:
- `ask_planner.rs`: #1750's real how-to test supersedes #1749's `how_to_intent_routes_unsupported_in_this_slice` placeholder (how-to is now supported); #1749's synthesis+calculation tests kept.
- `impl_search.rs`: merged the routing match — kept #1749's `Unsupported → PlannerPrepass::FallThrough` and converted #1750's new `Suggest` arm to `PlannerPrepass::Handled` (matching #1748's enum refactor).
- `e2e_ask_planner_core.rs`: additive — both synthesis (#1749) and how-to (#1750) e2e tests kept.

`cargo check` clean, fmt applied.

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785855477&installation_id=129708444&pr_number=1760&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1760&signature=4e64d3ad9b7aa07239332788181c8b0473960e75ea33212616f0d35c19ce5a2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->