### PR TITLE
chore: #1793 Ephemeral store: writes + `--save` graduation to embedded single-file

### DIFF
--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -89,6 +89,7 @@ fn run_ephemeral_query(
     sql: &str,
     json_mode: bool,
     row_format: RowFormat,
+    save_path: Option<String>,
 ) -> ! {
     use std::path::Path;
 
@@ -109,14 +110,42 @@ fn run_ephemeral_query(
         std::process::exit(1);
     });
 
-    // Throwaway in-memory store — nothing durable is written.
-    let rt = reddb::RedDBRuntime::in_memory().unwrap_or_else(|err| {
-        if json_mode {
-            json_error("query", &err.to_string());
+    let rt = match save_path.as_deref() {
+        Some(path) if path.trim().is_empty() => {
+            if json_mode {
+                json_error("query", "--save requires a non-empty path");
+            }
+            eprintln!("query: --save requires a non-empty path");
+            std::process::exit(1);
         }
-        eprintln!("error: {err}");
-        std::process::exit(1);
-    });
+        Some(path) => {
+            if Path::new(path).exists() {
+                if json_mode {
+                    json_error("query", &format!("save target '{path}' already exists"));
+                }
+                eprintln!("query: save target '{path}' already exists");
+                std::process::exit(1);
+            }
+            reddb::RedDBRuntime::with_options(reddb::api::RedDBOptions::persistent(path))
+                .unwrap_or_else(|err| {
+                    if json_mode {
+                        json_error("query", &err.to_string());
+                    }
+                    eprintln!("error: {err}");
+                    std::process::exit(1);
+                })
+        }
+        None => {
+            // Throwaway in-memory store — nothing durable is written.
+            reddb::RedDBRuntime::in_memory().unwrap_or_else(|err| {
+                if json_mode {
+                    json_error("query", &err.to_string());
+                }
+                eprintln!("error: {err}");
+                std::process::exit(1);
+            })
+        }
+    };
 
     if let Err(err) = rt.materialize_data_file(Path::new(file)) {
         // Missing, unreadable, or malformed files land here as a
@@ -156,6 +185,15 @@ fn run_ephemeral_query(
 
     match exec_result {
         Ok(qr) => {
+            if let Some(path) = save_path.as_deref() {
+                if let Err(err) = rt.checkpoint() {
+                    if json_mode {
+                        json_error("query", &err.to_string());
+                    }
+                    eprintln!("query: failed to save '{path}': {err}");
+                    std::process::exit(1);
+                }
+            }
             if json_mode {
                 json_ok("query", &format_result_json(&qr));
             } else {
@@ -1405,6 +1443,7 @@ fn main() {
                     remaining[1].as_str(),
                     json_mode,
                     row_format,
+                    flag_string(&result.flags, "save"),
                 );
             }
             let sql = remaining.first().map(|s| s.as_str()).unwrap_or("");
@@ -3818,6 +3857,9 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 ));
                 flags.push(cli::types::FlagSchema::new("format").with_description(
                     "Row output format for query results (table|json|ndjson|csv|tsv).",
+                ));
+                flags.push(cli::types::FlagSchema::new("save").with_description(
+                    "Persist an ephemeral data-file query session as a new embedded .rdb file",
                 ));
             }
         }

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -27,6 +27,18 @@ fn run_query(file: &str, sql: &str, extra: &[&str]) -> (i32, String, String) {
     )
 }
 
+fn run_red(args: &[&str]) -> (i32, String, String) {
+    let out = Command::new(red_binary())
+        .args(args)
+        .output()
+        .expect("spawn red");
+    (
+        out.status.code().unwrap_or(-1),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
 fn temp_dir(label: &str) -> tempfile::TempDir {
     tempfile::Builder::new()
         .prefix(&format!("reddb-test-cli-ephemeral-{label}-"))
@@ -62,6 +74,107 @@ fn red_query_csv_file_no_server_no_store() {
     assert!(!stdout.contains("\"Bob\""), "Bob leaked: {stdout}");
 
     // The ephemeral store leaves no durable artifacts next to the file.
+    let mut names: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["people.csv".to_string()]);
+}
+
+#[test]
+fn red_query_csv_write_save_reopen_embedded_store() {
+    let dir = temp_dir("save");
+    let fixture = dir.path().join("people.csv");
+    let update_saved = dir.path().join("people-update.rdb");
+    let insert_saved = dir.path().join("people-insert.rdb");
+    let delete_saved = dir.path().join("people-delete.rdb");
+    fs::write(&fixture, "id,name,age\n1,Alice,30\n2,Bob,9\n").expect("write fixture");
+    let fixture_str = fixture.display().to_string();
+    let update_saved_str = update_saved.display().to_string();
+    let insert_saved_str = insert_saved.display().to_string();
+    let delete_saved_str = delete_saved.display().to_string();
+
+    let (code, _stdout, stderr) = run_query(
+        &fixture_str,
+        "UPDATE people SET age = 31 WHERE name = 'Alice'",
+        &["--save", &update_saved_str],
+    );
+    assert_eq!(code, 0, "update/save failed; stderr: {stderr}");
+    assert!(
+        update_saved.exists(),
+        "--save should create an embedded store"
+    );
+
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &update_saved_str,
+        "SELECT name, age FROM people WHERE name = 'Alice'",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "reopen query failed; stderr: {stderr}");
+    assert!(stdout.contains("\"Alice\""), "stdout: {stdout}");
+    assert!(stdout.contains("\"age\":31"), "stdout: {stdout}");
+
+    let (code, _stdout, stderr) = run_query(
+        &fixture_str,
+        "INSERT INTO people (id, name, age) VALUES (3, 'Cara', 44)",
+        &["--save", &insert_saved_str],
+    );
+    assert_eq!(code, 0, "insert/save failed; stderr: {stderr}");
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &insert_saved_str,
+        "SELECT count(*) AS n FROM people",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "reopen inserted store failed; stderr: {stderr}");
+    assert!(stdout.contains("\"n\":3"), "stdout: {stdout}");
+
+    let (code, _stdout, stderr) = run_query(
+        &fixture_str,
+        "DELETE FROM people WHERE name = 'Bob'",
+        &["--save", &delete_saved_str],
+    );
+    assert_eq!(code, 0, "delete/save failed; stderr: {stderr}");
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &delete_saved_str,
+        "SELECT count(*) AS n FROM people",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "reopen deleted store failed; stderr: {stderr}");
+    assert!(stdout.contains("\"n\":1"), "stdout: {stdout}");
+
+    let (code, _stdout, stderr) = run_query(
+        &fixture_str,
+        "INSERT INTO people (id, name, age) VALUES (3, 'Cara', 44)",
+        &["--save", &update_saved_str],
+    );
+    assert_ne!(code, 0, "existing save target must be refused");
+    assert!(
+        stderr.contains("already exists"),
+        "expected overwrite refusal; stderr: {stderr}"
+    );
+}
+
+#[test]
+fn red_query_csv_writes_without_save_leave_no_durable_artifact() {
+    let dir = temp_dir("write-nosave");
+    let path = dir.path().join("people.csv");
+    fs::write(&path, "id,name,age\n1,Alice,30\n2,Bob,9\n").expect("write fixture");
+    let path_str = path.display().to_string();
+
+    let (code, _stdout, stderr) = run_query(
+        &path_str,
+        "DELETE FROM people WHERE name = 'Bob'",
+        &["--json"],
+    );
+    assert_eq!(code, 0, "delete failed; stderr: {stderr}");
+
     let mut names: Vec<String> = fs::read_dir(dir.path())
         .unwrap()
         .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())


### PR DESCRIPTION
Automated AFK landing for #1793. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1793

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786002328&installation_id=129708444&pr_number=1886&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1886&signature=468e2a05a37c1568a3be94ed8ca5d5d42f95b51a3d6636e67056db2213140d98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->