### PR TITLE
chore: #1802 Push idempotency key core: DEDUP push with WAL-durable queue-scoped window

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -2946,10 +2946,12 @@ pub const DEFAULT_QUEUE_MAX_ATTEMPTS: u32 = 3;
 pub const DEFAULT_QUEUE_LOCK_DEADLINE_MS: u64 = 30_000;
 /// Default `IN_FLIGHT_CAP_PER_GROUP` for `CREATE QUEUE` when omitted.
 pub const DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP: u32 = 10_000;
+/// Default push idempotency window for `QUEUE PUSH ... DEDUP` when omitted.
+pub const DEFAULT_QUEUE_DEDUP_WINDOW_MS: u64 = 300_000;
 
 /// CREATE QUEUE name [MAX_SIZE n] [PRIORITY] [WITH TTL duration] [WITH DLQ name]
 /// [MAX_ATTEMPTS n] [LOCK_DEADLINE_MS n] [IN_FLIGHT_CAP_PER_GROUP n]
-/// [RETRY_DELAY duration]
+/// [RETRY_DELAY duration] [DEDUP_WINDOW duration]
 #[derive(Debug, Clone)]
 pub struct CreateQueueQuery {
     pub name: String,
@@ -2969,6 +2971,9 @@ pub struct CreateQueueQuery {
     /// issue #722 to defer the next delivery attempt. An authorized
     /// `NACK ... WITH DELAY <duration>` overrides this per-failure.
     pub retry_delay_ms: Option<u64>,
+    /// Queue-scoped push idempotency window. `None` means the engine
+    /// default applies at runtime.
+    pub dedup_window_ms: Option<u64>,
 }
 
 /// ALTER QUEUE name SET <clause>
@@ -2978,6 +2983,7 @@ pub struct CreateQueueQuery {
 ///   IN_FLIGHT_CAP_PER_GROUP n
 ///   DLQ name
 ///   RETRY_DELAY duration
+///   DEDUP_WINDOW duration
 #[derive(Debug, Clone, Default)]
 pub struct AlterQueueQuery {
     pub name: String,
@@ -2989,6 +2995,8 @@ pub struct AlterQueueQuery {
     /// Update the queue's default retry delay (issue #723). `Some(0)`
     /// clears the delay back to immediate requeue.
     pub retry_delay_ms: Option<u64>,
+    /// Update the queue-scoped push idempotency window.
+    pub dedup_window_ms: Option<u64>,
 }
 
 /// DROP QUEUE [IF EXISTS] name
@@ -3049,6 +3057,10 @@ pub enum QueueCommand {
         /// (`QUEUE READ`, `QUEUE POP`, `QUEUE READ … WAIT`) refuse to
         /// deliver the message until that instant.
         available: Option<QueueAvailability>,
+        /// Optional producer push idempotency key. Duplicate pushes with
+        /// the same key on the same queue return the first message id
+        /// while the queue's dedup window is active.
+        dedup_key: Option<String>,
     },
     Pop {
         queue: String,

--- a/crates/reddb-rql/src/parser/property_tests.rs
+++ b/crates/reddb-rql/src/parser/property_tests.rs
@@ -166,6 +166,7 @@ fn arb_queue_push() -> impl Strategy<Value = QueryExpr> {
             priority: None,
             key: None,
             available: None,
+            dedup_key: None,
         })
     })
 }

--- a/crates/reddb-rql/src/parser/queue.rs
+++ b/crates/reddb-rql/src/parser/queue.rs
@@ -24,6 +24,7 @@ impl<'a> Parser<'a> {
         let mut lock_deadline_ms = DEFAULT_QUEUE_LOCK_DEADLINE_MS;
         let mut in_flight_cap_per_group = DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP;
         let mut retry_delay_ms: Option<u64> = None;
+        let mut dedup_window_ms: Option<u64> = None;
 
         // Parse optional clauses in any order
         loop {
@@ -45,6 +46,10 @@ impl<'a> Parser<'a> {
                 let value = self.parse_float()?;
                 let unit = self.parse_queue_duration_unit()?;
                 retry_delay_ms = Some((value * unit).max(0.0) as u64);
+            } else if self.consume_ident_ci("DEDUP_WINDOW")? {
+                let value = self.parse_float()?;
+                let unit = self.parse_queue_duration_unit()?;
+                dedup_window_ms = Some((value * unit).max(0.0) as u64);
             } else if self.consume(&Token::With)? {
                 if self.consume_ident_ci("EVENTS")? {
                     return Err(ParseError::new(
@@ -75,6 +80,7 @@ impl<'a> Parser<'a> {
             in_flight_cap_per_group,
             if_not_exists,
             retry_delay_ms,
+            dedup_window_ms,
         }))
     }
 
@@ -115,6 +121,10 @@ impl<'a> Parser<'a> {
             let value = self.parse_float()?;
             let unit = self.parse_queue_duration_unit()?;
             alter.retry_delay_ms = Some((value * unit).max(0.0) as u64);
+        } else if self.consume_ident_ci("DEDUP_WINDOW")? {
+            let value = self.parse_float()?;
+            let unit = self.parse_queue_duration_unit()?;
+            alter.dedup_window_ms = Some((value * unit).max(0.0) as u64);
         } else {
             return Err(ParseError::expected(
                 vec![
@@ -124,6 +134,7 @@ impl<'a> Parser<'a> {
                     "IN_FLIGHT_CAP_PER_GROUP",
                     "DLQ",
                     "RETRY_DELAY",
+                    "DEDUP_WINDOW",
                 ],
                 self.peek(),
                 self.position(),
@@ -149,7 +160,7 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (priority, key, available) = self.parse_push_tail_clauses()?;
+                let (priority, key, available, dedup_key) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
@@ -157,6 +168,7 @@ impl<'a> Parser<'a> {
                     priority,
                     key,
                     available,
+                    dedup_key,
                 }))
             }
             Token::Pop => {
@@ -251,7 +263,7 @@ impl<'a> Parser<'a> {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (_priority, key, available) = self.parse_push_tail_clauses()?;
+                let (_priority, key, available, dedup_key) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
@@ -259,13 +271,14 @@ impl<'a> Parser<'a> {
                     priority: None,
                     key,
                     available,
+                    dedup_key,
                 }))
             }
             Token::Ident(ref name) if name.eq_ignore_ascii_case("RPUSH") => {
                 self.advance()?;
                 let queue = self.expect_ident()?;
                 let value = self.parse_value()?;
-                let (priority, key, available) = self.parse_push_tail_clauses()?;
+                let (priority, key, available, dedup_key) = self.parse_push_tail_clauses()?;
                 Ok(QueryExpr::QueueCommand(QueueCommand::Push {
                     queue,
                     value,
@@ -273,6 +286,7 @@ impl<'a> Parser<'a> {
                     priority,
                     key,
                     available,
+                    dedup_key,
                 }))
             }
             Token::Group => {
@@ -461,7 +475,7 @@ impl<'a> Parser<'a> {
         Ok((group, message_id, delivery_id, delay_ms))
     }
 
-    /// Parse the optional `PRIORITY <int>`, `KEY '<key>'`,
+    /// Parse the optional `PRIORITY <int>`, `KEY '<key>'`, `DEDUP '<key>'`,
     /// `DELAY <duration>`, and `AVAILABLE AT <unix_ms>` tail of a
     /// `QUEUE PUSH` / `RPUSH` / `LPUSH`
     /// (issue #722). Clauses may appear in any order; each may appear at
@@ -470,10 +484,19 @@ impl<'a> Parser<'a> {
     /// would force the parser to pick a winner silently.
     fn parse_push_tail_clauses(
         &mut self,
-    ) -> Result<(Option<i32>, Option<String>, Option<QueueAvailability>), ParseError> {
+    ) -> Result<
+        (
+            Option<i32>,
+            Option<String>,
+            Option<QueueAvailability>,
+            Option<String>,
+        ),
+        ParseError,
+    > {
         let mut priority: Option<i32> = None;
         let mut key: Option<String> = None;
         let mut available: Option<QueueAvailability> = None;
+        let mut dedup_key: Option<String> = None;
         loop {
             if self.consume(&Token::Priority)? {
                 if priority.is_some() {
@@ -497,6 +520,14 @@ impl<'a> Parser<'a> {
                     ));
                 }
                 key = Some(self.parse_string()?);
+            } else if self.consume_ident_ci("DEDUP")? {
+                if dedup_key.is_some() {
+                    return Err(ParseError::new(
+                        "duplicate DEDUP clause".to_string(),
+                        self.position(),
+                    ));
+                }
+                dedup_key = Some(self.parse_string()?);
             } else if self.peek_ident_ci("DELAY") {
                 self.advance()?;
                 if available.is_some() {
@@ -541,7 +572,7 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
-        Ok((priority, key, available))
+        Ok((priority, key, available, dedup_key))
     }
 
     /// Parse an optional `WAIT <duration>` tail (slice A of PRD #718).
@@ -609,6 +640,10 @@ impl<'a> Parser<'a> {
     /// Parse duration unit for queue TTL
     fn parse_queue_duration_unit(&mut self) -> Result<f64, ParseError> {
         match self.peek().clone() {
+            Token::Min => {
+                self.advance()?;
+                Ok(60_000.0)
+            }
             Token::Ident(ref unit) => {
                 let mult = match unit.to_ascii_lowercase().as_str() {
                     "ms" => 1.0,

--- a/crates/reddb-rql/src/parser/tests.rs
+++ b/crates/reddb-rql/src/parser/tests.rs
@@ -6946,6 +6946,27 @@ fn queue_push_accepts_ordering_key_suffix() {
 }
 
 #[test]
+fn queue_push_accepts_dedup_suffix_and_queue_window_ddl() {
+    let q = parse("QUEUE PUSH tasks 'job-1' DEDUP 'retry-42'").unwrap();
+    let QueryExpr::QueueCommand(QueueCommand::Push { dedup_key, .. }) = q else {
+        panic!("expected Push");
+    };
+    assert_eq!(dedup_key.as_deref(), Some("retry-42"));
+
+    let create = parse("CREATE QUEUE tasks DEDUP_WINDOW 5 min").unwrap();
+    let QueryExpr::CreateQueue(create) = create else {
+        panic!("expected CreateQueue");
+    };
+    assert_eq!(create.dedup_window_ms, Some(300_000));
+
+    let alter = parse("ALTER QUEUE tasks SET DEDUP_WINDOW 30 s").unwrap();
+    let QueryExpr::AlterQueue(alter) = alter else {
+        panic!("expected AlterQueue");
+    };
+    assert_eq!(alter.dedup_window_ms, Some(30_000));
+}
+
+#[test]
 fn queue_push_rejects_key_with_delayed_availability() {
     for sql in [
         "QUEUE PUSH tasks 'job-1' KEY 'customer-42' DELAY 1s",

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -167,6 +167,7 @@ const OUTBOX_MAX_BYTES: u64 = 10 * (1 << 30);
 static OUTBOX_APPROX_BYTES: AtomicU64 = AtomicU64::new(0);
 
 const QUEUE_META_COLLECTION: &str = "red_queue_meta";
+const KIND_QUEUE_PUSH_DEDUP: &str = "queue_push_dedup";
 const QUEUE_POSITION_CENTER: u64 = u64::MAX / 2;
 const WORK_DEFAULT_GROUP: &str = "_work_default";
 const FANOUT_GROUP_PREFIX: &str = "_fanout_";
@@ -186,6 +187,9 @@ pub(super) struct QueueRuntimeConfig {
     /// pre-#723 immediate-requeue behaviour. Overridden per-failure by
     /// an authorized `NACK ... WITH DELAY <duration>`.
     pub(super) retry_delay_ms: Option<u64>,
+    /// Queue-scoped push idempotency window. `None` means use the engine
+    /// default from the RQL AST crate.
+    pub(super) dedup_window_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -725,6 +729,7 @@ impl RedDBRuntime {
                 lock_deadline_ms: query.lock_deadline_ms,
                 in_flight_cap_per_group: query.in_flight_cap_per_group,
                 retry_delay_ms: query.retry_delay_ms,
+                dedup_window_ms: query.dedup_window_ms,
             },
         )?;
 
@@ -845,6 +850,10 @@ impl RedDBRuntime {
             };
             summary.push(format!("retry_delay_ms={retry_delay_ms}"));
         }
+        if let Some(dedup_window_ms) = query.dedup_window_ms {
+            config.dedup_window_ms = Some(dedup_window_ms);
+            summary.push(format!("dedup_window_ms={dedup_window_ms}"));
+        }
 
         save_queue_config(store.as_ref(), &query.name, &config)?;
 
@@ -935,6 +944,7 @@ impl RedDBRuntime {
                 priority,
                 key,
                 available,
+                dedup_key,
             } => {
                 let store = self.inner.db.store();
                 ensure_queue_exists(store.as_ref(), queue)?;
@@ -950,6 +960,41 @@ impl RedDBRuntime {
                         "queue '{}' is not a priority queue",
                         queue
                     )));
+                }
+                if let Some(dedup_key) = dedup_key.as_deref() {
+                    let now = now_ns();
+                    reclaim_expired_queue_dedup(store.as_ref(), queue, now)?;
+                    if let Some(existing_id) =
+                        find_queue_dedup(store.as_ref(), queue, dedup_key, now)
+                    {
+                        let mut result = UnifiedResult::with_columns(vec![
+                            "message_id".into(),
+                            "side".into(),
+                            "queue".into(),
+                        ]);
+                        let mut record = UnifiedRecord::new();
+                        record.set("message_id", Value::text(message_id_string(existing_id)));
+                        record.set(
+                            "side",
+                            Value::text(match side {
+                                QueueSide::Left => "left".to_string(),
+                                QueueSide::Right => "right".to_string(),
+                            }),
+                        );
+                        record.set("queue", Value::text(queue.clone()));
+                        result.push(record);
+
+                        return Ok(RuntimeQueryResult {
+                            query: raw_query.to_string(),
+                            mode: QueryMode::Sql,
+                            statement: "queue_push",
+                            engine: "runtime-queue",
+                            result,
+                            affected_rows: 1,
+                            statement_type: "insert",
+                            bookmark: None,
+                        });
+                    }
                 }
                 if let Some(max_size) = config.max_size {
                     let current_len =
@@ -987,6 +1032,14 @@ impl RedDBRuntime {
                 let id = store
                     .insert_auto(queue, entity)
                     .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                if let Some(dedup_key) = dedup_key.as_deref() {
+                    let window_ms = config
+                        .dedup_window_ms
+                        .unwrap_or(crate::storage::query::DEFAULT_QUEUE_DEDUP_WINDOW_MS);
+                    let expires_at_ns =
+                        now_ns().saturating_add(window_ms.saturating_mul(1_000_000));
+                    record_queue_dedup(store.as_ref(), queue, dedup_key, id, expires_at_ns)?;
+                }
                 // Resolve per-message availability (issue #722): DELAY is
                 // relative to the push instant, AVAILABLE AT carries an
                 // absolute unix-ms. Both collapse to a unix-ns timestamp
@@ -1903,6 +1956,7 @@ pub(super) fn load_queue_config(store: &UnifiedStore, queue: &str) -> QueueRunti
         lock_deadline_ms: crate::storage::query::DEFAULT_QUEUE_LOCK_DEADLINE_MS,
         in_flight_cap_per_group: crate::storage::query::DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP,
         retry_delay_ms: None,
+        dedup_window_ms: None,
     };
 
     let Some(manager) = store.get_collection(QUEUE_META_COLLECTION) else {
@@ -1936,6 +1990,7 @@ pub(super) fn load_queue_config(store: &UnifiedStore, queue: &str) -> QueueRunti
                     .map(|value| value as u32)
                     .unwrap_or(crate::storage::query::DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP),
                 retry_delay_ms: row_u64(row, "retry_delay_ms").filter(|v| *v > 0),
+                dedup_window_ms: row_u64(row, "dedup_window_ms"),
             })
         })
         .unwrap_or(default)
@@ -1997,6 +2052,13 @@ fn save_queue_config(
         "retry_delay_ms".to_string(),
         config
             .retry_delay_ms
+            .map(Value::UnsignedInteger)
+            .unwrap_or(Value::Null),
+    );
+    fields.insert(
+        "dedup_window_ms".to_string(),
+        config
+            .dedup_window_ms
             .map(Value::UnsignedInteger)
             .unwrap_or(Value::Null),
     );
@@ -2924,6 +2986,94 @@ pub(super) fn remove_meta_rows(store: &UnifiedStore, predicate: impl Fn(&RowData
     for row in rows {
         let _ = store.delete(QUEUE_META_COLLECTION, row.id);
     }
+}
+
+pub(super) fn reclaim_expired_queue_dedup(
+    store: &UnifiedStore,
+    queue: &str,
+    now_ns: u64,
+) -> RedDBResult<usize> {
+    let Some(manager) = store.get_collection(QUEUE_META_COLLECTION) else {
+        return Ok(0);
+    };
+    let queue = queue.to_string();
+    let rows = manager.query_all(|entity| {
+        entity.data.as_row().is_some_and(|row| {
+            row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
+                && row_text(row, "queue").as_deref() == Some(&queue)
+                && row_u64(row, "expires_at_ns")
+                    .map(|expires_at| expires_at <= now_ns)
+                    .unwrap_or(true)
+        })
+    });
+    let count = rows.len();
+    for row in rows {
+        store
+            .delete(QUEUE_META_COLLECTION, row.id)
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+    }
+    Ok(count)
+}
+
+pub(super) fn find_queue_dedup(
+    store: &UnifiedStore,
+    queue: &str,
+    dedup_key: &str,
+    now_ns: u64,
+) -> Option<EntityId> {
+    let manager = store.get_collection(QUEUE_META_COLLECTION)?;
+    let queue = queue.to_string();
+    let dedup_key = dedup_key.to_string();
+    manager
+        .query_all(|entity| {
+            entity.data.as_row().is_some_and(|row| {
+                row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
+                    && row_text(row, "queue").as_deref() == Some(&queue)
+                    && row_text(row, "dedup_key").as_deref() == Some(&dedup_key)
+                    && row_u64(row, "expires_at_ns")
+                        .map(|expires_at| expires_at > now_ns)
+                        .unwrap_or(false)
+            })
+        })
+        .into_iter()
+        .filter_map(|entity| {
+            let row = entity.data.as_row()?;
+            row_u64(row, "message_id").map(EntityId::new)
+        })
+        .next()
+}
+
+pub(super) fn record_queue_dedup(
+    store: &UnifiedStore,
+    queue: &str,
+    dedup_key: &str,
+    message_id: EntityId,
+    expires_at_ns: u64,
+) -> RedDBResult<()> {
+    let queue_owned = queue.to_string();
+    let key_owned = dedup_key.to_string();
+    remove_meta_rows(store, |row| {
+        row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
+            && row_text(row, "queue").as_deref() == Some(&queue_owned)
+            && row_text(row, "dedup_key").as_deref() == Some(&key_owned)
+    });
+
+    let mut fields = HashMap::new();
+    fields.insert(
+        "kind".to_string(),
+        Value::text(KIND_QUEUE_PUSH_DEDUP.to_string()),
+    );
+    fields.insert("queue".to_string(), Value::text(queue.to_string()));
+    fields.insert("dedup_key".to_string(), Value::text(dedup_key.to_string()));
+    fields.insert(
+        "message_id".to_string(),
+        Value::UnsignedInteger(message_id.raw()),
+    );
+    fields.insert(
+        "expires_at_ns".to_string(),
+        Value::UnsignedInteger(expires_at_ns),
+    );
+    insert_meta_row(store, fields)
 }
 
 pub(super) fn delete_meta_entity(store: &UnifiedStore, entity_id: EntityId) {

--- a/crates/reddb-server/src/runtime/primary_queue_store.rs
+++ b/crates/reddb-server/src/runtime/primary_queue_store.rs
@@ -526,7 +526,14 @@ fn delete_message_with_state(
 
 fn remove_message_state(store: &UnifiedStore, queue: &str, message_id: MessageId) {
     super::impl_queue::remove_meta_rows(store, |row| {
-        super::impl_queue::row_text(row, "queue").as_deref() == Some(queue)
+        let kind = super::impl_queue::row_text(row, "kind");
+        matches!(
+            kind.as_deref(),
+            Some(KIND_PENDING_LC)
+                | Some(KIND_ACKED_LC)
+                | Some(KIND_ATTEMPTS_LC)
+                | Some(KIND_PENDING_LEGACY)
+        ) && super::impl_queue::row_text(row, "queue").as_deref() == Some(queue)
             && super::impl_queue::row_u64(row, "message_id") == Some(message_id)
     });
 }
@@ -1024,6 +1031,37 @@ impl QueueStore for PrimaryQueueStore {
             }
         }
         Ok(popped.len())
+    }
+
+    fn reclaim_expired_dedup(&self, _txn: &QueueTxn, queue: &str, now_ns: u64) -> Result<usize> {
+        let store = self.runtime.db().store();
+        super::impl_queue::reclaim_expired_queue_dedup(store.as_ref(), queue, now_ns)
+            .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))
+    }
+
+    fn find_dedup(&self, queue: &str, dedup_key: &str, now_ns: u64) -> Option<MessageId> {
+        let store = self.runtime.db().store();
+        super::impl_queue::find_queue_dedup(store.as_ref(), queue, dedup_key, now_ns)
+            .map(|id| id.raw())
+    }
+
+    fn record_dedup(
+        &self,
+        _txn: &QueueTxn,
+        queue: &str,
+        dedup_key: &str,
+        message_id: MessageId,
+        expires_at_ns: u64,
+    ) -> Result<()> {
+        let store = self.runtime.db().store();
+        super::impl_queue::record_queue_dedup(
+            store.as_ref(),
+            queue,
+            dedup_key,
+            EntityId::new(message_id),
+            expires_at_ns,
+        )
+        .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))
     }
 }
 

--- a/crates/reddb-server/src/runtime/replica_queue_store.rs
+++ b/crates/reddb-server/src/runtime/replica_queue_store.rs
@@ -460,6 +460,27 @@ impl QueueStore for ReplicaQueueStore {
     ) -> Result<usize> {
         Err(QueueStoreError::ReplicaImmutable)
     }
+
+    fn reclaim_expired_dedup(&self, _txn: &QueueTxn, _queue: &str, _now_ns: u64) -> Result<usize> {
+        Err(QueueStoreError::ReplicaImmutable)
+    }
+
+    fn find_dedup(&self, queue: &str, dedup_key: &str, now_ns: u64) -> Option<MessageId> {
+        let store = self.store();
+        super::impl_queue::find_queue_dedup(store.as_ref(), queue, dedup_key, now_ns)
+            .map(|id| id.raw())
+    }
+
+    fn record_dedup(
+        &self,
+        _txn: &QueueTxn,
+        _queue: &str,
+        _dedup_key: &str,
+        _message_id: MessageId,
+        _expires_at_ns: u64,
+    ) -> Result<()> {
+        Err(QueueStoreError::ReplicaImmutable)
+    }
 }
 
 /// Read attempts as an externally observable counter — used by tests
@@ -633,10 +654,49 @@ mod tests {
             replica.purge_queue(&t, "q").unwrap_err(),
             QueueStoreError::ReplicaImmutable
         ));
+        assert!(matches!(
+            replica
+                .record_dedup(&t, "q", "retry", 1, now_unix_ns())
+                .unwrap_err(),
+            QueueStoreError::ReplicaImmutable
+        ));
         // Replica txn must remain untouched across reject paths.
         assert!(
             t.recorded_tombstones().is_empty(),
             "rejected mutations must not record tombstones"
+        );
+    }
+
+    #[test]
+    fn replica_replays_push_dedup_outcomes_without_deciding() {
+        let primary_rt = boot();
+        primary_rt
+            .execute_query("CREATE QUEUE qdedup DEDUP_WINDOW 1 s")
+            .expect("create");
+        primary_rt
+            .execute_query("QUEUE PUSH qdedup 'first' DEDUP 'retry-1'")
+            .expect("push");
+
+        let primary_store = PrimaryQueueStore::new(primary_rt.clone());
+        let now = now_unix_ns();
+        let primary_id = primary_store
+            .find_dedup("qdedup", "retry-1", now)
+            .expect("primary dedup outcome");
+
+        let replica_rt = boot();
+        replica_rt
+            .execute_query("CREATE QUEUE qdedup")
+            .expect("replica create");
+        replay_collections(
+            &primary_rt.db().store(),
+            &replica_rt.db(),
+            &["qdedup", QUEUE_META_COLLECTION],
+        );
+        let replica_store = ReplicaQueueStore::new(replica_rt);
+        assert_eq!(
+            replica_store.find_dedup("qdedup", "retry-1", now),
+            Some(primary_id),
+            "replica must observe the primary's replayed dedup outcome",
         );
     }
 

--- a/crates/reddb-server/src/storage/query/mod.rs
+++ b/crates/reddb-server/src/storage/query/mod.rs
@@ -90,8 +90,8 @@ pub use ast::{
     NodePattern, NodeSelector, OrderByClause, PathQuery, PolicyPrincipalRef, PolicyResourceRef,
     PolicyUserRef, Projection, QueryExpr, QueryWithCte, RevokeStmt, SearchCommand, SelectItem,
     TableQuery, TreeCommand, TreeNodeSpec, TreePosition, UpdateQuery, WithClause,
-    DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP, DEFAULT_QUEUE_LOCK_DEADLINE_MS,
-    DEFAULT_QUEUE_MAX_ATTEMPTS,
+    DEFAULT_QUEUE_DEDUP_WINDOW_MS, DEFAULT_QUEUE_IN_FLIGHT_CAP_PER_GROUP,
+    DEFAULT_QUEUE_LOCK_DEADLINE_MS, DEFAULT_QUEUE_MAX_ATTEMPTS,
 };
 pub use engine::{
     Binding, BindingBuilder, BindingIterator, Op, OpBGP, OpDisjunction, OpDistinct, OpExtend,

--- a/crates/reddb-server/src/storage/queue/lifecycle.rs
+++ b/crates/reddb-server/src/storage/queue/lifecycle.rs
@@ -349,6 +349,23 @@ pub(crate) trait QueueStore {
         side: QueueSide,
         count: usize,
     ) -> Result<usize>;
+
+    /// Remove expired push-idempotency entries for `queue`. Called on
+    /// producer push; there is no background sweeper.
+    fn reclaim_expired_dedup(&self, txn: &QueueTxn, queue: &str, now_ns: u64) -> Result<usize>;
+
+    /// Look up a live push-idempotency key.
+    fn find_dedup(&self, queue: &str, dedup_key: &str, now_ns: u64) -> Option<MessageId>;
+
+    /// Record the first producer push outcome for `dedup_key`.
+    fn record_dedup(
+        &self,
+        txn: &QueueTxn,
+        queue: &str,
+        dedup_key: &str,
+        message_id: MessageId,
+        expires_at_ns: u64,
+    ) -> Result<()>;
 }
 
 /// Read-only view of a pending delivery, returned by
@@ -421,7 +438,15 @@ struct State {
     max_attempts: HashMap<(QueueId, MessageId), u32>,
     /// Optional ordering keys keyed by `(queue, message_id)`.
     ordering_keys: HashMap<(QueueId, MessageId), String>,
+    /// Queue-scoped push idempotency entries keyed by `(queue, dedup_key)`.
+    dedup: HashMap<(QueueId, String), DedupEntry>,
     dlq: Vec<DlqRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct DedupEntry {
+    message_id: MessageId,
+    expires_at_ns: u64,
 }
 
 /// In-memory fake for unit tests. Thread-safe via a single Mutex — the
@@ -954,6 +979,46 @@ impl QueueStore for InMemoryQueueStore {
         }
         Ok(moved)
     }
+
+    fn reclaim_expired_dedup(&self, _txn: &QueueTxn, queue: &str, now_ns: u64) -> Result<usize> {
+        let mut state = self.state.lock().expect("state poisoned");
+        let before = state.dedup.len();
+        state
+            .dedup
+            .retain(|(q, _), entry| q != queue || entry.expires_at_ns > now_ns);
+        Ok(before.saturating_sub(state.dedup.len()))
+    }
+
+    fn find_dedup(&self, queue: &str, dedup_key: &str, now_ns: u64) -> Option<MessageId> {
+        let state = self.state.lock().expect("state poisoned");
+        state
+            .dedup
+            .get(&(queue.to_string(), dedup_key.to_string()))
+            .filter(|entry| entry.expires_at_ns > now_ns)
+            .map(|entry| entry.message_id)
+    }
+
+    fn record_dedup(
+        &self,
+        _txn: &QueueTxn,
+        queue: &str,
+        dedup_key: &str,
+        message_id: MessageId,
+        expires_at_ns: u64,
+    ) -> Result<()> {
+        let mut state = self.state.lock().expect("state poisoned");
+        if !state.queues.contains_key(queue) {
+            return Err(QueueStoreError::UnknownQueue(queue.to_string()));
+        }
+        state.dedup.insert(
+            (queue.to_string(), dedup_key.to_string()),
+            DedupEntry {
+                message_id,
+                expires_at_ns,
+            },
+        );
+        Ok(())
+    }
 }
 
 /// RFC 4648 base32 (lowercase, no padding). Hand-rolled — no `base32`
@@ -1078,6 +1143,32 @@ mod tests {
         // Tombstone recorded for each source id.
         let stones = t.recorded_tombstones();
         assert_eq!(stones.len(), 2);
+    }
+
+    #[test]
+    fn dedup_key_lookup_survives_message_retirement_until_window_expires() {
+        let store = InMemoryQueueStore::new();
+        store.seed_queue("q", vec![10]);
+        store.seed_payload("q", 10, Value::text("first"));
+        let t = txn();
+
+        store
+            .record_dedup(&t, "q", "retry-1", 10, 2_000)
+            .expect("record dedup");
+        assert_eq!(store.find_dedup("q", "retry-1", 1_000), Some(10));
+
+        let delivery = store
+            .mark_pending(&t, "q", 10, "workers", "alice", deadline_in(1000))
+            .expect("mark pending");
+        store.ack_pending(&t, &delivery).expect("ack original");
+        assert_eq!(
+            store.find_dedup("q", "retry-1", 1_500),
+            Some(10),
+            "consuming the original message must not remove the dedup outcome",
+        );
+
+        assert_eq!(store.reclaim_expired_dedup(&t, "q", 2_000).unwrap(), 1);
+        assert_eq!(store.find_dedup("q", "retry-1", 2_001), None);
     }
 
     #[test]

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -496,6 +496,66 @@ fn test_queue_persistent_reopen_retains_messages_and_recovers_pending() {
 }
 
 #[test]
+fn test_queue_push_dedup_suppresses_retry_until_window_expires() {
+    let rt = rt();
+
+    exec(&rt, "CREATE QUEUE dedup_jobs DEDUP_WINDOW 1 s");
+    let first = exec(&rt, "QUEUE PUSH dedup_jobs 'first' DEDUP 'retry-1'");
+    let first_id = text(&first.result.records[0], "message_id");
+
+    let duplicate = exec(&rt, "QUEUE PUSH dedup_jobs 'duplicate' DEDUP 'retry-1'");
+    assert_eq!(text(&duplicate.result.records[0], "message_id"), first_id);
+    let len = exec(&rt, "QUEUE LEN dedup_jobs");
+    assert_eq!(uint(&len.result.records[0], "len"), 1);
+
+    let popped = exec(&rt, "QUEUE POP dedup_jobs COUNT 1");
+    assert_eq!(payloads(&popped), vec!["first"]);
+    let duplicate_after_consume = exec(&rt, "QUEUE PUSH dedup_jobs 'after' DEDUP 'retry-1'");
+    assert_eq!(
+        text(&duplicate_after_consume.result.records[0], "message_id"),
+        first_id,
+        "consuming the original message must not reopen the dedup window",
+    );
+    let len = exec(&rt, "QUEUE LEN dedup_jobs");
+    assert_eq!(uint(&len.result.records[0], "len"), 0);
+
+    exec(&rt, "ALTER QUEUE dedup_jobs SET DEDUP_WINDOW 50 ms");
+    let second = exec(&rt, "QUEUE PUSH dedup_jobs 'second' DEDUP 'retry-2'");
+    let second_id = text(&second.result.records[0], "message_id");
+    let second_duplicate = exec(&rt, "QUEUE PUSH dedup_jobs 'second-dup' DEDUP 'retry-2'");
+    assert_eq!(
+        text(&second_duplicate.result.records[0], "message_id"),
+        second_id,
+        "ALTER QUEUE SET DEDUP_WINDOW must apply to later pushes",
+    );
+
+    sleep(Duration::from_millis(80));
+    let after_expiry = exec(&rt, "QUEUE PUSH dedup_jobs 'new-window' DEDUP 'retry-2'");
+    assert_ne!(
+        text(&after_expiry.result.records[0], "message_id"),
+        second_id
+    );
+    let len = exec(&rt, "QUEUE LEN dedup_jobs");
+    assert_eq!(uint(&len.result.records[0], "len"), 2);
+}
+
+#[test]
+fn test_queue_push_dedup_survives_persistent_reopen() {
+    let path = PersistentDbPath::new("queue_dedup_reopen");
+    let rt = path.open_runtime();
+
+    exec(&rt, "CREATE QUEUE durable_dedup DEDUP_WINDOW 1 s");
+    let first = exec(&rt, "QUEUE PUSH durable_dedup 'first' DEDUP 'retry-1'");
+    let first_id = text(&first.result.records[0], "message_id");
+
+    let rt = checkpoint_and_reopen(&path, rt);
+    let duplicate = exec(&rt, "QUEUE PUSH durable_dedup 'duplicate' DEDUP 'retry-1'");
+    assert_eq!(text(&duplicate.result.records[0], "message_id"), first_id);
+    let len = exec(&rt, "QUEUE LEN durable_dedup");
+    assert_eq!(uint(&len.result.records[0], "len"), 1);
+}
+
+#[test]
 fn test_queue_mode_persists_and_defaults_to_work() {
     let path = PersistentDbPath::new("queue_mode_catalog");
     let rt = path.open_runtime();


### PR DESCRIPTION
Automated AFK landing for #1802. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1802

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786006993&installation_id=129708444&pr_number=1890&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1890&signature=4e0b1f2ee99981499f3eba944ada0cda6c8642d0483fcaf6c94899f2d186a840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added queue push idempotency with dedup keys and a configurable dedup window.
  * `CREATE QUEUE` and `ALTER QUEUE` now support setting a dedup window for queue messages.
  * Duplicate pushes within the active window now reuse the original message result instead of creating a new one.
* **Bug Fixes**
  * Improved queue dedup behavior across retries, updates, and reopen/recovery scenarios.
  * Updated queue processing to keep dedup results consistent even after messages are consumed or the system restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->