### PR TITLE
chore: #1804 Push idempotency key under transactions: first-committer-wins conflict

### DIFF
--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1167,6 +1167,12 @@ struct RuntimeInner {
             )>,
         >,
     >,
+    /// Per-connection push idempotency keys written by an open transaction.
+    /// Each entry is `(queue, dedup_key, metadata_entity_id)`. COMMIT checks
+    /// the queue/key subject for first-committer-wins conflicts; ROLLBACK
+    /// removes the uncommitted metadata row so later producer retries enqueue
+    /// normally.
+    pending_queue_dedup: parking_lot::RwLock<HashMap<u64, Vec<(String, String, EntityId)>>>,
     pending_kv_watch_events:
         parking_lot::RwLock<HashMap<u64, Vec<crate::replication::cdc::KvWatchEvent>>>,
     pending_store_wal_actions:

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -1472,6 +1472,27 @@ impl RedDBRuntime {
                                     self.release_pending_claim_locks(conn_id);
                                     return Err(err);
                                 }
+                                if let Err(err) = self.check_queue_dedup_write_conflicts(
+                                    conn_id,
+                                    &ctx.snapshot,
+                                    &own_xids,
+                                ) {
+                                    for (_, sub) in &ctx.savepoints {
+                                        self.inner.snapshot_manager.rollback(*sub);
+                                    }
+                                    for sub in &ctx.released_sub_xids {
+                                        self.inner.snapshot_manager.rollback(*sub);
+                                    }
+                                    self.inner.snapshot_manager.rollback(ctx.xid);
+                                    self.revive_pending_versioned_updates(conn_id);
+                                    self.revive_pending_tombstones(conn_id);
+                                    self.discard_pending_queue_dedup(conn_id);
+                                    self.discard_pending_kv_watch_events(conn_id);
+                                    self.discard_pending_queue_wakes(conn_id);
+                                    self.discard_pending_store_wal_actions(conn_id);
+                                    self.release_pending_claim_locks(conn_id);
+                                    return Err(err);
+                                }
                                 self.restore_pending_write_stamps(conn_id);
                                 if let Err(err) = self.flush_pending_store_wal_actions(conn_id) {
                                     for (_, sub) in &ctx.savepoints {
@@ -1483,6 +1504,7 @@ impl RedDBRuntime {
                                     self.inner.snapshot_manager.rollback(ctx.xid);
                                     self.revive_pending_versioned_updates(conn_id);
                                     self.revive_pending_tombstones(conn_id);
+                                    self.discard_pending_queue_dedup(conn_id);
                                     self.discard_pending_kv_watch_events(conn_id);
                                     self.discard_pending_queue_wakes(conn_id);
                                     self.release_pending_claim_locks(conn_id);
@@ -1502,6 +1524,7 @@ impl RedDBRuntime {
                                 self.inner.snapshot_manager.commit(ctx.xid);
                                 self.finalize_pending_versioned_updates(conn_id);
                                 self.finalize_pending_tombstones(conn_id);
+                                self.finalize_pending_queue_dedup(conn_id);
                                 self.finalize_pending_kv_watch_events(conn_id);
                                 self.finalize_pending_queue_wakes(conn_id);
                                 self.release_pending_claim_locks(conn_id);
@@ -1532,6 +1555,7 @@ impl RedDBRuntime {
                                 // back to 0 so later snapshots see them.
                                 self.revive_pending_versioned_updates(conn_id);
                                 self.revive_pending_tombstones(conn_id);
+                                self.discard_pending_queue_dedup(conn_id);
                                 self.discard_pending_kv_watch_events(conn_id);
                                 self.discard_pending_queue_wakes(conn_id);
                                 self.discard_pending_store_wal_actions(conn_id);

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -296,6 +296,7 @@ impl RedDBRuntime {
                 foreign_tables: Arc::new(crate::storage::fdw::ForeignTableRegistry::with_builtins()),
                 pending_tombstones: parking_lot::RwLock::new(HashMap::new()),
                 pending_versioned_updates: parking_lot::RwLock::new(HashMap::new()),
+                pending_queue_dedup: parking_lot::RwLock::new(HashMap::new()),
                 pending_kv_watch_events: parking_lot::RwLock::new(HashMap::new()),
                 pending_store_wal_actions: parking_lot::RwLock::new(HashMap::new()),
                 pending_claim_locks: parking_lot::RwLock::new(HashMap::new()),

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use crate::runtime::audit_log::{AuditAuthSource, AuditEvent, AuditFieldEscaper, Outcome};
 use crate::runtime::impl_core::{
-    clear_current_auth_identity, clear_current_tenant, current_auth_identity, current_tenant,
-    set_current_auth_identity, set_current_tenant,
+    clear_current_auth_identity, clear_current_tenant, current_auth_identity,
+    current_connection_id, current_tenant, set_current_auth_identity, set_current_tenant,
 };
 use crate::runtime::queue_telemetry::NackOutcomeLabel;
 use crate::storage::queue::QueueMode;
@@ -166,8 +166,8 @@ const OUTBOX_MAX_BYTES: u64 = 10 * (1 << 30);
 /// Running estimate of bytes pending in event queues (approximate; not decremented on consume).
 static OUTBOX_APPROX_BYTES: AtomicU64 = AtomicU64::new(0);
 
-const QUEUE_META_COLLECTION: &str = "red_queue_meta";
-const KIND_QUEUE_PUSH_DEDUP: &str = "queue_push_dedup";
+pub(super) const QUEUE_META_COLLECTION: &str = "red_queue_meta";
+pub(super) const KIND_QUEUE_PUSH_DEDUP: &str = "queue_push_dedup";
 const QUEUE_POSITION_CENTER: u64 = u64::MAX / 2;
 const WORK_DEFAULT_GROUP: &str = "_work_default";
 const FANOUT_GROUP_PREFIX: &str = "_fanout_";
@@ -1038,7 +1038,17 @@ impl RedDBRuntime {
                         .unwrap_or(crate::storage::query::DEFAULT_QUEUE_DEDUP_WINDOW_MS);
                     let expires_at_ns =
                         now_ns().saturating_add(window_ms.saturating_mul(1_000_000));
-                    record_queue_dedup(store.as_ref(), queue, dedup_key, id, expires_at_ns)?;
+                    let metadata_id =
+                        record_queue_dedup(store.as_ref(), queue, dedup_key, id, expires_at_ns)?;
+                    self.stamp_xmin_if_in_txn(QUEUE_META_COLLECTION, metadata_id);
+                    if self.current_xid().is_some() {
+                        self.record_pending_queue_dedup(
+                            current_connection_id(),
+                            queue,
+                            dedup_key,
+                            metadata_id,
+                        );
+                    }
                 }
                 // Resolve per-message availability (issue #722): DELAY is
                 // relative to the push instant, AVAILABLE AT carries an
@@ -2075,7 +2085,7 @@ fn save_queue_config(
             .map(Value::UnsignedInteger)
             .unwrap_or(Value::Null),
     );
-    insert_meta_row(store, fields)
+    insert_meta_row(store, fields).map(|_| ())
 }
 
 fn remove_queue_metadata(store: &UnifiedStore, queue: &str) {
@@ -2165,7 +2175,7 @@ fn save_queue_group(store: &UnifiedStore, queue: &str, group: &str) -> RedDBResu
         "created_at_ns".to_string(),
         Value::UnsignedInteger(now_ns()),
     );
-    insert_meta_row(store, fields)
+    insert_meta_row(store, fields).map(|_| ())
 }
 
 pub(super) fn load_pending_entries(
@@ -2281,7 +2291,7 @@ pub(super) fn save_queue_pending(
         "delivery_count".to_string(),
         Value::UnsignedInteger(u64::from(delivery_count)),
     );
-    insert_meta_row(store, fields)
+    insert_meta_row(store, fields).map(|_| ())
 }
 
 pub(super) fn require_pending_entry(
@@ -2357,7 +2367,7 @@ pub(super) fn save_queue_ack(
         Value::UnsignedInteger(message_id.raw()),
     );
     fields.insert("acked_at_ns".to_string(), Value::UnsignedInteger(now_ns()));
-    insert_meta_row(store, fields)
+    insert_meta_row(store, fields).map(|_| ())
 }
 
 pub(super) fn queue_message_completed_for_all_groups(
@@ -2969,9 +2979,9 @@ pub(super) fn queue_message_data(
     }
 }
 
-fn insert_meta_row(store: &UnifiedStore, fields: HashMap<String, Value>) -> RedDBResult<()> {
+fn insert_meta_row(store: &UnifiedStore, fields: HashMap<String, Value>) -> RedDBResult<EntityId> {
     let _ = store.get_or_create_collection(QUEUE_META_COLLECTION);
-    store
+    let id = store
         .insert_auto(
             QUEUE_META_COLLECTION,
             UnifiedEntity::new(
@@ -2988,7 +2998,7 @@ fn insert_meta_row(store: &UnifiedStore, fields: HashMap<String, Value>) -> RedD
             ),
         )
         .map_err(|err| RedDBError::Internal(err.to_string()))?;
-    Ok(())
+    Ok(id)
 }
 
 pub(super) fn remove_meta_rows(store: &UnifiedStore, predicate: impl Fn(&RowData) -> bool + Sync) {
@@ -3037,8 +3047,12 @@ pub(super) fn find_queue_dedup(
     let manager = store.get_collection(QUEUE_META_COLLECTION)?;
     let queue = queue.to_string();
     let dedup_key = dedup_key.to_string();
+    let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     manager
         .query_all(|entity| {
+            if !crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity) {
+                return false;
+            }
             entity.data.as_row().is_some_and(|row| {
                 row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
                     && row_text(row, "queue").as_deref() == Some(&queue)
@@ -3062,15 +3076,7 @@ pub(super) fn record_queue_dedup(
     dedup_key: &str,
     message_id: EntityId,
     expires_at_ns: u64,
-) -> RedDBResult<()> {
-    let queue_owned = queue.to_string();
-    let key_owned = dedup_key.to_string();
-    remove_meta_rows(store, |row| {
-        row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
-            && row_text(row, "queue").as_deref() == Some(&queue_owned)
-            && row_text(row, "dedup_key").as_deref() == Some(&key_owned)
-    });
-
+) -> RedDBResult<EntityId> {
     let mut fields = HashMap::new();
     fields.insert(
         "kind".to_string(),

--- a/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
@@ -66,6 +66,21 @@ impl RedDBRuntime {
             ));
     }
 
+    pub(crate) fn record_pending_queue_dedup(
+        &self,
+        conn_id: u64,
+        queue: &str,
+        dedup_key: &str,
+        metadata_id: crate::storage::unified::entity::EntityId,
+    ) {
+        self.inner
+            .pending_queue_dedup
+            .write()
+            .entry(conn_id)
+            .or_default()
+            .push((queue.to_string(), dedup_key.to_string(), metadata_id));
+    }
+
     pub(crate) fn with_deferred_store_wal_if_transaction<T>(
         &self,
         f: impl FnOnce() -> RedDBResult<T>,
@@ -321,6 +336,56 @@ impl RedDBRuntime {
         Ok(())
     }
 
+    pub(crate) fn check_queue_dedup_write_conflicts(
+        &self,
+        conn_id: u64,
+        snapshot: &crate::storage::transaction::snapshot::Snapshot,
+        own_xids: &std::collections::HashSet<crate::storage::transaction::snapshot::Xid>,
+    ) -> RedDBResult<()> {
+        let pending = self
+            .inner
+            .pending_queue_dedup
+            .read()
+            .get(&conn_id)
+            .cloned()
+            .unwrap_or_default();
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        let store = self.inner.db.store();
+        let Some(manager) = store.get_collection(crate::runtime::impl_queue::QUEUE_META_COLLECTION)
+        else {
+            return Ok(());
+        };
+
+        for (queue, dedup_key, metadata_id) in pending {
+            for candidate in manager.query_all(|entity| {
+                entity.data.as_row().is_some_and(|row| {
+                    crate::runtime::impl_queue::row_text(row, "kind").as_deref()
+                        == Some(crate::runtime::impl_queue::KIND_QUEUE_PUSH_DEDUP)
+                        && crate::runtime::impl_queue::row_text(row, "queue").as_deref()
+                            == Some(&queue)
+                        && crate::runtime::impl_queue::row_text(row, "dedup_key").as_deref()
+                            == Some(&dedup_key)
+                })
+            }) {
+                if candidate.id == metadata_id
+                    || self.inner.snapshot_manager.is_aborted(candidate.xmin)
+                {
+                    continue;
+                }
+                if self.xid_conflicts_with_snapshot(candidate.xmin, snapshot, own_xids) {
+                    return Err(RedDBError::Query(format!(
+                        "serialization conflict: queue dedup key {queue}/{dedup_key} was modified by concurrent transaction {}",
+                        candidate.xmin
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
     pub(crate) fn restore_pending_write_stamps(&self, conn_id: u64) {
         let versioned_updates = self
             .inner
@@ -361,6 +426,23 @@ impl RedDBRuntime {
             .pending_versioned_updates
             .write()
             .remove(&conn_id);
+    }
+
+    pub(crate) fn finalize_pending_queue_dedup(&self, conn_id: u64) {
+        self.inner.pending_queue_dedup.write().remove(&conn_id);
+    }
+
+    pub(crate) fn discard_pending_queue_dedup(&self, conn_id: u64) {
+        let Some(pending) = self.inner.pending_queue_dedup.write().remove(&conn_id) else {
+            return;
+        };
+        let store = self.inner.db.store();
+        for (_queue, _dedup_key, metadata_id) in pending {
+            let _ = store.delete(
+                crate::runtime::impl_queue::QUEUE_META_COLLECTION,
+                metadata_id,
+            );
+        }
     }
 
     pub(crate) fn revive_pending_versioned_updates(&self, conn_id: u64) {

--- a/crates/reddb-server/src/runtime/primary_queue_store.rs
+++ b/crates/reddb-server/src/runtime/primary_queue_store.rs
@@ -27,6 +27,7 @@ use crate::storage::schema::Value;
 use crate::storage::unified::entity::{QueueMessageData, RowData};
 use crate::storage::{EntityData, EntityId, EntityKind, UnifiedEntity, UnifiedStore};
 
+use super::impl_core::current_connection_id;
 use super::queue_lifecycle::LifecycleConfig;
 use super::RedDBRuntime;
 
@@ -1073,14 +1074,25 @@ impl QueueStore for PrimaryQueueStore {
         expires_at_ns: u64,
     ) -> Result<()> {
         let store = self.runtime.db().store();
-        super::impl_queue::record_queue_dedup(
+        let metadata_id = super::impl_queue::record_queue_dedup(
             store.as_ref(),
             queue,
             dedup_key,
             EntityId::new(message_id),
             expires_at_ns,
         )
-        .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))
+        .map_err(|err| QueueStoreError::UnknownQueue(err.to_string()))?;
+        self.runtime
+            .stamp_xmin_if_in_txn(super::impl_queue::QUEUE_META_COLLECTION, metadata_id);
+        if self.runtime.current_xid().is_some() {
+            self.runtime.record_pending_queue_dedup(
+                current_connection_id(),
+                queue,
+                dedup_key,
+                metadata_id,
+            );
+        }
+        Ok(())
     }
 }
 

--- a/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
+++ b/tests/grouped/mvcc_transactions/e2e_mvcc_first_committer_wins.rs
@@ -44,6 +44,22 @@ fn label_for(rt: &RedDBRuntime, table: &str, rid: u64) -> Option<String> {
         })
 }
 
+fn text(record: &reddb::storage::query::UnifiedRecord, column: &str) -> String {
+    match record.get(column) {
+        Some(Value::Text(value)) => value.to_string(),
+        Some(Value::UnsignedInteger(value)) => value.to_string(),
+        other => panic!("expected text-like value for {column}, got {other:?}"),
+    }
+}
+
+fn uint(record: &reddb::storage::query::UnifiedRecord, column: &str) -> u64 {
+    match record.get(column) {
+        Some(Value::UnsignedInteger(value)) => *value,
+        Some(Value::Integer(value)) if *value >= 0 => *value as u64,
+        other => panic!("expected unsigned integer for {column}, got {other:?}"),
+    }
+}
+
 fn assert_conflict(message: &str) {
     assert!(
         message.contains("serialization conflict"),
@@ -239,6 +255,73 @@ fn stale_transaction_conflicts_with_autocommit_update() {
         label_for(&rt, "fcw_autocommit", eid).as_deref(),
         Some("auto")
     );
+    clear_current_connection_id();
+}
+
+#[test]
+fn queue_push_dedup_key_is_first_committer_wins_under_transactions() {
+    let rt = rt();
+    set_current_connection_id(43961);
+    exec(&rt, "CREATE QUEUE fcw_dedup DEDUP_WINDOW 1 s");
+
+    set_current_connection_id(43962);
+    exec(&rt, "BEGIN");
+    let first = rt
+        .execute_query("QUEUE PUSH fcw_dedup 'first' DEDUP 'producer-1'")
+        .expect("first transactional dedup push");
+    let first_id = text(&first.result.records[0], "message_id");
+
+    set_current_connection_id(43963);
+    exec(&rt, "BEGIN");
+    let second = rt
+        .execute_query("QUEUE PUSH fcw_dedup 'second' DEDUP 'producer-1'")
+        .expect("second transactional dedup push");
+    let second_id = text(&second.result.records[0], "message_id");
+    assert_ne!(
+        second_id, first_id,
+        "concurrent transaction must not observe the uncommitted dedup outcome"
+    );
+
+    set_current_connection_id(43962);
+    exec(&rt, "COMMIT");
+    set_current_connection_id(43963);
+    assert_conflict(&exec_err(&rt, "COMMIT"));
+
+    set_current_connection_id(43964);
+    exec(&rt, "BEGIN");
+    let retry = rt
+        .execute_query("QUEUE PUSH fcw_dedup 'retry' DEDUP 'producer-1'")
+        .expect("retry observes committed dedup outcome");
+    assert_eq!(text(&retry.result.records[0], "message_id"), first_id);
+    exec(&rt, "COMMIT");
+
+    let len = rt
+        .execute_query("QUEUE LEN fcw_dedup")
+        .expect("queue len after retry");
+    assert_eq!(uint(&len.result.records[0], "len"), 1);
+
+    set_current_connection_id(43965);
+    exec(&rt, "BEGIN");
+    let rolled_back = rt
+        .execute_query("QUEUE PUSH fcw_dedup 'rolled-back' DEDUP 'producer-rollback'")
+        .expect("rolled-back dedup push");
+    let rolled_back_id = text(&rolled_back.result.records[0], "message_id");
+    exec(&rt, "ROLLBACK");
+
+    set_current_connection_id(43966);
+    let after_rollback = rt
+        .execute_query("QUEUE PUSH fcw_dedup 'after-rollback' DEDUP 'producer-rollback'")
+        .expect("dedup key should be reusable after rollback");
+    assert_ne!(
+        text(&after_rollback.result.records[0], "message_id"),
+        rolled_back_id,
+        "rolled-back dedup outcome must not be reused"
+    );
+    let len = rt
+        .execute_query("QUEUE LEN fcw_dedup")
+        .expect("queue len after rollback reuse");
+    assert_eq!(uint(&len.result.records[0], "len"), 2);
+
     clear_current_connection_id();
 }
 


### PR DESCRIPTION
Automated AFK landing for #1804. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1804

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786026407&installation_id=129708444&pr_number=1899&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1899&signature=71390e44dda14a20d0104ca8412db8c6ed7446782ba9a91d3280a8d6c93c9ed7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->