### PR TITLE
chore: #1807 Ordering key replay: QUEUE MOVE preserves key and joins tail-of-key

### DIFF
--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -2550,17 +2550,21 @@ fn insert_moved_queue_message(
                 None
             },
             enqueued_at_ns: message.enqueued_at_ns,
-            attempts: message.attempts,
-            max_attempts: message.max_attempts,
+            attempts: 0,
+            max_attempts: config.max_attempts,
             acked: false,
         }),
     );
     let id = store
         .insert_auto(queue, entity)
         .map_err(|err| RedDBError::Internal(err.to_string()))?;
-    if let Some(ttl_ms) = config.ttl_ms {
+    if config.ttl_ms.is_some() || message.ordering_key.is_some() {
         store
-            .set_metadata(queue, id, queue_message_ttl_metadata(ttl_ms))
+            .set_metadata(
+                queue,
+                id,
+                queue_message_metadata(config.ttl_ms, None, message.ordering_key.as_deref()),
+            )
             .map_err(|err| RedDBError::Internal(err.to_string()))?;
     }
     Ok(id)

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -584,6 +584,73 @@ fn test_queue_move_bypasses_push_dedup_but_preserves_producer_guard() {
 }
 
 #[test]
+fn test_queue_move_preserves_ordering_key_and_replays_tail_of_key() {
+    let rt = rt();
+
+    exec(&rt, "CREATE QUEUE jobs WITH DLQ failed_jobs MAX_ATTEMPTS 1");
+    exec(&rt, "QUEUE GROUP CREATE jobs workers");
+    exec(&rt, "QUEUE PUSH jobs 'a-dead' KEY 'account-a'");
+    exec(&rt, "QUEUE PUSH jobs 'b-dead' KEY 'account-b'");
+
+    let failed = exec(&rt, "QUEUE READ jobs GROUP workers CONSUMER reaper COUNT 2");
+    assert_eq!(payloads(&failed), vec!["a-dead", "b-dead"]);
+    for row in &failed.result.records {
+        let id = text(row, "message_id");
+        exec(&rt, &format!("QUEUE NACK jobs GROUP workers '{id}'"));
+    }
+
+    let dlq_a = exec(
+        &rt,
+        "SELECT payload, key FROM QUEUE failed_jobs WHERE key = 'account-a' LIMIT 10",
+    );
+    assert_eq!(payloads(&dlq_a), vec!["a-dead"]);
+    assert_eq!(text(&dlq_a.result.records[0], "key"), "account-a");
+
+    exec(&rt, "QUEUE PUSH jobs 'a-live' KEY 'account-a'");
+    exec(&rt, "QUEUE PUSH jobs 'b-live' KEY 'account-b'");
+
+    let moved = exec(
+        &rt,
+        "QUEUE MOVE FROM failed_jobs TO jobs WHERE key = 'account-a' LIMIT 10",
+    );
+    assert_eq!(uint(&moved.result.records[0], "committed"), 1);
+    assert_eq!(
+        payloads(&exec(&rt, "SELECT payload FROM QUEUE failed_jobs")),
+        vec!["b-dead"],
+        "MOVE must filter the DLQ by ordering key",
+    );
+
+    let jobs_a = exec(
+        &rt,
+        "SELECT payload, key FROM QUEUE jobs WHERE key = 'account-a' LIMIT 10",
+    );
+    assert_eq!(payloads(&jobs_a), vec!["a-live", "a-dead"]);
+    assert!(jobs_a
+        .result
+        .records
+        .iter()
+        .all(|row| text(row, "key") == "account-a"));
+
+    let first_redelivery = exec(
+        &rt,
+        "QUEUE READ jobs GROUP workers CONSUMER worker1 COUNT 3",
+    );
+    assert_eq!(
+        payloads(&first_redelivery),
+        vec!["a-live", "b-live"],
+        "replayed same-key message must wait behind the current key tail",
+    );
+    let live_a_id = text(&first_redelivery.result.records[0], "message_id");
+
+    exec(&rt, &format!("QUEUE ACK jobs GROUP workers '{live_a_id}'"));
+    let replayed = exec(
+        &rt,
+        "QUEUE READ jobs GROUP workers CONSUMER worker2 COUNT 1",
+    );
+    assert_eq!(payloads(&replayed), vec!["a-dead"]);
+}
+
+#[test]
 fn test_dlq_promotion_bypasses_target_push_dedup_index() {
     let rt = rt();
 


### PR DESCRIPTION
Automated AFK landing for #1807. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1807

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786029901&installation_id=129708444&pr_number=1902&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1902&signature=100ee88b561b25df24e8727ae6011d108a9fbf59d9ae0bb7bfbd40ed2ff38420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->