### PR TITLE
merge: #1790 Commit-time effect invariant: aborted transactions leak no observable effects

### DIFF
--- a/docs/query/transactions.md
+++ b/docs/query/transactions.md
@@ -54,6 +54,19 @@ If the application crashes or the connection drops before `COMMIT`,
 in-flight transaction state is discarded because the WAL never sees a
 complete commit record.
 
+## Commit-time observable effects
+
+Observable effects fire only at `COMMIT`. Subscription event delivery,
+queue message visibility, and queue-wait notifications are not published
+while a transaction is executing. If the transaction aborts, those effects
+are discarded with the staged writes and must not be observable on any
+channel.
+
+This is an engine contract, not a best-effort behavior. It is required by
+[ADR 0071](../../.red/adr/0071-explain-never-commits.md), where
+`EXPLAIN ANALYZE` for mutating statements executes inside a transaction
+that always aborts.
+
 ## Canonical reservation recipe
 
 Use a transaction when a workflow must claim resource units, remember an

--- a/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
+++ b/tests/grouped/mvcc_transactions/docs_transaction_guarantees.rs
@@ -45,6 +45,22 @@ fn transaction_docs_name_supported_table_row_guarantees() {
 }
 
 #[test]
+fn transaction_docs_name_commit_time_observable_effect_contract() {
+    for required in [
+        "Commit-time observable effects",
+        "Observable effects fire only at `COMMIT`",
+        "Subscription event delivery",
+        "queue message visibility",
+        "queue-wait notifications",
+        "must not be observable on any\nchannel",
+        "ADR 0071",
+        "always aborts",
+    ] {
+        assert_contains(TRANSACTIONS_DOC, required);
+    }
+}
+
+#[test]
 fn transaction_docs_name_explicit_deferrals() {
     for required in [
         "Full multi-model rollout is out of scope",

--- a/tests/grouped/mvcc_transactions/e2e_commit_time_effect_invariant.rs
+++ b/tests/grouped/mvcc_transactions/e2e_commit_time_effect_invariant.rs
@@ -1,0 +1,195 @@
+//! Commit-time observable-effect invariant.
+//!
+//! ADR 0071 depends on every side channel firing only at COMMIT. These
+//! e2e checks pin the public effects that can otherwise leak from an
+//! execute-and-abort transaction: event subscriptions, queue messages,
+//! and queue-wait notifications.
+
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::{RedDBOptions, RedDBRuntime};
+
+fn open_runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime should open in-memory")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn read_count(rt: &RedDBRuntime, sql: &str) -> usize {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
+        .result
+        .records
+        .len()
+}
+
+#[test]
+fn subscription_events_are_observable_only_after_commit() {
+    let rt = open_runtime();
+    exec(
+        &rt,
+        "CREATE TABLE users (id INT, email TEXT) WITH EVENTS TO users_events",
+    );
+    exec(&rt, "QUEUE GROUP CREATE users_events readers");
+
+    set_current_connection_id(179001);
+    exec(&rt, "BEGIN");
+    exec(
+        &rt,
+        "INSERT INTO users (id, email) VALUES (1, 'abort@example.com')",
+    );
+
+    set_current_connection_id(179002);
+    assert_eq!(
+        read_count(
+            &rt,
+            "QUEUE READ users_events GROUP readers CONSUMER c1 COUNT 1"
+        ),
+        0,
+        "subscription event must not be observable before commit"
+    );
+
+    set_current_connection_id(179001);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(179002);
+    assert_eq!(
+        read_count(
+            &rt,
+            "QUEUE READ users_events GROUP readers CONSUMER c1 COUNT 1"
+        ),
+        0,
+        "aborted subscription event must not be observable"
+    );
+
+    set_current_connection_id(179001);
+    exec(&rt, "BEGIN");
+    exec(
+        &rt,
+        "INSERT INTO users (id, email) VALUES (2, 'commit@example.com')",
+    );
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(179002);
+    assert_eq!(
+        read_count(
+            &rt,
+            "QUEUE READ users_events GROUP readers CONSUMER c1 COUNT 1"
+        ),
+        1,
+        "committed subscription event must be observable"
+    );
+
+    clear_current_connection_id();
+}
+
+#[test]
+fn queue_messages_are_observable_only_after_commit() {
+    let rt = open_runtime();
+    exec(&rt, "CREATE QUEUE jobs");
+    exec(&rt, "QUEUE GROUP CREATE jobs workers");
+
+    set_current_connection_id(179011);
+    exec(&rt, "BEGIN");
+    exec(&rt, "QUEUE PUSH jobs 'abort'");
+
+    set_current_connection_id(179012);
+    assert_eq!(
+        read_count(&rt, "QUEUE READ jobs GROUP workers CONSUMER c1 COUNT 1"),
+        0,
+        "queue message must not be observable before commit"
+    );
+
+    set_current_connection_id(179011);
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(179012);
+    assert_eq!(
+        read_count(&rt, "QUEUE READ jobs GROUP workers CONSUMER c1 COUNT 1"),
+        0,
+        "aborted queue message must not be observable"
+    );
+
+    set_current_connection_id(179011);
+    exec(&rt, "BEGIN");
+    exec(&rt, "QUEUE PUSH jobs 'commit'");
+    exec(&rt, "COMMIT");
+
+    set_current_connection_id(179012);
+    assert_eq!(
+        read_count(&rt, "QUEUE READ jobs GROUP workers CONSUMER c1 COUNT 1"),
+        1,
+        "committed queue message must be observable"
+    );
+
+    clear_current_connection_id();
+}
+
+#[test]
+fn queue_wait_notifications_fire_only_after_commit() {
+    let rt = Arc::new(open_runtime());
+    exec(&rt, "CREATE QUEUE wakeups");
+    exec(&rt, "QUEUE GROUP CREATE wakeups workers");
+
+    let producer_rt = Arc::clone(&rt);
+    let producer = thread::spawn(move || {
+        set_current_connection_id(179021);
+        thread::sleep(Duration::from_millis(60));
+        exec(&producer_rt, "BEGIN");
+        exec(&producer_rt, "QUEUE PUSH wakeups 'abort'");
+        exec(&producer_rt, "ROLLBACK");
+        clear_current_connection_id();
+    });
+
+    set_current_connection_id(179022);
+    let started = Instant::now();
+    let rolled_back = rt
+        .execute_query("QUEUE READ wakeups GROUP workers CONSUMER c1 COUNT 1 WAIT 350ms")
+        .expect("rollback wait");
+    let elapsed = started.elapsed();
+    producer.join().expect("rollback producer joined");
+
+    assert!(
+        rolled_back.result.records.is_empty(),
+        "rolled-back enqueue must not deliver through a wait notification"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(300),
+        "rollback must not notify the waiter early (elapsed={elapsed:?})"
+    );
+
+    let producer_rt = Arc::clone(&rt);
+    let producer = thread::spawn(move || {
+        set_current_connection_id(179023);
+        thread::sleep(Duration::from_millis(80));
+        exec(&producer_rt, "BEGIN");
+        exec(&producer_rt, "QUEUE PUSH wakeups 'commit'");
+        exec(&producer_rt, "COMMIT");
+        clear_current_connection_id();
+    });
+
+    let started = Instant::now();
+    let committed = rt
+        .execute_query("QUEUE READ wakeups GROUP workers CONSUMER c1 COUNT 1 WAIT 5s")
+        .expect("commit wait");
+    let elapsed = started.elapsed();
+    producer.join().expect("commit producer joined");
+
+    assert_eq!(
+        committed.result.records.len(),
+        1,
+        "committed enqueue must notify the waiter and deliver"
+    );
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "commit notification should wake before the WAIT budget (elapsed={elapsed:?})"
+    );
+
+    clear_current_connection_id();
+}

--- a/tests/grouped_mvcc_transactions.rs
+++ b/tests/grouped_mvcc_transactions.rs
@@ -3,6 +3,9 @@
 #[path = "grouped/mvcc_transactions/docs_transaction_guarantees.rs"]
 mod docs_transaction_guarantees;
 
+#[path = "grouped/mvcc_transactions/e2e_commit_time_effect_invariant.rs"]
+mod e2e_commit_time_effect_invariant;
+
 #[path = "grouped/mvcc_transactions/e2e_cross_model_tx.rs"]
 mod e2e_cross_model_tx;
 


### PR DESCRIPTION
Automated AFK landing for #1790. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1790

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785947129&installation_id=129708444&pr_number=1867&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1867&signature=f360a6f0705c6419051ae4dfcffd3a08acfe38297cabf68e70c9f3b74224921c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified transaction behavior for observable side effects, including when subscription events, queue messages, and wait notifications become visible.
  * Added guidance that aborted transactions do not publish these effects.

* **Bug Fixes**
  * Added coverage to ensure side effects are only observable after `COMMIT`.
  * Improved validation around queue delivery timing and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->