### PR TITLE
merge: #1825 Boolean segment-manager bloom probe; delete materializing query_with_bloom_hint path

### DIFF
--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -906,8 +906,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         // Bloom filter: extract PK key for segment pruning
         let bloom_key = extract_bloom_key_for_pk(filter);
         if let Some(ref key) = bloom_key {
-            let (entities, _pruned) = manager.query_with_bloom_hint(Some(key), |_| true);
-            if entities.is_empty() {
+            if !manager.bloom_may_contain_key(key) {
                 return Ok(Vec::new());
             }
         }

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -375,34 +375,6 @@ pub(crate) fn stream_runtime_table_source_scan(
     ))
 }
 
-/// Scan with bloom filter optimization: when we know the exact key we're looking for,
-/// use the bloom filter to skip segments that definitely don't contain it.
-pub(super) fn scan_runtime_table_with_bloom_hint(
-    db: &RedDB,
-    table: &str,
-    key_hint: Option<&[u8]>,
-) -> RedDBResult<(Vec<UnifiedRecord>, bool)> {
-    use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
-
-    let manager = db
-        .store()
-        .get_collection(table)
-        .ok_or_else(|| RedDBError::NotFound(table.to_string()))?;
-
-    let (entities, pruned) = manager.query_with_bloom_hint(key_hint, |_| true);
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
-    let records = entities
-        .into_iter()
-        .filter(|entity| table_row_resolver.resolve_read_candidate(entity).is_some())
-        .filter_map(|entity| {
-            let mut record = runtime_table_record_from_entity(entity)?;
-            set_source_collection(&mut record, table);
-            Some(record)
-        })
-        .collect();
-    Ok((records, pruned))
-}
-
 pub(super) fn is_universal_entity_source(table: &str) -> bool {
     is_universal_query_source(table)
 }

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -1353,59 +1353,29 @@ impl SegmentManager {
         results
     }
 
-    /// Query with bloom filter hint: skip the growing segment when bloom says key is absent.
+    /// Probe segment blooms for a key without materializing matching entities.
     ///
-    /// This is the integration point for bloom filter pruning.
-    /// When a query has an equality predicate on a known key, the executor
-    /// can call this instead of `query_all` to avoid scanning when the
-    /// bloom filter proves the key doesn't exist.
-    ///
-    /// Returns (results, bloom_pruned) where bloom_pruned indicates if the
-    /// segment was skipped.
-    pub fn query_with_bloom_hint<F>(
-        &self,
-        key_hint: Option<&[u8]>,
-        filter: F,
-    ) -> (Vec<UnifiedEntity>, bool)
-    where
-        F: Fn(&UnifiedEntity) -> bool,
-    {
-        let mut results = Vec::new();
-        let mut bloom_pruned = false;
-
+    /// Returns `false` only when every consulted segment bloom proves absence.
+    /// Missing segment state is conservative and returns `true`.
+    pub fn bloom_may_contain_key(&self, key: &[u8]) -> bool {
         if let Some(growing_arc) = self.growing.read().as_ref() {
             let growing = growing_arc.read();
-            if let Some(key) = key_hint {
-                if !growing.bloom_might_contain_key(key) {
-                    bloom_pruned = true;
-                    return (results, bloom_pruned);
-                }
+            if growing.bloom_might_contain_key(key) {
+                return true;
             }
-            for entity in growing.iter() {
-                if filter(entity) {
-                    results.push(entity.clone());
-                }
-            }
+        } else {
+            return true;
         }
 
-        // Sealed segments (currently empty iter, but future-proofed)
         let sealed = self.sealed.read();
         for segment_arc in sealed.iter() {
             let segment = segment_arc.read();
-            if let Some(key) = key_hint {
-                if !segment.bloom_might_contain_key(key) {
-                    bloom_pruned = true;
-                    continue;
-                }
-            }
-            for entity in segment.iter() {
-                if filter(entity) {
-                    results.push(entity.clone());
-                }
+            if segment.bloom_might_contain_key(key) {
+                return true;
             }
         }
 
-        (results, bloom_pruned)
+        false
     }
 
     /// Filter by metadata across all segments
@@ -1620,6 +1590,23 @@ mod tests {
         let id = manager.insert(entity).unwrap();
         assert!(manager.get(id).is_some());
         assert_eq!(manager.count(), 1);
+    }
+
+    #[test]
+    fn bloom_may_contain_key_probes_inserted_rid_bytes() {
+        let manager = SegmentManager::new("test_collection");
+
+        let entity = UnifiedEntity::table_row(
+            manager.next_entity_id(),
+            "users",
+            1,
+            vec![Value::text("Alice".to_string())],
+        );
+
+        let id = manager.insert(entity).unwrap();
+
+        assert!(manager.bloom_may_contain_key(&id.raw().to_le_bytes()));
+        assert!(!manager.bloom_may_contain_key(&u64::MAX.to_le_bytes()));
     }
 
     #[test]

--- a/tests/grouped/multimodel_query/integration_entity_query.rs
+++ b/tests/grouped/multimodel_query/integration_entity_query.rs
@@ -2354,6 +2354,69 @@ fn test_fast_entity_id_lookup_persistent() {
 }
 
 #[test]
+fn test_rid_filter_with_bloom_probe_keeps_row_sets() {
+    let rt = rt();
+    let query = QueryUseCases::new(&rt);
+
+    query
+        .execute(ExecuteQueryInput {
+            query: "INSERT INTO rid_bloom_probe (name, dept) VALUES ('alice', 'engineering')"
+                .into(),
+        })
+        .expect("insert should succeed");
+
+    let all = query
+        .execute(ExecuteQueryInput {
+            query: "SELECT * FROM rid_bloom_probe".into(),
+        })
+        .expect("select all should succeed");
+    let rid = match all.result.records[0].get("rid") {
+        Some(Value::UnsignedInteger(n)) => *n,
+        other => panic!("rid was not UnsignedInteger: {other:?}"),
+    };
+
+    let by_rid = query
+        .execute(ExecuteQueryInput {
+            query: format!("SELECT * FROM rid_bloom_probe WHERE rid = {rid}"),
+        })
+        .expect("select by present rid should succeed");
+    let by_rid_and_dept = query
+        .execute(ExecuteQueryInput {
+            query: format!(
+                "SELECT * FROM rid_bloom_probe WHERE rid = {rid} AND dept = 'engineering'"
+            ),
+        })
+        .expect("select by present rid and conjunct should succeed");
+    assert_eq!(by_rid.result.records.len(), 1);
+    assert_eq!(by_rid_and_dept.result.records.len(), 1);
+    assert_eq!(
+        by_rid_and_dept.result.records[0].get("name"),
+        by_rid.result.records[0].get("name")
+    );
+    assert_eq!(
+        by_rid_and_dept.result.records[0].get("dept"),
+        by_rid.result.records[0].get("dept")
+    );
+
+    let absent_rid = rid + 1000;
+    let absent_by_rid = query
+        .execute(ExecuteQueryInput {
+            query: format!("SELECT * FROM rid_bloom_probe WHERE rid = {absent_rid}"),
+        })
+        .expect("select by absent rid should succeed");
+    let absent_by_rid_and_dept = query
+        .execute(ExecuteQueryInput {
+            query: format!(
+                "SELECT * FROM rid_bloom_probe WHERE rid = {absent_rid} AND dept = 'engineering'"
+            ),
+        })
+        .expect("select by absent rid and conjunct should succeed");
+
+    assert!(absent_by_rid.result.records.is_empty());
+    assert!(absent_by_rid_and_dept.result.records.is_empty());
+}
+
+#[test]
 fn test_drop_table_cleans_contract_and_indices() {
     let rt = rt();
     let query = QueryUseCases::new(&rt);


### PR DESCRIPTION
Automated AFK landing for #1825. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1825

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785968576&installation_id=129708444&pr_number=1879&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1879&signature=3c888d405414a05b27f2420602b6a4d32afe728c9ba5c7f6f5790795a35330b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->