### PR TITLE
chore: #1791 Ephemeral store: JSON/NDJSON files materialize as document collections

### DIFF
--- a/crates/reddb-server/src/runtime/impl_ephemeral.rs
+++ b/crates/reddb-server/src/runtime/impl_ephemeral.rs
@@ -17,8 +17,11 @@
 //! `SELECT … FROM <stem>` resolve identically for every query shape
 //! (projections, filters, and aggregates alike).
 
+use std::io::{BufRead, BufReader};
 use std::path::Path;
 
+use crate::application::ports::RuntimeEntityPort;
+use crate::application::CreateDocumentInput;
 use crate::runtime::RedDBRuntime;
 use crate::storage::import::{CsvConfig, CsvImporter};
 
@@ -45,12 +48,16 @@ pub struct EphemeralTable {
 pub enum EphemeralError {
     /// The path does not point at a readable regular file.
     NotAFile { path: String },
-    /// The extension is neither `.csv` nor `.tsv`/`.tab`.
+    /// The extension is not one of the ephemeral data formats.
     UnsupportedExtension { path: String, ext: String },
     /// The file stem sanitized to an empty identifier.
     EmptyStem { path: String },
     /// The CSV import path rejected the file (I/O or parse failure).
     Import { path: String, source: String },
+    /// The JSON or NDJSON document parser rejected the file.
+    Json { path: String, source: String },
+    /// A JSON file parsed successfully but was not an array of objects.
+    JsonShape { path: String, source: String },
 }
 
 impl std::fmt::Display for EphemeralError {
@@ -61,14 +68,20 @@ impl std::fmt::Display for EphemeralError {
             }
             EphemeralError::UnsupportedExtension { path, ext } => write!(
                 f,
-                "unsupported data file '{path}': '.{ext}' is not a CSV or TSV file \
-                 (expected .csv, .tsv, or .tab)"
+                "unsupported data file '{path}': '.{ext}' is not a supported ephemeral data file \
+                 (expected .csv, .tsv, .tab, .json, .jsonl, or .ndjson)"
             ),
             EphemeralError::EmptyStem { path } => write!(
                 f,
                 "cannot derive a table name from '{path}': the file stem is empty"
             ),
             EphemeralError::Import { path, source } => {
+                write!(f, "failed to load '{path}': {source}")
+            }
+            EphemeralError::Json { path, source } => {
+                write!(f, "failed to parse '{path}': {source}")
+            }
+            EphemeralError::JsonShape { path, source } => {
                 write!(f, "failed to load '{path}': {source}")
             }
         }
@@ -108,11 +121,20 @@ pub fn sanitize_stem(stem: &str) -> Option<String> {
     }
 }
 
-/// Field delimiter inferred from a data file's extension.
-fn delimiter_for_extension(ext: &str) -> Option<u8> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EphemeralFormat {
+    Delimited(u8),
+    JsonArray,
+    Ndjson,
+}
+
+/// Data format inferred from a data file's extension.
+fn format_for_extension(ext: &str) -> Option<EphemeralFormat> {
     match ext {
-        "csv" => Some(b','),
-        "tsv" | "tab" => Some(b'\t'),
+        "csv" => Some(EphemeralFormat::Delimited(b',')),
+        "tsv" | "tab" => Some(EphemeralFormat::Delimited(b'\t')),
+        "json" => Some(EphemeralFormat::JsonArray),
+        "jsonl" | "ndjson" => Some(EphemeralFormat::Ndjson),
         _ => None,
     }
 }
@@ -137,8 +159,8 @@ impl RedDBRuntime {
             .and_then(|e| e.to_str())
             .unwrap_or("")
             .to_ascii_lowercase();
-        let delimiter =
-            delimiter_for_extension(&ext).ok_or_else(|| EphemeralError::UnsupportedExtension {
+        let format =
+            format_for_extension(&ext).ok_or_else(|| EphemeralError::UnsupportedExtension {
                 path: display.clone(),
                 ext: ext.clone(),
             })?;
@@ -151,7 +173,15 @@ impl RedDBRuntime {
             path: display.clone(),
         })?;
 
-        let rows_imported = self.import_csv_into(path, &collection, delimiter, &display)?;
+        let rows_imported = match format {
+            EphemeralFormat::Delimited(delimiter) => {
+                self.import_csv_into(path, &collection, delimiter, &display)?
+            }
+            EphemeralFormat::JsonArray => {
+                self.import_json_array_into(path, &collection, &display)?
+            }
+            EphemeralFormat::Ndjson => self.import_ndjson_into(path, &collection, &display)?,
+        };
 
         // The single loaded file is also addressable by the positional
         // alias `t`. Rather than a rewrite view — which leaks on
@@ -160,7 +190,17 @@ impl RedDBRuntime {
         // through either name. Skipped when the stem already sanitized to
         // `t` (e.g. `t.csv`), which would collide.
         if collection != POSITIONAL_ALIAS {
-            self.import_csv_into(path, POSITIONAL_ALIAS, delimiter, &display)?;
+            match format {
+                EphemeralFormat::Delimited(delimiter) => {
+                    self.import_csv_into(path, POSITIONAL_ALIAS, delimiter, &display)?;
+                }
+                EphemeralFormat::JsonArray => {
+                    self.import_json_array_into(path, POSITIONAL_ALIAS, &display)?;
+                }
+                EphemeralFormat::Ndjson => {
+                    self.import_ndjson_into(path, POSITIONAL_ALIAS, &display)?;
+                }
+            }
         }
 
         Ok(EphemeralTable {
@@ -207,6 +247,108 @@ impl RedDBRuntime {
 
         Ok(stats.records_imported)
     }
+
+    fn import_json_array_into(
+        &self,
+        path: &Path,
+        collection: &str,
+        display: &str,
+    ) -> Result<usize, EphemeralError> {
+        let raw = std::fs::read_to_string(path).map_err(|e| EphemeralError::Json {
+            path: display.to_string(),
+            source: e.to_string(),
+        })?;
+        let parsed: crate::serde_json::Value =
+            crate::serde_json::from_str(&raw).map_err(|e| EphemeralError::Json {
+                path: display.to_string(),
+                source: e.to_string(),
+            })?;
+        let crate::serde_json::Value::Array(values) = parsed else {
+            return Err(EphemeralError::JsonShape {
+                path: display.to_string(),
+                source: "top-level JSON value must be an array of document objects".to_string(),
+            });
+        };
+
+        for (idx, value) in values.iter().enumerate() {
+            if !matches!(value, crate::serde_json::Value::Object(_)) {
+                return Err(EphemeralError::JsonShape {
+                    path: display.to_string(),
+                    source: format!("element {} is not a JSON object", idx + 1),
+                });
+            }
+        }
+
+        self.insert_documents(collection, values, display)
+    }
+
+    fn import_ndjson_into(
+        &self,
+        path: &Path,
+        collection: &str,
+        display: &str,
+    ) -> Result<usize, EphemeralError> {
+        let file = std::fs::File::open(path).map_err(|e| EphemeralError::Json {
+            path: display.to_string(),
+            source: e.to_string(),
+        })?;
+        let mut values = Vec::new();
+        for (idx, line) in BufReader::new(file).lines().enumerate() {
+            let line_number = idx + 1;
+            let line = line.map_err(|e| EphemeralError::Json {
+                path: display.to_string(),
+                source: format!("line {line_number}: {e}"),
+            })?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let value: crate::serde_json::Value =
+                crate::serde_json::from_str(trimmed).map_err(|e| EphemeralError::Json {
+                    path: display.to_string(),
+                    source: format!("line {line_number}: {e}"),
+                })?;
+            if !matches!(value, crate::serde_json::Value::Object(_)) {
+                return Err(EphemeralError::JsonShape {
+                    path: display.to_string(),
+                    source: format!("line {line_number} is not a JSON object"),
+                });
+            }
+            values.push(value);
+        }
+
+        self.insert_documents(collection, values, display)
+    }
+
+    fn insert_documents(
+        &self,
+        collection: &str,
+        values: Vec<crate::serde_json::Value>,
+        display: &str,
+    ) -> Result<usize, EphemeralError> {
+        let rows_imported = values.len();
+        self.execute_query(&format!("CREATE DOCUMENT {collection}"))
+            .map_err(|e| EphemeralError::Import {
+                path: display.to_string(),
+                source: e.to_string(),
+            })?;
+
+        for value in values {
+            self.create_document(CreateDocumentInput {
+                collection: collection.to_string(),
+                body: value,
+                metadata: Vec::new(),
+                node_links: Vec::new(),
+                vector_links: Vec::new(),
+            })
+            .map_err(|e| EphemeralError::Import {
+                path: display.to_string(),
+                source: e.to_string(),
+            })?;
+        }
+
+        Ok(rows_imported)
+    }
 }
 
 #[cfg(test)]
@@ -244,9 +386,27 @@ mod tests {
 
     #[test]
     fn delimiter_inference() {
-        assert_eq!(delimiter_for_extension("csv"), Some(b','));
-        assert_eq!(delimiter_for_extension("tsv"), Some(b'\t'));
-        assert_eq!(delimiter_for_extension("tab"), Some(b'\t'));
-        assert_eq!(delimiter_for_extension("json"), None);
+        assert_eq!(
+            format_for_extension("csv"),
+            Some(EphemeralFormat::Delimited(b','))
+        );
+        assert_eq!(
+            format_for_extension("tsv"),
+            Some(EphemeralFormat::Delimited(b'\t'))
+        );
+        assert_eq!(
+            format_for_extension("tab"),
+            Some(EphemeralFormat::Delimited(b'\t'))
+        );
+        assert_eq!(
+            format_for_extension("json"),
+            Some(EphemeralFormat::JsonArray)
+        );
+        assert_eq!(format_for_extension("jsonl"), Some(EphemeralFormat::Ndjson));
+        assert_eq!(
+            format_for_extension("ndjson"),
+            Some(EphemeralFormat::Ndjson)
+        );
+        assert_eq!(format_for_extension("txt"), None);
     }
 }

--- a/crates/reddb-server/src/storage/query/planner/cache_key.rs
+++ b/crates/reddb-server/src/storage/query/planner/cache_key.rs
@@ -166,18 +166,13 @@ pub fn normalize_cache_key(sql: &str) -> String {
             {
                 out.push('?');
                 preserve_numeric_literal = false;
-            } else {
-                // Uppercase the word so `select` and `SELECT`
-                // collapse. This over-normalises — it also
-                // uppercases column names — but plan cache
-                // equivalence still holds because the column
-                // names are part of the normalised form and
-                // retain their identity within the query.
-                for c in word.chars() {
-                    out.push(c.to_ascii_uppercase());
-                }
+            } else if is_cache_key_keyword(word) {
+                push_uppercase(&mut out, word);
                 preserve_numeric_literal =
                     word.eq_ignore_ascii_case("limit") || word.eq_ignore_ascii_case("offset");
+            } else {
+                out.push_str(word);
+                preserve_numeric_literal = false;
             }
             last_was_space = false;
             continue;
@@ -343,12 +338,13 @@ pub fn normalize_and_extract(sql: &str) -> (String, Vec<Value>) {
                 out.push('?');
                 binds.push(Value::Null);
                 preserve_numeric_literal = false;
-            } else {
-                for c in word.chars() {
-                    out.push(c.to_ascii_uppercase());
-                }
+            } else if is_cache_key_keyword(word) {
+                push_uppercase(&mut out, word);
                 preserve_numeric_literal =
                     word.eq_ignore_ascii_case("limit") || word.eq_ignore_ascii_case("offset");
+            } else {
+                out.push_str(word);
+                preserve_numeric_literal = false;
             }
             last_was_space = false;
             continue;
@@ -365,6 +361,72 @@ pub fn normalize_and_extract(sql: &str) -> (String, Vec<Value>) {
     }
 
     (out, binds)
+}
+
+fn is_cache_key_keyword(word: &str) -> bool {
+    matches!(
+        word.to_ascii_uppercase().as_str(),
+        "SELECT"
+            | "FROM"
+            | "WHERE"
+            | "AND"
+            | "OR"
+            | "NOT"
+            | "AS"
+            | "IS"
+            | "BETWEEN"
+            | "LIKE"
+            | "IN"
+            | "ORDER"
+            | "BY"
+            | "ASC"
+            | "DESC"
+            | "NULLS"
+            | "FIRST"
+            | "LAST"
+            | "LIMIT"
+            | "OFFSET"
+            | "GROUP"
+            | "HAVING"
+            | "COUNT"
+            | "SUM"
+            | "AVG"
+            | "MIN"
+            | "MAX"
+            | "DISTINCT"
+            | "INSERT"
+            | "INTO"
+            | "VALUES"
+            | "UPDATE"
+            | "SET"
+            | "DELETE"
+            | "CREATE"
+            | "TABLE"
+            | "DOCUMENT"
+            | "KV"
+            | "DROP"
+            | "ALTER"
+            | "INDEX"
+            | "JOIN"
+            | "INNER"
+            | "LEFT"
+            | "RIGHT"
+            | "FULL"
+            | "OUTER"
+            | "ON"
+            | "RETURNING"
+            | "CONTAINS"
+            | "STARTS"
+            | "ENDS"
+            | "WITH"
+            | "EXPLAIN"
+    )
+}
+
+fn push_uppercase(out: &mut String, word: &str) {
+    for c in word.chars() {
+        out.push(c.to_ascii_uppercase());
+    }
 }
 
 pub fn extract_literal_bindings(sql: &str) -> Result<Vec<Value>, String> {
@@ -483,6 +545,18 @@ mod tests {
         assert_ne!(
             normalize_cache_key(r#"SELECT "col" FROM t"#),
             normalize_cache_key(r#"SELECT "other" FROM t"#),
+        );
+    }
+
+    #[test]
+    fn unquoted_identifier_case_is_preserved() {
+        assert_ne!(
+            normalize_cache_key("SELECT name FROM docs WHERE UserId = 1"),
+            normalize_cache_key("SELECT name FROM docs WHERE userid = 1"),
+        );
+        assert_ne!(
+            normalize_and_extract("SELECT name FROM docs WHERE UserId = 1").0,
+            normalize_and_extract("SELECT name FROM docs WHERE userid = 1").0,
         );
     }
 

--- a/crates/reddb-server/tests/ephemeral_store_1786.rs
+++ b/crates/reddb-server/tests/ephemeral_store_1786.rs
@@ -92,6 +92,71 @@ fn tsv_materializes_with_tab_delimiter() {
 }
 
 #[test]
+fn ndjson_materializes_as_document_collection() {
+    let dir = temp_dir("ndjson-docs");
+    let path = write_fixture(
+        dir.path(),
+        "events.ndjson",
+        "{\"UserId\":7,\"name\":\"Ada\",\"event_type\":\"login\"}\n\
+         {\"UserId\":8,\"name\":\"Linus\",\"event_type\":\"logout\"}\n",
+    );
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let table = rt.materialize_data_file(&path).expect("materialize ndjson");
+
+    assert_eq!(table.collection, "events");
+    assert_eq!(table.alias, POSITIONAL_ALIAS);
+    assert_eq!(table.rows_imported, 2);
+
+    let by_stem = rt
+        .execute_query("SELECT name FROM events WHERE UserId = 8")
+        .expect("query ndjson by exact body key");
+    assert_eq!(by_stem.result.records.len(), 1);
+
+    let by_alias = rt
+        .execute_query("SELECT name FROM t WHERE event_type = 'login'")
+        .expect("query ndjson by alias");
+    assert_eq!(by_alias.result.records.len(), 1);
+
+    let wrong_case = rt
+        .execute_query("SELECT name FROM events WHERE userid = 8")
+        .expect("query ndjson wrong case");
+    assert_eq!(
+        wrong_case.result.records.len(),
+        0,
+        "document body keys must keep exact casing"
+    );
+}
+
+#[test]
+fn json_array_materializes_as_document_collection() {
+    let dir = temp_dir("json-docs");
+    let path = write_fixture(
+        dir.path(),
+        "products.json",
+        r#"[{"sku":"A","qty":3},{"sku":"B","qty":10}]"#,
+    );
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let table = rt
+        .materialize_data_file(&path)
+        .expect("materialize json array");
+
+    assert_eq!(table.collection, "products");
+    assert_eq!(table.rows_imported, 2);
+
+    let rows = rt
+        .execute_query("SELECT sku FROM products WHERE qty > 5")
+        .expect("query json array documents");
+    assert_eq!(rows.result.records.len(), 1);
+
+    let alias_rows = rt
+        .execute_query("SELECT sku FROM t WHERE qty = 3")
+        .expect("query json array alias");
+    assert_eq!(alias_rows.result.records.len(), 1);
+}
+
+#[test]
 fn file_stem_is_sanitized_into_a_collection_name() {
     let dir = temp_dir("sanitize");
     let path = write_fixture(dir.path(), "vendas-2026 (v2).csv", "a,b\n1,2\n");
@@ -122,15 +187,61 @@ fn missing_file_is_a_didactic_error_not_a_panic() {
 #[test]
 fn unsupported_extension_is_a_didactic_error() {
     let dir = temp_dir("unsupported");
-    let path = write_fixture(dir.path(), "data.json", "{}\n");
+    let path = write_fixture(dir.path(), "data.txt", "{}\n");
 
     let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
     let err = rt
         .materialize_data_file(&path)
-        .expect_err("json is out of scope for this slice");
+        .expect_err("txt is out of scope for this slice");
     let msg = err.to_string();
     assert!(
-        msg.contains("not a CSV or TSV"),
+        msg.contains("not a supported ephemeral data file"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn malformed_ndjson_names_the_offending_line() {
+    let dir = temp_dir("bad-ndjson");
+    let path = write_fixture(
+        dir.path(),
+        "broken.ndjson",
+        "{\"name\":\"ok\"}\n{\"name\":\"broken\"\n",
+    );
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("malformed ndjson must error");
+    let msg = err.to_string();
+    assert!(msg.contains("line 2"), "unexpected message: {msg}");
+}
+
+#[test]
+fn json_array_non_object_element_names_the_element() {
+    let dir = temp_dir("bad-json-element");
+    let path = write_fixture(dir.path(), "broken.json", r#"[{"name":"ok"}, 42]"#);
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("non-object json array element must error");
+    let msg = err.to_string();
+    assert!(msg.contains("element 2"), "unexpected message: {msg}");
+}
+
+#[test]
+fn non_array_json_top_level_is_rejected() {
+    let dir = temp_dir("bad-json-top");
+    let path = write_fixture(dir.path(), "object.json", r#"{"name":"not an array"}"#);
+
+    let rt = RedDBRuntime::in_memory().expect("in-memory runtime");
+    let err = rt
+        .materialize_data_file(&path)
+        .expect_err("non-array json must error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("top-level JSON value must be an array"),
         "unexpected message: {msg}"
     );
 }

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -70,15 +70,20 @@ fn checkpoint_local_runtime(rt: &reddb::RedDBRuntime) {
     let _ = rt.checkpoint();
 }
 
-/// Returns `true` when the first `query` positional names a CSV/TSV data
+/// Returns `true` when the first `query` positional names a supported data
 /// file, triggering the ephemeral-store tracer (PRD #1785, issue #1786):
-/// `red query <file.csv> <sql>`.
+/// `red query <file.csv|file.json> <sql>`.
 fn is_ephemeral_data_file(arg: &str) -> bool {
     let lower = arg.to_ascii_lowercase();
-    lower.ends_with(".csv") || lower.ends_with(".tsv") || lower.ends_with(".tab")
+    lower.ends_with(".csv")
+        || lower.ends_with(".tsv")
+        || lower.ends_with(".tab")
+        || lower.ends_with(".json")
+        || lower.ends_with(".jsonl")
+        || lower.ends_with(".ndjson")
 }
 
-/// Run the ephemeral-store tracer: materialize a local CSV/TSV file into
+/// Run the ephemeral-store tracer: materialize a local data file into
 /// a throwaway in-memory embedded store, execute the query against it,
 /// print the result, and discard the store. No server, no pre-existing
 /// store, nothing durable created — the collection is addressable by its
@@ -94,9 +99,12 @@ fn run_ephemeral_query(
 
     if sql.is_empty() {
         if json_mode {
-            json_error("query", "Usage: red query <file.csv|file.tsv> <sql>");
+            json_error(
+                "query",
+                "Usage: red query <file.csv|file.tsv|file.json|file.ndjson> <sql>",
+            );
         }
-        eprintln!("Usage: red query <file.csv|file.tsv> <sql>");
+        eprintln!("Usage: red query <file.csv|file.tsv|file.json|file.ndjson> <sql>");
         eprintln!("Example: red query data.csv \"SELECT * FROM t\"");
         std::process::exit(1);
     }
@@ -1394,7 +1402,7 @@ fn main() {
                 std::process::exit(1);
             });
             // Ephemeral-store tracer (PRD #1785, issue #1786):
-            // `red query <file.csv|file.tsv> <sql>` materializes the file
+            // `red query <file.csv|file.tsv|file.json|file.ndjson> <sql>` materializes the file
             // into a throwaway in-memory store and queries it. Detected
             // when a second positional is present and the first names a
             // CSV/TSV data file.

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -1,7 +1,7 @@
 //! End-to-end CLI tests for the ephemeral-store tracer (issue #1786).
 //!
 //! Spawns the real `red` binary via `CARGO_BIN_EXE_red` so the full
-//! `main()` path is exercised: `red query <file.csv|file.tsv> <sql>`
+//! `main()` path is exercised: `red query <file.csv|file.tsv|file.json|file.ndjson> <sql>`
 //! materializes the file into a throwaway in-memory store, runs the
 //! query, prints the result, and leaves nothing durable behind.
 
@@ -85,6 +85,44 @@ fn red_query_tsv_file_by_alias() {
     assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
     assert!(stdout.contains("\"Porto\""), "stdout: {stdout}");
     assert!(!stdout.contains("\"Lisbon\""), "Lisbon leaked: {stdout}");
+}
+
+#[test]
+fn red_query_ndjson_file_as_documents() {
+    let dir = temp_dir("ndjson");
+    let path = dir.path().join("events.ndjson");
+    fs::write(
+        &path,
+        "{\"UserId\":7,\"name\":\"Ada\"}\n{\"UserId\":8,\"name\":\"Linus\"}\n",
+    )
+    .expect("write fixture");
+    let path_str = path.display().to_string();
+
+    let (code, stdout, stderr) = run_query(
+        &path_str,
+        "SELECT name FROM t WHERE UserId = 8",
+        &["--json"],
+    );
+    assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
+    assert!(stdout.contains("\"Linus\""), "stdout: {stdout}");
+    assert!(!stdout.contains("\"Ada\""), "Ada leaked: {stdout}");
+}
+
+#[test]
+fn red_query_json_array_file_as_documents() {
+    let dir = temp_dir("json");
+    let path = dir.path().join("products.json");
+    fs::write(&path, r#"[{"sku":"A","qty":3},{"sku":"B","qty":10}]"#).expect("write fixture");
+    let path_str = path.display().to_string();
+
+    let (code, stdout, stderr) = run_query(
+        &path_str,
+        "SELECT sku FROM products WHERE qty > 5",
+        &["--json"],
+    );
+    assert_eq!(code, 0, "exit != 0; stderr: {stderr}");
+    assert!(stdout.contains("\"B\""), "stdout: {stdout}");
+    assert!(!stdout.contains("\"A\""), "A leaked: {stdout}");
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1791. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1791

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786000489&installation_id=129708444&pr_number=1884&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1884&signature=e1aefcecb9898fa2a70039b0cd2a089ed5f335c9f316dacc7d5bd556c1b0dd46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->