### PR TITLE
chore: #1796 TOON row format: token-oriented output for agent consumption

### DIFF
--- a/crates/reddb-client/src/bin/red_client.rs
+++ b/crates/reddb-client/src/bin/red_client.rs
@@ -345,7 +345,7 @@ const USAGE: &str = "\
 red_client — thin RedDB client (remote-only)
 
 USAGE:
-    red_client <URI> [--token TOKEN] [--command SQL] [--repl]
+    red_client <URI> [--token TOKEN] [--format FORMAT] [--command SQL] [--repl]
 
 EXAMPLES:
     red_client red://reddb.example.com:5050 --token sk-abc
@@ -354,6 +354,9 @@ EXAMPLES:
 
 ACCEPTED SCHEMES:
     red://, reds://, grpc://, grpcs://
+
+ROW FORMATS:
+    table, json, ndjson, csv, tsv, toon
 
 REJECTED SCHEMES (use the full `red` binary):
     memory://, file:///path, red:///path, red://:memory:

--- a/crates/reddb-client/src/row_format.rs
+++ b/crates/reddb-client/src/row_format.rs
@@ -7,6 +7,7 @@ pub enum RowFormat {
     Ndjson,
     Csv,
     Tsv,
+    Toon,
 }
 
 impl RowFormat {
@@ -17,12 +18,13 @@ impl RowFormat {
             "ndjson" => Some(Self::Ndjson),
             "csv" => Some(Self::Csv),
             "tsv" => Some(Self::Tsv),
+            "toon" => Some(Self::Toon),
             _ => None,
         }
     }
 
     pub fn vocabulary() -> &'static str {
-        "table, json, ndjson, csv, tsv"
+        "table, json, ndjson, csv, tsv, toon"
     }
 }
 
@@ -33,6 +35,7 @@ pub fn format_query_result(result: &QueryResult, format: RowFormat) -> Vec<u8> {
         RowFormat::Ndjson => format_ndjson(result).into_bytes(),
         RowFormat::Csv => format_delimited(result, b','),
         RowFormat::Tsv => format_delimited(result, b'\t'),
+        RowFormat::Toon => format_toon(result).into_bytes(),
     }
 }
 
@@ -125,6 +128,36 @@ fn format_ndjson(result: &QueryResult) -> String {
     out
 }
 
+fn format_toon(result: &QueryResult) -> String {
+    let columns = columns(result);
+    let mut out = String::new();
+    out.push('[');
+    out.push_str(&result.rows.len().to_string());
+    out.push_str("]{");
+    for (index, column) in columns.iter().enumerate() {
+        if index > 0 {
+            out.push(',');
+        }
+        write_toon_key(&mut out, column);
+    }
+    out.push_str("}:\n");
+    for row in &result.rows {
+        out.push_str("  ");
+        for (index, column) in columns.iter().enumerate() {
+            if index > 0 {
+                out.push(',');
+            }
+            if let Some(value) = value_at(row, column) {
+                write_toon_value(&mut out, value);
+            } else {
+                out.push_str("null");
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
 fn write_json_row(out: &mut String, row: &[(String, ValueOut)], columns: &[String]) {
     out.push('{');
     for (index, column) in columns.iter().enumerate() {
@@ -140,6 +173,70 @@ fn write_json_row(out: &mut String, row: &[(String, ValueOut)], columns: &[Strin
         }
     }
     out.push('}');
+}
+
+fn write_toon_key(out: &mut String, value: &str) {
+    if is_toon_bare_key(value) {
+        out.push_str(value);
+    } else {
+        write_toon_string(out, value);
+    }
+}
+
+fn write_toon_value(out: &mut String, value: &ValueOut) {
+    match value {
+        ValueOut::Null => out.push_str("null"),
+        ValueOut::Bool(value) => out.push_str(if *value { "true" } else { "false" }),
+        ValueOut::Integer(value) => out.push_str(&value.to_string()),
+        ValueOut::Float(value) => out.push_str(&value.to_string()),
+        ValueOut::String(value) => {
+            if is_toon_bare_string(value) {
+                out.push_str(value);
+            } else {
+                write_toon_string(out, value);
+            }
+        }
+    }
+}
+
+fn is_toon_bare_key(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c == '-' || c == '.' || c.is_ascii_alphanumeric())
+}
+
+fn is_toon_bare_string(value: &str) -> bool {
+    !value.is_empty()
+        && !matches!(value, "true" | "false" | "null")
+        && value.parse::<f64>().is_err()
+        && !value.starts_with('-')
+        && !value.chars().any(|c| {
+            matches!(
+                c,
+                ',' | ':' | '{' | '}' | '[' | ']' | '"' | '\\' | '\n' | '\r' | '\t'
+            )
+        })
+}
+
+fn write_toon_string(out: &mut String, value: &str) {
+    out.push('"');
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
 }
 
 fn format_delimited(result: &QueryResult, delimiter: u8) -> Vec<u8> {
@@ -299,6 +396,50 @@ mod tests {
         assert_eq!(
             format_query_result(&sample(), RowFormat::Tsv),
             b"id\tname\tnote\n1\tAda\t\"quote \"\" comma ,\"\n2\tLinus\t\"tab\tline\nend\"\n"
+        );
+    }
+
+    #[test]
+    fn formats_toon_byte_exact() {
+        assert_eq!(
+            format_query_result(&sample(), RowFormat::Toon),
+            br#"[2]{id,name,note}:
+  1,Ada,"quote \" comma ,"
+  2,Linus,"tab\tline\nend"
+"#
+        );
+    }
+
+    #[test]
+    fn formats_toon_quotes_delimiters_and_scalar_like_strings() {
+        let result = QueryResult {
+            statement: "select".to_string(),
+            affected: 0,
+            columns: vec![
+                "label".to_string(),
+                "empty".to_string(),
+                "dash".to_string(),
+                "truthy".to_string(),
+                "nullable".to_string(),
+                "count".to_string(),
+                "enabled".to_string(),
+            ],
+            rows: vec![vec![
+                ("label".to_string(), ValueOut::String("a,b".to_string())),
+                ("empty".to_string(), ValueOut::String(String::new())),
+                ("dash".to_string(), ValueOut::String("-x".to_string())),
+                ("truthy".to_string(), ValueOut::String("true".to_string())),
+                ("nullable".to_string(), ValueOut::Null),
+                ("count".to_string(), ValueOut::Integer(7)),
+                ("enabled".to_string(), ValueOut::Bool(false)),
+            ]],
+        };
+
+        assert_eq!(
+            format_query_result(&result, RowFormat::Toon),
+            br#"[1]{label,empty,dash,truthy,nullable,count,enabled}:
+  "a,b","","-x","true",null,7,false
+"#
         );
     }
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -150,6 +150,7 @@ red query "SELECT * FROM users WHERE age > 21" --path ./data.rdb
 | `--path` | | (in-memory) | Open a local `.rdb` file |
 | `--param` | `-p` | | Positional parameter for `$1`, `$2`, … (repeatable) |
 | `--param-type` | | (auto) | Type override for the preceding `--param` |
+| `--format` | | `table` | Row output format: `table`, `json`, `ndjson`, `csv`, `tsv`, `toon` |
 | `--json` | | `false` | Emit a JSON envelope on stdout |
 
 ### Parameterized queries
@@ -200,6 +201,29 @@ red query "INSERT INTO articles (title, body) VALUES ($1, $2)" \
 Parameter binding goes through the same `user_params` binder the
 HTTP `/query` and `POST { "query": ..., "params": [...] }` paths
 use, so semantics are identical across surfaces.
+
+### Agent output
+
+Use `--format toon` when query rows are headed into an agent or LLM
+context. TOON (Token-Oriented Object Notation) keeps a single column
+header and emits comma-delimited row values, so repeated object keys are
+not duplicated per row:
+
+```bash
+red query data.csv "SELECT id, name FROM t ORDER BY id" --format toon
+```
+
+```toon
+[2]{id,name}:
+  1,Ada
+  2,Linus
+```
+
+For that representative two-row shape, the equivalent compact JSON is
+48 bytes, while TOON is 32 bytes, a 33% reduction in the text that
+tokenizers must consume. The exact token reduction depends on row width,
+column names, and the target tokenizer; wider rowsets tend to benefit
+more because the column names are not repeated for every row.
 
 Examples:
 

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -3817,7 +3817,7 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                              (text|int|float|bool|null|vec|json).",
                 ));
                 flags.push(cli::types::FlagSchema::new("format").with_description(
-                    "Row output format for query results (table|json|ndjson|csv|tsv).",
+                    "Row output format for query results (table|json|ndjson|csv|tsv|toon).",
                 ));
             }
         }

--- a/tests/grouped/cli_transport/e2e_issue_1788_row_formats.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1788_row_formats.rs
@@ -52,6 +52,7 @@ fn red_query_accepts_each_row_format() {
         ),
         ("csv", "id,name\n1,Ada\n2,Linus\n"),
         ("tsv", "id\tname\n1\tAda\n2\tLinus\n"),
+        ("toon", "[2]{id,name}:\n  1,Ada\n  2,Linus\n"),
     ] {
         let (code, stdout, stderr) = run_query(&path, format);
         assert_eq!(code, 0, "{format} stderr: {stderr}");


### PR DESCRIPTION
Automated AFK landing for #1796. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1796

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786005080&installation_id=129708444&pr_number=1889&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1889&signature=bafe58bcdd83bd9336212cef28a887cca60ed0bc4682f0183d4819c25f09f6f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->