### PR TITLE
merge: #1801 Ordering key core: serialized queue delivery per (consumer group, key)

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -3040,6 +3040,9 @@ pub enum QueueCommand {
         value: Value,
         side: QueueSide,
         priority: Option<i32>,
+        /// Optional per-message ordering key. Grouped delivery serializes
+        /// messages sharing this key per consumer group.
+        key: Option<String>,
         /// Per-message delayed availability (issue #722). `None` means the
         /// message is deliverable immediately. `Some(_)` resolves to an
         /// `available_at_ns` metadata field at push time; delivery paths

--- a/crates/reddb-rql/src/parser/property_tests.rs
+++ b/crates/reddb-rql/src/parser/property_tests.rs
@@ -164,6 +164,7 @@ fn arb_queue_push() -> impl Strategy<Value = QueryExpr> {
             value,
             side: QueueSide::Right,
             priority: None,
+            key: None,
             available: None,
         })
     })

--- a/crates/reddb-rql/src/parser/queue.rs
+++ b/crates/reddb-rql/src/parser/queue.rs
@@ -149,12 +149,13 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (priority, available) = self.parse_push_tail_clauses()?;
+                let (priority, key, available) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
                     side: QueueSide::Right,
                     priority,
+                    key,
                     available,
                 }))
             }
@@ -250,12 +251,13 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (_priority, available) = self.parse_push_tail_clauses()?;
+                let (_priority, key, available) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
                     side: QueueSide::Left,
                     priority: None,
+                    key,
                     available,
                 }))
             }
@@ -263,12 +265,13 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (priority, available) = self.parse_push_tail_clauses()?;
+                let (priority, key, available) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
                     side: QueueSide::Right,
                     priority,
+                    key,
                     available,
                 }))
             }
@@ -458,16 +461,18 @@ impl<'a> Parser<'a> {
         Ok((group, message_id, delivery_id, delay_ms))
     }
 
-    /// Parse the optional `PRIORITY <int>`, `DELAY <duration>`, and
-    /// `AVAILABLE AT <unix_ms>` tail of a `QUEUE PUSH` / `RPUSH` / `LPUSH`
+    /// Parse the optional `PRIORITY <int>`, `KEY '<key>'`,
+    /// `DELAY <duration>`, and `AVAILABLE AT <unix_ms>` tail of a
+    /// `QUEUE PUSH` / `RPUSH` / `LPUSH`
     /// (issue #722). Clauses may appear in any order; each may appear at
     /// most once. `AVAILABLE AT` and `DELAY` are mutually exclusive — both
     /// produce a per-message availability instant, so accepting both
     /// would force the parser to pick a winner silently.
     fn parse_push_tail_clauses(
         &mut self,
-    ) -> Result<(Option<i32>, Option<QueueAvailability>), ParseError> {
+    ) -> Result<(Option<i32>, Option<String>, Option<QueueAvailability>), ParseError> {
         let mut priority: Option<i32> = None;
+        let mut key: Option<String> = None;
         let mut available: Option<QueueAvailability> = None;
         loop {
             if self.consume(&Token::Priority)? {
@@ -478,11 +483,31 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 priority = Some(self.parse_integer()? as i32);
+            } else if self.consume(&Token::Key)? {
+                if key.is_some() {
+                    return Err(ParseError::new(
+                        "duplicate KEY clause".to_string(),
+                        self.position(),
+                    ));
+                }
+                if available.is_some() {
+                    return Err(ParseError::new(
+                        "QUEUE PUSH KEY cannot be combined with DELAY / AVAILABLE AT".to_string(),
+                        self.position(),
+                    ));
+                }
+                key = Some(self.parse_string()?);
             } else if self.peek_ident_ci("DELAY") {
                 self.advance()?;
                 if available.is_some() {
                     return Err(ParseError::new(
                         "QUEUE PUSH accepts at most one of DELAY / AVAILABLE AT".to_string(),
+                        self.position(),
+                    ));
+                }
+                if key.is_some() {
+                    return Err(ParseError::new(
+                        "QUEUE PUSH KEY cannot be combined with DELAY / AVAILABLE AT".to_string(),
                         self.position(),
                     ));
                 }
@@ -504,13 +529,19 @@ impl<'a> Parser<'a> {
                         self.position(),
                     ));
                 }
+                if key.is_some() {
+                    return Err(ParseError::new(
+                        "QUEUE PUSH KEY cannot be combined with DELAY / AVAILABLE AT".to_string(),
+                        self.position(),
+                    ));
+                }
                 let unix_ms = self.parse_integer()?.max(0) as u64;
                 available = Some(QueueAvailability::AtUnixMs(unix_ms));
             } else {
                 break;
             }
         }
-        Ok((priority, available))
+        Ok((priority, key, available))
     }
 
     /// Parse an optional `WAIT <duration>` tail (slice A of PRD #718).

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -6937,6 +6937,30 @@ fn doc_form_queue_push_raw_json_with_priority_suffix() {
 }
 
 #[test]
+fn queue_push_accepts_ordering_key_suffix() {
+    let q = parse("QUEUE PUSH tasks 'job-1' KEY 'customer-42'").unwrap();
+    let QueryExpr::QueueCommand(QueueCommand::Push { key, .. }) = q else {
+        panic!("expected Push");
+    };
+    assert_eq!(key.as_deref(), Some("customer-42"));
+}
+
+#[test]
+fn queue_push_rejects_key_with_delayed_availability() {
+    for sql in [
+        "QUEUE PUSH tasks 'job-1' KEY 'customer-42' DELAY 1s",
+        "QUEUE PUSH tasks 'job-1' AVAILABLE AT 1735689600000 KEY 'customer-42'",
+    ] {
+        let err = parse(sql).expect_err("KEY plus delayed availability must fail");
+        assert!(
+            err.to_string()
+                .contains("QUEUE PUSH KEY cannot be combined with DELAY / AVAILABLE AT"),
+            "{sql}: {err}"
+        );
+    }
+}
+
+#[test]
 fn doc_form_insert_document_with_raw_json_literal_in_values() {
     // README.md:44, landing +page.svelte:54/150/492
     let q =

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -224,6 +224,8 @@ pub(super) struct QueueMessageView {
     /// means immediate availability. Sourced from the
     /// `_available_at_ns` metadata field, populated on push.
     pub(super) available_at_ns: Option<u64>,
+    /// Optional grouped-delivery ordering key, sourced from message metadata.
+    pub(super) ordering_key: Option<String>,
 }
 
 impl QueueMessageView {
@@ -931,11 +933,18 @@ impl RedDBRuntime {
                 value,
                 side,
                 priority,
+                key,
                 available,
             } => {
                 let store = self.inner.db.store();
                 ensure_queue_exists(store.as_ref(), queue)?;
                 let config = load_queue_config(store.as_ref(), queue);
+                if key.is_some() && config.priority {
+                    return Err(RedDBError::Query(format!(
+                        "ordering key is not supported on priority queue '{}'",
+                        queue
+                    )));
+                }
                 if priority.is_some() && !config.priority {
                     return Err(RedDBError::Query(format!(
                         "queue '{}' is not a priority queue",
@@ -990,12 +999,12 @@ impl RedDBRuntime {
                         ms.saturating_mul(1_000_000)
                     }
                 });
-                if config.ttl_ms.is_some() || available_at_ns.is_some() {
+                if config.ttl_ms.is_some() || available_at_ns.is_some() || key.is_some() {
                     store
                         .set_metadata(
                             queue,
                             id,
-                            queue_message_metadata(config.ttl_ms, available_at_ns),
+                            queue_message_metadata(config.ttl_ms, available_at_ns, key.as_deref()),
                         )
                         .map_err(|err| RedDBError::Internal(err.to_string()))?;
                 }
@@ -2364,6 +2373,7 @@ pub(super) fn load_queue_message_views_with_runtime(
         .filter_map(queue_message_view_from_entity)
         .map(|mut view| {
             view.available_at_ns = read_message_available_at_ns(store, queue, view.id);
+            view.ordering_key = read_message_ordering_key(store, queue, view.id);
             view
         })
         .collect())
@@ -2387,6 +2397,7 @@ fn queue_message_view_from_entity(entity: UnifiedEntity) -> Option<QueueMessageV
         max_attempts: data.max_attempts,
         enqueued_at_ns: data.enqueued_at_ns,
         available_at_ns: None,
+        ordering_key: None,
     })
 }
 
@@ -2479,6 +2490,7 @@ fn queue_projection_default_columns() -> Vec<String> {
         "last_error",
         "enqueued_at",
         "available_at",
+        "key",
         "dlq",
         "tenant",
     ]
@@ -2513,6 +2525,13 @@ fn queue_projection_value(message: &QueueMessageView, dlq: bool, column: &str) -
         "available_at" => Some(Value::UnsignedInteger(
             message.available_at_ns.unwrap_or(message.enqueued_at_ns),
         )),
+        "key" => Some(
+            message
+                .ordering_key
+                .as_ref()
+                .map(|key| Value::text(key.clone()))
+                .unwrap_or(Value::Null),
+        ),
         "dlq" => Some(Value::Boolean(dlq)),
         "tenant" => queue_message_tenant(&message.payload).or(Some(Value::Null)),
         _ => None,
@@ -3203,7 +3222,7 @@ pub(super) fn now_ns() -> u64 {
 }
 
 pub(super) fn queue_message_ttl_metadata(ttl_ms: u64) -> Metadata {
-    queue_message_metadata(Some(ttl_ms), None)
+    queue_message_metadata(Some(ttl_ms), None, None)
 }
 
 /// Build the per-message metadata row attached to a queue message. Both
@@ -3214,6 +3233,7 @@ pub(super) fn queue_message_ttl_metadata(ttl_ms: u64) -> Metadata {
 pub(super) fn queue_message_metadata(
     ttl_ms: Option<u64>,
     available_at_ns: Option<u64>,
+    ordering_key: Option<&str>,
 ) -> Metadata {
     let mut fields = HashMap::new();
     if let Some(ttl_ms) = ttl_ms {
@@ -3230,6 +3250,12 @@ pub(super) fn queue_message_metadata(
         fields.insert(
             "_available_at_ns".to_string(),
             MetadataValue::Timestamp(at_ns),
+        );
+    }
+    if let Some(key) = ordering_key {
+        fields.insert(
+            "_ordering_key".to_string(),
+            MetadataValue::String(key.to_string()),
         );
     }
     Metadata::with_fields(fields)
@@ -3277,11 +3303,30 @@ pub(super) fn set_message_available_at_ns(
             _ => None,
         })
         .or(fallback_ttl_ms);
-    let metadata = queue_message_metadata(existing_ttl_ms, available_at_ns);
+    let existing_ordering_key = read_message_ordering_key(store, queue, message_id);
+    let metadata = queue_message_metadata(
+        existing_ttl_ms,
+        available_at_ns,
+        existing_ordering_key.as_deref(),
+    );
     match store.set_metadata(queue, message_id, metadata) {
         Ok(()) => Ok(()),
         Err(crate::storage::StoreError::CollectionNotFound(_)) => Ok(()),
         Err(err) => Err(RedDBError::Internal(err.to_string())),
+    }
+}
+
+/// Read the `_ordering_key` metadata for a queue message. Returns `None`
+/// for keyless messages or when the metadata row is absent.
+pub(super) fn read_message_ordering_key(
+    store: &UnifiedStore,
+    queue: &str,
+    message_id: EntityId,
+) -> Option<String> {
+    let md = store.get_metadata(queue, message_id)?;
+    match md.get("_ordering_key")? {
+        MetadataValue::String(value) => Some(value.clone()),
+        _ => None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/primary_queue_store.rs
+++ b/crates/reddb-server/src/runtime/primary_queue_store.rs
@@ -821,6 +821,24 @@ impl QueueStore for PrimaryQueueStore {
         }
     }
 
+    fn read_ordering_key(&self, queue: &str, message_id: MessageId) -> Option<String> {
+        let store = self.store();
+        super::impl_queue::read_message_ordering_key(
+            store.as_ref(),
+            queue,
+            EntityId::new(message_id),
+        )
+    }
+
+    fn ordering_key_in_flight(&self, queue: &str, group: &str, ordering_key: &str) -> bool {
+        self.pending_message_ids(queue, Some(group))
+            .into_iter()
+            .any(|message_id| {
+                self.read_ordering_key(queue, message_id)
+                    .is_some_and(|key| key == ordering_key)
+            })
+    }
+
     fn read_pending_payload(&self, delivery_id: &str) -> Option<Value> {
         let (_, row) = self.find_pending_by_delivery(delivery_id)?;
         self.read_message(&row.queue, row.message_id)

--- a/crates/reddb-server/src/runtime/queue_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/queue_lifecycle.rs
@@ -198,7 +198,13 @@ impl<S: QueueStore> QueueLifecycle<S> {
             }
         };
         let mut out = Vec::with_capacity(count.min(available.len()));
-        for message_id in available.into_iter().take(count) {
+        for message_id in available {
+            if out.len() >= count {
+                break;
+            }
+            if self.ordering_key_blocked(queue, group, message_id) {
+                continue;
+            }
             let deadline = now + self.config.lock_duration;
             let delivery_id = self
                 .store
@@ -270,6 +276,9 @@ impl<S: QueueStore> QueueLifecycle<S> {
         for message_id in available {
             if out.len() >= count {
                 break;
+            }
+            if self.ordering_key_blocked(queue, group, message_id) {
+                continue;
             }
             let deadline = now + self.config.lock_duration;
             let delivery_id = self
@@ -605,6 +614,12 @@ impl<S: QueueStore> QueueLifecycle<S> {
             .push(outcome);
     }
 
+    fn ordering_key_blocked(&self, queue: &str, group: &str, message_id: MessageId) -> bool {
+        self.store
+            .read_ordering_key(queue, message_id)
+            .is_some_and(|key| self.store.ordering_key_in_flight(queue, group, &key))
+    }
+
     #[cfg(test)]
     pub(crate) fn recorded_outcomes(&self) -> Vec<RetirementOutcome> {
         self.outcomes.lock().expect("outcomes poisoned").clone()
@@ -686,6 +701,62 @@ mod tests {
         assert_ne!(a[0].delivery_id, b[0].delivery_id);
         assert_ne!(a[0].payload, b[0].payload);
         assert_eq!(b[0].payload, Value::text("second"));
+    }
+
+    #[test]
+    fn work_ordering_key_skip_scan_blocks_same_key_only_for_group() {
+        let store = store_with(&[(1, "first-a"), (2, "second-a"), (3, "first-b")]);
+        store.seed_ordering_key("q", 1, "a");
+        store.seed_ordering_key("q", 2, "a");
+        store.seed_ordering_key("q", 3, "b");
+        let lc = lifecycle(store);
+
+        let first = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "alice", 1)
+            .expect("first read");
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].payload, Value::text("first-a"));
+
+        let second = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "bob", 2)
+            .expect("second read");
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].payload, Value::text("first-b"));
+
+        lc.ack(&QueueTxn::new(), &first[0].delivery_id)
+            .expect("ack first key");
+        let unblocked = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "carol", 1)
+            .expect("unblocked read");
+        assert_eq!(unblocked.len(), 1);
+        assert_eq!(unblocked[0].payload, Value::text("second-a"));
+    }
+
+    #[test]
+    fn fanout_ordering_keys_are_scoped_per_group() {
+        let store = store_with(&[(1, "first"), (2, "second")]);
+        store.seed_ordering_key("q", 1, "same");
+        store.seed_ordering_key("q", 2, "same");
+        let mut config = LifecycleConfig::default();
+        config.mode = QueueMode::Fanout;
+        let lc = QueueLifecycle::new(store, config);
+
+        let alice = lc
+            .group_read(&QueueTxn::new(), "q", "_fanout_alice", "alice", 1)
+            .expect("alice read");
+        assert_eq!(alice.len(), 1);
+        assert_eq!(alice[0].payload, Value::text("first"));
+
+        let bob = lc
+            .group_read(&QueueTxn::new(), "q", "_fanout_bob", "bob", 1)
+            .expect("bob read");
+        assert_eq!(bob.len(), 1);
+        assert_eq!(bob[0].payload, Value::text("first"));
+
+        let alice_blocked = lc
+            .group_read(&QueueTxn::new(), "q", "_fanout_alice", "alice", 1)
+            .expect("alice second read");
+        assert!(alice_blocked.is_empty());
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -264,11 +264,12 @@ const QUEUE_COLUMNS: [&str; 8] = [
     "internal",
 ];
 
-const QUEUE_PENDING_COLUMNS: [&str; 7] = [
+const QUEUE_PENDING_COLUMNS: [&str; 8] = [
     "queue",
     "group",
     "message_id",
     "delivery_id",
+    "key",
     "attempts",
     "lock_deadline",
     "locked_by",

--- a/crates/reddb-server/src/runtime/red_schema/ops_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/ops_views.rs
@@ -470,6 +470,13 @@ pub(super) fn queue_pending_snapshot(
             (lock_deadline_ms, delivery_count, delivery_id)
         };
         let attempts = delivery_count.saturating_sub(1);
+        let ordering_key = super::super::impl_queue::read_message_ordering_key(
+            store.as_ref(),
+            &queue,
+            EntityId::new(message_id),
+        )
+        .map(Value::text)
+        .unwrap_or(Value::Null);
 
         records.push(UnifiedRecord::with_schema(
             Arc::clone(&schema),
@@ -478,6 +485,7 @@ pub(super) fn queue_pending_snapshot(
                 Value::text(group),
                 Value::UnsignedInteger(message_id),
                 Value::text(delivery_id),
+                ordering_key,
                 Value::UnsignedInteger(attempts),
                 Value::TimestampMs(lock_deadline_ms as i64),
                 Value::text(consumer),

--- a/crates/reddb-server/src/runtime/replica_queue_store.rs
+++ b/crates/reddb-server/src/runtime/replica_queue_store.rs
@@ -358,6 +358,24 @@ impl QueueStore for ReplicaQueueStore {
         }
     }
 
+    fn read_ordering_key(&self, queue: &str, message_id: MessageId) -> Option<String> {
+        let store = self.store();
+        super::impl_queue::read_message_ordering_key(
+            store.as_ref(),
+            queue,
+            EntityId::new(message_id),
+        )
+    }
+
+    fn ordering_key_in_flight(&self, queue: &str, group: &str, ordering_key: &str) -> bool {
+        self.pending_message_ids(queue, Some(group))
+            .into_iter()
+            .any(|message_id| {
+                self.read_ordering_key(queue, message_id)
+                    .is_some_and(|key| key == ordering_key)
+            })
+    }
+
     fn read_pending_payload(&self, delivery_id: &str) -> Option<Value> {
         let row = self.pending_for_delivery(delivery_id)?;
         self.read_message(&row.queue, row.message_id)

--- a/crates/reddb-server/src/storage/queue/lifecycle.rs
+++ b/crates/reddb-server/src/storage/queue/lifecycle.rs
@@ -269,6 +269,12 @@ pub(crate) trait QueueStore {
     /// Read the stored payload for `message_id` on `queue`, if known.
     fn read_message(&self, queue: &str, message_id: MessageId) -> Option<Value>;
 
+    /// Read the optional ordering key stored on `message_id`.
+    fn read_ordering_key(&self, queue: &str, message_id: MessageId) -> Option<String>;
+
+    /// Whether `group` already has a pending delivery with `ordering_key`.
+    fn ordering_key_in_flight(&self, queue: &str, group: &str, ordering_key: &str) -> bool;
+
     /// Read the stored payload for the message backing `delivery_id`, if it
     /// is currently held. Used by `QueueLifecycle::nack` to capture the
     /// payload before `ack_pending` retires the underlying message.
@@ -413,6 +419,8 @@ struct State {
     /// by tests via `seed_max_attempts`; absence falls back to
     /// `DEFAULT_READ_MAX_ATTEMPTS`.
     max_attempts: HashMap<(QueueId, MessageId), u32>,
+    /// Optional ordering keys keyed by `(queue, message_id)`.
+    ordering_keys: HashMap<(QueueId, MessageId), String>,
     dlq: Vec<DlqRecord>,
 }
 
@@ -465,6 +473,14 @@ impl InMemoryQueueStore {
         state
             .payloads
             .insert((queue.to_string(), message_id), payload);
+    }
+
+    /// Associate an ordering key with `(queue, message_id)` — test helper.
+    pub(crate) fn seed_ordering_key(&self, queue: &str, message_id: MessageId, key: &str) {
+        let mut state = self.state.lock().expect("state poisoned");
+        state
+            .ordering_keys
+            .insert((queue.to_string(), message_id), key.to_string());
     }
 
     fn next_delivery_id(&self) -> DeliveryId {
@@ -581,6 +597,9 @@ impl QueueStore for InMemoryQueueStore {
         }
         state
             .payloads
+            .remove(&(entry.queue.clone(), entry.message_id));
+        state
+            .ordering_keys
             .remove(&(entry.queue.clone(), entry.message_id));
         // ack-and-delete on a WORK-mode queue tombstones the underlying
         // message — mirror the runtime-side `record_pending_tombstone`
@@ -700,6 +719,26 @@ impl QueueStore for InMemoryQueueStore {
             .cloned()
     }
 
+    fn read_ordering_key(&self, queue: &str, message_id: MessageId) -> Option<String> {
+        let state = self.state.lock().expect("state poisoned");
+        state
+            .ordering_keys
+            .get(&(queue.to_string(), message_id))
+            .cloned()
+    }
+
+    fn ordering_key_in_flight(&self, queue: &str, group: &str, ordering_key: &str) -> bool {
+        let state = self.state.lock().expect("state poisoned");
+        state.pending.values().any(|pending| {
+            pending.queue == queue
+                && pending.group == group
+                && state
+                    .ordering_keys
+                    .get(&(pending.queue.clone(), pending.message_id))
+                    .is_some_and(|key| key == ordering_key)
+        })
+    }
+
     fn read_pending_payload(&self, delivery_id: &str) -> Option<Value> {
         let state = self.state.lock().expect("state poisoned");
         let entry = state.pending.get(delivery_id)?;
@@ -769,6 +808,7 @@ impl QueueStore for InMemoryQueueStore {
             // Drop the available rows and their payloads.
             state.queues.remove(queue);
             state.payloads.retain(|(q, _), _| q != queue);
+            state.ordering_keys.retain(|(q, _), _| q != queue);
         }
 
         // Tombstones recorded after the state mutation, mirroring the

--- a/docs/data-models/queues.md
+++ b/docs/data-models/queues.md
@@ -117,6 +117,9 @@ QUEUE LPUSH tasks {"urgent":true}
 -- Push with priority (priority queues only)
 QUEUE PUSH urgent_tasks {"job":"deploy"} PRIORITY 10
 
+-- Push with an ordering key for grouped FIFO-per-entity delivery
+QUEUE PUSH tasks {"job":"invoice","account_id":"acct_123"} KEY 'acct_123'
+
 -- Delayed delivery (relative): message is durable and inspectable
 -- but not deliverable until 30 s after push.
 QUEUE PUSH tasks {"job":"reminder"} DELAY 30s
@@ -145,6 +148,29 @@ A delayed message is delivered the next time a reader runs after its
 availability instant has passed. `QUEUE READ ... WAIT <duration>`
 honours `DELAY` natively — a parked waiter wakes when the message
 becomes due, capped by the caller's `WAIT` budget.
+
+### Ordering keys
+
+`QUEUE PUSH ... KEY '<key>'` serializes grouped delivery for messages with the
+same key. For each `(consumer group, key)`, RedDB returns at most one pending
+delivery at a time; later messages with that key are skipped until the pending
+message is ACKed. Messages with different keys, and keyless messages, continue
+to deliver normally.
+
+Use one ordering key per entity when you need FIFO processing for that entity:
+for example, use `KEY 'acct_123'` for all jobs that mutate account `acct_123`
+instead of creating one queue or one consumer per account. In FANOUT queues each
+consumer group serializes the key independently, so one group's in-flight
+message does not block another group.
+
+Ordering keys apply only to grouped delivery (`QUEUE READ` plus ACK/NACK).
+Raw deque pops (`QUEUE POP`, `LPOP`, `RPOP`) intentionally stay outside the
+ordering guarantee; mixing POP consumers with keyed grouped consumers can
+observe or remove messages without respecting key serialization.
+
+Ordering keys cannot be combined with `DELAY` / `AVAILABLE AT`, and priority
+queues reject keyed pushes because delayed and priority delivery both reorder
+messages by definition.
 
 ### Pop (dequeue)
 
@@ -454,7 +480,7 @@ WHERE attempts >= 3
 LIMIT 50
 ```
 
-Queue projection columns are `id`, `payload`, `priority`, `attempts`, `last_error`, `enqueued_at`, `available_at`, `dlq`, and `tenant`.
+Queue projection columns are `id`, `payload`, `priority`, `attempts`, `last_error`, `enqueued_at`, `available_at`, `key`, `dlq`, and `tenant`.
 
 Use `QUEUE MOVE` to replay a bounded batch from one queue to another:
 
@@ -470,6 +496,7 @@ LIMIT 100
 
 - **At-least-once delivery**: unacknowledged messages reappear after crash recovery.
 - **Consumer group tracking**: per-consumer delivery state with NACK/claim support.
+- **Ordering keys**: grouped consumers receive at most one pending delivery per `(group, key)`.
 - **WAL integration**: push/pop/ack are durable via write-ahead log.
 
 ## Configuration

--- a/tests/grouped/docs_kv_queue/e2e_red_queue_pending.rs
+++ b/tests/grouped/docs_kv_queue/e2e_red_queue_pending.rs
@@ -11,11 +11,12 @@ use reddb::runtime::mvcc::{
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
 
-const QUEUE_PENDING_COLUMNS: [&str; 7] = [
+const QUEUE_PENDING_COLUMNS: [&str; 8] = [
     "queue",
     "group",
     "message_id",
     "delivery_id",
+    "key",
     "attempts",
     "lock_deadline",
     "locked_by",
@@ -23,6 +24,31 @@ const QUEUE_PENDING_COLUMNS: [&str; 7] = [
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime")
+}
+
+#[test]
+fn red_queue_pending_exposes_ordering_key() {
+    cleanup_scope();
+    let rt = runtime();
+    exec(&rt, "CREATE QUEUE keyed WITH MAX_ATTEMPTS 3");
+    exec(&rt, "QUEUE GROUP CREATE keyed workers");
+    exec(&rt, "QUEUE PUSH keyed 'job' KEY 'tenant-7'");
+    exec(
+        &rt,
+        "QUEUE READ keyed GROUP workers CONSUMER worker1 COUNT 1",
+    );
+
+    let result = rt
+        .execute_query("SELECT queue, key FROM red.queue_pending")
+        .expect("red.queue_pending select")
+        .result;
+
+    assert_eq!(result.records.len(), 1);
+    let row = &result.records[0];
+    assert_eq!(row.get("queue"), Some(&Value::text("keyed")));
+    assert_eq!(row.get("key"), Some(&Value::text("tenant-7")));
+
+    cleanup_scope();
 }
 
 fn exec(rt: &RedDBRuntime, sql: &str) {

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -695,6 +695,84 @@ fn test_fanout_queue_ack_isolation() {
 }
 
 #[test]
+fn test_ordering_key_serializes_grouped_delivery_and_exposes_key() {
+    let rt = rt();
+
+    exec(&rt, "CREATE QUEUE keyed WORK");
+    exec(&rt, "QUEUE GROUP CREATE keyed workers");
+    exec(&rt, "QUEUE PUSH keyed 'a1' KEY 'account-a'");
+    exec(&rt, "QUEUE PUSH keyed 'a2' KEY 'account-a'");
+    exec(&rt, "QUEUE PUSH keyed 'b1' KEY 'account-b'");
+
+    let first = exec(&rt, "QUEUE READ keyed GROUP workers CONSUMER alice COUNT 1");
+    assert_eq!(first.result.records.len(), 1);
+    assert_eq!(text(&first.result.records[0], "payload"), "a1");
+    let first_id = text(&first.result.records[0], "message_id");
+
+    let second = exec(&rt, "QUEUE READ keyed GROUP workers CONSUMER bob COUNT 2");
+    assert_eq!(second.result.records.len(), 1);
+    assert_eq!(text(&second.result.records[0], "payload"), "b1");
+
+    let projection = exec(&rt, "SELECT id, payload, key FROM QUEUE keyed");
+    let rows: Vec<_> = projection
+        .result
+        .records
+        .iter()
+        .map(|row| (text(row, "payload"), text(row, "key")))
+        .collect();
+    assert_eq!(
+        rows,
+        vec![
+            ("a1".to_string(), "account-a".to_string()),
+            ("a2".to_string(), "account-a".to_string()),
+            ("b1".to_string(), "account-b".to_string()),
+        ]
+    );
+
+    exec(&rt, &format!("QUEUE ACK keyed GROUP workers '{first_id}'"));
+    let unblocked = exec(&rt, "QUEUE READ keyed GROUP workers CONSUMER carol COUNT 1");
+    assert_eq!(unblocked.result.records.len(), 1);
+    assert_eq!(text(&unblocked.result.records[0], "payload"), "a2");
+}
+
+#[test]
+fn test_fanout_ordering_key_is_independent_per_consumer_group() {
+    let rt = rt();
+
+    exec(&rt, "CREATE QUEUE fanout_keyed FANOUT");
+    exec(&rt, "QUEUE PUSH fanout_keyed 'first' KEY 'tenant-1'");
+    exec(&rt, "QUEUE PUSH fanout_keyed 'second' KEY 'tenant-1'");
+
+    let alice = exec(&rt, "QUEUE READ fanout_keyed CONSUMER alice COUNT 1");
+    assert_eq!(alice.result.records.len(), 1);
+    assert_eq!(text(&alice.result.records[0], "payload"), "first");
+
+    let bob = exec(&rt, "QUEUE READ fanout_keyed CONSUMER bob COUNT 1");
+    assert_eq!(bob.result.records.len(), 1);
+    assert_eq!(text(&bob.result.records[0], "payload"), "first");
+
+    let alice_blocked = exec(&rt, "QUEUE READ fanout_keyed CONSUMER alice COUNT 1");
+    assert!(
+        alice_blocked.result.records.is_empty(),
+        "alice must not receive the second same-key message until first is ACKed"
+    );
+}
+
+#[test]
+fn test_ordering_key_rejects_priority_queue_push() {
+    let rt = rt();
+
+    exec(&rt, "CREATE QUEUE urgent_keyed PRIORITY");
+    let err = rt
+        .execute_query("QUEUE PUSH urgent_keyed 'job' KEY 'account-a'")
+        .expect_err("KEY onto priority queue must fail");
+    assert!(
+        format!("{err:?}").contains("ordering key"),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test]
 fn test_fanout_queue_dlq_per_consumer() {
     let rt = rt();
 


### PR DESCRIPTION
Automated AFK landing for #1801. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1801

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785950192&installation_id=129708444&pr_number=1868&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1868&signature=ce6b03075d0201c97d001e098fd9d53405ec49ce22629d6df327cd028c0fe7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->