### PR TITLE
merge: #1772 Automatic projection policy: size floor + per-collection opt-out

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -2907,8 +2907,10 @@ pub struct CreateTimeSeriesQuery {
     /// `SESSION_GAP <duration>` — default inactivity gap (ms) for the
     /// `SESSIONIZE` operator. Issue #576 slice 1.
     pub session_gap_ms: Option<u64>,
-    /// `COLUMNAR` — activate columnar analytical storage (PRD #850,
-    /// #911). When true the collection contract is built with
+    /// Columnar analytical storage policy (PRD #850, #911, #1772).
+    /// Defaults to true for in-scope collections; `NO COLUMNAR` sets it
+    /// false as the per-collection opt-out. When true the collection
+    /// contract is built with
     /// `analytical_storage.columnar = true`, so sealing a chunk routes
     /// through `seal_chunk_with_config`'s columnar arm and emits an
     /// RDCC `ColumnBlock` instead of the row seal.

--- a/crates/reddb-rql/src/parser/timeseries.rs
+++ b/crates/reddb-rql/src/parser/timeseries.rs
@@ -20,7 +20,7 @@ impl<'a> Parser<'a> {
         let mut downsample_policies = Vec::new();
         let mut session_key: Option<String> = None;
         let mut session_gap_ms: Option<u64> = None;
-        let mut columnar = false;
+        let mut columnar = true;
 
         // Parse optional clauses in any order
         loop {
@@ -30,8 +30,18 @@ impl<'a> Parser<'a> {
                 retention_ms = Some((value * unit) as u64);
             } else if self.consume_ident_ci("CHUNK_SIZE")? || self.consume_ident_ci("CHUNKSIZE")? {
                 chunk_size = Some(self.parse_integer()? as usize);
+            } else if self.consume_ident_ci("NO")? {
+                if !self.consume_ident_ci("COLUMNAR")? {
+                    return Err(ParseError::expected(
+                        vec!["COLUMNAR"],
+                        self.peek(),
+                        self.position(),
+                    ));
+                }
+                columnar = false;
             } else if self.consume_ident_ci("COLUMNAR")? {
-                // `COLUMNAR` — activate columnar analytical storage (#911).
+                // `COLUMNAR` is accepted as an explicit spelling of the
+                // automatic default.
                 columnar = true;
             } else if self.consume_ident_ci("DOWNSAMPLE")? {
                 downsample_policies.push(self.parse_downsample_policy_spec()?);
@@ -355,15 +365,25 @@ impl<'a> Parser<'a> {
         let mut chunk_interval_ns: Option<u64> = None;
         let mut ttl_ns: Option<u64> = None;
         let mut retention_ms = None;
-        let mut columnar = false;
+        let mut columnar = true;
 
         loop {
             if self.consume_ident_ci("TIME_COLUMN")? {
                 time_column = Some(self.expect_ident()?);
             } else if self.consume_ident_ci("CHUNK_INTERVAL")? {
                 chunk_interval_ns = Some(self.parse_duration_ns_literal("CHUNK_INTERVAL")?);
+            } else if self.consume_ident_ci("NO")? {
+                if !self.consume_ident_ci("COLUMNAR")? {
+                    return Err(ParseError::expected(
+                        vec!["COLUMNAR"],
+                        self.peek(),
+                        self.position(),
+                    ));
+                }
+                columnar = false;
             } else if self.consume_ident_ci("COLUMNAR")? {
-                // `COLUMNAR` — activate columnar analytical storage (#911).
+                // `COLUMNAR` is accepted as an explicit spelling of the
+                // automatic default.
                 columnar = true;
             } else if self.consume_ident_ci("TTL")? {
                 ttl_ns = Some(self.parse_duration_ns_literal("TTL")?);
@@ -546,7 +566,7 @@ mod tests {
     #[test]
     fn create_timeseries_accepts_clause_order_defaults_and_columnar() {
         let query = parse_query(
-            "CREATE TIMESERIES IF NOT EXISTS readings COLUMNAR DOWNSAMPLE 1h:raw \
+            "CREATE TIMESERIES IF NOT EXISTS readings DOWNSAMPLE 1h:raw \
              RETENTION 2 h CHUNKSIZE 64",
         )
         .unwrap();
@@ -563,6 +583,15 @@ mod tests {
         assert_eq!(timeseries.session_key, None);
         assert_eq!(timeseries.session_gap_ms, None);
         assert!(timeseries.hypertable.is_none());
+    }
+
+    #[test]
+    fn create_timeseries_accepts_no_columnar_opt_out() {
+        let query = parse_query("CREATE TIMESERIES readings NO COLUMNAR").unwrap();
+        let QueryExpr::CreateTimeSeries(timeseries) = query else {
+            panic!("expected create timeseries");
+        };
+        assert!(!timeseries.columnar);
     }
 
     #[test]
@@ -628,7 +657,7 @@ mod tests {
     #[test]
     fn create_hypertable_and_drop_timeseries_parse_variants() {
         let query = parse_query(
-            "CREATE HYPERTABLE IF NOT EXISTS events TIME_COLUMN ts COLUMNAR \
+            "CREATE HYPERTABLE IF NOT EXISTS events TIME_COLUMN ts \
              CHUNK_INTERVAL '30m' TTL '10s' RETENTION 1 h",
         )
         .unwrap();
@@ -643,6 +672,15 @@ mod tests {
         assert_eq!(hypertable.time_column, "ts");
         assert_eq!(hypertable.chunk_interval_ns, 30 * 60 * 1_000_000_000);
         assert_eq!(hypertable.default_ttl_ns, Some(10 * 1_000_000_000));
+
+        let query = parse_query(
+            "CREATE HYPERTABLE cold_events TIME_COLUMN ts CHUNK_INTERVAL '1h' NO COLUMNAR",
+        )
+        .unwrap();
+        let QueryExpr::CreateTimeSeries(timeseries) = query else {
+            panic!("expected hypertable as timeseries");
+        };
+        assert!(!timeseries.columnar);
 
         let query = parse_query("DROP TIMESERIES IF EXISTS tenant.metrics.*").unwrap();
         assert!(matches!(

--- a/crates/reddb-server/src/application/ports_impls_schema.rs
+++ b/crates/reddb-server/src/application/ports_impls_schema.rs
@@ -106,9 +106,9 @@ impl RuntimeSchemaPort for RedDBRuntime {
             hypertable: None,
             session_key: None,
             session_gap_ms: None,
-            // Programmatic create_timeseries has no DDL surface for the
-            // columnar flag; default to the row engine (#911).
-            columnar: false,
+            // Programmatic create_timeseries follows the automatic
+            // projection policy; SQL callers can opt out with NO COLUMNAR.
+            columnar: true,
         };
         RedDBRuntime::execute_create_timeseries(self, &raw_query, &query)
     }

--- a/crates/reddb-server/src/catalog.rs
+++ b/crates/reddb-server/src/catalog.rs
@@ -15,12 +15,11 @@ use crate::storage::{EntityKind, UnifiedEntity};
 
 /// Per-collection analytical-storage seam (PRD #850, Phase 1).
 ///
-/// Declares that a `Metrics`/`TimeSeries` collection's hypertable chunks
+/// Declares whether a `Metrics`/`TimeSeries` collection's hypertable chunks
 /// are backed by the **columnar** sealed-chunk layout
-/// ([`column_block`](crate::storage::unified::column_block)) rather than
-/// the default row engine. `columnar = false` (or the whole config
-/// absent) keeps the row engine — the seal dispatch routes only
-/// columnar-flagged chunks to the `ColumnBlock` writer.
+/// ([`column_block`](crate::storage::unified::column_block)). In-scope
+/// collections get `columnar = true` automatically; `columnar = false` (or
+/// the whole config absent on older contracts) keeps the row engine.
 ///
 /// `time_key` / `order_by_key` mirror the ClickHouse `ORDER BY` intent so
 /// downstream slices (#854 granules, #856 vectorized read) can lay the

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use super::*;
 
 const TIMESERIES_META_COLLECTION: &str = "red_timeseries_meta";
+const COLUMNAR_PROJECTION_SIZE_FLOOR_ROWS: usize = 4;
 
 impl RedDBRuntime {
     pub fn execute_create_timeseries(
@@ -206,9 +207,10 @@ impl RedDBRuntime {
     /// chunk's rows are materialised from the entity store into a
     /// `TimeSeriesChunk`, sealed columnar, and the resulting RDCC
     /// `ColumnBlock` recorded in `ChunkMeta.columnar_page` (bytes stashed
-    /// for read-back). Without the flag the chunk falls to the row seal
-    /// and `columnar_page` stays `None` — no behaviour change. Returns the
-    /// number of chunks sealed columnar.
+    /// for read-back). Columnar-eligible chunks below the projection size
+    /// floor stay open and are picked up by a later seal once they grow.
+    /// Opted-out chunks fall to the row seal and `columnar_page` stays
+    /// `None`. Returns the number of chunks sealed columnar.
     pub fn seal_hypertable_chunks(&self, collection: &str) -> RedDBResult<usize> {
         let analytical = self
             .inner
@@ -237,6 +239,10 @@ impl RedDBRuntime {
             // lands in this chunk's `[start, end)` window — the same
             // entity/row reader the read-bridge serves row chunks from.
             let points = materialize_row_points(&manager, &time_col, start, end);
+            let columnar_enabled = analytical.as_ref().is_some_and(|cfg| cfg.columnar);
+            if columnar_enabled && points.len() < COLUMNAR_PROJECTION_SIZE_FLOOR_ROWS {
+                continue;
+            }
 
             let mut chunk = crate::storage::timeseries::TimeSeriesChunk::with_max_points(
                 collection.to_string(),
@@ -536,11 +542,11 @@ fn remove_timeseries_metadata(store: &crate::storage::unified::UnifiedStore, ser
     }
 }
 
-/// Build the contract's [`AnalyticalStorageConfig`] when the DDL carried
-/// `COLUMNAR` (#911). `time_key` is the column carrying the time axis —
+/// Build the contract's [`AnalyticalStorageConfig`] for the automatic
+/// projection policy. `time_key` is the column carrying the time axis —
 /// the hypertable's declared time column, or the timeseries `timestamp`
-/// convention. `None` when columnar was not requested, so non-columnar
-/// collections keep the row engine default.
+/// convention. `None` means the collection explicitly opted out and keeps
+/// the row engine.
 fn analytical_storage_for(
     columnar: bool,
     time_key: &str,

--- a/crates/reddb-server/tests/columnar_activation_e2e.rs
+++ b/crates/reddb-server/tests/columnar_activation_e2e.rs
@@ -4,7 +4,7 @@
 //! skip, vectorized read) but left it dark: no production path activated
 //! it. This test pins the activation wiring this slice adds:
 //!
-//!   1. `CREATE HYPERTABLE ... COLUMNAR` sets the contract's
+//!   1. `CREATE HYPERTABLE ...` sets the contract's
 //!      `analytical_storage.columnar = true`.
 //!   2. `RedDBRuntime::seal_hypertable_chunks` — the production caller of
 //!      `seal_chunk_with_config` — routes a columnar chunk's seal through
@@ -12,8 +12,8 @@
 //!      `ChunkMeta.columnar_page`.
 //!   3. Read-back over that columnar chunk (the #856 column-block range
 //!      scan) returns the ingested points.
-//!   4. A hypertable created WITHOUT `COLUMNAR` still seals row-oriented:
-//!      no `columnar_page`, no columnar block.
+//!   4. `NO COLUMNAR` opts a collection out: row seal, no `columnar_page`,
+//!      analytical reads fall back through the row bridge.
 
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
@@ -42,7 +42,7 @@ fn columnar_hypertable_seals_through_columnar_arm_and_reads_back() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
     seed(
         &rt,
-        "CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h' COLUMNAR",
+        "CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'",
         "cpu",
     );
 
@@ -73,14 +73,14 @@ fn non_columnar_hypertable_seals_row_oriented() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
     seed(
         &rt,
-        "CREATE HYPERTABLE mem TIME_COLUMN ts CHUNK_INTERVAL '1h'",
+        "CREATE HYPERTABLE mem TIME_COLUMN ts CHUNK_INTERVAL '1h' NO COLUMNAR",
         "mem",
     );
 
-    // Criterion 3: without the flag the chunk seals row-oriented — no
+    // Criterion 3: with the opt-out the chunk seals row-oriented — no
     // columnar seal, no columnar_page, no columnar block to read.
     let sealed = rt.seal_hypertable_chunks("mem").expect("seal mem");
-    assert_eq!(sealed, 0, "no chunk should seal columnar without the flag");
+    assert_eq!(sealed, 0, "opted-out chunks must not seal columnar");
     assert_eq!(
         rt.columnar_chunk_count("mem"),
         0,
@@ -90,4 +90,43 @@ fn non_columnar_hypertable_seals_row_oriented() {
         rt.columnar_chunk_points("mem", 0, 0, u64::MAX).is_none(),
         "row-sealed chunk exposes no columnar block"
     );
+    let got = rt
+        .read_bridge_points("mem", 0, u64::MAX)
+        .expect("row bridge");
+    let want: Vec<(u64, f64)> = POINTS.iter().map(|(ts, v)| (*ts, *v as f64)).collect();
+    assert_eq!(got, want, "opted-out analytical reads fall back to rows");
+}
+
+#[test]
+fn automatic_columnar_skips_tiny_chunks_until_they_cross_the_floor() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    rt.execute_query("CREATE HYPERTABLE tiny TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+        .expect("create hypertable");
+
+    for (ts, value) in &POINTS[..3] {
+        rt.execute_query(&format!(
+            "INSERT INTO tiny (ts, value) VALUES ({ts}, {value})"
+        ))
+        .expect("insert under floor");
+    }
+    assert_eq!(
+        rt.seal_hypertable_chunks("tiny").expect("seal under floor"),
+        0,
+        "under-floor chunks are skipped, not row-sealed"
+    );
+    assert_eq!(rt.columnar_chunk_count("tiny"), 0);
+
+    for (ts, value) in &POINTS[3..4] {
+        rt.execute_query(&format!(
+            "INSERT INTO tiny (ts, value) VALUES ({ts}, {value})"
+        ))
+        .expect("insert crossing floor");
+    }
+    assert_eq!(
+        rt.seal_hypertable_chunks("tiny")
+            .expect("seal after crossing floor"),
+        1,
+        "the same collection is picked up once it crosses the floor"
+    );
+    assert_eq!(rt.columnar_chunk_count("tiny"), 1);
 }

--- a/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
+++ b/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
@@ -28,8 +28,14 @@ const OLD_ROW: &[(u64, i64)] = &[
 ];
 
 /// Post-upgrade data: lands in the SECOND chunk (`[1h, 2h)`), sealed
-/// columnar after `COLUMNAR` is turned on.
-const NEW_COLUMNAR: &[(u64, i64)] = &[(HOUR_NS + 1_000_000_000, 40), (HOUR_NS + 2_000_000_000, 50)];
+/// columnar after columnar projection is turned on. Four rows crosses
+/// the automatic projection size floor.
+const NEW_COLUMNAR: &[(u64, i64)] = &[
+    (HOUR_NS + 1_000_000_000, 40),
+    (HOUR_NS + 2_000_000_000, 50),
+    (HOUR_NS + 3_000_000_000, 60),
+    (HOUR_NS + 4_000_000_000, 70),
+];
 
 fn insert(rt: &RedDBRuntime, collection: &str, rows: &[(u64, i64)]) {
     for (ts, value) in rows {
@@ -53,7 +59,7 @@ fn enable_columnar(rt: &RedDBRuntime, collection: &str, time_key: &str) {
         order_by_key: None,
     });
     db.save_collection_contract(contract)
-        .expect("save columnar-enabled contract");
+        .expect("save columnar contract");
 }
 
 fn want(rows: &[(u64, i64)]) -> Vec<(u64, f64)> {
@@ -64,16 +70,16 @@ fn want(rows: &[(u64, i64)]) -> Vec<(u64, f64)> {
 fn read_bridge_serves_row_and_columnar_chunks_after_enabling_columnar() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
 
-    // --- Before the upgrade: a plain (non-columnar) hypertable with data ---
-    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+    // --- Before the upgrade: an opted-out hypertable with row-stored data ---
+    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h' NO COLUMNAR")
         .expect("create hypertable");
     insert(&rt, "cpu", OLD_ROW);
 
-    // Seal the existing chunk row-oriented (no columnar flag yet).
+    // Seal the existing chunk row-oriented (the collection opted out).
     assert_eq!(
         rt.seal_hypertable_chunks("cpu").expect("seal row"),
         0,
-        "without the flag nothing seals columnar"
+        "the opt-out keeps existing chunks row-stored"
     );
     assert_eq!(
         rt.columnar_chunk_count("cpu"),
@@ -124,7 +130,7 @@ fn read_bridge_serves_row_and_columnar_chunks_after_enabling_columnar() {
 #[test]
 fn read_bridge_prunes_chunks_outside_the_query_range() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
-    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h' NO COLUMNAR")
         .expect("create hypertable");
 
     insert(&rt, "cpu", OLD_ROW);


### PR DESCRIPTION
Automated AFK landing for #1772. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785934881&installation_id=129708444&pr_number=1860&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1860&signature=1b983171e00c894c3e91f823e094d0ac01bbdb43ce257b5e9e8c5d203edb99b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->