### PR TITLE
merge: #1743 Ungated inline $config/CONFIG()/KV() resolver leaks plaintext red.config.* values to any tenant

### DIFF
--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -577,19 +577,35 @@ pub(crate) fn current_config_value(path: &str) -> Option<Value> {
         if resolver.values.is_none() {
             resolver.values = Some(latest_config_snapshot(&resolver.db));
         }
-        let values = resolver.values.as_ref()?;
         // #1370 — `$config.<path>` desugars to `CONFIG("red.config/<path>")`,
         // but `SET CONFIG <path>` stores under the bare key. Mirror the secret
         // resolver: after the namespaced key, fall back to the stripped bare
-        // key, then the dotted `red.config.<rest>` legacy form.
-        values.get(&key).cloned().or_else(|| {
-            key.strip_prefix("red.config/").and_then(|rest| {
-                values
-                    .get(rest)
-                    .cloned()
-                    .or_else(|| values.get(&format!("red.config.{rest}")).cloned())
-            })
-        })
+        // key, then the dotted `red.config.<rest>` legacy form. Track the key
+        // that matched so the `config:read` gate authorizes the real target.
+        let found = {
+            let values = resolver.values.as_ref()?;
+            values
+                .get(&key)
+                .map(|value| (key.clone(), value.clone()))
+                .or_else(|| {
+                    key.strip_prefix("red.config/").and_then(|rest| {
+                        values
+                            .get(rest)
+                            .map(|value| (rest.to_string(), value.clone()))
+                            .or_else(|| {
+                                let legacy = format!("red.config.{rest}");
+                                values.get(&legacy).map(|value| (legacy, value.clone()))
+                            })
+                    })
+                })
+        }?;
+        // #1743 — hard-block the reserved `red.config.*` namespace and gate the
+        // read on `config:read`, mirroring the `$secret` sibling. Denied reads
+        // resolve to `None` (→ SQL NULL), never an error.
+        if !resolver.can_read(&found.0) {
+            return None;
+        }
+        Some(found.1)
     })
 }
 
@@ -709,6 +725,34 @@ mod tests {
     }
 
     #[test]
+    fn config_key_read_allowed_hard_blocks_reserved_namespace() {
+        // The reserved `red.config.*` system namespace is denied role- and
+        // store-independently, mirroring the `red.secret.*` block (#1743).
+        assert!(!config_key_read_allowed(
+            None,
+            None,
+            "red.config/red.config.aes_key"
+        ));
+        assert!(!config_key_read_allowed(None, None, "red.config.aes_key"));
+        // Ordinary config keys pass when no store is installed (non-IAM path).
+        assert!(config_key_read_allowed(
+            None,
+            None,
+            "red.config/ai.openrouter.default.key"
+        ));
+        assert!(config_key_read_allowed(None, None, "acme.flags.beta"));
+    }
+
+    #[test]
+    fn is_config_collection_matches_system_config_stores() {
+        assert!(is_config_collection("red_config"));
+        assert!(is_config_collection("RED_CONFIG"));
+        assert!(is_config_collection("red.config"));
+        assert!(!is_config_collection("users"));
+        assert!(!is_config_collection("red_kv"));
+    }
+
+    #[test]
     fn update_current_kv_value_reflects_in_resolver() {
         with_kv_values(HashMap::new(), || {
             assert_eq!(current_kv_value("red.kv/feature.flag"), None);
@@ -789,7 +833,99 @@ fn insert_latest_config_value(
 
 struct ConfigResolver {
     db: Arc<RedDB>,
+    store: Option<Arc<crate::auth::store::AuthStore>>,
+    identity: Option<(String, crate::auth::Role, Option<String>)>,
     values: Option<HashMap<String, Value>>,
+}
+
+impl ConfigResolver {
+    fn can_read(&self, key: &str) -> bool {
+        config_key_read_allowed(self.store.as_ref(), self.identity.as_ref(), key)
+    }
+}
+
+/// The reserved `red.config.*` system-config namespace. Never expose it via
+/// the inline `$config`/`CONFIG()`/`KV()` resolver regardless of IAM role,
+/// mirroring the role-independent `red.secret.*` hard-block (#1743).
+fn is_reserved_config_key(key: &str) -> bool {
+    let key = key.strip_prefix("red.config/").unwrap_or(key);
+    key.starts_with("red.config.") || key == "red.config"
+}
+
+/// The system config-store collections (`red_config` / `red.config`) reached
+/// by the inline resolver. A `KV(<collection>, key)` read of one of these is
+/// gated exactly like `$config`; any other collection is unaffected (#1743).
+fn is_config_collection(collection: &str) -> bool {
+    matches!(
+        collection.to_ascii_lowercase().as_str(),
+        "red_config" | "red.config"
+    )
+}
+
+fn config_resource_target(key: &str) -> String {
+    let bare = key.strip_prefix("red.config/").unwrap_or(key);
+    format!("red.config/{bare}")
+}
+
+/// Shared inline-config read gate: a role-independent hard-block on the
+/// reserved `red.config.*` namespace, then a `config:read` capability check
+/// mirroring `SHOW CONFIG` / the `$secret` sibling (#1743). Absent a store or
+/// with IAM authorization disabled, only the hard-block applies so existing
+/// non-IAM `$config` reads keep working.
+fn config_key_read_allowed(
+    store: Option<&Arc<crate::auth::store::AuthStore>>,
+    identity: Option<&(String, crate::auth::Role, Option<String>)>,
+    key: &str,
+) -> bool {
+    if is_reserved_config_key(key) {
+        return false;
+    }
+    let Some(store) = store else {
+        return true;
+    };
+    if !store.iam_authorization_enabled() {
+        return true;
+    }
+    let Some((username, role, tenant)) = identity else {
+        return true;
+    };
+    let principal = crate::auth::UserId::from_parts(tenant.as_deref(), username);
+    let mut resource =
+        crate::auth::policies::ResourceRef::new("config".to_string(), config_resource_target(key));
+    if let Some(tenant) = tenant {
+        resource = resource.with_tenant(tenant.clone());
+    }
+    let ctx = crate::auth::policies::EvalContext {
+        principal_tenant: tenant.clone(),
+        current_tenant: tenant.clone(),
+        peer_ip: None,
+        mfa_present: false,
+        now_ms: crate::auth::now_ms(),
+        principal_is_admin_role: *role == crate::auth::Role::Admin,
+        principal_is_platform_scoped: tenant.is_none(),
+    };
+    store.check_policy_authz_with_role(&principal, "config:read", &resource, &ctx, *role)
+}
+
+/// Whether the current principal may read config `key` through the inline
+/// `$config`/`CONFIG()`/`KV('red_config', …)` resolver. Used by the db-fallback
+/// lookup paths that bypass [`current_config_value`] (#1743).
+pub(crate) fn config_read_permitted(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    CURRENT_CONFIG_RESOLVER.with(|cell| match cell.borrow().as_ref() {
+        Some(resolver) => resolver.can_read(&key),
+        None => !is_reserved_config_key(&key),
+    })
+}
+
+/// Gate a raw `KV(collection, key)` read: config system collections go through
+/// the `$config` gate; every other collection is unaffected (#1743).
+pub(crate) fn kv_read_permitted(collection: &str, key: &str) -> bool {
+    if is_config_collection(collection) {
+        config_read_permitted(key)
+    } else {
+        true
+    }
 }
 
 pub(crate) struct ConfigSnapshotGuard {
@@ -797,9 +933,22 @@ pub(crate) struct ConfigSnapshotGuard {
 }
 
 impl ConfigSnapshotGuard {
-    pub(super) fn install(db: Arc<RedDB>) -> Self {
-        let previous = CURRENT_CONFIG_RESOLVER
-            .with(|cell| cell.replace(Some(ConfigResolver { db, values: None })));
+    pub(super) fn install(
+        db: Arc<RedDB>,
+        store: Option<Arc<crate::auth::store::AuthStore>>,
+    ) -> Self {
+        let identity = current_auth_identity().map(|(username, role)| {
+            let tenant = current_tenant();
+            (username, role, tenant)
+        });
+        let previous = CURRENT_CONFIG_RESOLVER.with(|cell| {
+            cell.replace(Some(ConfigResolver {
+                db,
+                store,
+                identity,
+                values: None,
+            }))
+        });
         Self { previous }
     }
 }

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -359,14 +359,19 @@ fn evaluate_runtime_config_function(
         return Some(value);
     }
     if let Some(db) = db {
-        // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
-        // stores under the bare key — so try the stripped key too (#1370).
-        let key_str: &str = key.as_ref();
-        let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
-        if let Some(value) = lookup_latest_kv_value(db, "red_config", &key)
-            .or_else(|| lookup_latest_kv_value(db, "red_config", bare))
-        {
-            return Some(value);
+        // #1743 — gate the raw `red_config` fallback on `config:read`; without
+        // it a principal denied by `current_config_value` would leak the value
+        // through this bypass path.
+        if crate::runtime::impl_core::config_read_permitted(&key) {
+            // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
+            // stores under the bare key — so try the stripped key too (#1370).
+            let key_str: &str = key.as_ref();
+            let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
+            if let Some(value) = lookup_latest_kv_value(db, "red_config", &key)
+                .or_else(|| lookup_latest_kv_value(db, "red_config", bare))
+            {
+                return Some(value);
+            }
         }
     }
     args.get(1)
@@ -384,8 +389,13 @@ fn evaluate_runtime_kv_function(
     let collection = expr_path_text(args.first()?)?;
     let key = expr_path_text(args.get(1)?)?;
     if let Some(db) = db {
-        if let Some(value) = lookup_latest_kv_value(db, &collection, &key) {
-            return Some(value);
+        // #1743 — `KV('red_config', …)` is the same leak surface as `$config`;
+        // gate config-collection reads on `config:read`. Other collections are
+        // unaffected.
+        if crate::runtime::impl_core::kv_read_permitted(&collection, &key) {
+            if let Some(value) = lookup_latest_kv_value(db, &collection, &key) {
+                return Some(value);
+            }
         }
     }
     args.get(2)

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -70,12 +70,13 @@ pub use super::execution_context::{
     SnapshotBundle, SnapshotContext,
 };
 pub(crate) use super::execution_context::{
-    current_auth_identity, current_config_value, current_kv_value, current_role_projected,
-    current_scope_override, current_secret_value, current_snapshot_requires_index_fallback,
-    current_user_projected, has_scope_override_active, parse_set_local_tenant,
-    update_current_config_value, update_current_kv_value, update_current_secret_value,
-    xids_visible_under_current_snapshot, ConfigSnapshotGuard, CurrentSnapshotGuard, KvStoreGuard,
-    ScopeOverrideGuard, SecretStoreGuard, TxLocalTenantGuard,
+    config_read_permitted, current_auth_identity, current_config_value, current_kv_value,
+    current_role_projected, current_scope_override, current_secret_value,
+    current_snapshot_requires_index_fallback, current_user_projected, has_scope_override_active,
+    kv_read_permitted, parse_set_local_tenant, update_current_config_value,
+    update_current_kv_value, update_current_secret_value, xids_visible_under_current_snapshot,
+    ConfigSnapshotGuard, CurrentSnapshotGuard, KvStoreGuard, ScopeOverrideGuard, SecretStoreGuard,
+    TxLocalTenantGuard,
 };
 
 /// Cheap prefix check for a leading `WITH` keyword. Used to gate the
@@ -2433,7 +2434,10 @@ impl RedDBRuntime {
     ///
     /// Applies secret decryption on SELECT results, identical to `execute_query`.
     pub fn execute_query_expr(&self, expr: QueryExpr) -> RedDBResult<RuntimeQueryResult> {
-        let _config_snapshot_guard = ConfigSnapshotGuard::install(Arc::clone(&self.inner.db));
+        let _config_snapshot_guard = ConfigSnapshotGuard::install(
+            Arc::clone(&self.inner.db),
+            self.inner.auth_store.read().clone(),
+        );
         let _secret_store_guard = SecretStoreGuard::install(self.inner.auth_store.read().clone());
         // View rewrite (Phase 2.1): substitute any `QueryExpr::Table(tq)`
         // whose `tq.table` matches a registered view with the view's

--- a/crates/reddb-server/src/runtime/join_filter/projection_eval.rs
+++ b/crates/reddb-server/src/runtime/join_filter/projection_eval.rs
@@ -245,15 +245,19 @@ pub(in crate::runtime::join_filter) fn evaluate_projection_config_function(
         return Some(value);
     }
     if let Some(db) = db {
-        // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
-        // stores under the bare key — try the stripped key too (#1370). This is
-        // the WHERE-clause / projection legacy path (evaluate_scalar_function_with_db).
-        let key_str: &str = key.as_ref();
-        let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
-        if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, "red_config", &key)
-            .or_else(|| super::expr_eval::lookup_latest_kv_value(db, "red_config", bare))
-        {
-            return Some(value);
+        // #1743 — gate the raw `red_config` fallback on `config:read`, matching
+        // the expression-path resolver.
+        if crate::runtime::impl_core::config_read_permitted(&key) {
+            // `$config.<path>` desugars to CONFIG("red.config/<path>") but SET CONFIG
+            // stores under the bare key — try the stripped key too (#1370). This is
+            // the WHERE-clause / projection legacy path (evaluate_scalar_function_with_db).
+            let key_str: &str = key.as_ref();
+            let bare = key_str.strip_prefix("red.config/").unwrap_or(key_str);
+            if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, "red_config", &key)
+                .or_else(|| super::expr_eval::lookup_latest_kv_value(db, "red_config", bare))
+            {
+                return Some(value);
+            }
         }
     }
     args.get(1)
@@ -269,8 +273,11 @@ pub(in crate::runtime::join_filter) fn evaluate_projection_kv_function(
     let collection = projection_path_text(args.first()?)?;
     let key = projection_path_text(args.get(1)?)?;
     if let Some(db) = db {
-        if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, &collection, &key) {
-            return Some(value);
+        // #1743 — config-collection `KV()` reads are gated on `config:read`.
+        if crate::runtime::impl_core::kv_read_permitted(&collection, &key) {
+            if let Some(value) = super::expr_eval::lookup_latest_kv_value(db, &collection, &key) {
+                return Some(value);
+            }
         }
     }
     args.get(2)

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -388,7 +388,10 @@ impl StatementExecutionFrame {
     pub(super) fn install(&self, runtime: &RedDBRuntime) -> StatementFrameGuards {
         StatementFrameGuards {
             _tx_local_guard: TxLocalTenantGuard::install(self.tx_local_tenant.clone()),
-            _config_snapshot_guard: ConfigSnapshotGuard::install(Arc::clone(&runtime.inner.db)),
+            _config_snapshot_guard: ConfigSnapshotGuard::install(
+                Arc::clone(&runtime.inner.db),
+                runtime.inner.auth_store.read().clone(),
+            ),
             _secret_store_guard: SecretStoreGuard::install(runtime.inner.auth_store.read().clone()),
             _kv_store_guard: KvStoreGuard::install(runtime.inner.auth_store.read().clone()),
             _snapshot_guard: CurrentSnapshotGuard::install(SnapshotContext {

--- a/crates/reddb-server/tests/inline_config_read_gate_1743.rs
+++ b/crates/reddb-server/tests/inline_config_read_gate_1743.rs
@@ -1,0 +1,111 @@
+//! #1743 — the inline `$config` / `CONFIG()` / `KV('red_config', …)` resolver
+//! must gate reads on `config:read`, mirroring the `$secret` sibling. An
+//! authenticated tenant without `config:read` is refused (deny → SQL NULL);
+//! a principal that holds `config:read` still reads the value.
+
+use std::sync::Arc;
+
+use reddb_server::auth::policies::Policy;
+use reddb_server::auth::store::{AuthStore, PrincipalRef};
+use reddb_server::auth::{AuthConfig, Role, UserId};
+use reddb_server::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
+use reddb_server::RedDBRuntime;
+
+fn allow_policy(id: &str, action: &str, resource: &str) -> Policy {
+    Policy::from_json_str(&format!(
+        r#"{{
+            "id":"{id}",
+            "version":1,
+            "statements":[{{
+                "effect":"allow",
+                "actions":["{action}"],
+                "resources":["{resource}"]
+            }}]
+        }}"#
+    ))
+    .unwrap()
+}
+
+fn put_policy(auth: &AuthStore, policy: Policy) -> String {
+    let id = policy.id.clone();
+    auth.put_policy(policy).expect("put policy");
+    id
+}
+
+fn attach(auth: &AuthStore, user: &UserId, policy_id: &str) {
+    auth.attach_policy(PrincipalRef::User(user.clone()), policy_id)
+        .expect("attach policy");
+}
+
+fn as_user<T>(name: &str, role: Role, f: impl FnOnce() -> T) -> T {
+    set_current_auth_identity(name.to_string(), role);
+    let out = f();
+    clear_current_auth_identity();
+    out
+}
+
+/// Whether the inline resolver expression matched the staged secret. The
+/// predicate `'sk-secret' = <resolver>` yields one row when the resolver
+/// returns the value and zero rows when it is denied (→ SQL NULL, which never
+/// compares equal).
+fn resolver_matches(rt: &RedDBRuntime, resolver_expr: &str) -> bool {
+    let sql = format!("SELECT id FROM t WHERE 'sk-secret' = {resolver_expr}");
+    let result = rt
+        .execute_query(&sql)
+        .unwrap_or_else(|err| panic!("query `{sql}` should execute: {err}"));
+    !result.result.records.is_empty()
+}
+
+#[test]
+fn inline_config_resolver_gates_on_config_read() {
+    let rt = RedDBRuntime::in_memory().expect("runtime boots");
+
+    // Seed a table row and a sensitive config value before IAM is engaged.
+    rt.execute_query("CREATE TABLE t (id INT)")
+        .expect("create t");
+    rt.execute_query("INSERT INTO t (id) VALUES (1)")
+        .expect("insert t");
+    rt.execute_query("SET CONFIG ai.openrouter.default.key = 'sk-secret'")
+        .expect("stage config key");
+
+    // Wire IAM: `reader` holds `config:read`, `tenant` does not. The first
+    // policy write flips `iam_authorization_enabled` on.
+    let auth = Arc::new(AuthStore::new(AuthConfig::default()));
+    auth.create_user("reader", "p", Role::Read).expect("reader");
+    auth.create_user("tenant", "p", Role::Read).expect("tenant");
+    // Both principals may read table `t`; only `reader` additionally holds
+    // `config:read`, isolating the inline-config gate as the sole difference.
+    let table_read = put_policy(&auth, allow_policy("p-table-read", "select", "table:*"));
+    let config_read = put_policy(
+        &auth,
+        allow_policy("p-config-read", "config:read", "config:*"),
+    );
+    attach(&auth, &UserId::platform("reader"), &table_read);
+    attach(&auth, &UserId::platform("reader"), &config_read);
+    attach(&auth, &UserId::platform("tenant"), &table_read);
+    rt.set_auth_store(auth);
+
+    // Tenant without `config:read`: both inline paths deny → SQL NULL.
+    as_user("tenant", Role::Read, || {
+        assert!(
+            !resolver_matches(&rt, "$config.ai.openrouter.default.key"),
+            "$config read must be denied without config:read"
+        );
+        assert!(
+            !resolver_matches(&rt, "KV('red_config', 'ai.openrouter.default.key')"),
+            "KV('red_config', …) read must be denied without config:read"
+        );
+    });
+
+    // Principal with `config:read`: the value resolves through both paths.
+    as_user("reader", Role::Read, || {
+        assert!(
+            resolver_matches(&rt, "$config.ai.openrouter.default.key"),
+            "$config read must succeed with config:read"
+        );
+        assert!(
+            resolver_matches(&rt, "KV('red_config', 'ai.openrouter.default.key')"),
+            "KV('red_config', …) read must succeed with config:read"
+        );
+    });
+}


### PR DESCRIPTION
Automated AFK landing for #1743. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1743

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785888431&installation_id=129708444&pr_number=1762&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1762&signature=b36c07f2c810e9695c115998f5c07d6d7faecb30f1ec8098f6695fd16ff6151c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->