### PR TITLE
chore: #1797 EXPLAIN ANALYZE for DML: execute-and-always-abort with real counts (ADR 0071)

### DIFF
--- a/crates/reddb-rql/tests/reddb_corpus/README.md
+++ b/crates/reddb-rql/tests/reddb_corpus/README.md
@@ -32,11 +32,11 @@ run-varying columns: auto-assigned entity ids (`entity_id`, `node_id`,
 numbers, `red_*` capability metadata, and raw distance/score floats whose exact
 value is engine-defined rather than oracle-defined. The harness projects every
 result down to a fixed allowlist of **semantic, deterministic** columns
-(`label`, `name`, `content`, `depth`, `path_found`, `hop_count`,
-`total_weight`, `nodes_visited`, `negative_cycle_detected`, and focused scalar
-test aliases) in a canonical order. A golden therefore asserts the *meaning* of
-a result and stays silent about engine bookkeeping, so it never freezes
-non-determinism.
+(`op`, `label`, `name`, `content`, `depth`, `path_found`, `hop_count`,
+`total_weight`, `nodes_visited`, `negative_cycle_detected`, `actual_rows`, and
+focused scalar test aliases) in a canonical order. A golden therefore asserts
+the *meaning* of a result and stays silent about engine bookkeeping, so it never
+freezes non-determinism.
 
 ## Characterization is clearly marked regression-only
 
@@ -57,6 +57,9 @@ semantic columns for it.
 - `graph_commands.slt` — TRUTH: `GRAPH NEIGHBORHOOD` / `TRAVERSE` /
   `PROPERTIES` / `SHORTEST_PATH` / `CENTRALITY` over a directed chain.
 - `json_builtins.slt` — TRUTH: RedDB-specific JSON scalar builtin semantics.
+- `explain_analyze_dml.slt` — TRUTH: ADR 0071's pinned RedDB-vs-Postgres
+  divergence where `EXPLAIN ANALYZE` over DML reports real affected counts but
+  never commits.
 - `characterization_unprojected_surfaces.slt` — REGRESSION-ONLY: Gremlin,
   Cypher, SPARQL, Path, natural-language, and the `SEARCH SIMILAR … COLLECTION`
   form, each pinned with `statement ok`.

--- a/crates/reddb-rql/tests/reddb_corpus/explain_analyze_dml.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/explain_analyze_dml.slt
@@ -1,0 +1,25 @@
+# ADR 0071 (#1797) — EXPLAIN never commits, including ANALYZE over DML.
+#
+# TRUTH is hand-authored (a pinned RedDB-vs-Postgres divergence): PostgreSQL
+# commits EXPLAIN ANALYZE DML, while RedDB executes it inside a transaction that
+# always aborts. The golden pins the deterministic result shape projected by
+# the harness: plan operator, depth, and actual affected rows. The volatile
+# timing counter and source column are covered by e2e column-shape tests, not by
+# this golden value.
+
+statement ok
+CREATE TABLE explain_analyze_accounts (id INTEGER, name TEXT)
+
+statement ok
+INSERT INTO explain_analyze_accounts (id, name) VALUES (1, 'open'), (2, 'open'), (3, 'closed')
+
+query TII rowsort
+EXPLAIN ANALYZE UPDATE explain_analyze_accounts SET name = 'archived' WHERE name = 'open'
+----
+dml_ddl 0 2
+
+query T rowsort
+SELECT name FROM explain_analyze_accounts WHERE id IN (1, 2)
+----
+open
+open

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -553,6 +553,13 @@ impl RedDBRuntime {
             Err(msg) => return Err(RedDBError::Query(msg)),
         }
 
+        // `EXPLAIN ANALYZE <dml>` — paid truth tier. Executes the
+        // mutating statement inside a transaction that is always
+        // rolled back, then reports the actual affected row count.
+        if let Some(inner) = strip_explain_analyze_prefix(query) {
+            return self.explain_analyze_as_rows(query, inner);
+        }
+
         // `EXPLAIN <stmt>` — introspection. Runs the planner on the
         // inner statement (WITHOUT executing it) and returns the
         // CanonicalLogicalNode tree as rows so the caller can see the
@@ -3215,6 +3222,111 @@ impl RedDBRuntime {
             bookmark: None,
         })
     }
+
+    fn explain_analyze_as_rows(
+        &self,
+        raw_query: &str,
+        inner_sql: &str,
+    ) -> RedDBResult<RuntimeQueryResult> {
+        if !starts_with_dml_keyword(inner_sql) {
+            return Err(RedDBError::Query(
+                "EXPLAIN ANALYZE currently supports INSERT, UPDATE, and DELETE".to_string(),
+            ));
+        }
+
+        let explain = self.explain_query(inner_sql)?;
+        let conn_id = current_connection_id();
+        if self.inner.tx_contexts.read().contains_key(&conn_id) {
+            return Err(RedDBError::Query(
+                "EXPLAIN ANALYZE requires no active transaction".to_string(),
+            ));
+        }
+
+        self.execute_query_inner("BEGIN")?;
+        let started = std::time::Instant::now();
+        let execution = self.execute_query_inner(inner_sql);
+        let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+        let rollback = self.execute_query_inner("ROLLBACK");
+
+        let affected_rows = match execution {
+            Ok(result) => result.affected_rows,
+            Err(err) => {
+                rollback?;
+                return Err(err);
+            }
+        };
+        rollback?;
+
+        let columns = vec![
+            "op".to_string(),
+            "source".to_string(),
+            "estimated_rows".to_string(),
+            "estimated_cost".to_string(),
+            "actual_rows".to_string(),
+            "actual_ms".to_string(),
+            "depth".to_string(),
+        ];
+        let mut records = Vec::new();
+        walk_analyze_plan_node(
+            &explain.logical_plan.root,
+            0,
+            affected_rows,
+            elapsed_ms,
+            &mut records,
+        );
+
+        let result = crate::storage::query::unified::UnifiedResult {
+            columns,
+            records,
+            stats: Default::default(),
+            pre_serialized_json: None,
+        };
+
+        Ok(RuntimeQueryResult {
+            query: raw_query.to_string(),
+            mode: explain.mode,
+            statement: "explain_analyze",
+            engine: "runtime-explain-analyze",
+            result,
+            affected_rows: 0,
+            statement_type: "select",
+            bookmark: None,
+        })
+    }
+}
+
+fn strip_explain_analyze_prefix(sql: &str) -> Option<&str> {
+    let rest = strip_keyword_ci(sql.trim_start(), "EXPLAIN")?.trim_start();
+    Some(strip_keyword_ci(rest, "ANALYZE")?.trim_start()).filter(|inner| !inner.is_empty())
+}
+
+fn strip_keyword_ci<'a>(sql: &'a str, keyword: &str) -> Option<&'a str> {
+    if sql.len() < keyword.len() {
+        return None;
+    }
+    let (head, rest) = sql.split_at(keyword.len());
+    if !head.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+    if rest
+        .chars()
+        .next()
+        .is_some_and(|ch| !ch.is_ascii_whitespace())
+    {
+        return None;
+    }
+    Some(rest)
+}
+
+fn starts_with_dml_keyword(sql: &str) -> bool {
+    let trimmed = sql.trim_start();
+    let head_end = trimmed
+        .find(|ch: char| ch.is_ascii_whitespace())
+        .unwrap_or(trimmed.len());
+    let head = &trimmed[..head_end];
+    head.eq_ignore_ascii_case("INSERT")
+        || head.eq_ignore_ascii_case("UPDATE")
+        || head.eq_ignore_ascii_case("DELETE")
 }
 
 fn walk_plan_node(
@@ -3241,6 +3353,44 @@ fn walk_plan_node(
     out.push(rec);
     for child in &node.children {
         walk_plan_node(child, depth + 1, out);
+    }
+}
+
+fn walk_analyze_plan_node(
+    node: &crate::storage::query::planner::CanonicalLogicalNode,
+    depth: usize,
+    affected_rows: u64,
+    elapsed_ms: f64,
+    out: &mut Vec<crate::storage::query::unified::UnifiedRecord>,
+) {
+    use std::sync::Arc;
+    let mut rec = crate::storage::query::unified::UnifiedRecord::default();
+    rec.set_arc(Arc::from("op"), Value::text(node.operator.clone()));
+    rec.set_arc(
+        Arc::from("source"),
+        node.source.clone().map(Value::text).unwrap_or(Value::Null),
+    );
+    rec.set_arc(
+        Arc::from("estimated_rows"),
+        Value::Float(node.estimated_rows),
+    );
+    rec.set_arc(
+        Arc::from("estimated_cost"),
+        Value::Float(node.operator_cost),
+    );
+    rec.set_arc(
+        Arc::from("actual_rows"),
+        Value::UnsignedInteger(if depth == 0 { affected_rows } else { 0 }),
+    );
+    rec.set_arc(
+        Arc::from("actual_ms"),
+        Value::Float(if depth == 0 { elapsed_ms } else { 0.0 }),
+    );
+    rec.set_arc(Arc::from("depth"), Value::Integer(depth as i64));
+    out.push(rec);
+
+    for child in &node.children {
+        walk_analyze_plan_node(child, depth + 1, 0, 0.0, out);
     }
 }
 

--- a/docs/api/postgres-wire.md
+++ b/docs/api/postgres-wire.md
@@ -309,6 +309,19 @@ The canonical RedDB-native contract for notifications is the runtime API in
 interoperability layer for existing client libraries, not the source of
 truth.
 
+## `EXPLAIN ANALYZE` DML Never Commits
+
+RedDB deliberately diverges from PostgreSQL for mutating `EXPLAIN ANALYZE`.
+PostgreSQL executes and commits DML under `EXPLAIN ANALYZE`; RedDB executes the
+statement inside a snapshot-isolation transaction that always aborts. The result
+reports real counters such as `actual_rows` and `actual_ms`, but no INSERT,
+UPDATE, DELETE, subscription event, queue message, or trigger effect is
+committed.
+
+Use `EXPLAIN <dml>` for the cheap plan-only tier and `EXPLAIN ANALYZE <dml>` for
+paid truth counts. In both cases, the invariant is the same: RedDB never commits
+under `EXPLAIN`.
+
 ## Limitations
 
 - Binary format output is not yet emitted — everything returns in

--- a/docs/clients/sdk-compatibility.md
+++ b/docs/clients/sdk-compatibility.md
@@ -53,6 +53,11 @@ Stable enough that off-the-shelf PostgreSQL clients connect and run common workl
 
 If your application relies on a feature in the second list, prefer the gRPC or HTTP transport — those expose first-class APIs (vector search, graph traversal, time-series).
 
+For DML, RedDB's `EXPLAIN ANALYZE` is a pinned PostgreSQL-wire divergence:
+RedDB executes the mutating statement to get real counters, then always aborts
+the transaction. PostgreSQL commits that DML; RedDB never commits under
+`EXPLAIN`.
+
 ## gRPC
 
 Schema in [`proto/reddb.proto`](../../proto/reddb.proto). Code-gen with `tonic-build` for Rust or your favourite gRPC compiler for Go/Java/Python/etc.

--- a/docs/query/select.md
+++ b/docs/query/select.md
@@ -253,6 +253,11 @@ grpcurl -plaintext \
   127.0.0.1:55055 reddb.v1.RedDb/ExplainQuery
 ```
 
+For mutating statements, `EXPLAIN <dml>` is plan-only. `EXPLAIN ANALYZE <dml>`
+executes the statement inside a transaction that always aborts and returns real
+counters such as `actual_rows` and `actual_ms`. RedDB never commits under
+`EXPLAIN`, including over the PostgreSQL wire protocol.
+
 > [!NOTE]
 > Row results include the public RedDB ID envelope fields `rid`, `collection`,
 > `kind`, `tenant`, `created_at`, and `updated_at`. For ordinary table rows,

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -12,6 +12,9 @@ mod e2e_advisory_locks;
 #[path = "schema_query_core/e2e_composite_index.rs"]
 mod e2e_composite_index;
 
+#[path = "sql_window/e2e_explain.rs"]
+mod e2e_explain;
+
 #[path = "mvcc_transactions/e2e_cross_model_tx.rs"]
 mod e2e_cross_model_tx;
 

--- a/tests/grouped/sql_window/e2e_explain.rs
+++ b/tests/grouped/sql_window/e2e_explain.rs
@@ -13,6 +13,15 @@ use reddb::{RedDBOptions, RedDBRuntime};
 
 const EXPLAIN_PLAN_COLUMNS: &[&str] =
     &["op", "source", "estimated_rows", "estimated_cost", "depth"];
+const EXPLAIN_ANALYZE_COLUMNS: &[&str] = &[
+    "op",
+    "source",
+    "estimated_rows",
+    "estimated_cost",
+    "actual_rows",
+    "actual_ms",
+    "depth",
+];
 
 fn rt() -> RedDBRuntime {
     RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("in-memory runtime")
@@ -21,6 +30,34 @@ fn rt() -> RedDBRuntime {
 fn exec(rt: &RedDBRuntime, sql: &str) {
     rt.execute_query(sql)
         .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+}
+
+fn uint_value(row: &reddb::storage::query::unified::UnifiedRecord, column: &str) -> u64 {
+    match row.get(column) {
+        Some(Value::UnsignedInteger(value)) => *value,
+        Some(Value::Integer(value)) => *value as u64,
+        other => panic!("{column} must be an integer count, got {other:?}"),
+    }
+}
+
+fn analyze_dml(rt: &RedDBRuntime, sql: &str, expected_rows: u64) {
+    let analyzed = rt.execute_query(sql).expect(sql);
+    assert_eq!(analyzed.statement, "explain_analyze", "{sql}");
+    assert_eq!(analyzed.statement_type, "select", "{sql}");
+    assert_eq!(analyzed.affected_rows, 0, "{sql}");
+    assert_eq!(analyzed.result.columns, EXPLAIN_ANALYZE_COLUMNS, "{sql}");
+    assert_eq!(analyzed.result.records.len(), 1, "{sql}");
+
+    let root = &analyzed.result.records[0];
+    assert!(
+        matches!(root.get("op"), Some(Value::Text(op)) if op.as_ref() == "dml_ddl"),
+        "{sql}: {root:?}"
+    );
+    assert_eq!(uint_value(root, "actual_rows"), expected_rows, "{sql}");
+    assert!(
+        matches!(root.get("actual_ms"), Some(Value::Float(ms)) if *ms >= 0.0),
+        "{sql}: {root:?}"
+    );
 }
 
 #[test]
@@ -134,6 +171,105 @@ fn explain_dml_returns_plan_rows_without_executing_inner_statement() {
     assert!(after.result.records.iter().any(|row| {
         matches!(row.get("id"), Some(Value::Integer(2)))
             && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "remove")
+    }));
+}
+
+#[test]
+fn explain_analyze_dml_reports_real_counts_and_always_aborts() {
+    let rt = rt();
+    exec(&rt, "CREATE TABLE audit_analyze (id INT, note TEXT)");
+    exec(
+        &rt,
+        "INSERT INTO audit_analyze (id, note) VALUES (1, 'keep'), (2, 'update'), (3, 'delete')",
+    );
+    exec(
+        &rt,
+        "ALTER TABLE audit_analyze ENABLE EVENTS TO audit_analyze_events",
+    );
+    exec(&rt, "QUEUE GROUP CREATE audit_analyze_events readers");
+
+    analyze_dml(
+        &rt,
+        "EXPLAIN ANALYZE UPDATE audit_analyze SET note = 'changed' WHERE id IN (1, 2)",
+        2,
+    );
+    analyze_dml(
+        &rt,
+        "EXPLAIN ANALYZE DELETE FROM audit_analyze WHERE id = 3",
+        1,
+    );
+    analyze_dml(
+        &rt,
+        "EXPLAIN ANALYZE INSERT INTO audit_analyze (id, note) VALUES (4, 'inserted')",
+        1,
+    );
+
+    let after = rt
+        .execute_query("SELECT id, note FROM audit_analyze")
+        .expect("SELECT after EXPLAIN ANALYZE");
+    assert_eq!(
+        after.result.records.len(),
+        3,
+        "EXPLAIN ANALYZE must not materialise INSERT, UPDATE, or DELETE"
+    );
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(1)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "keep")
+    }));
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(2)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "update")
+    }));
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(3)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "delete")
+    }));
+
+    let events = rt
+        .execute_query("QUEUE READ audit_analyze_events GROUP readers CONSUMER c1 COUNT 10")
+        .expect("read event queue after EXPLAIN ANALYZE");
+    assert_eq!(
+        events.result.records.len(),
+        0,
+        "EXPLAIN ANALYZE DML must not leak commit-time effects"
+    );
+}
+
+#[test]
+fn explain_analyze_dml_error_path_aborts_staged_writes() {
+    let rt = rt();
+    exec(
+        &rt,
+        "CREATE TABLE analyze_error_path (id INT PRIMARY KEY, note TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO analyze_error_path (id, note) VALUES (1, 'base')",
+    );
+
+    let err = rt
+        .execute_query(
+            "EXPLAIN ANALYZE INSERT INTO analyze_error_path (id, note) \
+             VALUES (2, 'staged'), (1, 'duplicate')",
+        )
+        .expect_err("duplicate insert under EXPLAIN ANALYZE should fail");
+    let message = format!("{err:?}");
+    assert!(
+        message.contains("duplicate") || message.contains("unique") || message.contains("violated"),
+        "error should name the uniqueness failure: {err:?}"
+    );
+
+    let after = rt
+        .execute_query("SELECT id, note FROM analyze_error_path")
+        .expect("SELECT after failed EXPLAIN ANALYZE");
+    assert_eq!(
+        after.result.records.len(),
+        1,
+        "failed EXPLAIN ANALYZE must roll back any staged rows"
+    );
+    assert!(after.result.records.iter().any(|row| {
+        matches!(row.get("id"), Some(Value::Integer(1)))
+            && matches!(row.get("note"), Some(Value::Text(note)) if note.as_ref() == "base")
     }));
 }
 

--- a/tests/grouped/surface_contracts/rql_reddb_conformance.rs
+++ b/tests/grouped/surface_contracts/rql_reddb_conformance.rs
@@ -48,6 +48,7 @@ use sqllogictest::{DBOutput, DefaultColumnType, Runner, DB};
 /// comparison. A surface that yields none of these columns is treated as
 /// accepted-but-unprojected and pinned with `statement ok` (characterization).
 const KEEP: &[&str] = &[
+    "op",
     "label",
     "name",
     "content",
@@ -62,6 +63,7 @@ const KEEP: &[&str] = &[
     "json_column_name",
     "json_column_visits",
     "json_computed_name",
+    "actual_rows",
 ];
 
 use super::support::PersistentRuntime;


### PR DESCRIPTION
Automated AFK landing for #1797. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1797

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786024105&installation_id=129708444&pr_number=1897&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1897&signature=3e7629cd45f5d9e57a06efb342f86a3fff8fcf6957c6537652cb1bc8f4081f4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `EXPLAIN ANALYZE` on mutating statements, returning real row and timing metrics while preserving non-committing behavior.
  * Expanded end-to-end coverage for update, insert, delete, and error cases.

* **Bug Fixes**
  * Ensured `EXPLAIN ANALYZE` always rolls back changes, even when execution fails.
  * Updated conformance expectations so result columns now include the new operation and actual-row fields.

* **Documentation**
  * Clarified `EXPLAIN` vs. `EXPLAIN ANALYZE` behavior and the no-commit guarantee in the API and query docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->