### PR TITLE
merge: #1787 `red.stats` virtual table + `SHOW STATS` for row tables (computed tier)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -273,8 +273,9 @@ Scope: compare the `red-ui` pages (`query`, `collections`, `cluster`,
    latency, error count, last write timestamp, and last error. This should feed
    both collection list badges and per-collection toolbar status.
 
-   Current gap: `red.stats.last_write_ms` is documented as `NULL` because the
-   backing stats APIs do not expose collection-level write timestamps.
+   Current gap: no `red.*` surface exposes collection-level write timestamps —
+   the backing stats APIs do not track them, and `red.stats` is now the
+   long-format profiling view (row/column metrics), not operational counters.
 
 4. Add server-side query pagination/cursor support for large UI tables.
 

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2585,6 +2585,24 @@ fn test_parse_show_stats_name_desugars_with_collection_filter() {
 }
 
 #[test]
+fn test_parse_show_stats_for_name_desugars_with_collection_filter() {
+    let query = parse("SHOW STATS FOR users").unwrap();
+    if let QueryExpr::Table(tq) = query {
+        assert_eq!(tq.table, "red.stats");
+        assert!(matches!(
+            tq.filter,
+            Some(Filter::Compare {
+                field: FieldRef::TableColumn { ref column, .. },
+                op: CompareOp::Eq,
+                value: reddb_types::types::Value::Text(ref value),
+            }) if column == "collection" && value.as_ref() == "users"
+        ));
+    } else {
+        panic!("Expected Table");
+    }
+}
+
+#[test]
 fn test_parse_events_status_desugars_to_red_subscriptions_select() {
     let query = parse("EVENTS STATUS").unwrap();
     if let QueryExpr::Table(tq) = query {

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -4253,6 +4253,9 @@ impl<'a> Parser<'a> {
                     Ok(SqlCommand::Select(query))
                 } else if self.consume_ident_ci("STATS")? {
                     let mut query = TableQuery::new("red.stats");
+                    // Optional `FOR` keyword: `SHOW STATS FOR <collection>`
+                    // desugars identically to `SHOW STATS <collection>`.
+                    let _ = self.consume(&Token::For)?;
                     let collection = match self.peek().clone() {
                         Token::Ident(name) => {
                             self.advance()?;

--- a/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
@@ -480,9 +480,26 @@ pub(super) fn collections_snapshot(
         .collect()
 }
 
+/// Number of most-common values surfaced per column in `red.stats`.
+/// The planner tracks up to 100; the introspection view keeps the
+/// hottest handful so the long-format `value` array stays readable.
+const STATS_MCV_LIMIT: usize = 10;
+
+/// Long-format `red.stats` profiling view (issue #1787). This is the
+/// **computed** freshness tier: every read runs an on-demand profiling
+/// scan over the target row tables rather than serving a cached
+/// snapshot. Emitted rows are `(collection, entity, metric, value)`:
+///
+/// * `row_count` — one row per collection, `entity` is `NULL`.
+/// * `null_count` / `distinct_count` / `most_common_values` — one row
+///   per column, `entity` is the column name.
+///
+/// This slice profiles row (`TABLE`) collections only; other models
+/// share the same contract in later slices.
 pub(super) fn stats_snapshot(
     runtime: &RedDBRuntime,
     visible_collections: Option<&std::collections::HashSet<String>>,
+    query: &TableQuery,
 ) -> Vec<UnifiedRecord> {
     let snapshot = runtime.db().catalog_model_snapshot();
     let schema = Arc::new(
@@ -492,61 +509,106 @@ pub(super) fn stats_snapshot(
             .collect::<Vec<_>>(),
     );
     let store = runtime.db().store();
+    // `SHOW STATS <name>` desugars to a `collection = '<name>'` filter;
+    // scope the profiling scan to that one collection so an unfiltered
+    // `SELECT * FROM red.stats` is the only path that scans everything.
+    let target = stats_target_collection(query);
 
-    snapshot
-        .collections
-        .into_iter()
-        .filter(|collection| {
-            visible_collections.is_none_or(|visible| visible.contains(&collection.name))
-        })
-        .map(|collection| {
-            let manager_stats = store
-                .get_collection(&collection.name)
-                .map(|manager| manager.stats());
-            let entities = manager_stats
-                .as_ref()
-                .map(|stats| stats.total_entities)
-                .unwrap_or(collection.entities);
-            let growing_count = manager_stats
-                .as_ref()
-                .map(|stats| stats.growing_count)
-                .unwrap_or(0);
-            let sealed_count = manager_stats
-                .as_ref()
-                .map(|stats| stats.sealed_count)
-                .unwrap_or(0);
-            let archived_count = manager_stats
-                .as_ref()
-                .map(|stats| stats.archived_count)
-                .unwrap_or(0);
-            let segments = manager_stats
-                .as_ref()
-                .map(|stats| stats.growing_count + stats.sealed_count + stats.archived_count)
-                .unwrap_or(collection.segments);
-            let seal_ops = manager_stats
-                .as_ref()
-                .map(|stats| stats.seal_ops)
-                .unwrap_or(0);
-            let compact_ops = manager_stats
-                .as_ref()
-                .map(|stats| stats.compact_ops)
-                .unwrap_or(0);
+    let mut rows = Vec::new();
+    for collection in snapshot.collections {
+        if collection.model != CollectionModel::Table {
+            continue;
+        }
+        if let Some(target) = target.as_deref() {
+            if collection.name != target {
+                continue;
+            }
+        }
+        if !visible_collections.is_none_or(|visible| visible.contains(&collection.name)) {
+            continue;
+        }
+        let Some(analyzed) = crate::storage::query::planner::stats_catalog::analyze_collection(
+            store.as_ref(),
+            &collection.name,
+        ) else {
+            continue;
+        };
 
-            UnifiedRecord::with_schema(
-                Arc::clone(&schema),
-                vec![
-                    Value::text(collection.name),
-                    Value::UnsignedInteger(entities as u64),
-                    Value::UnsignedInteger(segments as u64),
-                    Value::UnsignedInteger(growing_count as u64),
-                    Value::UnsignedInteger(sealed_count as u64),
-                    Value::UnsignedInteger(archived_count as u64),
-                    Value::UnsignedInteger(seal_ops),
-                    Value::UnsignedInteger(compact_ops),
-                    Value::Null,
-                    Value::UnsignedInteger(collection.attention_score as u64),
-                ],
-            )
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "row_count",
+            Value::UnsignedInteger(analyzed.row_count),
+        ));
+        for column in &analyzed.columns {
+            rows.push(stats_row(
+                &schema,
+                &collection.name,
+                Value::text(column.name.clone()),
+                "null_count",
+                Value::UnsignedInteger(column.null_count),
+            ));
+            rows.push(stats_row(
+                &schema,
+                &collection.name,
+                Value::text(column.name.clone()),
+                "distinct_count",
+                Value::UnsignedInteger(column.distinct_count),
+            ));
+            rows.push(stats_row(
+                &schema,
+                &collection.name,
+                Value::text(column.name.clone()),
+                "most_common_values",
+                Value::Array(most_common_values(column.mcv.as_ref())),
+            ));
+        }
+    }
+    rows
+}
+
+fn stats_row(
+    schema: &Arc<Vec<Arc<str>>>,
+    collection: &str,
+    entity: Value,
+    metric: &str,
+    value: Value,
+) -> UnifiedRecord {
+    UnifiedRecord::with_schema(
+        Arc::clone(schema),
+        vec![Value::text(collection), entity, Value::text(metric), value],
+    )
+}
+
+/// Extract the single collection targeted by a `collection = '<name>'`
+/// equality filter (as produced by `SHOW STATS <name>`). Returns `None`
+/// for any other shape so the caller profiles every visible row table.
+fn stats_target_collection(query: &TableQuery) -> Option<String> {
+    match query.filter.as_ref() {
+        Some(Filter::Compare {
+            field: FieldRef::TableColumn { column, .. },
+            op: CompareOp::Eq,
+            value: Value::Text(collection),
+        }) if column == "collection" => Some(collection.to_string()),
+        _ => None,
+    }
+}
+
+fn most_common_values(
+    mcv: Option<&crate::storage::query::planner::MostCommonValues>,
+) -> Vec<Value> {
+    use crate::storage::query::planner::ColumnValue;
+    let Some(mcv) = mcv else {
+        return Vec::new();
+    };
+    mcv.values
+        .iter()
+        .take(STATS_MCV_LIMIT)
+        .map(|(value, _freq)| match value {
+            ColumnValue::Int(v) => Value::Integer(*v),
+            ColumnValue::Float(v) => Value::Float(*v),
+            ColumnValue::Text(v) => Value::text(v.clone()),
         })
         .collect()
 }

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -233,18 +233,14 @@ const POLICY_COLUMNS: [&str; 8] = [
     "enabled",
 ];
 
-const STATS_COLUMNS: [&str; 10] = [
-    "collection",
-    "entities",
-    "segments",
-    "growing_count",
-    "sealed_count",
-    "archived_count",
-    "seal_ops",
-    "compact_ops",
-    "last_write_ms",
-    "attention_score",
-];
+// Issue #1787 — `red.stats` is the long-format profiling view served
+// from the third, **computed** freshness tier: reading it runs an
+// on-demand profiling scan (never a cached snapshot). Each row is one
+// `(collection, entity, metric, value)` tuple. `entity` is the column
+// name for per-column metrics and `NULL` for collection-wide metrics
+// (e.g. `row_count`). This slice profiles row tables; other models
+// share the same contract in later slices.
+const STATS_COLUMNS: [&str; 4] = ["collection", "entity", "metric", "value"];
 
 const RETENTION_COLUMNS: [&str; 7] = [
     "name",
@@ -858,7 +854,9 @@ pub(super) fn red_query(
         VirtualTableKind::Policies => {
             governance_views::policies_snapshot(runtime, tenant, visible_collections)
         }
-        VirtualTableKind::Stats => catalog_views::stats_snapshot(runtime, visible_collections),
+        VirtualTableKind::Stats => {
+            catalog_views::stats_snapshot(runtime, visible_collections, query)
+        }
         VirtualTableKind::Subscriptions => {
             ops_views::subscriptions_snapshot(runtime, visible_collections)
         }

--- a/crates/reddb-server/tests/conformance/show_stats.toml
+++ b/crates/reddb-server/tests/conformance/show_stats.toml
@@ -1,4 +1,4 @@
 input = "SHOW STATS"
 expected_kind = "Table"
-source = "docs/reference/red-schema.md:35"
+source = "docs/reference/red-schema.md:236"
 kind = "positive"

--- a/crates/reddb-server/tests/conformance/show_stats_for_named.toml
+++ b/crates/reddb-server/tests/conformance/show_stats_for_named.toml
@@ -1,0 +1,4 @@
+input = "SHOW STATS FOR users"
+expected_kind = "Table"
+source = "docs/reference/red-schema.md:239"
+kind = "positive"

--- a/crates/reddb-server/tests/conformance/show_stats_named.toml
+++ b/crates/reddb-server/tests/conformance/show_stats_named.toml
@@ -1,4 +1,4 @@
 input = "SHOW STATS users"
 expected_kind = "Table"
-source = "docs/reference/red-schema.md:41"
+source = "docs/reference/red-schema.md:243"
 kind = "positive"

--- a/docs/api/deprecated-catalog-endpoints.md
+++ b/docs/api/deprecated-catalog-endpoints.md
@@ -21,5 +21,5 @@ Use `POST /query` with the corresponding `red.*` SQL relation instead. `GET /cat
 | `GET /catalog/analytics-jobs/operational` | `SELECT * FROM red.analytics_jobs WHERE operational = true` |
 | `GET /catalog/analytics-jobs/status` | `SELECT * FROM red.analytics_jobs` |
 | `GET /catalog/analytics-jobs/attention` | `SELECT * FROM red.analytics_jobs WHERE needs_attention = true` |
-| `GET /catalog/collections/readiness` | No exact implemented `red.*` equivalent yet; use `SELECT name, model, schema_mode, entities, segments, internal, tenant_id FROM red.collections` plus `red.stats` for operational counters. |
-| `GET /catalog/collections/readiness/attention` | No exact implemented `red.*` equivalent yet; use `SELECT * FROM red.stats WHERE attention_score > 0` for currently exposed collection attention. |
+| `GET /catalog/collections/readiness` | No exact implemented `red.*` equivalent yet; use `SELECT name, model, schema_mode, entities, segments, internal, tenant_id FROM red.collections`. (`red.stats` is now the long-format profiling view — row/column metrics, not operational counters.) |
+| `GET /catalog/collections/readiness/attention` | No exact implemented `red.*` equivalent yet; collection attention is no longer surfaced via `red.stats` (which became the long-format profiling view). |

--- a/docs/reference/red-schema.md
+++ b/docs/reference/red-schema.md
@@ -19,7 +19,7 @@ Implemented relations:
 | `red.show_indexes` | `SHOW INDEXES`, `SHOW INDICES`, `SHOW INDEXES ON <collection>`, `SHOW INDICES ON <collection>` |
 | `red.indices`     | Full index status metadata |
 | `red.policies`    | `SHOW POLICIES`, `SHOW POLICIES ON <collection>` |
-| `red.stats`       | `SHOW STATS`, `SHOW STATS <collection>` |
+| `red.stats`       | `SHOW STATS`, `SHOW STATS [FOR] <collection>` |
 | `red.subscriptions` | `EVENTS STATUS`, `EVENTS STATUS <collection>` |
 | `red.registry` | Governance registry metadata; see [Control Evidence Matrix](../compliance/control-evidence-matrix.md). |
 | `red.registry_history` | Governance registry supersession history; see [Control Evidence Matrix](../compliance/control-evidence-matrix.md). |
@@ -221,33 +221,66 @@ available from the auth registry.
 
 ## `red.stats`
 
-`red.stats` exposes one operational stats row per visible collection. `SHOW
-STATS` is syntax sugar for:
+`red.stats` is the **computed**-tier profiling view. Unlike the hot and cold
+catalog-snapshot tiers, reading `red.stats` triggers an on-demand profiling scan
+of the target collections — it never serves a cached snapshot. See the
+[freshness tiers](#freshness-tiers) section below.
+
+The view is **long-format**: each row is one `(collection, entity, metric,
+value)` tuple, so every model can share one output contract. `entity` is the
+column name for per-column metrics and `NULL` for collection-wide metrics.
+
+`SHOW STATS` is syntax sugar for:
 
 ```sql
 SELECT * FROM red.stats;
 ```
 
-`SHOW STATS <name>` adds a collection filter:
+`SHOW STATS <name>` and the equivalent `SHOW STATS FOR <name>` add a collection
+filter (and scope the profiling scan to that one collection):
 
 ```sql
 SELECT * FROM red.stats WHERE collection = '<name>';
 ```
 
-Current columns:
+Because the shape is long-format, individual metrics are directly
+filterable/joinable:
 
-| Column            | Description |
-|-------------------|-------------|
-| `collection`      | Collection name. |
-| `entities`        | Live entity count from `ManagerStats` when available, otherwise the catalog snapshot count. |
-| `segments`        | Segment count from `ManagerStats` when available, otherwise the catalog snapshot count. |
-| `growing_count`   | Number of growing segments reported by `ManagerStats`, or `0` when unavailable. |
-| `sealed_count`    | Number of sealed segments reported by `ManagerStats`, or `0` when unavailable. |
-| `archived_count`  | Number of archived segments reported by `ManagerStats`, or `0` when unavailable. |
-| `seal_ops`        | Number of seal operations reported by `ManagerStats`, or `0` when unavailable. |
-| `compact_ops`     | Number of compaction operations reported by `ManagerStats`, or `0` when unavailable. |
-| `last_write_ms`   | Last write timestamp in Unix milliseconds. Currently `NULL` because collection-level write timestamps are not exposed by `ManagerStats` or the catalog snapshot APIs. |
-| `attention_score` | Catalog attention score for the collection. Larger numbers indicate more severe drift, rebuild, rematerialization, or rerun needs. |
+```sql
+SELECT * FROM red.stats WHERE collection = 'users' AND metric = 'distinct_count';
+```
+
+Columns:
+
+| Column       | Description |
+|--------------|-------------|
+| `collection` | Collection name being profiled. |
+| `entity`     | The sub-entity the metric describes: the column name for per-column metrics, or `NULL` for collection-wide metrics. |
+| `metric`     | The metric name (see below). |
+| `value`      | The metric value. Type varies by metric (integer counts, or an array for `most_common_values`). |
+
+Row-table (`TABLE` model) metric set — this slice profiles row tables; other
+models share the same contract in later slices:
+
+| Metric | Entity | Value |
+|--------|--------|-------|
+| `row_count` | `NULL` | Number of rows in the collection. |
+| `null_count` | column name | Number of rows where the column is `NULL` or absent. |
+| `distinct_count` | column name | Number of distinct non-null values in the column. |
+| `most_common_values` | column name | Array of the column's most common values (hottest first, capped). |
+
+### Freshness tiers
+
+`red.*` columns and views split across three consistency tiers:
+
+- **hot** — fields such as `name`, `model`, `entities`, `segments`,
+  `attention`, `in_memory_bytes` read directly from the live catalog snapshot on
+  every query (sub-ms).
+- **cold** — fields requiring B-tree walks (e.g. `on_disk_bytes`) cache for a
+  short window per collection.
+- **computed** — `red.stats` runs an on-demand profiling scan on every read,
+  never a cached snapshot. Computation is scan-based; the columnar analytics
+  projection is a planned fast-path, not a prerequisite.
 
 ## `red.subscriptions`
 

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -44,18 +44,8 @@ const POLICY_COLUMNS: [&str; 8] = [
     "enabled",
 ];
 
-const STATS_COLUMNS: [&str; 10] = [
-    "collection",
-    "entities",
-    "segments",
-    "growing_count",
-    "sealed_count",
-    "archived_count",
-    "seal_ops",
-    "compact_ops",
-    "last_write_ms",
-    "attention_score",
-];
+// Issue #1787 — `red.stats` is the long-format computed profiling view.
+const STATS_COLUMNS: [&str; 4] = ["collection", "entity", "metric", "value"];
 
 const REGISTRY_COLUMNS: [&str; 12] = [
     "id",
@@ -463,6 +453,110 @@ fn red_schema_introspection_is_stable_across_virtual_tables() {
         assert_eq!(first, second, "{sql} changed between reads");
         assert!(!first.1.is_empty(), "{sql} returned no rows");
     }
+
+    cleanup_scope();
+}
+
+#[test]
+fn show_stats_row_table_returns_long_format_metric_set() {
+    cleanup_scope();
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active BOOLEAN)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO users (id, email, active) VALUES (1, 'a@example.com', true)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO users (id, email, active) VALUES (2, 'b@example.com', true)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO users (id, email, active) VALUES (3, NULL, false)",
+    );
+
+    let (columns, rows) = query_snapshot(&rt, "SHOW STATS users");
+    assert_eq!(columns, vec!["collection", "entity", "metric", "value"]);
+    assert!(
+        rows.iter().all(|row| row[0] == Value::text("users")),
+        "every SHOW STATS row is scoped to the requested collection: {rows:?}"
+    );
+
+    // Collection-wide `row_count` carries a NULL entity.
+    let row_count = rows
+        .iter()
+        .find(|row| row[2] == Value::text("row_count"))
+        .expect("row_count metric present");
+    assert_eq!(row_count[1], Value::Null);
+    assert_eq!(row_count[3], Value::UnsignedInteger(3));
+
+    // Per-column null / distinct counts for `email` (one NULL, two distinct).
+    let email_nulls = rows
+        .iter()
+        .find(|row| row[1] == Value::text("email") && row[2] == Value::text("null_count"))
+        .expect("email null_count present");
+    assert_eq!(email_nulls[3], Value::UnsignedInteger(1));
+    let email_distinct = rows
+        .iter()
+        .find(|row| row[1] == Value::text("email") && row[2] == Value::text("distinct_count"))
+        .expect("email distinct_count present");
+    assert_eq!(email_distinct[3], Value::UnsignedInteger(2));
+
+    // Most-common-values is emitted per column as an array.
+    assert!(
+        rows.iter().any(|row| row[1] == Value::text("email")
+            && row[2] == Value::text("most_common_values")
+            && matches!(row[3], Value::Array(_))),
+        "email most_common_values array present: {rows:?}"
+    );
+
+    // The long format is directly filterable/joinable on `metric`.
+    let (_, filtered) = query_snapshot(
+        &rt,
+        "SELECT * FROM red.stats WHERE collection = 'users' AND metric = 'distinct_count'",
+    );
+    assert!(!filtered.is_empty(), "metric-filtered select returns rows");
+    assert!(
+        filtered
+            .iter()
+            .all(|row| row[2] == Value::text("distinct_count")),
+        "metric filter keeps only distinct_count rows: {filtered:?}"
+    );
+
+    cleanup_scope();
+}
+
+#[test]
+fn show_stats_requires_tenant_for_non_admin_identity() {
+    cleanup_scope();
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE users (id INT)");
+    set_current_connection_id(24403);
+    set_current_auth_identity("alice".to_string(), Role::Read);
+
+    // `red.stats` follows the shared `red.*` tenant gate: a tenant-less
+    // non-admin identity is rejected before any profiling scan runs.
+    let err = rt
+        .execute_query("SHOW STATS")
+        .expect_err("tenant-less non-admin should be rejected")
+        .to_string();
+    assert!(err.contains("active tenant"), "error was: {err}");
+
+    // With an active tenant the scan runs and stays scoped to the tenant.
+    set_current_tenant("acme".to_string());
+    let scoped = rt
+        .execute_query(
+            "SELECT * FROM red.stats WHERE collection = 'users' AND metric = 'row_count'",
+        )
+        .expect("tenant-scoped red.stats read");
+    assert!(scoped
+        .result
+        .records
+        .iter()
+        .all(|record| record.get("collection") == Some(&Value::text("users"))));
 
     cleanup_scope();
 }
@@ -983,7 +1077,7 @@ fn select_from_red_indices_materializes_index_status_rows() {
 }
 
 #[test]
-fn select_from_red_stats_materializes_collection_counters() {
+fn select_from_red_stats_materializes_long_format_profiling_rows() {
     cleanup_scope();
     let rt = runtime();
     exec(&rt, "CREATE TABLE users (id INT, name TEXT)");
@@ -995,36 +1089,30 @@ fn select_from_red_stats_materializes_collection_counters() {
 
     assert_eq!(
         result.result.columns,
-        vec![
-            "collection",
-            "entities",
-            "segments",
-            "growing_count",
-            "sealed_count",
-            "archived_count",
-            "seal_ops",
-            "compact_ops",
-            "last_write_ms",
-            "attention_score"
-        ]
+        vec!["collection", "entity", "metric", "value"]
     );
-    assert_eq!(result.result.records.len(), 1);
-    let row = &result.result.records[0];
-    assert_eq!(row.get("collection"), Some(&Value::text("users")));
-    assert_eq!(row.get("entities"), Some(&Value::UnsignedInteger(1)));
-    assert!(matches!(
-        row.get("segments"),
-        Some(Value::UnsignedInteger(_))
-    ));
-    assert!(matches!(
-        row.get("growing_count"),
-        Some(Value::UnsignedInteger(_))
-    ));
-    assert_eq!(row.get("last_write_ms"), Some(&Value::Null));
-    assert!(matches!(
-        row.get("attention_score"),
-        Some(Value::UnsignedInteger(_))
-    ));
+    assert!(!result.result.records.is_empty());
+    assert!(result
+        .result
+        .records
+        .iter()
+        .all(|row| row.get("collection") == Some(&Value::text("users"))));
+
+    // Collection-wide row_count with a NULL entity.
+    let row_count = result
+        .result
+        .records
+        .iter()
+        .find(|row| row.get("metric") == Some(&Value::text("row_count")))
+        .expect("row_count metric present");
+    assert_eq!(row_count.get("entity"), Some(&Value::Null));
+    assert_eq!(row_count.get("value"), Some(&Value::UnsignedInteger(1)));
+
+    // Per-column metrics carry the column name as `entity`.
+    assert!(result.result.records.iter().any(|row| {
+        row.get("entity") == Some(&Value::text("name"))
+            && row.get("metric") == Some(&Value::text("distinct_count"))
+    }));
 
     cleanup_scope();
 }
@@ -1250,18 +1338,21 @@ fn show_stats_desugars_to_red_stats() {
     let single = rt
         .execute_query("SHOW STATS users")
         .expect("show stats users");
-    assert_eq!(single.result.records.len(), 1);
-    assert_eq!(
-        single.result.records[0].get("collection"),
-        Some(&Value::text("users"))
-    );
-    let expected = rt
-        .execute_query("SELECT attention_score FROM red.stats WHERE collection = 'users'")
-        .expect("red.stats users");
-    assert_eq!(
-        single.result.records[0].get("attention_score"),
-        expected.result.records[0].get("attention_score")
-    );
+    // Long-format: every row is scoped to `users` and carries a
+    // NULL-entity `row_count` row plus per-column metric rows.
+    assert!(single
+        .result
+        .records
+        .iter()
+        .all(|record| record.get("collection") == Some(&Value::text("users"))));
+    let row_count = single
+        .result
+        .records
+        .iter()
+        .find(|record| record.get("metric") == Some(&Value::text("row_count")))
+        .expect("row_count metric present");
+    assert_eq!(row_count.get("entity"), Some(&Value::Null));
+    assert_eq!(row_count.get("value"), Some(&Value::UnsignedInteger(1)));
 
     let all = rt.execute_query("SHOW STATS").expect("show stats");
     let collections = all


### PR DESCRIPTION
Automated AFK landing for #1787. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1787

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785919436&installation_id=129708444&pr_number=1855&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1855&signature=0098c69074b1dec89851976f8bf633193bf44b097e39275c8a60088e340bb420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->