### PR TITLE
merge: #1810 Route plain CREATE TIMESERIES through the chunked storage path (clean break from row-entity points)

### DIFF
--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -195,6 +195,10 @@ harness = false
 name = "concurrent_commit_bench"
 harness = false
 
+[[bench]]
+name = "timeseries_ingest_bench"
+harness = false
+
 [dev-dependencies]
 # Criterion benchmark harness for blob_cache_bench (#190).
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/crates/reddb-server/benches/timeseries_ingest_bench.rs
+++ b/crates/reddb-server/benches/timeseries_ingest_bench.rs
@@ -1,0 +1,108 @@
+//! Plain timeseries ingest benchmark (#1810).
+//!
+//! Run:
+//!   cargo bench -p reddb-io-server --bench timeseries_ingest_bench
+//!
+//! The two scenarios run in the same Criterion group so native
+//! timeseries chunk-routing throughput is measured against a local
+//! row-table insert baseline in one bench run.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use reddb_server::{RedDBOptions, RedDBRuntime};
+use std::hint::black_box;
+
+const ROWS: usize = 1_000;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn timeseries_values(rows: usize) -> String {
+    (0..rows)
+        .map(|i| {
+            format!(
+                "('cpu.usage', {:.1}, {{host: 'srv{}'}}, {})",
+                50.0 + (i % 50) as f64,
+                i % 16,
+                i as u64 * 1_000_000_000
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn row_values(rows: usize) -> String {
+    (0..rows)
+        .map(|i| {
+            format!(
+                "('cpu.usage', {:.1}, 'srv{}', {})",
+                50.0 + (i % 50) as f64,
+                i % 16,
+                i as u64 * 1_000_000_000
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn ingest_timeseries(values: &str) -> u64 {
+    let rt = runtime();
+    exec(&rt, "CREATE TIMESERIES cpu RETENTION 7 d");
+    exec(
+        &rt,
+        &format!("INSERT INTO cpu (metric, value, tags, timestamp) VALUES {values}"),
+    );
+    rt.db().hypertables().total_rows("cpu")
+}
+
+fn ingest_row_table(values: &str) -> u64 {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE TABLE cpu_rows (metric TEXT, value FLOAT, host TEXT, timestamp BIGINT)",
+    );
+    exec(
+        &rt,
+        &format!("INSERT INTO cpu_rows (metric, value, host, timestamp) VALUES {values}"),
+    );
+    rt.db()
+        .store()
+        .get_collection("cpu_rows")
+        .map(|manager| manager.stats().total_entities as u64)
+        .unwrap_or(0)
+}
+
+fn bench_timeseries_ingest(c: &mut Criterion) {
+    let ts_values = timeseries_values(ROWS);
+    let table_values = row_values(ROWS);
+
+    let mut group = c.benchmark_group("timeseries-ingest");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(ROWS as u64));
+
+    group.bench_function("plain-timeseries-chunked-native-points", |b| {
+        b.iter_batched(
+            || ts_values.clone(),
+            |values| black_box(ingest_timeseries(black_box(&values))),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("row-table-reference", |b| {
+        b.iter_batched(
+            || table_values.clone(),
+            |values| black_box(ingest_row_table(black_box(&values))),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_timeseries_ingest);
+criterion_main!(benches);

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1248,6 +1248,8 @@ impl RedDBRuntime {
             );
         }
 
+        let _ = self.inner.db.hypertables().route(collection, timestamp_ns);
+
         self.cdc_emit(
             crate::replication::cdc::ChangeOperation::Insert,
             collection,

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -7,6 +7,7 @@ use super::*;
 
 const TIMESERIES_META_COLLECTION: &str = "red_timeseries_meta";
 const COLUMNAR_PROJECTION_SIZE_FLOOR_ROWS: usize = 4;
+const DEFAULT_TIMESERIES_CHUNK_INTERVAL_NS: u64 = 86_400_000_000_000;
 
 impl RedDBRuntime {
     pub fn execute_create_timeseries(
@@ -70,21 +71,31 @@ impl RedDBRuntime {
         }
         save_timeseries_metadata(store.as_ref(), query)?;
 
-        // `CREATE HYPERTABLE` additionally registers a HypertableSpec
-        // so chunk routing + retention sweeps can address this table.
-        // Plain `CREATE TIMESERIES` leaves `hypertable` = None and the
-        // runtime behaves as before.
-        if let Some(ht) = &query.hypertable {
-            let mut spec = crate::storage::timeseries::HypertableSpec::new(
-                query.name.clone(),
-                ht.time_column.clone(),
-                ht.chunk_interval_ns,
-            );
-            if let Some(ttl) = ht.default_ttl_ns {
-                spec = spec.with_ttl_ns(ttl);
+        let spec = match &query.hypertable {
+            Some(ht) => {
+                let mut spec = crate::storage::timeseries::HypertableSpec::new(
+                    query.name.clone(),
+                    ht.time_column.clone(),
+                    ht.chunk_interval_ns,
+                );
+                if let Some(ttl) = ht.default_ttl_ns {
+                    spec = spec.with_ttl_ns(ttl);
+                }
+                spec
             }
-            self.inner.db.hypertables().register(spec);
-        }
+            None => {
+                let mut spec = crate::storage::timeseries::HypertableSpec::new(
+                    query.name.clone(),
+                    "timestamp",
+                    DEFAULT_TIMESERIES_CHUNK_INTERVAL_NS,
+                );
+                if let Some(ttl_ms) = query.retention_ms {
+                    spec = spec.with_ttl_ns(ttl_ms.saturating_mul(1_000_000));
+                }
+                spec
+            }
+        };
+        self.inner.db.hypertables().register(spec);
 
         self.invalidate_result_cache();
         self.inner
@@ -471,19 +482,22 @@ fn materialize_row_points(
 ) -> Vec<(u64, f64)> {
     let mut points: Vec<(u64, f64)> = manager
         .query_all(|entity| {
-            entity
-                .data
-                .as_row()
-                .and_then(|row| row.get_field(time_col))
-                .and_then(field_as_u64)
-                .is_some_and(|ts| ts >= start && ts < end)
+            let ts = match &entity.data {
+                EntityData::Row(row) => row.get_field(time_col).and_then(field_as_u64),
+                EntityData::TimeSeries(point) => Some(point.timestamp_ns),
+                _ => None,
+            };
+            ts.is_some_and(|ts| ts >= start && ts < end)
         })
         .iter()
-        .filter_map(|entity| {
-            let row = entity.data.as_row()?;
-            let ts = row.get_field(time_col).and_then(field_as_u64)?;
-            let value = row.get_field("value").and_then(field_as_f64).unwrap_or(0.0);
-            Some((ts, value))
+        .filter_map(|entity| match &entity.data {
+            EntityData::Row(row) => {
+                let ts = row.get_field(time_col).and_then(field_as_u64)?;
+                let value = row.get_field("value").and_then(field_as_f64).unwrap_or(0.0);
+                Some((ts, value))
+            }
+            EntityData::TimeSeries(point) => Some((point.timestamp_ns, point.value)),
+            _ => None,
         })
         .collect();
     points.sort_by_key(|(ts, _)| *ts);

--- a/crates/reddb-server/src/runtime/red_schema/model_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/model_views.rs
@@ -663,14 +663,18 @@ pub(super) fn timeseries_writes_snapshot(
         let buckets: BTreeMap<(u64, u64), u64> = manager.fold_entities_parallel(
             BTreeMap::new,
             |mut local, entity| {
-                let Some(row) = entity.data.as_row() else {
-                    return local;
-                };
-                let Some(value) = row.get_field(&time_col) else {
-                    return local;
-                };
-                let Some(ts_ns) = value_to_unsigned_ns(value) else {
-                    return local;
+                let ts_ns = match &entity.data {
+                    EntityData::Row(row) => {
+                        let Some(value) = row.get_field(&time_col) else {
+                            return local;
+                        };
+                        let Some(ts_ns) = value_to_unsigned_ns(value) else {
+                            return local;
+                        };
+                        ts_ns
+                    }
+                    EntityData::TimeSeries(point) => point.timestamp_ns,
+                    _ => return local,
                 };
                 let ts_ms = ts_ns / 1_000_000;
                 for size in &active_sizes {

--- a/docs/data-models/timeseries.md
+++ b/docs/data-models/timeseries.md
@@ -24,8 +24,9 @@ CREATE TIMESERIES cpu_metrics RETENTION 90 d
 ```
 
 `CREATE TIMESERIES` is not just documentation. It persists the collection contract as a native
-time-series model, and that is what makes `INSERT INTO cpu_metrics (...)` validate and store native
-time-series points instead of generic table rows.
+time-series model, registers an inferred 1-day chunk interval on the `timestamp` axis, and routes
+`INSERT INTO cpu_metrics (...)` through native point validation and chunk metadata instead of
+generic table rows.
 
 With downsampling policies:
 
@@ -42,6 +43,7 @@ Parameters:
 | `RETENTION` | Auto-delete data older than duration | None (keep forever) |
 | `DOWNSAMPLE` | `target:source:aggregation` policies | None |
 | `CHUNK_SIZE` | Points per chunk before sealing | 1024 |
+| Chunk interval | Inferred timestamp chunk width | 1 day |
 
 ## Inserting Data Points
 
@@ -146,33 +148,35 @@ SELECT * FROM cpu_metrics
 
 Time-series data uses a chunked storage model for efficiency:
 
-- **Points** are grouped by (metric, tags) into **chunks** of up to 1024 points
-- **Delta-of-delta encoding** for timestamps: regular intervals compress to near-zero overhead
-- **Gorilla XOR compression** for float values: similar consecutive values compress extremely well
-- **Chunks seal automatically** when full, enabling immutable compressed storage
+- **Points** are routed into timestamp chunks using the inferred `timestamp`
+  time axis and a default 1-day chunk interval
+- **SQL reads** still expose the same logical point columns (`metric`, `value`,
+  `timestamp`, `tags`), including range predicates, `time_bucket()`, and tag
+  filters
+- **Delta-of-delta encoding** compresses sealed timestamp streams
+- **Gorilla XOR compression** compresses sealed float values
 - **Retention policies** run in the maintenance cycle, dropping expired chunks
 
-## Columnar analytical storage
-
-By default a sealed chunk is stored **row-oriented**. For analytical
-workloads — large scans and aggregations over sealed history — you can opt a
-collection into **columnar** storage with the `COLUMNAR` keyword at create
-time. Sealed chunks are then written in the column-major
+Sealed chunks are stored in the column-major
 [RDCC format](../engine/columnar-chunk-format.md): each column is compressed
 with a codec matched to its shape (delta-of-delta for timestamps, Gorilla
 XOR for float values) and carries skip indexes so the reader prunes data it
-cannot need.
+cannot need. `NO COLUMNAR` is the explicit opt-out for workloads that need
+row-sealed chunks instead.
 
 ```sql
--- A columnar time-series collection.
+-- Columnar is the default; this spelling is accepted for clarity.
 CREATE TIMESERIES cpu_cold COLUMNAR RETENTION 365 d
+
+-- Opt out of RDCC sealing while keeping native chunk routing.
+CREATE TIMESERIES cpu_recent NO COLUMNAR RETENTION 7 d
 ```
 
 `COLUMNAR` is a standalone keyword and composes with the other clauses in any
 order (`RETENTION`, `CHUNK_SIZE`, `DOWNSAMPLE`, …). It is also accepted on
 `CREATE HYPERTABLE` — see [Hypertables → Columnar storage](./hypertables.md#columnar-storage).
 
-### Worked example
+### Columnar Seal Example
 
 ```sql
 -- 1. Create a columnar hypertable: sealed chunks land in RDCC form.
@@ -199,12 +203,12 @@ ingestion and recent-data queries behave identically to the row engine.
 
 | Workload | Storage |
 |:---------|:--------|
-| Analytical scans / aggregations over large sealed history | **Columnar** (`COLUMNAR`) |
-| General-purpose collections, point lookups, recent-data reads | **Row** (default) |
+| Analytical scans / aggregations over large sealed history | **Columnar** (default) |
+| General-purpose collections, point lookups, recent-data reads | **Row** (`NO COLUMNAR`) |
 
 Columnar wins when queries sweep many sealed rows but touch few columns and
-benefit from granule + bloom skipping. The row engine stays the default for
-everything else — it has lower per-chunk overhead and no transpose cost on
+benefit from granule + bloom skipping. The row seal path remains available
+for collections that want lower per-chunk overhead and no transpose cost on
 seal. The choice is per collection and fixed at create time.
 
 ## Retention Policies
@@ -232,8 +236,8 @@ mixed-TTL / per-chunk override recipes.
 
 ## Scaling out — hypertables + continuous aggregates
 
-`CREATE TIMESERIES` stays the lightest surface for a single stream.
-For workloads with many series, heavy analytics, or dashboards,
+`CREATE TIMESERIES` stays the lightest chunked surface for native points.
+For workloads with many arbitrary columns, heavy analytics, or dashboards,
 graduate to:
 
 - [**Hypertables**](./hypertables.md) — auto chunking by time, O(1)

--- a/tests/grouped/timeseries_metrics/e2e_create_hypertable.rs
+++ b/tests/grouped/timeseries_metrics/e2e_create_hypertable.rs
@@ -148,13 +148,87 @@ fn drop_hypertable_removes_registry_entry() {
 }
 
 #[test]
-fn plain_create_timeseries_does_not_register_hypertable() {
+fn plain_create_timeseries_registers_default_chunk_spec_and_routes_points() {
     let rt = rt();
     let q = QueryUseCases::new(&rt);
     q.execute(ExecuteQueryInput {
         query: "CREATE TIMESERIES legacy RETENTION 30 DAYS".into(),
     })
     .expect("create timeseries ok");
+    q.execute(ExecuteQueryInput {
+        query: "INSERT INTO legacy (metric, value, timestamp) VALUES ('cpu.idle', 94.8, 1704067200000000000)".into(),
+    })
+    .expect("insert timeseries point");
+
     let db = rt.db();
-    assert!(db.hypertables().get("legacy").is_none());
+    let spec = db
+        .hypertables()
+        .get("legacy")
+        .expect("plain timeseries registered for chunk routing");
+    assert_eq!(spec.time_column, "timestamp");
+    assert_eq!(spec.chunk_interval_ns, 86_400_000_000_000);
+    assert_eq!(spec.default_ttl_ns, Some(30 * 86_400_000_000_000));
+
+    let chunks = db.hypertables().show_chunks("legacy");
+    assert_eq!(chunks.len(), 1, "point should land in a chunk");
+    assert_eq!(chunks[0].row_count, 1);
+}
+
+#[test]
+fn plain_create_timeseries_batch_insert_seals_columnar_and_keeps_sql_reads() {
+    let rt = rt();
+    let q = QueryUseCases::new(&rt);
+    q.execute(ExecuteQueryInput {
+        query: "CREATE TIMESERIES cpu RETENTION 7 DAYS".into(),
+    })
+    .expect("create timeseries ok");
+    q.execute(ExecuteQueryInput {
+        query: "INSERT INTO cpu (metric, value, tags, timestamp) VALUES \
+                ('cpu.usage', 10.0, {host: 'srv1'}, 0), \
+                ('cpu.usage', 20.0, {host: 'srv1'}, 60000000000), \
+                ('cpu.usage', 30.0, {host: 'srv2'}, 300000000000), \
+                ('cpu.usage', 40.0, {host: 'srv2'}, 360000000000)"
+            .into(),
+    })
+    .expect("batch insert native points");
+
+    let rows = q
+        .execute(ExecuteQueryInput {
+            query:
+                "SELECT time_bucket(5m) AS bucket, avg(value) AS avg_value, count(*) AS samples \
+                    FROM cpu WHERE metric = 'cpu.usage' GROUP BY time_bucket(5m)"
+                    .into(),
+        })
+        .expect("time_bucket read");
+    assert_eq!(rows.result.records.len(), 2);
+
+    let tag_filtered = q
+        .execute(ExecuteQueryInput {
+            query: "SELECT metric, value, timestamp, tags FROM cpu WHERE tags.host = 'srv1' ORDER BY timestamp ASC".into(),
+        })
+        .expect("tag filtered read");
+    assert_eq!(tag_filtered.result.records.len(), 2);
+
+    let db = rt.db();
+    let chunks = db.hypertables().show_chunks("cpu");
+    assert_eq!(
+        chunks.len(),
+        1,
+        "batch should route through one default chunk"
+    );
+    assert_eq!(chunks[0].row_count, 4);
+
+    assert_eq!(
+        rt.seal_hypertable_chunks("cpu")
+            .expect("seal plain timeseries"),
+        1,
+        "sealed plain timeseries chunk should use columnar compression"
+    );
+    assert_eq!(rt.columnar_chunk_count("cpu"), 1);
+    assert_eq!(
+        rt.columnar_chunk_points("cpu", 0, 0, 360_000_000_000)
+            .expect("columnar chunk points")
+            .len(),
+        4
+    );
 }

--- a/tests/grouped/timeseries_remaining/e2e_issue_747_red_typed_timeseries_metrics.rs
+++ b/tests/grouped/timeseries_remaining/e2e_issue_747_red_typed_timeseries_metrics.rs
@@ -128,11 +128,14 @@ fn red_timeseries_exposes_timeseries_shaped_columns_for_plain_timeseries() {
 
     let row = find_row(&result.result.records, "name", "events").expect("events row");
     assert!(
-        !boolean(row, "is_hypertable"),
-        "plain CREATE TIMESERIES is not a hypertable"
+        boolean(row, "is_hypertable"),
+        "plain CREATE TIMESERIES uses the chunked storage path"
     );
-    assert!(matches!(row.get("time_column"), Some(Value::Null)));
-    assert!(matches!(row.get("chunk_interval_ms"), Some(Value::Null)));
+    assert_eq!(row.get("time_column"), Some(&Value::text("timestamp")));
+    assert_eq!(
+        row.get("chunk_interval_ms"),
+        Some(&Value::UnsignedInteger(86_400_000))
+    );
     assert!(matches!(row.get("oldest_ts_ms"), Some(Value::Null)));
     assert!(matches!(row.get("newest_ts_ms"), Some(Value::Null)));
     // retention 7 days → 604_800_000 ms.

--- a/tests/grouped/timeseries_remaining/e2e_issue_748_red_hypertable_chunks.rs
+++ b/tests/grouped/timeseries_remaining/e2e_issue_748_red_hypertable_chunks.rs
@@ -154,9 +154,13 @@ fn red_hypertable_chunks_marks_empty_chunks_with_null_bounds() {
 }
 
 #[test]
-fn red_hypertable_chunks_skips_non_hypertable_collections() {
+fn red_hypertable_chunks_includes_plain_timeseries_chunks() {
     let rt = rt();
     exec(&rt, "CREATE TIMESERIES legacy RETENTION 1 d");
+    exec(
+        &rt,
+        "INSERT INTO legacy (metric, value, timestamp) VALUES ('cpu.idle', 94.8, 0)",
+    );
     exec(&rt, "CREATE TABLE plain_table (id INT)");
 
     let result = select(&rt, "SELECT * FROM red.hypertable_chunks");
@@ -171,8 +175,8 @@ fn red_hypertable_chunks_skips_non_hypertable_collections() {
         })
         .collect();
     assert!(
-        !names.contains("legacy"),
-        "plain timeseries are not hypertables: {names:?}"
+        names.contains("legacy"),
+        "plain timeseries chunks should be visible: {names:?}"
     );
     assert!(
         !names.contains("plain_table"),
@@ -372,26 +376,33 @@ fn red_timeseries_writes_collection_filter_narrows_to_one_hypertable() {
 }
 
 #[test]
-fn red_timeseries_writes_skips_non_hypertable_timeseries() {
+fn red_timeseries_writes_buckets_plain_timeseries_points() {
     let rt = rt();
-    // Plain CREATE TIMESERIES does not declare a time column, so the
-    // bucketed-writes surface has nothing to bucket by — it must not
-    // emit rows for these collections.
     exec(&rt, "CREATE TIMESERIES legacy RETENTION 1 d");
+    exec(
+        &rt,
+        "INSERT INTO legacy (metric, value, timestamp) VALUES ('cpu.idle', 94.8, 0)",
+    );
 
     let result = select(&rt, "SELECT * FROM red.timeseries_writes");
     assert!(
-        result.result.records.is_empty(),
-        "plain timeseries has no time column to bucket: {:?}",
+        result.result.records.iter().any(
+            |row| matches!(row.get("collection"), Some(Value::Text(name)) if &**name == "legacy")
+        ),
+        "plain timeseries points should be bucketed: {:?}",
         result.result.records
     );
 
-    // Sanity: also no rows when filtered to that specific collection.
     let filtered = select(
         &rt,
         "SELECT * FROM red.timeseries_writes WHERE collection = 'legacy'",
     );
-    assert!(filtered.result.records.is_empty());
+    assert_eq!(filtered.result.records.len(), 3);
+    assert!(filtered
+        .result
+        .records
+        .iter()
+        .all(|row| uint(row, "events_count") == 1));
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1810. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1810

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785957669&installation_id=129708444&pr_number=1870&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1870&signature=f0c7dc47da048af1ed4bf3781d5ca0213ca47ec429af26c305d0c40ac5d923e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->