### PR TITLE
merge: #1786 Ephemeral store tracer: CSV/TSV file → row table → query output in `red`

### DIFF
--- a/crates/reddb-server/src/lib.rs
+++ b/crates/reddb-server/src/lib.rs
@@ -166,6 +166,7 @@ pub use crate::physical::{
     SHM_HEADER_SIZE, SHM_MAGIC, SHM_VERSION,
 };
 pub use crate::replication::{ReplicationConfig, ReplicationRole};
+pub use crate::runtime::impl_ephemeral::{EphemeralError, EphemeralTable, POSITIONAL_ALIAS};
 pub use crate::runtime::{
     ConnectionPoolConfig, RedDBRuntime, RuntimeConnection, RuntimeFilter, RuntimeFilterValue,
     RuntimeGraphCentralityAlgorithm, RuntimeGraphCentralityResult, RuntimeGraphCentralityScore,

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1397,6 +1397,7 @@ mod impl_dml_ttl;
 mod impl_dml_update_analysis;
 mod impl_dml_update_target;
 mod impl_ec;
+pub mod impl_ephemeral;
 mod impl_events;
 mod impl_fast_path;
 mod impl_graph;

--- a/crates/reddb-server/src/runtime/impl_ephemeral.rs
+++ b/crates/reddb-server/src/runtime/impl_ephemeral.rs
@@ -12,9 +12,10 @@
 //! types.
 //!
 //! The loaded collection is named by its sanitized file stem and — as the
-//! single loaded file — is also addressable by the positional file alias
-//! [`POSITIONAL_ALIAS`] (`t`), wired as a non-materialized view so
-//! `SELECT … FROM t` rewrites to the underlying collection.
+//! single loaded file — is also materialized under the positional file
+//! alias [`POSITIONAL_ALIAS`] (`t`), so `SELECT … FROM t` and
+//! `SELECT … FROM <stem>` resolve identically for every query shape
+//! (projections, filters, and aggregates alike).
 
 use std::path::Path;
 
@@ -124,11 +125,11 @@ fn delimiter_for_extension(ext: &str) -> Option<u8> {
 impl RedDBRuntime {
     /// Materialize a local CSV/TSV file as a row table in this runtime.
     ///
-    /// The collection is auto-created from the sanitized file stem and a
-    /// non-materialized view `t` ([`POSITIONAL_ALIAS`]) is registered so
-    /// the single loaded file is addressable both ways. Intended for the
-    /// in-memory ephemeral store — nothing durable is written beyond what
-    /// this runtime already persists.
+    /// The collection is auto-created from the sanitized file stem, and —
+    /// as the single loaded file — is also materialized under the
+    /// positional alias `t` ([`POSITIONAL_ALIAS`]) so it is addressable
+    /// both ways. Intended for the in-memory ephemeral store — nothing
+    /// durable is written beyond what this runtime already persists.
     pub fn materialize_data_file(&self, path: &Path) -> Result<EphemeralTable, EphemeralError> {
         let display = path.display().to_string();
 
@@ -156,8 +157,36 @@ impl RedDBRuntime {
             path: display.clone(),
         })?;
 
+        let rows_imported = self.import_csv_into(path, &collection, delimiter, &display)?;
+
+        // The single loaded file is also addressable by the positional
+        // alias `t`. Rather than a rewrite view — which leaks on
+        // aggregates and other non-trivial shapes — `t` is materialized
+        // as its own real collection so every query resolves identically
+        // through either name. Skipped when the stem already sanitized to
+        // `t` (e.g. `t.csv`), which would collide.
+        if collection != POSITIONAL_ALIAS {
+            self.import_csv_into(path, POSITIONAL_ALIAS, delimiter, &display)?;
+        }
+
+        Ok(EphemeralTable {
+            collection,
+            alias: POSITIONAL_ALIAS.to_string(),
+            rows_imported,
+        })
+    }
+
+    /// Import `path` into `collection` via the shared [`CsvImporter`],
+    /// returning the number of data rows written.
+    fn import_csv_into(
+        &self,
+        path: &Path,
+        collection: &str,
+        delimiter: u8,
+        display: &str,
+    ) -> Result<usize, EphemeralError> {
         let importer = CsvImporter::new(CsvConfig {
-            collection: collection.clone(),
+            collection: collection.to_string(),
             has_header: true,
             delimiter,
             skip_errors: false,
@@ -165,34 +194,23 @@ impl RedDBRuntime {
         });
 
         let store = self.inner.db.store();
+        // The shared CsvImporter writes straight through `store.insert`,
+        // which does not auto-create the collection — provision it up
+        // front the same way the runtime's INSERT path does on first
+        // write.
+        let _ = store.get_or_create_collection(collection);
         let stats = importer
             .import_file(path, store.as_ref())
             .map_err(|e| EphemeralError::Import {
-                path: display.clone(),
+                path: display.to_string(),
                 source: e.to_string(),
             })?;
 
         // The rows were written straight through the store, so nudge the
         // planner/result cache exactly as the COPY path does.
-        self.note_table_write(&collection);
+        self.note_table_write(collection);
 
-        // Register the positional alias as a plain (non-materialized)
-        // view so `FROM t` rewrites to the underlying collection. Both
-        // names are safe identifiers, so the inline SQL is well-formed.
-        if collection != POSITIONAL_ALIAS {
-            let create_view =
-                format!("CREATE VIEW {POSITIONAL_ALIAS} AS SELECT * FROM {collection}");
-            self.execute_query(&create_view)
-                .map_err(|e| EphemeralError::Alias {
-                    source: e.to_string(),
-                })?;
-        }
-
-        Ok(EphemeralTable {
-            collection,
-            alias: POSITIONAL_ALIAS.to_string(),
-            rows_imported: stats.records_imported,
-        })
+        Ok(stats.records_imported)
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_ephemeral.rs
+++ b/crates/reddb-server/src/runtime/impl_ephemeral.rs
@@ -1,0 +1,236 @@
+//! Ephemeral store materialization (PRD #1785, issue #1786).
+//!
+//! The `red` binary can take a local CSV/TSV file plus an RQL query,
+//! materialize the file as a row table inside a throwaway in-memory
+//! embedded store, run the query, and discard the store — no server, no
+//! pre-existing store, nothing durable created.
+//!
+//! This module is the CSV/TSV tracer: the skeleton every other ephemeral
+//! slice (JSON/documents, multi-file, writes/`--save`) extends. It rides
+//! the existing CSV import path (the shared [`CsvImporter`]) so the file
+//! becomes a real row table with header-derived columns and inferred
+//! types.
+//!
+//! The loaded collection is named by its sanitized file stem and — as the
+//! single loaded file — is also addressable by the positional file alias
+//! [`POSITIONAL_ALIAS`] (`t`), wired as a non-materialized view so
+//! `SELECT … FROM t` rewrites to the underlying collection.
+
+use std::path::Path;
+
+use crate::runtime::RedDBRuntime;
+use crate::storage::import::{CsvConfig, CsvImporter};
+
+/// Positional alias for the single loaded file: `SELECT … FROM t`.
+pub const POSITIONAL_ALIAS: &str = "t";
+
+/// Outcome of materializing a data file into the ephemeral store.
+#[derive(Debug, Clone)]
+pub struct EphemeralTable {
+    /// Collection name derived from the sanitized file stem.
+    pub collection: String,
+    /// Positional alias (`t`) also addressing the collection.
+    pub alias: String,
+    /// Number of data rows imported (header excluded).
+    pub rows_imported: usize,
+}
+
+/// A didactic error explaining why a file could not be materialized.
+///
+/// Every variant renders to a human-readable, non-panicking message: a
+/// missing, unreadable, unsupported, or malformed file never aborts the
+/// process abnormally.
+#[derive(Debug)]
+pub enum EphemeralError {
+    /// The path does not point at a readable regular file.
+    NotAFile { path: String },
+    /// The extension is neither `.csv` nor `.tsv`/`.tab`.
+    UnsupportedExtension { path: String, ext: String },
+    /// The file stem sanitized to an empty identifier.
+    EmptyStem { path: String },
+    /// The CSV import path rejected the file (I/O or parse failure).
+    Import { path: String, source: String },
+    /// Registering the positional alias view failed.
+    Alias { source: String },
+}
+
+impl std::fmt::Display for EphemeralError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EphemeralError::NotAFile { path } => {
+                write!(f, "cannot read data file '{path}': no such file")
+            }
+            EphemeralError::UnsupportedExtension { path, ext } => write!(
+                f,
+                "unsupported data file '{path}': '.{ext}' is not a CSV or TSV file \
+                 (expected .csv, .tsv, or .tab)"
+            ),
+            EphemeralError::EmptyStem { path } => write!(
+                f,
+                "cannot derive a table name from '{path}': the file stem is empty"
+            ),
+            EphemeralError::Import { path, source } => {
+                write!(f, "failed to load '{path}': {source}")
+            }
+            EphemeralError::Alias { source } => {
+                write!(f, "failed to register positional alias '{POSITIONAL_ALIAS}': {source}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for EphemeralError {}
+
+/// Sanitize a file stem into a safe collection identifier.
+///
+/// Non-alphanumeric characters collapse to a single `_`; leading/trailing
+/// underscores are trimmed; a leading digit is prefixed with `_` so the
+/// result is always a valid identifier. Returns `None` when nothing
+/// usable survives (e.g. a stem of only punctuation).
+#[must_use]
+pub fn sanitize_stem(stem: &str) -> Option<String> {
+    let mut out = String::with_capacity(stem.len());
+    let mut prev_underscore = false;
+    for ch in stem.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_underscore = false;
+        } else if !prev_underscore {
+            out.push('_');
+            prev_underscore = true;
+        }
+    }
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Identifiers cannot start with a digit.
+    if trimmed.starts_with(|c: char| c.is_ascii_digit()) {
+        Some(format!("_{trimmed}"))
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Field delimiter inferred from a data file's extension.
+fn delimiter_for_extension(ext: &str) -> Option<u8> {
+    match ext {
+        "csv" => Some(b','),
+        "tsv" | "tab" => Some(b'\t'),
+        _ => None,
+    }
+}
+
+impl RedDBRuntime {
+    /// Materialize a local CSV/TSV file as a row table in this runtime.
+    ///
+    /// The collection is auto-created from the sanitized file stem and a
+    /// non-materialized view `t` ([`POSITIONAL_ALIAS`]) is registered so
+    /// the single loaded file is addressable both ways. Intended for the
+    /// in-memory ephemeral store — nothing durable is written beyond what
+    /// this runtime already persists.
+    pub fn materialize_data_file(&self, path: &Path) -> Result<EphemeralTable, EphemeralError> {
+        let display = path.display().to_string();
+
+        if !path.is_file() {
+            return Err(EphemeralError::NotAFile { path: display });
+        }
+
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let delimiter = delimiter_for_extension(&ext).ok_or_else(|| {
+            EphemeralError::UnsupportedExtension {
+                path: display.clone(),
+                ext: ext.clone(),
+            }
+        })?;
+
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+        let collection = sanitize_stem(stem).ok_or_else(|| EphemeralError::EmptyStem {
+            path: display.clone(),
+        })?;
+
+        let importer = CsvImporter::new(CsvConfig {
+            collection: collection.clone(),
+            has_header: true,
+            delimiter,
+            skip_errors: false,
+            ..CsvConfig::default()
+        });
+
+        let store = self.inner.db.store();
+        let stats = importer
+            .import_file(path, store.as_ref())
+            .map_err(|e| EphemeralError::Import {
+                path: display.clone(),
+                source: e.to_string(),
+            })?;
+
+        // The rows were written straight through the store, so nudge the
+        // planner/result cache exactly as the COPY path does.
+        self.note_table_write(&collection);
+
+        // Register the positional alias as a plain (non-materialized)
+        // view so `FROM t` rewrites to the underlying collection. Both
+        // names are safe identifiers, so the inline SQL is well-formed.
+        if collection != POSITIONAL_ALIAS {
+            let create_view =
+                format!("CREATE VIEW {POSITIONAL_ALIAS} AS SELECT * FROM {collection}");
+            self.execute_query(&create_view)
+                .map_err(|e| EphemeralError::Alias {
+                    source: e.to_string(),
+                })?;
+        }
+
+        Ok(EphemeralTable {
+            collection,
+            alias: POSITIONAL_ALIAS.to_string(),
+            rows_imported: stats.records_imported,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_stem_basic() {
+        assert_eq!(sanitize_stem("data").as_deref(), Some("data"));
+        assert_eq!(sanitize_stem("Users").as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn sanitize_stem_collapses_and_trims() {
+        assert_eq!(
+            sanitize_stem("vendas-2026 (v2)").as_deref(),
+            Some("vendas_2026_v2")
+        );
+        assert_eq!(sanitize_stem("__weird__name__").as_deref(), Some("weird_name"));
+    }
+
+    #[test]
+    fn sanitize_stem_leading_digit_prefixed() {
+        assert_eq!(sanitize_stem("2026sales").as_deref(), Some("_2026sales"));
+    }
+
+    #[test]
+    fn sanitize_stem_all_punctuation_is_none() {
+        assert_eq!(sanitize_stem("---"), None);
+        assert_eq!(sanitize_stem(""), None);
+    }
+
+    #[test]
+    fn delimiter_inference() {
+        assert_eq!(delimiter_for_extension("csv"), Some(b','));
+        assert_eq!(delimiter_for_extension("tsv"), Some(b'\t'));
+        assert_eq!(delimiter_for_extension("tab"), Some(b'\t'));
+        assert_eq!(delimiter_for_extension("json"), None);
+    }
+}

--- a/crates/reddb-server/src/runtime/impl_ephemeral.rs
+++ b/crates/reddb-server/src/runtime/impl_ephemeral.rs
@@ -51,8 +51,6 @@ pub enum EphemeralError {
     EmptyStem { path: String },
     /// The CSV import path rejected the file (I/O or parse failure).
     Import { path: String, source: String },
-    /// Registering the positional alias view failed.
-    Alias { source: String },
 }
 
 impl std::fmt::Display for EphemeralError {
@@ -72,9 +70,6 @@ impl std::fmt::Display for EphemeralError {
             ),
             EphemeralError::Import { path, source } => {
                 write!(f, "failed to load '{path}': {source}")
-            }
-            EphemeralError::Alias { source } => {
-                write!(f, "failed to register positional alias '{POSITIONAL_ALIAS}': {source}")
             }
         }
     }
@@ -142,12 +137,11 @@ impl RedDBRuntime {
             .and_then(|e| e.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        let delimiter = delimiter_for_extension(&ext).ok_or_else(|| {
-            EphemeralError::UnsupportedExtension {
+        let delimiter =
+            delimiter_for_extension(&ext).ok_or_else(|| EphemeralError::UnsupportedExtension {
                 path: display.clone(),
                 ext: ext.clone(),
-            }
-        })?;
+            })?;
 
         let stem = path
             .file_stem()
@@ -199,12 +193,13 @@ impl RedDBRuntime {
         // front the same way the runtime's INSERT path does on first
         // write.
         let _ = store.get_or_create_collection(collection);
-        let stats = importer
-            .import_file(path, store.as_ref())
-            .map_err(|e| EphemeralError::Import {
-                path: display.to_string(),
-                source: e.to_string(),
-            })?;
+        let stats =
+            importer
+                .import_file(path, store.as_ref())
+                .map_err(|e| EphemeralError::Import {
+                    path: display.to_string(),
+                    source: e.to_string(),
+                })?;
 
         // The rows were written straight through the store, so nudge the
         // planner/result cache exactly as the COPY path does.
@@ -230,7 +225,10 @@ mod tests {
             sanitize_stem("vendas-2026 (v2)").as_deref(),
             Some("vendas_2026_v2")
         );
-        assert_eq!(sanitize_stem("__weird__name__").as_deref(), Some("weird_name"));
+        assert_eq!(
+            sanitize_stem("__weird__name__").as_deref(),
+            Some("weird_name")
+        );
     }
 
     #[test]

--- a/crates/reddb-server/tests/ephemeral_store_1786.rs
+++ b/crates/reddb-server/tests/ephemeral_store_1786.rs
@@ -1,0 +1,155 @@
+//! Embedded integration tests for the ephemeral-store tracer
+//! (PRD #1785, issue #1786): fixture file → materialize → query.
+//!
+//! Exercises `RedDBRuntime::materialize_data_file` directly against an
+//! in-memory runtime, the same seam the `red` binary drives.
+
+use std::fs;
+use std::path::Path;
+
+use reddb_server::runtime::impl_ephemeral::sanitize_stem;
+use reddb_server::{RedDBRuntime, POSITIONAL_ALIAS};
+
+/// Auto-cleaning temp dir for fixture files.
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-ephemeral-{label}-"))
+        .tempdir()
+        .expect("temp dir")
+}
+
+fn write_fixture(dir: &Path, name: &str, contents: &str) -> std::path::PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, contents).expect("write fixture");
+    path
+}
+
+#[test]
+fn csv_materializes_as_row_table_addressable_by_stem_and_alias() {
+    let dir = temp_dir("csv-basic");
+    // Ages 30 and 9 discriminate numeric vs. lexical comparison: `age > 26`
+    // returns only Alice under numeric typing, but both rows if the column
+    // stayed textual ('9' > '26' lexically).
+    let path = write_fixture(dir.path(), "people.csv", "id,name,age\n1,Alice,30\n2,Bob,9\n");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let table = rt.materialize_data_file(&path).expect("materialize csv");
+
+    assert_eq!(table.collection, "people");
+    assert_eq!(table.alias, POSITIONAL_ALIAS);
+    assert_eq!(table.rows_imported, 2);
+
+    // Addressable by the sanitized file-stem name.
+    let by_stem = rt
+        .execute_query("SELECT * FROM people")
+        .expect("select by stem");
+    assert_eq!(by_stem.result.records.len(), 2);
+
+    // Addressable by the positional alias `t`.
+    let by_alias = rt.execute_query("SELECT * FROM t").expect("select by alias");
+    assert_eq!(by_alias.result.records.len(), 2);
+
+    // Header-derived column with inferred integer type: numeric `>` keeps
+    // only the age-30 row through either name.
+    let filtered_stem = rt
+        .execute_query("SELECT name FROM people WHERE age > 26")
+        .expect("numeric filter by stem");
+    assert_eq!(filtered_stem.result.records.len(), 1);
+
+    let filtered_alias = rt
+        .execute_query("SELECT name FROM t WHERE age > 26")
+        .expect("numeric filter by alias");
+    assert_eq!(filtered_alias.result.records.len(), 1);
+
+    // Aggregates resolve identically through the alias (regression guard:
+    // a rewrite-view alias silently dropped the aggregate).
+    let count_alias = rt
+        .execute_query("SELECT count(*) AS n FROM t")
+        .expect("aggregate by alias");
+    assert_eq!(count_alias.result.records.len(), 1);
+}
+
+#[test]
+fn tsv_materializes_with_tab_delimiter() {
+    let dir = temp_dir("tsv-basic");
+    let path = write_fixture(dir.path(), "places.tsv", "id\tcity\n1\tLisbon\n2\tPorto\n");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let table = rt.materialize_data_file(&path).expect("materialize tsv");
+    assert_eq!(table.collection, "places");
+    assert_eq!(table.rows_imported, 2);
+
+    let rows = rt
+        .execute_query("SELECT city FROM t WHERE city = 'Porto'")
+        .expect("query tsv");
+    assert_eq!(rows.result.records.len(), 1);
+}
+
+#[test]
+fn file_stem_is_sanitized_into_a_collection_name() {
+    let dir = temp_dir("sanitize");
+    let path = write_fixture(dir.path(), "vendas-2026 (v2).csv", "a,b\n1,2\n");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let table = rt.materialize_data_file(&path).expect("materialize");
+    assert_eq!(table.collection, "vendas_2026_v2");
+    // The sanitized name resolves; the raw stem never would.
+    let rows = rt
+        .execute_query("SELECT * FROM vendas_2026_v2")
+        .expect("query sanitized name");
+    assert_eq!(rows.result.records.len(), 1);
+}
+
+#[test]
+fn missing_file_is_a_didactic_error_not_a_panic() {
+    let dir = temp_dir("missing");
+    let path = dir.path().join("nope.csv");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("missing file must error");
+    let msg = err.to_string();
+    assert!(msg.contains("no such file"), "unexpected message: {msg}");
+}
+
+#[test]
+fn unsupported_extension_is_a_didactic_error() {
+    let dir = temp_dir("unsupported");
+    let path = write_fixture(dir.path(), "data.json", "{}\n");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("json is out of scope for this slice");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("not a CSV or TSV"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn malformed_csv_is_a_didactic_error_not_a_panic() {
+    let dir = temp_dir("malformed");
+    // Unterminated quoted field: the RFC-4180 parser rejects it.
+    let path = write_fixture(dir.path(), "broken.csv", "a,b\n1,\"unterminated\n");
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("malformed csv must error");
+    let msg = err.to_string();
+    assert!(msg.contains("failed to load"), "unexpected message: {msg}");
+}
+
+#[test]
+fn sanitize_stem_rules() {
+    assert_eq!(sanitize_stem("data").as_deref(), Some("data"));
+    assert_eq!(
+        sanitize_stem("vendas-2026 (v2)").as_deref(),
+        Some("vendas_2026_v2")
+    );
+    assert_eq!(sanitize_stem("2026").as_deref(), Some("_2026"));
+    assert_eq!(sanitize_stem("***"), None);
+}

--- a/crates/reddb-server/tests/ephemeral_store_1786.rs
+++ b/crates/reddb-server/tests/ephemeral_store_1786.rs
@@ -30,7 +30,11 @@ fn csv_materializes_as_row_table_addressable_by_stem_and_alias() {
     // Ages 30 and 9 discriminate numeric vs. lexical comparison: `age > 26`
     // returns only Alice under numeric typing, but both rows if the column
     // stayed textual ('9' > '26' lexically).
-    let path = write_fixture(dir.path(), "people.csv", "id,name,age\n1,Alice,30\n2,Bob,9\n");
+    let path = write_fixture(
+        dir.path(),
+        "people.csv",
+        "id,name,age\n1,Alice,30\n2,Bob,9\n",
+    );
 
     let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
     let table = rt.materialize_data_file(&path).expect("materialize csv");
@@ -46,7 +50,9 @@ fn csv_materializes_as_row_table_addressable_by_stem_and_alias() {
     assert_eq!(by_stem.result.records.len(), 2);
 
     // Addressable by the positional alias `t`.
-    let by_alias = rt.execute_query("SELECT * FROM t").expect("select by alias");
+    let by_alias = rt
+        .execute_query("SELECT * FROM t")
+        .expect("select by alias");
     assert_eq!(by_alias.result.records.len(), 2);
 
     // Header-derived column with inferred integer type: numeric `>` keeps

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -69,6 +69,103 @@ fn checkpoint_local_runtime(rt: &reddb::RedDBRuntime) {
     let _ = rt.checkpoint();
 }
 
+/// Returns `true` when the first `query` positional names a CSV/TSV data
+/// file, triggering the ephemeral-store tracer (PRD #1785, issue #1786):
+/// `red query <file.csv> <sql>`.
+fn is_ephemeral_data_file(arg: &str) -> bool {
+    let lower = arg.to_ascii_lowercase();
+    lower.ends_with(".csv") || lower.ends_with(".tsv") || lower.ends_with(".tab")
+}
+
+/// Run the ephemeral-store tracer: materialize a local CSV/TSV file into
+/// a throwaway in-memory embedded store, execute the query against it,
+/// print the result, and discard the store. No server, no pre-existing
+/// store, nothing durable created — the collection is addressable by its
+/// sanitized file-stem name and by the positional alias `t`.
+fn run_ephemeral_query(args: &[String], file: &str, sql: &str, json_mode: bool) -> ! {
+    use std::path::Path;
+
+    if sql.is_empty() {
+        if json_mode {
+            json_error("query", "Usage: red query <file.csv|file.tsv> <sql>");
+        }
+        eprintln!("Usage: red query <file.csv|file.tsv> <sql>");
+        eprintln!("Example: red query data.csv \"SELECT * FROM t\"");
+        std::process::exit(1);
+    }
+
+    let params = collect_query_params(args).unwrap_or_else(|err| {
+        if json_mode {
+            json_error("query", &err);
+        }
+        eprintln!("query: {err}");
+        std::process::exit(1);
+    });
+
+    // Throwaway in-memory store — nothing durable is written.
+    let rt = reddb::RedDBRuntime::in_memory().unwrap_or_else(|err| {
+        if json_mode {
+            json_error("query", &err.to_string());
+        }
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    });
+
+    if let Err(err) = rt.materialize_data_file(Path::new(file)) {
+        // Missing, unreadable, or malformed files land here as a
+        // didactic message rather than a panic.
+        if json_mode {
+            json_error("query", &err.to_string());
+        }
+        eprintln!("query error: {err}");
+        std::process::exit(1);
+    }
+
+    let exec_result = if params.is_empty() {
+        rt.execute_query(sql)
+    } else {
+        use reddb::storage::query::modes::parse_multi;
+        use reddb::storage::query::user_params;
+        match parse_multi(sql) {
+            Ok(expr) => match user_params::bind(&expr, &params) {
+                Ok(bound) => rt.execute_query_expr(bound),
+                Err(err) => {
+                    if json_mode {
+                        json_error("query", &err.to_string());
+                    }
+                    eprintln!("query error: {err}");
+                    std::process::exit(1);
+                }
+            },
+            Err(err) => {
+                if json_mode {
+                    json_error("query", &err.to_string());
+                }
+                eprintln!("query error: {err}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    match exec_result {
+        Ok(qr) => {
+            if json_mode {
+                json_ok("query", &format_result_json(&qr));
+            } else {
+                print!("{}", format_result_pretty(&qr));
+            }
+            std::process::exit(0);
+        }
+        Err(err) => {
+            if json_mode {
+                json_error("query", &err.to_string());
+            }
+            eprintln!("query error: {err}");
+            std::process::exit(1);
+        }
+    }
+}
+
 #[derive(Clone)]
 struct McpClientOptions {
     redacted_uri: String,
@@ -1192,6 +1289,14 @@ fn main() {
 
         "query" => {
             let json_mode = wants_json(&result.flags);
+            // Ephemeral-store tracer (PRD #1785, issue #1786):
+            // `red query <file.csv|file.tsv> <sql>` materializes the file
+            // into a throwaway in-memory store and queries it. Detected
+            // when a second positional is present and the first names a
+            // CSV/TSV data file.
+            if remaining.len() >= 2 && is_ephemeral_data_file(remaining[0].as_str()) {
+                run_ephemeral_query(&args, remaining[0].as_str(), remaining[1].as_str(), json_mode);
+            }
             let sql = remaining.first().map(|s| s.as_str()).unwrap_or("");
             if sql.is_empty() {
                 if json_mode {

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1295,7 +1295,12 @@ fn main() {
             // when a second positional is present and the first names a
             // CSV/TSV data file.
             if remaining.len() >= 2 && is_ephemeral_data_file(remaining[0].as_str()) {
-                run_ephemeral_query(&args, remaining[0].as_str(), remaining[1].as_str(), json_mode);
+                run_ephemeral_query(
+                    &args,
+                    remaining[0].as_str(),
+                    remaining[1].as_str(),
+                    json_mode,
+                );
             }
             let sql = remaining.first().map(|s| s.as_str()).unwrap_or("");
             if sql.is_empty() {

--- a/tests/grouped/cli_transport.rs
+++ b/tests/grouped/cli_transport.rs
@@ -24,6 +24,9 @@ mod cli_query_param;
 #[path = "cli_transport/e2e_issue_1588_wire_tls_bind.rs"]
 mod e2e_issue_1588_wire_tls_bind;
 
+#[path = "cli_transport/e2e_issue_1786_ephemeral_query.rs"]
+mod e2e_issue_1786_ephemeral_query;
+
 #[path = "surface_contracts/cross_binary_smoke.rs"]
 mod cross_binary_smoke;
 

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -1,0 +1,94 @@
+//! End-to-end CLI tests for the ephemeral-store tracer (issue #1786).
+//!
+//! Spawns the real `red` binary via `CARGO_BIN_EXE_red` so the full
+//! `main()` path is exercised: `red query <file.csv|file.tsv> <sql>`
+//! materializes the file into a throwaway in-memory store, runs the
+//! query, prints the result, and leaves nothing durable behind.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+fn run_query(file: &str, sql: &str, extra: &[&str]) -> (i32, String, String) {
+    let mut cmd = Command::new(red_binary());
+    cmd.arg("query").arg(file).arg(sql);
+    for a in extra {
+        cmd.arg(a);
+    }
+    let out = cmd.output().expect("spawn red query");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-cli-ephemeral-{label}-"))
+        .tempdir()
+        .expect("temp dir")
+}
+
+#[test]
+fn red_query_csv_file_no_server_no_store() {
+    let dir = temp_dir("csv");
+    let path = dir.path().join("people.csv");
+    fs::write(&path, "id,name,age\n1,Alice,30\n2,Bob,9\n").expect("write fixture");
+    let path_str = path.display().to_string();
+
+    // Query by the positional alias, JSON so the assertion is byte-stable.
+    let (code, stdout, stderr) =
+        run_query(&path_str, "SELECT count(*) AS n FROM t", &["--json"]);
+    assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
+    assert!(stdout.contains("\"ok\":true"), "stdout: {stdout}");
+    assert!(stdout.contains("\"n\":2"), "expected count 2; stdout: {stdout}");
+
+    // Query by the sanitized file-stem name, numeric filter proves typed
+    // columns (only the age-30 row survives `age > 26`).
+    let (code, stdout, stderr) =
+        run_query(&path_str, "SELECT name FROM people WHERE age > 26", &["--json"]);
+    assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
+    assert!(stdout.contains("\"Alice\""), "stdout: {stdout}");
+    assert!(!stdout.contains("\"Bob\""), "Bob leaked: {stdout}");
+
+    // The ephemeral store leaves no durable artifacts next to the file.
+    let mut names: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["people.csv".to_string()]);
+}
+
+#[test]
+fn red_query_tsv_file_by_alias() {
+    let dir = temp_dir("tsv");
+    let path = dir.path().join("places.tsv");
+    fs::write(&path, "id\tcity\n1\tLisbon\n2\tPorto\n").expect("write fixture");
+    let path_str = path.display().to_string();
+
+    let (code, stdout, stderr) =
+        run_query(&path_str, "SELECT city FROM t WHERE city = 'Porto'", &["--json"]);
+    assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
+    assert!(stdout.contains("\"Porto\""), "stdout: {stdout}");
+    assert!(!stdout.contains("\"Lisbon\""), "Lisbon leaked: {stdout}");
+}
+
+#[test]
+fn red_query_missing_file_errors_didactically() {
+    let dir = temp_dir("missing");
+    let path = dir.path().join("nope.csv");
+    let path_str = path.display().to_string();
+
+    let (code, _stdout, stderr) = run_query(&path_str, "SELECT * FROM t", &[]);
+    assert_ne!(code, 0, "missing file should fail");
+    assert!(
+        stderr.contains("no such file"),
+        "expected didactic error; stderr: {stderr}"
+    );
+}

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -42,16 +42,21 @@ fn red_query_csv_file_no_server_no_store() {
     let path_str = path.display().to_string();
 
     // Query by the positional alias, JSON so the assertion is byte-stable.
-    let (code, stdout, stderr) =
-        run_query(&path_str, "SELECT count(*) AS n FROM t", &["--json"]);
+    let (code, stdout, stderr) = run_query(&path_str, "SELECT count(*) AS n FROM t", &["--json"]);
     assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
     assert!(stdout.contains("\"ok\":true"), "stdout: {stdout}");
-    assert!(stdout.contains("\"n\":2"), "expected count 2; stdout: {stdout}");
+    assert!(
+        stdout.contains("\"n\":2"),
+        "expected count 2; stdout: {stdout}"
+    );
 
     // Query by the sanitized file-stem name, numeric filter proves typed
     // columns (only the age-30 row survives `age > 26`).
-    let (code, stdout, stderr) =
-        run_query(&path_str, "SELECT name FROM people WHERE age > 26", &["--json"]);
+    let (code, stdout, stderr) = run_query(
+        &path_str,
+        "SELECT name FROM people WHERE age > 26",
+        &["--json"],
+    );
     assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
     assert!(stdout.contains("\"Alice\""), "stdout: {stdout}");
     assert!(!stdout.contains("\"Bob\""), "Bob leaked: {stdout}");
@@ -72,8 +77,11 @@ fn red_query_tsv_file_by_alias() {
     fs::write(&path, "id\tcity\n1\tLisbon\n2\tPorto\n").expect("write fixture");
     let path_str = path.display().to_string();
 
-    let (code, stdout, stderr) =
-        run_query(&path_str, "SELECT city FROM t WHERE city = 'Porto'", &["--json"]);
+    let (code, stdout, stderr) = run_query(
+        &path_str,
+        "SELECT city FROM t WHERE city = 'Porto'",
+        &["--json"],
+    );
     assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
     assert!(stdout.contains("\"Porto\""), "stdout: {stdout}");
     assert!(!stdout.contains("\"Lisbon\""), "Lisbon leaked: {stdout}");


### PR DESCRIPTION
Automated AFK landing for #1786. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1786

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785917126&installation_id=129708444&pr_number=1854&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1854&signature=2b39b13019aed159110cc3240e2848507a78d4e24ab1e02525b666178597e261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `red query` can now run SQL directly against local `.csv`, `.tsv`, and `.tab` files without creating a permanent store.
  * Added support for querying imported data by both a generated table name and a short alias.

* **Bug Fixes**
  * Improved error handling for missing files, unsupported file types, and malformed input.
  * Added support for tab-delimited file parsing and more reliable output in both pretty and JSON modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->