### PR TITLE
chore: #1789 EXPLAIN plan-only tier for DML (EXPLAIN family, ADR 0071)

### DIFF
--- a/crates/reddb-rql/src/builders.rs
+++ b/crates/reddb-rql/src/builders.rs
@@ -337,6 +337,7 @@ impl JoinQueryBuilder {
             | QueryExpr::ApplyMigration(_)
             | QueryExpr::RollbackMigration(_)
             | QueryExpr::ExplainMigration(_)
+            | QueryExpr::Explain(_)
             | QueryExpr::EventsBackfill(_)
             | QueryExpr::EventsBackfillStatus { .. } => {}
         }

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -148,6 +148,11 @@ pub enum QueryExpr {
     RollbackMigration(RollbackMigrationQuery),
     /// EXPLAIN MIGRATION name
     ExplainMigration(ExplainMigrationQuery),
+    /// EXPLAIN <statement>
+    ///
+    /// Plan-only wrapper: the executor must inspect the wrapped statement
+    /// without executing it.
+    Explain(ExplainQuery),
     /// `EVENTS BACKFILL collection [WHERE pred] TO queue [LIMIT n]`.
     EventsBackfill(EventsBackfillQuery),
     /// `EVENTS BACKFILL STATUS collection` placeholder for the status slice.
@@ -782,6 +787,11 @@ pub struct RollbackMigrationQuery {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ExplainMigrationQuery {
     pub name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExplainQuery {
+    pub inner: Box<QueryExpr>,
 }
 
 /// Probabilistic data structure commands

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -2183,6 +2183,39 @@ fn test_parse_update_dotted_path_target_round_trips_unmarked() {
 }
 
 #[test]
+fn explain_insert_round_trips_as_plan_only_wrapper() {
+    let sql = "EXPLAIN INSERT INTO audit (id, note) VALUES (1, 'planned')";
+    let query = parse(sql).unwrap();
+    let QueryExpr::Explain(explain) = &query else {
+        panic!("Expected Explain wrapper");
+    };
+    assert!(matches!(explain.inner.as_ref(), QueryExpr::Insert(_)));
+    assert_eq!(crate::renderer::render(&query), sql);
+}
+
+#[test]
+fn explain_update_round_trips_as_plan_only_wrapper() {
+    let sql = "EXPLAIN UPDATE audit SET note = 'planned' WHERE id = 1";
+    let query = parse(sql).unwrap();
+    let QueryExpr::Explain(explain) = &query else {
+        panic!("Expected Explain wrapper");
+    };
+    assert!(matches!(explain.inner.as_ref(), QueryExpr::Update(_)));
+    assert_eq!(crate::renderer::render(&query), sql);
+}
+
+#[test]
+fn explain_delete_round_trips_as_plan_only_wrapper() {
+    let sql = "EXPLAIN DELETE FROM audit WHERE id = 1";
+    let query = parse(sql).unwrap();
+    let QueryExpr::Explain(explain) = &query else {
+        panic!("Expected Explain wrapper");
+    };
+    assert!(matches!(explain.inner.as_ref(), QueryExpr::Delete(_)));
+    assert_eq!(crate::renderer::render(&query), sql);
+}
+
+#[test]
 fn test_parse_update_from_any_remains_rejected() {
     let err = parse("UPDATE FROM ANY SET status = 'bad'").unwrap_err();
     assert!(err.to_string().contains("expected: identifier"));

--- a/crates/reddb-rql/src/planner/optimizer.rs
+++ b/crates/reddb-rql/src/planner/optimizer.rs
@@ -282,6 +282,7 @@ impl JoinReorderingPass {
                 let base = structured_size.min(vector_size);
                 hq.limit.map(|l| base.min(l as f64)).unwrap_or(base)
             }
+            QueryExpr::Explain(explain) => Self::estimate_size(&explain.inner),
             // DML/DDL/Command statements return minimal result sets
             QueryExpr::Insert(_)
             | QueryExpr::Update(_)

--- a/crates/reddb-rql/src/planner/rewriter.rs
+++ b/crates/reddb-rql/src/planner/rewriter.rs
@@ -181,6 +181,10 @@ impl RewriteRule for NormalizeRule {
                 hq.structured = Box::new(self.apply(*hq.structured, ctx));
                 QueryExpr::Hybrid(hq)
             }
+            QueryExpr::Explain(mut explain) => {
+                explain.inner = Box::new(self.apply(*explain.inner, ctx));
+                QueryExpr::Explain(explain)
+            }
             // DML/DDL/Command statements pass through without normalization
             other @ (QueryExpr::Insert(_)
             | QueryExpr::Update(_)
@@ -320,6 +324,10 @@ impl RewriteRule for SimplifyFiltersRule {
                 hq.structured = Box::new(self.apply(*hq.structured, ctx));
                 QueryExpr::Hybrid(hq)
             }
+            QueryExpr::Explain(mut explain) => {
+                explain.inner = Box::new(self.apply(*explain.inner, ctx));
+                QueryExpr::Explain(explain)
+            }
             // DML/DDL/Command statements pass through without filter simplification
             other @ (QueryExpr::Insert(_)
             | QueryExpr::Update(_)
@@ -418,6 +426,7 @@ impl RewriteRule for SimplifyFiltersRule {
             QueryExpr::Path(_) => false,
             QueryExpr::Vector(vq) => effective_vector_filter(vq).is_some(),
             QueryExpr::Hybrid(_) => true, // May have filters in structured part
+            QueryExpr::Explain(explain) => self.is_applicable(&explain.inner),
             // DML/DDL/Command statements are not applicable for filter simplification
             QueryExpr::Insert(_)
             | QueryExpr::Update(_)

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -11,8 +11,8 @@
 //! ```
 
 use crate::ast::{
-    BinOp, CompareOp, Expr, FieldRef, Filter, InsertQuery, Projection, QueryExpr, QueueCommand,
-    TableQuery, UpdateQuery, UpdateTarget,
+    BinOp, CompareOp, DeleteQuery, Expr, FieldRef, Filter, InsertQuery, Projection, QueryExpr,
+    QueueCommand, TableQuery, UpdateQuery, UpdateTarget,
 };
 use reddb_types::types::Value;
 
@@ -24,8 +24,19 @@ pub fn render(expr: &QueryExpr) -> String {
         QueryExpr::Table(tq) => render_table(tq),
         QueryExpr::Insert(iq) => render_insert(iq),
         QueryExpr::Update(uq) => render_update(uq),
+        QueryExpr::Delete(dq) => render_delete(dq),
         QueryExpr::QueueCommand(qc) => render_queue_command(qc),
+        QueryExpr::Explain(explain) => render_explain(explain.inner.as_ref()),
         _ => String::new(),
+    }
+}
+
+fn render_explain(inner: &QueryExpr) -> String {
+    let rendered = render(inner);
+    if rendered.is_empty() {
+        String::new()
+    } else {
+        format!("EXPLAIN {rendered}")
     }
 }
 
@@ -104,6 +115,15 @@ fn render_update(uq: &UpdateQuery) -> String {
             sql.push_str(" CLAIM LIMIT ");
         }
         sql.push_str(&claim_limit.to_string());
+    }
+    sql
+}
+
+fn render_delete(dq: &DeleteQuery) -> String {
+    let mut sql = format!("DELETE FROM {}", dq.table);
+    if let Some(filter) = &dq.filter {
+        sql.push_str(" WHERE ");
+        sql.push_str(&render_filter(filter));
     }
     sql
 }

--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -8,9 +8,9 @@ use crate::ast::{
     DropDocumentQuery, DropForeignTableQuery, DropGraphQuery, DropIndexQuery, DropKvQuery,
     DropPolicyQuery, DropQueueQuery, DropSchemaQuery, DropSequenceQuery, DropServerQuery,
     DropTableQuery, DropTimeSeriesQuery, DropTreeQuery, DropVcsRefQuery, DropVectorQuery,
-    DropViewQuery, EventsBackfillQuery, ExplainAlterQuery, ExplainMigrationQuery, Expr, FieldRef,
-    Filter, ForeignColumnDef, GrantStmt, GraphCommand, GraphQuery, HybridQuery, InsertQuery,
-    IsolationLevel, JoinQuery, KvCommand, MaintenanceCommand, PathQuery, PolicyAction,
+    DropViewQuery, EventsBackfillQuery, ExplainAlterQuery, ExplainMigrationQuery, ExplainQuery,
+    Expr, FieldRef, Filter, ForeignColumnDef, GrantStmt, GraphCommand, GraphQuery, HybridQuery,
+    InsertQuery, IsolationLevel, JoinQuery, KvCommand, MaintenanceCommand, PathQuery, PolicyAction,
     ProbabilisticCommand, QueryExpr, QueueCommand, QueueSelectQuery, RankOfQuery, RankRangeQuery,
     RefreshMaterializedViewQuery, RevokeStmt, RollbackMigrationQuery, SearchCommand, Span,
     TableQuery, TreeCommand, TruncateQuery, TxnControl, UpdateQuery, VcsCommand,
@@ -54,6 +54,7 @@ pub enum FrontendStatement {
     KvCommand(KvCommand),
     ConfigCommand(ConfigCommand),
     Ranking(QueryExpr),
+    Explain(ExplainQuery),
 }
 
 #[derive(Debug, Clone)]
@@ -1654,6 +1655,7 @@ impl FrontendStatement {
             FrontendStatement::KvCommand(command) => QueryExpr::KvCommand(command),
             FrontendStatement::ConfigCommand(command) => QueryExpr::ConfigCommand(command),
             FrontendStatement::Ranking(expr) => expr,
+            FrontendStatement::Explain(query) => QueryExpr::Explain(query),
         }
     }
 }
@@ -2081,8 +2083,18 @@ impl<'a> Parser<'a> {
                             self.position(),
                         )),
                     }
-                } else {
+                } else if match self.peek_next()? {
+                    Token::Alter => true,
+                    Token::Ident(name) if name.eq_ignore_ascii_case("MIGRATION") => true,
+                    _ => false,
+                } {
                     self.parse_sql_statement().map(FrontendStatement::Sql)
+                } else {
+                    self.advance()?; // EXPLAIN
+                    let inner = self.parse_sql_statement()?.into_query_expr();
+                    Ok(FrontendStatement::Explain(ExplainQuery {
+                        inner: Box::new(inner),
+                    }))
                 }
             }
             Token::Ident(name) if name.eq_ignore_ascii_case("SHOW") => {

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3163,7 +3163,7 @@ impl RedDBRuntime {
     /// `RuntimeQueryResult` so callers over the SQL interface see the
     /// plan tree in the same shape a SELECT produces.
     ///
-    /// Columns: `op`, `source`, `est_rows`, `est_cost`, `depth`.
+    /// Columns: `op`, `source`, `estimated_rows`, `estimated_cost`, `depth`.
     /// Nodes are walked depth-first; `depth` counts from 0 at the
     /// root so a text renderer can indent without re-walking.
     fn explain_as_rows(&self, raw_query: &str, inner_sql: &str) -> RedDBResult<RuntimeQueryResult> {
@@ -3172,8 +3172,8 @@ impl RedDBRuntime {
         let columns = vec![
             "op".to_string(),
             "source".to_string(),
-            "est_rows".to_string(),
-            "est_cost".to_string(),
+            "estimated_rows".to_string(),
+            "estimated_cost".to_string(),
             "depth".to_string(),
         ];
 
@@ -3189,8 +3189,8 @@ impl RedDBRuntime {
             let mut rec = crate::storage::query::unified::UnifiedRecord::default();
             rec.set_arc(Arc::from("op"), Value::text("CteScan".to_string()));
             rec.set_arc(Arc::from("source"), Value::text(name.clone()));
-            rec.set_arc(Arc::from("est_rows"), Value::Float(0.0));
-            rec.set_arc(Arc::from("est_cost"), Value::Float(0.0));
+            rec.set_arc(Arc::from("estimated_rows"), Value::Float(0.0));
+            rec.set_arc(Arc::from("estimated_cost"), Value::Float(0.0));
             rec.set_arc(Arc::from("depth"), Value::Integer(0));
             records.push(rec);
         }
@@ -3229,8 +3229,14 @@ fn walk_plan_node(
         Arc::from("source"),
         node.source.clone().map(Value::text).unwrap_or(Value::Null),
     );
-    rec.set_arc(Arc::from("est_rows"), Value::Float(node.estimated_rows));
-    rec.set_arc(Arc::from("est_cost"), Value::Float(node.operator_cost));
+    rec.set_arc(
+        Arc::from("estimated_rows"),
+        Value::Float(node.estimated_rows),
+    );
+    rec.set_arc(
+        Arc::from("estimated_cost"),
+        Value::Float(node.operator_cost),
+    );
     rec.set_arc(Arc::from("depth"), Value::Integer(depth as i64));
     out.push(rec);
     for child in &node.children {

--- a/crates/reddb-server/src/storage/query/executors/vector.rs
+++ b/crates/reddb-server/src/storage/query/executors/vector.rs
@@ -653,6 +653,7 @@ fn query_expr_name(expr: &QueryExpr) -> &'static str {
         QueryExpr::ApplyMigration(_) => "apply_migration",
         QueryExpr::RollbackMigration(_) => "rollback_migration",
         QueryExpr::ExplainMigration(_) => "explain_migration",
+        QueryExpr::Explain(_) => "explain",
         QueryExpr::EventsBackfill(_) => "events_backfill",
         QueryExpr::EventsBackfillStatus { .. } => "events_backfill_status",
     }

--- a/crates/reddb-server/src/storage/query/planner/cost.rs
+++ b/crates/reddb-server/src/storage/query/planner/cost.rs
@@ -287,6 +287,7 @@ impl CostEstimator {
             QueryExpr::Path(pq) => self.estimate_path(pq),
             QueryExpr::Vector(vq) => self.estimate_vector(vq),
             QueryExpr::Hybrid(hq) => self.estimate_hybrid(hq),
+            QueryExpr::Explain(explain) => self.estimate(&explain.inner),
             // DML/DDL statements have minimal query cost
             QueryExpr::Insert(_)
             | QueryExpr::Update(_)
@@ -386,6 +387,7 @@ impl CostEstimator {
             QueryExpr::Path(pq) => self.estimate_path_cardinality(pq),
             QueryExpr::Vector(vq) => self.estimate_vector_cardinality(vq),
             QueryExpr::Hybrid(hq) => self.estimate_hybrid_cardinality(hq),
+            QueryExpr::Explain(explain) => self.estimate_cardinality(&explain.inner),
             // DML/DDL/Command statements return affected-row count or nothing
             QueryExpr::Insert(_)
             | QueryExpr::Update(_)

--- a/crates/reddb-server/src/storage/query/planner/logical.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical.rs
@@ -21,6 +21,7 @@ use logical_helpers::*;
 
 pub(super) fn logical_plan_node_with_catalog(db: &RedDB, expr: &QueryExpr) -> CanonicalLogicalNode {
     match expr {
+        QueryExpr::Explain(explain) => logical_plan_node_with_catalog(db, &explain.inner),
         QueryExpr::Table(query) => {
             let mut details = BTreeMap::new();
             let effective_projection_count = effective_table_projections(query).len();

--- a/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
@@ -426,6 +426,7 @@ pub(crate) fn join_expr_exposes_field_table(expr: &QueryExpr, table: &str) -> bo
         QueryExpr::Vector(query) => query.alias.as_deref() == Some(table) || table == "vector",
         QueryExpr::Hybrid(query) => query.alias.as_deref() == Some(table) || table == "hybrid",
         QueryExpr::Join(query) => join_query_exposes_field_table(query, table),
+        QueryExpr::Explain(query) => join_expr_exposes_field_table(&query.inner, table),
         QueryExpr::Insert(_)
         | QueryExpr::Update(_)
         | QueryExpr::Delete(_)
@@ -893,6 +894,7 @@ pub(crate) fn query_expr_kind(expr: &QueryExpr) -> &'static str {
         QueryExpr::ApplyMigration(_) => "apply_migration",
         QueryExpr::RollbackMigration(_) => "rollback_migration",
         QueryExpr::ExplainMigration(_) => "explain_migration",
+        QueryExpr::Explain(_) => "explain",
         QueryExpr::EventsBackfill(_) => "events_backfill",
         QueryExpr::EventsBackfillStatus { .. } => "events_backfill_status",
     }

--- a/crates/reddb-server/src/storage/query/unified/executor.rs
+++ b/crates/reddb-server/src/storage/query/unified/executor.rs
@@ -257,6 +257,7 @@ impl UnifiedExecutor {
             | QueryExpr::ApplyMigration(_)
             | QueryExpr::RollbackMigration(_)
             | QueryExpr::ExplainMigration(_)
+            | QueryExpr::Explain(_)
             | QueryExpr::EventsBackfill(_)
             | QueryExpr::EventsBackfillStatus { .. } => Err(ExecutionError::new(
                 "DML/DDL/Command statements are not supported in UnifiedExecutor",
@@ -505,6 +506,7 @@ impl UnifiedExecutor {
             | QueryExpr::ApplyMigration(_)
             | QueryExpr::RollbackMigration(_)
             | QueryExpr::ExplainMigration(_)
+            | QueryExpr::Explain(_)
             | QueryExpr::EventsBackfill(_)
             | QueryExpr::EventsBackfillStatus { .. } => Err(ExecutionError::new(
                 "DML/DDL/Command statements are not supported in UnifiedExecutor",

--- a/crates/reddb-server/tests/conformance.rs
+++ b/crates/reddb-server/tests/conformance.rs
@@ -125,6 +125,7 @@ fn variant_name(q: &QueryExpr) -> &'static str {
         QueryExpr::ApplyMigration(_) => "ApplyMigration",
         QueryExpr::RollbackMigration(_) => "RollbackMigration",
         QueryExpr::ExplainMigration(_) => "ExplainMigration",
+        QueryExpr::Explain(_) => "Explain",
         QueryExpr::TransactionControl(_) => "TransactionControl",
         QueryExpr::MaintenanceCommand(_) => "MaintenanceCommand",
         QueryExpr::CreateSchema(_) => "CreateSchema",

--- a/crates/reddb-server/tests/conformance/explain_delete_audit.toml
+++ b/crates/reddb-server/tests/conformance/explain_delete_audit.toml
@@ -1,0 +1,4 @@
+input = "EXPLAIN DELETE FROM audit WHERE id = 2"
+expected_kind = "Explain"
+source = "tests/grouped/sql_window/e2e_explain.rs:91"
+kind = "positive"

--- a/crates/reddb-server/tests/conformance/explain_insert_audit.toml
+++ b/crates/reddb-server/tests/conformance/explain_insert_audit.toml
@@ -1,0 +1,4 @@
+input = "EXPLAIN INSERT INTO audit (id, note) VALUES (99, 'boom')"
+expected_kind = "Explain"
+source = "tests/grouped/sql_window/e2e_explain.rs:89"
+kind = "positive"

--- a/crates/reddb-server/tests/conformance/explain_update_audit.toml
+++ b/crates/reddb-server/tests/conformance/explain_update_audit.toml
@@ -1,0 +1,4 @@
+input = "EXPLAIN UPDATE audit SET note = 'changed' WHERE id = 1"
+expected_kind = "Explain"
+source = "tests/grouped/sql_window/e2e_explain.rs:90"
+kind = "positive"

--- a/tests/grouped/sql_window/e2e_explain.rs
+++ b/tests/grouped/sql_window/e2e_explain.rs
@@ -3,13 +3,16 @@
 //! Covers the plain `EXPLAIN <stmt>` surface: the runtime intercepts
 //! before SQL parsing, runs the planner on the inner statement
 //! without executing it, and returns the CanonicalLogicalNode tree
-//! as rows. Columns: op, source, est_rows, est_cost, depth.
+//! as rows. Columns: op, source, estimated_rows, estimated_cost, depth.
 //!
 //! `EXPLAIN ALTER FOR CREATE TABLE ...` is a separate schema-diff
 //! command and stays on the regular SQL path.
 
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime};
+
+const EXPLAIN_PLAN_COLUMNS: &[&str] =
+    &["op", "source", "estimated_rows", "estimated_cost", "depth"];
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
@@ -38,10 +41,7 @@ fn explain_select_returns_plan_tree_rows() {
     assert_eq!(result.affected_rows, 0);
 
     // Column contract — HTTP/gRPC surface depends on this shape.
-    assert_eq!(
-        result.result.columns,
-        vec!["op", "source", "est_rows", "est_cost", "depth"]
-    );
+    assert_eq!(result.result.columns, EXPLAIN_PLAN_COLUMNS);
 
     assert!(
         !result.result.records.is_empty(),
@@ -58,9 +58,9 @@ fn explain_select_returns_plan_tree_rows() {
         Some(Value::Text(op)) => assert!(!op.is_empty(), "root op must be non-empty"),
         other => panic!("root op must be Text, got {other:?}"),
     }
-    // est_rows/est_cost are floats.
-    assert!(matches!(root.get("est_rows"), Some(Value::Float(_))));
-    assert!(matches!(root.get("est_cost"), Some(Value::Float(_))));
+    // Planner row counts and costs must be explicitly labeled as estimates.
+    assert!(matches!(root.get("estimated_rows"), Some(Value::Float(_))));
+    assert!(matches!(root.get("estimated_cost"), Some(Value::Float(_))));
 }
 
 #[test]
@@ -77,23 +77,64 @@ fn explain_is_case_insensitive() {
 }
 
 #[test]
-fn explain_does_not_execute_the_inner_statement() {
+fn explain_dml_returns_plan_rows_without_executing_inner_statement() {
     let rt = rt();
     exec(&rt, "CREATE TABLE audit (id INT, note TEXT)");
+    exec(
+        &rt,
+        "INSERT INTO audit (id, note) VALUES (1, 'keep'), (2, 'remove')",
+    );
 
-    // EXPLAIN on an INSERT must not actually write the row.
-    let _ = rt
-        .execute_query("EXPLAIN INSERT INTO audit (id, note) VALUES (99, 'boom')")
-        .expect("EXPLAIN INSERT should succeed");
+    for sql in [
+        "EXPLAIN INSERT INTO audit (id, note) VALUES (99, 'boom')",
+        "EXPLAIN UPDATE audit SET note = 'changed' WHERE id = 1",
+        "EXPLAIN DELETE FROM audit WHERE id = 2",
+    ] {
+        let explained = rt.execute_query(sql).expect(sql);
+        assert_eq!(explained.statement, "explain", "{sql}");
+        assert_eq!(explained.affected_rows, 0, "{sql}");
+        assert_eq!(explained.result.columns, EXPLAIN_PLAN_COLUMNS, "{sql}");
+        assert_eq!(explained.result.records.len(), 1, "{sql}");
+
+        let root = &explained.result.records[0];
+        assert!(
+            matches!(root.get("op"), Some(Value::Text(op)) if op.as_ref() == "dml_ddl"),
+            "{sql}: {root:?}"
+        );
+        assert!(
+            matches!(root.get("source"), Some(Value::Null)),
+            "{sql}: {root:?}"
+        );
+        assert!(
+            matches!(root.get("estimated_rows"), Some(Value::Float(0.0))),
+            "{sql}: {root:?}"
+        );
+        assert!(
+            matches!(root.get("estimated_cost"), Some(Value::Float(1.0))),
+            "{sql}: {root:?}"
+        );
+        assert!(
+            matches!(root.get("depth"), Some(Value::Integer(0))),
+            "{sql}: {root:?}"
+        );
+    }
 
     let after = rt
-        .execute_query("SELECT * FROM audit")
+        .execute_query("SELECT id, note FROM audit")
         .expect("SELECT after EXPLAIN");
     assert_eq!(
         after.result.records.len(),
-        0,
-        "EXPLAIN must not materialise the INSERT"
+        2,
+        "EXPLAIN must not materialise INSERT, UPDATE, or DELETE"
     );
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(1)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "keep")
+    }));
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(2)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "remove")
+    }));
 }
 
 #[test]
@@ -112,10 +153,10 @@ fn explain_alter_still_routes_to_schema_diff() {
         result.err()
     );
     let r = result.unwrap();
-    // Both my new EXPLAIN and the existing EXPLAIN ALTER set
+    // Both generic EXPLAIN and the existing EXPLAIN ALTER set
     // statement="explain", so distinguish by the column shape: the
     // schema-diff command reports ["table","format","diff"], while
-    // the plan-tree shape is ["op","source","est_rows","est_cost","depth"].
+    // the plan-tree shape is ["op","source","estimated_rows","estimated_cost","depth"].
     assert_eq!(
         r.result.columns,
         vec!["table", "format", "diff"],


### PR DESCRIPTION
Automated AFK landing for #1789. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1789

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785998876&installation_id=129708444&pr_number=1883&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1883&signature=c62a4ab9fa41177ec3096a859ee61988a686dbe71416e76ece35ded862be87a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->