### PR TITLE
feat(#1767): store fork tracer — FORK STORE at LSN, isolation, DROP FORK with GC

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -250,7 +250,7 @@ pub use native_store::{
     STORE_VERSION_V1, STORE_VERSION_V10, STORE_VERSION_V2, STORE_VERSION_V3, STORE_VERSION_V4,
     STORE_VERSION_V5, STORE_VERSION_V6, STORE_VERSION_V7, STORE_VERSION_V8, STORE_VERSION_V9,
 };
-pub use operational_manifest::OperationalManifest;
+pub use operational_manifest::{ForkInfo, ForkOrigin, OperationalManifest};
 pub use physical_metadata::{
     copy_physical_export_data_file, copy_physical_metadata_binary_to_journal,
     decode_persisted_physical_hypertable_chunk_json, decode_persisted_physical_hypertable_json,

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -16,6 +16,34 @@ pub const MANIFEST_FILE: &str = "manifest.json";
 pub const NEXT_MANIFEST_FILE: &str = "manifest.json.next";
 pub const COLLECTIONS_DIR: &str = "collections";
 pub const QUARANTINE_DIR: &str = "quarantine";
+/// Directory (under a parent store's operational root) that holds store forks.
+///
+/// This is the store-fork surface of ADR 0070 — deliberately distinct from the
+/// VCS data model's `branch`/`CHECKPOINT` vocabulary (#1567). A store fork is
+/// storage mechanics for experiment-and-discard workflows; it is never a branch.
+pub const FORKS_DIR: &str = "forks";
+
+/// Where a store fork came from: the parent store's identity and the durable LSN
+/// the fork is pinned at. Recorded in the fork's own operational manifest so a
+/// listing can report each fork's parent and fork LSN without opening the parent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkOrigin {
+    /// The fork's own name (as given to `FORK STORE AS <name>`).
+    pub name: String,
+    /// Identity of the parent store this fork was taken from.
+    pub parent_store: String,
+    /// The durable LSN the fork is pinned at (the parent's current durable LSN
+    /// at fork-create time).
+    pub fork_lsn: u64,
+}
+
+/// A single row of the fork listing (`SHOW FORKS`): the fork name plus origin.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForkInfo {
+    pub name: String,
+    pub parent_store: String,
+    pub fork_lsn: u64,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CollectionState {
@@ -46,12 +74,19 @@ impl CollectionState {
 struct CollectionEntry {
     state: CollectionState,
     path: String,
+    /// For a store fork: absolute path to the parent's collection file that this
+    /// entry is shared-by-reference with. `None` for a normal (owned) collection
+    /// file, or once a fork has hydrated a private copy (copy-on-write). ADR 0070:
+    /// mutable collection files hydrate lazily on first touch.
+    source: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 struct Manifest {
     generation: u64,
     collections: BTreeMap<String, CollectionEntry>,
+    /// Present only for a store fork's own manifest; `None` for a parent store.
+    fork_origin: Option<ForkOrigin>,
 }
 
 #[derive(Debug, Clone)]
@@ -76,6 +111,7 @@ impl OperationalManifest {
                 let mut manifest = Manifest {
                     generation: 0,
                     collections: BTreeMap::new(),
+                    fork_origin: None,
                 };
                 for collection in existing_collections {
                     let path = self.collection_file_name(collection);
@@ -85,6 +121,7 @@ impl OperationalManifest {
                         CollectionEntry {
                             state: CollectionState::Active,
                             path,
+                            source: None,
                         },
                     );
                 }
@@ -139,6 +176,7 @@ impl OperationalManifest {
             CollectionEntry {
                 state: CollectionState::Active,
                 path,
+                source: None,
             },
         );
         manifest.generation += 1;
@@ -173,6 +211,193 @@ impl OperationalManifest {
         self.publish(&manifest)
     }
 
+    /// Identity of this store — its operational manifest root path. This is the
+    /// value recorded as `parent_store` on any fork taken from this store, and
+    /// reported by the fork listing.
+    pub fn store_identity(&self) -> String {
+        self.root.to_string_lossy().into_owned()
+    }
+
+    /// A fork's own operational manifest, rooted under this store's `forks/` dir.
+    /// The fork is a full operational store root in its own right.
+    pub fn fork_handle(&self, name: &str) -> Self {
+        Self {
+            root: self.forks_dir().join(sanitize_component(name)),
+        }
+    }
+
+    /// Create a store fork pinned at `fork_lsn` (ADR 0070). O(metadata): every
+    /// active parent collection is referenced by absolute source path — no data
+    /// file is copied at create time. The fork gets its own operational manifest
+    /// carrying [`ForkOrigin`]; mutable collection files hydrate lazily on first
+    /// write (see [`hydrate_collection`](Self::hydrate_collection)).
+    ///
+    /// This is the *store fork* surface, distinct from the VCS `CHECKPOINT`/branch
+    /// model (#1567): forks live on the storage/deploy axis.
+    pub fn create_fork(&self, name: &str, fork_lsn: u64) -> io::Result<()> {
+        let parent = self
+            .load_current()?
+            .ok_or_else(|| invalid_data("cannot fork a store with no operational manifest"))?;
+        let fork = self.fork_handle(name);
+        if fork.load_current()?.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!("store fork already exists: {name}"),
+            ));
+        }
+        fork.ensure_dirs()?;
+
+        let mut collections = BTreeMap::new();
+        for (cname, entry) in &parent.collections {
+            if entry.state != CollectionState::Active {
+                continue;
+            }
+            let source = self.collections_dir().join(&entry.path);
+            collections.insert(
+                cname.clone(),
+                CollectionEntry {
+                    state: CollectionState::Active,
+                    path: entry.path.clone(),
+                    source: Some(source.to_string_lossy().into_owned()),
+                },
+            );
+        }
+
+        let manifest = Manifest {
+            generation: 0,
+            collections,
+            fork_origin: Some(ForkOrigin {
+                name: name.to_string(),
+                parent_store: self.store_identity(),
+                fork_lsn,
+            }),
+        };
+        fork.publish(&manifest)?;
+        sync_dir(&self.forks_dir())
+    }
+
+    /// Hydrate a fork collection's private copy (copy-on-write): called on the
+    /// *fork* handle before the fork first writes a shared collection. Copies the
+    /// referenced parent bytes into the fork's own `collections/` dir and drops
+    /// the shared reference. Idempotent and a no-op for owned collections.
+    pub fn hydrate_collection(&self, name: &str) -> io::Result<()> {
+        let mut manifest = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(()),
+        };
+        let Some(entry) = manifest.collections.get_mut(name) else {
+            return Ok(());
+        };
+        let Some(source) = entry.source.clone() else {
+            return Ok(());
+        };
+        self.ensure_dirs()?;
+        let dest = self.collections_dir().join(&entry.path);
+        copy_file_durable(Path::new(&source), &dest)?;
+        entry.source = None;
+        manifest.generation += 1;
+        self.publish(&manifest)
+    }
+
+    /// Preserve fork isolation before the *parent* mutates a collection file in
+    /// place: any live fork still sharing that collection by reference gets its
+    /// as-of-fork snapshot materialized first (copy-on-write on the parent side).
+    /// Call on the parent handle immediately before an in-place collection write.
+    pub fn materialize_forks_before_write(&self, collection: &str) -> io::Result<()> {
+        let parent = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(()),
+        };
+        let Some(entry) = parent.collections.get(collection) else {
+            return Ok(());
+        };
+        let source = self.collections_dir().join(&entry.path);
+        for fork in self.fork_handles()? {
+            let mut manifest = match fork.load_current()? {
+                Some(manifest) => manifest,
+                None => continue,
+            };
+            let Some(fork_entry) = manifest.collections.get_mut(collection) else {
+                continue;
+            };
+            if fork_entry.source.is_none() {
+                continue;
+            }
+            fork.ensure_dirs()?;
+            let dest = fork.collections_dir().join(&fork_entry.path);
+            copy_file_durable(&source, &dest)?;
+            fork_entry.source = None;
+            manifest.generation += 1;
+            fork.publish(&manifest)?;
+        }
+        Ok(())
+    }
+
+    /// List every store fork of this store: name, parent identity, and fork LSN.
+    pub fn list_forks(&self) -> io::Result<Vec<ForkInfo>> {
+        let mut out = Vec::new();
+        let entries = match fs::read_dir(self.forks_dir()) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
+            Err(err) => return Err(err),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let fork = Self { root: entry.path() };
+            if let Some(origin) = fork.fork_origin()? {
+                out.push(ForkInfo {
+                    name: origin.name,
+                    parent_store: origin.parent_store,
+                    fork_lsn: origin.fork_lsn,
+                });
+            }
+        }
+        out.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(out)
+    }
+
+    /// Drop a store fork: remove its manifest and garbage-collect its private
+    /// (hydrated) files. Shared-by-reference entries are only path strings, so
+    /// the parent store's data is never touched. Idempotent. Returns whether a
+    /// fork was actually removed.
+    pub fn drop_fork(&self, name: &str) -> io::Result<bool> {
+        let fork = self.fork_handle(name);
+        if !fork.root.exists() {
+            return Ok(false);
+        }
+        fs::remove_dir_all(&fork.root)?;
+        let _ = sync_dir(&self.forks_dir());
+        Ok(true)
+    }
+
+    /// Read this manifest's fork origin, if it is a fork.
+    pub fn fork_origin(&self) -> io::Result<Option<ForkOrigin>> {
+        Ok(self.load_current()?.and_then(|manifest| manifest.fork_origin))
+    }
+
+    fn forks_dir(&self) -> PathBuf {
+        self.root.join(FORKS_DIR)
+    }
+
+    fn fork_handles(&self) -> io::Result<Vec<Self>> {
+        let mut out = Vec::new();
+        let entries = match fs::read_dir(self.forks_dir()) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
+            Err(err) => return Err(err),
+        };
+        for entry in entries {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                out.push(Self { root: entry.path() });
+            }
+        }
+        Ok(out)
+    }
+
     pub fn read_generation_for_test(&self) -> io::Result<u64> {
         self.load_current()?
             .map(|manifest| manifest.generation)
@@ -199,6 +424,7 @@ impl OperationalManifest {
             CollectionEntry {
                 state: CollectionState::Active,
                 path: self.collection_file_name(name),
+                source: None,
             },
         );
         manifest.generation += 1;
@@ -293,6 +519,7 @@ fn empty_manifest() -> Manifest {
     Manifest {
         generation: 0,
         collections: BTreeMap::new(),
+        fork_origin: None,
     }
 }
 
@@ -367,11 +594,50 @@ fn manifest_from_object(object: &Map<String, Value>) -> io::Result<Manifest> {
             .and_then(Value::as_str)
             .ok_or_else(|| invalid_data("manifest collection path is missing"))?
             .to_string();
-        collections.insert(name.clone(), CollectionEntry { state, path });
+        let source = entry
+            .get("source")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        collections.insert(
+            name.clone(),
+            CollectionEntry {
+                state,
+                path,
+                source,
+            },
+        );
     }
+    let fork_origin = match object.get("fork_origin") {
+        Some(Value::Object(origin)) => Some(fork_origin_from_object(origin)?),
+        Some(Value::Null) | None => None,
+        Some(_) => return Err(invalid_data("manifest fork_origin must be an object")),
+    };
     Ok(Manifest {
         generation,
         collections,
+        fork_origin,
+    })
+}
+
+fn fork_origin_from_object(object: &Map<String, Value>) -> io::Result<ForkOrigin> {
+    let name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_data("manifest fork_origin name is missing"))?
+        .to_string();
+    let parent_store = object
+        .get("parent_store")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_data("manifest fork_origin parent_store is missing"))?
+        .to_string();
+    let fork_lsn = object
+        .get("fork_lsn")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("manifest fork_origin fork_lsn is missing"))?;
+    Ok(ForkOrigin {
+        name,
+        parent_store,
+        fork_lsn,
     })
 }
 
@@ -390,6 +656,11 @@ fn manifest_body_json(manifest: &Manifest) -> Map<String, Value> {
             Value::String(entry.state.as_str().to_string()),
         );
         entry_object.insert("path".to_string(), Value::String(entry.path.clone()));
+        // Only emit `source` for shared-by-reference fork entries, so a normal
+        // parent manifest stays byte-identical (and checksum-stable) to before.
+        if let Some(source) = &entry.source {
+            entry_object.insert("source".to_string(), Value::String(source.clone()));
+        }
         collections.insert(name.clone(), Value::Object(entry_object));
     }
 
@@ -397,6 +668,18 @@ fn manifest_body_json(manifest: &Manifest) -> Map<String, Value> {
     object.insert("format_version".to_string(), Value::from(FORMAT_VERSION));
     object.insert("generation".to_string(), Value::from(manifest.generation));
     object.insert("collections".to_string(), Value::Object(collections));
+    // Only emit `fork_origin` for a fork's own manifest, so a parent manifest is
+    // unchanged from the pre-fork format.
+    if let Some(origin) = &manifest.fork_origin {
+        let mut origin_object = Map::new();
+        origin_object.insert("name".to_string(), Value::String(origin.name.clone()));
+        origin_object.insert(
+            "parent_store".to_string(),
+            Value::String(origin.parent_store.clone()),
+        );
+        origin_object.insert("fork_lsn".to_string(), Value::from(origin.fork_lsn));
+        object.insert("fork_origin".to_string(), Value::Object(origin_object));
+    }
     object
 }
 
@@ -412,6 +695,35 @@ fn unique_quarantine_path(dir: &Path, file_name: &str) -> PathBuf {
         }
     }
     unreachable!()
+}
+
+/// Escape an arbitrary name into a single safe path component (no separators),
+/// mirroring the collection-file escaping so a fork name like `tenant/exp 1`
+/// becomes one directory.
+fn sanitize_component(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for byte in name.as_bytes() {
+        match *byte {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b'-' | b'.' => {
+                out.push(*byte as char);
+            }
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
+/// Copy a file's bytes to `dest` durably (fsync file + parent dir). Used to
+/// hydrate a fork's private collection copy on copy-on-write.
+fn copy_file_durable(source: &Path, dest: &Path) -> io::Result<()> {
+    let bytes = fs::read(source)?;
+    let mut file = File::create(dest)?;
+    file.write_all(&bytes)?;
+    file.sync_all()?;
+    if let Some(parent) = dest.parent() {
+        sync_dir(parent)?;
+    }
+    Ok(())
 }
 
 fn sync_dir(path: &Path) -> io::Result<()> {
@@ -449,6 +761,7 @@ mod tests {
             CollectionEntry {
                 state: CollectionState::Active,
                 path: "users.rcol".to_string(),
+                source: None,
             },
         );
 
@@ -586,6 +899,118 @@ mod tests {
         assert_eq!(
             unique_quarantine_path(dir.path(), "orphan.rcol"),
             dir.path().join("orphan.rcol.2")
+        );
+    }
+
+    // Write bytes straight to a collection's file so the fork isolation tests
+    // have observable per-collection content to diverge.
+    fn write_collection(manifest: &OperationalManifest, name: &str, bytes: &[u8]) {
+        fs::write(manifest.collection_path_for_test(name), bytes).unwrap();
+    }
+
+    fn read_collection(manifest: &OperationalManifest, name: &str) -> Vec<u8> {
+        fs::read(manifest.collection_path_for_test(name)).unwrap()
+    }
+
+    #[test]
+    fn fork_create_is_metadata_only_and_copies_no_data() {
+        let path = temp_db_path("fork_metadata");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"parent-rows");
+
+        parent.create_fork("exp", 42).unwrap();
+        let fork = parent.fork_handle("exp");
+
+        // The fork references the parent's collection file by path; it did not
+        // materialize its own copy at create time.
+        assert!(!fork.collection_path_for_test("users").exists());
+        // Listing reports the parent identity and the pinned fork LSN.
+        let forks = parent.list_forks().unwrap();
+        assert_eq!(forks.len(), 1);
+        assert_eq!(forks[0].name, "exp");
+        assert_eq!(forks[0].fork_lsn, 42);
+        assert_eq!(forks[0].parent_store, parent.store_identity());
+        // The fork's own manifest carries the origin.
+        assert_eq!(fork.fork_origin().unwrap().unwrap().fork_lsn, 42);
+        // The parent is not itself a fork.
+        assert!(parent.fork_origin().unwrap().is_none());
+    }
+
+    #[test]
+    fn fork_writes_are_invisible_to_parent() {
+        let path = temp_db_path("fork_to_parent");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"v0");
+        parent.create_fork("exp", 1).unwrap();
+        let fork = parent.fork_handle("exp");
+
+        // Fork writes: hydrate (copy-on-write) then mutate the fork's own copy.
+        fork.hydrate_collection("users").unwrap();
+        write_collection(&fork, "users", b"fork-only");
+
+        assert_eq!(read_collection(&fork, "users"), b"fork-only");
+        // Parent is untouched by the fork's write.
+        assert_eq!(read_collection(&parent, "users"), b"v0");
+        // Hydration dropped the shared reference.
+        assert!(fork.fork_origin().unwrap().is_some());
+    }
+
+    #[test]
+    fn parent_writes_after_fork_are_invisible_to_fork() {
+        let path = temp_db_path("parent_to_fork");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"as-of-fork");
+        parent.create_fork("exp", 5).unwrap();
+        let fork = parent.fork_handle("exp");
+
+        // Parent write: snapshot referencing forks first (copy-on-write on the
+        // parent side), then mutate the parent's file in place.
+        parent.materialize_forks_before_write("users").unwrap();
+        write_collection(&parent, "users", b"parent-moved-on");
+
+        // Fork still sees the as-of-fork snapshot; parent's later write is invisible.
+        assert_eq!(read_collection(&fork, "users"), b"as-of-fork");
+        assert_eq!(read_collection(&parent, "users"), b"parent-moved-on");
+    }
+
+    #[test]
+    fn drop_fork_removes_private_files_and_leaves_parent_intact() {
+        let path = temp_db_path("drop_fork");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"keep-me");
+        parent.create_fork("exp", 9).unwrap();
+        let fork = parent.fork_handle("exp");
+        fork.hydrate_collection("users").unwrap();
+        write_collection(&fork, "users", b"fork-private");
+        let fork_root = fork.root.clone();
+
+        assert!(parent.drop_fork("exp").unwrap());
+        // Fork-private files are gone; the parent's data survives untouched.
+        assert!(!fork_root.exists());
+        assert_eq!(read_collection(&parent, "users"), b"keep-me");
+        assert!(parent.list_forks().unwrap().is_empty());
+        // Dropping again is idempotent.
+        assert!(!parent.drop_fork("exp").unwrap());
+    }
+
+    #[test]
+    fn fork_creation_rejects_duplicate_and_missing_parent() {
+        let path = temp_db_path("fork_errors");
+        let parent = OperationalManifest::for_db_path(&path);
+        // A store with no manifest cannot be forked.
+        assert_eq!(
+            parent.create_fork("exp", 0).unwrap_err().kind(),
+            io::ErrorKind::InvalidData
+        );
+        parent.recover_or_bootstrap(&[]).unwrap();
+        parent.create_fork("exp", 0).unwrap();
+        assert_eq!(
+            parent.create_fork("exp", 0).unwrap_err().kind(),
+            io::ErrorKind::AlreadyExists
         );
     }
 }

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -375,7 +375,9 @@ impl OperationalManifest {
 
     /// Read this manifest's fork origin, if it is a fork.
     pub fn fork_origin(&self) -> io::Result<Option<ForkOrigin>> {
-        Ok(self.load_current()?.and_then(|manifest| manifest.fork_origin))
+        Ok(self
+            .load_current()?
+            .and_then(|manifest| manifest.fork_origin))
     }
 
     fn forks_dir(&self) -> PathBuf {


### PR DESCRIPTION
Lands #1767 (store-fork tracer, PRD #1764) from the AFK worker branch after a cargo-fmt-only lint-gate bounce. test/typecheck/build were already green; this adds the single `cargo fmt` fix on `operational_manifest.rs`.

Closes #1767

https://claude.ai/code/session_01DxakkcBhYTJUQ1Po4LufEm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785903490&installation_id=129708444&pr_number=1853&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1853&signature=90c2da296be719e0f2ccb12a390b00fda26173985d603e71ec2c3da681686758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->