### PR TITLE
merge: #1809 Persist sealed RDCC column blocks through the engine page layer; restore after restart

### DIFF
--- a/crates/reddb-file/src/physical_metadata.rs
+++ b/crates/reddb-file/src/physical_metadata.rs
@@ -1837,6 +1837,10 @@ fn hypertable_chunk_json_value(chunk: &PersistedPhysicalHypertableChunk) -> serd
             .map(page_location_json_value)
             .unwrap_or(serde_json::Value::Null),
     );
+    object.insert(
+        "columnar_derived".to_string(),
+        serde_json::Value::Bool(chunk.columnar_derived),
+    );
     serde_json::Value::Object(object)
 }
 
@@ -1844,6 +1848,14 @@ fn hypertable_chunk_from_json_value(
     value: &serde_json::Value,
 ) -> RdbFileResult<PersistedPhysicalHypertableChunk> {
     let object = expect_object(value, "hypertable chunk")?;
+    let columnar_page = match object.get("columnar_page") {
+        Some(serde_json::Value::Null) | None => None,
+        Some(value) => Some(page_location_from_json_value(value)?),
+    };
+    let columnar_derived = object
+        .get("columnar_derived")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(columnar_page.is_some());
     Ok(PersistedPhysicalHypertableChunk {
         start_ns: json_u64_required(object, "start_ns")?,
         end_ns_exclusive: json_u64_required(object, "end_ns_exclusive")?,
@@ -1858,10 +1870,8 @@ fn hypertable_chunk_from_json_value(
             Some(serde_json::Value::Null) | None => None,
             Some(value) => Some(json_u64_value(value)?),
         },
-        columnar_page: match object.get("columnar_page") {
-            Some(serde_json::Value::Null) | None => None,
-            Some(value) => Some(page_location_from_json_value(value)?),
-        },
+        columnar_page,
+        columnar_derived,
     })
 }
 

--- a/crates/reddb-file/src/physical_metadata/tests.rs
+++ b/crates/reddb-file/src/physical_metadata/tests.rs
@@ -578,6 +578,7 @@ fn physical_metadata_core_contracts_round_trip() {
                 offset: 45,
                 length: 46,
             }),
+            columnar_derived: true,
         }],
     };
     let hypertable_json = encode_persisted_physical_hypertable_json(&hypertable).unwrap();
@@ -591,4 +592,5 @@ fn physical_metadata_core_contracts_round_trip() {
             length: 46,
         })
     );
+    assert!(decoded_hypertable.chunks[0].columnar_derived);
 }

--- a/crates/reddb-file/src/physical_metadata/types.rs
+++ b/crates/reddb-file/src/physical_metadata/types.rs
@@ -172,6 +172,7 @@ pub struct PersistedPhysicalHypertableChunk {
     pub sealed: bool,
     pub ttl_override_ns: Option<u64>,
     pub columnar_page: Option<PhysicalPageLocation>,
+    pub columnar_derived: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/reddb-server/src/physical.rs
+++ b/crates/reddb-server/src/physical.rs
@@ -356,6 +356,9 @@ pub struct PhysicalHypertableChunk {
     /// `RDCC` `ColumnBlock` location; `None` → legacy row-stored. Absent on
     /// sidecars written before the feature, decoding to `None`.
     pub columnar_page: Option<crate::storage::engine::PageLocation>,
+    /// Columnar blocks are derived, rebuildable artifacts (ADR 0069), not
+    /// source-of-truth row data. Backup/restore may skip or rebuild them.
+    pub columnar_derived: bool,
 }
 
 /// A persisted hypertable spec plus all of its chunks. Stored in the

--- a/crates/reddb-server/src/physical/json_codec.rs
+++ b/crates/reddb-server/src/physical/json_codec.rs
@@ -997,12 +997,20 @@ fn hypertable_chunk_to_persisted(
                 offset: loc.offset,
                 length: loc.length,
             }),
+        columnar_derived: chunk.columnar_derived,
     }
 }
 
 fn hypertable_chunk_from_persisted(
     chunk: reddb_file::PersistedPhysicalHypertableChunk,
 ) -> PhysicalHypertableChunk {
+    let columnar_page = chunk
+        .columnar_page
+        .map(|loc| crate::storage::engine::PageLocation {
+            page_id: loc.page_id,
+            offset: loc.offset,
+            length: loc.length,
+        });
     PhysicalHypertableChunk {
         start_ns: chunk.start_ns,
         end_ns_exclusive: chunk.end_ns_exclusive,
@@ -1011,13 +1019,8 @@ fn hypertable_chunk_from_persisted(
         max_ts_ns: chunk.max_ts_ns,
         sealed: chunk.sealed,
         ttl_override_ns: chunk.ttl_override_ns,
-        columnar_page: chunk
-            .columnar_page
-            .map(|loc| crate::storage::engine::PageLocation {
-                page_id: loc.page_id,
-                offset: loc.offset,
-                length: loc.length,
-            }),
+        columnar_page,
+        columnar_derived: chunk.columnar_derived,
     }
 }
 
@@ -1141,6 +1144,7 @@ mod tests {
             sealed: true,
             ttl_override_ns: Some(99),
             columnar_page: Some(crate::storage::engine::PageLocation::new(7, 0, 1234)),
+            columnar_derived: true,
         };
         let decoded =
             hypertable_chunk_from_json(&hypertable_chunk_to_json(&chunk)).expect("decode");
@@ -1148,6 +1152,7 @@ mod tests {
             decoded.columnar_page,
             Some(crate::storage::engine::PageLocation::new(7, 0, 1234))
         );
+        assert!(decoded.columnar_derived);
         assert!(decoded.sealed);
         assert_eq!(decoded.ttl_override_ns, Some(99));
     }
@@ -1164,6 +1169,7 @@ mod tests {
         obj.insert("max_ts_ns".to_string(), JsonValue::Number(0.0));
         let decoded = hypertable_chunk_from_json(&JsonValue::Object(obj)).expect("decode");
         assert_eq!(decoded.columnar_page, None);
+        assert!(!decoded.columnar_derived);
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -228,6 +228,7 @@ impl RedDBRuntime {
         };
 
         let mut sealed_columnar = 0usize;
+        let mut changed = false;
         for meta in registry.show_chunks(collection) {
             if meta.sealed {
                 continue;
@@ -263,14 +264,28 @@ impl RedDBRuntime {
 
             match routed {
                 crate::storage::timeseries::chunk::SealedChunkStorage::Columnar(bytes) => {
-                    let page = crate::storage::engine::PageLocation::new(0, 0, bytes.len() as u32);
+                    let page = self
+                        .inner
+                        .db
+                        .write_column_block_page(&bytes)
+                        .map_err(|err| {
+                            RedDBError::Internal(format!("columnar page write failed: {err}"))
+                        })?;
                     registry.seal_chunk_columnar(&meta.id, page, bytes);
                     sealed_columnar += 1;
+                    changed = true;
                 }
                 crate::storage::timeseries::chunk::SealedChunkStorage::Row => {
                     registry.seal_chunk(&meta.id);
+                    changed = true;
                 }
             }
+        }
+        if changed {
+            self.inner
+                .db
+                .persist_metadata()
+                .map_err(|e| RedDBError::Internal(e.to_string()))?;
         }
         Ok(sealed_columnar)
     }
@@ -314,6 +329,35 @@ impl RedDBRuntime {
                 .map(|p| (p.timestamp_ns, p.value))
                 .collect(),
         )
+    }
+
+    pub fn columnar_chunk_range_scan(
+        &self,
+        collection: &str,
+        chunk_start_ns: u64,
+        start_ns: u64,
+        end_ns: u64,
+    ) -> Option<crate::storage::timeseries::chunk::PrunedColumnScan> {
+        let id = crate::storage::timeseries::ChunkId {
+            hypertable: collection.to_string(),
+            start_ns: chunk_start_ns,
+        };
+        let bytes = self.inner.db.hypertables().columnar_block(&id)?;
+        crate::storage::timeseries::chunk::query_column_block_range(&bytes, start_ns, end_ns).ok()
+    }
+
+    pub fn columnar_chunk_value_eq_scan(
+        &self,
+        collection: &str,
+        chunk_start_ns: u64,
+        target: f64,
+    ) -> Option<crate::storage::timeseries::chunk::PrunedColumnScan> {
+        let id = crate::storage::timeseries::ChunkId {
+            hypertable: collection.to_string(),
+            start_ns: chunk_start_ns,
+        };
+        let bytes = self.inner.db.hypertables().columnar_block(&id)?;
+        crate::storage::timeseries::chunk::query_column_block_value_eq(&bytes, target).ok()
     }
 
     /// Read-bridge (#861): read every point of `collection` in the

--- a/crates/reddb-server/src/storage/timeseries/hypertable.rs
+++ b/crates/reddb-server/src/storage/timeseries/hypertable.rs
@@ -254,10 +254,8 @@ struct RegistryInner {
     chunks: BTreeMap<(String, u64), ChunkMeta>,
     /// `(hypertable, start_ns)` → the sealed chunk's RDCC `ColumnBlock`
     /// bytes, populated by [`seal_chunk_columnar`](HypertableRegistry::seal_chunk_columnar)
-    /// (PRD #850, #911). RAM-resident: the migration discriminant
-    /// `ChunkMeta.columnar_page` persists across restart, but durable
-    /// engine-page persistence of these bytes is a follow-up — until the
-    /// page-write bridge lands, a columnar chunk's block lives only here.
+    /// during seal and by [`restore_columnar_block`](HypertableRegistry::restore_columnar_block)
+    /// during boot after reading the recorded engine page.
     columnar_blocks: BTreeMap<(String, u64), Vec<u8>>,
 }
 
@@ -546,10 +544,30 @@ impl HypertableRegistry {
         }
     }
 
+    /// Rehydrate a previously persisted RDCC block after boot has restored
+    /// the chunk metadata and read the recorded `ColumnBlock` page.
+    pub fn restore_columnar_block(&self, id: &ChunkId, bytes: Vec<u8>) -> bool {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let key = (id.hypertable.clone(), id.start_ns);
+        if guard
+            .chunks
+            .get(&key)
+            .is_some_and(|meta| meta.columnar_page.is_some())
+        {
+            guard.columnar_blocks.insert(key, bytes);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Fetch the RDCC `ColumnBlock` bytes recorded for a columnar-sealed
     /// chunk by [`seal_chunk_columnar`](Self::seal_chunk_columnar). `None`
-    /// for row-sealed chunks or chunks whose bytes are not RAM-resident
-    /// (e.g. after a restart, pending the durable page-write bridge).
+    /// for row-sealed chunks or chunks whose durable page could not be
+    /// rehydrated.
     pub fn columnar_block(&self, id: &ChunkId) -> Option<Vec<u8>> {
         let guard = match self.inner.lock() {
             Ok(g) => g,

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_registry.rs
@@ -1,6 +1,85 @@
 use super::*;
 
 impl RedDB {
+    pub(crate) fn write_column_block_page(
+        &self,
+        bytes: &[u8],
+    ) -> Result<crate::storage::engine::PageLocation, Box<dyn std::error::Error>> {
+        use crate::storage::engine::PageType;
+
+        let store = self.store();
+        let Some(pager) = store.pager() else {
+            return Ok(crate::storage::engine::PageLocation::new(
+                0,
+                0,
+                bytes.len() as u32,
+            ));
+        };
+        let content_size = crate::storage::engine::page::CONTENT_SIZE;
+        let page_count = bytes.len().max(1).div_ceil(content_size);
+        let mut first_page_id = None;
+        for page_index in 0..page_count {
+            let mut page = pager.allocate_page(PageType::ColumnBlock)?;
+            let page_id = page.page_id();
+            if let Some(first) = first_page_id {
+                let expected = first + page_index as u32;
+                if page_id != expected {
+                    return Err(format!(
+                        "column block page allocation was not contiguous: got {page_id}, expected {expected}"
+                    )
+                    .into());
+                }
+            } else {
+                first_page_id = Some(page_id);
+            }
+            let start = page_index * content_size;
+            let end = (start + content_size).min(bytes.len());
+            if start < end {
+                page.content_mut()[..end - start].copy_from_slice(&bytes[start..end]);
+            }
+            pager.write_page_encrypted(page_id, page)?;
+        }
+        Ok(crate::storage::engine::PageLocation::new(
+            first_page_id.expect("page_count is at least one"),
+            0,
+            bytes.len() as u32,
+        ))
+    }
+
+    pub(crate) fn read_column_block_page(
+        &self,
+        loc: crate::storage::engine::PageLocation,
+    ) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+        let store = self.store();
+        let Some(pager) = store.pager() else {
+            return Ok(None);
+        };
+        let content_size = crate::storage::engine::page::CONTENT_SIZE;
+        let mut remaining = loc.length as usize;
+        let mut page_id = loc.page_id;
+        let mut offset = loc.offset as usize;
+        let mut out = Vec::with_capacity(remaining);
+        while remaining > 0 {
+            let page = pager.read_page_decrypted(page_id)?;
+            if page.page_type()? != crate::storage::engine::PageType::ColumnBlock {
+                return Err(format!("page {page_id} is not a ColumnBlock page").into());
+            }
+            if offset > content_size {
+                return Err(format!(
+                    "column block page location offset out of bounds: {offset} > {content_size}"
+                )
+                .into());
+            }
+            let available = content_size - offset;
+            let take = remaining.min(available);
+            out.extend_from_slice(&page.content()[offset..offset + take]);
+            remaining -= take;
+            page_id = page_id.saturating_add(1);
+            offset = 0;
+        }
+        Ok(Some(out))
+    }
+
     pub fn tree_definitions(&self) -> Vec<crate::physical::PhysicalTreeDefinition> {
         self.physical_metadata()
             .map(|metadata| metadata.tree_definitions)
@@ -365,6 +444,7 @@ impl RedDB {
                     sealed: chunk.sealed,
                     ttl_override_ns: chunk.ttl_override_ns,
                     columnar_page: chunk.columnar_page,
+                    columnar_derived: chunk.columnar_page.is_some(),
                 });
         }
         registry
@@ -404,7 +484,7 @@ impl RedDB {
             }
             registry.register(spec);
             for chunk in &hypertable.chunks {
-                registry.restore_chunk(crate::storage::timeseries::ChunkMeta {
+                let meta = crate::storage::timeseries::ChunkMeta {
                     id: crate::storage::timeseries::ChunkId {
                         hypertable: hypertable.name.clone(),
                         start_ns: chunk.start_ns,
@@ -416,7 +496,15 @@ impl RedDB {
                     sealed: chunk.sealed,
                     ttl_override_ns: chunk.ttl_override_ns,
                     columnar_page: chunk.columnar_page,
-                });
+                };
+                let id = meta.id.clone();
+                let columnar_page = meta.columnar_page;
+                registry.restore_chunk(meta);
+                if let Some(loc) = columnar_page {
+                    if let Ok(Some(bytes)) = self.read_column_block_page(loc) {
+                        registry.restore_columnar_block(&id, bytes);
+                    }
+                }
             }
         }
     }

--- a/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
+++ b/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
@@ -15,10 +15,11 @@
 //!   3. No data is lost or stranded across the upgrade.
 
 use reddb_server::catalog::AnalyticalStorageConfig;
-use reddb_server::{RedDBOptions, RedDBRuntime};
+use reddb_server::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 /// 1-hour chunk interval, in nanoseconds — matches `CHUNK_INTERVAL '1h'`.
 const HOUR_NS: u64 = 3_600 * 1_000_000_000;
+const GRANULE_ROWS_PLUS_ONE: u64 = 8_193;
 
 /// Pre-existing (row-stored) data: lands wholly in the chunk starting at 0.
 const OLD_ROW: &[(u64, i64)] = &[
@@ -44,6 +45,27 @@ fn insert(rt: &RedDBRuntime, collection: &str, rows: &[(u64, i64)]) {
         ))
         .unwrap_or_else(|e| panic!("insert ({ts}, {value}): {e}"));
     }
+}
+
+fn insert_many(rt: &RedDBRuntime, collection: &str, row_count: u64) {
+    for batch_start in (0..row_count).step_by(500) {
+        let batch_end = (batch_start + 500).min(row_count);
+        let values = (batch_start..batch_end)
+            .map(|i| format!("({}, {})", i + 1, i as i64))
+            .collect::<Vec<_>>()
+            .join(", ");
+        rt.execute_query(&format!(
+            "INSERT INTO {collection} (ts, value) VALUES {values}"
+        ))
+        .unwrap_or_else(|e| panic!("insert batch {batch_start}..{batch_end}: {e}"));
+    }
+}
+
+fn open_paged_runtime(path: &std::path::Path) -> RedDBRuntime {
+    let options = RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())
+        .expect("serverless profile");
+    RedDBRuntime::with_options(options).expect("persistent runtime boots")
 }
 
 /// Flip an existing collection's contract to columnar — the "enable
@@ -151,4 +173,69 @@ fn read_bridge_prunes_chunks_outside_the_query_range() {
         .read_bridge_points("cpu", HOUR_NS, u64::MAX)
         .expect("read bridge");
     assert_eq!(only_col, want(NEW_COLUMNAR), "columnar chunk served alone");
+}
+
+#[test]
+fn durable_columnar_blocks_survive_restart_and_keep_pruning() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("columnar.rdb");
+
+    let before_range;
+    let before_eq;
+    {
+        let rt = open_paged_runtime(&path);
+        rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+            .expect("create hypertable");
+        insert_many(&rt, "cpu", GRANULE_ROWS_PLUS_ONE);
+
+        assert_eq!(
+            rt.seal_hypertable_chunks("cpu").expect("seal columnar"),
+            1,
+            "single chunk seals columnar"
+        );
+        let chunk = rt.db().hypertables().show_chunks("cpu")[0].clone();
+        assert!(
+            chunk.columnar_page.is_some_and(|loc| loc.page_id != 0),
+            "columnar seal must record a real engine page location"
+        );
+        let metadata = rt.db().physical_metadata().expect("physical metadata");
+        let persisted_chunk = &metadata.hypertables[0].chunks[0];
+        assert!(
+            persisted_chunk.columnar_derived,
+            "persisted metadata must mark columnar blocks derived"
+        );
+
+        before_range = rt
+            .columnar_chunk_range_scan("cpu", 0, 100, 120)
+            .expect("pre-restart range scan");
+        assert!(
+            before_range.granules_scanned < before_range.granules_total,
+            "selective range scan should prune granules before restart"
+        );
+        before_eq = rt
+            .columnar_chunk_value_eq_scan("cpu", 0, 42.0)
+            .expect("pre-restart equality scan");
+
+        rt.create_snapshot().expect("snapshot before restart");
+        rt.checkpoint().expect("checkpoint before restart");
+    }
+
+    let rt = open_paged_runtime(&path);
+    let after_range = rt
+        .columnar_chunk_range_scan("cpu", 0, 100, 120)
+        .expect("post-restart range scan");
+    assert_eq!(after_range.points, before_range.points);
+    assert_eq!(after_range.granules_total, before_range.granules_total);
+    assert_eq!(after_range.granules_scanned, before_range.granules_scanned);
+    assert!(
+        after_range.granules_scanned < after_range.granules_total,
+        "durable range path should keep granule pruning observable"
+    );
+
+    let after_eq = rt
+        .columnar_chunk_value_eq_scan("cpu", 0, 42.0)
+        .expect("post-restart equality scan");
+    assert_eq!(after_eq.points, before_eq.points);
+    assert_eq!(after_eq.granules_total, before_eq.granules_total);
+    assert_eq!(after_eq.granules_scanned, before_eq.granules_scanned);
 }


### PR DESCRIPTION
Automated AFK landing for #1809. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1809

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785955557&installation_id=129708444&pr_number=1869&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1869&signature=d22fe03de96923babcdf7ecdb9cd45e5a784d3ad32bfbeef47984c24ef3285ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->