### PR TITLE
chore: #1819 DOWNSAMPLE executor riding the retention sweep: materialize rollups, then retire raw chunks

### DIFF
--- a/crates/reddb-server/src/runtime/impl_physical.rs
+++ b/crates/reddb-server/src/runtime/impl_physical.rs
@@ -1,5 +1,94 @@
 use super::*;
 
+#[derive(Debug, Clone)]
+struct MetricsRetentionRollupPolicy {
+    target: String,
+    aggregation: String,
+    bucket_ns: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct MetricsRollupKey {
+    metric: String,
+    bucket_ns: u64,
+    tags: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone)]
+struct MetricsRollupAccumulator {
+    count: u64,
+    sum: f64,
+    min: f64,
+    max: f64,
+}
+
+impl MetricsRollupAccumulator {
+    fn new(value: f64) -> Self {
+        Self {
+            count: 1,
+            sum: value,
+            min: value,
+            max: value,
+        }
+    }
+
+    fn push(&mut self, value: f64) {
+        self.count = self.count.saturating_add(1);
+        self.sum += value;
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+    }
+
+    fn value(&self, aggregation: &str) -> f64 {
+        match aggregation {
+            "sum" => self.sum,
+            "min" => self.min,
+            "max" => self.max,
+            "count" => self.count as f64,
+            _ => self.sum / self.count.max(1) as f64,
+        }
+    }
+}
+
+fn metrics_rollup_policies_for_retention(
+    contract: &crate::physical::CollectionContract,
+) -> Vec<MetricsRetentionRollupPolicy> {
+    contract
+        .metrics_rollup_policies
+        .iter()
+        .filter_map(|spec| {
+            let parsed = crate::storage::timeseries::retention::DownsamplePolicy::parse(spec)?;
+            if parsed.source != "raw"
+                || !matches!(
+                    parsed.aggregation.as_str(),
+                    "avg" | "sum" | "min" | "max" | "count"
+                )
+            {
+                return None;
+            }
+            Some(MetricsRetentionRollupPolicy {
+                target: parsed.target,
+                aggregation: parsed.aggregation,
+                bucket_ns: parsed.bucket_ns,
+            })
+        })
+        .collect()
+}
+
+fn metrics_rollup_collection_for_retention(raw_collection: &str, target: &str) -> String {
+    let sanitized = target
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("red_metrics_rollup_{raw_collection}_{sanitized}")
+}
+
 impl RedDBRuntime {
     pub fn create_export(&self, name: impl Into<String>) -> RedDBResult<ExportDescriptor> {
         self.inner
@@ -329,6 +418,7 @@ impl RedDBRuntime {
                 crate::storage::EntityData::TimeSeries(point) => point.timestamp_ns < cutoff_ns,
                 _ => false,
             });
+            self.materialize_metrics_rollups_for_retention(&contract, &expired)?;
             for entity in expired {
                 let deleted = store
                     .delete(&contract.name, entity.id)
@@ -342,6 +432,93 @@ impl RedDBRuntime {
                         "entity",
                     );
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn materialize_metrics_rollups_for_retention(
+        &self,
+        contract: &crate::physical::CollectionContract,
+        raw_points: &[crate::storage::UnifiedEntity],
+    ) -> RedDBResult<()> {
+        if raw_points.is_empty() {
+            return Ok(());
+        }
+        let policies = metrics_rollup_policies_for_retention(contract);
+        if policies.is_empty() {
+            return Ok(());
+        }
+
+        let store = self.inner.db.store();
+        for policy in policies {
+            let rollup_collection =
+                metrics_rollup_collection_for_retention(&contract.name, &policy.target);
+            if store.get_collection(&rollup_collection).is_none() {
+                store
+                    .create_collection(&rollup_collection)
+                    .map_err(|err| RedDBError::Internal(err.to_string()))?;
+            }
+
+            let mut buckets = BTreeMap::<MetricsRollupKey, MetricsRollupAccumulator>::new();
+            for entity in raw_points {
+                let crate::storage::EntityData::TimeSeries(point) = &entity.data else {
+                    continue;
+                };
+                let bucket_ns = (point.timestamp_ns / policy.bucket_ns) * policy.bucket_ns;
+                let mut tags = point
+                    .tags
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.clone()))
+                    .collect::<Vec<_>>();
+                tags.sort();
+                let key = MetricsRollupKey {
+                    metric: point.metric.clone(),
+                    bucket_ns,
+                    tags,
+                };
+                buckets
+                    .entry(key)
+                    .and_modify(|acc| acc.push(point.value))
+                    .or_insert_with(|| MetricsRollupAccumulator::new(point.value));
+            }
+
+            for (key, accumulator) in buckets {
+                let tags = key.tags.into_iter().collect::<HashMap<_, _>>();
+                if let Some(manager) = store.get_collection(&rollup_collection) {
+                    for entity in manager.query_all(|entity| match &entity.data {
+                        crate::storage::EntityData::TimeSeries(point) => {
+                            point.metric == key.metric
+                                && point.timestamp_ns == key.bucket_ns
+                                && point.tags == tags
+                        }
+                        _ => false,
+                    }) {
+                        store
+                            .delete(&rollup_collection, entity.id)
+                            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                    }
+                }
+
+                let entity = crate::storage::UnifiedEntity::new(
+                    crate::storage::EntityId::new(0),
+                    crate::storage::EntityKind::TimeSeriesPoint(Box::new(
+                        crate::storage::TimeSeriesPointKind {
+                            series: rollup_collection.clone(),
+                            metric: key.metric.clone(),
+                        },
+                    )),
+                    crate::storage::EntityData::TimeSeries(crate::storage::TimeSeriesData {
+                        metric: key.metric,
+                        timestamp_ns: key.bucket_ns,
+                        value: accumulator.value(&policy.aggregation),
+                        tags,
+                    }),
+                );
+                store
+                    .insert_auto(&rollup_collection, entity)
+                    .map_err(|err| RedDBError::Internal(err.to_string()))?;
             }
         }
 

--- a/crates/reddb-server/src/server/handlers_metrics.rs
+++ b/crates/reddb-server/src/server/handlers_metrics.rs
@@ -422,45 +422,48 @@ impl RedDBServer {
             .into_iter()
             .filter(|contract| contract.declared_model == CollectionModel::Metrics)
         {
-            let source_collection =
-                select_metrics_range_collection(store.as_ref(), &contract, range);
-            let Some(manager) = store.get_collection(&source_collection) else {
-                continue;
-            };
-            let entities =
-                manager.query_all(|entity| matches!(entity.data, EntityData::TimeSeries(_)));
-            for entity in entities {
-                let EntityData::TimeSeries(point) = entity.data else {
+            for source in metrics_range_sources(store.as_ref(), &contract, range) {
+                let Some(manager) = store.get_collection(&source.collection) else {
                     continue;
                 };
-                if point.metric != selector.metric {
-                    continue;
+                let entities =
+                    manager.query_all(|entity| matches!(entity.data, EntityData::TimeSeries(_)));
+                for entity in entities {
+                    let EntityData::TimeSeries(point) = entity.data else {
+                        continue;
+                    };
+                    if !source.contains(point.timestamp_ns) {
+                        continue;
+                    }
+                    if point.metric != selector.metric {
+                        continue;
+                    }
+                    if point.timestamp_ns < range.start_ns || point.timestamp_ns > range.end_ns {
+                        continue;
+                    }
+                    if !point_in_metrics_scope(&point, scope) {
+                        continue;
+                    }
+                    let labels = prometheus_labels_for_point(&point);
+                    if !selector_matches(&selector, &labels) {
+                        continue;
+                    }
+                    let series_key = labels
+                        .iter()
+                        .map(|(name, value)| (name.clone(), value.clone()))
+                        .collect::<Vec<_>>();
+                    samples_by_series
+                        .entry(series_key)
+                        .or_insert_with(|| PromRangeSeries {
+                            labels,
+                            values: Vec::new(),
+                        })
+                        .values
+                        .push(PromRangeValue {
+                            timestamp_ns: point.timestamp_ns,
+                            value: point.value,
+                        });
                 }
-                if point.timestamp_ns < range.start_ns || point.timestamp_ns > range.end_ns {
-                    continue;
-                }
-                if !point_in_metrics_scope(&point, scope) {
-                    continue;
-                }
-                let labels = prometheus_labels_for_point(&point);
-                if !selector_matches(&selector, &labels) {
-                    continue;
-                }
-                let series_key = labels
-                    .iter()
-                    .map(|(name, value)| (name.clone(), value.clone()))
-                    .collect::<Vec<_>>();
-                samples_by_series
-                    .entry(series_key)
-                    .or_insert_with(|| PromRangeSeries {
-                        labels,
-                        values: Vec::new(),
-                    })
-                    .values
-                    .push(PromRangeValue {
-                        timestamp_ns: point.timestamp_ns,
-                        value: point.value,
-                    });
             }
         }
 
@@ -2253,24 +2256,70 @@ fn materialize_metrics_rollups(
     Ok(())
 }
 
-fn select_metrics_range_collection(
+#[derive(Debug, Clone)]
+struct MetricsRangeSource {
+    collection: String,
+    min_inclusive_ns: Option<u64>,
+    max_exclusive_ns: Option<u64>,
+}
+
+impl MetricsRangeSource {
+    fn contains(&self, timestamp_ns: u64) -> bool {
+        self.min_inclusive_ns.is_none_or(|min| timestamp_ns >= min)
+            && self.max_exclusive_ns.is_none_or(|max| timestamp_ns < max)
+    }
+}
+
+fn metrics_range_sources(
     store: &crate::storage::unified::UnifiedStore,
     contract: &crate::physical::CollectionContract,
     range: PromQueryRange,
-) -> String {
+) -> Vec<MetricsRangeSource> {
     let Some(policy) = metrics_rollup_policies(contract)
         .into_iter()
         .filter(|policy| policy.bucket_ns <= range.step_ns)
         .max_by_key(|policy| policy.bucket_ns)
     else {
-        return contract.name.clone();
+        return vec![MetricsRangeSource {
+            collection: contract.name.clone(),
+            min_inclusive_ns: None,
+            max_exclusive_ns: None,
+        }];
     };
     let rollup_collection = metrics_rollup_collection(&contract.name, &policy.target);
-    if store.get_collection(&rollup_collection).is_some() {
-        rollup_collection
-    } else {
-        contract.name.clone()
+    if store.get_collection(&rollup_collection).is_none() {
+        return vec![MetricsRangeSource {
+            collection: contract.name.clone(),
+            min_inclusive_ns: None,
+            max_exclusive_ns: None,
+        }];
     }
+
+    let Some(raw_retention_ms) = contract.metrics_raw_retention_ms else {
+        return vec![MetricsRangeSource {
+            collection: rollup_collection,
+            min_inclusive_ns: None,
+            max_exclusive_ns: None,
+        }];
+    };
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos()
+        .min(u128::from(u64::MAX)) as u64;
+    let cutoff_ns = now_ns.saturating_sub(raw_retention_ms.saturating_mul(1_000_000));
+    vec![
+        MetricsRangeSource {
+            collection: rollup_collection,
+            min_inclusive_ns: None,
+            max_exclusive_ns: Some(cutoff_ns),
+        },
+        MetricsRangeSource {
+            collection: contract.name.clone(),
+            min_inclusive_ns: Some(cutoff_ns),
+            max_exclusive_ns: None,
+        },
+    ]
 }
 
 fn metrics_rollup_policies(

--- a/tests/grouped/timeseries_remaining/e2e_metrics_rollup_retention.rs
+++ b/tests/grouped/timeseries_remaining/e2e_metrics_rollup_retention.rs
@@ -2,9 +2,12 @@
 mod support;
 
 use reddb::catalog::CollectionModel;
-use reddb::storage::EntityData;
+use reddb::storage::{
+    EntityData, EntityId, EntityKind, TimeSeriesData, TimeSeriesPointKind, UnifiedEntity,
+};
 use reddb::RedDBRuntime;
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 use support::prometheus::{
     encode_query_value, get, label, post_remote_write, sample, TimeSeries, WriteRequest,
 };
@@ -31,6 +34,33 @@ fn ingest(rt: &RedDBRuntime, collection: &str, samples: Vec<(f64, i64)>) {
     };
     let (status, body) = post_remote_write(rt.clone(), collection, &request);
     assert_eq!(status, 204, "remote_write should ingest: {body}");
+}
+
+fn insert_raw_metric(rt: &RedDBRuntime, collection: &str, timestamp_ms: i64, value: f64) {
+    let tags = HashMap::from([
+        ("__tenant_id".to_string(), "default".to_string()),
+        ("__namespace".to_string(), "default".to_string()),
+        ("job".to_string(), "api".to_string()),
+        ("instance".to_string(), "i1".to_string()),
+        ("service".to_string(), "checkout".to_string()),
+    ]);
+    let entity = UnifiedEntity::new(
+        EntityId::new(0),
+        EntityKind::TimeSeriesPoint(Box::new(TimeSeriesPointKind {
+            series: collection.to_string(),
+            metric: "http_requests_total".to_string(),
+        })),
+        EntityData::TimeSeries(TimeSeriesData {
+            metric: "http_requests_total".to_string(),
+            timestamp_ns: (timestamp_ms as u64).saturating_mul(1_000_000),
+            value,
+            tags,
+        }),
+    );
+    rt.db()
+        .store()
+        .insert_auto(collection, entity)
+        .expect("raw metric insert should succeed");
 }
 
 fn query_range(rt: &RedDBRuntime, promql: &str, start: &str, end: &str, step: &str) -> JsonValue {
@@ -182,5 +212,102 @@ fn expired_raw_metrics_are_removed_without_removing_rollups() {
     assert_eq!(
         only_values(&response),
         &serde_json::json!([[bucket_ms / 1000, "150"]])
+    );
+}
+
+#[test]
+fn retention_sweep_materializes_rollup_before_retiring_raw_and_is_idempotent() {
+    let rt = RedDBRuntime::in_memory().expect("runtime");
+    exec(
+        &rt,
+        "CREATE METRICS sre RETENTION 1 s DOWNSAMPLE 60s:raw:avg",
+    );
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    let bucket_ms = ((now_ms / 60_000) - 2) * 60_000;
+    insert_raw_metric(&rt, "sre", bucket_ms, 120.0);
+    insert_raw_metric(&rt, "sre", bucket_ms + 10_000, 180.0);
+
+    rt.apply_retention_policy()
+        .expect("metrics retention sweep should succeed");
+    rt.apply_retention_policy()
+        .expect("second metrics retention sweep should be idempotent");
+
+    let raw = rt
+        .db()
+        .store()
+        .get_collection("sre")
+        .expect("raw metrics collection should exist")
+        .query_all(|entity| matches!(entity.data, EntityData::TimeSeries(_)));
+    assert!(raw.is_empty(), "expired raw samples should be retired");
+
+    let rollup = rt
+        .db()
+        .store()
+        .get_collection("red_metrics_rollup_sre_60s")
+        .expect("retention sweep should create the rollup collection")
+        .query_all(|entity| matches!(entity.data, EntityData::TimeSeries(_)));
+    assert_eq!(
+        rollup.len(),
+        1,
+        "re-running the sweep must not duplicate rollups"
+    );
+
+    let bucket_seconds = (bucket_ms / 1000).to_string();
+    let response = query_range(
+        &rt,
+        "http_requests_total",
+        &bucket_seconds,
+        &bucket_seconds,
+        "60s",
+    );
+    assert_eq!(
+        only_values(&response),
+        &serde_json::json!([[bucket_ms / 1000, "150"]])
+    );
+}
+
+#[test]
+fn query_range_spanning_retention_boundary_merges_rollup_and_recent_raw() {
+    let rt = RedDBRuntime::in_memory().expect("runtime");
+    exec(
+        &rt,
+        "CREATE METRICS sre RETENTION 1 h DOWNSAMPLE 60s:raw:avg",
+    );
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    let old_bucket_ms = ((now_ms / 60_000) - 120) * 60_000;
+    let recent_bucket_ms = (now_ms / 60_000) * 60_000;
+    insert_raw_metric(&rt, "sre", old_bucket_ms, 100.0);
+    insert_raw_metric(&rt, "sre", old_bucket_ms + 10_000, 200.0);
+    insert_raw_metric(&rt, "sre", recent_bucket_ms, 300.0);
+
+    rt.apply_retention_policy()
+        .expect("metrics retention sweep should succeed");
+
+    let response = query_range(
+        &rt,
+        "http_requests_total",
+        &(old_bucket_ms / 1000).to_string(),
+        &(recent_bucket_ms / 1000).to_string(),
+        "60s",
+    );
+    let values = only_values(&response)
+        .as_array()
+        .expect("query_range values should be an array");
+    assert!(values.len() >= 2, "expected a range crossing the boundary");
+    assert_eq!(
+        values.first(),
+        Some(&serde_json::json!([old_bucket_ms / 1000, "150"]))
+    );
+    assert_eq!(
+        values.last(),
+        Some(&serde_json::json!([recent_bucket_ms / 1000, "300"]))
     );
 }


### PR DESCRIPTION
Automated AFK landing for #1819. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1819

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786014557&installation_id=129708444&pr_number=1895&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1895&signature=d873d063154d7e65946ddbde7d28c93f0ca1fa349cb44c8da3b3cf410dce92ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->