### PR TITLE
merge: #1778 Embedded single-file profile fork path via export to the operational layout

### DIFF
--- a/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
+++ b/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
@@ -1,6 +1,40 @@
 use super::*;
 
+const SINGLE_FILE_FORK_GUIDANCE: &str = "store fork is not available directly on embedded \
+single-file stores. Export the .rdb through the operational-directory layout first, then fork \
+that operational store. See docs/engine/operational-storage-profiles.md#forking-an-embedded-single-file-store";
+
 impl RedDBRuntime {
+    pub fn fork_store(&self, name: &str) -> RedDBResult<reddb_file::ForkInfo> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(RedDBError::InvalidOperation(
+                "store fork name cannot be empty".to_string(),
+            ));
+        }
+        if self.inner.embedded_single_file {
+            return Err(RedDBError::InvalidOperation(
+                SINGLE_FILE_FORK_GUIDANCE.to_string(),
+            ));
+        }
+        let data_path = self.inner.db.options().data_path.as_ref().ok_or_else(|| {
+            RedDBError::InvalidOperation("store fork requires a data path".into())
+        })?;
+
+        self.flush()?;
+        let fork_lsn = self.primary_logical_head_lsn().max(self.cdc_current_lsn());
+        let manifest =
+            crate::storage::operational_manifest::OperationalManifest::for_db_path(data_path);
+        manifest
+            .create_fork(name, fork_lsn)
+            .map_err(|err| RedDBError::InvalidOperation(err.to_string()))?;
+        Ok(reddb_file::ForkInfo {
+            name: name.to_string(),
+            parent_store: manifest.store_identity(),
+            fork_lsn,
+        })
+    }
+
     pub fn replica_relay_manifest_path(&self, replica_id: &str) -> Option<std::path::PathBuf> {
         let plan = self.primary_replica_file_plan()?;
         Some(plan.relay_manifest_path(replica_id))

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -145,6 +145,38 @@ fn promote_ready_replica_rebootstrap(
     Ok(true)
 }
 
+fn operational_store_from_embedded_artifact(
+    path: &Path,
+    config: UnifiedStoreConfig,
+) -> Result<Option<UnifiedStore>, Box<dyn std::error::Error>> {
+    let artifact = match crate::storage::EmbeddedRdbArtifact::open(path) {
+        Ok(artifact) => artifact,
+        Err(_) => return Ok(None),
+    };
+    let Some(snapshot) = crate::storage::EmbeddedRdbArtifact::read_snapshot(&artifact)? else {
+        return Ok(None);
+    };
+    let source = UnifiedStore::load_from_bytes_with_config(&snapshot, config.clone())?;
+
+    std::fs::remove_file(path)?;
+    let store = UnifiedStore::open_with_config(path, config)?;
+    for collection in source.list_collections() {
+        store.create_collection(collection.clone())?;
+        let Some(manager) = source.get_collection(&collection) else {
+            continue;
+        };
+        for entity in manager.query_all(|_| true) {
+            store.insert_auto(&collection, entity)?;
+        }
+    }
+    let aux = source.aux_metadata();
+    if !aux.is_empty() {
+        store.set_aux_metadata(aux);
+    }
+    store.persist()?;
+    Ok(Some(store))
+}
+
 fn should_cleanup_ephemeral_data_path(options: &RedDBOptions, path: &Path) -> bool {
     options
         .metadata
@@ -477,6 +509,10 @@ impl RedDB {
                     Some(path_buf),
                     false,
                 )
+            } else if let Some(store) =
+                operational_store_from_embedded_artifact(&path_buf, store_config.clone())?
+            {
+                (store, Some(path_buf), true)
             } else {
                 (
                     UnifiedStore::open_with_config(&path_buf, store_config.clone())?,

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
@@ -1054,7 +1054,24 @@ impl RedDB {
 
         self.flush()?;
 
-        let mut metadata = self.load_or_bootstrap_physical_metadata(true)?;
+        let mut metadata = match self.load_or_bootstrap_physical_metadata(true) {
+            Ok(metadata) => metadata,
+            Err(_)
+                if self.options.storage_profile.deploy_profile
+                    == crate::storage::DeployProfile::Embedded
+                    && self.options.storage_profile.packaging
+                        == crate::storage::StoragePackaging::SingleFile =>
+            {
+                crate::physical::PhysicalMetadataFile::from_state(
+                    self.options.clone(),
+                    self.catalog_snapshot(),
+                    self.physical_collection_roots(),
+                    self.physical_index_state(),
+                    None,
+                )
+            }
+            Err(err) => return Err(err),
+        };
         let export_data_path = reddb_file::copy_physical_export_data_file(path, &name)?;
         let export_metadata_path = PhysicalMetadataFile::metadata_path_for(&export_data_path);
         let export_metadata_binary_path =

--- a/crates/reddb-server/tests/store_fork_profile.rs
+++ b/crates/reddb-server/tests/store_fork_profile.rs
@@ -1,0 +1,74 @@
+use reddb_server::{RedDBError, RedDBOptions, RedDBRuntime, StorageDeployPreset};
+
+fn temp_data_path(name: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+    let dir = tempfile::Builder::new()
+        .prefix(name)
+        .tempdir()
+        .expect("tempdir");
+    let path = dir.path().join("db.rdb");
+    (dir, path)
+}
+
+#[test]
+fn embedded_single_file_fork_points_to_export_path() {
+    let (_dir, path) = temp_data_path("embedded-fork-guide");
+    let runtime = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime");
+
+    let err = runtime
+        .fork_store("experiment")
+        .expect_err("single-file store should not fork directly");
+
+    let RedDBError::InvalidOperation(message) = err else {
+        panic!("unexpected error: {err:?}");
+    };
+    assert!(message.contains("single-file"), "got: {message}");
+    assert!(
+        message.to_ascii_lowercase().contains("export"),
+        "got: {message}"
+    );
+    assert!(message.contains("operational-directory"), "got: {message}");
+    assert!(
+        message.contains("docs/engine/operational-storage-profiles.md"),
+        "got: {message}"
+    );
+}
+
+#[test]
+fn operational_directory_fork_uses_exported_layout() {
+    let (_dir, source_path) = temp_data_path("operational-fork");
+    let source = RedDBRuntime::with_options(RedDBOptions::persistent(&source_path))
+        .expect("single-file source runtime");
+    source
+        .execute_query("CREATE TABLE users (id INT)")
+        .expect("create table");
+    source
+        .execute_query("INSERT INTO users (id) VALUES (1)")
+        .expect("insert row");
+    let export = source
+        .create_export("fork-source")
+        .expect("export single-file source");
+    drop(source);
+
+    let export_path = std::path::PathBuf::from(export.data_path);
+    let options = RedDBOptions::persistent(&export_path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("operational storage profile");
+    let runtime = RedDBRuntime::with_options(options).expect("runtime");
+    assert_eq!(
+        runtime
+            .execute_query("SELECT id FROM users")
+            .expect("exported row is readable")
+            .result
+            .len(),
+        1
+    );
+
+    let fork = runtime.fork_store("experiment").expect("fork store");
+
+    let manifest = reddb_file::OperationalManifest::for_db_path(&export_path);
+    let forks = manifest.list_forks().expect("list forks");
+    assert_eq!(forks.len(), 1);
+    assert_eq!(forks[0].name, "experiment");
+    assert_eq!(forks[0].fork_lsn, fork.fork_lsn);
+    assert_eq!(forks[0].parent_store, manifest.store_identity());
+}

--- a/docs/engine/operational-storage-profiles.md
+++ b/docs/engine/operational-storage-profiles.md
@@ -69,6 +69,36 @@ Primary-replica production and all cluster deployments use an operational
 directory rather than a single file. The directory model is split across several
 ADRs:
 
+### Forking an embedded single-file store
+
+Store forks (ADR 0070) require the operational directory substrate because the
+fork manifest shares immutable artifacts with the parent and hydrates mutable
+collection files lazily on first write. An embedded single-file `.rdb` has no
+shared-segment substrate, so RedDB rejects direct fork attempts on that profile
+instead of silently copying the file.
+
+The supported path is explicit:
+
+1. Open the embedded `.rdb` source and create a named physical export.
+2. Open the exported `.rdb` with an operational-directory storage profile, such
+   as `primary-replica-production-ha`.
+3. Fork that operational store. The fork records the exported store's identity
+   as `parent_store` and the current durable LSN as `fork_lsn`.
+
+With the runtime API, the shape is:
+
+```rust
+let export = single_file_runtime.create_export("fork-source")?;
+let operational = RedDBRuntime::with_options(
+    RedDBOptions::persistent(&export.data_path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())?,
+)?;
+let fork = operational.fork_store("experiment")?;
+```
+
+Calling `fork_store` on the original embedded single-file runtime returns a
+didactic error that points back to this export path.
+
 ### Collection layouts (ADR 0041)
 
 [ADR 0041](../../.red/adr/0041-operational-collection-layouts.md) gives mutable and


### PR DESCRIPTION
Automated AFK landing for #1778. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1778

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785943300&installation_id=129708444&pr_number=1864&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1864&signature=179df24aa6acc9b37bc05f933d79ac7fef6752c412017ec977d01a637072f69d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating store forks from operational deployments, including fork metadata such as parent store identity and fork position.
  * Embedded single-file stores can now be opened and converted into an operational layout at startup when applicable.

* **Bug Fixes**
  * Improved handling when opening existing embedded stores by automatically converting supported artifacts instead of failing.
  * Added clearer guidance when a fork is attempted from an unsupported single-file store.

* **Documentation**
  * Updated storage profile docs with the recommended export-and-fork workflow and related fork details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->