### PR TITLE
merge: #1776 Fork-aware retention: parent compaction never prunes segments referenced by a live fork

### DIFF
--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -130,8 +130,8 @@ impl OperationalManifest {
             }
         };
 
-        let active_paths = active_collection_paths(&manifest);
-        self.quarantine_unreferenced_files(&active_paths)?;
+        let protected_paths = self.protected_collection_paths(&manifest)?;
+        self.quarantine_unreferenced_files(&protected_paths)?;
 
         let pending_drops = manifest
             .collections
@@ -144,16 +144,19 @@ impl OperationalManifest {
             .map(|(name, _)| name.clone())
             .collect::<Vec<_>>();
         if !pending_drops.is_empty() {
+            let fork_referenced_paths = self.fork_referenced_collection_paths()?;
             for (_, path) in &pending_drops {
-                let _ = fs::remove_file(self.collections_dir().join(path));
+                if !fork_referenced_paths.contains(path) {
+                    let _ = fs::remove_file(self.collections_dir().join(path));
+                }
             }
             for (name, _) in pending_drops {
                 manifest.collections.remove(&name);
             }
             manifest.generation += 1;
             self.publish(&manifest)?;
-            let active_paths = active_collection_paths(&manifest);
-            self.quarantine_unreferenced_files(&active_paths)?;
+            let protected_paths = self.protected_collection_paths(&manifest)?;
+            self.quarantine_unreferenced_files(&protected_paths)?;
         }
 
         Ok(completed_pending_drops)
@@ -206,7 +209,12 @@ impl OperationalManifest {
         let Some(entry) = manifest.collections.remove(name) else {
             return Ok(());
         };
-        let _ = fs::remove_file(self.collections_dir().join(entry.path));
+        if !self
+            .fork_referenced_collection_paths()?
+            .contains(&entry.path)
+        {
+            let _ = fs::remove_file(self.collections_dir().join(entry.path));
+        }
         manifest.generation += 1;
         self.publish(&manifest)
     }
@@ -370,6 +378,10 @@ impl OperationalManifest {
         }
         fs::remove_dir_all(&fork.root)?;
         let _ = sync_dir(&self.forks_dir());
+        if let Some(manifest) = self.load_current()? {
+            let protected_paths = self.protected_collection_paths(&manifest)?;
+            self.quarantine_unreferenced_files(&protected_paths)?;
+        }
         Ok(true)
     }
 
@@ -398,6 +410,40 @@ impl OperationalManifest {
             }
         }
         Ok(out)
+    }
+
+    fn protected_collection_paths(&self, manifest: &Manifest) -> io::Result<BTreeSet<String>> {
+        let mut paths = active_collection_paths(manifest);
+        paths.extend(self.fork_referenced_collection_paths()?);
+        Ok(paths)
+    }
+
+    fn fork_referenced_collection_paths(&self) -> io::Result<BTreeSet<String>> {
+        let mut paths = BTreeSet::new();
+        let parent_identity = self.store_identity();
+        let parent_collections_dir = self.collections_dir();
+        for fork in self.fork_handles()? {
+            let Some(manifest) = fork.load_current()? else {
+                continue;
+            };
+            if manifest
+                .fork_origin
+                .as_ref()
+                .map(|origin| origin.parent_store.as_str())
+                != Some(parent_identity.as_str())
+            {
+                continue;
+            }
+            for entry in manifest.collections.values() {
+                let Some(source) = &entry.source else {
+                    continue;
+                };
+                if Path::new(source) == parent_collections_dir.join(&entry.path) {
+                    paths.insert(entry.path.clone());
+                }
+            }
+        }
+        Ok(paths)
     }
 
     pub fn read_generation_for_test(&self) -> io::Result<u64> {
@@ -997,6 +1043,43 @@ mod tests {
         assert!(parent.list_forks().unwrap().is_empty());
         // Dropping again is idempotent.
         assert!(!parent.drop_fork("exp").unwrap());
+    }
+
+    #[test]
+    fn parent_recovery_retains_dropped_collection_file_referenced_by_live_fork() {
+        let path = temp_db_path("fork_retains_parent_drop");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"as-of-fork");
+        parent.create_fork("exp", 12).unwrap();
+
+        parent.begin_drop_collection("users").unwrap();
+        let completed = parent.recover_or_bootstrap(&[]).unwrap();
+
+        assert_eq!(completed, vec!["users".to_string()]);
+        assert!(
+            parent.collection_path_for_test("users").exists(),
+            "live fork source must keep the parent artifact available"
+        );
+        let fork = parent.fork_handle("exp");
+        fork.hydrate_collection("users").unwrap();
+        assert_eq!(read_collection(&fork, "users"), b"as-of-fork");
+    }
+
+    #[test]
+    fn dropping_last_referencing_fork_releases_parent_file_to_retention() {
+        let path = temp_db_path("fork_drop_releases_parent_file");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"as-of-fork");
+        parent.create_fork("exp", 12).unwrap();
+        parent.begin_drop_collection("users").unwrap();
+        parent.recover_or_bootstrap(&[]).unwrap();
+
+        assert!(parent.drop_fork("exp").unwrap());
+
+        assert!(!parent.collection_path_for_test("users").exists());
+        assert!(parent.quarantine_path_for_test("users.rcol").exists());
     }
 
     #[test]

--- a/crates/reddb-file/src/primary_replica/wal.rs
+++ b/crates/reddb-file/src/primary_replica/wal.rs
@@ -170,13 +170,24 @@ impl PrimaryReplicaFilePlan {
         slots: &ReplicationSlotCatalog,
         current_lsn: u64,
     ) -> RdbFileResult<WalRetentionPlan> {
+        self.plan_wal_retention_with_fork_lsns(slots, &[], current_lsn)
+    }
+
+    pub fn plan_wal_retention_with_fork_lsns(
+        &self,
+        slots: &ReplicationSlotCatalog,
+        fork_lsns: &[u64],
+        current_lsn: u64,
+    ) -> RdbFileResult<WalRetentionPlan> {
         if slots.timeline != self.timeline {
             return Err(RdbFileError::InvalidOperation(format!(
                 "slot catalog timeline {} does not match file plan timeline {}",
                 slots.timeline.0, self.timeline.0
             )));
         }
-        let oldest_required_lsn = slots.retention_floor_lsn();
+        let replica_floor_lsn = slots.retention_floor_lsn();
+        let fork_floor_lsn = fork_lsns.iter().copied().min();
+        let oldest_required_lsn = min_optional_lsn(replica_floor_lsn, fork_floor_lsn);
         let current_segment = self.wal_segment_index(current_lsn);
         let keep_from_segment =
             current_segment.saturating_sub(self.retention.min_segments.saturating_sub(1));
@@ -193,7 +204,7 @@ impl PrimaryReplicaFilePlan {
             if *segment_index >= keep_from_segment {
                 continue;
             }
-            if !self.wal_segment_released_by_slots(*segment_index, oldest_required_lsn) {
+            if !self.wal_segment_released(*segment_index, replica_floor_lsn, fork_floor_lsn) {
                 continue;
             }
             removable_bytes = removable_bytes.saturating_add(*bytes);
@@ -216,7 +227,7 @@ impl PrimaryReplicaFilePlan {
                 {
                     continue;
                 }
-                if !self.wal_segment_released_by_slots(*segment_index, oldest_required_lsn) {
+                if !self.wal_segment_released(*segment_index, replica_floor_lsn, fork_floor_lsn) {
                     continue;
                 }
                 removable_bytes = removable_bytes.saturating_add(*bytes);
@@ -241,7 +252,16 @@ impl PrimaryReplicaFilePlan {
         slots: &ReplicationSlotCatalog,
         current_lsn: u64,
     ) -> RdbFileResult<WalPruneResult> {
-        let plan = self.plan_wal_retention(slots, current_lsn)?;
+        self.prune_wal_segments_with_fork_lsns(slots, &[], current_lsn)
+    }
+
+    pub fn prune_wal_segments_with_fork_lsns(
+        &self,
+        slots: &ReplicationSlotCatalog,
+        fork_lsns: &[u64],
+        current_lsn: u64,
+    ) -> RdbFileResult<WalPruneResult> {
+        let plan = self.plan_wal_retention_with_fork_lsns(slots, fork_lsns, current_lsn)?;
         let mut removed_segments = Vec::new();
         for path in &plan.removable_segments {
             fs::remove_file(path)?;
@@ -288,18 +308,33 @@ impl PrimaryReplicaFilePlan {
         Ok(segments)
     }
 
-    fn wal_segment_released_by_slots(
+    fn wal_segment_released(
         &self,
         segment_index: u64,
-        oldest_required_lsn: Option<u64>,
+        replica_floor_lsn: Option<u64>,
+        fork_floor_lsn: Option<u64>,
     ) -> bool {
+        if fork_floor_lsn
+            .map(|floor| self.wal_segment_end_lsn(segment_index) > floor)
+            .unwrap_or(false)
+        {
+            return false;
+        }
         if !self.retention.keep_until_replicas_ack {
             return true;
         }
-        let Some(floor) = oldest_required_lsn else {
+        let Some(floor) = replica_floor_lsn else {
             return false;
         };
         self.wal_segment_end_lsn(segment_index) <= floor
+    }
+}
+
+fn min_optional_lsn(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
     }
 }
 
@@ -553,4 +588,60 @@ fn decode_wal_record(
         lsn,
         payload,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_root(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "reddb_file_primary_replica_wal_{name}_{}_{}",
+            std::process::id(),
+            nanos
+        ));
+        fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    #[test]
+    fn wal_retention_floor_accounts_for_live_fork_lsns() {
+        let root = temp_root("fork_floor");
+        let plan = PrimaryReplicaFilePlan::new(&root, TimelineId(1))
+            .with_segment_bytes(1024 * 1024)
+            .with_retention(WalRetentionPolicy {
+                min_segments: 1,
+                max_bytes: 1024 * 1024 * 1024,
+                keep_until_replicas_ack: false,
+            });
+        for index in 0..5 {
+            let path = plan.wal_segment_path(index * plan.segment_bytes);
+            write_bytes_atomically(&path, &[index as u8]).expect("write fake redwal");
+        }
+        let catalog = ReplicationSlotCatalog::new(TimelineId(1));
+
+        let retention = plan
+            .plan_wal_retention_with_fork_lsns(
+                &catalog,
+                &[2 * plan.segment_bytes],
+                5 * plan.segment_bytes,
+            )
+            .expect("plan retention");
+
+        assert_eq!(retention.oldest_required_lsn, Some(2 * plan.segment_bytes));
+        assert_eq!(retention.retained_bytes_before_prune, 5);
+        assert_eq!(retention.retained_bytes_after_prune, 3);
+        assert_eq!(retention.removable_segments.len(), 2);
+        assert_eq!(retention.removable_segments[0], plan.wal_segment_path(0));
+        assert_eq!(
+            retention.removable_segments[1],
+            plan.wal_segment_path(plan.segment_bytes)
+        );
+
+        let _ = fs::remove_dir_all(root);
+    }
 }

--- a/crates/reddb-file/tests/layout_authority/runtime.rs
+++ b/crates/reddb-file/tests/layout_authority/runtime.rs
@@ -697,8 +697,8 @@ fn server_primary_replica_wal_segments_are_file_owned() {
     let runtime = read(root.join("crates/reddb-server/src/runtime/impl_primary_replica_file.rs"));
     let runtime_non_test = non_test_source(&runtime);
     for required in [
-        "plan.plan_wal_retention(&catalog, current_lsn)",
-        "plan.prune_wal_segments(&catalog, current_lsn)",
+        "plan.plan_wal_retention_with_fork_lsns(&catalog, &fork_lsns, current_lsn)",
+        "plan.prune_wal_segments_with_fork_lsns(&catalog, &fork_lsns, current_lsn)",
     ] {
         assert!(
             runtime_non_test.contains(required),

--- a/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
+++ b/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
@@ -295,6 +295,16 @@ impl RedDBRuntime {
         }
     }
 
+    fn primary_replica_fork_lsns(&self) -> RedDBResult<Vec<u64>> {
+        let Some(data_path) = self.inner.db.options().data_path.as_ref() else {
+            return Ok(Vec::new());
+        };
+        crate::storage::operational_manifest::OperationalManifest::for_db_path(data_path)
+            .list_forks()
+            .map(|forks| forks.into_iter().map(|fork| fork.fork_lsn).collect())
+            .map_err(|err| RedDBError::Internal(err.to_string()))
+    }
+
     pub fn primary_replica_wal_retention_plan(
         &self,
     ) -> RedDBResult<Option<reddb_file::WalRetentionPlan>> {
@@ -305,8 +315,9 @@ impl RedDBRuntime {
             return Ok(None);
         };
         let current_lsn = self.primary_logical_head_lsn().max(self.cdc_current_lsn());
+        let fork_lsns = self.primary_replica_fork_lsns()?;
         Ok(Some(
-            plan.plan_wal_retention(&catalog, current_lsn)
+            plan.plan_wal_retention_with_fork_lsns(&catalog, &fork_lsns, current_lsn)
                 .map_err(|err| RedDBError::Internal(err.to_string()))?,
         ))
     }
@@ -431,8 +442,9 @@ impl RedDBRuntime {
         let Some(catalog) = self.primary_replica_slot_catalog()? else {
             return Ok(None);
         };
+        let fork_lsns = self.primary_replica_fork_lsns()?;
         Ok(Some(
-            plan.prune_wal_segments(&catalog, current_lsn)
+            plan.prune_wal_segments_with_fork_lsns(&catalog, &fork_lsns, current_lsn)
                 .map_err(|err| RedDBError::Internal(err.to_string()))?,
         ))
     }


### PR DESCRIPTION
Automated AFK landing for #1776. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1776

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785940428&installation_id=129708444&pr_number=1863&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1863&signature=2130d6483fbaeabcc188355276c8b78eeb9ef9d68d1b136737495bf84ac915d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->