### PR TITLE
chore: #1798 CLI `--dry-run`: preview destructive commands via EXPLAIN desugar

### DIFF
--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -569,6 +569,8 @@ fn query_flags() -> Vec<FlagSchema> {
             .with_short('p')
             .with_description("Positional parameter for $1, $2, ... (repeatable)"),
         FlagSchema::new("param-type").with_description("Type override for the preceding --param"),
+        FlagSchema::boolean("dry-run")
+            .with_description("Preview the statement via EXPLAIN without executing it"),
     ]
 }
 

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -95,6 +95,7 @@ fn run_ephemeral_query(
     json_mode: bool,
     row_format: RowFormat,
     save_path: Option<String>,
+    dry_run: bool,
 ) -> ! {
     use std::path::Path;
 
@@ -127,6 +128,16 @@ fn run_ephemeral_query(
             }
             eprintln!("query: --save requires a non-empty path");
             std::process::exit(1);
+        }
+        Some(_) if dry_run => {
+            // Preview the statement only; do not create the requested save target.
+            reddb::RedDBRuntime::in_memory().unwrap_or_else(|err| {
+                if json_mode {
+                    json_error("query", &err.to_string());
+                }
+                eprintln!("error: {err}");
+                std::process::exit(1);
+            })
         }
         Some(path) => {
             if Path::new(path).exists() {
@@ -168,12 +179,15 @@ fn run_ephemeral_query(
         std::process::exit(1);
     }
 
+    let preview_sql = dry_run.then(|| format!("EXPLAIN {sql}"));
+    let sql_to_run = preview_sql.as_deref().unwrap_or(sql);
+
     let exec_result = if params.is_empty() {
-        rt.execute_query(sql)
+        rt.execute_query(sql_to_run)
     } else {
         use reddb::storage::query::modes::parse_multi;
         use reddb::storage::query::user_params;
-        match parse_multi(sql) {
+        match parse_multi(sql_to_run) {
             Ok(expr) => match user_params::bind(&expr, &params) {
                 Ok(bound) => rt.execute_query_expr(bound),
                 Err(err) => {
@@ -196,7 +210,7 @@ fn run_ephemeral_query(
 
     match exec_result {
         Ok(qr) => {
-            if let Some(path) = save_path.as_deref() {
+            if let Some(path) = save_path.as_deref().filter(|_| !dry_run) {
                 if let Err(err) = rt.checkpoint() {
                     if json_mode {
                         json_error("query", &err.to_string());
@@ -206,8 +220,16 @@ fn run_ephemeral_query(
                 }
             }
             if json_mode {
-                json_ok("query", &format_result_json(&qr));
+                if let Some(preview_sql) = preview_sql.as_deref() {
+                    json_ok("query", &format_dry_run_result_json(sql, preview_sql, &qr));
+                } else {
+                    json_ok("query", &format_result_json(&qr));
+                }
             } else {
+                if let Some(preview_sql) = preview_sql.as_deref() {
+                    println!("dry-run: {sql}");
+                    println!("preview: {preview_sql}");
+                }
                 print_row_result(&qr, row_format);
             }
             std::process::exit(0);
@@ -1143,6 +1165,19 @@ fn format_result_json(result: &reddb::runtime::RuntimeQueryResult) -> String {
     out
 }
 
+fn format_dry_run_result_json(
+    statement: &str,
+    preview_statement: &str,
+    result: &reddb::runtime::RuntimeQueryResult,
+) -> String {
+    format!(
+        "{{\"statement\":\"explain\",\"dry_run\":true,\"would_run\":\"{}\",\"preview_statement\":\"{}\",\"preview\":{}}}",
+        json_escape(statement),
+        json_escape(preview_statement),
+        format_result_json(result),
+    )
+}
+
 /// Print an error JSON envelope to **stderr** and exit with code 1.
 fn json_error(command: &str, error: &str) -> ! {
     eprintln!(
@@ -1462,6 +1497,7 @@ fn main() {
                     json_mode,
                     row_format,
                     flag_string(&result.flags, "save"),
+                    flag_bool(&result.flags, "dry-run"),
                 );
             }
             let sql = remaining.first().map(|s| s.as_str()).unwrap_or("");
@@ -1487,12 +1523,15 @@ fn main() {
                 eprintln!("error: {err}");
                 std::process::exit(1);
             });
+            let dry_run = flag_bool(&result.flags, "dry-run");
+            let preview_sql = dry_run.then(|| format!("EXPLAIN {sql}"));
+            let sql_to_run = preview_sql.as_deref().unwrap_or(sql);
             let exec_result = if params.is_empty() {
-                rt.execute_query(sql)
+                rt.execute_query(sql_to_run)
             } else {
                 use reddb::storage::query::modes::parse_multi;
                 use reddb::storage::query::user_params;
-                match parse_multi(sql) {
+                match parse_multi(sql_to_run) {
                     Ok(expr) => match user_params::bind(&expr, &params) {
                         Ok(bound) => rt.execute_query_expr(bound),
                         Err(err) => {
@@ -1514,10 +1553,20 @@ fn main() {
             };
             match exec_result {
                 Ok(qr) => {
-                    checkpoint_local_runtime(&rt);
+                    if !dry_run {
+                        checkpoint_local_runtime(&rt);
+                    }
                     if json_mode {
-                        json_ok("query", &format_result_json(&qr));
+                        if let Some(preview_sql) = preview_sql.as_deref() {
+                            json_ok("query", &format_dry_run_result_json(sql, preview_sql, &qr));
+                        } else {
+                            json_ok("query", &format_result_json(&qr));
+                        }
                     } else {
+                        if let Some(preview_sql) = preview_sql.as_deref() {
+                            println!("dry-run: {sql}");
+                            println!("preview: {preview_sql}");
+                        }
                         print_row_result(&qr, row_format);
                     }
                 }
@@ -3879,6 +3928,10 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                 flags.push(cli::types::FlagSchema::new("save").with_description(
                     "Persist an ephemeral data-file query session as a new embedded .rdb file",
                 ));
+                flags
+                    .push(cli::types::FlagSchema::boolean("dry-run").with_description(
+                        "Preview the statement via EXPLAIN without executing it",
+                    ));
             }
         }
         Some("admin") => {

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -202,6 +202,53 @@ fn red_query_csv_writes_without_save_leave_no_durable_artifact() {
 }
 
 #[test]
+fn red_query_dry_run_delete_prints_explain_and_keeps_rows() {
+    let dir = temp_dir("dry-run-delete");
+    let db = dir.path().join("people.rdb");
+    let db_str = db.display().to_string();
+
+    let (code, _stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &db_str,
+        "CREATE TABLE people (id INT, name TEXT)",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "create failed; stderr: {stderr}");
+    let (code, _stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &db_str,
+        "INSERT INTO people (id, name) VALUES (1, 'Alice'), (2, 'Bob')",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "insert failed; stderr: {stderr}");
+
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &db_str,
+        "DELETE FROM people WHERE name = 'Bob'",
+        "--dry-run",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "dry-run failed; stderr: {stderr}");
+    assert!(stdout.contains("\"ok\":true"), "stdout: {stdout}");
+    assert!(stdout.contains("\"statement\":\"explain\""), "stdout: {stdout}");
+    assert!(stdout.contains("DELETE FROM people"), "stdout: {stdout}");
+
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &db_str,
+        "SELECT count(*) AS n FROM people",
+        "--json",
+    ]);
+    assert_eq!(code, 0, "count failed; stderr: {stderr}");
+    assert!(stdout.contains("\"n\":2"), "dry-run deleted a row: {stdout}");
+}
+
+#[test]
 fn red_query_tsv_file_by_alias() {
     let dir = temp_dir("tsv");
     let path = dir.path().join("places.tsv");

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -234,7 +234,10 @@ fn red_query_dry_run_delete_prints_explain_and_keeps_rows() {
     ]);
     assert_eq!(code, 0, "dry-run failed; stderr: {stderr}");
     assert!(stdout.contains("\"ok\":true"), "stdout: {stdout}");
-    assert!(stdout.contains("\"statement\":\"explain\""), "stdout: {stdout}");
+    assert!(
+        stdout.contains("\"statement\":\"explain\""),
+        "stdout: {stdout}"
+    );
     assert!(stdout.contains("DELETE FROM people"), "stdout: {stdout}");
 
     let (code, stdout, stderr) = run_red(&[
@@ -245,7 +248,10 @@ fn red_query_dry_run_delete_prints_explain_and_keeps_rows() {
         "--json",
     ]);
     assert_eq!(code, 0, "count failed; stderr: {stderr}");
-    assert!(stdout.contains("\"n\":2"), "dry-run deleted a row: {stdout}");
+    assert!(
+        stdout.contains("\"n\":2"),
+        "dry-run deleted a row: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1798. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1798

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786025228&installation_id=129708444&pr_number=1898&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1898&signature=b4e7c5ea3126cc3399c4723f81d085358bea8c084d237049da8dafff414524da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->