### PR TITLE
chore: #1815 Seal timeseries chunks on the checkpoint path under an emission budget (ADR 0069)

### DIFF
--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -188,6 +188,9 @@ pub struct RedDBOptions {
     pub durability_mode: DurabilityMode,
     pub group_commit: GroupCommitOptions,
     pub auto_checkpoint_pages: u32,
+    /// Maximum hypertable chunks the checkpoint path may seal into derived
+    /// columnar artifacts per checkpoint. `usize::MAX` means no practical cap.
+    pub checkpoint_columnar_emission_budget_chunks: usize,
     pub cache_pages: usize,
     pub snapshot_retention: usize,
     pub export_retention: usize,
@@ -253,6 +256,10 @@ impl fmt::Debug for RedDBOptions {
             .field("durability_mode", &self.durability_mode)
             .field("group_commit", &self.group_commit)
             .field("auto_checkpoint_pages", &self.auto_checkpoint_pages)
+            .field(
+                "checkpoint_columnar_emission_budget_chunks",
+                &self.checkpoint_columnar_emission_budget_chunks,
+            )
             .field("cache_pages", &self.cache_pages)
             .field("snapshot_retention", &self.snapshot_retention)
             .field("export_retention", &self.export_retention)
@@ -283,6 +290,8 @@ impl Clone for RedDBOptions {
             durability_mode: self.durability_mode,
             group_commit: self.group_commit,
             auto_checkpoint_pages: self.auto_checkpoint_pages,
+            checkpoint_columnar_emission_budget_chunks: self
+                .checkpoint_columnar_emission_budget_chunks,
             cache_pages: self.cache_pages,
             snapshot_retention: self.snapshot_retention,
             export_retention: self.export_retention,
@@ -321,6 +330,7 @@ impl Default for RedDBOptions {
             durability_mode: DurabilityMode::WalDurableGrouped,
             group_commit: GroupCommitOptions::default(),
             auto_checkpoint_pages: 1000,
+            checkpoint_columnar_emission_budget_chunks: usize::MAX,
             cache_pages: 10_000,
             snapshot_retention: DEFAULT_SNAPSHOT_RETENTION,
             export_retention: DEFAULT_EXPORT_RETENTION,
@@ -397,6 +407,7 @@ impl RedDBOptions {
             mode: StorageMode::Persistent,
             data_path: Some(path),
             auto_checkpoint_pages: 0,
+            checkpoint_columnar_emission_budget_chunks: usize::MAX,
             cache_pages: 2_000,
             snapshot_retention: DEFAULT_SNAPSHOT_RETENTION,
             export_retention: DEFAULT_EXPORT_RETENTION,
@@ -442,6 +453,11 @@ impl RedDBOptions {
 
     pub fn with_auto_checkpoint(mut self, pages: u32) -> Self {
         self.auto_checkpoint_pages = pages;
+        self
+    }
+
+    pub fn with_checkpoint_columnar_emission_budget_chunks(mut self, chunks: usize) -> Self {
+        self.checkpoint_columnar_emission_budget_chunks = chunks;
         self
     }
 

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1002,6 +1002,7 @@ struct RuntimeInner {
     index_store: index_store::IndexStore,
     cdc: crate::replication::cdc::CdcBuffer,
     pub(crate) checkpoint_projection_stats: CheckpointProjectionStats,
+    pub(crate) checkpoint_columnar_emission_budget_chunks: usize,
     backup_scheduler: crate::replication::scheduler::BackupScheduler,
     query_cache: parking_lot::RwLock<crate::storage::query::planner::cache::PlanCache>,
     result_cache: parking_lot::RwLock<(

--- a/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
+++ b/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
@@ -54,6 +54,9 @@ impl RedDBRuntime {
         // The remote upload is the side-effect that risks clobbering a
         // peer's state, so it's behind the lease gate.
         let started = std::time::Instant::now();
+        self.seal_hypertable_chunks_for_checkpoint(
+            self.inner.checkpoint_columnar_emission_budget_chunks,
+        )?;
         self.inner.db.flush_local_only().map_err(|err| {
             // Issue #205 — local flush failure is a CheckpointFailed
             // operator-grade event. The local-flush path also covers

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -222,6 +222,8 @@ impl RedDBRuntime {
                 index_store: super::index_store::IndexStore::new(),
                 cdc: crate::replication::cdc::CdcBuffer::new(100_000),
                 checkpoint_projection_stats: super::CheckpointProjectionStats::default(),
+                checkpoint_columnar_emission_budget_chunks: options
+                    .checkpoint_columnar_emission_budget_chunks,
                 backup_scheduler: crate::replication::scheduler::BackupScheduler::new(3600),
                 query_cache: parking_lot::RwLock::new(
                     crate::storage::query::planner::cache::PlanCache::new(1000),

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -335,7 +335,7 @@ impl RedDBRuntime {
                         .write_column_block_page(&bytes)
                         .map_err(|err| {
                             RedDBError::Internal(format!("columnar page write failed: {err}"))
-                    })?;
+                        })?;
                     registry.seal_chunk_columnar(&meta.id, page, bytes);
                     outcome.columnar_chunks_sealed += 1;
                     outcome.chunks_sealed += 1;

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -9,6 +9,12 @@ const TIMESERIES_META_COLLECTION: &str = "red_timeseries_meta";
 const COLUMNAR_PROJECTION_SIZE_FLOOR_ROWS: usize = 4;
 const DEFAULT_TIMESERIES_CHUNK_INTERVAL_NS: u64 = 86_400_000_000_000;
 
+#[derive(Default)]
+struct SealHypertableChunksOutcome {
+    chunks_sealed: usize,
+    columnar_chunks_sealed: usize,
+}
+
 impl RedDBRuntime {
     pub fn execute_create_timeseries(
         &self,
@@ -223,6 +229,41 @@ impl RedDBRuntime {
     /// Opted-out chunks fall to the row seal and `columnar_page` stays
     /// `None`. Returns the number of chunks sealed columnar.
     pub fn seal_hypertable_chunks(&self, collection: &str) -> RedDBResult<usize> {
+        self.seal_hypertable_chunks_internal(collection, usize::MAX, true)
+            .map(|outcome| outcome.columnar_chunks_sealed)
+    }
+
+    pub(crate) fn seal_hypertable_chunks_for_checkpoint(
+        &self,
+        max_chunks: usize,
+    ) -> RedDBResult<usize> {
+        if max_chunks == 0 {
+            return Ok(0);
+        }
+
+        let mut remaining = max_chunks;
+        let mut sealed = 0usize;
+        for collection in self.inner.db.hypertables().names() {
+            if remaining == 0 {
+                break;
+            }
+            let outcome = self.seal_hypertable_chunks_internal(&collection, remaining, false)?;
+            remaining = remaining.saturating_sub(outcome.chunks_sealed);
+            sealed += outcome.chunks_sealed;
+        }
+        Ok(sealed)
+    }
+
+    fn seal_hypertable_chunks_internal(
+        &self,
+        collection: &str,
+        max_chunks: usize,
+        include_tail_chunk: bool,
+    ) -> RedDBResult<SealHypertableChunksOutcome> {
+        if max_chunks == 0 {
+            return Ok(SealHypertableChunksOutcome::default());
+        }
+
         let analytical = self
             .inner
             .db
@@ -230,18 +271,31 @@ impl RedDBRuntime {
             .and_then(|c| c.analytical_storage.clone());
         let registry = self.inner.db.hypertables();
         let Some(spec) = registry.get(collection) else {
-            return Ok(0);
+            return Ok(SealHypertableChunksOutcome::default());
         };
         let time_col = spec.time_column.clone();
         let store = self.inner.db.store();
         let Some(manager) = store.get_collection(collection) else {
-            return Ok(0);
+            return Ok(SealHypertableChunksOutcome::default());
         };
 
-        let mut sealed_columnar = 0usize;
+        let chunks = registry.show_chunks(collection);
+        let tail_chunk_start = if include_tail_chunk {
+            None
+        } else {
+            chunks.iter().map(|meta| meta.id.start_ns).max()
+        };
+
+        let mut outcome = SealHypertableChunksOutcome::default();
         let mut changed = false;
-        for meta in registry.show_chunks(collection) {
+        for meta in chunks {
+            if outcome.chunks_sealed >= max_chunks {
+                break;
+            }
             if meta.sealed {
+                continue;
+            }
+            if Some(meta.id.start_ns) == tail_chunk_start {
                 continue;
             }
             let start = meta.id.start_ns;
@@ -281,13 +335,15 @@ impl RedDBRuntime {
                         .write_column_block_page(&bytes)
                         .map_err(|err| {
                             RedDBError::Internal(format!("columnar page write failed: {err}"))
-                        })?;
+                    })?;
                     registry.seal_chunk_columnar(&meta.id, page, bytes);
-                    sealed_columnar += 1;
+                    outcome.columnar_chunks_sealed += 1;
+                    outcome.chunks_sealed += 1;
                     changed = true;
                 }
                 crate::storage::timeseries::chunk::SealedChunkStorage::Row => {
                     registry.seal_chunk(&meta.id);
+                    outcome.chunks_sealed += 1;
                     changed = true;
                 }
             }
@@ -298,7 +354,7 @@ impl RedDBRuntime {
                 .persist_metadata()
                 .map_err(|e| RedDBError::Internal(e.to_string()))?;
         }
-        Ok(sealed_columnar)
+        Ok(outcome)
     }
 
     /// Count this hypertable's chunks that were sealed columnar — i.e.

--- a/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
+++ b/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
@@ -305,7 +305,10 @@ fn checkpoint_columnar_budget_defers_closed_chunks_and_keeps_row_tail_fresh() {
         1,
         "budget allows one closed chunk per checkpoint"
     );
-    assert_eq!(rt.read_bridge_points("cpu", 0, u64::MAX).unwrap(), want(&expected));
+    assert_eq!(
+        rt.read_bridge_points("cpu", 0, u64::MAX).unwrap(),
+        want(&expected)
+    );
 
     rt.checkpoint().expect("second checkpoint");
     assert_eq!(

--- a/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
+++ b/crates/reddb-server/tests/columnar_read_bridge_e2e.rs
@@ -15,6 +15,7 @@
 //!   3. No data is lost or stranded across the upgrade.
 
 use reddb_server::catalog::AnalyticalStorageConfig;
+use reddb_server::storage::schema::Value;
 use reddb_server::{RedDBOptions, RedDBRuntime, StorageDeployPreset};
 
 /// 1-hour chunk interval, in nanoseconds — matches `CHUNK_INTERVAL '1h'`.
@@ -61,6 +62,20 @@ fn insert_many(rt: &RedDBRuntime, collection: &str, row_count: u64) {
     }
 }
 
+fn insert_chunk_rows(
+    rt: &RedDBRuntime,
+    collection: &str,
+    chunk_index: u64,
+    row_count: u64,
+) -> Vec<(u64, i64)> {
+    let start = chunk_index * HOUR_NS;
+    let rows = (0..row_count)
+        .map(|i| (start + i + 1, (chunk_index * 100 + i) as i64))
+        .collect::<Vec<_>>();
+    insert(rt, collection, &rows);
+    rows
+}
+
 fn open_paged_runtime(path: &std::path::Path) -> RedDBRuntime {
     let options = RedDBOptions::persistent(path)
         .with_storage_profile(StorageDeployPreset::Serverless.selection())
@@ -86,6 +101,22 @@ fn enable_columnar(rt: &RedDBRuntime, collection: &str, time_key: &str) {
 
 fn want(rows: &[(u64, i64)]) -> Vec<(u64, f64)> {
     rows.iter().map(|(ts, v)| (*ts, *v as f64)).collect()
+}
+
+fn assert_recent_sql_rows(rt: &RedDBRuntime, collection: &str, start_ns: u64, want_rows: usize) {
+    let result = rt
+        .execute_query(&format!(
+            "SELECT ts, value FROM {collection} WHERE ts >= {start_ns} ORDER BY ts ASC"
+        ))
+        .expect("recent row query");
+    assert_eq!(result.result.records.len(), want_rows);
+    if let Some(row) = result.result.records.first() {
+        let ts = match row.get("ts") {
+            Some(Value::Integer(n)) if *n >= 0 => *n as u64,
+            other => panic!("unexpected ts value: {other:?}"),
+        };
+        assert!(ts >= start_ns);
+    }
 }
 
 #[test]
@@ -187,19 +218,35 @@ fn durable_columnar_blocks_survive_restart_and_keep_pruning() {
         rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
             .expect("create hypertable");
         insert_many(&rt, "cpu", GRANULE_ROWS_PLUS_ONE);
+        insert(&rt, "cpu", &[(HOUR_NS + 1, 99)]);
 
-        assert_eq!(
-            rt.seal_hypertable_chunks("cpu").expect("seal columnar"),
-            1,
-            "single chunk seals columnar"
-        );
-        let chunk = rt.db().hypertables().show_chunks("cpu")[0].clone();
+        rt.checkpoint().expect("checkpoint seals closed chunk");
+        assert_eq!(rt.columnar_chunk_count("cpu"), 1);
+        let chunks = rt.db().hypertables().show_chunks("cpu");
+        assert_eq!(chunks.len(), 2, "closed chunk plus open row tail");
+        let chunk = chunks
+            .iter()
+            .find(|chunk| chunk.id.start_ns == 0)
+            .expect("closed chunk")
+            .clone();
         assert!(
             chunk.columnar_page.is_some_and(|loc| loc.page_id != 0),
             "columnar seal must record a real engine page location"
         );
+        let tail = chunks
+            .iter()
+            .find(|chunk| chunk.id.start_ns == HOUR_NS)
+            .expect("tail chunk");
+        assert!(
+            !tail.sealed && tail.columnar_page.is_none(),
+            "checkpoint must leave the newest chunk on the row tail"
+        );
         let metadata = rt.db().physical_metadata().expect("physical metadata");
-        let persisted_chunk = &metadata.hypertables[0].chunks[0];
+        let persisted_chunk = metadata.hypertables[0]
+            .chunks
+            .iter()
+            .find(|chunk| chunk.start_ns == 0)
+            .expect("persisted closed chunk");
         assert!(
             persisted_chunk.columnar_derived,
             "persisted metadata must mark columnar blocks derived"
@@ -216,8 +263,7 @@ fn durable_columnar_blocks_survive_restart_and_keep_pruning() {
             .columnar_chunk_value_eq_scan("cpu", 0, 42.0)
             .expect("pre-restart equality scan");
 
-        rt.create_snapshot().expect("snapshot before restart");
-        rt.checkpoint().expect("checkpoint before restart");
+        assert_recent_sql_rows(&rt, "cpu", HOUR_NS, 1);
     }
 
     let rt = open_paged_runtime(&path);
@@ -238,4 +284,54 @@ fn durable_columnar_blocks_survive_restart_and_keep_pruning() {
     assert_eq!(after_eq.points, before_eq.points);
     assert_eq!(after_eq.granules_total, before_eq.granules_total);
     assert_eq!(after_eq.granules_scanned, before_eq.granules_scanned);
+}
+
+#[test]
+fn checkpoint_columnar_budget_defers_closed_chunks_and_keeps_row_tail_fresh() {
+    let options = RedDBOptions::in_memory().with_checkpoint_columnar_emission_budget_chunks(1);
+    let rt = RedDBRuntime::with_options(options).expect("runtime boots");
+    rt.execute_query("CREATE HYPERTABLE cpu TIME_COLUMN ts CHUNK_INTERVAL '1h'")
+        .expect("create hypertable");
+
+    let mut expected = Vec::new();
+    for chunk_index in 0..4 {
+        expected.extend(insert_chunk_rows(&rt, "cpu", chunk_index, 4));
+    }
+    expected.extend(insert_chunk_rows(&rt, "cpu", 4, 1));
+
+    rt.checkpoint().expect("first checkpoint");
+    assert_eq!(
+        rt.columnar_chunk_count("cpu"),
+        1,
+        "budget allows one closed chunk per checkpoint"
+    );
+    assert_eq!(rt.read_bridge_points("cpu", 0, u64::MAX).unwrap(), want(&expected));
+
+    rt.checkpoint().expect("second checkpoint");
+    assert_eq!(
+        rt.columnar_chunk_count("cpu"),
+        2,
+        "deferred chunks are picked up on the next checkpoint"
+    );
+
+    rt.checkpoint().expect("third checkpoint");
+    rt.checkpoint().expect("fourth checkpoint");
+    assert_eq!(
+        rt.columnar_chunk_count("cpu"),
+        4,
+        "all closed chunks eventually seal"
+    );
+
+    let tail = rt
+        .db()
+        .hypertables()
+        .show_chunks("cpu")
+        .into_iter()
+        .find(|chunk| chunk.id.start_ns == 4 * HOUR_NS)
+        .expect("open tail chunk");
+    assert!(
+        !tail.sealed && tail.columnar_page.is_none(),
+        "the newest chunk remains row-backed"
+    );
+    assert_recent_sql_rows(&rt, "cpu", 4 * HOUR_NS, 1);
 }


### PR DESCRIPTION
Automated AFK landing for #1815. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1815

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786010630&installation_id=129708444&pr_number=1893&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1893&signature=54d606cf59a2daaef81a91d2104e03c5f51cdd5cac0e38a7a5882a17af26b935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable checkpoint emission budget to limit how many chunks can be converted during a checkpoint.
  * Checkpoint behavior now leaves the newest chunk in row format when the budget is reached.

* **Bug Fixes**
  * Improved checkpoint sealing flow so chunk metadata is updated more predictably before flush and upload steps.
  * Strengthened end-to-end coverage for recent-row SQL reads and durable restart behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->