### PR TITLE
chore: #1820 WAL delta records and checkpoint snapshots for probabilistic sidecar persistence

### DIFF
--- a/crates/reddb-file/src/wal_record.rs
+++ b/crates/reddb-file/src/wal_record.rs
@@ -25,6 +25,7 @@ pub enum MainWalRecordType {
     TxCommitBatch = 7,
     FullPageImage = 8,
     VectorInsert = 9,
+    ProbabilisticDelta = 10,
 }
 
 impl MainWalRecordType {
@@ -39,6 +40,7 @@ impl MainWalRecordType {
             7 => Some(Self::TxCommitBatch),
             8 => Some(Self::FullPageImage),
             9 => Some(Self::VectorInsert),
+            10 => Some(Self::ProbabilisticDelta),
             _ => None,
         }
     }
@@ -91,6 +93,12 @@ pub enum MainWalRecordFrame {
         collection: String,
         entity_id: u64,
         vector: Vec<f32>,
+    },
+    ProbabilisticDelta {
+        kind: u8,
+        operation: u8,
+        name: String,
+        operands: Vec<Vec<u8>>,
     },
     Checkpoint {
         lsn: u64,
@@ -183,6 +191,23 @@ pub fn encode_main_wal_record_frame_into(
             write_u32_len(out, vector.len(), "main wal vector length")?;
             for value in vector {
                 out.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+        MainWalRecordFrame::ProbabilisticDelta {
+            kind,
+            operation,
+            name,
+            operands,
+        } => {
+            write_type_and_term(out, MainWalRecordType::ProbabilisticDelta, term);
+            out.push(*kind);
+            out.push(*operation);
+            write_u32_len(out, name.len(), "main wal probabilistic name length")?;
+            out.extend_from_slice(name.as_bytes());
+            write_u32_len(out, operands.len(), "main wal probabilistic operand count")?;
+            for operand in operands {
+                write_u32_len(out, operand.len(), "main wal probabilistic operand length")?;
+                out.extend_from_slice(operand);
             }
         }
         MainWalRecordFrame::Checkpoint { lsn } => {
@@ -311,6 +336,28 @@ pub fn decode_main_wal_record_frame<R: Read>(
                 vector,
             }
         }
+        MainWalRecordType::ProbabilisticDelta => {
+            let kind = read_u8_tracked(reader, &mut checksum_bytes)?;
+            let operation = read_u8_tracked(reader, &mut checksum_bytes)?;
+            let name = String::from_utf8(read_bytes_tracked(reader, &mut checksum_bytes)?)
+                .map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("invalid probabilistic name utf8: {err}"),
+                    )
+                })?;
+            let count = read_u32_tracked(reader, &mut checksum_bytes)? as usize;
+            let mut operands = Vec::with_capacity(count);
+            for _ in 0..count {
+                operands.push(read_bytes_tracked(reader, &mut checksum_bytes)?);
+            }
+            MainWalRecordFrame::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
+            }
+        }
         MainWalRecordType::Checkpoint => MainWalRecordFrame::Checkpoint {
             lsn: read_u64_tracked(reader, &mut checksum_bytes)?,
         },
@@ -387,6 +434,10 @@ fn read_u32_tracked<R: Read>(reader: &mut R, checksum_bytes: &mut Vec<u8>) -> io
     )?))
 }
 
+fn read_u8_tracked<R: Read>(reader: &mut R, checksum_bytes: &mut Vec<u8>) -> io::Result<u8> {
+    Ok(read_array_tracked::<_, 1>(reader, checksum_bytes)?[0])
+}
+
 fn read_array_tracked<R: Read, const N: usize>(
     reader: &mut R,
     checksum_bytes: &mut Vec<u8>,
@@ -418,7 +469,11 @@ mod tests {
             MainWalRecordType::from_u8(9),
             Some(MainWalRecordType::VectorInsert)
         );
-        assert_eq!(MainWalRecordType::from_u8(10), None);
+        assert_eq!(
+            MainWalRecordType::from_u8(10),
+            Some(MainWalRecordType::ProbabilisticDelta)
+        );
+        assert_eq!(MainWalRecordType::from_u8(11), None);
     }
 
     #[test]
@@ -447,6 +502,12 @@ mod tests {
                 collection: "vectors".into(),
                 entity_id: 11,
                 vector: vec![1.0, -0.5, 0.25],
+            },
+            MainWalRecordFrame::ProbabilisticDelta {
+                kind: 1,
+                operation: 1,
+                name: "visitors".into(),
+                operands: vec![b"alice".to_vec()],
             },
         ];
 

--- a/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
+++ b/crates/reddb-server/src/runtime/impl_catalog_accessors.rs
@@ -57,6 +57,7 @@ impl RedDBRuntime {
         self.seal_hypertable_chunks_for_checkpoint(
             self.inner.checkpoint_columnar_emission_budget_chunks,
         )?;
+        self.persist_probabilistic_snapshots()?;
         self.inner.db.flush_local_only().map_err(|err| {
             // Issue #205 — local flush failure is a CheckpointFailed
             // operator-grade event. The local-flush path also covers

--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -8,6 +8,13 @@ const PROB_SKETCH_STATE_PREFIX: &str = "red.probabilistic.sketch.";
 const PROB_FILTER_STATE_PREFIX: &str = "red.probabilistic.filter.";
 const PROB_ENCODING_MARKER_KEY: &str = "red.probabilistic.state_encoding";
 const PROB_ENCODING_RAW_V1: &str = "raw-v1";
+const PROB_WAL_KIND_HLL: u8 = 1;
+const PROB_WAL_KIND_SKETCH: u8 = 2;
+const PROB_WAL_KIND_FILTER: u8 = 3;
+const PROB_WAL_OP_ADD: u8 = 1;
+const PROB_WAL_OP_DELETE: u8 = 2;
+const PROB_WAL_OP_SNAPSHOT: u8 = 3;
+const PROB_WAL_OP_DROP: u8 = 4;
 
 fn probabilistic_read<'a, T>(lock: &'a RwLock<T>, _name: &str) -> RwLockReadGuard<'a, T> {
     lock.read()
@@ -179,6 +186,7 @@ impl RedDBRuntime {
         if migrated_legacy_hex {
             self.persist_probabilistic_encoding_marker();
         }
+        self.apply_replayed_probabilistic_deltas()?;
         Ok(())
     }
 
@@ -309,6 +317,220 @@ impl RedDBRuntime {
         let key = format!("{prefix}{}", hex::encode(name.as_bytes()));
         self.compact_config_key(&key);
         self.insert_config_value(&key, Value::Null)?;
+        Ok(())
+    }
+
+    pub(crate) fn persist_probabilistic_snapshots(&self) -> RedDBResult<()> {
+        let hll_snapshots: Vec<(String, Vec<u8>)> = {
+            let hlls =
+                probabilistic_read(&self.inner.probabilistic.hlls, "probabilistic HLL store");
+            hlls.iter()
+                .map(|(name, hll)| (name.clone(), hll.as_bytes().to_vec()))
+                .collect()
+        };
+        for (name, bytes) in hll_snapshots {
+            self.persist_probabilistic_blob(PROB_HLL_STATE_PREFIX, &name, &bytes)?;
+            self.append_probabilistic_snapshot_delta(PROB_WAL_KIND_HLL, &name, bytes)?;
+        }
+
+        let sketch_snapshots: Vec<(String, Vec<u8>)> = {
+            let sketches = probabilistic_read(
+                &self.inner.probabilistic.sketches,
+                "probabilistic sketch store",
+            );
+            sketches
+                .iter()
+                .map(|(name, sketch)| (name.clone(), sketch.as_bytes()))
+                .collect()
+        };
+        for (name, bytes) in sketch_snapshots {
+            self.persist_probabilistic_blob(PROB_SKETCH_STATE_PREFIX, &name, &bytes)?;
+            self.append_probabilistic_snapshot_delta(PROB_WAL_KIND_SKETCH, &name, bytes)?;
+        }
+
+        let filter_snapshots: Vec<(String, Vec<u8>)> = {
+            let filters = probabilistic_read(
+                &self.inner.probabilistic.filters,
+                "probabilistic filter store",
+            );
+            filters
+                .iter()
+                .map(|(name, filter)| (name.clone(), filter.as_bytes()))
+                .collect()
+        };
+        for (name, bytes) in filter_snapshots {
+            self.persist_probabilistic_blob(PROB_FILTER_STATE_PREFIX, &name, &bytes)?;
+            self.append_probabilistic_snapshot_delta(PROB_WAL_KIND_FILTER, &name, bytes)?;
+        }
+
+        Ok(())
+    }
+
+    fn append_probabilistic_add_delta(
+        &self,
+        kind: u8,
+        name: &str,
+        operands: Vec<Vec<u8>>,
+    ) -> RedDBResult<()> {
+        self.append_probabilistic_delta(kind, PROB_WAL_OP_ADD, name, operands)
+    }
+
+    fn append_probabilistic_snapshot_delta(
+        &self,
+        kind: u8,
+        name: &str,
+        bytes: Vec<u8>,
+    ) -> RedDBResult<()> {
+        self.append_probabilistic_delta(kind, PROB_WAL_OP_SNAPSHOT, name, vec![bytes])
+    }
+
+    fn append_probabilistic_drop_delta(&self, kind: u8, name: &str) -> RedDBResult<()> {
+        self.append_probabilistic_delta(kind, PROB_WAL_OP_DROP, name, Vec::new())
+    }
+
+    fn append_probabilistic_delete_delta(
+        &self,
+        kind: u8,
+        name: &str,
+        operands: Vec<Vec<u8>>,
+    ) -> RedDBResult<()> {
+        self.append_probabilistic_delta(kind, PROB_WAL_OP_DELETE, name, operands)
+    }
+
+    fn append_probabilistic_delta(
+        &self,
+        kind: u8,
+        operation: u8,
+        name: &str,
+        operands: Vec<Vec<u8>>,
+    ) -> RedDBResult<()> {
+        self.inner
+            .db
+            .store()
+            .append_probabilistic_delta_record(kind, operation, name, operands)
+            .map_err(|err| RedDBError::Internal(format!("append probabilistic WAL delta: {err}")))
+    }
+
+    fn apply_replayed_probabilistic_deltas(&self) -> RedDBResult<()> {
+        let deltas = self.inner.db.store().take_replayed_probabilistic_deltas();
+        for (kind, operation, name, operands) in deltas {
+            self.apply_replayed_probabilistic_delta(kind, operation, &name, operands)?;
+        }
+        Ok(())
+    }
+
+    fn apply_replayed_probabilistic_delta(
+        &self,
+        kind: u8,
+        operation: u8,
+        name: &str,
+        operands: Vec<Vec<u8>>,
+    ) -> RedDBResult<()> {
+        match (kind, operation) {
+            (PROB_WAL_KIND_HLL, PROB_WAL_OP_SNAPSHOT) => {
+                let bytes = single_probabilistic_operand(operands, "HLL snapshot")?;
+                let hll = crate::storage::primitives::hyperloglog::HyperLogLog::from_bytes(bytes)
+                    .ok_or_else(|| {
+                    RedDBError::Internal(format!("invalid WAL HLL snapshot for '{name}'"))
+                })?;
+                let mut hlls =
+                    probabilistic_write(&self.inner.probabilistic.hlls, "probabilistic HLL store");
+                hlls.insert(name.to_string(), hll);
+            }
+            (PROB_WAL_KIND_HLL, PROB_WAL_OP_ADD) => {
+                let mut hlls =
+                    probabilistic_write(&self.inner.probabilistic.hlls, "probabilistic HLL store");
+                if let Some(hll) = hlls.get_mut(name) {
+                    for element in operands {
+                        hll.add(&element);
+                    }
+                }
+            }
+            (PROB_WAL_KIND_HLL, PROB_WAL_OP_DROP) => {
+                let mut hlls =
+                    probabilistic_write(&self.inner.probabilistic.hlls, "probabilistic HLL store");
+                hlls.remove(name);
+            }
+            (PROB_WAL_KIND_SKETCH, PROB_WAL_OP_SNAPSHOT) => {
+                let bytes = single_probabilistic_operand(operands, "SKETCH snapshot")?;
+                let sketch =
+                    crate::storage::primitives::count_min_sketch::CountMinSketch::from_bytes(
+                        &bytes,
+                    )
+                    .ok_or_else(|| {
+                        RedDBError::Internal(format!("invalid WAL SKETCH snapshot for '{name}'"))
+                    })?;
+                let mut sketches = probabilistic_write(
+                    &self.inner.probabilistic.sketches,
+                    "probabilistic sketch store",
+                );
+                sketches.insert(name.to_string(), sketch);
+            }
+            (PROB_WAL_KIND_SKETCH, PROB_WAL_OP_ADD) => {
+                let (element, count) = sketch_add_operands(operands)?;
+                let mut sketches = probabilistic_write(
+                    &self.inner.probabilistic.sketches,
+                    "probabilistic sketch store",
+                );
+                if let Some(sketch) = sketches.get_mut(name) {
+                    sketch.add(&element, count);
+                }
+            }
+            (PROB_WAL_KIND_SKETCH, PROB_WAL_OP_DROP) => {
+                let mut sketches = probabilistic_write(
+                    &self.inner.probabilistic.sketches,
+                    "probabilistic sketch store",
+                );
+                sketches.remove(name);
+            }
+            (PROB_WAL_KIND_FILTER, PROB_WAL_OP_SNAPSHOT) => {
+                let bytes = single_probabilistic_operand(operands, "FILTER snapshot")?;
+                let filter =
+                    crate::storage::primitives::cuckoo_filter::CuckooFilter::from_bytes(&bytes)
+                        .ok_or_else(|| {
+                            RedDBError::Internal(format!(
+                                "invalid WAL FILTER snapshot for '{name}'"
+                            ))
+                        })?;
+                let mut filters = probabilistic_write(
+                    &self.inner.probabilistic.filters,
+                    "probabilistic filter store",
+                );
+                filters.insert(name.to_string(), filter);
+            }
+            (PROB_WAL_KIND_FILTER, PROB_WAL_OP_ADD) => {
+                let element = single_probabilistic_operand(operands, "FILTER ADD")?;
+                let mut filters = probabilistic_write(
+                    &self.inner.probabilistic.filters,
+                    "probabilistic filter store",
+                );
+                if let Some(filter) = filters.get_mut(name) {
+                    let _ = filter.insert(&element);
+                }
+            }
+            (PROB_WAL_KIND_FILTER, PROB_WAL_OP_DELETE) => {
+                let element = single_probabilistic_operand(operands, "FILTER DELETE")?;
+                let mut filters = probabilistic_write(
+                    &self.inner.probabilistic.filters,
+                    "probabilistic filter store",
+                );
+                if let Some(filter) = filters.get_mut(name) {
+                    let _ = filter.delete(&element);
+                }
+            }
+            (PROB_WAL_KIND_FILTER, PROB_WAL_OP_DROP) => {
+                let mut filters = probabilistic_write(
+                    &self.inner.probabilistic.filters,
+                    "probabilistic filter store",
+                );
+                filters.remove(name);
+            }
+            _ => {
+                return Err(RedDBError::Internal(format!(
+                    "unknown probabilistic WAL delta kind={kind} operation={operation}"
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -533,6 +755,11 @@ impl RedDBRuntime {
                     crate::catalog::CollectionModel::Hll,
                 )?;
                 self.persist_probabilistic_blob(PROB_HLL_STATE_PREFIX, name, hll.as_bytes())?;
+                self.append_probabilistic_snapshot_delta(
+                    PROB_WAL_KIND_HLL,
+                    name,
+                    hll.as_bytes().to_vec(),
+                )?;
                 hlls.insert(name.clone(), hll);
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -549,7 +776,14 @@ impl RedDBRuntime {
                 for elem in elements {
                     hll.add(elem.as_bytes());
                 }
-                self.persist_probabilistic_blob(PROB_HLL_STATE_PREFIX, name, hll.as_bytes())?;
+                self.append_probabilistic_add_delta(
+                    PROB_WAL_KIND_HLL,
+                    name,
+                    elements
+                        .iter()
+                        .map(|element| element.as_bytes().to_vec())
+                        .collect(),
+                )?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
                     &format!("{} element(s) added to HLL '{}'", elements.len(), name),
@@ -658,6 +892,11 @@ impl RedDBRuntime {
                     merged.merge(hll);
                 }
                 self.persist_probabilistic_blob(PROB_HLL_STATE_PREFIX, dest, merged.as_bytes())?;
+                self.append_probabilistic_snapshot_delta(
+                    PROB_WAL_KIND_HLL,
+                    dest,
+                    merged.as_bytes().to_vec(),
+                )?;
                 hlls.insert(dest.clone(), merged);
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -716,6 +955,7 @@ impl RedDBRuntime {
                 }
                 self.drop_probabilistic_catalog_entry(name)?;
                 self.delete_probabilistic_blob(PROB_HLL_STATE_PREFIX, name)?;
+                self.append_probabilistic_drop_delta(PROB_WAL_KIND_HLL, name)?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
                     &format!("HLL '{}' dropped", name),
@@ -759,6 +999,11 @@ impl RedDBRuntime {
                     name,
                     &sketch.as_bytes(),
                 )?;
+                self.append_probabilistic_snapshot_delta(
+                    PROB_WAL_KIND_SKETCH,
+                    name,
+                    sketch.as_bytes(),
+                )?;
                 sketches.insert(name.clone(), sketch);
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -782,10 +1027,10 @@ impl RedDBRuntime {
                     .get_mut(name)
                     .ok_or_else(|| RedDBError::NotFound(format!("SKETCH '{}' not found", name)))?;
                 sketch.add(element.as_bytes(), *count);
-                self.persist_probabilistic_blob(
-                    PROB_SKETCH_STATE_PREFIX,
+                self.append_probabilistic_add_delta(
+                    PROB_WAL_KIND_SKETCH,
                     name,
-                    &sketch.as_bytes(),
+                    vec![element.as_bytes().to_vec(), count.to_le_bytes().to_vec()],
                 )?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -844,6 +1089,11 @@ impl RedDBRuntime {
                     PROB_SKETCH_STATE_PREFIX,
                     dest,
                     &merged.as_bytes(),
+                )?;
+                self.append_probabilistic_snapshot_delta(
+                    PROB_WAL_KIND_SKETCH,
+                    dest,
+                    merged.as_bytes(),
                 )?;
                 sketches.insert(dest.clone(), merged);
                 Ok(RuntimeQueryResult::ok_message(
@@ -909,6 +1159,7 @@ impl RedDBRuntime {
                 }
                 self.drop_probabilistic_catalog_entry(name)?;
                 self.delete_probabilistic_blob(PROB_SKETCH_STATE_PREFIX, name)?;
+                self.append_probabilistic_drop_delta(PROB_WAL_KIND_SKETCH, name)?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
                     &format!("SKETCH '{}' dropped", name),
@@ -950,6 +1201,11 @@ impl RedDBRuntime {
                     name,
                     &filter.as_bytes(),
                 )?;
+                self.append_probabilistic_snapshot_delta(
+                    PROB_WAL_KIND_FILTER,
+                    name,
+                    filter.as_bytes(),
+                )?;
                 filters.insert(name.clone(), filter);
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -968,10 +1224,10 @@ impl RedDBRuntime {
                 if !filter.insert(element.as_bytes()) {
                     return Err(RedDBError::Query(format!("FILTER '{}' is full", name)));
                 }
-                self.persist_probabilistic_blob(
-                    PROB_FILTER_STATE_PREFIX,
+                self.append_probabilistic_add_delta(
+                    PROB_WAL_KIND_FILTER,
                     name,
-                    &filter.as_bytes(),
+                    vec![element.as_bytes().to_vec()],
                 )?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -1012,10 +1268,10 @@ impl RedDBRuntime {
                     .get_mut(name)
                     .ok_or_else(|| RedDBError::NotFound(format!("FILTER '{}' not found", name)))?;
                 let removed = filter.delete(element.as_bytes());
-                self.persist_probabilistic_blob(
-                    PROB_FILTER_STATE_PREFIX,
+                self.append_probabilistic_delete_delta(
+                    PROB_WAL_KIND_FILTER,
                     name,
-                    &filter.as_bytes(),
+                    vec![element.as_bytes().to_vec()],
                 )?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
@@ -1101,6 +1357,7 @@ impl RedDBRuntime {
                 }
                 self.drop_probabilistic_catalog_entry(name)?;
                 self.delete_probabilistic_blob(PROB_FILTER_STATE_PREFIX, name)?;
+                self.append_probabilistic_drop_delta(PROB_WAL_KIND_FILTER, name)?;
                 Ok(RuntimeQueryResult::ok_message(
                     raw_query.to_string(),
                     &format!("FILTER '{}' dropped", name),
@@ -1142,6 +1399,33 @@ fn parse_probabilistic_read_projection(
     }
 
     Ok(None)
+}
+
+fn single_probabilistic_operand(mut operands: Vec<Vec<u8>>, context: &str) -> RedDBResult<Vec<u8>> {
+    if operands.len() != 1 {
+        return Err(RedDBError::Internal(format!(
+            "{context} WAL delta expected one operand, got {}",
+            operands.len()
+        )));
+    }
+    Ok(operands.remove(0))
+}
+
+fn sketch_add_operands(mut operands: Vec<Vec<u8>>) -> RedDBResult<(Vec<u8>, u64)> {
+    if operands.len() != 2 {
+        return Err(RedDBError::Internal(format!(
+            "SKETCH ADD WAL delta expected two operands, got {}",
+            operands.len()
+        )));
+    }
+    let count_bytes = operands.remove(1);
+    let count_array: [u8; 8] = count_bytes.as_slice().try_into().map_err(|_| {
+        RedDBError::Internal(format!(
+            "SKETCH ADD WAL delta count expected 8 bytes, got {}",
+            count_bytes.len()
+        ))
+    })?;
+    Ok((operands.remove(0), u64::from_le_bytes(count_array)))
 }
 
 fn validate_probabilistic_read_model(

--- a/crates/reddb-server/src/storage/unified/store.rs
+++ b/crates/reddb-server/src/storage/unified/store.rs
@@ -353,6 +353,11 @@ pub struct UnifiedStore {
     /// rebuilt state is byte-deterministic against the pre-restart
     /// state under a fixed codec seed.
     pub(crate) replayed_turbo_inserts: parking_lot::Mutex<HashMap<String, Vec<(u64, Vec<f32>)>>>,
+    /// WAL-replayed probabilistic mutation deltas captured at open time.
+    /// Runtime recovery drains these after loading the latest full
+    /// probabilistic snapshot from store state.
+    pub(crate) replayed_probabilistic_deltas:
+        parking_lot::Mutex<Vec<(u8, u8, String, Vec<Vec<u8>>)>>,
     /// Opaque store-level auxiliary metadata persisted inside the binary dump
     /// (store format V10+). RedDB uses this to carry collection contracts
     /// through the single-file artifact so a collection's `declared_model`

--- a/crates/reddb-server/src/storage/unified/store/commit.rs
+++ b/crates/reddb-server/src/storage/unified/store/commit.rs
@@ -624,6 +624,15 @@ impl StoreCommitCoordinator {
                     let mut map = store.replayed_turbo_inserts.lock();
                     map.entry(collection).or_default().push((entity_id, vector));
                 }
+                WalRecord::ProbabilisticDelta {
+                    kind,
+                    operation,
+                    name,
+                    operands,
+                } => {
+                    let mut deltas = store.replayed_probabilistic_deltas.lock();
+                    deltas.push((kind, operation, name, operands));
+                }
                 WalRecord::FullPageImage { .. } => {
                     // Pager-level FPI (gh-478); store replay ignores.
                 }
@@ -855,6 +864,25 @@ impl UnifiedStore {
             collection: collection.to_string(),
             entity_id,
             vector: vector.to_vec(),
+        };
+        commit.append_single_record(record)
+    }
+
+    pub(crate) fn append_probabilistic_delta_record(
+        &self,
+        kind: u8,
+        operation: u8,
+        name: &str,
+        operands: Vec<Vec<u8>>,
+    ) -> std::io::Result<()> {
+        let Some(commit) = &self.commit else {
+            return Ok(());
+        };
+        let record = WalRecord::ProbabilisticDelta {
+            kind,
+            operation,
+            name: name.to_string(),
+            operands,
         };
         commit.append_single_record(record)
     }

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -314,6 +314,11 @@ impl UnifiedStore {
         map.remove(collection)
     }
 
+    pub(crate) fn take_replayed_probabilistic_deltas(&self) -> Vec<(u8, u8, String, Vec<Vec<u8>>)> {
+        let mut deltas = self.replayed_probabilistic_deltas.lock();
+        std::mem::take(&mut *deltas)
+    }
+
     /// Set multiple config KV pairs at once from a JSON tree.
     /// Keys are flattened with dot-notation: `{"a":{"b":1}}` → `a.b = 1`.
     pub fn set_config_tree(&self, prefix: &str, json: &crate::serde_json::Value) -> usize {

--- a/crates/reddb-server/src/storage/unified/store/impl_pages.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_pages.rs
@@ -341,6 +341,7 @@ impl UnifiedStore {
             commit: None,
             unindex_cross_refs_fast_path: AtomicU64::new(0),
             replayed_turbo_inserts: parking_lot::Mutex::new(HashMap::new()),
+            replayed_probabilistic_deltas: parking_lot::Mutex::new(Vec::new()),
             aux_metadata: RwLock::new(Vec::new()),
         }
     }
@@ -415,6 +416,7 @@ impl UnifiedStore {
             commit,
             unindex_cross_refs_fast_path: AtomicU64::new(0),
             replayed_turbo_inserts: parking_lot::Mutex::new(HashMap::new()),
+            replayed_probabilistic_deltas: parking_lot::Mutex::new(Vec::new()),
             aux_metadata: RwLock::new(Vec::new()),
         };
 

--- a/crates/reddb-server/src/storage/wal/checkpoint.rs
+++ b/crates/reddb-server/src/storage/wal/checkpoint.rs
@@ -213,6 +213,10 @@ impl Checkpointer {
                         crate::runtime::turbo_crash_inject::InjectionPoint::MidCheckpoint,
                     );
                 }
+                WalRecord::ProbabilisticDelta { .. } => {
+                    // Probabilistic sidecar deltas are replayed by the
+                    // runtime after loading the latest full snapshot.
+                }
                 WalRecord::FullPageImage { tx_id, .. } => {
                     result_observe_tx_id(&mut max_transaction_id, tx_id);
                     // FPI records (gh-478) are consumed by the pager

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -43,6 +43,15 @@ pub enum WalRecord {
         entity_id: u64,
         vector: Vec<f32>,
     },
+    /// Logical probabilistic-structure mutation delta. Checkpoints carry
+    /// full snapshots through the regular store state; crash recovery
+    /// replays these deltas after loading the latest snapshot.
+    ProbabilisticDelta {
+        kind: u8,
+        operation: u8,
+        name: String,
+        operands: Vec<Vec<u8>>,
+    },
     /// Checkpoint marker (indicates up to which LSN pages are flushed)
     Checkpoint { lsn: u64 },
 }
@@ -151,6 +160,17 @@ impl WalRecord {
                 entity_id: *entity_id,
                 vector: vector.clone(),
             },
+            WalRecord::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
+            } => MainWalRecordFrame::ProbabilisticDelta {
+                kind: *kind,
+                operation: *operation,
+                name: name.clone(),
+                operands: operands.clone(),
+            },
             WalRecord::Checkpoint { lsn } => MainWalRecordFrame::Checkpoint { lsn: *lsn },
         }
     }
@@ -191,6 +211,17 @@ impl WalRecord {
                 collection,
                 entity_id,
                 vector,
+            },
+            MainWalRecordFrame::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
+            } => WalRecord::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
             },
             MainWalRecordFrame::Checkpoint { lsn } => WalRecord::Checkpoint { lsn },
         }

--- a/crates/unreliable-libc/src/oracle.rs
+++ b/crates/unreliable-libc/src/oracle.rs
@@ -236,7 +236,8 @@ fn validate_frame(
         MainWalRecordFrame::Rollback { .. }
         | MainWalRecordFrame::TxCommitBatch { .. }
         | MainWalRecordFrame::FullPageImage { .. }
-        | MainWalRecordFrame::VectorInsert { .. } => {}
+        | MainWalRecordFrame::VectorInsert { .. }
+        | MainWalRecordFrame::ProbabilisticDelta { .. } => {}
     }
     Ok(())
 }

--- a/crates/unreliable-libc/src/tm_commit_path.rs
+++ b/crates/unreliable-libc/src/tm_commit_path.rs
@@ -354,7 +354,8 @@ pub fn recover_tm_commit_path(dir: &Path) -> io::Result<Vec<TmRecoveredTx>> {
             }
             MainWalRecordFrame::Checkpoint { .. }
             | MainWalRecordFrame::FullPageImage { .. }
-            | MainWalRecordFrame::VectorInsert { .. } => {}
+            | MainWalRecordFrame::VectorInsert { .. }
+            | MainWalRecordFrame::ProbabilisticDelta { .. } => {}
         }
     }
 

--- a/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
+++ b/tests/grouped/probabilistic/e2e_probabilistic_public_contract.rs
@@ -5,10 +5,12 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
+use reddb::api::DurabilityMode;
 use reddb::runtime::{RedDBRuntime, RuntimeQueryResult};
 use reddb::server::RedDBServer;
 use reddb::storage::query::UnifiedRecord;
 use reddb::storage::schema::Value;
+use reddb::storage::wal::{WalReader, WalRecord};
 use reddb::storage::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
 use reddb::{RedDBOptions, StorageDeployPreset};
 use serde_json::{json, Value as JsonValue};
@@ -149,6 +151,20 @@ fn open_persistent_runtime(path: &std::path::Path) -> Result<RedDBRuntime, Strin
     let options = RedDBOptions::persistent(&path)
         .with_storage_profile(StorageDeployPreset::Serverless.selection())?;
     RedDBRuntime::with_options(options).map_err(|err| format!("{err:?}"))
+}
+
+fn open_wal_durable_runtime(path: &std::path::Path) -> RedDBRuntime {
+    let options = RedDBOptions::persistent(path)
+        .with_durability_mode(DurabilityMode::WalDurableGrouped)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("primary-replica operational profile");
+    RedDBRuntime::with_options(options).expect("open WAL-durable runtime")
+}
+
+fn wal_file_len(path: &std::path::Path) -> u64 {
+    std::fs::metadata(reddb_file::unified_wal_path(path))
+        .expect("WAL metadata")
+        .len()
 }
 
 fn spawn_http_server() -> (support::TempDbFile, String) {
@@ -328,12 +344,46 @@ fn probabilistic_state_writes_raw_blobs_and_compacts_superseded_rows() {
 }
 
 #[test]
+fn hll_add_persists_delta_bytes_and_recovers_from_wal_tail() {
+    let db = support::temp_db_file("probabilistic-hll-delta-wal");
+    let rt = open_wal_durable_runtime(db.path());
+
+    exec(&rt, "CREATE HLL visitors");
+    let before_add_len = wal_file_len(db.path());
+    exec(&rt, "HLL ADD visitors 'alice'");
+    let add_bytes = wal_file_len(db.path()) - before_add_len;
+
+    assert!(
+        add_bytes < 4096,
+        "single HLL ADD should persist a delta, not the full 16 KiB sketch; wrote {add_bytes} bytes"
+    );
+
+    drop(rt);
+    let reopened = open_wal_durable_runtime(db.path());
+    let hll_command = exec(&reopened, "HLL COUNT visitors");
+    assert_eq!(uint_value(only_record(&hll_command), "count"), 1);
+
+    let records: Vec<_> = WalReader::open(reddb_file::unified_wal_path(db.path()))
+        .expect("open WAL")
+        .iter()
+        .map(|record| record.expect("valid WAL record").1)
+        .collect();
+    assert!(
+        records
+            .iter()
+            .any(|record| matches!(record, WalRecord::ProbabilisticDelta { .. })),
+        "WAL should carry a dedicated probabilistic delta record"
+    );
+}
+
+#[test]
 fn probabilistic_legacy_hex_state_migrates_once_to_raw_blob() {
     let path = PersistentDbPath::new("probabilistic_legacy_migration");
     let rt = path.open_runtime();
 
     exec(&rt, "CREATE HLL visitors");
     exec(&rt, "HLL ADD visitors 'alice' 'bob'");
+    rt.checkpoint().expect("checkpoint full HLL snapshot");
     let key = state_key(PROB_HLL_STATE_PREFIX, "visitors");
     let raw = match config_values(&rt, &key).pop() {
         Some(Value::Blob(bytes)) => bytes,
@@ -343,7 +393,8 @@ fn probabilistic_legacy_hex_state_migrates_once_to_raw_blob() {
     delete_config_key(&rt, &key);
     insert_config_value(&rt, &key, Value::text(hex_encode(&raw)));
 
-    let reopened = checkpoint_and_reopen(&path, rt);
+    drop(rt);
+    let reopened = path.open_runtime();
     let hll_command = exec(&reopened, "HLL COUNT visitors");
     assert_eq!(uint_value(only_record(&hll_command), "count"), 2);
 
@@ -377,16 +428,13 @@ fn probabilistic_legacy_hex_state_is_rejected_after_raw_marker() {
 
     exec(&rt, "CREATE HLL visitors");
     exec(&rt, "HLL ADD visitors 'alice'");
+    rt.checkpoint().expect("checkpoint full HLL snapshot");
     let key = state_key(PROB_HLL_STATE_PREFIX, "visitors");
     let raw = match config_values(&rt, &key).pop() {
         Some(Value::Blob(bytes)) => bytes,
         other => panic!("expected raw HLL state before legacy append, got {other:?}"),
     };
     insert_config_value(&rt, &key, Value::text(hex_encode(&raw)));
-
-    let native = reddb::NativeUseCases::new(&rt);
-    native.create_snapshot().expect("snapshot");
-    native.checkpoint().expect("checkpoint");
     drop(rt);
 
     let message = match open_persistent_runtime(&path) {


### PR DESCRIPTION
Automated AFK landing for #1820. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1820

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786015910&installation_id=129708444&pr_number=1896&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1896&signature=d423b786245461abb301b079bfce4f878c9cd77ee5b51c2655fefcefd9bb674a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->