### PR TITLE
chore: #1777 Fork observability: parent, fork LSN, and hydration state queryable

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -250,7 +250,7 @@ pub use native_store::{
     STORE_VERSION_V1, STORE_VERSION_V10, STORE_VERSION_V2, STORE_VERSION_V3, STORE_VERSION_V4,
     STORE_VERSION_V5, STORE_VERSION_V6, STORE_VERSION_V7, STORE_VERSION_V8, STORE_VERSION_V9,
 };
-pub use operational_manifest::{ForkInfo, ForkOrigin, OperationalManifest};
+pub use operational_manifest::{ForkHydrationState, ForkInfo, ForkOrigin, OperationalManifest};
 pub use physical_metadata::{
     copy_physical_export_data_file, copy_physical_metadata_binary_to_journal,
     decode_persisted_physical_hypertable_chunk_json, decode_persisted_physical_hypertable_json,

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -43,6 +43,28 @@ pub struct ForkInfo {
     pub name: String,
     pub parent_store: String,
     pub fork_lsn: u64,
+    pub hydration_state: ForkHydrationState,
+    pub collections_total: u64,
+    pub shared_by_reference: u64,
+    pub hydrating: u64,
+    pub hydrated: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForkHydrationState {
+    SharedByReference,
+    Hydrating,
+    Hydrated,
+}
+
+impl ForkHydrationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SharedByReference => "shared_by_reference",
+            Self::Hydrating => "hydrating",
+            Self::Hydrated => "hydrated",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -355,11 +377,20 @@ impl OperationalManifest {
                 continue;
             }
             let fork = Self { root: entry.path() };
-            if let Some(origin) = fork.fork_origin()? {
+            if let Some(manifest) = fork.load_current()? {
+                let Some(origin) = manifest.fork_origin.as_ref() else {
+                    continue;
+                };
+                let progress = fork.hydration_progress(&manifest);
                 out.push(ForkInfo {
-                    name: origin.name,
-                    parent_store: origin.parent_store,
+                    name: origin.name.clone(),
+                    parent_store: origin.parent_store.clone(),
                     fork_lsn: origin.fork_lsn,
+                    hydration_state: progress.state,
+                    collections_total: progress.collections_total,
+                    shared_by_reference: progress.shared_by_reference,
+                    hydrating: progress.hydrating,
+                    hydrated: progress.hydrated,
                 });
             }
         }
@@ -444,6 +475,33 @@ impl OperationalManifest {
             }
         }
         Ok(paths)
+    }
+
+    fn hydration_progress(&self, manifest: &Manifest) -> ForkHydrationProgress {
+        let mut progress = ForkHydrationProgress::default();
+        for entry in manifest.collections.values() {
+            if entry.state != CollectionState::Active {
+                continue;
+            }
+            progress.collections_total += 1;
+            if entry.source.is_none() {
+                progress.hydrated += 1;
+                continue;
+            }
+            if self.collections_dir().join(&entry.path).exists() {
+                progress.hydrating += 1;
+            } else {
+                progress.shared_by_reference += 1;
+            }
+        }
+        progress.state = if progress.hydrating > 0 {
+            ForkHydrationState::Hydrating
+        } else if progress.shared_by_reference > 0 {
+            ForkHydrationState::SharedByReference
+        } else {
+            ForkHydrationState::Hydrated
+        };
+        progress
     }
 
     pub fn read_generation_for_test(&self) -> io::Result<u64> {
@@ -560,6 +618,27 @@ impl OperationalManifest {
         }
         out.push_str(".rcol");
         out
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ForkHydrationProgress {
+    state: ForkHydrationState,
+    collections_total: u64,
+    shared_by_reference: u64,
+    hydrating: u64,
+    hydrated: u64,
+}
+
+impl Default for ForkHydrationProgress {
+    fn default() -> Self {
+        Self {
+            state: ForkHydrationState::Hydrated,
+            collections_total: 0,
+            shared_by_reference: 0,
+            hydrating: 0,
+            hydrated: 0,
+        }
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
+++ b/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
@@ -28,11 +28,12 @@ impl RedDBRuntime {
         manifest
             .create_fork(name, fork_lsn)
             .map_err(|err| RedDBError::InvalidOperation(err.to_string()))?;
-        Ok(reddb_file::ForkInfo {
-            name: name.to_string(),
-            parent_store: manifest.store_identity(),
-            fork_lsn,
-        })
+        manifest
+            .list_forks()
+            .map_err(|err| RedDBError::InvalidOperation(err.to_string()))?
+            .into_iter()
+            .find(|fork| fork.name == name)
+            .ok_or_else(|| RedDBError::Internal(format!("created store fork {name} is missing")))
     }
 
     pub fn replica_relay_manifest_path(&self, replica_id: &str) -> Option<std::path::PathBuf> {

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -68,6 +68,10 @@ pub(super) const QUEUE_PENDING_INTERNAL: &str = "__red_schema_queue_pending";
 // `red.collections.internal` contract.
 pub(super) const QUEUES: &str = "red.queues";
 pub(super) const QUEUES_INTERNAL: &str = "__red_schema_queues";
+// Issue #1777 — store-fork observability. One row per fork rooted
+// under the current persistent store's operational manifest.
+pub(super) const FORKS: &str = "red.forks";
+pub(super) const FORKS_INTERNAL: &str = "__red_schema_forks";
 // Issue #577 — AnalyticsSchemaRegistry slice 2. Per-event-name schema
 // versions: `(event_name, version, schema_json, registered_at)`.
 pub(super) const SCHEMA_REGISTRY: &str = "red.schema_registry";
@@ -262,6 +266,17 @@ const QUEUE_COLUMNS: [&str; 8] = [
     "dlq_target",
     "attention",
     "internal",
+];
+
+const FORK_COLUMNS: [&str; 8] = [
+    "name",
+    "parent_store",
+    "fork_lsn",
+    "hydration_state",
+    "collections_total",
+    "shared_by_reference",
+    "hydrating",
+    "hydrated",
 ];
 
 const QUEUE_PENDING_COLUMNS: [&str; 8] = [
@@ -664,6 +679,7 @@ pub(super) fn rewrite_virtual_names(query: &str) -> Option<String> {
         (MATERIALIZED_VIEWS, MATERIALIZED_VIEWS_INTERNAL),
         (QUEUE_PENDING, QUEUE_PENDING_INTERNAL),
         (QUEUES, QUEUES_INTERNAL),
+        (FORKS, FORKS_INTERNAL),
         (ANALYTICS_METRICS, ANALYTICS_METRICS_INTERNAL),
         (ANALYTICS_SLOS, ANALYTICS_SLOS_INTERNAL),
         (ANALYTICS_SOURCES, ANALYTICS_SOURCES_INTERNAL),
@@ -752,6 +768,8 @@ pub(super) fn is_virtual_table(table: &str) -> bool {
         || table.eq_ignore_ascii_case(QUEUE_PENDING)
         || table.eq_ignore_ascii_case(QUEUES_INTERNAL)
         || table.eq_ignore_ascii_case(QUEUES)
+        || table.eq_ignore_ascii_case(FORKS_INTERNAL)
+        || table.eq_ignore_ascii_case(FORKS)
         || table.eq_ignore_ascii_case(ANALYTICS_METRICS_INTERNAL)
         || table.eq_ignore_ascii_case(ANALYTICS_METRICS)
         || table.eq_ignore_ascii_case(ANALYTICS_SLOS_INTERNAL)
@@ -869,6 +887,7 @@ pub(super) fn red_query(
         VirtualTableKind::Queues => {
             ops_views::queues_snapshot(runtime, tenant, visible_collections)
         }
+        VirtualTableKind::Forks => ops_views::forks_snapshot(runtime)?,
         VirtualTableKind::AnalyticsMetrics => ops_views::analytics_metrics_snapshot(runtime),
         VirtualTableKind::AnalyticsSlos => ops_views::analytics_slos_snapshot(runtime),
         VirtualTableKind::AnalyticsSources => {
@@ -1027,6 +1046,7 @@ enum VirtualTableKind {
     MaterializedViews,
     QueuePending,
     Queues,
+    Forks,
     AnalyticsMetrics,
     AnalyticsSlos,
     AnalyticsSources,
@@ -1072,6 +1092,7 @@ impl VirtualTableKind {
             Self::MaterializedViews => &MATERIALIZED_VIEW_COLUMNS,
             Self::QueuePending => &QUEUE_PENDING_COLUMNS,
             Self::Queues => &QUEUE_COLUMNS,
+            Self::Forks => &FORK_COLUMNS,
             Self::AnalyticsMetrics => &ANALYTICS_METRIC_COLUMNS,
             Self::AnalyticsSlos => &ANALYTICS_SLO_COLUMNS,
             Self::AnalyticsSources => &ANALYTICS_SOURCE_COLUMNS,
@@ -1116,6 +1137,7 @@ impl VirtualTableKind {
             Self::MaterializedViews => MATERIALIZED_VIEWS,
             Self::QueuePending => QUEUE_PENDING,
             Self::Queues => QUEUES,
+            Self::Forks => FORKS,
             Self::AnalyticsMetrics => ANALYTICS_METRICS,
             Self::AnalyticsSlos => ANALYTICS_SLOS,
             Self::AnalyticsSources => ANALYTICS_SOURCES,
@@ -1190,6 +1212,9 @@ fn virtual_table_kind(name: &str) -> RedDBResult<VirtualTableKind> {
     }
     if name.eq_ignore_ascii_case(QUEUES_INTERNAL) || name.eq_ignore_ascii_case(QUEUES) {
         return Ok(VirtualTableKind::Queues);
+    }
+    if name.eq_ignore_ascii_case(FORKS_INTERNAL) || name.eq_ignore_ascii_case(FORKS) {
+        return Ok(VirtualTableKind::Forks);
     }
     if name.eq_ignore_ascii_case(ANALYTICS_METRICS_INTERNAL)
         || name.eq_ignore_ascii_case(ANALYTICS_METRICS)

--- a/crates/reddb-server/src/runtime/red_schema/ops_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/ops_views.rs
@@ -123,6 +123,41 @@ pub(super) fn analytics_sources_snapshot(
         })
         .collect()
 }
+
+pub(super) fn forks_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<UnifiedRecord>> {
+    let db = runtime.db();
+    let Some(path) = db.options().data_path.as_ref() else {
+        return Ok(Vec::new());
+    };
+    let schema = Arc::new(
+        FORK_COLUMNS
+            .iter()
+            .map(|name| Arc::<str>::from(*name))
+            .collect::<Vec<_>>(),
+    );
+    let forks = reddb_file::OperationalManifest::for_db_path(path)
+        .list_forks()
+        .map_err(RedDBError::Io)?;
+    Ok(forks
+        .into_iter()
+        .map(|fork| {
+            UnifiedRecord::with_schema(
+                Arc::clone(&schema),
+                vec![
+                    Value::text(fork.name),
+                    Value::text(fork.parent_store),
+                    Value::UnsignedInteger(fork.fork_lsn),
+                    Value::text(fork.hydration_state.as_str()),
+                    Value::UnsignedInteger(fork.collections_total),
+                    Value::UnsignedInteger(fork.shared_by_reference),
+                    Value::UnsignedInteger(fork.hydrating),
+                    Value::UnsignedInteger(fork.hydrated),
+                ],
+            )
+        })
+        .collect())
+}
+
 pub(super) fn subscriptions_snapshot(
     runtime: &RedDBRuntime,
     visible_collections: Option<&std::collections::HashSet<String>>,

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -139,6 +139,17 @@ const POLICY_ACTION_COLUMNS: [&str; 6] = [
     "gates_description",
 ];
 
+const FORK_COLUMNS: [&str; 8] = [
+    "name",
+    "parent_store",
+    "fork_lsn",
+    "hydration_state",
+    "collections_total",
+    "shared_by_reference",
+    "hydrating",
+    "hydrated",
+];
+
 fn runtime() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime")
 }
@@ -296,6 +307,76 @@ fn uint_field(record: &reddb::storage::query::unified::UnifiedRecord, field: &st
         Some(Value::UnsignedInteger(value)) => *value,
         other => panic!("expected unsigned integer field {field}, got {other:?}"),
     }
+}
+
+#[test]
+fn red_forks_surfaces_parent_lsn_and_hydration_progress() {
+    cleanup_scope();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db_path = dir.path().join("forks.rdb");
+    let rt =
+        RedDBRuntime::with_options(RedDBOptions::persistent(&db_path)).expect("persistent runtime");
+
+    let manifest = reddb_file::OperationalManifest::for_db_path(&db_path);
+    manifest
+        .recover_or_bootstrap(&["users".to_string(), "orders".to_string()])
+        .expect("bootstrap operational manifest");
+    manifest
+        .create_fork("migration-test", 42)
+        .expect("create fork");
+
+    let result = rt
+        .execute_query("SELECT * FROM red.forks")
+        .expect("red.forks select");
+    assert_eq!(result.result.columns, FORK_COLUMNS.map(str::to_string));
+    assert_eq!(result.result.records.len(), 1);
+    let row = &result.result.records[0];
+    assert_eq!(text_field(row, "name"), "migration-test");
+    assert_eq!(text_field(row, "parent_store"), manifest.store_identity());
+    assert_eq!(uint_field(row, "fork_lsn"), 42);
+    assert_eq!(text_field(row, "hydration_state"), "shared_by_reference");
+    assert_eq!(uint_field(row, "collections_total"), 2);
+    assert_eq!(uint_field(row, "shared_by_reference"), 2);
+    assert_eq!(uint_field(row, "hydrating"), 0);
+    assert_eq!(uint_field(row, "hydrated"), 0);
+
+    let fork = manifest.fork_handle("migration-test");
+    std::fs::write(fork.collection_path_for_test("users"), b"partial copy")
+        .expect("simulate in-progress hydration");
+    let hydrating = rt
+        .execute_query(
+            "SELECT hydration_state, shared_by_reference, hydrating, hydrated FROM red.forks",
+        )
+        .expect("red.forks hydrating select");
+    let row = &hydrating.result.records[0];
+    assert_eq!(text_field(row, "hydration_state"), "hydrating");
+    assert_eq!(uint_field(row, "shared_by_reference"), 1);
+    assert_eq!(uint_field(row, "hydrating"), 1);
+    assert_eq!(uint_field(row, "hydrated"), 0);
+
+    fork.hydrate_collection("users").expect("hydrate users");
+    let hydrated = rt
+        .execute_query(
+            "SELECT hydration_state, shared_by_reference, hydrating, hydrated FROM red.forks",
+        )
+        .expect("red.forks hydrated select");
+    let row = &hydrated.result.records[0];
+    assert_eq!(text_field(row, "hydration_state"), "shared_by_reference");
+    assert_eq!(uint_field(row, "shared_by_reference"), 1);
+    assert_eq!(uint_field(row, "hydrating"), 0);
+    assert_eq!(uint_field(row, "hydrated"), 1);
+
+    fork.hydrate_collection("orders").expect("hydrate orders");
+    let hydrated = rt
+        .execute_query(
+            "SELECT hydration_state, shared_by_reference, hydrating, hydrated FROM red.forks",
+        )
+        .expect("red.forks fully hydrated select");
+    let row = &hydrated.result.records[0];
+    assert_eq!(text_field(row, "hydration_state"), "hydrated");
+    assert_eq!(uint_field(row, "shared_by_reference"), 0);
+    assert_eq!(uint_field(row, "hydrating"), 0);
+    assert_eq!(uint_field(row, "hydrated"), 2);
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1777. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1777

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785996633&installation_id=129708444&pr_number=1881&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1881&signature=75850f883162089aabf3b92a443c944cdc8bf7c0274158e69893ba4d508f233a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->