### PR TITLE
merge: #1773 Checkpoint/projection stats on the SQL surface (retires the dead WAL-sidecar test proxy)

### DIFF
--- a/crates/reddb-client/tests/embedded_bulk_insert.rs
+++ b/crates/reddb-client/tests/embedded_bulk_insert.rs
@@ -4,18 +4,15 @@
 //! through the columnar `create_rows_batch_columnar` port (#110).
 //!
 //! `bulk_insert(N rows)` must produce a single batched
-//! `BulkUpsertEntityRecords` WAL action — not N per-row records the
-//! old `execute_query` loop emitted. We pin that by comparing on-disk
-//! WAL byte growth: per-row inserts grow proportional to N records
-//! (each carries the full collection-name + per-row framing overhead),
-//! a single batch grows by one record's worth of framing plus the
-//! row payloads.
+//! `BulkUpsertEntityRecords` write — not N per-row writes the old
+//! `execute_query` loop emitted. We pin that through the SQL stats
+//! surface: before a checkpoint, per-row inserts create many more
+//! pending embedded WAL records than the batched path.
 
 use std::path::{Path, PathBuf};
 
 use reddb_client::embedded::EmbeddedClient;
-use reddb_client::JsonValue;
-use reddb_server::storage::EmbeddedRdbArtifact;
+use reddb_client::{JsonValue, ValueOut};
 
 /// Auto-cleaning DB path: holds the [`tempfile::TempDir`] guard so the temp
 /// directory and the `.rdb` artifact are removed on drop, including on panic.
@@ -42,16 +39,23 @@ fn unique_db_path(label: &str) -> TempDbPath {
     TempDbPath { _dir: dir, path }
 }
 
-/// Inspects the live WAL embedded in the single-file `.rdb` artifact (there is
-/// no `.rdb-uwal` sidecar — the WAL lives inside the artifact). Returns
-/// `(record_count, encoded_bytes)`. Must be called *before* dropping the
-/// client: drop triggers a checkpoint that drains and truncates the WAL,
-/// washing out exactly the per-batch-vs-per-row records we compare.
-fn wal_stats(data_path: &Path) -> (usize, u64) {
-    let open = EmbeddedRdbArtifact::open(data_path).expect("open rdb artifact");
-    let payloads = EmbeddedRdbArtifact::read_wal_payloads(&open).expect("read wal payloads");
-    let bytes = EmbeddedRdbArtifact::wal_payloads_encoded_len(&payloads).expect("wal encoded len");
-    (payloads.len(), bytes)
+fn stats_metric(db: &EmbeddedClient, collection: &str, metric: &str) -> u64 {
+    let result = db
+        .query(&format!(
+            "SELECT value FROM red.stats WHERE collection = '{collection}' \
+             AND metric = '{metric}'"
+        ))
+        .expect("stats query");
+    let row = result.rows.first().expect("stats row");
+    let value = row
+        .iter()
+        .find(|(name, _)| name == "value")
+        .map(|(_, value)| value)
+        .expect("stats value");
+    match value {
+        ValueOut::Integer(value) if *value >= 0 => *value as u64,
+        other => panic!("expected unsigned {metric}, got {other:?}"),
+    }
 }
 
 fn rows(n: usize) -> Vec<JsonValue> {
@@ -70,17 +74,8 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
     const N: usize = 50;
 
     // Run 1: single bulk_insert(N).
-    //
-    // We count WAL records *before* drop — the engine's
-    // `WalDurableGrouped` mode waits for durability before
-    // `append_actions` returns, so the records are on disk by the time
-    // `bulk_insert` returns. We avoid `close()` because it triggers a
-    // checkpoint that drains and truncates the WAL, washing out exactly
-    // the per-batch-vs-per-row records we want to compare. Opening a DB
-    // writes a shared ~115-record catalog baseline, so we compare the
-    // *delta* between the two paths, not absolute counts.
     let bulk_path = unique_db_path("bulk");
-    let bulk_count = {
+    let bulk_lag = {
         let db = EmbeddedClient::open(bulk_path.to_path_buf()).expect("open bulk db");
         let inserted = db.bulk_insert("users", &rows(N)).expect("bulk insert");
         assert_eq!(
@@ -92,7 +87,7 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
             N,
             "bulk_insert returned wrong ids count"
         );
-        let after = wal_stats(&bulk_path).0;
+        let after = stats_metric(&db, "users", "pending_wal_records");
         drop(db);
         after
     };
@@ -101,7 +96,7 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
     // `bulk_insert` loop used to do internally. Same payload set,
     // same engine config.
     let perrow_path = unique_db_path("perrow");
-    let perrow_count = {
+    let perrow_lag = {
         let db = EmbeddedClient::open(perrow_path.to_path_buf()).expect("open perrow db");
         for i in 0..N {
             let sql = format!(
@@ -110,25 +105,22 @@ fn bulk_insert_emits_one_wal_record_per_batch() {
             );
             db.query(&sql).expect("per-row insert");
         }
-        let after = wal_stats(&perrow_path).0;
+        let after = stats_metric(&db, "users", "pending_wal_records");
         drop(db);
         after
     };
 
     eprintln!(
-        "WAL records for {N} rows: bulk_insert={bulk_count}, per-row={perrow_count} (delta {})",
-        perrow_count.saturating_sub(bulk_count)
+        "pending WAL records for {N} rows: bulk_insert={bulk_lag}, per-row={perrow_lag} (delta {})",
+        perrow_lag.saturating_sub(bulk_lag)
     );
 
-    // The batch path emits one `BulkUpsertEntityRecords` WAL record for
-    // all N rows; the per-row path emits one transaction per row. Both
-    // share the catalog baseline, so the signal is the delta: per-row
-    // adds ~N records, the batch adds 1. A conservative N/2 threshold
-    // catches a regression where `bulk_insert` reverts to a per-row loop
-    // (its count would jump by ~N and collapse this margin).
+    // A conservative N/2 threshold catches a regression where
+    // `bulk_insert` reverts to a per-row loop: pending WAL records
+    // would jump by ~N and collapse this margin.
     assert!(
-        perrow_count >= bulk_count + N / 2,
-        "expected per-row WAL ({perrow_count} records) to dwarf batch WAL ({bulk_count}) by ~N — bulk_insert likely regressed back to a per-row loop"
+        perrow_lag >= bulk_lag + N as u64 / 2,
+        "expected per-row pending WAL records ({perrow_lag}) to dwarf batch pending WAL records ({bulk_lag}) by ~N; bulk_insert likely regressed back to a per-row loop"
     );
 }
 
@@ -209,15 +201,15 @@ fn bulk_insert_empty_is_noop() {
 
 /// Pins #111: `EmbeddedClient::insert` routes through the same
 /// `create_rows_batch_columnar` port as `bulk_insert`, so a single
-/// `insert` call must produce a byte-identical WAL append to a 1-row
+/// `insert` call should leave pending WAL records exactly like a 1-row
 /// `bulk_insert`. If anyone re-introduces the `build_insert_sql` +
-/// `execute_query` round-trip, the SQL parser path changes the WAL
-/// framing and these counts/bytes diverge.
+/// `execute_query` round-trip, the SQL parser path changes the write
+/// shape and these stats diverge.
 #[test]
-fn insert_emits_one_wal_record_per_call() {
+fn insert_and_one_row_bulk_insert_advance_projection_lag_equally() {
     // Run 1: a single `insert` of one row.
     let insert_path = unique_db_path("insert-one");
-    let (insert_count, insert_bytes) = {
+    let insert_lag = {
         let db = EmbeddedClient::open(insert_path.to_path_buf()).expect("open insert db");
         let res = db
             .insert(
@@ -229,17 +221,16 @@ fn insert_emits_one_wal_record_per_call() {
             )
             .expect("single insert");
         assert_eq!(res.affected, 1, "insert returned wrong affected count");
-        let after = wal_stats(&insert_path);
+        let after = stats_metric(&db, "users", "pending_wal_records");
         drop(db);
         after
     };
 
     // Run 2: a 1-row `bulk_insert` of the same payload — known to
     // route through `create_rows_batch_columnar` post-#110. Both runs
-    // hit the same port with the same row, so the WAL must be
-    // byte-identical.
+    // hit the same port with the same row, so the stats should match.
     let bulk_path = unique_db_path("bulk-one");
-    let (bulk_count, bulk_bytes) = {
+    let bulk_lag = {
         let db = EmbeddedClient::open(bulk_path.to_path_buf()).expect("open bulk db");
         let inserted = db
             .bulk_insert(
@@ -252,27 +243,20 @@ fn insert_emits_one_wal_record_per_call() {
             .expect("bulk insert one");
         assert_eq!(inserted.affected, 1);
         assert_eq!(inserted.ids.len(), 1);
-        let after = wal_stats(&bulk_path);
+        let after = stats_metric(&db, "users", "pending_wal_records");
         drop(db);
         after
     };
 
-    eprintln!(
-        "WAL for 1 row: insert=({insert_count} records, {insert_bytes} bytes), bulk_insert(1)=({bulk_count} records, {bulk_bytes} bytes)"
-    );
+    eprintln!("pending WAL records for 1 row: insert={insert_lag}, bulk_insert(1)={bulk_lag}");
 
-    // The direct columnar port shares the same WAL framing as the 1-row
-    // bulk path. Identical record count *and* byte length pin that
-    // `insert` hits `create_rows_batch_columnar`, not the SQL
-    // `execute_query` round-trip (which wraps the row in extra
-    // parser/transaction framing and would shift these values).
+    // The direct columnar port shares the same write shape as the 1-row
+    // bulk path. Identical lag pins that `insert` hits
+    // `create_rows_batch_columnar`, not the SQL `execute_query`
+    // round-trip.
     assert_eq!(
-        insert_count, bulk_count,
-        "insert WAL record count ({insert_count}) should match 1-row bulk_insert ({bulk_count})"
-    );
-    assert_eq!(
-        insert_bytes, bulk_bytes,
-        "insert WAL bytes ({insert_bytes}) should match 1-row bulk_insert ({bulk_bytes}) — insert likely regressed back to the SQL round-trip"
+        insert_lag, bulk_lag,
+        "insert pending WAL records ({insert_lag}) should match 1-row bulk_insert ({bulk_lag})"
     );
 }
 

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -950,6 +950,46 @@ impl RmwLockTable {
     }
 }
 
+#[derive(Debug, Default)]
+pub(crate) struct CheckpointProjectionStats {
+    last_materialized_lsn: std::sync::atomic::AtomicU64,
+    checkpoints_completed: std::sync::atomic::AtomicU64,
+    last_checkpoint_duration_ms: std::sync::atomic::AtomicU64,
+}
+
+impl CheckpointProjectionStats {
+    pub(crate) fn record_checkpoint(&self, lsn: u64, duration_ms: u64) {
+        use std::sync::atomic::Ordering;
+
+        self.last_materialized_lsn.store(lsn, Ordering::Relaxed);
+        self.last_checkpoint_duration_ms
+            .store(duration_ms, Ordering::Relaxed);
+        self.checkpoints_completed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self, current_lsn: u64) -> CheckpointProjectionStatsSnapshot {
+        use std::sync::atomic::Ordering;
+
+        let last_materialized_lsn = self.last_materialized_lsn.load(Ordering::Relaxed);
+        CheckpointProjectionStatsSnapshot {
+            current_lsn,
+            last_materialized_lsn,
+            projection_lag: current_lsn.saturating_sub(last_materialized_lsn),
+            checkpoints_completed: self.checkpoints_completed.load(Ordering::Relaxed),
+            last_checkpoint_duration_ms: self.last_checkpoint_duration_ms.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CheckpointProjectionStatsSnapshot {
+    pub(crate) current_lsn: u64,
+    pub(crate) last_materialized_lsn: u64,
+    pub(crate) projection_lag: u64,
+    pub(crate) checkpoints_completed: u64,
+    pub(crate) last_checkpoint_duration_ms: u64,
+}
+
 struct RuntimeInner {
     db: Arc<RedDB>,
     layout: PhysicalLayout,
@@ -961,6 +1001,7 @@ struct RuntimeInner {
     probabilistic: probabilistic_store::ProbabilisticStore,
     index_store: index_store::IndexStore,
     cdc: crate::replication::cdc::CdcBuffer,
+    pub(crate) checkpoint_projection_stats: CheckpointProjectionStats,
     backup_scheduler: crate::replication::scheduler::BackupScheduler,
     query_cache: parking_lot::RwLock<crate::storage::query::planner::cache::PlanCache>,
     result_cache: parking_lot::RwLock<(

--- a/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
+++ b/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
@@ -53,6 +53,7 @@ impl RedDBRuntime {
         // prevent us from durably persisting what's already in memory.
         // The remote upload is the side-effect that risks clobbering a
         // peer's state, so it's behind the lease gate.
+        let started = std::time::Instant::now();
         self.inner.db.flush_local_only().map_err(|err| {
             // Issue #205 — local flush failure is a CheckpointFailed
             // operator-grade event. The local-flush path also covers
@@ -71,6 +72,10 @@ impl RedDBRuntime {
             .emit_global();
             RedDBError::Engine(msg)
         })?;
+        let checkpoint_lsn = self.cdc_current_lsn();
+        self.inner
+            .checkpoint_projection_stats
+            .record_checkpoint(checkpoint_lsn, started.elapsed().as_millis() as u64);
         if let Err(err) = self.assert_remote_write_allowed("checkpoint") {
             tracing::warn!(
                 target: "reddb::serverless::lease",

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -221,6 +221,7 @@ impl RedDBRuntime {
                 probabilistic: super::probabilistic_store::ProbabilisticStore::new(),
                 index_store: super::index_store::IndexStore::new(),
                 cdc: crate::replication::cdc::CdcBuffer::new(100_000),
+                checkpoint_projection_stats: super::CheckpointProjectionStats::default(),
                 backup_scheduler: crate::replication::scheduler::BackupScheduler::new(3600),
                 query_cache: parking_lot::RwLock::new(
                     crate::storage::query::planner::cache::PlanCache::new(1000),

--- a/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
@@ -514,17 +514,67 @@ pub(super) fn stats_snapshot(
     // `SELECT * FROM red.stats` is the only path that scans everything.
     let target = stats_target_collection(query);
 
+    let checkpoint_stats = runtime
+        .inner
+        .checkpoint_projection_stats
+        .snapshot(runtime.cdc_current_lsn());
+    let pending_wal_records = runtime.db().embedded_pending_wal_records().unwrap_or(0);
+
     let mut rows = Vec::new();
     for collection in snapshot.collections {
-        if collection.model != CollectionModel::Table {
-            continue;
-        }
         if let Some(target) = target.as_deref() {
             if collection.name != target {
                 continue;
             }
         }
         if !visible_collections.is_none_or(|visible| visible.contains(&collection.name)) {
+            continue;
+        }
+
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "pending_wal_records",
+            Value::UnsignedInteger(pending_wal_records),
+        ));
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "current_lsn",
+            Value::UnsignedInteger(checkpoint_stats.current_lsn),
+        ));
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "last_materialized_lsn",
+            Value::UnsignedInteger(checkpoint_stats.last_materialized_lsn),
+        ));
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "projection_lag",
+            Value::UnsignedInteger(checkpoint_stats.projection_lag),
+        ));
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "checkpoints_completed",
+            Value::UnsignedInteger(checkpoint_stats.checkpoints_completed),
+        ));
+        rows.push(stats_row(
+            &schema,
+            &collection.name,
+            Value::Null,
+            "last_checkpoint_duration_ms",
+            Value::UnsignedInteger(checkpoint_stats.last_checkpoint_duration_ms),
+        ));
+
+        if collection.model != CollectionModel::Table {
             continue;
         }
         let Some(analyzed) = crate::storage::query::planner::stats_catalog::analyze_collection(

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -596,6 +596,16 @@ impl RedDB {
         Ok(())
     }
 
+    pub fn embedded_pending_wal_records(&self) -> Option<u64> {
+        if !embedded_single_file_selected(&self.options) {
+            return None;
+        }
+        let path = self.path.as_ref()?;
+        let artifact = crate::storage::EmbeddedRdbArtifact::open(path).ok()?;
+        let payloads = crate::storage::EmbeddedRdbArtifact::read_wal_payloads(&artifact).ok()?;
+        Some(payloads.len() as u64)
+    }
+
     /// Walk the registered `vector.turbo` collections and trigger one
     /// async snapshot dump per collection. `lsn` is recorded in the
     /// snapshot header; pass `0` when the runtime layer doesn't track

--- a/docs/reference/red-schema.md
+++ b/docs/reference/red-schema.md
@@ -265,6 +265,12 @@ models share the same contract in later slices:
 | Metric | Entity | Value |
 |--------|--------|-------|
 | `row_count` | `NULL` | Number of rows in the collection. |
+| `current_lsn` | `NULL` | Current runtime LSN used as the freshness pin for projection health. |
+| `last_materialized_lsn` | `NULL` | Last LSN durably materialized by the checkpoint/projection path. |
+| `projection_lag` | `NULL` | Difference between `current_lsn` and `last_materialized_lsn`. |
+| `checkpoints_completed` | `NULL` | Number of checkpoints completed by this runtime. |
+| `last_checkpoint_duration_ms` | `NULL` | Duration of the last completed checkpoint in milliseconds. |
+| `pending_wal_records` | `NULL` | Pending embedded WAL records in the single-file artifact; `0` for non-embedded runtimes. |
 | `null_count` | column name | Number of rows where the column is `NULL` or absent. |
 | `distinct_count` | column name | Number of distinct non-null values in the column. |
 | `most_common_values` | column name | Array of the column's most common values (hottest first, capped). |

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -1118,6 +1118,59 @@ fn select_from_red_stats_materializes_long_format_profiling_rows() {
 }
 
 #[test]
+fn red_stats_exposes_checkpoint_projection_lag() {
+    cleanup_scope();
+    let rt = runtime();
+    exec(&rt, "CREATE TABLE events (id INT, name TEXT)");
+    exec(&rt, "INSERT INTO events (id, name) VALUES (1, 'created')");
+
+    rt.checkpoint().expect("checkpoint should succeed");
+
+    let after_checkpoint = rt
+        .execute_query(
+            "SELECT * FROM red.stats WHERE collection = 'events' \
+             AND metric IN ('last_materialized_lsn', 'projection_lag')",
+        )
+        .expect("red.stats checkpoint projection metrics")
+        .result
+        .records;
+
+    let materialized = after_checkpoint
+        .iter()
+        .find(|row| row.get("metric") == Some(&Value::text("last_materialized_lsn")))
+        .expect("last_materialized_lsn metric present");
+    let materialized_lsn = uint_field(materialized, "value");
+    assert!(
+        materialized_lsn > 0,
+        "checkpoint should publish a non-zero materialized LSN"
+    );
+
+    let lag = after_checkpoint
+        .iter()
+        .find(|row| row.get("metric") == Some(&Value::text("projection_lag")))
+        .expect("projection_lag metric present");
+    assert_eq!(uint_field(lag, "value"), 0);
+
+    exec(&rt, "INSERT INTO events (id, name) VALUES (2, 'updated')");
+
+    let after_write = rt
+        .execute_query(
+            "SELECT * FROM red.stats WHERE collection = 'events' \
+             AND metric = 'projection_lag'",
+        )
+        .expect("red.stats projection lag after write")
+        .result
+        .records;
+    let lag = after_write.first().expect("projection_lag row present");
+    assert!(
+        uint_field(lag, "value") > 0,
+        "a write after checkpoint should create projection lag"
+    );
+
+    cleanup_scope();
+}
+
+#[test]
 fn show_schema_desugars_to_red_columns_collection_filter() {
     cleanup_scope();
     let rt = runtime();


### PR DESCRIPTION
Automated AFK landing for #1773. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1773

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785936363&installation_id=129708444&pr_number=1861&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1861&signature=632d82bcbff4d835e1400ce573cc1ec1bc95367cb8971eb1b4b1e033f0fbe1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->