### PR TITLE
chore: #1781 DETACH FORK: graduate a fork to an independent store

### DIFF
--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -385,6 +385,50 @@ impl OperationalManifest {
         Ok(true)
     }
 
+    /// Detach a store fork into an independent operational store root. All
+    /// shared-by-reference collections are hydrated before the fork is moved out
+    /// from under the parent store; the final manifest then drops its
+    /// [`ForkOrigin`], so parent retention and WAL pruning no longer see it as a
+    /// live fork.
+    ///
+    /// The operation is restartable across the two durable phases:
+    /// - if hydration finished but the fork is still nested, rerun hydrates as a
+    ///   no-op and moves it;
+    /// - if the move finished but origin clearing did not, rerun finishes the
+    ///   detached manifest in place.
+    pub fn detach_fork(&self, name: &str) -> io::Result<Option<Self>> {
+        let fork = self.fork_handle(name);
+        let detached = self.detached_fork_handle(name);
+
+        if detached.root.exists() {
+            if fork.root.exists() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!("detached store already exists for fork: {name}"),
+                ));
+            }
+            let was_fork = detached.fork_origin()?.is_some();
+            detached.clear_fork_origin()?;
+            return Ok(was_fork.then_some(detached));
+        }
+
+        if !fork.root.exists() {
+            return Ok(None);
+        }
+
+        fork.hydrate_shared_collections()?;
+        if let Some(parent) = detached.root.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(&fork.root, &detached.root)?;
+        sync_dir(&self.forks_dir())?;
+        if let Some(parent) = detached.root.parent() {
+            sync_dir(parent)?;
+        }
+        detached.clear_fork_origin()?;
+        Ok(Some(detached))
+    }
+
     /// Read this manifest's fork origin, if it is a fork.
     pub fn fork_origin(&self) -> io::Result<Option<ForkOrigin>> {
         Ok(self
@@ -410,6 +454,55 @@ impl OperationalManifest {
             }
         }
         Ok(out)
+    }
+
+    fn detached_fork_handle(&self, name: &str) -> Self {
+        let root_name = self
+            .root
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "store.ops".to_string());
+        Self {
+            root: self
+                .root
+                .with_file_name(format!("{root_name}.detached-{}", sanitize_component(name))),
+        }
+    }
+
+    fn hydrate_shared_collections(&self) -> io::Result<()> {
+        let mut manifest = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(()),
+        };
+        let mut changed = false;
+        self.ensure_dirs()?;
+        for entry in manifest.collections.values_mut() {
+            let Some(source) = entry.source.clone() else {
+                continue;
+            };
+            let dest = self.collections_dir().join(&entry.path);
+            copy_file_durable(Path::new(&source), &dest)?;
+            entry.source = None;
+            changed = true;
+        }
+        if changed {
+            manifest.generation += 1;
+            self.publish(&manifest)?;
+        }
+        Ok(())
+    }
+
+    fn clear_fork_origin(&self) -> io::Result<()> {
+        let mut manifest = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(()),
+        };
+        if manifest.fork_origin.is_none() {
+            return Ok(());
+        }
+        manifest.fork_origin = None;
+        manifest.generation += 1;
+        self.publish(&manifest)
     }
 
     fn protected_collection_paths(&self, manifest: &Manifest) -> io::Result<BTreeSet<String>> {
@@ -1080,6 +1173,73 @@ mod tests {
 
         assert!(!parent.collection_path_for_test("users").exists());
         assert!(parent.quarantine_path_for_test("users.rcol").exists());
+    }
+
+    #[test]
+    fn detach_fork_hydrates_and_survives_parent_removal() {
+        let path = temp_db_path("detach_fork");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"successful-experiment");
+        parent.create_fork("exp", 21).unwrap();
+
+        let detached = parent.detach_fork("exp").unwrap().unwrap();
+
+        assert!(parent.list_forks().unwrap().is_empty());
+        assert!(detached.fork_origin().unwrap().is_none());
+        assert_eq!(
+            read_collection(&detached, "users"),
+            b"successful-experiment"
+        );
+
+        fs::remove_dir_all(&parent.root).unwrap();
+        assert_eq!(
+            detached.recover_or_bootstrap(&[]).unwrap(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            read_collection(&detached, "users"),
+            b"successful-experiment"
+        );
+    }
+
+    #[test]
+    fn detach_fork_resumes_after_move_before_origin_clear() {
+        let path = temp_db_path("detach_fork_resume");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"as-of-fork");
+        parent.create_fork("exp", 34).unwrap();
+
+        let fork = parent.fork_handle("exp");
+        fork.hydrate_shared_collections().unwrap();
+        let detached = parent.detached_fork_handle("exp");
+        fs::rename(&fork.root, &detached.root).unwrap();
+
+        let resumed = parent.detach_fork("exp").unwrap().unwrap();
+
+        assert_eq!(resumed.root, detached.root);
+        assert!(parent.list_forks().unwrap().is_empty());
+        assert!(resumed.fork_origin().unwrap().is_none());
+        assert_eq!(read_collection(&resumed, "users"), b"as-of-fork");
+    }
+
+    #[test]
+    fn detach_fork_releases_parent_retention_pin() {
+        let path = temp_db_path("detach_releases_parent_pin");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"as-of-fork");
+        parent.create_fork("exp", 55).unwrap();
+        parent.begin_drop_collection("users").unwrap();
+        parent.recover_or_bootstrap(&[]).unwrap();
+        assert!(parent.collection_path_for_test("users").exists());
+
+        let detached = parent.detach_fork("exp").unwrap().unwrap();
+        parent.recover_or_bootstrap(&[]).unwrap();
+
+        assert!(!parent.collection_path_for_test("users").exists());
+        assert_eq!(read_collection(&detached, "users"), b"as-of-fork");
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
+++ b/crates/reddb-server/src/runtime/impl_primary_replica_file.rs
@@ -35,6 +35,25 @@ impl RedDBRuntime {
         })
     }
 
+    pub fn detach_fork_store(&self, name: &str) -> RedDBResult<bool> {
+        let name = name.trim();
+        if name.is_empty() {
+            return Err(RedDBError::InvalidOperation(
+                "store fork name cannot be empty".to_string(),
+            ));
+        }
+        let data_path = self.inner.db.options().data_path.as_ref().ok_or_else(|| {
+            RedDBError::InvalidOperation("store fork requires a data path".into())
+        })?;
+
+        let manifest =
+            crate::storage::operational_manifest::OperationalManifest::for_db_path(data_path);
+        manifest
+            .detach_fork(name)
+            .map(|detached| detached.is_some())
+            .map_err(|err| RedDBError::InvalidOperation(err.to_string()))
+    }
+
     pub fn replica_relay_manifest_path(&self, replica_id: &str) -> Option<std::path::PathBuf> {
         let plan = self.primary_replica_file_plan()?;
         Some(plan.relay_manifest_path(replica_id))

--- a/crates/reddb-server/tests/store_fork_profile.rs
+++ b/crates/reddb-server/tests/store_fork_profile.rs
@@ -71,4 +71,18 @@ fn operational_directory_fork_uses_exported_layout() {
     assert_eq!(forks[0].name, "experiment");
     assert_eq!(forks[0].fork_lsn, fork.fork_lsn);
     assert_eq!(forks[0].parent_store, manifest.store_identity());
+
+    assert!(runtime
+        .detach_fork_store("experiment")
+        .expect("detach fork store"));
+    assert!(
+        manifest
+            .list_forks()
+            .expect("list forks after detach")
+            .is_empty(),
+        "detached fork must no longer pin parent retention"
+    );
+    assert!(!runtime
+        .detach_fork_store("experiment")
+        .expect("detach missing fork is idempotent"));
 }


### PR DESCRIPTION
Automated AFK landing for #1781. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1781

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785997570&installation_id=129708444&pr_number=1882&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1882&signature=8086d5b69d22cf6f551e4f13f9b2dd7026bc95dc2f80d6c21d517fc17e6ce4c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detaching a forked store so it becomes an independent store.
  * Detach operations are now safe to retry after interruptions, helping recover from partial completion.

* **Bug Fixes**
  * Detached forks now properly stop keeping the parent store retained once the detachment completes.
  * Repeating a detach request for a missing fork now completes cleanly without error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->