### PR TITLE
chore: #1803 Ordering key strict-under-failure: NACK blocks key, DLQ retirement unblocks

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -1460,18 +1460,31 @@ impl RedDBRuntime {
                 let effective_delay_ms = delay_ms.or(config.retry_delay_ms).unwrap_or(0);
                 let pending_attempt = ps.read_pending_attempt(&did).map_err(map_qse)?;
                 let nack_attempts = pending_attempt.attempts.saturating_add(1);
-                let outcome = lifecycle.nack(&txn, &did).map_err(map_qse)?;
+                let retry_available_at_ns = if effective_delay_ms > 0 {
+                    Some(now_ns().saturating_add(effective_delay_ms.saturating_mul(1_000_000)))
+                } else {
+                    None
+                };
+                let retry_deadline = if effective_delay_ms > 0 {
+                    Some(
+                        std::time::Instant::now()
+                            + std::time::Duration::from_millis(effective_delay_ms),
+                    )
+                } else {
+                    None
+                };
+                let outcome = lifecycle
+                    .nack_with_retry_deadline(&txn, &did, retry_deadline)
+                    .map_err(map_qse)?;
                 // Apply delay only when the message was actually
                 // requeued — DLQ promotion / drop terminate the
                 // retry cycle and a delay would be meaningless.
                 if matches!(outcome, RetirementOutcome::Requeued) && effective_delay_ms > 0 {
-                    let at_ns =
-                        now_ns().saturating_add(effective_delay_ms.saturating_mul(1_000_000));
                     set_message_available_at_ns(
                         store.as_ref(),
                         queue,
                         message_entity,
-                        Some(at_ns),
+                        retry_available_at_ns,
                         config.ttl_ms,
                     )?;
                 }

--- a/crates/reddb-server/src/runtime/primary_queue_store.rs
+++ b/crates/reddb-server/src/runtime/primary_queue_store.rs
@@ -736,6 +736,8 @@ impl QueueStore for PrimaryQueueStore {
             attempts: next,
             queue: row.queue,
             message_id: row.message_id,
+            group: row.group,
+            consumer: row.consumer,
         })
     }
 
@@ -747,6 +749,8 @@ impl QueueStore for PrimaryQueueStore {
             attempts: self.read_attempts(&row.queue, row.message_id, &row.group),
             queue: row.queue,
             message_id: row.message_id,
+            group: row.group,
+            consumer: row.consumer,
         })
     }
 
@@ -770,7 +774,13 @@ impl QueueStore for PrimaryQueueStore {
         }
     }
 
-    fn enqueue_dlq(&self, _txn: &QueueTxn, dlq_target: &str, original: Value) -> Result<()> {
+    fn enqueue_dlq(
+        &self,
+        _txn: &QueueTxn,
+        dlq_target: &str,
+        original: Value,
+        ordering_key: Option<&str>,
+    ) -> Result<()> {
         let store = self.store();
         if store.get_collection(dlq_target).is_none() {
             store
@@ -793,9 +803,18 @@ impl QueueStore for PrimaryQueueStore {
                 acked: false,
             }),
         );
-        store
+        let id = store
             .insert_auto(dlq_target, entity)
             .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))?;
+        if ordering_key.is_some() {
+            store
+                .set_metadata(
+                    dlq_target,
+                    id,
+                    super::impl_queue::queue_message_metadata(None, None, ordering_key),
+                )
+                .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))?;
+        }
         Ok(())
     }
 

--- a/crates/reddb-server/src/runtime/queue_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/queue_lifecycle.rs
@@ -342,6 +342,15 @@ impl<S: QueueStore> QueueLifecycle<S> {
     /// it. Callers never see the decision — observe outcomes via the test
     /// tap.
     pub(crate) fn nack(&self, txn: &QueueTxn, delivery_id: &str) -> Result<RetirementOutcome> {
+        self.nack_with_retry_deadline(txn, delivery_id, None)
+    }
+
+    pub(crate) fn nack_with_retry_deadline(
+        &self,
+        txn: &QueueTxn,
+        delivery_id: &str,
+        retry_deadline: Option<Instant>,
+    ) -> Result<RetirementOutcome> {
         let bumped = self.store.bump_attempt(txn, delivery_id)?;
         let max_attempts = self
             .store
@@ -355,8 +364,12 @@ impl<S: QueueStore> QueueLifecycle<S> {
                         .store
                         .read_pending_payload(delivery_id)
                         .ok_or_else(|| QueueStoreError::UnknownDelivery(delivery_id.to_string()))?;
+                    let ordering_key = self
+                        .store
+                        .read_ordering_key(&bumped.queue, bumped.message_id);
                     self.retire(txn, delivery_id)?;
-                    self.store.enqueue_dlq(txn, target, payload)?;
+                    self.store
+                        .enqueue_dlq(txn, target, payload, ordering_key.as_deref())?;
                     outcome = RetirementOutcome::MovedToDlq(target.clone());
                     self.record(outcome.clone());
                 }
@@ -367,7 +380,18 @@ impl<S: QueueStore> QueueLifecycle<S> {
                 }
             }
         } else {
-            self.store.release_pending(txn, delivery_id)?;
+            if let Some(deadline) = retry_deadline {
+                self.store.mark_pending(
+                    txn,
+                    &bumped.queue,
+                    bumped.message_id,
+                    &bumped.group,
+                    &bumped.consumer,
+                    deadline,
+                )?;
+            } else {
+                self.store.release_pending(txn, delivery_id)?;
+            }
             outcome = RetirementOutcome::Requeued;
             self.record(outcome.clone());
         }
@@ -539,12 +563,17 @@ impl<S: QueueStore> QueueLifecycle<S> {
     fn retire_exhausted(&self, txn: &QueueTxn, delivery_id: &str) -> Result<()> {
         match &self.config.dlq_target {
             Some(target) => {
+                let pending = self.store.read_pending_attempt(delivery_id)?;
                 let payload = self
                     .store
                     .read_pending_payload(delivery_id)
                     .ok_or_else(|| QueueStoreError::UnknownDelivery(delivery_id.to_string()))?;
+                let ordering_key = self
+                    .store
+                    .read_ordering_key(&pending.queue, pending.message_id);
                 self.retire(txn, delivery_id)?;
-                self.store.enqueue_dlq(txn, target, payload)?;
+                self.store
+                    .enqueue_dlq(txn, target, payload, ordering_key.as_deref())?;
                 self.record(RetirementOutcome::MovedToDlq(target.clone()));
             }
             None => {
@@ -730,6 +759,83 @@ mod tests {
             .expect("unblocked read");
         assert_eq!(unblocked.len(), 1);
         assert_eq!(unblocked[0].payload, Value::text("second-a"));
+    }
+
+    #[test]
+    fn delayed_nack_keeps_ordering_key_blocked_until_retry_deadline() {
+        let clock = Arc::new(TestClock::new());
+        let store = store_with(&[(1, "first-a"), (2, "second-a")]);
+        store.seed_ordering_key("q", 1, "a");
+        store.seed_ordering_key("q", 2, "a");
+        store.seed_max_attempts("q", 1, 5);
+        let lc = QueueLifecycle::with_clock(
+            store,
+            LifecycleConfig::default(),
+            clock.clone() as Arc<dyn Clock>,
+        );
+
+        let first = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "alice", 1)
+            .expect("first read");
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].payload, Value::text("first-a"));
+
+        let retry_deadline = clock.now() + Duration::from_millis(100);
+        lc.nack_with_retry_deadline(
+            &QueueTxn::new(),
+            &first[0].delivery_id,
+            Some(retry_deadline),
+        )
+        .expect("delayed nack");
+
+        let blocked = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "bob", 1)
+            .expect("same-key read before retry");
+        assert!(
+            blocked.is_empty(),
+            "later same-key message must not overtake delayed retry"
+        );
+
+        clock.advance(Duration::from_millis(101));
+        let retry = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "carol", 1)
+            .expect("retry read");
+        assert_eq!(retry.len(), 1);
+        assert_eq!(retry[0].payload, Value::text("first-a"));
+    }
+
+    #[test]
+    fn claim_refresh_keeps_ordering_key_blocking_later_same_key_messages() {
+        let clock = Arc::new(TestClock::new());
+        let store = store_with(&[(1, "first-a"), (2, "second-a")]);
+        store.seed_ordering_key("q", 1, "a");
+        store.seed_ordering_key("q", 2, "a");
+        store.seed_max_attempts("q", 1, 5);
+        let lc = QueueLifecycle::with_clock(
+            store,
+            config_with_lock(Duration::from_millis(100)),
+            clock.clone() as Arc<dyn Clock>,
+        );
+
+        let first = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "alice", 1)
+            .expect("first read");
+        assert_eq!(first.len(), 1);
+
+        clock.advance(Duration::from_millis(150));
+        let claimed = lc
+            .claim_delivering("q", "bob", 0, &QueueTxn::new())
+            .expect("claim expired");
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].payload, Value::text("first-a"));
+
+        let blocked = lc
+            .group_read(&QueueTxn::new(), "q", "workers", "carol", 1)
+            .expect("same-key read after claim");
+        assert!(
+            blocked.is_empty(),
+            "claimed delivery must keep same-key successor blocked"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/replica_queue_store.rs
+++ b/crates/reddb-server/src/runtime/replica_queue_store.rs
@@ -315,6 +315,8 @@ impl QueueStore for ReplicaQueueStore {
             attempts: self.read_attempts(&row.queue, row.message_id, &row.group),
             queue: row.queue,
             message_id: row.message_id,
+            group: row.group,
+            consumer: String::new(),
         })
     }
 
@@ -337,7 +339,13 @@ impl QueueStore for ReplicaQueueStore {
         }
     }
 
-    fn enqueue_dlq(&self, _txn: &QueueTxn, _dlq_target: &str, _original: Value) -> Result<()> {
+    fn enqueue_dlq(
+        &self,
+        _txn: &QueueTxn,
+        _dlq_target: &str,
+        _original: Value,
+        _ordering_key: Option<&str>,
+    ) -> Result<()> {
         Err(QueueStoreError::ReplicaImmutable)
     }
 
@@ -619,7 +627,7 @@ mod tests {
         ));
         assert!(matches!(
             replica
-                .enqueue_dlq(&t, "dlq", Value::text("x"))
+                .enqueue_dlq(&t, "dlq", Value::text("x"), None)
                 .unwrap_err(),
             QueueStoreError::ReplicaImmutable
         ));

--- a/crates/reddb-server/src/storage/queue/lifecycle.rs
+++ b/crates/reddb-server/src/storage/queue/lifecycle.rs
@@ -261,7 +261,13 @@ pub(crate) trait QueueStore {
     fn read_max_attempts(&self, queue: &str, message_id: MessageId) -> u32;
 
     /// Move `original` onto the DLQ at `dlq_target`.
-    fn enqueue_dlq(&self, txn: &QueueTxn, dlq_target: &str, original: Value) -> Result<()>;
+    fn enqueue_dlq(
+        &self,
+        txn: &QueueTxn,
+        dlq_target: &str,
+        original: Value,
+        ordering_key: Option<&str>,
+    ) -> Result<()>;
 
     /// Pending deadline for `delivery_id`, if it is currently held.
     fn read_lock_deadline(&self, delivery_id: &str) -> Option<Instant>;
@@ -381,6 +387,8 @@ pub(crate) struct BumpedAttempt {
     pub(crate) attempts: u32,
     pub(crate) queue: QueueId,
     pub(crate) message_id: MessageId,
+    pub(crate) group: ConsumerGroupId,
+    pub(crate) consumer: String,
 }
 
 /// Crate-wide fallback when a `read_max_attempts` caller hits a tuple
@@ -394,6 +402,7 @@ pub(crate) const DEFAULT_READ_MAX_ATTEMPTS: u32 = 3;
 pub(crate) struct DlqRecord {
     pub target: DlqTarget,
     pub original: Value,
+    pub ordering_key: Option<String>,
 }
 
 #[derive(Default)]
@@ -666,12 +675,16 @@ impl QueueStore for InMemoryQueueStore {
         let count = entry.attempts;
         let queue = entry.queue.clone();
         let message_id = entry.message_id;
-        let key = (queue.clone(), message_id, entry.group.clone());
+        let group = entry.group.clone();
+        let consumer = entry.consumer.clone();
+        let key = (queue.clone(), message_id, group.clone());
         state.attempts.insert(key, count);
         Ok(BumpedAttempt {
             attempts: count,
             queue,
             message_id,
+            group,
+            consumer,
         })
     }
 
@@ -685,6 +698,8 @@ impl QueueStore for InMemoryQueueStore {
             attempts: entry.attempts,
             queue: entry.queue.clone(),
             message_id: entry.message_id,
+            group: entry.group.clone(),
+            consumer: entry.consumer.clone(),
         })
     }
 
@@ -697,11 +712,18 @@ impl QueueStore for InMemoryQueueStore {
             .unwrap_or(DEFAULT_READ_MAX_ATTEMPTS)
     }
 
-    fn enqueue_dlq(&self, _txn: &QueueTxn, dlq_target: &str, original: Value) -> Result<()> {
+    fn enqueue_dlq(
+        &self,
+        _txn: &QueueTxn,
+        dlq_target: &str,
+        original: Value,
+        ordering_key: Option<&str>,
+    ) -> Result<()> {
         let mut state = self.state.lock().expect("state poisoned");
         state.dlq.push(DlqRecord {
             target: dlq_target.to_string(),
             original,
+            ordering_key: ordering_key.map(str::to_string),
         });
         Ok(())
     }
@@ -1269,16 +1291,23 @@ mod tests {
         let store = InMemoryQueueStore::new();
         let t = txn();
         store
-            .enqueue_dlq(&t, "orders.dlq", Value::text("payload-1"))
+            .enqueue_dlq(
+                &t,
+                "orders.dlq",
+                Value::text("payload-1"),
+                Some("account-7"),
+            )
             .unwrap();
         store
-            .enqueue_dlq(&t, "orders.dlq", Value::Integer(42))
+            .enqueue_dlq(&t, "orders.dlq", Value::Integer(42), None)
             .unwrap();
         let snap = store.dlq_snapshot();
         assert_eq!(snap.len(), 2);
         assert_eq!(snap[0].target, "orders.dlq");
         assert_eq!(snap[0].original, Value::text("payload-1"));
+        assert_eq!(snap[0].ordering_key.as_deref(), Some("account-7"));
         assert_eq!(snap[1].original, Value::Integer(42));
+        assert_eq!(snap[1].ordering_key, None);
     }
 
     #[test]

--- a/crates/reddb-server/tests/queue_retry_policy.rs
+++ b/crates/reddb-server/tests/queue_retry_policy.rs
@@ -38,6 +38,15 @@ fn read_one_message_id(rt: &RedDBRuntime, sql: &str) -> Option<String> {
         .map(|v| format!("{v:?}"))
 }
 
+fn text_value(record: &reddb_server::storage::query::UnifiedRecord, column: &str) -> String {
+    match record.get(column) {
+        Some(reddb_server::storage::schema::Value::Text(value)) => value.to_string(),
+        Some(reddb_server::storage::schema::Value::UnsignedInteger(value)) => value.to_string(),
+        Some(reddb_server::storage::schema::Value::Integer(value)) => value.to_string(),
+        other => panic!("expected text-like value for {column}, got {other:?}"),
+    }
+}
+
 /// Pull the `message_id` of a single delivered record as the textual
 /// form the wire serializer would produce. The runtime stores message
 /// ids as `EntityId`; we only need a stable handle to NACK against.
@@ -99,6 +108,43 @@ fn default_retry_delay_defers_requeue_after_nack() {
         1,
         "message should be re-delivered after RETRY_DELAY elapses, got {:?}",
         later.result.records
+    );
+}
+
+#[test]
+fn retry_delay_keeps_ordering_key_blocked_after_nack() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE QUEUE qretry_keyed RETRY_DELAY 500ms MAX_ATTEMPTS 5",
+    );
+    exec(&rt, "QUEUE GROUP CREATE qretry_keyed workers");
+    exec(&rt, "QUEUE PUSH qretry_keyed 'payload-1' KEY 'account-7'");
+    exec(&rt, "QUEUE PUSH qretry_keyed 'payload-2' KEY 'account-7'");
+
+    let mid = delivered_message_id(&rt, "qretry_keyed", "workers");
+    exec(
+        &rt,
+        &format!("QUEUE NACK qretry_keyed GROUP workers '{mid}'"),
+    );
+
+    let early = rt
+        .execute_query("QUEUE READ qretry_keyed GROUP workers CONSUMER c1 COUNT 1")
+        .expect("read");
+    assert!(
+        early.result.records.is_empty(),
+        "same-key message must not overtake delayed retry, got {:?}",
+        early.result.records
+    );
+
+    thread::sleep(Duration::from_millis(650));
+    let later = rt
+        .execute_query("QUEUE READ qretry_keyed GROUP workers CONSUMER c1 COUNT 1")
+        .expect("read");
+    assert_eq!(
+        later.result.records.len(),
+        1,
+        "failed message should be re-delivered after RETRY_DELAY elapses",
     );
 }
 
@@ -206,6 +252,50 @@ fn nack_promotes_to_dlq_once_max_attempts_reached() {
         after.result.records
     );
     let _ = read_one_message_id;
+}
+
+#[test]
+fn terminal_nack_carries_ordering_key_to_dlq_and_unblocks_successor() {
+    let rt = runtime();
+    exec(
+        &rt,
+        "CREATE QUEUE qretry_keyed_dlq WITH DLQ qretry_keyed_dead MAX_ATTEMPTS 2",
+    );
+    exec(&rt, "QUEUE GROUP CREATE qretry_keyed_dlq workers");
+    exec(
+        &rt,
+        "QUEUE PUSH qretry_keyed_dlq 'payload-1' KEY 'account-7'",
+    );
+    exec(
+        &rt,
+        "QUEUE PUSH qretry_keyed_dlq 'payload-2' KEY 'account-7'",
+    );
+
+    let mid = delivered_message_id(&rt, "qretry_keyed_dlq", "workers");
+    exec(
+        &rt,
+        &format!("QUEUE NACK qretry_keyed_dlq GROUP workers '{mid}'"),
+    );
+
+    let dlq = rt
+        .execute_query("SELECT payload, key FROM QUEUE qretry_keyed_dead")
+        .expect("select dlq");
+    assert_eq!(dlq.result.records.len(), 1);
+    assert_eq!(text_value(&dlq.result.records[0], "payload"), "payload-1");
+    assert_eq!(text_value(&dlq.result.records[0], "key"), "account-7");
+
+    let successor = rt
+        .execute_query("QUEUE READ qretry_keyed_dlq GROUP workers CONSUMER c1 COUNT 1")
+        .expect("read successor");
+    assert_eq!(
+        successor.result.records.len(),
+        1,
+        "DLQ retirement must unblock the same ordering key"
+    );
+    assert_eq!(
+        text_value(&successor.result.records[0], "payload"),
+        "payload-2"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1803. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1803

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786008498&installation_id=129708444&pr_number=1891&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1891&signature=4524099321bbadadee1467203822861f548ab677a3358ec4e0c719eaf4dc1a1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->