### PR TITLE
merge: #1812 Probabilistic sidecar persistence: raw-byte encoding, lossless sketch total, state compaction

### DIFF
--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -6,6 +6,8 @@ use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 const PROB_HLL_STATE_PREFIX: &str = "red.probabilistic.hll.";
 const PROB_SKETCH_STATE_PREFIX: &str = "red.probabilistic.sketch.";
 const PROB_FILTER_STATE_PREFIX: &str = "red.probabilistic.filter.";
+const PROB_ENCODING_MARKER_KEY: &str = "red.probabilistic.state_encoding";
+const PROB_ENCODING_RAW_V1: &str = "raw-v1";
 
 fn probabilistic_read<'a, T>(lock: &'a RwLock<T>, _name: &str) -> RwLockReadGuard<'a, T> {
     lock.read()
@@ -70,81 +72,126 @@ enum ProbabilisticReadProjection {
     Contains { element: String, label: String },
 }
 
+struct ProbabilisticStateEntry {
+    name: String,
+    bytes: Vec<u8>,
+    migrated_from_legacy_hex: bool,
+}
+
 impl RedDBRuntime {
     pub(crate) fn load_probabilistic_state(&self) -> RedDBResult<()> {
+        let reject_legacy_hex = self.probabilistic_raw_encoding_marker();
+        let mut migrated_legacy_hex = false;
         {
-            let entries = self.latest_probabilistic_state_entries(PROB_HLL_STATE_PREFIX);
+            let entries = self.latest_probabilistic_state_entries(
+                PROB_HLL_STATE_PREFIX,
+                "HLL",
+                reject_legacy_hex,
+            )?;
             let mut hlls =
                 probabilistic_write(&self.inner.probabilistic.hlls, "probabilistic HLL store");
-            for (name, data_hex) in entries {
-                let bytes = hex::decode(&data_hex).map_err(|err| {
-                    RedDBError::Internal(format!("invalid persisted HLL state for '{name}': {err}"))
-                })?;
-                let Some(hll) =
-                    crate::storage::primitives::hyperloglog::HyperLogLog::from_bytes(bytes)
-                else {
+            for entry in entries {
+                let Some(hll) = crate::storage::primitives::hyperloglog::HyperLogLog::from_bytes(
+                    entry.bytes.clone(),
+                ) else {
                     return Err(RedDBError::Internal(format!(
-                        "invalid persisted HLL state for '{name}'"
+                        "invalid persisted HLL state for '{}'",
+                        entry.name
                     )));
                 };
-                hlls.insert(name, hll);
+                if entry.migrated_from_legacy_hex {
+                    self.persist_probabilistic_blob(
+                        PROB_HLL_STATE_PREFIX,
+                        &entry.name,
+                        &entry.bytes,
+                    )?;
+                    migrated_legacy_hex = true;
+                }
+                hlls.insert(entry.name, hll);
             }
         }
 
         {
-            let entries = self.latest_probabilistic_state_entries(PROB_SKETCH_STATE_PREFIX);
+            let entries = self.latest_probabilistic_state_entries(
+                PROB_SKETCH_STATE_PREFIX,
+                "SKETCH",
+                reject_legacy_hex,
+            )?;
             let mut sketches = probabilistic_write(
                 &self.inner.probabilistic.sketches,
                 "probabilistic sketch store",
             );
-            for (name, data_hex) in entries {
-                let bytes = hex::decode(&data_hex).map_err(|err| {
-                    RedDBError::Internal(format!(
-                        "invalid persisted SKETCH state for '{name}': {err}"
-                    ))
-                })?;
+            for entry in entries {
                 let sketch =
                     crate::storage::primitives::count_min_sketch::CountMinSketch::from_bytes(
-                        &bytes,
+                        &entry.bytes,
                     )
                     .ok_or_else(|| {
-                        RedDBError::Internal(format!("invalid persisted SKETCH state for '{name}'"))
+                        RedDBError::Internal(format!(
+                            "invalid persisted SKETCH state for '{}'",
+                            entry.name
+                        ))
                     })?;
-                sketches.insert(name, sketch);
+                if entry.migrated_from_legacy_hex {
+                    self.persist_probabilistic_blob(
+                        PROB_SKETCH_STATE_PREFIX,
+                        &entry.name,
+                        &entry.bytes,
+                    )?;
+                    migrated_legacy_hex = true;
+                }
+                sketches.insert(entry.name, sketch);
             }
         }
 
         {
-            let entries = self.latest_probabilistic_state_entries(PROB_FILTER_STATE_PREFIX);
+            let entries = self.latest_probabilistic_state_entries(
+                PROB_FILTER_STATE_PREFIX,
+                "FILTER",
+                reject_legacy_hex,
+            )?;
             let mut filters = probabilistic_write(
                 &self.inner.probabilistic.filters,
                 "probabilistic filter store",
             );
-            for (name, data_hex) in entries {
-                let bytes = hex::decode(&data_hex).map_err(|err| {
+            for entry in entries {
+                let filter = crate::storage::primitives::cuckoo_filter::CuckooFilter::from_bytes(
+                    &entry.bytes,
+                )
+                .ok_or_else(|| {
                     RedDBError::Internal(format!(
-                        "invalid persisted FILTER state for '{name}': {err}"
+                        "invalid persisted FILTER state for '{}'",
+                        entry.name
                     ))
                 })?;
-                let filter =
-                    crate::storage::primitives::cuckoo_filter::CuckooFilter::from_bytes(&bytes)
-                        .ok_or_else(|| {
-                            RedDBError::Internal(format!(
-                                "invalid persisted FILTER state for '{name}'"
-                            ))
-                        })?;
-                filters.insert(name, filter);
+                if entry.migrated_from_legacy_hex {
+                    self.persist_probabilistic_blob(
+                        PROB_FILTER_STATE_PREFIX,
+                        &entry.name,
+                        &entry.bytes,
+                    )?;
+                    migrated_legacy_hex = true;
+                }
+                filters.insert(entry.name, filter);
             }
         }
 
+        if migrated_legacy_hex {
+            self.persist_probabilistic_encoding_marker();
+        }
         Ok(())
     }
 
-    fn latest_probabilistic_state_entries(&self, prefix: &str) -> Vec<(String, String)> {
+    fn latest_probabilistic_state_entries(
+        &self,
+        prefix: &str,
+        kind: &str,
+        reject_legacy_hex: bool,
+    ) -> RedDBResult<Vec<ProbabilisticStateEntry>> {
         let Some(manager) = self.inner.db.store().get_collection("red_config") else {
-            return Vec::new();
+            return Ok(Vec::new());
         };
-        let mut latest: std::collections::HashMap<String, (u64, Option<String>)> =
+        let mut latest: std::collections::HashMap<String, (u64, Option<Value>)> =
             std::collections::HashMap::new();
         for entity in manager.query_all(|_| true) {
             let EntityData::Row(row) = &entity.data else {
@@ -160,7 +207,8 @@ impl RedDBRuntime {
                 continue;
             };
             let value = match named.get("value") {
-                Some(Value::Text(value)) => Some(value.to_string()),
+                Some(Value::Blob(value)) => Some(Value::Blob(value.clone())),
+                Some(Value::Text(value)) => Some(Value::Text(value.clone())),
                 Some(Value::Null) => None,
                 _ => continue,
             };
@@ -173,15 +221,75 @@ impl RedDBRuntime {
             }
         }
 
-        latest
-            .into_iter()
-            .filter_map(|(encoded_name, (_, value))| {
-                let value = value?;
-                let bytes = hex::decode(encoded_name).ok()?;
-                let name = String::from_utf8(bytes).ok()?;
-                Some((name, value))
-            })
-            .collect()
+        let mut entries = Vec::new();
+        for (encoded_name, (_, value)) in latest {
+            let Some(value) = value else {
+                continue;
+            };
+            let Some(name) = hex::decode(&encoded_name)
+                .ok()
+                .and_then(|bytes| String::from_utf8(bytes).ok())
+            else {
+                continue;
+            };
+            match value {
+                Value::Blob(bytes) => entries.push(ProbabilisticStateEntry {
+                    name,
+                    bytes,
+                    migrated_from_legacy_hex: false,
+                }),
+                Value::Text(data_hex) if reject_legacy_hex => {
+                    return Err(RedDBError::Internal(format!(
+                        "legacy hex-encoded {kind} state for '{name}' is rejected after probabilistic state migrated to raw bytes"
+                    )));
+                }
+                Value::Text(data_hex) => {
+                    let bytes = hex::decode(data_hex.as_ref()).map_err(|err| {
+                        RedDBError::Internal(format!(
+                            "invalid legacy hex-encoded {kind} state for '{name}': {err}"
+                        ))
+                    })?;
+                    entries.push(ProbabilisticStateEntry {
+                        name,
+                        bytes,
+                        migrated_from_legacy_hex: true,
+                    });
+                }
+                _ => {}
+            }
+        }
+        Ok(entries)
+    }
+
+    fn probabilistic_raw_encoding_marker(&self) -> bool {
+        let Some(manager) = self.inner.db.store().get_collection("red_config") else {
+            return false;
+        };
+        let mut latest: Option<(u64, bool)> = None;
+        for entity in manager.query_all(|_| true) {
+            let EntityData::Row(row) = &entity.data else {
+                continue;
+            };
+            let Some(named) = &row.named else {
+                continue;
+            };
+            let Some(Value::Text(key)) = named.get("key") else {
+                continue;
+            };
+            if key.as_ref() != PROB_ENCODING_MARKER_KEY {
+                continue;
+            }
+            let is_raw = matches!(
+                named.get("value"),
+                Some(Value::Text(value)) if value.as_ref() == PROB_ENCODING_RAW_V1
+            );
+            let entity_id = entity.id.raw();
+            match latest {
+                Some((existing_id, _)) if existing_id > entity_id => {}
+                _ => latest = Some((entity_id, is_raw)),
+            }
+        }
+        latest.map(|(_, is_raw)| is_raw).unwrap_or(false)
     }
 
     fn persist_probabilistic_blob(
@@ -191,19 +299,76 @@ impl RedDBRuntime {
         bytes: &[u8],
     ) -> RedDBResult<()> {
         let key = format!("{prefix}{}", hex::encode(name.as_bytes()));
-        self.inner
-            .db
-            .store()
-            .set_config_tree(&key, &crate::serde_json::Value::String(hex::encode(bytes)));
+        self.compact_config_key(&key);
+        self.insert_config_value(&key, Value::Blob(bytes.to_vec()))?;
+        self.persist_probabilistic_encoding_marker();
         Ok(())
     }
 
     fn delete_probabilistic_blob(&self, prefix: &str, name: &str) -> RedDBResult<()> {
         let key = format!("{prefix}{}", hex::encode(name.as_bytes()));
-        self.inner
-            .db
-            .store()
-            .set_config_tree(&key, &crate::serde_json::Value::Null);
+        self.compact_config_key(&key);
+        self.insert_config_value(&key, Value::Null)?;
+        Ok(())
+    }
+
+    fn persist_probabilistic_encoding_marker(&self) {
+        self.compact_config_key(PROB_ENCODING_MARKER_KEY);
+        let _ = self.insert_config_value(
+            PROB_ENCODING_MARKER_KEY,
+            Value::text(PROB_ENCODING_RAW_V1.to_string()),
+        );
+    }
+
+    fn compact_config_key(&self, key: &str) {
+        let store = self.inner.db.store();
+        let Some(manager) = store.get_collection("red_config") else {
+            return;
+        };
+        let ids: Vec<EntityId> = manager
+            .query_all(|_| true)
+            .into_iter()
+            .filter_map(|entity| {
+                let EntityData::Row(row) = &entity.data else {
+                    return None;
+                };
+                let named = row.named.as_ref()?;
+                let Some(Value::Text(candidate)) = named.get("key") else {
+                    return None;
+                };
+                (candidate.as_ref() == key).then_some(entity.id)
+            })
+            .collect();
+        for id in ids {
+            let _ = store.delete("red_config", id);
+        }
+    }
+
+    fn insert_config_value(&self, key: &str, value: Value) -> RedDBResult<()> {
+        let store = self.inner.db.store();
+        let _ = store.get_or_create_collection("red_config");
+        let entity = UnifiedEntity::new(
+            EntityId::new(0),
+            EntityKind::TableRow {
+                table: std::sync::Arc::from("red_config"),
+                row_id: 0,
+            },
+            EntityData::Row(crate::storage::RowData {
+                columns: Vec::new(),
+                named: Some(
+                    [
+                        ("key".to_string(), Value::text(key.to_string())),
+                        ("value".to_string(), value),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+                schema: None,
+            }),
+        );
+        store
+            .insert_auto("red_config", entity)
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
         Ok(())
     }
 

--- a/crates/reddb-server/src/storage/primitives/count_min_sketch.rs
+++ b/crates/reddb-server/src/storage/primitives/count_min_sketch.rs
@@ -102,11 +102,12 @@ impl CountMinSketch {
             + self.depth * std::mem::size_of::<Vec<u64>>()
     }
 
-    /// Serialize to bytes: [width:4][depth:4][counters...]
+    /// Serialize to bytes: [width:4][depth:4][total:8][counters...]
     pub fn as_bytes(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(8 + self.depth * self.width * 8);
+        let mut buf = Vec::with_capacity(16 + self.depth * self.width * 8);
         buf.extend_from_slice(&(self.width as u32).to_le_bytes());
         buf.extend_from_slice(&(self.depth as u32).to_le_bytes());
+        buf.extend_from_slice(&self.total.to_le_bytes());
         for row in &self.counters {
             for &val in row {
                 buf.extend_from_slice(&val.to_le_bytes());
@@ -122,22 +123,27 @@ impl CountMinSketch {
         }
         let width = u32::from_le_bytes(bytes[0..4].try_into().ok()?) as usize;
         let depth = u32::from_le_bytes(bytes[4..8].try_into().ok()?) as usize;
-        let expected = 8 + depth * width * 8;
-        if bytes.len() != expected {
+        let counters_len = depth * width * 8;
+        let legacy_len = 8 + counters_len;
+        let current_len = 16 + counters_len;
+        let (mut offset, mut total) = if bytes.len() == current_len {
+            (16, u64::from_le_bytes(bytes[8..16].try_into().ok()?))
+        } else if bytes.len() == legacy_len {
+            (8, 0)
+        } else {
             return None;
-        }
+        };
         let mut counters = vec![vec![0u64; width]; depth];
-        let mut offset = 8;
-        let mut total = 0u64;
         for row in &mut counters {
             for cell in row.iter_mut() {
                 *cell = u64::from_le_bytes(bytes[offset..offset + 8].try_into().ok()?);
                 offset += 8;
             }
         }
-        // Approximate total from first row
-        for &val in &counters[0] {
-            total = total.saturating_add(val);
+        if bytes.len() == legacy_len {
+            for &val in &counters[0] {
+                total = total.saturating_add(val);
+            }
         }
         Some(Self {
             counters,
@@ -264,6 +270,7 @@ mod tests {
         assert_eq!(restored.width(), 100);
         assert_eq!(restored.depth(), 3);
         assert!(restored.estimate(b"test") >= 42);
+        assert_eq!(restored.total(), 42);
     }
 
     #[test]

--- a/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
+++ b/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use reddb::runtime::{RedDBRuntime, RuntimeQueryResult};
 use reddb::server::RedDBServer;
 use reddb::storage::query::UnifiedRecord;
-use reddb::storage::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
 use reddb::storage::schema::Value;
+use reddb::storage::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
 use reddb::{RedDBOptions, StorageDeployPreset};
 use serde_json::{json, Value as JsonValue};
 use support::{checkpoint_and_reopen, PersistentDbPath};
@@ -315,7 +315,11 @@ fn probabilistic_state_writes_raw_blobs_and_compacts_superseded_rows() {
         state_key(PROB_FILTER_STATE_PREFIX, "sessions"),
     ] {
         let values = config_values(&rt, &key);
-        assert_eq!(values.len(), 1, "expected compacted single state row for {key}");
+        assert_eq!(
+            values.len(),
+            1,
+            "expected compacted single state row for {key}"
+        );
         assert!(
             matches!(values.first(), Some(Value::Blob(_))),
             "expected raw Blob state for {key}, got {values:?}"
@@ -344,7 +348,11 @@ fn probabilistic_legacy_hex_state_migrates_once_to_raw_blob() {
     assert_eq!(uint_value(only_record(&hll_command), "count"), 2);
 
     let values = config_values(&reopened, &key);
-    assert_eq!(values.len(), 1, "legacy row should be compacted during migration");
+    assert_eq!(
+        values.len(),
+        1,
+        "legacy row should be compacted during migration"
+    );
     assert!(
         matches!(values.first(), Some(Value::Blob(bytes)) if bytes == &raw),
         "expected migrated raw HLL state, got {values:?}"

--- a/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
+++ b/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
@@ -8,9 +8,16 @@ use std::time::Duration;
 use reddb::runtime::{RedDBRuntime, RuntimeQueryResult};
 use reddb::server::RedDBServer;
 use reddb::storage::query::UnifiedRecord;
+use reddb::storage::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
 use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, StorageDeployPreset};
 use serde_json::{json, Value as JsonValue};
 use support::{checkpoint_and_reopen, PersistentDbPath};
+
+const PROB_HLL_STATE_PREFIX: &str = "red.probabilistic.hll.";
+const PROB_SKETCH_STATE_PREFIX: &str = "red.probabilistic.sketch.";
+const PROB_FILTER_STATE_PREFIX: &str = "red.probabilistic.filter.";
+const PROB_ENCODING_MARKER_KEY: &str = "red.probabilistic.state_encoding";
 
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::in_memory().expect("runtime")
@@ -44,6 +51,104 @@ fn bool_value(row: &UnifiedRecord, column: &str) -> bool {
         Some(Value::Boolean(value)) => *value,
         other => panic!("expected bool column {column}, got {other:?}"),
     }
+}
+
+fn state_key(prefix: &str, name: &str) -> String {
+    format!("{prefix}{}", hex_encode(name.as_bytes()))
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
+fn config_values(rt: &RedDBRuntime, key: &str) -> Vec<Value> {
+    let Some(manager) = rt.db().store().get_collection("red_config") else {
+        return Vec::new();
+    };
+    manager
+        .query_all(|_| true)
+        .into_iter()
+        .filter_map(|entity| {
+            let EntityData::Row(row) = entity.data else {
+                return None;
+            };
+            let named = row.named?;
+            let Some(Value::Text(candidate)) = named.get("key") else {
+                return None;
+            };
+            if candidate.as_ref() == key {
+                named.get("value").cloned()
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn delete_config_key(rt: &RedDBRuntime, key: &str) {
+    let store = rt.db().store();
+    let Some(manager) = store.get_collection("red_config") else {
+        return;
+    };
+    let ids: Vec<EntityId> = manager
+        .query_all(|_| true)
+        .into_iter()
+        .filter_map(|entity| {
+            let EntityData::Row(row) = &entity.data else {
+                return None;
+            };
+            let named = row.named.as_ref()?;
+            let Some(Value::Text(candidate)) = named.get("key") else {
+                return None;
+            };
+            (candidate.as_ref() == key).then_some(entity.id)
+        })
+        .collect();
+    for id in ids {
+        store
+            .delete("red_config", id)
+            .expect("delete seeded config row");
+    }
+}
+
+fn insert_config_value(rt: &RedDBRuntime, key: &str, value: Value) {
+    let store = rt.db().store();
+    let _ = store.get_or_create_collection("red_config");
+    let entity = UnifiedEntity::new(
+        EntityId::new(0),
+        EntityKind::TableRow {
+            table: std::sync::Arc::from("red_config"),
+            row_id: 0,
+        },
+        EntityData::Row(RowData {
+            columns: Vec::new(),
+            named: Some(
+                [
+                    ("key".to_string(), Value::text(key.to_string())),
+                    ("value".to_string(), value),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            schema: None,
+        }),
+    );
+    store
+        .insert_auto("red_config", entity)
+        .expect("insert seeded config row");
+}
+
+fn open_persistent_runtime(path: &std::path::Path) -> Result<RedDBRuntime, String> {
+    let path = path.to_string_lossy().to_string();
+    let options = RedDBOptions::persistent(&path)
+        .with_storage_profile(StorageDeployPreset::Serverless.selection())?;
+    RedDBRuntime::with_options(options).map_err(|err| format!("{err:?}"))
 }
 
 fn spawn_http_server() -> (support::TempDbFile, String) {
@@ -148,9 +253,11 @@ fn probabilistic_state_survives_reopen_for_commands_and_sql_read_forms() {
 
     exec(&rt, "CREATE SKETCH clicks");
     exec(&rt, "SKETCH ADD clicks 'signup' 5");
+    exec(&rt, "SKETCH ADD clicks 'login' 2");
 
     exec(&rt, "CREATE FILTER sessions");
     exec(&rt, "FILTER ADD sessions 'sess:abc'");
+    exec(&rt, "FILTER ADD sessions 'sess:def'");
 
     let reopened = checkpoint_and_reopen(&path, rt);
 
@@ -165,18 +272,123 @@ fn probabilistic_state_survives_reopen_for_commands_and_sql_read_forms() {
 
     let sketch_command = exec(&reopened, "SKETCH COUNT clicks 'signup'");
     assert_eq!(uint_value(only_record(&sketch_command), "estimate"), 5);
+    let sketch_info = exec(&reopened, "SKETCH INFO clicks");
+    assert_eq!(uint_value(only_record(&sketch_info), "total"), 7);
     let sketch_sql = exec(&reopened, "SELECT FREQ('signup') AS freq FROM clicks");
     assert_eq!(sketch_sql.result.columns, vec!["freq"]);
     assert_eq!(uint_value(only_record(&sketch_sql), "freq"), 5);
 
     let filter_command = exec(&reopened, "FILTER CHECK sessions 'sess:abc'");
     assert!(bool_value(only_record(&filter_command), "exists"));
+    let filter_info = exec(&reopened, "FILTER INFO sessions");
+    assert_eq!(uint_value(only_record(&filter_info), "count"), 2);
     let filter_sql = exec(
         &reopened,
         "SELECT CONTAINS('sess:abc') AS hit FROM sessions",
     );
     assert_eq!(filter_sql.result.columns, vec!["hit"]);
     assert!(bool_value(only_record(&filter_sql), "hit"));
+}
+
+#[test]
+fn probabilistic_state_writes_raw_blobs_and_compacts_superseded_rows() {
+    let rt = runtime();
+
+    exec(&rt, "CREATE HLL visitors");
+    for i in 0..8 {
+        exec(&rt, &format!("HLL ADD visitors 'user-{i}'"));
+    }
+
+    exec(&rt, "CREATE SKETCH clicks WIDTH 16 DEPTH 3");
+    for i in 0..8 {
+        exec(&rt, &format!("SKETCH ADD clicks 'button-{i}' {}", i + 1));
+    }
+
+    exec(&rt, "CREATE FILTER sessions CAPACITY 100");
+    for i in 0..8 {
+        exec(&rt, &format!("FILTER ADD sessions 'sess-{i}'"));
+    }
+
+    for key in [
+        state_key(PROB_HLL_STATE_PREFIX, "visitors"),
+        state_key(PROB_SKETCH_STATE_PREFIX, "clicks"),
+        state_key(PROB_FILTER_STATE_PREFIX, "sessions"),
+    ] {
+        let values = config_values(&rt, &key);
+        assert_eq!(values.len(), 1, "expected compacted single state row for {key}");
+        assert!(
+            matches!(values.first(), Some(Value::Blob(_))),
+            "expected raw Blob state for {key}, got {values:?}"
+        );
+    }
+}
+
+#[test]
+fn probabilistic_legacy_hex_state_migrates_once_to_raw_blob() {
+    let path = PersistentDbPath::new("probabilistic_legacy_migration");
+    let rt = path.open_runtime();
+
+    exec(&rt, "CREATE HLL visitors");
+    exec(&rt, "HLL ADD visitors 'alice' 'bob'");
+    let key = state_key(PROB_HLL_STATE_PREFIX, "visitors");
+    let raw = match config_values(&rt, &key).pop() {
+        Some(Value::Blob(bytes)) => bytes,
+        other => panic!("expected raw HLL state before legacy seed, got {other:?}"),
+    };
+    delete_config_key(&rt, PROB_ENCODING_MARKER_KEY);
+    delete_config_key(&rt, &key);
+    insert_config_value(&rt, &key, Value::text(hex_encode(&raw)));
+
+    let reopened = checkpoint_and_reopen(&path, rt);
+    let hll_command = exec(&reopened, "HLL COUNT visitors");
+    assert_eq!(uint_value(only_record(&hll_command), "count"), 2);
+
+    let values = config_values(&reopened, &key);
+    assert_eq!(values.len(), 1, "legacy row should be compacted during migration");
+    assert!(
+        matches!(values.first(), Some(Value::Blob(bytes)) if bytes == &raw),
+        "expected migrated raw HLL state, got {values:?}"
+    );
+    assert!(
+        matches!(
+            config_values(&reopened, PROB_ENCODING_MARKER_KEY).last(),
+            Some(Value::Text(value)) if value.as_ref() == "raw-v1"
+        ),
+        "migration should stamp the raw encoding marker"
+    );
+}
+
+#[test]
+fn probabilistic_legacy_hex_state_is_rejected_after_raw_marker() {
+    let dir = tempfile::Builder::new()
+        .prefix("reddb-probabilistic-legacy-reject-")
+        .tempdir()
+        .expect("temp dir");
+    let path = dir.path().join("data.rdb");
+    let rt = open_persistent_runtime(&path).expect("open runtime");
+
+    exec(&rt, "CREATE HLL visitors");
+    exec(&rt, "HLL ADD visitors 'alice'");
+    let key = state_key(PROB_HLL_STATE_PREFIX, "visitors");
+    let raw = match config_values(&rt, &key).pop() {
+        Some(Value::Blob(bytes)) => bytes,
+        other => panic!("expected raw HLL state before legacy append, got {other:?}"),
+    };
+    insert_config_value(&rt, &key, Value::text(hex_encode(&raw)));
+
+    let native = reddb::NativeUseCases::new(&rt);
+    native.create_snapshot().expect("snapshot");
+    native.checkpoint().expect("checkpoint");
+    drop(rt);
+
+    let message = match open_persistent_runtime(&path) {
+        Ok(_) => panic!("raw-marked legacy state should fail"),
+        Err(err) => err,
+    };
+    assert!(
+        message.contains("legacy hex-encoded HLL state for 'visitors' is rejected"),
+        "unexpected error: {message}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1812. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1812

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785964896&installation_id=129708444&pr_number=1872&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1872&signature=a462a5e316333045fcc8c922761510c5bd00ba84ea462a6a8e841942de9258a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->