### PR TITLE
merge: #1771 Projection disposability: drop-and-rebuild repair + backup independence

### DIFF
--- a/crates/reddb-server/src/storage/columnar_projection.rs
+++ b/crates/reddb-server/src/storage/columnar_projection.rs
@@ -126,6 +126,15 @@ impl std::fmt::Display for ProjectionError {
 
 impl std::error::Error for ProjectionError {}
 
+impl ProjectionError {
+    fn is_projection_artifact_failure(&self) -> bool {
+        matches!(
+            self,
+            Self::Block(_) | Self::Envelope(_) | Self::CorruptSegment(_)
+        )
+    }
+}
+
 impl From<ColumnBlockError> for ProjectionError {
     fn from(e: ColumnBlockError) -> Self {
         Self::Block(e)
@@ -345,6 +354,19 @@ impl ColumnarProjection {
         self.manifest = ProjectionManifest::default();
     }
 
+    /// Rebuild the derived projection from the row log. This is the repair
+    /// primitive for missing or corrupt projection artifacts: truth stays in
+    /// [`AppendOnlyCollection`], so repair is drop-and-regenerate.
+    pub fn rebuild_from_truth(
+        &mut self,
+        collection: &AppendOnlyCollection,
+        checkpoint_lsn: u64,
+        budget: TranscodeBudget,
+    ) -> Result<EmitOutcome, ProjectionError> {
+        self.drop_projection();
+        self.emit_at_checkpoint(collection, checkpoint_lsn, budget)
+    }
+
     /// Emit columnar segments for the un-materialized tail up to `checkpoint_lsn`,
     /// bounded by `budget`. Never fails for lack of budget: it transcodes a
     /// prefix and defers the rest. This is the *only* producer of columnar
@@ -489,6 +511,45 @@ impl ColumnarProjection {
             out.push(lsn_row.row.clone());
         }
         Ok(out)
+    }
+
+    /// Analytical scan with projection repair. Missing derived segment bytes
+    /// or checksum/envelope/frame failures never make the query depend on a
+    /// bad projection: the projection is dropped, rebuilt from the row log, and
+    /// scanned again under the same LSN pin.
+    pub fn repairing_analytical_scan(
+        &mut self,
+        collection: &AppendOnlyCollection,
+        pinned_lsn: u64,
+        budget: TranscodeBudget,
+    ) -> Result<Vec<Row>, ProjectionError> {
+        if self.projection_artifacts_missing() {
+            self.rebuild_from_truth(collection, pinned_lsn, budget)?;
+            return self.analytical_scan(collection, pinned_lsn);
+        }
+
+        match self.analytical_scan(collection, pinned_lsn) {
+            Ok(rows) => Ok(rows),
+            Err(err) if err.is_projection_artifact_failure() => {
+                self.rebuild_from_truth(collection, pinned_lsn, budget)?;
+                self.analytical_scan(collection, pinned_lsn)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    fn projection_artifacts_missing(&self) -> bool {
+        if self.manifest.segments.is_empty() {
+            return false;
+        }
+        if self.manifest.segments.len() != self.segments.len() {
+            return true;
+        }
+        self.manifest
+            .segments
+            .iter()
+            .zip(self.segments.iter())
+            .any(|(manifest, stored)| manifest != &stored.entry)
     }
 
     /// Verify a sealed segment (envelope + `RDCC` CRC), decode it, and push its
@@ -1166,6 +1227,51 @@ mod tests {
             .expect("rebuild");
         let after = projection.analytical_scan(&collection, 300).expect("scan");
         assert_eq!(before, after);
+    }
+
+    #[test]
+    fn repairing_scan_rebuilds_after_projection_artifacts_are_deleted() {
+        let collection = filled(300);
+        let mut projection = ColumnarProjection::new(schema(), KEY);
+        projection
+            .emit_at_checkpoint(&collection, 300, TranscodeBudget::default())
+            .expect("emit");
+        assert!(!projection.segments.is_empty());
+
+        // Simulate a backup/restore or operator cleanup that preserves truth
+        // but omits the derived segment files.
+        projection.segments.clear();
+
+        let scan = projection
+            .repairing_analytical_scan(&collection, 300, TranscodeBudget::default())
+            .expect("repairing scan");
+
+        assert_eq!(scan, collection.row_scan(300));
+        assert!(!projection.manifest().segments().is_empty());
+        assert!(!projection.segments.is_empty());
+    }
+
+    #[test]
+    fn repairing_scan_rebuilds_after_projection_checksum_mismatch() {
+        let collection = filled(20);
+        let mut projection = ColumnarProjection::new(schema(), KEY);
+        projection
+            .emit_at_checkpoint(&collection, 20, TranscodeBudget::default())
+            .expect("emit");
+        let original_segment_id = projection.manifest().segments()[0].segment_id;
+
+        projection.segments[0].sealed[0] ^= 0xFF;
+
+        let scan = projection
+            .repairing_analytical_scan(&collection, 20, TranscodeBudget::default())
+            .expect("repairing scan");
+
+        assert_eq!(scan, collection.row_scan(20));
+        assert_ne!(
+            projection.manifest().segments()[0].segment_id,
+            original_segment_id,
+            "corrupt projection bytes must be replaced by a rebuilt segment"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1771. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1771

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785934099&installation_id=129708444&pr_number=1859&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1859&signature=f0d9cbe94b8bbec9e5167c7104e8e72ee929d4d7fd93929f7d518e81ae835d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analytical scans now automatically repair missing or corrupted derived projection data and retry the query.
  * Added a recovery flow that can rebuild projection data from the source record log when needed.

* **Bug Fixes**
  * Fixed scan failures caused by missing projection segments, mismatched stored metadata, or corrupted segment data.
  * Improved resilience so valid data can still be queried after partial projection damage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->