### PR TITLE
#1751 ASK clause clean break: remove EXECUTE/AS RQL, PLAN param, EXPLAIN ASK (rebased)

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -962,13 +962,12 @@ pub struct AskQuery {
     pub stream: bool,
     /// Per-query answer-cache override.
     pub cache: AskCacheClause,
-    /// `ASK '...' AS RQL` returns a validated RQL candidate instead of
-    /// calling an AI provider. The runtime owns translation and validation.
-    pub as_rql: bool,
-    /// `ASK '...' EXECUTE` opts in to auto-running a generated RQL
-    /// candidate when (and only when) it is read-only. A mutating
-    /// candidate is refused for auto-execution regardless of this flag.
-    pub execute: bool,
+    /// `ASK '...' PLAN` returns the typed plan (routed intent + candidate
+    /// query) without executing the candidate and without the synthesis
+    /// call (ADR 0068, #1751). The `EXECUTE` and `AS RQL` clauses were
+    /// removed in the same clean break: read-only candidates auto-execute
+    /// by default, and `PLAN` is the inspection-only surface.
+    pub plan_only: bool,
     /// Per-query plan-step budget request (`ASK '...' STEPS N`). Clamped to
     /// `red.config.ai.ask.max_plan_steps` at planning time and never exceeds
     /// it; `None` falls back to the configured cap.

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -669,7 +669,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse: ASK 'question' [USING provider] [MODEL 'model'] [DEPTH n]
-    /// [LIMIT n] [MIN_SCORE x] [COLLECTION col] [AS RQL]
+    /// [LIMIT n] [MIN_SCORE x] [COLLECTION col] [PLAN]
     pub fn parse_ask_query(&mut self) -> Result<QueryExpr, ParseError> {
         self.parse_ask_query_with_explain(false)
     }
@@ -716,8 +716,7 @@ impl<'a> Parser<'a> {
         let mut strict = true;
         let mut stream = false;
         let mut cache = AskCacheClause::Default;
-        let mut as_rql = false;
-        let mut execute = false;
+        let mut plan_only = false;
         let mut steps = None;
 
         // Parse optional clauses in any order. Loop bound = number of
@@ -777,28 +776,31 @@ impl<'a> Parser<'a> {
                 }
                 cache = AskCacheClause::NoCache;
             } else if self.consume(&Token::As)? {
-                if as_rql {
-                    return Err(ParseError::new(
-                        "ASK AS RQL specified more than once",
-                        self.position(),
-                    ));
-                }
-                let output = self.expect_ident_or_keyword()?;
-                if !output.eq_ignore_ascii_case("RQL") {
-                    return Err(ParseError::new(
-                        "Expected RQL after ASK AS",
-                        self.position(),
-                    ));
-                }
-                as_rql = true;
+                // Clean break (ADR 0068, #1751): `ASK ... AS RQL` was removed.
+                // Point the caller at the replacement: `PLAN` returns the
+                // typed plan and candidate query without executing.
+                return Err(ParseError::new(
+                    "ASK ... AS RQL was removed: use `ASK '<question>' PLAN` to return the \
+                     typed plan and candidate query without executing",
+                    self.position(),
+                ));
             } else if self.consume_ident_ci("EXECUTE")? {
-                if execute {
+                // Clean break (ADR 0068, #1751): `ASK ... EXECUTE` was removed.
+                // Read-only candidates auto-execute by default; `PLAN`
+                // inspects the query without running it.
+                return Err(ParseError::new(
+                    "ASK ... EXECUTE was removed: read-only candidates auto-execute by default; \
+                     use `ASK '<question>' PLAN` to inspect the query without executing",
+                    self.position(),
+                ));
+            } else if self.consume_ident_ci("PLAN")? {
+                if plan_only {
                     return Err(ParseError::new(
-                        "ASK EXECUTE specified more than once",
+                        "ASK PLAN specified more than once",
                         self.position(),
                     ));
                 }
-                execute = true;
+                plan_only = true;
             } else if self.consume_ident_ci("STEPS")? {
                 if steps.is_some() {
                     return Err(ParseError::new(
@@ -834,8 +836,7 @@ impl<'a> Parser<'a> {
             strict,
             stream,
             cache,
-            as_rql,
-            execute,
+            plan_only,
             steps,
         }))
     }

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2008,12 +2008,25 @@ fn test_parse_dml_extended_literals_auto_embed_and_ask_forms() {
     };
     assert!(matches!(ask.cache, crate::ast::AskCacheClause::NoCache));
 
-    let query = parse("ASK 'who owns passport FDD-12313?' AS RQL").unwrap();
+    // Clean break (ADR 0068, #1751): `PLAN` returns the typed plan without
+    // executing; `AS RQL` and `EXECUTE` were removed with didactic errors.
+    let query = parse("ASK 'who owns passport FDD-12313?' PLAN").unwrap();
     let QueryExpr::Ask(ask) = query else {
         panic!("Expected AskQuery");
     };
-    assert!(ask.as_rql);
+    assert!(ask.plan_only);
     assert!(!ask.explain);
+
+    let err = parse("ASK 'who owns passport FDD-12313?' AS RQL").unwrap_err();
+    assert!(
+        err.to_string().contains("AS RQL was removed") && err.to_string().contains("PLAN"),
+        "AS RQL must reject with a didactic error naming PLAN, got: {err}"
+    );
+    let err = parse("ASK 'list travelers' EXECUTE").unwrap_err();
+    assert!(
+        err.to_string().contains("EXECUTE was removed") && err.to_string().contains("PLAN"),
+        "EXECUTE must reject with a didactic error naming PLAN, got: {err}"
+    );
 
     let query = parse("EXPLAIN ASK 'q' USING openai LIMIT 3 MIN_SCORE 0.7 DEPTH 2").unwrap();
     let QueryExpr::Ask(ask) = query else {

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -219,8 +219,7 @@ fn ask_query_from_request(
         strict: request.strict.unwrap_or(true),
         stream,
         cache: crate::storage::query::ast::AskCacheClause::Default,
-        as_rql: false,
-        execute: false,
+        plan_only: false,
         steps: None,
     })
 }

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -423,8 +423,7 @@ impl McpServer {
             } else {
                 crate::storage::query::ast::AskCacheClause::Default
             },
-            as_rql: false,
-            execute: false,
+            plan_only: false,
             steps: None,
         };
         let result = self

--- a/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
+++ b/crates/reddb-server/src/runtime/ai/ask_rql_planner.rs
@@ -1,207 +1,24 @@
-//! Deterministic `ASK ... AS RQL` planner.
+//! Read-only RQL candidate validation for the planner-first ASK path.
 //!
-//! This is deliberately not text-to-SQL execution. It builds a small,
-//! read-only RQL candidate from the same token/schema vocabulary used by
-//! AskPipeline, validates the generated text through the parser, and returns
-//! the candidate for caller approval/execution.
-
-use std::collections::BTreeSet;
+//! The deterministic `ASK ... AS RQL` planner and its LLM inference variant
+//! were removed in the ADR 0068 clean break (#1751): auto-execution of
+//! read-only candidates is now the default and the planner-first path
+//! ([`super::ask_planner`]) owns candidate generation. What survives here is
+//! the shared seam that path depends on — re-validate a candidate RQL string
+//! through the production parser and classify it read-only vs mutating so a
+//! mutating candidate is never auto-executed.
 
 use crate::api::{RedDBError, RedDBResult};
-use crate::runtime::ask_pipeline::{CandidateCollections, TokenSet};
 use crate::storage::query::ast::QueryExpr;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AskRqlPlan {
-    pub rql: String,
-    pub field: String,
-    pub value: String,
-    pub collection: Option<String>,
-    pub candidate_fields: Vec<String>,
-    pub candidate_collections: Vec<String>,
-    pub warnings: Vec<String>,
-}
-
-pub fn plan(
-    question: &str,
-    tokens: &TokenSet,
-    candidates: &CandidateCollections,
-    requested_collection: Option<&str>,
-) -> RedDBResult<AskRqlPlan> {
-    let candidate_fields = candidate_fields(tokens, candidates);
-    let field = candidate_fields.first().cloned().ok_or_else(|| {
-        RedDBError::Query(
-            "ASK AS RQL could not infer a WHERE field from the prompt and schema vocabulary"
-                .to_string(),
-        )
-    })?;
-    validate_ident("field", &field)?;
-
-    let value = literal_for_field(question, tokens, &field).ok_or_else(|| {
-        RedDBError::Query(
-            "ASK AS RQL could not infer a literal value for the generated WHERE clause".to_string(),
-        )
-    })?;
-
-    let collection = requested_collection.map(str::to_string);
-    if let Some(collection) = &collection {
-        validate_ident("collection", collection)?;
-    }
-
-    let rql = if let Some(collection) = &collection {
-        format!(
-            "SELECT * FROM {} WHERE {} = {}",
-            collection,
-            field,
-            sql_string_literal(&value)
-        )
-    } else {
-        format!("SELECT * WHERE {} = {}", field, sql_string_literal(&value))
-    };
-
-    validate_read_only_table_query(&rql)?;
-
-    let mut warnings = Vec::new();
-    if candidate_fields.len() > 1 {
-        warnings.push(format!(
-            "multiple candidate fields matched; selected `{}` from {:?}",
-            field, candidate_fields
-        ));
-    }
-    if tokens.literals.len() > 1 {
-        warnings.push(format!(
-            "multiple literal tokens matched; selected `{}` from {:?}",
-            value, tokens.literals
-        ));
-    }
-    if requested_collection.is_none() {
-        warnings.push(
-            "no COLLECTION was specified; generated RQL uses implicit universal source `any`"
-                .to_string(),
-        );
-    }
-
-    Ok(AskRqlPlan {
-        rql,
-        field,
-        value,
-        collection,
-        candidate_fields,
-        candidate_collections: candidates.collections.clone(),
-        warnings,
-    })
-}
-
-fn candidate_fields(tokens: &TokenSet, candidates: &CandidateCollections) -> Vec<String> {
-    let mut all: BTreeSet<String> = BTreeSet::new();
-    for columns in candidates.columns_by_collection.values() {
-        for column in columns {
-            all.insert(column.clone());
-        }
-    }
-
-    let mut ordered = Vec::new();
-    for keyword in &tokens.keywords {
-        for column in &all {
-            if column.eq_ignore_ascii_case(keyword) && !ordered.contains(column) {
-                ordered.push(column.clone());
-            }
-        }
-    }
-    for column in all {
-        if !ordered.contains(&column) {
-            ordered.push(column);
-        }
-    }
-    ordered
-}
-
-fn literal_for_field(question: &str, tokens: &TokenSet, field: &str) -> Option<String> {
-    if let Some(literal) = tokens.literals.first() {
-        return Some(literal.clone());
-    }
-
-    let terms = question_terms(question);
-    for (idx, term) in terms.iter().enumerate() {
-        if term.eq_ignore_ascii_case(field) {
-            if let Some(next) = terms.get(idx + 1) {
-                return Some(next.clone());
-            }
-        }
-    }
-
-    terms
-        .into_iter()
-        .find(|term| term.chars().any(|c| c.is_ascii_digit()) && term.len() >= 3)
-}
-
-fn question_terms(question: &str) -> Vec<String> {
-    let mut terms = Vec::new();
-    let mut buf = String::new();
-    for ch in question.chars() {
-        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' || ch == '.' || ch == ':' {
-            buf.push(ch);
-        } else if !buf.is_empty() {
-            terms.push(std::mem::take(&mut buf));
-        }
-    }
-    if !buf.is_empty() {
-        terms.push(buf);
-    }
-    terms
-}
-
-fn validate_ident(kind: &str, value: &str) -> RedDBResult<()> {
-    let mut chars = value.chars();
-    let valid = chars
-        .next()
-        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
-        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_');
-    if valid {
-        Ok(())
-    } else {
-        Err(RedDBError::Query(format!(
-            "ASK AS RQL inferred unsafe {kind} identifier `{value}`"
-        )))
-    }
-}
-
-fn sql_string_literal(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "''"))
-}
-
-fn validate_read_only_table_query(rql: &str) -> RedDBResult<()> {
-    let parsed = crate::storage::query::parser::parse(rql)
-        .map_err(|err| RedDBError::Query(err.to_string()))?;
-    match parsed.query {
-        QueryExpr::Table(table) if table.filter.is_some() => Ok(()),
-        QueryExpr::Table(_) => Err(RedDBError::Query(
-            "ASK AS RQL generated a table query without a WHERE clause".to_string(),
-        )),
-        other => Err(RedDBError::Query(format!(
-            "ASK AS RQL generated a non-table query: {other:?}"
-        ))),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Inference path (#1273): augment — not replace — the deterministic planner.
-//
-// `ASK '<natural language>'` can be translated to an RQL candidate by the
-// configured text2text (generate) provider. The model output is *never*
-// trusted: it is always re-validated through the production parser via the
-// same read-only-candidate seam used by the deterministic planner, and a
-// mutating candidate is never auto-executed regardless of `EXECUTE`.
-// ---------------------------------------------------------------------------
 
 /// Read-only vs mutating classification of a parser-validated candidate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CandidateDisposition {
     /// The candidate only reads (SELECT / MATCH / vector / search / …) and
-    /// may be auto-executed when `EXECUTE` is requested.
+    /// may be auto-executed.
     ReadOnly,
     /// The candidate writes, drops, alters, or otherwise mutates state and
-    /// is refused for auto-execution regardless of `EXECUTE`.
+    /// is refused for auto-execution under any flag.
     Mutating,
 }
 
@@ -223,38 +40,6 @@ impl ValidatedCandidate {
     }
 }
 
-/// Result of an inference translation pass.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AskRqlInference {
-    /// The parser-validated candidate.
-    pub candidate: ValidatedCandidate,
-    /// The prompt that was sent to the model (for explain/audit).
-    pub prompt: String,
-    /// Whether the candidate should be auto-executed by the caller. True
-    /// only when `EXECUTE` was requested *and* the candidate is read-only.
-    pub execute: bool,
-    /// Non-fatal advisories surfaced to the caller.
-    pub warnings: Vec<String>,
-}
-
-/// A model that turns an inference prompt into a single RQL candidate.
-///
-/// The blanket impl over `Fn(&str) -> RedDBResult<String>` lets callers
-/// pass a closure wrapping the configured provider (production) or a canned
-/// string (tests / mock model) without a bespoke type.
-pub trait RqlModel {
-    fn generate_rql(&self, prompt: &str) -> RedDBResult<String>;
-}
-
-impl<F> RqlModel for F
-where
-    F: Fn(&str) -> RedDBResult<String>,
-{
-    fn generate_rql(&self, prompt: &str) -> RedDBResult<String> {
-        self(prompt)
-    }
-}
-
 /// Re-validate a model-generated RQL candidate through the production
 /// parser and classify it read-only vs mutating. An invalid candidate
 /// surfaces an error and is never returned for execution.
@@ -262,12 +47,12 @@ pub fn validate_candidate(rql: &str) -> RedDBResult<ValidatedCandidate> {
     let trimmed = rql.trim();
     if trimmed.is_empty() {
         return Err(RedDBError::Query(
-            "ASK inference produced an empty RQL candidate".to_string(),
+            "ASK planner produced an empty RQL candidate".to_string(),
         ));
     }
     let parsed = crate::storage::query::parser::parse(trimmed).map_err(|err| {
         RedDBError::Query(format!(
-            "ASK inference produced an invalid RQL candidate: {err}"
+            "ASK planner produced an invalid RQL candidate: {err}"
         ))
     })?;
     let (disposition, statement_type) = classify(&parsed.query);
@@ -313,248 +98,33 @@ fn classify(query: &QueryExpr) -> (CandidateDisposition, &'static str) {
     }
 }
 
-/// Translate a natural-language question into a parser-validated RQL
-/// candidate via the supplied model, then apply the read-only-candidate /
-/// `EXECUTE` policy.
-///
-/// - The candidate is *always* re-validated through the parser.
-/// - Default (`execute = false`) returns the candidate without executing.
-/// - `execute = true` marks read-only candidates for auto-execution.
-/// - A mutating candidate is refused for auto-execution when `execute`
-///   is requested, and is never marked executable.
-pub fn infer<M: RqlModel>(
-    question: &str,
-    candidates: &CandidateCollections,
-    requested_collection: Option<&str>,
-    execute: bool,
-    model: &M,
-) -> RedDBResult<AskRqlInference> {
-    let prompt = build_inference_prompt(question, candidates, requested_collection);
-    let raw = model.generate_rql(&prompt)?;
-    let candidate = validate_candidate(&raw)?;
-
-    let mut warnings = Vec::new();
-    let execute = if execute {
-        match candidate.disposition {
-            CandidateDisposition::ReadOnly => true,
-            CandidateDisposition::Mutating => {
-                return Err(RedDBError::Query(format!(
-                    "ASK ... EXECUTE refused: generated `{}` candidate is mutating and is \
-                     never auto-executed",
-                    candidate.statement_type
-                )));
-            }
-        }
-    } else {
-        if candidate.is_read_only() {
-            warnings.push(
-                "candidate not executed; add EXECUTE to auto-run read-only candidates".to_string(),
-            );
-        } else {
-            warnings.push(format!(
-                "candidate is a mutating `{}` statement and is never auto-executed",
-                candidate.statement_type
-            ));
-        }
-        false
-    };
-
-    if requested_collection.is_none() {
-        warnings.push(
-            "no COLLECTION was specified; candidate validated against the full schema vocabulary"
-                .to_string(),
-        );
-    }
-
-    Ok(AskRqlInference {
-        candidate,
-        prompt,
-        execute,
-        warnings,
-    })
-}
-
-/// Assemble the inference prompt: the question plus the schema vocabulary
-/// (collections + columns) the model may reference, with an explicit
-/// instruction to emit a single read-only RQL statement.
-pub fn build_inference_prompt(
-    question: &str,
-    candidates: &CandidateCollections,
-    requested_collection: Option<&str>,
-) -> String {
-    let mut prompt = String::new();
-    prompt.push_str(
-        "Translate the user's question into a single read-only RQL SELECT statement. \
-         Return only the RQL, with no commentary, code fences, or trailing semicolon.\n\n",
-    );
-
-    if let Some(collection) = requested_collection {
-        prompt.push_str("Target collection: ");
-        prompt.push_str(collection);
-        prompt.push('\n');
-    }
-
-    if !candidates.collections.is_empty() {
-        prompt.push_str("Available collections: ");
-        prompt.push_str(&candidates.collections.join(", "));
-        prompt.push('\n');
-    }
-
-    let mut columns: BTreeSet<String> = BTreeSet::new();
-    for cols in candidates.columns_by_collection.values() {
-        for col in cols {
-            columns.insert(col.clone());
-        }
-    }
-    if !columns.is_empty() {
-        prompt.push_str("Available columns: ");
-        prompt.push_str(&columns.into_iter().collect::<Vec<_>>().join(", "));
-        prompt.push('\n');
-    }
-
-    prompt.push_str("\nQuestion: ");
-    prompt.push_str(question);
-    prompt
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use super::*;
 
-    fn candidates() -> CandidateCollections {
-        CandidateCollections {
-            collections: vec!["incidents".to_string(), "travelers".to_string()],
-            columns_by_collection: HashMap::from([
-                ("incidents".to_string(), vec!["host".to_string()]),
-                ("travelers".to_string(), vec!["passport".to_string()]),
-            ]),
-        }
+    #[test]
+    fn validate_candidate_classifies_read_only_select() {
+        let candidate =
+            validate_candidate("SELECT * FROM travelers WHERE passport = 'FDD-1'").unwrap();
+        assert!(candidate.is_read_only());
+        assert_eq!(candidate.statement_type, "select");
     }
 
     #[test]
-    fn plans_universal_field_literal_query() {
-        let tokens = TokenSet {
-            keywords: vec!["who".to_string(), "passport".to_string()],
-            literals: vec!["FDD-12313".to_string()],
-        };
-        let plan = plan("who owns passport FDD-12313?", &tokens, &candidates(), None).unwrap();
-        assert_eq!(plan.rql, "SELECT * WHERE passport = 'FDD-12313'");
-        assert_eq!(plan.field, "passport");
-        assert_eq!(plan.value, "FDD-12313");
+    fn validate_candidate_classifies_mutating_delete() {
+        let candidate =
+            validate_candidate("DELETE FROM travelers WHERE passport = 'FDD-1'").unwrap();
+        assert_eq!(candidate.disposition, CandidateDisposition::Mutating);
+        assert_eq!(candidate.statement_type, "delete");
     }
 
     #[test]
-    fn plans_collection_scoped_query_with_ip_value() {
-        let tokens = TokenSet {
-            keywords: vec!["host".to_string()],
-            literals: Vec::new(),
-        };
-        let plan = plan("host 10.0.0.1", &tokens, &candidates(), Some("incidents")).unwrap();
-        assert_eq!(plan.rql, "SELECT * FROM incidents WHERE host = '10.0.0.1'");
-    }
-
-    #[test]
-    fn rejects_missing_field() {
-        let tokens = TokenSet {
-            keywords: vec!["anything".to_string()],
-            literals: vec!["FDD-12313".to_string()],
-        };
-        let err = plan(
-            "anything FDD-12313",
-            &tokens,
-            &CandidateCollections::default(),
-            None,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("could not infer a WHERE field"));
-    }
-
-    // ---- inference path (#1273) ------------------------------------
-
-    /// A mock model that returns a fixed candidate string regardless of
-    /// the prompt — stands in for the configured generate provider.
-    fn mock_model(candidate: &'static str) -> impl RqlModel {
-        move |_prompt: &str| Ok(candidate.to_string())
-    }
-
-    #[test]
-    fn infer_validates_candidate_through_parser() {
-        let err = infer(
-            "anything",
-            &candidates(),
-            None,
-            false,
-            &mock_model("this is not valid rql"),
-        )
-        .unwrap_err();
+    fn validate_candidate_rejects_invalid() {
+        let err = validate_candidate("this is not valid rql").unwrap_err();
         assert!(
             err.to_string().contains("invalid RQL candidate"),
             "got: {err}"
         );
-    }
-
-    #[test]
-    fn infer_default_returns_candidate_without_executing() {
-        let out = infer(
-            "who owns passport FDD-12313?",
-            &candidates(),
-            Some("travelers"),
-            false,
-            &mock_model("SELECT * FROM travelers WHERE passport = 'FDD-12313'"),
-        )
-        .unwrap();
-        assert!(!out.execute, "default must not execute");
-        assert!(out.candidate.is_read_only());
-        assert_eq!(out.candidate.statement_type, "select");
-        assert_eq!(
-            out.candidate.rql,
-            "SELECT * FROM travelers WHERE passport = 'FDD-12313'"
-        );
-    }
-
-    #[test]
-    fn infer_execute_marks_read_only_candidate_for_run() {
-        let out = infer(
-            "list travelers",
-            &candidates(),
-            Some("travelers"),
-            true,
-            &mock_model("SELECT * FROM travelers WHERE passport = 'FDD-12313'"),
-        )
-        .unwrap();
-        assert!(out.execute, "EXECUTE on read-only candidate must run");
-        assert!(out.candidate.is_read_only());
-    }
-
-    #[test]
-    fn infer_refuses_mutating_candidate_for_execute() {
-        let err = infer(
-            "delete everything",
-            &candidates(),
-            Some("travelers"),
-            true,
-            &mock_model("DELETE FROM travelers WHERE passport = 'FDD-12313'"),
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("refused"), "got: {err}");
-        assert!(err.to_string().contains("mutating"), "got: {err}");
-    }
-
-    #[test]
-    fn infer_mutating_candidate_never_executes_without_execute() {
-        let out = infer(
-            "delete everything",
-            &candidates(),
-            Some("travelers"),
-            false,
-            &mock_model("DELETE FROM travelers WHERE passport = 'FDD-12313'"),
-        )
-        .unwrap();
-        assert!(!out.execute);
-        assert_eq!(out.candidate.disposition, CandidateDisposition::Mutating);
-        assert_eq!(out.candidate.statement_type, "delete");
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1228,8 +1228,18 @@ impl RedDBRuntime {
     ) -> RedDBResult<RuntimeQueryResult> {
         use crate::ai::{parse_provider, resolve_api_key_from_runtime};
 
-        if ask.as_rql {
-            return self.execute_ask_as_rql(raw_query, ask);
+        // ADR 0068 / #1751: `ASK ... PLAN` returns the typed plan (routed
+        // intent + candidate query) without executing the candidate and
+        // without the synthesis call. It always runs the planner — even when
+        // the `red.config.ai.ask.planner` gate is off — because it is an
+        // explicit request to inspect the plan. Zero execution, zero synthesis.
+        if ask.plan_only {
+            match self.execute_ask_planner_prepass(raw_query, ask, true)? {
+                PlannerPrepass::Handled(result) => return Ok(*result),
+                PlannerPrepass::FallThrough { .. } => {
+                    unreachable!("plan_only prepass builds the plan before routing")
+                }
+            }
         }
 
         // ADR 0068 / #1747 / #1749: planner-first path. When enabled, ASK runs
@@ -1240,7 +1250,7 @@ impl RedDBRuntime {
         // downstream audit row records the routing decision (#1749).
         let mut routed_intent: Option<&'static str> = None;
         if !ask.explain && self.ask_planner_enabled() {
-            match self.execute_ask_planner_prepass(raw_query, ask)? {
+            match self.execute_ask_planner_prepass(raw_query, ask, false)? {
                 PlannerPrepass::Handled(result) => return Ok(*result),
                 PlannerPrepass::FallThrough { intent } => {
                     routed_intent = Some(intent.as_str());
@@ -1742,6 +1752,7 @@ impl RedDBRuntime {
         &self,
         raw_query: &str,
         ask: &crate::storage::query::ast::AskQuery,
+        plan_only: bool,
     ) -> RedDBResult<PlannerPrepass> {
         use crate::ai::{parse_provider, resolve_api_key_from_runtime};
         use crate::runtime::ai::ask_planner;
@@ -1850,6 +1861,15 @@ impl RedDBRuntime {
             Ok(response.output_text)
         };
         let route = ask_planner::plan_and_route(&ask.question, &slice, &planner_closure)?;
+
+        // #1751: `ASK ... PLAN` stops here — the typed plan (intent + candidate
+        // query) is returned without executing the candidate or synthesizing.
+        // The `Query` plan step is never charged because nothing runs.
+        if plan_only {
+            return Ok(PlannerPrepass::Handled(Box::new(
+                self.build_plan_only_result(raw_query, &scope, &route)?,
+            )));
+        }
 
         match route.routing {
             // #1749: synthesis / how-to route to the ADR 0013 RAG path
@@ -2224,6 +2244,101 @@ impl RedDBRuntime {
         }
     }
 
+    /// `ASK ... PLAN` (ADR 0068 §4, #1751): return the typed plan — routed
+    /// intent, candidate query, and its read-only/mutating disposition —
+    /// without executing the candidate and without the synthesis call. The
+    /// planner LLM has already run (routing decided); nothing downstream runs.
+    /// The inspection is audited like any other ASK, with no executed query.
+    fn build_plan_only_result(
+        &self,
+        raw_query: &str,
+        scope: &crate::runtime::statement_frame::EffectiveScope,
+        route: &crate::runtime::ai::ask_planner::PlannedRoute,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        use crate::runtime::ai::ask_planner::PlanRouting;
+
+        let plan = &route.plan;
+        // Resolve the candidate query + disposition from the routing decision.
+        // A non-factual intent (synthesis / how-to) carries no candidate.
+        let (candidate_query, candidate_type, mutating) = match &route.routing {
+            PlanRouting::Execute { candidate } => (
+                Some(candidate.rql.clone()),
+                Some(candidate.statement_type.to_string()),
+                Some(false),
+            ),
+            PlanRouting::RefuseMutating {
+                statement_type,
+                rql,
+            } => (
+                Some(rql.clone()),
+                Some(statement_type.to_string()),
+                Some(true),
+            ),
+            PlanRouting::Unsupported { .. } => (None, None, None),
+        };
+
+        let plan_summary = plan.summary();
+        self.record_ask_audit(AskAuditInput {
+            scope,
+            question: &plan_summary,
+            source_urns: &[],
+            provider: "",
+            model: "",
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cost_usd: 0.0,
+            answer: "",
+            citations: &[],
+            cache_hit: false,
+            effective_mode: crate::runtime::ai::strict_validator::Mode::Lenient,
+            temperature: None,
+            seed: None,
+            validation_ok: true,
+            retry_count: 0,
+            errors: &[],
+            intent: Some(plan.intent.as_str()),
+            plan_summary: Some(&plan_summary),
+            executed_query: None,
+        })?;
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "plan_only".into(),
+            "intent".into(),
+            "candidate_query".into(),
+            "candidate_type".into(),
+            "mutating".into(),
+            "rationale".into(),
+        ]);
+        let mut record = UnifiedRecord::new();
+        record.set("plan_only", Value::Boolean(true));
+        record.set("intent", Value::text(plan.intent.as_str().to_string()));
+        match candidate_query {
+            Some(query) => record.set("candidate_query", Value::text(query)),
+            None => record.set("candidate_query", Value::Null),
+        }
+        match candidate_type {
+            Some(kind) => record.set("candidate_type", Value::text(kind)),
+            None => record.set("candidate_type", Value::Null),
+        }
+        match mutating {
+            Some(flag) => record.set("mutating", Value::Boolean(flag)),
+            None => record.set("mutating", Value::Null),
+        }
+        record.set("rationale", Value::text(plan.rationale.clone()));
+        result.push(record);
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: QueryMode::Sql,
+            statement: "ask",
+            engine: "runtime-ai",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+
     /// Structured refusal for a mutating planner candidate. The candidate is
     /// never executed under any flag; the suggestion envelope arrives later.
     fn build_planner_refusal_result(
@@ -2552,181 +2667,45 @@ impl RedDBRuntime {
         })
     }
 
-    fn execute_ask_as_rql(
-        &self,
-        raw_query: &str,
-        ask: &crate::storage::query::ast::AskQuery,
-    ) -> RedDBResult<RuntimeQueryResult> {
-        let scope = self.ai_scope();
-        let tokens = crate::runtime::ask_pipeline::extract_tokens(&ask.question);
-        if tokens.is_empty() {
-            return Err(RedDBError::Query(
-                "ASK AS RQL question yielded no usable tokens".to_string(),
-            ));
-        }
-        let candidates = crate::runtime::ask_pipeline::match_schema(self, &scope, &tokens)?;
-
-        // Inference path (#1273): when `ai.ask_rql.backend = "llm"` and a
-        // generate provider is available, the model proposes the RQL
-        // candidate; otherwise fall back to the deterministic planner. Both
-        // candidates are re-validated through the parser via the same seam.
-        let candidate;
-        let engine;
-        let field;
-        let value;
-        let candidate_fields;
-        let candidate_collections;
-        let mut warnings;
-        let used_inference;
-        match self.ask_rql_inference(ask, &candidates)? {
-            Some(inference) => {
-                candidate = inference.candidate;
-                engine = "runtime-ai-rql-inference";
-                field = None;
-                value = None;
-                candidate_fields = Vec::new();
-                candidate_collections = candidates.collections.clone();
-                warnings = inference.warnings;
-                used_inference = true;
-            }
-            None => {
-                let plan = crate::runtime::ai::ask_rql_planner::plan(
-                    &ask.question,
-                    &tokens,
-                    &candidates,
-                    ask.collection.as_deref(),
-                )?;
-                // Re-validate the deterministic candidate through the same
-                // parser seam so the disposition / EXECUTE gating is shared.
-                candidate = crate::runtime::ai::ask_rql_planner::validate_candidate(&plan.rql)?;
-                engine = "runtime-ai-rql-planner";
-                field = Some(plan.field);
-                value = Some(plan.value);
-                candidate_fields = plan.candidate_fields;
-                candidate_collections = plan.candidate_collections;
-                warnings = plan.warnings;
-                used_inference = false;
-            }
-        }
-
-        // EXECUTE policy: auto-run read-only candidates only; a mutating
-        // candidate is refused for auto-execution regardless of EXECUTE.
-        if ask.execute {
-            if candidate.is_read_only() {
-                let mut executed = self.execute_query(&candidate.rql)?;
-                executed.query = raw_query.to_string();
-                return Ok(executed);
-            }
-            return Err(RedDBError::Query(format!(
-                "ASK ... EXECUTE refused: generated `{}` candidate is mutating and is never \
-                 auto-executed",
-                candidate.statement_type
-            )));
-        }
-
-        // The inference path already records the not-executed / mutating
-        // advisory inside `infer`; only the deterministic path needs it here.
-        if !used_inference {
-            if candidate.is_read_only() {
-                warnings.push(
-                    "candidate not executed; add EXECUTE to auto-run read-only candidates"
-                        .to_string(),
-                );
-            } else {
-                warnings.push(format!(
-                    "candidate is a mutating `{}` statement and is never auto-executed",
-                    candidate.statement_type
-                ));
-            }
-        }
-
-        let mut result = UnifiedResult::with_columns(vec![
-            "rql".into(),
-            "statement_type".into(),
-            "field".into(),
-            "value".into(),
-            "collection".into(),
-            "candidate_fields".into(),
-            "candidate_collections".into(),
-            "warnings".into(),
-        ]);
-        let mut record = UnifiedRecord::new();
-        record.set("rql", Value::text(candidate.rql));
-        record.set("statement_type", Value::text(candidate.statement_type));
-        match field {
-            Some(field) => record.set("field", Value::text(field)),
-            None => record.set("field", Value::Null),
-        }
-        match value {
-            Some(value) => record.set("value", Value::text(value)),
-            None => record.set("value", Value::Null),
-        }
-        match ask.collection.clone() {
-            Some(collection) => record.set("collection", Value::text(collection)),
-            None => record.set("collection", Value::Null),
-        }
-        record.set(
-            "candidate_fields",
-            Value::Json(json_string_array_bytes(&candidate_fields)),
-        );
-        record.set(
-            "candidate_collections",
-            Value::Json(json_string_array_bytes(&candidate_collections)),
-        );
-        record.set("warnings", Value::Json(json_string_array_bytes(&warnings)));
-        result.push(record);
-
-        Ok(RuntimeQueryResult {
-            query: raw_query.to_string(),
-            mode: QueryMode::Sql,
-            statement: "ask_as_rql",
-            engine,
-            result,
-            affected_rows: 0,
-            statement_type: "select",
-            bookmark: None,
-        })
-    }
-
-    /// Inference backend (#1273): when `ai.ask_rql.backend = "llm"`,
-    /// translate the question into an RQL candidate via the configured
-    /// generate provider. Returns `None` when the backend is disabled or no
-    /// provider / API key is available, so the caller falls back to the
-    /// deterministic planner. The model output is always re-validated
-    /// through the parser inside `ask_rql_planner::infer`.
-    fn ask_rql_inference(
+    /// Run the planner LLM over an already-grounded slice and route the plan —
+    /// WITHOUT executing the candidate or synthesizing. Shared by `EXPLAIN ASK`
+    /// (which reuses the funnel it already ran) and any other plan-inspection
+    /// caller. The planner model is resolved independently of the synthesis
+    /// model (ADR 0068 §3) and always runs deterministic (temperature 0).
+    fn plan_route_over_slice(
         &self,
         ask: &crate::storage::query::ast::AskQuery,
-        candidates: &crate::runtime::ask_pipeline::CandidateCollections,
-    ) -> RedDBResult<Option<crate::runtime::ai::ask_rql_planner::AskRqlInference>> {
-        if self.config_string("ai.ask_rql.backend", "deterministic") != "llm" {
-            return Ok(None);
-        }
+        slice: &crate::runtime::ai::ask_planner::NarrowedSlice,
+    ) -> RedDBResult<crate::runtime::ai::ask_planner::PlannedRoute> {
+        use crate::ai::{parse_provider, resolve_api_key_from_runtime};
+        use crate::runtime::ai::ask_planner;
 
         let (default_provider, default_model) = crate::ai::resolve_defaults_from_runtime(self);
-        let provider = match ask.provider.as_deref() {
-            Some(name) => crate::ai::parse_provider(name)?,
-            None => default_provider,
-        };
-        crate::runtime::ai::provider_gate::enforce(self, &provider)?;
-        let api_key = match crate::ai::resolve_api_key_from_runtime(&provider, None, self) {
-            Ok(key) => key,
-            Err(_) => return Ok(None),
-        };
-        let api_base = provider.resolve_api_base();
-        let model = ask.model.clone().unwrap_or(default_model);
-        let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
-        let max_tokens = self.config_f64("ai.ask_rql.max_tokens", 256.0).max(1.0) as usize;
+        let provider_names =
+            self.ask_provider_failover_names(ask.provider.as_deref(), &default_provider)?;
+        let planner_provider_name = provider_names
+            .first()
+            .cloned()
+            .unwrap_or_else(|| default_provider.token().to_string());
+        let planner_provider = parse_provider(&planner_provider_name)?;
+        crate::runtime::ai::provider_gate::enforce(self, &planner_provider)?;
 
-        let generate = move |prompt: &str| -> RedDBResult<String> {
+        let synth_model = ask.model.clone().unwrap_or(default_model);
+        let planner_model = crate::ai::resolve_ask_planner_model_from_runtime(self, &synth_model);
+        let settings = self.ask_cost_guard_settings();
+        let transport = crate::runtime::ai::transport::AiTransport::from_runtime(self);
+        let planner_api_key = resolve_api_key_from_runtime(&planner_provider, None, self)?;
+        let planner_api_base = planner_provider.resolve_api_base();
+
+        let planner_closure = |prompt: &str| -> RedDBResult<String> {
             let response = call_ask_llm(
-                &provider,
+                &planner_provider,
                 transport.clone(),
-                api_key.clone(),
-                model.clone(),
+                planner_api_key.clone(),
+                planner_model.clone(),
                 prompt.to_string(),
-                api_base.clone(),
-                max_tokens,
+                planner_api_base.clone(),
+                settings.max_completion_tokens as usize,
                 Some(0.0),
                 None,
                 false,
@@ -2734,15 +2713,7 @@ impl RedDBRuntime {
             )?;
             Ok(response.output_text)
         };
-
-        let inference = crate::runtime::ai::ask_rql_planner::infer(
-            &ask.question,
-            candidates,
-            ask.collection.as_deref(),
-            ask.execute,
-            &generate,
-        )?;
-        Ok(Some(inference))
+        ask_planner::plan_and_route(&ask.question, slice, &planner_closure)
     }
 
     fn execute_explain_ask(
@@ -2827,9 +2798,43 @@ impl RedDBRuntime {
             },
         );
 
-        let mut result = UnifiedResult::with_columns(vec!["plan".into()]);
+        // #1751: EXPLAIN ASK also surfaces the routed intent and candidate
+        // query — running at most the planner call, never execution or
+        // synthesis. When the planner is disabled or the funnel grounded
+        // nothing, the intent is reported as `unknown` with no candidate.
+        let (intent_label, candidate_query) = if self.ask_planner_enabled() {
+            let slice = narrowed_slice_from_context(ask_context);
+            if slice.is_empty() {
+                ("unknown".to_string(), None)
+            } else {
+                let route = self.plan_route_over_slice(ask, &slice)?;
+                let candidate = match &route.routing {
+                    crate::runtime::ai::ask_planner::PlanRouting::Execute { candidate } => {
+                        Some(candidate.rql.clone())
+                    }
+                    crate::runtime::ai::ask_planner::PlanRouting::RefuseMutating {
+                        rql, ..
+                    } => Some(rql.clone()),
+                    crate::runtime::ai::ask_planner::PlanRouting::Unsupported { .. } => None,
+                };
+                (route.plan.intent.as_str().to_string(), candidate)
+            }
+        } else {
+            ("unknown".to_string(), None)
+        };
+
+        let mut result = UnifiedResult::with_columns(vec![
+            "plan".into(),
+            "intent".into(),
+            "candidate_query".into(),
+        ]);
         let mut record = UnifiedRecord::new();
         record.set("plan", Value::Json(plan.to_string_compact().into_bytes()));
+        record.set("intent", Value::text(intent_label));
+        match candidate_query {
+            Some(query) => record.set("candidate_query", Value::text(query)),
+            None => record.set("candidate_query", Value::Null),
+        }
         result.push(record);
 
         Ok(RuntimeQueryResult {
@@ -5355,59 +5360,27 @@ mod citation_wedge_tests {
     }
 
     #[test]
-    fn ask_as_rql_returns_validated_universal_select_without_provider() {
+    fn ask_as_rql_and_execute_are_removed_with_didactic_errors() {
+        // Clean break (ADR 0068, #1751): the `AS RQL` and `EXECUTE` clauses
+        // were removed. Read-only candidates auto-execute by default and the
+        // `PLAN` clause inspects the query without running it. Both dead
+        // clauses reject at parse time with a didactic error naming `PLAN`.
         let rt = crate::runtime::RedDBRuntime::in_memory().expect("runtime");
-        rt.execute_query("CREATE TABLE travelers (passport TEXT, name TEXT)")
-            .expect("create table");
-        rt.execute_query("INSERT INTO travelers (passport, name) VALUES ('FDD-12313', 'Ada')")
-            .expect("insert row");
 
-        let planned = rt
+        let err = rt
             .execute_query("ASK 'who owns passport FDD-12313?' AS RQL")
-            .expect("ASK AS RQL should not require an AI provider");
-        assert_eq!(planned.engine, "runtime-ai-rql-planner");
-
-        let record = planned.result.records.first().expect("one plan row");
-        let rql = match record.get("rql") {
-            Some(Value::Text(text)) => text.to_string(),
-            other => panic!("rql column should be text, got {other:?}"),
-        };
-        assert_eq!(rql, "SELECT * WHERE passport = 'FDD-12313'");
-
-        let selected = rt
-            .execute_query(&rql)
-            .expect("generated RQL should parse and execute");
-        assert_eq!(selected.engine, "runtime-table");
-        assert_eq!(selected.result.records.len(), 1);
-        assert_eq!(
-            selected.result.records[0].get("name"),
-            Some(&Value::text("Ada".to_string()))
+            .expect_err("AS RQL was removed");
+        assert!(
+            err.to_string().contains("AS RQL was removed") && err.to_string().contains("PLAN"),
+            "AS RQL must reject with a didactic error naming PLAN, got: {err}"
         );
-    }
 
-    #[test]
-    fn ask_as_rql_execute_runs_read_only_candidate_and_returns_rows() {
-        let rt = crate::runtime::RedDBRuntime::in_memory().expect("runtime");
-        rt.execute_query("CREATE TABLE travelers (passport TEXT, name TEXT)")
-            .expect("create table");
-        rt.execute_query("INSERT INTO travelers (passport, name) VALUES ('FDD-12313', 'Ada')")
-            .expect("insert row");
-
-        // Default (no EXECUTE) returns the validated candidate, no rows.
-        let planned = rt
-            .execute_query("ASK 'who owns passport FDD-12313?' AS RQL")
-            .expect("ASK AS RQL candidate");
-        assert_eq!(planned.engine, "runtime-ai-rql-planner");
-
-        // EXECUTE auto-runs the read-only candidate and returns the rows.
-        let executed = rt
-            .execute_query("ASK 'who owns passport FDD-12313?' AS RQL EXECUTE")
-            .expect("ASK AS RQL EXECUTE should run the read-only candidate");
-        assert_eq!(executed.engine, "runtime-table");
-        assert_eq!(executed.result.records.len(), 1);
-        assert_eq!(
-            executed.result.records[0].get("name"),
-            Some(&Value::text("Ada".to_string()))
+        let err = rt
+            .execute_query("ASK 'list travelers' EXECUTE")
+            .expect_err("EXECUTE was removed");
+        assert!(
+            err.to_string().contains("EXECUTE was removed") && err.to_string().contains("PLAN"),
+            "EXECUTE must reject with a didactic error naming PLAN, got: {err}"
         );
     }
 

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -2275,6 +2275,9 @@ impl RedDBRuntime {
                 Some(true),
             ),
             PlanRouting::Unsupported { .. } => (None, None, None),
+            // A how-to suggestion envelope carries no single executable
+            // candidate — plan-only reports no candidate columns for it.
+            PlanRouting::Suggest { .. } => (None, None, None),
         };
 
         let plan_summary = plan.summary();
@@ -2816,6 +2819,8 @@ impl RedDBRuntime {
                         rql, ..
                     } => Some(rql.clone()),
                     crate::runtime::ai::ask_planner::PlanRouting::Unsupported { .. } => None,
+                    // A how-to suggestion envelope has no single candidate query.
+                    crate::runtime::ai::ask_planner::PlanRouting::Suggest { .. } => None,
                 };
                 (route.plan.intent.as_str().to_string(), candidate)
             }

--- a/crates/reddb-server/tests/ask_parser.rs
+++ b/crates/reddb-server/tests/ask_parser.rs
@@ -132,6 +132,19 @@ proptest! {
         );
     }
 
+    /// Clean break (ADR 0068, #1751): the removed `AS RQL` / `EXECUTE`
+    /// clauses must never round-trip — the parser rejects them (didactically)
+    /// rather than accepting the dead grammar. Pins the removal across the
+    /// whole question-string corpus.
+    #[test]
+    fn proptest_ask_removed_clauses_reject(s in ask_grammar::ask_removed_clause_stmt()) {
+        harness::roundtrip_property::<AskParser>(&s);
+        prop_assert!(
+            AskParser::parse(&s).is_err(),
+            "removed AS RQL / EXECUTE clause must not parse: {}", s
+        );
+    }
+
     /// Arbitrary-bytes suffix on each AI keyword: never panic.
     #[test]
     fn proptest_ask_arbitrary_suffix_no_panic(
@@ -309,101 +322,80 @@ fn search_context_full_clause_chain_parses() {
 }
 
 #[test]
-fn ask_as_rql_clause_parses() {
-    let q = parse_query("ASK 'who owns passport FDD-12313?' AS RQL");
+fn ask_plan_clause_sets_plan_only() {
+    // Clean break (ADR 0068, #1751): `PLAN` returns the typed plan and
+    // candidate query without executing or synthesizing.
+    let q = parse_query("ASK 'who owns passport FDD-12313?' PLAN");
     match q {
         QueryExpr::Ask(ask) => {
-            assert!(ask.as_rql, "AS RQL should set as_rql");
-            assert!(!ask.execute, "AS RQL without EXECUTE must not set execute");
+            assert!(ask.plan_only, "PLAN should set plan_only");
+            assert!(!ask.explain);
         }
         other => panic!("expected Ask, got {other:?}"),
     }
 }
 
 #[test]
-fn ask_as_rql_execute_clause_parses() {
-    // `EXECUTE` is the opt-in that auto-runs a read-only candidate; it
-    // can appear with `AS RQL` in any order.
-    let q = parse_query("ASK 'who owns passport FDD-12313?' AS RQL EXECUTE");
-    match q {
-        QueryExpr::Ask(ask) => {
-            assert!(ask.as_rql);
-            assert!(ask.execute, "EXECUTE should set execute");
-        }
-        other => panic!("expected Ask, got {other:?}"),
-    }
-}
-
-#[test]
-fn ask_execute_before_as_rql_parses() {
-    let q = parse_query("ASK 'q' EXECUTE AS RQL");
-    match q {
-        QueryExpr::Ask(ask) => {
-            assert!(ask.as_rql);
-            assert!(ask.execute);
-        }
-        other => panic!("expected Ask, got {other:?}"),
-    }
-}
-
-#[test]
-fn ask_execute_specified_twice_errors() {
-    let err = parser::parse("ASK 'q' EXECUTE EXECUTE").expect_err("double EXECUTE must error");
+fn ask_plan_specified_twice_errors() {
+    let err = parser::parse("ASK 'q' PLAN PLAN").expect_err("double PLAN must error");
     assert!(
-        err.to_string().contains("EXECUTE specified more than once"),
+        err.to_string().contains("PLAN specified more than once"),
         "got: {err}"
     );
 }
 
-// ---- inference seam with a mock model (#1273) --------------------
+#[test]
+fn ask_as_rql_clause_is_removed_with_didactic_error() {
+    // `AS RQL` was removed: the didactic error must name the `PLAN`
+    // replacement so callers can migrate without reading the changelog.
+    let err =
+        parser::parse("ASK 'who owns passport FDD-12313?' AS RQL").expect_err("AS RQL was removed");
+    assert!(
+        err.to_string().contains("AS RQL was removed") && err.to_string().contains("PLAN"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn ask_execute_clause_is_removed_with_didactic_error() {
+    // `EXECUTE` was removed: read-only candidates auto-execute by default;
+    // the didactic error must name the `PLAN` inspection replacement.
+    let err = parser::parse("ASK 'list travelers' EXECUTE").expect_err("EXECUTE was removed");
+    assert!(
+        err.to_string().contains("EXECUTE was removed") && err.to_string().contains("PLAN"),
+        "got: {err}"
+    );
+}
+
+// ---- read-only candidate validation seam -------------------------
 //
-// There is no stubbable LLM transport on the SQL ASK path, so the
-// generate-provider seam is exercised here through a mock `RqlModel`
-// closure that stands in for the configured text2text provider.
+// The deterministic `AS RQL` planner and its LLM inference variant were
+// removed in the ADR 0068 clean break (#1751); the planner-first path now
+// owns candidate generation. What survives is the shared parser + read-only
+// classifier seam, exercised here directly.
 
-mod ask_rql_inference {
-    use reddb_server::runtime::ai::ask_rql_planner::{infer, CandidateDisposition};
-    use reddb_server::runtime::ask_pipeline::CandidateCollections;
-
-    fn candidates() -> CandidateCollections {
-        CandidateCollections {
-            collections: vec!["travelers".to_string()],
-            columns_by_collection: std::collections::HashMap::from([(
-                "travelers".to_string(),
-                vec!["passport".to_string(), "name".to_string()],
-            )]),
-        }
-    }
+mod candidate_validation {
+    use reddb_server::runtime::ai::ask_rql_planner::{validate_candidate, CandidateDisposition};
 
     #[test]
     fn invalid_candidate_is_rejected_by_parser() {
-        let model = |_p: &str| Ok("not valid rql at all".to_string());
-        let err = infer("q", &candidates(), Some("travelers"), false, &model).unwrap_err();
+        let err = validate_candidate("not valid rql at all").unwrap_err();
         assert!(err.to_string().contains("invalid RQL candidate"), "{err}");
     }
 
     #[test]
-    fn default_returns_validated_candidate_without_executing() {
-        let model =
-            |_p: &str| Ok("SELECT * FROM travelers WHERE passport = 'FDD-12313'".to_string());
-        let out = infer("q", &candidates(), Some("travelers"), false, &model).unwrap();
-        assert!(!out.execute);
-        assert_eq!(out.candidate.disposition, CandidateDisposition::ReadOnly);
+    fn read_only_select_is_classified_read_only() {
+        let out =
+            validate_candidate("SELECT * FROM travelers WHERE passport = 'FDD-12313'").unwrap();
+        assert_eq!(out.disposition, CandidateDisposition::ReadOnly);
+        assert!(out.is_read_only());
     }
 
     #[test]
-    fn execute_runs_read_only_candidate() {
-        let model =
-            |_p: &str| Ok("SELECT * FROM travelers WHERE passport = 'FDD-12313'".to_string());
-        let out = infer("q", &candidates(), Some("travelers"), true, &model).unwrap();
-        assert!(out.execute, "read-only candidate with EXECUTE must run");
-    }
-
-    #[test]
-    fn mutating_candidate_refused_for_execute() {
-        let model = |_p: &str| Ok("DELETE FROM travelers WHERE passport = 'FDD-12313'".to_string());
-        let err = infer("q", &candidates(), Some("travelers"), true, &model).unwrap_err();
-        assert!(err.to_string().contains("refused"), "{err}");
+    fn mutating_delete_is_classified_mutating() {
+        let out = validate_candidate("DELETE FROM travelers WHERE passport = 'FDD-12313'").unwrap();
+        assert_eq!(out.disposition, CandidateDisposition::Mutating);
+        assert_eq!(out.statement_type, "delete");
     }
 }
 

--- a/crates/reddb-server/tests/ask_snapshots.rs
+++ b/crates/reddb-server/tests/ask_snapshots.rs
@@ -77,6 +77,17 @@ snap!(ask_limit_garbage, "ASK 'q' LIMIT @#$%");
 snap!(ask_collection_no_ident, "ASK 'q' COLLECTION");
 snap!(ask_garbage_after_question, "ASK 'q' @#$%");
 
+// ----- clean-break didactic errors (ADR 0068, #1751) -------------
+// `AS RQL` and `EXECUTE` were removed; each rejects with a didactic
+// error that names the `PLAN` replacement. The snapshots pin the
+// exact messages so a wording regression is caught in review.
+snap!(
+    ask_as_rql_removed,
+    "ASK 'who owns passport FDD-12313?' AS RQL"
+);
+snap!(ask_execute_removed, "ASK 'list travelers' EXECUTE");
+snap!(ask_plan_specified_twice, "ASK 'q' PLAN PLAN");
+
 // ----- SEARCH CONTEXT error scenarios ----------------------------
 
 snap!(search_context_eof, "SEARCH CONTEXT");

--- a/crates/reddb-server/tests/snapshots/ask_snapshots__ask_as_rql_removed.snap
+++ b/crates/reddb-server/tests/snapshots/ask_snapshots__ask_as_rql_removed.snap
@@ -1,0 +1,7 @@
+---
+source: crates/reddb-server/tests/ask_snapshots.rs
+expression: "fmt_parse_error(\"ASK 'who owns passport FDD-12313?' AS RQL\")"
+---
+input: "ASK 'who owns passport FDD-12313?' AS RQL"
+kind:  Syntax
+error: Parse error at 1:39: ASK ... AS RQL was removed: use `ASK '<question>' PLAN` to return the typed plan and candidate query without executing

--- a/crates/reddb-server/tests/snapshots/ask_snapshots__ask_execute_removed.snap
+++ b/crates/reddb-server/tests/snapshots/ask_snapshots__ask_execute_removed.snap
@@ -1,0 +1,7 @@
+---
+source: crates/reddb-server/tests/ask_snapshots.rs
+expression: "fmt_parse_error(\"ASK 'list travelers' EXECUTE\")"
+---
+input: "ASK 'list travelers' EXECUTE"
+kind:  Syntax
+error: Parse error at 1:29: ASK ... EXECUTE was removed: read-only candidates auto-execute by default; use `ASK '<question>' PLAN` to inspect the query without executing

--- a/crates/reddb-server/tests/snapshots/ask_snapshots__ask_plan_specified_twice.snap
+++ b/crates/reddb-server/tests/snapshots/ask_snapshots__ask_plan_specified_twice.snap
@@ -1,0 +1,7 @@
+---
+source: crates/reddb-server/tests/ask_snapshots.rs
+expression: "fmt_parse_error(\"ASK 'q' PLAN PLAN\")"
+---
+input: "ASK 'q' PLAN PLAN"
+kind:  Syntax
+error: Parse error at 1:18: ASK PLAN specified more than once

--- a/crates/reddb-server/tests/sql_injection_audit.rs
+++ b/crates/reddb-server/tests/sql_injection_audit.rs
@@ -184,17 +184,18 @@ fn ask_path_does_not_re_execute_llm_output_as_sql() {
         &ask.min_score,
         &ask.provider,
         &ask.model,
-        &ask.as_rql,
+        &ask.plan_only,
     );
-    assert!(!ask.as_rql);
+    assert!(!ask.plan_only);
 
-    let parsed =
-        parse_multi("ASK 'who owns passport FDD-12313?' AS RQL").expect("parse ASK AS RQL");
+    // Clean break (ADR 0068, #1751): `PLAN` returns the typed plan and
+    // candidate query without executing; it never re-parses LLM output.
+    let parsed = parse_multi("ASK 'who owns passport FDD-12313?' PLAN").expect("parse ASK PLAN");
     let ask = match parsed {
         QueryExpr::Ask(a) => a,
         other => panic!("expected Ask, got {:?}", other),
     };
-    assert!(ask.as_rql);
+    assert!(ask.plan_only);
 
     // Sanity: an injection-shaped question string is just text.
     let parsed = parse_multi("ASK '''; DROP TABLE users; --'").expect("parse ASK with payload");

--- a/crates/reddb-server/tests/support/parser_hardening/ask_grammar.rs
+++ b/crates/reddb-server/tests/support/parser_hardening/ask_grammar.rs
@@ -94,26 +94,47 @@ pub fn ask_stmt() -> impl Strategy<Value = String> {
         proptest::option::of(small_uint()),
         proptest::option::of(small_score()),
         proptest::option::of(ident()),
+        any::<bool>(),
     )
-        .prop_map(|(question, model, depth, limit, min_score, collection)| {
-            let mut s = format!("ASK {}", question);
-            if let Some(m) = model {
-                s.push_str(&format!(" MODEL {}", m));
-            }
-            if let Some(d) = depth {
-                s.push_str(&format!(" DEPTH {}", d));
-            }
-            if let Some(l) = limit {
-                s.push_str(&format!(" LIMIT {}", l));
-            }
-            if let Some(score) = min_score {
-                s.push_str(&format!(" MIN_SCORE {}", score));
-            }
-            if let Some(c) = collection {
-                s.push_str(&format!(" COLLECTION {}", c));
-            }
-            s
-        })
+        .prop_map(
+            |(question, model, depth, limit, min_score, collection, plan_only)| {
+                let mut s = format!("ASK {}", question);
+                if let Some(m) = model {
+                    s.push_str(&format!(" MODEL {}", m));
+                }
+                if let Some(d) = depth {
+                    s.push_str(&format!(" DEPTH {}", d));
+                }
+                if let Some(l) = limit {
+                    s.push_str(&format!(" LIMIT {}", l));
+                }
+                if let Some(score) = min_score {
+                    s.push_str(&format!(" MIN_SCORE {}", score));
+                }
+                if let Some(c) = collection {
+                    s.push_str(&format!(" COLLECTION {}", c));
+                }
+                // ADR 0068 / #1751: `PLAN` is the inspection-only clause that
+                // replaced the removed `AS RQL` / `EXECUTE` forms.
+                if plan_only {
+                    s.push_str(" PLAN");
+                }
+                s
+            },
+        )
+}
+
+/// The removed `AS RQL` / `EXECUTE` clauses (ADR 0068, #1751). These must
+/// no longer parse — feeding them through `parser::parse` in the property
+/// suite pins the clean break: they reject rather than round-trip.
+pub fn ask_removed_clause_stmt() -> impl Strategy<Value = String> {
+    (str_lit(), any::<bool>()).prop_map(|(q, as_rql)| {
+        if as_rql {
+            format!("ASK {} AS RQL", q)
+        } else {
+            format!("ASK {} EXECUTE", q)
+        }
+    })
 }
 
 /// `ASK 'question' USING <provider>`. Because of FIXME(#101), this

--- a/docs/guides/ask-your-database.md
+++ b/docs/guides/ask-your-database.md
@@ -593,16 +593,24 @@ SELECT * WHERE host = $1
 That form is parsed as the universal source `any`, equivalent in intent to
 `FROM ANY` plus a `WHERE` filter.
 
-When you want a prompt converted into a query candidate, request that contract
-explicitly:
+A **factual** `ASK` generates that query shape for you, auto-executes the
+read-only candidate under your RLS scope, and answers from the executed rows.
+To inspect the generated query without running it, add `PLAN`:
 
 ```sql
-ASK 'host 10.0.0.5' AS RQL
+ASK 'host 10.0.0.5' PLAN
 ```
 
-The `AS RQL` path does not call the LLM. It uses schema vocabulary and literal
-extraction, validates the generated read-only query through the parser, and
-returns the candidate in the `rql` column for the caller to execute or approve.
+`ASK ... PLAN` returns the routed `intent`, the `candidate_query`, its
+`candidate_type`, and a `mutating` flag — **it does not execute the candidate
+and does not call the synthesis model**. `EXPLAIN ASK '…'` goes one step
+lighter, returning the retrieval/provider/cost `plan` plus the intent and
+candidate query while running at most the planner call.
+
+> The `AS RQL` and `EXECUTE` clauses were removed in the ADR 0068 clean break
+> (#1751). Read-only candidates auto-execute by default; `PLAN` is the
+> inspection-only replacement. The removed clauses reject with a didactic
+> parse error that names `PLAN`.
 
 ### SEARCH CONTEXT = 3-Tier Strategy
 
@@ -639,8 +647,9 @@ paths. The provider boundary is enforced as follows:
 |:--------|:----------------|:----|
 | `SELECT … COUNT/SUM/AVG/MIN/MAX(…)` | SQL planner + executor | Exact, reproducible, no network call. |
 | `SEARCH CONTEXT 'term'` | Multi-tier index (field → token → scan) | Returns table rows, documents, KV entries, graph nodes/edges, and vectors when each backing collection exists. Empty result set when nothing matches &mdash; the contract is "ground or fall silent". |
-| `ASK '…'` | `AskPipeline` funnel + LLM synthesis | Pipeline grounds first (Stage 4 literal filter / Stage 3 BM25 + vector / Stage 3c graph), then the LLM rewrites the grounded rows into a citation-bearing sentence. |
-| `ASK '…' AS RQL` | Deterministic RQL planner | Uses schema vocabulary + literal extraction to return a parser-validated read-only query candidate. It does not call the LLM and does not execute the generated RQL. |
+| `ASK '…'` | Planner-first funnel + planner LLM + synthesis | Pipeline grounds first, the planner routes intent and (for factual) generates a read-only RQL candidate that auto-executes, then the LLM rewrites the executed/grounded rows into a citation-bearing sentence. |
+| `ASK '…' PLAN` | Planner-first funnel + planner LLM | Returns the routed intent + parser-validated candidate query without executing the candidate and without the synthesis call. |
+| `EXPLAIN ASK '…'` | Planner-first funnel + planner LLM (at most) | Returns the retrieval/provider/determinism/cost plan plus the routed intent and candidate query — never executes or synthesizes. |
 | Missing or unsupported analytics inside an `ASK` question | Pipeline short-circuits with a structured error OR returns an answer that openly cites "no matching sources" | The LLM never invents a number; it can only quote what `sources_flat` contains. |
 
 A practical rule: if the question is a calculation (`how many incidents are

--- a/docs/query/search-commands.md
+++ b/docs/query/search-commands.md
@@ -235,10 +235,18 @@ stable URNs for UI deep-links. See
 [ADR 0013](../../.red/adr/0013-ask-grounding-citations.md) for the grounding contract.
 
 > [!IMPORTANT]
-> Plain `ASK` is retrieval-grounded answer synthesis. It does not convert the
-> question into a `SELECT`, and LLM output is never parsed or executed as RQL.
-> Use `ASK ... AS RQL` when you want RedDB to return a validated read-only RQL
-> candidate for caller approval/execution.
+> `ASK` is planner-first (ADR 0068). Every question runs a planning step that
+> routes it to an intent and, for a factual question, generates a read-only
+> RQL candidate that **auto-executes by default**. A candidate that is not
+> read-only is never executed under any flag. To inspect the plan and the
+> generated query without running anything, add the `PLAN` clause; to see the
+> plan (intent, retrieval, provider, cost) without even calling the planner's
+> synthesis step, use `EXPLAIN ASK`.
+>
+> The `EXECUTE` and `AS RQL` clauses were **removed** (clean break, no
+> deprecation window). `EXECUTE` is gone because read-only candidates now
+> auto-execute; `AS RQL` is replaced by `PLAN`. Both dead clauses reject with
+> a didactic parse error that names `PLAN`.
 
 ```sql
 ASK 'what happened on host 10.0.0.1?' USING groq
@@ -261,7 +269,13 @@ ASK 'list all users with admin access' USING ollama MODEL 'llama3'
 | `STREAM` | No | HTTP/SSE token stream; transports without SSE return non-streaming rows |
 | `CACHE TTL '5m'` | No | Cache this answer for the supplied TTL |
 | `NOCACHE` | No | Bypass the global ASK cache default |
-| `AS RQL` | No | Return a deterministic, parser-validated RQL candidate instead of calling an AI provider |
+| `PLAN` | No | Return the typed plan (routed intent + candidate query) without executing the candidate and without the synthesis call |
+| `STEPS n` | No | Per-query plan-step budget, clamped to `red.config.ai.ask.max_plan_steps` |
+
+> [!NOTE]
+> `EXECUTE` and `AS RQL` were removed (ADR 0068, #1751). Read-only candidates
+> auto-execute by default; use `PLAN` to inspect the generated query without
+> running it. The removed clauses reject with a didactic parse error.
 
 ### Examples
 
@@ -275,8 +289,11 @@ ASK 'summarize all vulnerabilities' USING anthropic MODEL 'claude-sonnet-4-20250
 -- Scope to a collection with a result limit
 ASK 'what changed today?' COLLECTION audit_logs LIMIT 50
 
--- Convert a field/literal prompt into validated RQL without an LLM call
-ASK 'who owns passport FDD-12313?' AS RQL
+-- Inspect the routed intent + generated query without executing it
+ASK 'who owns passport FDD-12313?' PLAN
+
+-- Predict cost/behavior: intent + retrieval/provider/cost plan, no synthesis
+EXPLAIN ASK 'who owns passport FDD-12313?'
 
 -- All optional clauses combined
 ASK 'explain the network topology' USING ollama MODEL 'llama3' STRICT ON CACHE TTL '5m' DEPTH 3 LIMIT 100 COLLECTION network
@@ -298,26 +315,24 @@ ASK executes a retrieval-then-synthesis pipeline:
 
 3. **LLM Synthesis** — Sends the context + your question to the configured AI provider. The LLM generates a natural-language answer with inline `[^N]` markers, and RedDB validates those markers against `sources_flat`.
 
-There is no generated query-plan step in this pipeline. If the right operation
-is "find records where a field has this value", write that directly:
+For a **factual** question, the planner generates a read-only RQL candidate,
+re-validates it through the production parser, and auto-executes it under your
+RLS scope; the executed rows become the grounded sources for the cited answer.
+To inspect that candidate without running it, add `PLAN`:
 
 ```sql
-SELECT * WHERE passport = $1
+ASK 'who owns passport FDD-12313?' PLAN
 ```
 
-If you want RedDB to produce that query shape from a prompt, ask for an RQL
-candidate explicitly:
+`ASK ... PLAN` returns one row with the routed `intent`, the `candidate_query`,
+its `candidate_type`, and a `mutating` flag — **no execution, no synthesis**.
+A missing `FROM` means the universal source `any`, so the eventual query
+searches eligible collections and applies the `WHERE` filter itself.
 
-```sql
-ASK 'passport FDD-12313' AS RQL
-```
-
-`ASK ... AS RQL` uses schema vocabulary and literal extraction to produce a
-read-only `SELECT`, validates the generated text through the parser, and
-returns it in the `rql` column. Missing `FROM` means the universal source
-`any`, so the eventual query searches eligible collections and applies the
-`WHERE` filter itself. This path does not call an AI provider and does not
-execute the generated RQL for you.
+To predict cost and behavior without even the planner's synthesis step, use
+`EXPLAIN ASK` — it returns the retrieval/provider/determinism/cost `plan`
+alongside the routed `intent` and `candidate_query`, running at most the
+planner call.
 
 If no provider is configured, ASK returns an error. Configure one with:
 

--- a/tests/grouped/ai_search/e2e_ask_planner_core.rs
+++ b/tests/grouped/ai_search/e2e_ask_planner_core.rs
@@ -593,6 +593,151 @@ fn how_to_question_returns_answer_plus_validated_suggestion_never_executed() {
 }
 
 // ===========================================================================
+// #1751 — `ASK ... PLAN`: the plan-only parameter returns the routed intent,
+// the typed plan, and the candidate query WITHOUT executing the candidate and
+// WITHOUT the synthesis call.
+// ===========================================================================
+
+#[test]
+fn plan_only_returns_intent_and_candidate_without_executing_or_synthesizing() {
+    let _env = env_lock().lock().expect("env lock");
+
+    // Only the planner responds — there is NO scripted synthesis answer. If a
+    // synthesis call were made, the stub would fall through to the canned
+    // filler and the assertions below would catch it.
+    let stub = ScriptedStub::start(vec![
+        "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"passport lookup\"}".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES ('t1', 'FDD-1', 'Alice')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("ASK 'who owns passport FDD-1?' PLAN STRICT OFF")
+        .expect("ASK ... PLAN should return the typed plan");
+    let record = result
+        .result
+        .records
+        .first()
+        .expect("plan-only returns one canonical row");
+
+    // The row is the typed plan, not executed rows: intent + candidate query.
+    assert_eq!(record.get("plan_only"), Some(&Value::Boolean(true)));
+    assert_eq!(text(record, "intent").as_deref(), Some("factual"));
+    assert_eq!(
+        text(record, "candidate_query").as_deref(),
+        Some("SELECT * FROM travelers WHERE passport = 'FDD-1'"),
+        "plan-only must surface the candidate query verbatim"
+    );
+    assert_eq!(text(record, "candidate_type").as_deref(), Some("select"));
+    assert_eq!(record.get("mutating"), Some(&Value::Boolean(false)));
+    // No executed rows leaked into the plan-only result.
+    assert!(
+        record.get("answer").is_none() && record.get("name").is_none(),
+        "plan-only must not execute the candidate or synthesize an answer"
+    );
+
+    // Exactly one chat completion — the planner. Zero synthesis. (The funnel
+    // may separately hit /embeddings, which is not a chat completion.)
+    assert_eq!(
+        stub.chat_bodies().len(),
+        1,
+        "plan-only must call the planner once and never synthesize"
+    );
+
+    // The audit row records the routed intent + plan summary, but no executed
+    // query — nothing ran.
+    let audit = rt
+        .execute_query("SELECT * FROM red_ask_audit")
+        .expect("read audit rows");
+    let audit_row = audit
+        .result
+        .records
+        .iter()
+        .find(|r| text(r, "intent").as_deref() == Some("factual"))
+        .expect("a factual plan-only audit row");
+    assert!(
+        text(audit_row, "executed_query").is_none(),
+        "plan-only records no executed query — nothing ran"
+    );
+}
+
+// ===========================================================================
+// #1751 — `EXPLAIN ASK` shows the routed intent and the plan (retrieval,
+// provider, determinism, cost) WITHOUT executing the candidate or calling
+// the synthesis model — running at most the planner call.
+// ===========================================================================
+
+#[test]
+fn explain_ask_shows_intent_and_plan_without_executing_or_synthesizing() {
+    let _env = env_lock().lock().expect("env lock");
+
+    let stub = ScriptedStub::start(vec![
+        "{\"intent\":\"factual\",\"query\":\"SELECT * FROM travelers WHERE passport = 'FDD-1'\",\"rationale\":\"passport lookup\"}".to_string(),
+    ]);
+    let _p = EnvVarGuard::set("REDDB_AI_PROVIDER", "openai");
+    let _b = EnvVarGuard::set("REDDB_OPENAI_API_BASE", &format!("http://{}", stub.addr()));
+    let _k = EnvVarGuard::set("REDDB_OPENAI_API_KEY", "sk-test-mock");
+    let _m = EnvVarGuard::set("REDDB_OPENAI_PROMPT_MODEL", "synth-main");
+
+    let rt = open_rt();
+    exec(
+        &rt,
+        "CREATE TABLE travelers (id TEXT PRIMARY KEY, passport TEXT, name TEXT) \
+         WITH CONTEXT INDEX ON (id, passport, name)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO travelers (id, passport, name) VALUES ('t1', 'FDD-1', 'Alice')",
+    );
+
+    configure_planner(&rt);
+
+    let result = rt
+        .execute_query("EXPLAIN ASK 'who owns passport FDD-1?' STRICT OFF")
+        .expect("EXPLAIN ASK should return the plan");
+    let record = result
+        .result
+        .records
+        .first()
+        .expect("EXPLAIN ASK returns one canonical row");
+
+    // The retrieval/provider/determinism/cost plan is present, and it now also
+    // carries the routed intent + candidate query.
+    assert!(
+        record.get("plan").is_some(),
+        "EXPLAIN ASK must still carry the retrieval/provider/cost plan"
+    );
+    assert_eq!(text(record, "intent").as_deref(), Some("factual"));
+    assert_eq!(
+        text(record, "candidate_query").as_deref(),
+        Some("SELECT * FROM travelers WHERE passport = 'FDD-1'"),
+        "EXPLAIN ASK must surface the candidate query"
+    );
+
+    // At most the planner call — exactly one chat completion, never synthesis.
+    assert_eq!(
+        stub.chat_bodies().len(),
+        1,
+        "EXPLAIN ASK runs at most the planner call and never synthesizes"
+    );
+}
+
+// ===========================================================================
 // Scripted mock stub — sequenced chat completions + request-body capture.
 // ===========================================================================
 


### PR DESCRIPTION
Closes #1751. Final slice of PRD #1744.

Finish-from-branch landing of worker `wXDL8`'s #1751 (clean break: remove `EXECUTE`/`AS RQL`, add plan-only `PLAN` parameter, extend `EXPLAIN ASK` with intent+plan).

Hit the expected **merge-conflict** after #1748-1750 landed. Rebased onto main (14/15 commits clean); resolved:
- `e2e_ask_planner_core.rs`: additive — #1751's `plan_only` + `explain_ask` e2e tests kept alongside #1749/#1750's.
- `impl_search.rs`: two new match sites (plan-only builder, EXPLAIN ASK) needed the `PlanRouting::Suggest` arm that #1750 introduced — how-to's suggestion envelope carries no single candidate, so both report no candidate (like `Unsupported`).

`cargo check` clean, fmt applied. **This completes PRD #1744 (7/7 slices).**

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785858364&installation_id=129708444&pr_number=1761&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1761&signature=c7d0412d38c8d795c39cc6d277a08513c8801099133c51f39943ac71500d3b09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ASK ... PLAN` to inspect the routed intent and generated query without executing anything.
  * `EXPLAIN ASK` now shows more of the planner output, including the candidate query when available.

* **Bug Fixes**
  * Removed support for the older `AS RQL` and `EXECUTE` forms; they now return clear parse errors that point to `PLAN`.
  * Improved validation so duplicate `PLAN` clauses are rejected with a helpful message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->