### PR TITLE
merge: #1788 Row-oriented output formats: pure formatter + `--format` on both binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctr"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2597,7 @@ name = "reddb-io-client"
 version = "1.22.0"
 dependencies = [
  "async-trait",
+ "csv",
  "jsonwebtoken",
  "proptest",
  "prost",

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -115,6 +115,7 @@ async-trait = "0.1"
 proptest = "1"
 prost = "0.14"
 tempfile = "3"
+csv = "1"
 
 [[bin]]
 name = "red_client"

--- a/crates/reddb-client/src/bin/red_client.rs
+++ b/crates/reddb-client/src/bin/red_client.rs
@@ -32,7 +32,7 @@ use std::process::ExitCode;
 
 use reddb_client::connector::http::{query_one_shot as http_query_one_shot, Auth as HttpAuth};
 use reddb_client::redwire::{Auth as RedWireAuth, ConnectOptions, RedWireClient};
-use reddb_client::{repl::run_repl, RedDBClient};
+use reddb_client::{format_query_result, repl::run_repl, QueryResult, RedDBClient, RowFormat};
 use reddb_wire::{is_embedded_connection_uri, parse, ConnectionTarget, ParseErrorKind};
 
 const EXIT_USAGE: u8 = 1;
@@ -101,7 +101,7 @@ async fn run_http(base_url: String, parsed: ParsedArgs) -> ExitCode {
                     .await;
             match result {
                 Ok(Ok(body)) => {
-                    println!("{body}");
+                    print_one_shot_result(&body, parsed.format);
                     ExitCode::SUCCESS
                 }
                 Ok(Err(e)) => {
@@ -132,7 +132,7 @@ async fn run_grpc(endpoint: String, parsed: ParsedArgs) -> ExitCode {
     match parsed.command {
         Some(Command::OneShot(sql)) => match client.query(&sql).await {
             Ok(out) => {
-                println!("{out}");
+                print_one_shot_result(&out, parsed.format);
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -171,7 +171,7 @@ async fn run_redwire(host: String, port: u16, tls: bool, parsed: ParsedArgs) -> 
     match parsed.command {
         Some(Command::OneShot(sql)) => match client.query_raw(&sql).await {
             Ok(out) => {
-                println!("{out}");
+                print_one_shot_result(&out, parsed.format);
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -192,6 +192,7 @@ async fn run_redwire(host: String, port: u16, tls: bool, parsed: ParsedArgs) -> 
 struct ParsedArgs {
     uri: String,
     token: Option<String>,
+    format: RowFormat,
     command: Option<Command>,
 }
 
@@ -204,6 +205,7 @@ enum Command {
 fn parse_argv(args: &[String]) -> Result<ParsedArgs, String> {
     let mut uri: Option<String> = None;
     let mut token: Option<String> = None;
+    let mut format = RowFormat::Table;
     let mut command: Option<Command> = None;
     let mut i = 0;
     while i < args.len() {
@@ -219,6 +221,28 @@ fn parse_argv(args: &[String]) -> Result<ParsedArgs, String> {
                     .ok_or_else(|| format!("red_client: {a} requires a value"))?;
                 token = Some(v.clone());
                 i += 2;
+            }
+            "--format" => {
+                let v = args
+                    .get(i + 1)
+                    .ok_or_else(|| format!("red_client: {a} requires a value"))?;
+                format = RowFormat::parse(v).ok_or_else(|| {
+                    format!(
+                        "red_client: unknown --format {v}; expected {}",
+                        RowFormat::vocabulary()
+                    )
+                })?;
+                i += 2;
+            }
+            other if other.starts_with("--format=") => {
+                let v = other.trim_start_matches("--format=");
+                format = RowFormat::parse(v).ok_or_else(|| {
+                    format!(
+                        "red_client: unknown --format {v}; expected {}",
+                        RowFormat::vocabulary()
+                    )
+                })?;
+                i += 1;
             }
             "-c" | "--command" => {
                 let v = args
@@ -247,8 +271,20 @@ fn parse_argv(args: &[String]) -> Result<ParsedArgs, String> {
     Ok(ParsedArgs {
         uri,
         token,
+        format,
         command,
     })
+}
+
+fn print_one_shot_result(body: &str, format: RowFormat) {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        println!("{body}");
+        return;
+    };
+    let result = QueryResult::from_envelope(value);
+    let bytes = format_query_result(&result, format);
+    use std::io::Write;
+    std::io::stdout().write_all(&bytes).expect("write stdout");
 }
 
 #[derive(Debug)]

--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -71,12 +71,14 @@ pub mod grpc;
 pub mod router;
 
 pub mod redwire;
+pub mod row_format;
 
 #[cfg(feature = "http")]
 pub mod http;
 
 pub use error::{ClientError, ErrorCode, Result};
 pub use params::{IntoParams, IntoValue, Value};
+pub use row_format::{format_query_result, RowFormat};
 pub use types::{
     BulkInsertResult, DeleteResult, DocumentItem, ExistsResult, InsertResult, JsonValue, KvItem,
     KvWatchEvent, ListOptions, ListResult, QueryResult, Row, ValueOut,

--- a/crates/reddb-client/src/row_format.rs
+++ b/crates/reddb-client/src/row_format.rs
@@ -1,0 +1,319 @@
+use crate::{QueryResult, ValueOut};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowFormat {
+    Table,
+    Json,
+    Ndjson,
+    Csv,
+    Tsv,
+}
+
+impl RowFormat {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "table" => Some(Self::Table),
+            "json" => Some(Self::Json),
+            "ndjson" => Some(Self::Ndjson),
+            "csv" => Some(Self::Csv),
+            "tsv" => Some(Self::Tsv),
+            _ => None,
+        }
+    }
+
+    pub fn vocabulary() -> &'static str {
+        "table, json, ndjson, csv, tsv"
+    }
+}
+
+pub fn format_query_result(result: &QueryResult, format: RowFormat) -> Vec<u8> {
+    match format {
+        RowFormat::Table => format_table(result).into_bytes(),
+        RowFormat::Json => format_json(result).into_bytes(),
+        RowFormat::Ndjson => format_ndjson(result).into_bytes(),
+        RowFormat::Csv => format_delimited(result, b','),
+        RowFormat::Tsv => format_delimited(result, b'\t'),
+    }
+}
+
+fn columns(result: &QueryResult) -> Vec<String> {
+    if !result.columns.is_empty() {
+        return result.columns.clone();
+    }
+    result
+        .rows
+        .first()
+        .map(|row| row.iter().map(|(key, _)| key.clone()).collect())
+        .unwrap_or_default()
+}
+
+fn value_at<'a>(row: &'a [(String, ValueOut)], column: &str) -> Option<&'a ValueOut> {
+    row.iter()
+        .find(|(key, _)| key == column)
+        .map(|(_, value)| value)
+}
+
+fn format_table(result: &QueryResult) -> String {
+    let columns = columns(result);
+    if result.rows.is_empty() {
+        return "(no rows)\n".to_string();
+    }
+
+    let mut widths: Vec<usize> = columns.iter().map(|column| column.len()).collect();
+    for row in &result.rows {
+        for (index, column) in columns.iter().enumerate() {
+            let value = value_at(row, column)
+                .map(table_value)
+                .unwrap_or_else(|| "null".to_string());
+            widths[index] = widths[index].max(value.len());
+        }
+    }
+
+    let mut out = String::new();
+    write_table_line(&mut out, &columns, &widths);
+    let separator: Vec<String> = widths.iter().map(|width| "-".repeat(*width)).collect();
+    write_table_line(&mut out, &separator, &widths);
+    for row in &result.rows {
+        let values: Vec<String> = columns
+            .iter()
+            .map(|column| {
+                value_at(row, column)
+                    .map(table_value)
+                    .unwrap_or_else(|| "null".to_string())
+            })
+            .collect();
+        write_table_line(&mut out, &values, &widths);
+    }
+    out
+}
+
+fn write_table_line(out: &mut String, cells: &[String], widths: &[usize]) {
+    for (index, cell) in cells.iter().enumerate() {
+        if index > 0 {
+            out.push_str("  ");
+        }
+        out.push_str(cell);
+        if index + 1 < cells.len() {
+            for _ in cell.len()..widths[index] {
+                out.push(' ');
+            }
+        }
+    }
+    out.push('\n');
+}
+
+fn format_json(result: &QueryResult) -> String {
+    let columns = columns(result);
+    let mut out = String::from("[");
+    for (row_index, row) in result.rows.iter().enumerate() {
+        if row_index > 0 {
+            out.push(',');
+        }
+        write_json_row(&mut out, row, &columns);
+    }
+    out.push_str("]\n");
+    out
+}
+
+fn format_ndjson(result: &QueryResult) -> String {
+    let columns = columns(result);
+    let mut out = String::new();
+    for row in &result.rows {
+        write_json_row(&mut out, row, &columns);
+        out.push('\n');
+    }
+    out
+}
+
+fn write_json_row(out: &mut String, row: &[(String, ValueOut)], columns: &[String]) {
+    out.push('{');
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        write_json_string(out, column);
+        out.push(':');
+        if let Some(value) = value_at(row, column) {
+            write_json_value(out, value);
+        } else {
+            out.push_str("null");
+        }
+    }
+    out.push('}');
+}
+
+fn format_delimited(result: &QueryResult, delimiter: u8) -> Vec<u8> {
+    let columns = columns(result);
+    let mut out = Vec::new();
+    write_delimited_record(&mut out, &columns, delimiter);
+    for row in &result.rows {
+        let values: Vec<String> = columns
+            .iter()
+            .map(|column| value_at(row, column).map(raw_value).unwrap_or_default())
+            .collect();
+        write_delimited_record(&mut out, &values, delimiter);
+    }
+    out
+}
+
+fn write_delimited_record(out: &mut Vec<u8>, fields: &[String], delimiter: u8) {
+    for (index, field) in fields.iter().enumerate() {
+        if index > 0 {
+            out.push(delimiter);
+        }
+        write_delimited_field(out, field, delimiter);
+    }
+    out.push(b'\n');
+}
+
+fn write_delimited_field(out: &mut Vec<u8>, field: &str, delimiter: u8) {
+    let needs_quotes = field
+        .bytes()
+        .any(|byte| byte == delimiter || byte == b'"' || byte == b'\n' || byte == b'\r');
+    if !needs_quotes {
+        out.extend_from_slice(field.as_bytes());
+        return;
+    }
+    out.push(b'"');
+    for byte in field.bytes() {
+        if byte == b'"' {
+            out.extend_from_slice(b"\"\"");
+        } else {
+            out.push(byte);
+        }
+    }
+    out.push(b'"');
+}
+
+fn table_value(value: &ValueOut) -> String {
+    raw_value(value)
+        .replace('\\', "\\\\")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
+}
+
+fn raw_value(value: &ValueOut) -> String {
+    match value {
+        ValueOut::Null => String::new(),
+        ValueOut::Bool(value) => value.to_string(),
+        ValueOut::Integer(value) => value.to_string(),
+        ValueOut::Float(value) => value.to_string(),
+        ValueOut::String(value) => value.clone(),
+    }
+}
+
+fn write_json_value(out: &mut String, value: &ValueOut) {
+    match value {
+        ValueOut::Null => out.push_str("null"),
+        ValueOut::Bool(value) => out.push_str(if *value { "true" } else { "false" }),
+        ValueOut::Integer(value) => out.push_str(&value.to_string()),
+        ValueOut::Float(value) => out.push_str(&value.to_string()),
+        ValueOut::String(value) => write_json_string(out, value),
+    }
+}
+
+fn write_json_string(out: &mut String, value: &str) {
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> QueryResult {
+        QueryResult {
+            statement: "select".to_string(),
+            affected: 0,
+            columns: vec!["id".to_string(), "name".to_string(), "note".to_string()],
+            rows: vec![
+                vec![
+                    ("id".to_string(), ValueOut::Integer(1)),
+                    ("name".to_string(), ValueOut::String("Ada".to_string())),
+                    (
+                        "note".to_string(),
+                        ValueOut::String("quote \" comma ,".to_string()),
+                    ),
+                ],
+                vec![
+                    ("id".to_string(), ValueOut::Integer(2)),
+                    ("name".to_string(), ValueOut::String("Linus".to_string())),
+                    (
+                        "note".to_string(),
+                        ValueOut::String("tab\tline\nend".to_string()),
+                    ),
+                ],
+            ],
+        }
+    }
+
+    #[test]
+    fn formats_table_byte_exact() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Table),
+            b"id  name   note\n--  -----  ---------------\n1   Ada    quote \" comma ,\n2   Linus  tab\\tline\\nend\n"
+        );
+    }
+
+    #[test]
+    fn formats_json_byte_exact() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Json),
+            br#"[{"id":1,"name":"Ada","note":"quote \" comma ,"},{"id":2,"name":"Linus","note":"tab\tline\nend"}]
+"#
+        );
+    }
+
+    #[test]
+    fn formats_ndjson_one_object_per_row() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Ndjson),
+            br#"{"id":1,"name":"Ada","note":"quote \" comma ,"}
+{"id":2,"name":"Linus","note":"tab\tline\nend"}
+"#
+        );
+    }
+
+    #[test]
+    fn formats_csv_byte_exact() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Csv),
+            b"id,name,note\n1,Ada,\"quote \"\" comma ,\"\n2,Linus,\"tab\tline\nend\"\n"
+        );
+    }
+
+    #[test]
+    fn formats_tsv_byte_exact() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Tsv),
+            b"id\tname\tnote\n1\tAda\t\"quote \"\" comma ,\"\n2\tLinus\t\"tab\tline\nend\"\n"
+        );
+    }
+
+    #[test]
+    fn csv_and_tsv_round_trip_through_standard_parser() {
+        for (format, delimiter) in [(RowFormat::Csv, b','), (RowFormat::Tsv, b'\t')] {
+            let bytes = format_query_result(&sample(), format);
+            let mut reader = csv::ReaderBuilder::new()
+                .delimiter(delimiter)
+                .from_reader(bytes.as_slice());
+            let records: Vec<csv::StringRecord> =
+                reader.records().collect::<Result<_, _>>().unwrap();
+            assert_eq!(reader.headers().unwrap(), &["id", "name", "note"][..]);
+            assert_eq!(records[0].get(2), Some("quote \" comma ,"));
+            assert_eq!(records[1].get(2), Some("tab\tline\nend"));
+        }
+    }
+}

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -24,6 +24,7 @@ use reddb::service_cli::{
     install_systemd_service, probe_listener, render_systemd_unit, run_server_with_large_stack,
     BootstrapConfig, ServerCommandConfig, ServerTransport, SystemdServiceConfig,
 };
+use reddb_client::{format_query_result, QueryResult, RowFormat, ValueOut};
 
 // ---------------------------------------------------------------------------
 // JSON output helpers
@@ -82,7 +83,13 @@ fn is_ephemeral_data_file(arg: &str) -> bool {
 /// print the result, and discard the store. No server, no pre-existing
 /// store, nothing durable created — the collection is addressable by its
 /// sanitized file-stem name and by the positional alias `t`.
-fn run_ephemeral_query(args: &[String], file: &str, sql: &str, json_mode: bool) -> ! {
+fn run_ephemeral_query(
+    args: &[String],
+    file: &str,
+    sql: &str,
+    json_mode: bool,
+    row_format: RowFormat,
+) -> ! {
     use std::path::Path;
 
     if sql.is_empty() {
@@ -152,7 +159,7 @@ fn run_ephemeral_query(args: &[String], file: &str, sql: &str, json_mode: bool) 
             if json_mode {
                 json_ok("query", &format_result_json(&qr));
             } else {
-                print!("{}", format_result_pretty(&qr));
+                print_row_result(&qr, row_format);
             }
             std::process::exit(0);
         }
@@ -163,6 +170,96 @@ fn run_ephemeral_query(args: &[String], file: &str, sql: &str, json_mode: bool) 
             eprintln!("query error: {err}");
             std::process::exit(1);
         }
+    }
+}
+
+fn parse_row_format(flags: &HashMap<String, FlagValue>) -> Result<RowFormat, String> {
+    match flag_string(flags, "format") {
+        Some(value) => RowFormat::parse(value.as_str()).ok_or_else(|| {
+            format!(
+                "unknown row format '{value}'; expected {}",
+                RowFormat::vocabulary()
+            )
+        }),
+        None => Ok(RowFormat::Table),
+    }
+}
+
+fn print_row_result(result: &reddb::runtime::RuntimeQueryResult, format: RowFormat) {
+    let result = runtime_query_result_to_client(result);
+    let bytes = format_query_result(&result, format);
+    std::io::stdout().write_all(&bytes).expect("write stdout");
+}
+
+fn runtime_query_result_to_client(result: &reddb::runtime::RuntimeQueryResult) -> QueryResult {
+    let columns = if !result.result.columns.is_empty() {
+        result.result.columns.clone()
+    } else {
+        result
+            .result
+            .records
+            .first()
+            .map(|record| {
+                let mut keys: Vec<String> = record
+                    .column_names()
+                    .iter()
+                    .map(|key| key.to_string())
+                    .collect();
+                keys.sort();
+                keys
+            })
+            .unwrap_or_default()
+    };
+    let rows = result
+        .result
+        .records
+        .iter()
+        .map(|record| {
+            let mut entries: Vec<(&str, &reddb::storage::schema::Value)> = record
+                .iter_fields()
+                .map(|(key, value)| (key.as_ref(), value))
+                .collect();
+            entries.sort_by(|a, b| a.0.cmp(b.0));
+            entries
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), schema_value_to_value_out(value)))
+                .collect()
+        })
+        .collect();
+    QueryResult {
+        statement: result.statement_type.to_string(),
+        affected: result.affected_rows,
+        columns,
+        rows,
+    }
+}
+
+fn schema_value_to_value_out(value: &reddb::storage::schema::Value) -> ValueOut {
+    use reddb::storage::schema::Value;
+    match value {
+        Value::Null => ValueOut::Null,
+        Value::Boolean(value) => ValueOut::Bool(*value),
+        Value::Integer(value) => ValueOut::Integer(*value),
+        Value::UnsignedInteger(value) => i64::try_from(*value)
+            .map(ValueOut::Integer)
+            .unwrap_or_else(|_| ValueOut::String(value.to_string())),
+        Value::Float(value) => ValueOut::Float(*value),
+        Value::BigInt(value) => ValueOut::Integer(*value),
+        Value::TimestampMs(value)
+        | Value::Timestamp(value)
+        | Value::Duration(value)
+        | Value::Decimal(value) => ValueOut::Integer(*value),
+        Value::Password(_) | Value::Secret(_) => ValueOut::String("***".to_string()),
+        Value::Json(bytes) => reddb::json::from_slice::<reddb::json::Value>(bytes)
+            .ok()
+            .and_then(|json| reddb::json::to_string(&json).ok())
+            .map(ValueOut::String)
+            .unwrap_or(ValueOut::Null),
+        Value::Text(value) => ValueOut::String(value.to_string()),
+        Value::Email(value) | Value::Url(value) | Value::NodeRef(value) | Value::EdgeRef(value) => {
+            ValueOut::String(value.clone())
+        }
+        other => ValueOut::String(format!("{other}")),
     }
 }
 
@@ -1289,6 +1386,13 @@ fn main() {
 
         "query" => {
             let json_mode = wants_json(&result.flags);
+            let row_format = parse_row_format(&result.flags).unwrap_or_else(|err| {
+                if json_mode {
+                    json_error("query", &err);
+                }
+                eprintln!("query: {err}");
+                std::process::exit(1);
+            });
             // Ephemeral-store tracer (PRD #1785, issue #1786):
             // `red query <file.csv|file.tsv> <sql>` materializes the file
             // into a throwaway in-memory store and queries it. Detected
@@ -1300,6 +1404,7 @@ fn main() {
                     remaining[0].as_str(),
                     remaining[1].as_str(),
                     json_mode,
+                    row_format,
                 );
             }
             let sql = remaining.first().map(|s| s.as_str()).unwrap_or("");
@@ -1356,7 +1461,7 @@ fn main() {
                     if json_mode {
                         json_ok("query", &format_result_json(&qr));
                     } else {
-                        print!("{}", format_result_pretty(&qr));
+                        print_row_result(&qr, row_format);
                     }
                 }
                 Err(err) => {
@@ -3710,6 +3815,9 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 flags.push(cli::types::FlagSchema::new("param-type").with_description(
                     "Type override for the preceding --param \
                              (text|int|float|bool|null|vec|json).",
+                ));
+                flags.push(cli::types::FlagSchema::new("format").with_description(
+                    "Row output format for query results (table|json|ndjson|csv|tsv).",
                 ));
             }
         }

--- a/tests/grouped/cli_transport.rs
+++ b/tests/grouped/cli_transport.rs
@@ -27,6 +27,9 @@ mod e2e_issue_1588_wire_tls_bind;
 #[path = "cli_transport/e2e_issue_1786_ephemeral_query.rs"]
 mod e2e_issue_1786_ephemeral_query;
 
+#[path = "cli_transport/e2e_issue_1788_row_formats.rs"]
+mod e2e_issue_1788_row_formats;
+
 #[path = "surface_contracts/cross_binary_smoke.rs"]
 mod cross_binary_smoke;
 

--- a/tests/grouped/cli_transport/e2e_issue_1788_row_formats.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1788_row_formats.rs
@@ -1,0 +1,80 @@
+//! `red query --format` row-output process coverage (issue #1788).
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-cli-row-format-{label}-"))
+        .tempdir()
+        .expect("temp dir")
+}
+
+fn run_query(file: &str, format: &str) -> (i32, String, String) {
+    let out = Command::new(red_binary())
+        .args([
+            "query",
+            file,
+            "SELECT id, name FROM t ORDER BY id",
+            "--format",
+            format,
+        ])
+        .output()
+        .expect("spawn red query");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn red_query_accepts_each_row_format() {
+    let dir = temp_dir("all");
+    let path = dir.path().join("people.csv");
+    fs::write(&path, "id,name\n1,Ada\n2,Linus\n").expect("write fixture");
+    let path = path.display().to_string();
+
+    for (format, expected) in [
+        ("table", "id  name\n--  -----\n1   Ada\n2   Linus\n"),
+        (
+            "json",
+            "[{\"id\":1,\"name\":\"Ada\"},{\"id\":2,\"name\":\"Linus\"}]\n",
+        ),
+        (
+            "ndjson",
+            "{\"id\":1,\"name\":\"Ada\"}\n{\"id\":2,\"name\":\"Linus\"}\n",
+        ),
+        ("csv", "id,name\n1,Ada\n2,Linus\n"),
+        ("tsv", "id\tname\n1\tAda\n2\tLinus\n"),
+    ] {
+        let (code, stdout, stderr) = run_query(&path, format);
+        assert_eq!(code, 0, "{format} stderr: {stderr}");
+        assert_eq!(stdout, expected, "format {format}");
+    }
+}
+
+#[test]
+fn red_query_defaults_to_table_format() {
+    let dir = temp_dir("default");
+    let path = dir.path().join("people.csv");
+    fs::write(&path, "id,name\n1,Ada\n").expect("write fixture");
+    let out = Command::new(red_binary())
+        .args([
+            "query",
+            &path.display().to_string(),
+            "SELECT id, name FROM t ORDER BY id",
+        ])
+        .output()
+        .expect("spawn red query");
+    assert_eq!(out.status.code().unwrap_or(-1), 0);
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout),
+        "id  name\n--  ----\n1   Ada\n"
+    );
+}

--- a/tests/grouped/surface_contracts/cross_binary_smoke.rs
+++ b/tests/grouped/surface_contracts/cross_binary_smoke.rs
@@ -231,6 +231,46 @@ fn red_client_round_trips_against_red_over_grpc() {
 }
 
 #[test]
+fn red_client_accepts_each_row_format_over_grpc() {
+    let Some(red_client) = skip_if_no_red_client() else {
+        return;
+    };
+    let _guard = lock_boot();
+    let port = pick_port();
+    let _dir = support::temp_data_dir("cross-smoke-row-format");
+    let mut server = match boot_red_grpc(port, &_dir.join("data.rdb")) {
+        Ok(h) => h,
+        Err(e) => panic!("could not start `red server`: {e}"),
+    };
+
+    if !wait_for_listener("127.0.0.1", port, Duration::from_secs(15)) {
+        let (out, err) = drain_output(&mut server.child);
+        panic!("`red server` did not listen on {port} within 15s\nstdout:\n{out}\nstderr:\n{err}");
+    }
+
+    let uri = format!("grpc://127.0.0.1:{port}");
+    for (format, expected) in [
+        ("table", "LIT:1\n-----\n1\n"),
+        ("json", "[{\"LIT:1\":1}]\n"),
+        ("ndjson", "{\"LIT:1\":1}\n"),
+        ("csv", "LIT:1\n1\n"),
+        ("tsv", "LIT:1\n1\n"),
+    ] {
+        let out = Command::new(&red_client)
+            .args([&uri, "-c", "SELECT 1", "--format", format])
+            .output()
+            .expect("spawn red_client");
+        let code = out.status.code().unwrap_or(-1);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert_eq!(code, 0, "format {format}; stderr: {stderr}");
+        assert_eq!(stdout, expected, "format {format}");
+    }
+
+    server.kill();
+}
+
+#[test]
 fn red_client_round_trips_against_red_over_redwire() {
     let Some(red_client) = skip_if_no_red_client() else {
         return;


### PR DESCRIPTION
Automated AFK landing for #1788. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1788

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785944406&installation_id=129708444&pr_number=1865&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1865&signature=e995fc6fddddab885bd544f704ee692575f45fbb59b80b9565d4aee41f684636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->