### PR TITLE
merge: #1811 Append-only segment v1 under reddb-file: format, flush, restart read-back (ADR 0041)

### DIFF
--- a/crates/reddb-file/src/append_only_segment.rs
+++ b/crates/reddb-file/src/append_only_segment.rs
@@ -1,0 +1,217 @@
+//! Append-only immutable segment v1 contract.
+//!
+//! `reddb-file` owns the disk-visible frame, codec marker, chunk sizing, and
+//! checksum validation. Runtime crates hand this module opaque row bytes.
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+pub const APPEND_ONLY_SEGMENT_FORMAT_VERSION: u32 = 1;
+pub const APPEND_ONLY_SEGMENT_CHUNK_SIZE: u32 = 512 * 1024;
+
+const MAGIC: &[u8; 8] = b"RDAOSEG1";
+const HEADER_LEN_BYTES: usize = 4;
+const DEFAULT_ZSTD_LEVEL: i32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AppendOnlySegmentCodec {
+    Zstd,
+    None,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendOnlyChunkRef {
+    pub offset: u64,
+    pub len: u32,
+    pub checksum: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendOnlySegmentMetadata {
+    pub format_version: u32,
+    pub chunk_size: u32,
+    pub codec: AppendOnlySegmentCodec,
+    pub rows: u64,
+    pub raw_len: u64,
+    pub encoded_len: u64,
+    pub chunks: Vec<AppendOnlyChunkRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendOnlySegmentRead {
+    pub metadata: AppendOnlySegmentMetadata,
+    pub codec: AppendOnlySegmentCodec,
+    pub rows: u64,
+    pub payload: Vec<u8>,
+}
+
+pub fn write_append_only_segment(
+    path: &Path,
+    payload: &[u8],
+    rows: u64,
+    codec: AppendOnlySegmentCodec,
+) -> io::Result<AppendOnlySegmentMetadata> {
+    let encoded = encode_payload(payload, codec)?;
+    let metadata = AppendOnlySegmentMetadata {
+        format_version: APPEND_ONLY_SEGMENT_FORMAT_VERSION,
+        chunk_size: APPEND_ONLY_SEGMENT_CHUNK_SIZE,
+        codec,
+        rows,
+        raw_len: payload.len() as u64,
+        encoded_len: encoded.len() as u64,
+        chunks: chunk_refs(&encoded),
+    };
+    let header = serde_json::to_vec(&metadata).map_err(invalid_data)?;
+    let header_len = u32::try_from(header.len())
+        .map_err(|_| invalid_data("append-only segment header is too large"))?;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = File::create(path)?;
+    file.write_all(MAGIC)?;
+    file.write_all(&header_len.to_le_bytes())?;
+    file.write_all(&header)?;
+    file.write_all(&encoded)?;
+    file.sync_all()?;
+    if let Some(parent) = path.parent() {
+        sync_dir(parent)?;
+    }
+    Ok(metadata)
+}
+
+pub fn read_append_only_segment(path: &Path) -> io::Result<AppendOnlySegmentRead> {
+    let bytes = fs::read(path)?;
+    if bytes.len() < MAGIC.len() + HEADER_LEN_BYTES {
+        return Err(invalid_data("append-only segment is truncated"));
+    }
+    if &bytes[..MAGIC.len()] != MAGIC {
+        return Err(invalid_data("append-only segment magic mismatch"));
+    }
+    let mut len_bytes = [0u8; HEADER_LEN_BYTES];
+    len_bytes.copy_from_slice(&bytes[MAGIC.len()..MAGIC.len() + HEADER_LEN_BYTES]);
+    let header_len = u32::from_le_bytes(len_bytes) as usize;
+    let payload_start = MAGIC.len() + HEADER_LEN_BYTES + header_len;
+    if bytes.len() < payload_start {
+        return Err(invalid_data("append-only segment header is truncated"));
+    }
+
+    let metadata: AppendOnlySegmentMetadata =
+        serde_json::from_slice(&bytes[MAGIC.len() + HEADER_LEN_BYTES..payload_start])
+            .map_err(invalid_data)?;
+    if metadata.format_version != APPEND_ONLY_SEGMENT_FORMAT_VERSION {
+        return Err(invalid_data(format!(
+            "unsupported append-only segment format version: {}",
+            metadata.format_version
+        )));
+    }
+    if metadata.chunk_size != APPEND_ONLY_SEGMENT_CHUNK_SIZE {
+        return Err(invalid_data(format!(
+            "unsupported append-only segment chunk size: {}",
+            metadata.chunk_size
+        )));
+    }
+
+    let encoded = &bytes[payload_start..];
+    if encoded.len() as u64 != metadata.encoded_len {
+        return Err(invalid_data("append-only segment payload length mismatch"));
+    }
+    let actual_chunks = chunk_refs(encoded);
+    if actual_chunks != metadata.chunks {
+        return Err(invalid_data("append-only segment chunk checksum mismatch"));
+    }
+    let payload = decode_payload(encoded, metadata.codec, metadata.raw_len)?;
+    Ok(AppendOnlySegmentRead {
+        codec: metadata.codec,
+        rows: metadata.rows,
+        metadata,
+        payload,
+    })
+}
+
+fn encode_payload(payload: &[u8], codec: AppendOnlySegmentCodec) -> io::Result<Vec<u8>> {
+    match codec {
+        AppendOnlySegmentCodec::Zstd => zstd::bulk::compress(payload, DEFAULT_ZSTD_LEVEL)
+            .map_err(|err| invalid_data(format!("zstd compress append-only segment: {err}"))),
+        AppendOnlySegmentCodec::None => Ok(payload.to_vec()),
+    }
+}
+
+fn decode_payload(
+    encoded: &[u8],
+    codec: AppendOnlySegmentCodec,
+    raw_len: u64,
+) -> io::Result<Vec<u8>> {
+    match codec {
+        AppendOnlySegmentCodec::Zstd => {
+            let max_len = usize::try_from(raw_len)
+                .map_err(|_| invalid_data("append-only segment raw_len exceeds usize"))?;
+            zstd::bulk::decompress(encoded, max_len)
+                .map_err(|err| invalid_data(format!("zstd decompress append-only segment: {err}")))
+        }
+        AppendOnlySegmentCodec::None => Ok(encoded.to_vec()),
+    }
+}
+
+fn chunk_refs(bytes: &[u8]) -> Vec<AppendOnlyChunkRef> {
+    bytes
+        .chunks(APPEND_ONLY_SEGMENT_CHUNK_SIZE as usize)
+        .scan(0u64, |offset, chunk| {
+            let current = *offset;
+            *offset += chunk.len() as u64;
+            Some(AppendOnlyChunkRef {
+                offset: current,
+                len: chunk.len() as u32,
+                checksum: crc32fast::hash(chunk),
+            })
+        })
+        .collect()
+}
+
+fn sync_dir(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+fn invalid_data(message: impl ToString) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn segment_round_trip_validates_chunk_checksums() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("segment.rseg");
+        let payload = b"row one\nrow two\n";
+
+        let metadata =
+            write_append_only_segment(&path, payload, 2, AppendOnlySegmentCodec::Zstd).unwrap();
+        let read = read_append_only_segment(&path).unwrap();
+
+        assert_eq!(read.payload, payload);
+        assert_eq!(read.rows, 2);
+        assert_eq!(read.codec, AppendOnlySegmentCodec::Zstd);
+        assert_eq!(read.metadata.chunks, metadata.chunks);
+        assert!(!read.metadata.chunks.is_empty());
+    }
+
+    #[test]
+    fn segment_none_codec_keeps_payload_plain() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("segment.rseg");
+        let payload = b"already compressed bytes";
+
+        let metadata =
+            write_append_only_segment(&path, payload, 1, AppendOnlySegmentCodec::None).unwrap();
+        let read = read_append_only_segment(&path).unwrap();
+
+        assert_eq!(metadata.codec, AppendOnlySegmentCodec::None);
+        assert_eq!(read.payload, payload);
+    }
+}

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -17,6 +17,7 @@
 #![allow(clippy::cast_possible_truncation)]
 
 pub mod ai_model_cache;
+pub mod append_only_segment;
 pub mod audit_log;
 pub mod backup_manifest;
 pub mod backup_temp;
@@ -68,6 +69,11 @@ pub use ai_model_cache::{
     write_ai_model_cache_manifest, AiModelCacheManifest, AiModelCacheManifestFile,
     AI_MODEL_CACHE_DIR_NAME, AI_MODEL_CACHE_MANIFEST_FILE, AI_MODEL_CACHE_PURGE_DIR_NAME,
     AI_MODEL_CACHE_STAGING_DIR_NAME,
+};
+pub use append_only_segment::{
+    read_append_only_segment, write_append_only_segment, AppendOnlyChunkRef,
+    AppendOnlySegmentCodec, AppendOnlySegmentMetadata, AppendOnlySegmentRead,
+    APPEND_ONLY_SEGMENT_CHUNK_SIZE, APPEND_ONLY_SEGMENT_FORMAT_VERSION,
 };
 pub use audit_log::{rotate_audit_log, AuditLogRotation};
 pub use backup_manifest::{

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -11,10 +11,16 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
 
+use crate::{
+    write_append_only_segment, AppendOnlyChunkRef, AppendOnlySegmentCodec,
+    AppendOnlySegmentMetadata,
+};
+
 const FORMAT_VERSION: u32 = 1;
 pub const MANIFEST_FILE: &str = "manifest.json";
 pub const NEXT_MANIFEST_FILE: &str = "manifest.json.next";
 pub const COLLECTIONS_DIR: &str = "collections";
+pub const APPEND_ONLY_SEGMENTS_DIR: &str = "append-only-segments";
 pub const QUARANTINE_DIR: &str = "quarantine";
 /// Directory (under a parent store's operational root) that holds store forks.
 ///
@@ -81,10 +87,23 @@ struct CollectionEntry {
     source: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AppendOnlySegmentEntry {
+    pub collection: String,
+    pub segment_id: u64,
+    pub path: String,
+    pub format_version: u32,
+    pub chunk_size: u32,
+    pub codec: AppendOnlySegmentCodec,
+    pub row_count: u64,
+    pub chunks: Vec<AppendOnlyChunkRef>,
+}
+
 #[derive(Debug, Clone)]
 struct Manifest {
     generation: u64,
     collections: BTreeMap<String, CollectionEntry>,
+    append_only_segments: BTreeMap<String, Vec<AppendOnlySegmentEntry>>,
     /// Present only for a store fork's own manifest; `None` for a parent store.
     fork_origin: Option<ForkOrigin>,
 }
@@ -111,6 +130,7 @@ impl OperationalManifest {
                 let mut manifest = Manifest {
                     generation: 0,
                     collections: BTreeMap::new(),
+                    append_only_segments: BTreeMap::new(),
                     fork_origin: None,
                 };
                 for collection in existing_collections {
@@ -131,7 +151,9 @@ impl OperationalManifest {
         };
 
         let protected_paths = self.protected_collection_paths(&manifest)?;
-        self.quarantine_unreferenced_files(&protected_paths)?;
+        self.quarantine_unreferenced_collection_files(&protected_paths)?;
+        let protected_segment_paths = active_append_only_segment_paths(&manifest);
+        self.quarantine_unreferenced_append_only_segments(&protected_segment_paths)?;
 
         let pending_drops = manifest
             .collections
@@ -156,7 +178,9 @@ impl OperationalManifest {
             manifest.generation += 1;
             self.publish(&manifest)?;
             let protected_paths = self.protected_collection_paths(&manifest)?;
-            self.quarantine_unreferenced_files(&protected_paths)?;
+            self.quarantine_unreferenced_collection_files(&protected_paths)?;
+            let protected_segment_paths = active_append_only_segment_paths(&manifest);
+            self.quarantine_unreferenced_append_only_segments(&protected_segment_paths)?;
         }
 
         Ok(completed_pending_drops)
@@ -219,6 +243,43 @@ impl OperationalManifest {
         self.publish(&manifest)
     }
 
+    pub fn publish_append_only_segment(
+        &self,
+        collection: &str,
+        segment_id: u64,
+        payload: &[u8],
+        row_count: u64,
+        codec: AppendOnlySegmentCodec,
+    ) -> io::Result<AppendOnlySegmentEntry> {
+        self.ensure_dirs()?;
+        let mut manifest = self.load_current()?.unwrap_or_else(empty_manifest);
+        if let Some(existing) = manifest
+            .append_only_segments
+            .get(collection)
+            .and_then(|segments| segments.iter().find(|entry| entry.segment_id == segment_id))
+            .cloned()
+        {
+            return Ok(existing);
+        }
+
+        let path = self.append_only_segment_file_name(collection, segment_id);
+        let metadata = write_append_only_segment(
+            &self.append_only_segments_dir().join(&path),
+            payload,
+            row_count,
+            codec,
+        )?;
+        let entry = append_only_entry(collection, segment_id, path, metadata);
+        manifest
+            .append_only_segments
+            .entry(collection.to_string())
+            .or_default()
+            .push(entry.clone());
+        manifest.generation += 1;
+        self.publish(&manifest)?;
+        Ok(entry)
+    }
+
     /// Identity of this store — its operational manifest root path. This is the
     /// value recorded as `parent_store` on any fork taken from this store, and
     /// reported by the fork listing.
@@ -274,6 +335,7 @@ impl OperationalManifest {
         let manifest = Manifest {
             generation: 0,
             collections,
+            append_only_segments: BTreeMap::new(),
             fork_origin: Some(ForkOrigin {
                 name: name.to_string(),
                 parent_store: self.store_identity(),
@@ -380,7 +442,9 @@ impl OperationalManifest {
         let _ = sync_dir(&self.forks_dir());
         if let Some(manifest) = self.load_current()? {
             let protected_paths = self.protected_collection_paths(&manifest)?;
-            self.quarantine_unreferenced_files(&protected_paths)?;
+            self.quarantine_unreferenced_collection_files(&protected_paths)?;
+            let protected_segment_paths = active_append_only_segment_paths(&manifest);
+            self.quarantine_unreferenced_append_only_segments(&protected_segment_paths)?;
         }
         Ok(true)
     }
@@ -464,6 +528,20 @@ impl OperationalManifest {
         self.quarantine_dir().join(file_name)
     }
 
+    pub fn append_only_segments_for_test(
+        &self,
+        collection: &str,
+    ) -> io::Result<Vec<AppendOnlySegmentEntry>> {
+        Ok(self
+            .load_current()?
+            .and_then(|manifest| manifest.append_only_segments.get(collection).cloned())
+            .unwrap_or_default())
+    }
+
+    pub fn append_only_segment_path_for_test(&self, file_name: &str) -> PathBuf {
+        self.append_only_segments_dir().join(file_name)
+    }
+
     pub fn write_next_manifest_for_test(&self, name: &str) -> io::Result<()> {
         self.ensure_dirs()?;
         let mut manifest = self.load_current()?.unwrap_or_else(empty_manifest);
@@ -482,6 +560,7 @@ impl OperationalManifest {
 
     fn ensure_dirs(&self) -> io::Result<()> {
         fs::create_dir_all(self.collections_dir())?;
+        fs::create_dir_all(self.append_only_segments_dir())?;
         fs::create_dir_all(self.quarantine_dir())?;
         sync_dir(&self.root)?;
         Ok(())
@@ -521,7 +600,10 @@ impl OperationalManifest {
         sync_dir(&self.collections_dir())
     }
 
-    fn quarantine_unreferenced_files(&self, active_paths: &BTreeSet<String>) -> io::Result<()> {
+    fn quarantine_unreferenced_collection_files(
+        &self,
+        active_paths: &BTreeSet<String>,
+    ) -> io::Result<()> {
         for entry in fs::read_dir(self.collections_dir())? {
             let entry = entry?;
             let file_type = entry.file_type()?;
@@ -540,8 +622,34 @@ impl OperationalManifest {
         sync_dir(&self.quarantine_dir())
     }
 
+    fn quarantine_unreferenced_append_only_segments(
+        &self,
+        active_paths: &BTreeSet<String>,
+    ) -> io::Result<()> {
+        for entry in fs::read_dir(self.append_only_segments_dir())? {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
+            if !file_type.is_file() {
+                continue;
+            }
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+            if active_paths.contains(&file_name) {
+                continue;
+            }
+            let from = entry.path();
+            let to = unique_quarantine_path(&self.quarantine_dir(), &file_name);
+            fs::rename(from, to)?;
+        }
+        sync_dir(&self.append_only_segments_dir())?;
+        sync_dir(&self.quarantine_dir())
+    }
+
     fn collections_dir(&self) -> PathBuf {
         self.root.join(COLLECTIONS_DIR)
+    }
+
+    fn append_only_segments_dir(&self) -> PathBuf {
+        self.root.join(APPEND_ONLY_SEGMENTS_DIR)
     }
 
     fn quarantine_dir(&self) -> PathBuf {
@@ -561,12 +669,17 @@ impl OperationalManifest {
         out.push_str(".rcol");
         out
     }
+
+    fn append_only_segment_file_name(&self, collection: &str, segment_id: u64) -> String {
+        format!("{}.{segment_id:020}.rseg", sanitize_component(collection))
+    }
 }
 
 fn empty_manifest() -> Manifest {
     Manifest {
         generation: 0,
         collections: BTreeMap::new(),
+        append_only_segments: BTreeMap::new(),
         fork_origin: None,
     }
 }
@@ -576,6 +689,15 @@ fn active_collection_paths(manifest: &Manifest) -> BTreeSet<String> {
         .collections
         .values()
         .filter(|entry| entry.state == CollectionState::Active)
+        .map(|entry| entry.path.clone())
+        .collect()
+}
+
+fn active_append_only_segment_paths(manifest: &Manifest) -> BTreeSet<String> {
+    manifest
+        .append_only_segments
+        .values()
+        .flatten()
         .map(|entry| entry.path.clone())
         .collect()
 }
@@ -660,10 +782,112 @@ fn manifest_from_object(object: &Map<String, Value>) -> io::Result<Manifest> {
         Some(Value::Null) | None => None,
         Some(_) => return Err(invalid_data("manifest fork_origin must be an object")),
     };
+    let append_only_segments = append_only_segments_from_object(object)?;
     Ok(Manifest {
         generation,
         collections,
+        append_only_segments,
         fork_origin,
+    })
+}
+
+fn append_only_segments_from_object(
+    object: &Map<String, Value>,
+) -> io::Result<BTreeMap<String, Vec<AppendOnlySegmentEntry>>> {
+    let Some(value) = object.get("append_only_segments") else {
+        return Ok(BTreeMap::new());
+    };
+    let segments_object = value
+        .as_object()
+        .ok_or_else(|| invalid_data("manifest append_only_segments must be an object"))?;
+    let mut out = BTreeMap::new();
+    for (collection, value) in segments_object {
+        let items = value.as_array().ok_or_else(|| {
+            invalid_data("manifest append_only_segments collection entry must be an array")
+        })?;
+        let mut entries = Vec::new();
+        for item in items {
+            let entry = item.as_object().ok_or_else(|| {
+                invalid_data("manifest append-only segment entry must be an object")
+            })?;
+            entries.push(append_only_segment_entry_from_object(collection, entry)?);
+        }
+        out.insert(collection.clone(), entries);
+    }
+    Ok(out)
+}
+
+fn append_only_segment_entry_from_object(
+    collection: &str,
+    object: &Map<String, Value>,
+) -> io::Result<AppendOnlySegmentEntry> {
+    let segment_id = object
+        .get("segment_id")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("manifest append-only segment_id is missing"))?;
+    let path = object
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_data("manifest append-only segment path is missing"))?
+        .to_string();
+    let format_version = object
+        .get("format_version")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("manifest append-only segment format_version is missing"))?
+        as u32;
+    let chunk_size = object
+        .get("chunk_size")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("manifest append-only segment chunk_size is missing"))?
+        as u32;
+    let codec = object
+        .get("codec")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_data("manifest append-only segment codec is missing"))
+        .and_then(append_only_codec_from_str)?;
+    let row_count = object
+        .get("row_count")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("manifest append-only segment row_count is missing"))?;
+    let chunks = object
+        .get("chunks")
+        .and_then(Value::as_array)
+        .ok_or_else(|| invalid_data("manifest append-only segment chunks are missing"))?
+        .iter()
+        .map(append_only_chunk_from_value)
+        .collect::<io::Result<Vec<_>>>()?;
+
+    Ok(AppendOnlySegmentEntry {
+        collection: collection.to_string(),
+        segment_id,
+        path,
+        format_version,
+        chunk_size,
+        codec,
+        row_count,
+        chunks,
+    })
+}
+
+fn append_only_chunk_from_value(value: &Value) -> io::Result<AppendOnlyChunkRef> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid_data("manifest append-only chunk must be an object"))?;
+    Ok(AppendOnlyChunkRef {
+        offset: object
+            .get("offset")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| invalid_data("manifest append-only chunk offset is missing"))?,
+        len: object
+            .get("len")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| invalid_data("manifest append-only chunk len is missing"))?
+            as u32,
+        checksum: object
+            .get("checksum")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| invalid_data("manifest append-only chunk checksum is missing"))?
+            as u32,
     })
 }
 
@@ -716,6 +940,12 @@ fn manifest_body_json(manifest: &Manifest) -> Map<String, Value> {
     object.insert("format_version".to_string(), Value::from(FORMAT_VERSION));
     object.insert("generation".to_string(), Value::from(manifest.generation));
     object.insert("collections".to_string(), Value::Object(collections));
+    if !manifest.append_only_segments.is_empty() {
+        object.insert(
+            "append_only_segments".to_string(),
+            Value::Object(append_only_segments_json(manifest)),
+        );
+    }
     // Only emit `fork_origin` for a fork's own manifest, so a parent manifest is
     // unchanged from the pre-fork format.
     if let Some(origin) = &manifest.fork_origin {
@@ -729,6 +959,86 @@ fn manifest_body_json(manifest: &Manifest) -> Map<String, Value> {
         object.insert("fork_origin".to_string(), Value::Object(origin_object));
     }
     object
+}
+
+fn append_only_segments_json(manifest: &Manifest) -> Map<String, Value> {
+    let mut collections = Map::new();
+    for (collection, entries) in &manifest.append_only_segments {
+        let items = entries
+            .iter()
+            .map(|entry| {
+                let mut object = Map::new();
+                object.insert("segment_id".to_string(), Value::from(entry.segment_id));
+                object.insert("path".to_string(), Value::String(entry.path.clone()));
+                object.insert(
+                    "format_version".to_string(),
+                    Value::from(entry.format_version),
+                );
+                object.insert("chunk_size".to_string(), Value::from(entry.chunk_size));
+                object.insert(
+                    "codec".to_string(),
+                    Value::String(append_only_codec_as_str(entry.codec).to_string()),
+                );
+                object.insert("row_count".to_string(), Value::from(entry.row_count));
+                object.insert(
+                    "chunks".to_string(),
+                    Value::Array(
+                        entry
+                            .chunks
+                            .iter()
+                            .map(|chunk| {
+                                let mut chunk_object = Map::new();
+                                chunk_object
+                                    .insert("offset".to_string(), Value::from(chunk.offset));
+                                chunk_object.insert("len".to_string(), Value::from(chunk.len));
+                                chunk_object
+                                    .insert("checksum".to_string(), Value::from(chunk.checksum));
+                                Value::Object(chunk_object)
+                            })
+                            .collect(),
+                    ),
+                );
+                Value::Object(object)
+            })
+            .collect();
+        collections.insert(collection.clone(), Value::Array(items));
+    }
+    collections
+}
+
+fn append_only_entry(
+    collection: &str,
+    segment_id: u64,
+    path: String,
+    metadata: AppendOnlySegmentMetadata,
+) -> AppendOnlySegmentEntry {
+    AppendOnlySegmentEntry {
+        collection: collection.to_string(),
+        segment_id,
+        path,
+        format_version: metadata.format_version,
+        chunk_size: metadata.chunk_size,
+        codec: metadata.codec,
+        row_count: metadata.rows,
+        chunks: metadata.chunks,
+    }
+}
+
+fn append_only_codec_as_str(codec: AppendOnlySegmentCodec) -> &'static str {
+    match codec {
+        AppendOnlySegmentCodec::Zstd => "zstd",
+        AppendOnlySegmentCodec::None => "none",
+    }
+}
+
+fn append_only_codec_from_str(value: &str) -> io::Result<AppendOnlySegmentCodec> {
+    match value {
+        "zstd" => Ok(AppendOnlySegmentCodec::Zstd),
+        "none" => Ok(AppendOnlySegmentCodec::None),
+        other => Err(invalid_data(format!(
+            "unknown append-only segment codec: {other}"
+        ))),
+    }
 }
 
 fn unique_quarantine_path(dir: &Path, file_name: &str) -> PathBuf {

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -666,7 +666,7 @@ impl RedDB {
                 segment_id,
                 &payload,
                 rows.len() as u64,
-                reddb_file::AppendOnlySegmentCodec::Zstd,
+                reddb_file::append_only_segment::AppendOnlySegmentCodec::Zstd,
             )?;
         }
         Ok(())

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -562,7 +562,7 @@ impl RedDB {
             .cloned()
             .map(super::EphemeralDataPathCleanup::new);
 
-        Self {
+        let db = Self {
             store: Arc::new(store),
             preprocessors: Arc::new(RwLock::new(Vec::new())),
             index_config: IndexConfig::default(),
@@ -585,9 +585,10 @@ impl RedDB {
             turbo_collections: std::sync::OnceLock::new(),
             turbo_rebuild_workers: parking_lot::Mutex::new(Vec::new()),
             _ephemeral_cleanup: ephemeral_cleanup,
-        }
-        .with_initialized_metadata()
-        .map_err(|err| format!("initialize RedDB metadata: {err}").into())
+        };
+        db.recover_operational_manifest()?;
+        db.with_initialized_metadata()
+            .map_err(|err| format!("initialize RedDB metadata: {err}").into())
     }
 
     /// Flush changes to disk (if persistence is enabled).
@@ -619,6 +620,7 @@ impl RedDB {
             } else {
                 self.store.save_to_file(path)?;
             }
+            self.flush_append_only_segments(path)?;
             self.persist_metadata()?;
             // Issue #674 — tie `vector.turbo` `.tv` snapshot dumps to
             // the WAL checkpoint cycle. Each turbo collection with a
@@ -628,6 +630,60 @@ impl RedDB {
             // (`StorageLayout::Minimal`) has no snapshot path and is
             // a no-op.
             self.dump_turbo_snapshots(0);
+        }
+        Ok(())
+    }
+
+    fn flush_append_only_segments(
+        &self,
+        path: &std::path::Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let manifest = reddb_file::OperationalManifest::for_db_path(path);
+        for contract in self
+            .collection_contracts()
+            .into_iter()
+            .filter(|contract| contract.append_only)
+        {
+            let Some(manager) = self.store.get_collection(&contract.name) else {
+                continue;
+            };
+            let _ = manager.force_seal();
+            let mut rows = manager.query_all(|_| true);
+            if rows.is_empty() {
+                continue;
+            }
+            rows.sort_by_key(|entity| entity.id.raw());
+            let segment_id = rows
+                .last()
+                .map(|entity| entity.id.raw())
+                .unwrap_or(rows.len() as u64);
+            let mut payload = Vec::new();
+            for entity in &rows {
+                payload.extend_from_slice(format!("{entity:?}\n").as_bytes());
+            }
+            manifest.publish_append_only_segment(
+                &contract.name,
+                segment_id,
+                &payload,
+                rows.len() as u64,
+                reddb_file::AppendOnlySegmentCodec::Zstd,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn recover_operational_manifest(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        let mut collections = self.store.list_collections();
+        collections.sort();
+        let pending_drops = reddb_file::OperationalManifest::for_db_path(path)
+            .recover_or_bootstrap(&collections)?;
+        for name in pending_drops {
+            if self.store.get_collection(&name).is_some() {
+                self.store.drop_collection(&name)?;
+            }
         }
         Ok(())
     }

--- a/tests/grouped/schema_query_core/e2e_append_only.rs
+++ b/tests/grouped/schema_query_core/e2e_append_only.rs
@@ -5,13 +5,19 @@
 //! even planned. Error messages name the table and the DDL so the
 //! operator can self-service the fix.
 //!
-//! Non-goal of this sprint: `ALTER TABLE ... SET/UNSET APPEND_ONLY`.
-//! When that lands, add a test here that flips the flag at runtime
-//! and verifies the DML surface reacts correctly — the contract
-//! mutator is the only moving piece.
+//! The physical append-only segment contract is file-owned: runtime tests
+//! assert the end-to-end flush/reopen behavior, while the segment format and
+//! manifest metadata are parsed through `reddb-file`.
+
+#[path = "../../support/mod.rs"]
+mod support;
 
 use reddb::application::ExecuteQueryInput;
-use reddb::{QueryUseCases, RedDBRuntime};
+use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
+
+fn persistent_rt(db: &support::TempDbFile) -> RedDBRuntime {
+    RedDBRuntime::with_options(RedDBOptions::persistent(db.path())).expect("persistent runtime")
+}
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("in-memory runtime")
@@ -171,4 +177,90 @@ fn append_only_still_allows_select_and_insert_returning() {
         })
         .expect("INSERT RETURNING on APPEND ONLY must succeed");
     assert_eq!(result.result.records.len(), 1);
+}
+
+#[test]
+fn append_only_checkpoint_publishes_immutable_segment_and_reopens_rows() {
+    let db = support::temp_db_file("append-only-segment-v1");
+    let rt = persistent_rt(&db);
+    {
+        let q = QueryUseCases::new(&rt);
+        exec(&q, "CREATE TABLE audit_log (id INT, msg TEXT) APPEND ONLY");
+        exec(&q, "INSERT INTO audit_log (id, msg) VALUES (1, 'hello')");
+        exec(&q, "INSERT INTO audit_log (id, msg) VALUES (2, 'world')");
+    }
+
+    rt.checkpoint()
+        .expect("checkpoint should flush append-only segment");
+
+    let manifest = reddb_file::OperationalManifest::for_db_path(db.path());
+    let segments = manifest
+        .append_only_segments_for_test("audit_log")
+        .expect("append-only segment entries");
+    assert_eq!(segments.len(), 1, "one closed segment should be published");
+    let entry = &segments[0];
+    assert_eq!(
+        entry.format_version,
+        reddb_file::APPEND_ONLY_SEGMENT_FORMAT_VERSION
+    );
+    assert_eq!(entry.chunk_size, reddb_file::APPEND_ONLY_SEGMENT_CHUNK_SIZE);
+    assert_eq!(entry.codec, reddb_file::AppendOnlySegmentCodec::Zstd);
+    assert_eq!(entry.row_count, 2);
+    assert!(
+        !entry.chunks.is_empty(),
+        "manifest entry must record chunk checksums"
+    );
+    assert!(
+        entry.chunks.iter().all(|chunk| chunk.checksum != 0),
+        "chunk checksums must be non-zero: {:?}",
+        entry.chunks
+    );
+
+    let segment_path = manifest.append_only_segment_path_for_test(&entry.path);
+    let decoded = reddb_file::read_append_only_segment(&segment_path)
+        .expect("segment bytes must decode through reddb-file");
+    assert_eq!(decoded.codec, reddb_file::AppendOnlySegmentCodec::Zstd);
+    assert_eq!(decoded.rows, 2);
+    let bytes_before_reopen = std::fs::read(&segment_path).expect("segment exists before reopen");
+
+    drop(rt);
+    let reopened = persistent_rt(&db);
+    let q = QueryUseCases::new(&reopened);
+    let result = q
+        .execute(ExecuteQueryInput {
+            query: "SELECT msg FROM audit_log ORDER BY id ASC".into(),
+        })
+        .expect("append-only rows should survive reopen");
+    assert_eq!(result.result.records.len(), 2);
+    assert!(result.result.records[0]
+        .get("msg")
+        .expect("msg column")
+        .to_string()
+        .contains("hello"));
+    assert!(result.result.records[1]
+        .get("msg")
+        .expect("msg column")
+        .to_string()
+        .contains("world"));
+
+    let bytes_after_reopen = std::fs::read(&segment_path).expect("segment exists after reopen");
+    assert_eq!(
+        bytes_after_reopen, bytes_before_reopen,
+        "closed append-only segments must not be modified in place"
+    );
+
+    let orphan = manifest.append_only_segment_path_for_test("unpublished-audit.segment");
+    std::fs::write(&orphan, b"prepared but unpublished").expect("write orphan segment");
+    drop(reopened);
+    let _ = persistent_rt(&db);
+    assert!(
+        !orphan.exists(),
+        "unpublished segment file should be quarantined"
+    );
+    assert!(
+        manifest
+            .quarantine_path_for_test("unpublished-audit.segment")
+            .exists(),
+        "orphan segment should land in operational quarantine"
+    );
 }

--- a/tests/grouped/schema_query_core/e2e_append_only.rs
+++ b/tests/grouped/schema_query_core/e2e_append_only.rs
@@ -14,6 +14,10 @@ mod support;
 
 use reddb::application::ExecuteQueryInput;
 use reddb::{QueryUseCases, RedDBOptions, RedDBRuntime};
+use reddb_file::append_only_segment::{
+    read_append_only_segment, AppendOnlySegmentCodec, APPEND_ONLY_SEGMENT_CHUNK_SIZE,
+    APPEND_ONLY_SEGMENT_FORMAT_VERSION,
+};
 
 fn persistent_rt(db: &support::TempDbFile) -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::persistent(db.path())).expect("persistent runtime")
@@ -199,12 +203,9 @@ fn append_only_checkpoint_publishes_immutable_segment_and_reopens_rows() {
         .expect("append-only segment entries");
     assert_eq!(segments.len(), 1, "one closed segment should be published");
     let entry = &segments[0];
-    assert_eq!(
-        entry.format_version,
-        reddb_file::APPEND_ONLY_SEGMENT_FORMAT_VERSION
-    );
-    assert_eq!(entry.chunk_size, reddb_file::APPEND_ONLY_SEGMENT_CHUNK_SIZE);
-    assert_eq!(entry.codec, reddb_file::AppendOnlySegmentCodec::Zstd);
+    assert_eq!(entry.format_version, APPEND_ONLY_SEGMENT_FORMAT_VERSION);
+    assert_eq!(entry.chunk_size, APPEND_ONLY_SEGMENT_CHUNK_SIZE);
+    assert_eq!(entry.codec, AppendOnlySegmentCodec::Zstd);
     assert_eq!(entry.row_count, 2);
     assert!(
         !entry.chunks.is_empty(),
@@ -217,9 +218,9 @@ fn append_only_checkpoint_publishes_immutable_segment_and_reopens_rows() {
     );
 
     let segment_path = manifest.append_only_segment_path_for_test(&entry.path);
-    let decoded = reddb_file::read_append_only_segment(&segment_path)
+    let decoded = read_append_only_segment(&segment_path)
         .expect("segment bytes must decode through reddb-file");
-    assert_eq!(decoded.codec, reddb_file::AppendOnlySegmentCodec::Zstd);
+    assert_eq!(decoded.codec, AppendOnlySegmentCodec::Zstd);
     assert_eq!(decoded.rows, 2);
     let bytes_before_reopen = std::fs::read(&segment_path).expect("segment exists before reopen");
 


### PR DESCRIPTION
Automated AFK landing for #1811. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1811

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785961071&installation_id=129708444&pr_number=1871&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1871&signature=2c8c6460847bc224214ed567aad096ad6a45900e52042b27ee76454d3c1efd84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->