### PR TITLE
chore: #1817 Retention as O(1) append-only segment retirement through the operational manifest

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -257,7 +257,9 @@ pub use native_store::{
     STORE_VERSION_V4, STORE_VERSION_V5, STORE_VERSION_V6, STORE_VERSION_V7, STORE_VERSION_V8,
     STORE_VERSION_V9,
 };
-pub use operational_manifest::{ForkHydrationState, ForkInfo, ForkOrigin, OperationalManifest};
+pub use operational_manifest::{
+    AppendOnlySegmentState, ForkHydrationState, ForkInfo, ForkOrigin, OperationalManifest,
+};
 pub use physical_metadata::{
     copy_physical_export_data_file, copy_physical_metadata_binary_to_journal,
     decode_persisted_physical_hypertable_chunk_json, decode_persisted_physical_hypertable_json,

--- a/crates/reddb-file/src/operational_manifest.rs
+++ b/crates/reddb-file/src/operational_manifest.rs
@@ -114,21 +114,56 @@ struct Manifest {
     generation: u64,
     collections: BTreeMap<String, CollectionEntry>,
     append_only_segments: Vec<AppendOnlySegmentManifestEntry>,
+    append_only_retired: BTreeMap<String, AppendOnlyRetiredState>,
     /// Present only for a store fork's own manifest; `None` for a parent store.
     fork_origin: Option<ForkOrigin>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AppendOnlySegmentState {
+    Active,
+    PendingDrop,
+}
+
+impl AppendOnlySegmentState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::PendingDrop => "pending_drop",
+        }
+    }
+
+    fn parse(value: &str) -> io::Result<Self> {
+        match value {
+            "active" => Ok(Self::Active),
+            "pending_drop" => Ok(Self::PendingDrop),
+            other => Err(invalid_data(format!(
+                "unknown append-only segment state: {other}"
+            ))),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppendOnlySegmentManifestEntry {
     pub collection: String,
     pub segment_id: u64,
+    pub state: AppendOnlySegmentState,
     pub path: String,
     pub codec: AppendOnlySegmentCodec,
     pub chunk_size: u32,
     pub row_count: u64,
+    pub retention_min_ms: Option<i64>,
+    pub retention_max_ms: Option<i64>,
     pub primary_min: Option<String>,
     pub primary_max: Option<String>,
     pub chunk_checksums: Vec<AppendOnlySegmentChunkChecksum>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AppendOnlyRetiredState {
+    row_count: u64,
+    segment_high_water: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -154,6 +189,7 @@ impl OperationalManifest {
                     generation: 0,
                     collections: BTreeMap::new(),
                     append_only_segments: Vec::new(),
+                    append_only_retired: BTreeMap::new(),
                     fork_origin: None,
                 };
                 for collection in existing_collections {
@@ -197,6 +233,26 @@ impl OperationalManifest {
             for (name, _) in pending_drops {
                 manifest.collections.remove(&name);
             }
+            manifest.generation += 1;
+            self.publish(&manifest)?;
+            let protected_paths = self.protected_collection_paths(&manifest)?;
+            self.quarantine_unreferenced_collection_files(&protected_paths)?;
+            self.quarantine_unreferenced_append_only_segments(&manifest)?;
+        }
+        let pending_segments = manifest
+            .append_only_segments
+            .iter()
+            .filter(|entry| entry.state == AppendOnlySegmentState::PendingDrop)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !pending_segments.is_empty() {
+            for entry in &pending_segments {
+                let _ = fs::remove_file(self.append_only_segments_dir().join(&entry.path));
+                record_retired_append_only_segment(&mut manifest, entry);
+            }
+            manifest
+                .append_only_segments
+                .retain(|entry| entry.state != AppendOnlySegmentState::PendingDrop);
             manifest.generation += 1;
             self.publish(&manifest)?;
             let protected_paths = self.protected_collection_paths(&manifest)?;
@@ -320,6 +376,7 @@ impl OperationalManifest {
             generation: 0,
             collections,
             append_only_segments: Vec::new(),
+            append_only_retired: BTreeMap::new(),
             fork_origin: Some(ForkOrigin {
                 name: name.to_string(),
                 parent_store: self.store_identity(),
@@ -448,6 +505,20 @@ impl OperationalManifest {
         codec: AppendOnlySegmentCodec,
         bytes: &[u8],
     ) -> io::Result<AppendOnlySegmentManifestEntry> {
+        self.publish_append_only_segment_with_retention_bounds(
+            collection, segment_id, codec, bytes, None, None,
+        )
+    }
+
+    pub fn publish_append_only_segment_with_retention_bounds(
+        &self,
+        collection: &str,
+        segment_id: u64,
+        codec: AppendOnlySegmentCodec,
+        bytes: &[u8],
+        retention_min_ms: Option<i64>,
+        retention_max_ms: Option<i64>,
+    ) -> io::Result<AppendOnlySegmentManifestEntry> {
         self.ensure_dirs()?;
         let decoded = decode_append_only_segment(bytes).map_err(invalid_data)?;
         if decoded.codec != codec {
@@ -486,10 +557,13 @@ impl OperationalManifest {
         let entry = AppendOnlySegmentManifestEntry {
             collection: collection.to_string(),
             segment_id,
+            state: AppendOnlySegmentState::Active,
             path,
             codec,
             chunk_size: APPEND_ONLY_SEGMENT_CHUNK_BYTES,
             row_count: decoded.rows.len() as u64,
+            retention_min_ms,
+            retention_max_ms,
             primary_min: decoded.primary_min.as_ref().map(hex::encode),
             primary_max: decoded.primary_max.as_ref().map(hex::encode),
             chunk_checksums: append_only_segment_chunk_checksums(bytes),
@@ -498,9 +572,78 @@ impl OperationalManifest {
         manifest
             .append_only_segments
             .sort_by(|a, b| (&a.collection, a.segment_id).cmp(&(&b.collection, b.segment_id)));
+        let retired = manifest
+            .append_only_retired
+            .entry(collection.to_string())
+            .or_default();
+        retired.segment_high_water = retired.segment_high_water.max(segment_id);
         manifest.generation += 1;
         self.publish(&manifest)?;
         Ok(entry)
+    }
+
+    pub fn begin_retire_append_only_segment(
+        &self,
+        collection: &str,
+        segment_id: u64,
+    ) -> io::Result<bool> {
+        self.ensure_dirs()?;
+        let mut manifest = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(false),
+        };
+        let Some(entry) = manifest
+            .append_only_segments
+            .iter_mut()
+            .find(|entry| entry.collection == collection && entry.segment_id == segment_id)
+        else {
+            return Ok(false);
+        };
+        if entry.state == AppendOnlySegmentState::PendingDrop {
+            return Ok(true);
+        }
+        entry.state = AppendOnlySegmentState::PendingDrop;
+        manifest.generation += 1;
+        self.publish(&manifest)?;
+        Ok(true)
+    }
+
+    pub fn finish_retire_append_only_segment(
+        &self,
+        collection: &str,
+        segment_id: u64,
+    ) -> io::Result<bool> {
+        self.ensure_dirs()?;
+        let mut manifest = match self.load_current()? {
+            Some(manifest) => manifest,
+            None => return Ok(false),
+        };
+        let Some(index) = manifest
+            .append_only_segments
+            .iter()
+            .position(|entry| entry.collection == collection && entry.segment_id == segment_id)
+        else {
+            return Ok(false);
+        };
+        if manifest.append_only_segments[index].state != AppendOnlySegmentState::PendingDrop {
+            manifest.append_only_segments[index].state = AppendOnlySegmentState::PendingDrop;
+            manifest.generation += 1;
+            self.publish(&manifest)?;
+            manifest = self.load_current()?.unwrap_or_else(empty_manifest);
+        }
+        let Some(index) = manifest
+            .append_only_segments
+            .iter()
+            .position(|entry| entry.collection == collection && entry.segment_id == segment_id)
+        else {
+            return Ok(false);
+        };
+        let entry = manifest.append_only_segments.remove(index);
+        let _ = fs::remove_file(self.append_only_segments_dir().join(&entry.path));
+        record_retired_append_only_segment(&mut manifest, &entry);
+        manifest.generation += 1;
+        self.publish(&manifest)?;
+        Ok(true)
     }
 
     /// Detach a store fork into an independent operational store root. All
@@ -713,8 +856,35 @@ impl OperationalManifest {
     pub fn append_only_segments(&self) -> io::Result<Vec<AppendOnlySegmentManifestEntry>> {
         Ok(self
             .load_current()?
+            .map(|manifest| active_append_only_segments(&manifest))
+            .unwrap_or_default())
+    }
+
+    pub fn append_only_segments_with_pending_for_test(
+        &self,
+    ) -> io::Result<Vec<AppendOnlySegmentManifestEntry>> {
+        Ok(self
+            .load_current()?
             .map(|manifest| manifest.append_only_segments)
             .unwrap_or_default())
+    }
+
+    pub fn append_only_published_rows(&self, collection: &str) -> io::Result<u64> {
+        Ok(self
+            .load_current()?
+            .map(|manifest| append_only_published_rows(&manifest, collection))
+            .unwrap_or_default())
+    }
+
+    pub fn append_only_published_rows_for_test(&self, collection: &str) -> io::Result<u64> {
+        self.append_only_published_rows(collection)
+    }
+
+    pub fn next_append_only_segment_id(&self, collection: &str) -> io::Result<u64> {
+        Ok(self
+            .load_current()?
+            .map(|manifest| next_append_only_segment_id(&manifest, collection))
+            .unwrap_or(1))
     }
 
     pub fn write_next_manifest_for_test(&self, name: &str) -> io::Result<()> {
@@ -874,6 +1044,7 @@ fn empty_manifest() -> Manifest {
         generation: 0,
         collections: BTreeMap::new(),
         append_only_segments: Vec::new(),
+        append_only_retired: BTreeMap::new(),
         fork_origin: None,
     }
 }
@@ -885,6 +1056,59 @@ fn active_collection_paths(manifest: &Manifest) -> BTreeSet<String> {
         .filter(|entry| entry.state == CollectionState::Active)
         .map(|entry| entry.path.clone())
         .collect()
+}
+
+fn active_append_only_segments(manifest: &Manifest) -> Vec<AppendOnlySegmentManifestEntry> {
+    manifest
+        .append_only_segments
+        .iter()
+        .filter(|entry| entry.state == AppendOnlySegmentState::Active)
+        .cloned()
+        .collect()
+}
+
+fn record_retired_append_only_segment(
+    manifest: &mut Manifest,
+    entry: &AppendOnlySegmentManifestEntry,
+) {
+    let retired = manifest
+        .append_only_retired
+        .entry(entry.collection.clone())
+        .or_default();
+    retired.row_count = retired.row_count.saturating_add(entry.row_count);
+    retired.segment_high_water = retired.segment_high_water.max(entry.segment_id);
+}
+
+fn append_only_published_rows(manifest: &Manifest, collection: &str) -> u64 {
+    manifest
+        .append_only_retired
+        .get(collection)
+        .map(|retired| retired.row_count)
+        .unwrap_or_default()
+        .saturating_add(
+            manifest
+                .append_only_segments
+                .iter()
+                .filter(|entry| entry.collection == collection)
+                .map(|entry| entry.row_count)
+                .sum::<u64>(),
+        )
+}
+
+fn next_append_only_segment_id(manifest: &Manifest, collection: &str) -> u64 {
+    let active_high_water = manifest
+        .append_only_segments
+        .iter()
+        .filter(|entry| entry.collection == collection)
+        .map(|entry| entry.segment_id)
+        .max()
+        .unwrap_or_default();
+    let retired_high_water = manifest
+        .append_only_retired
+        .get(collection)
+        .map(|retired| retired.segment_high_water)
+        .unwrap_or_default();
+    active_high_water.max(retired_high_water).saturating_add(1)
 }
 
 fn manifest_to_bytes(manifest: &Manifest) -> io::Result<Vec<u8>> {
@@ -974,6 +1198,26 @@ fn manifest_from_object(object: &Map<String, Value>) -> io::Result<Manifest> {
             ))
         }
     };
+    let mut append_only_retired = match object.get("append_only_retired") {
+        Some(Value::Object(entries)) => entries
+            .iter()
+            .map(|(collection, value)| {
+                append_only_retired_from_value(value).map(|state| (collection.clone(), state))
+            })
+            .collect::<io::Result<BTreeMap<_, _>>>()?,
+        Some(Value::Null) | None => BTreeMap::new(),
+        Some(_) => {
+            return Err(invalid_data(
+                "manifest append_only_retired must be an object",
+            ))
+        }
+    };
+    for entry in &append_only_segments {
+        let retired = append_only_retired
+            .entry(entry.collection.clone())
+            .or_default();
+        retired.segment_high_water = retired.segment_high_water.max(entry.segment_id);
+    }
     let fork_origin = match object.get("fork_origin") {
         Some(Value::Object(origin)) => Some(fork_origin_from_object(origin)?),
         Some(Value::Null) | None => None,
@@ -983,6 +1227,7 @@ fn manifest_from_object(object: &Map<String, Value>) -> io::Result<Manifest> {
         generation,
         collections,
         append_only_segments,
+        append_only_retired,
         fork_origin,
     })
 }
@@ -1000,6 +1245,12 @@ fn append_only_segment_from_value(value: &Value) -> io::Result<AppendOnlySegment
         .get("segment_id")
         .and_then(Value::as_u64)
         .ok_or_else(|| invalid_data("append-only segment id is missing"))?;
+    let state = object
+        .get("state")
+        .and_then(Value::as_str)
+        .map(AppendOnlySegmentState::parse)
+        .transpose()?
+        .unwrap_or(AppendOnlySegmentState::Active);
     let path = object
         .get("path")
         .and_then(Value::as_str)
@@ -1035,6 +1286,8 @@ fn append_only_segment_from_value(value: &Value) -> io::Result<AppendOnlySegment
         .get("primary_max")
         .and_then(Value::as_str)
         .map(str::to_string);
+    let retention_min_ms = object.get("retention_min_ms").and_then(Value::as_i64);
+    let retention_max_ms = object.get("retention_max_ms").and_then(Value::as_i64);
     let chunk_checksums = object
         .get("chunk_checksums")
         .and_then(Value::as_array)
@@ -1045,13 +1298,34 @@ fn append_only_segment_from_value(value: &Value) -> io::Result<AppendOnlySegment
     Ok(AppendOnlySegmentManifestEntry {
         collection,
         segment_id,
+        state,
         path,
         codec,
         chunk_size,
         row_count,
+        retention_min_ms,
+        retention_max_ms,
         primary_min,
         primary_max,
         chunk_checksums,
+    })
+}
+
+fn append_only_retired_from_value(value: &Value) -> io::Result<AppendOnlyRetiredState> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid_data("append-only retired entry must be an object"))?;
+    let row_count = object
+        .get("row_count")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("append-only retired row_count is missing"))?;
+    let segment_high_water = object
+        .get("segment_high_water")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("append-only retired segment_high_water is missing"))?;
+    Ok(AppendOnlyRetiredState {
+        row_count,
+        segment_high_water,
     })
 }
 
@@ -1140,6 +1414,19 @@ fn manifest_body_json(manifest: &Manifest) -> Map<String, Value> {
             Value::Array(append_only_segments),
         );
     }
+    if !manifest.append_only_retired.is_empty() {
+        let mut retired = Map::new();
+        for (collection, state) in &manifest.append_only_retired {
+            let mut state_object = Map::new();
+            state_object.insert("row_count".to_string(), Value::from(state.row_count));
+            state_object.insert(
+                "segment_high_water".to_string(),
+                Value::from(state.segment_high_water),
+            );
+            retired.insert(collection.clone(), Value::Object(state_object));
+        }
+        object.insert("append_only_retired".to_string(), Value::Object(retired));
+    }
     // Only emit `fork_origin` for a fork's own manifest, so a parent manifest is
     // unchanged from the pre-fork format.
     if let Some(origin) = &manifest.fork_origin {
@@ -1162,6 +1449,10 @@ fn append_only_segment_to_value(entry: &AppendOnlySegmentManifestEntry) -> Value
         Value::String(entry.collection.clone()),
     );
     object.insert("segment_id".to_string(), Value::from(entry.segment_id));
+    object.insert(
+        "state".to_string(),
+        Value::String(entry.state.as_str().to_string()),
+    );
     object.insert("path".to_string(), Value::String(entry.path.clone()));
     object.insert(
         "codec".to_string(),
@@ -1169,6 +1460,18 @@ fn append_only_segment_to_value(entry: &AppendOnlySegmentManifestEntry) -> Value
     );
     object.insert("chunk_size".to_string(), Value::from(entry.chunk_size));
     object.insert("row_count".to_string(), Value::from(entry.row_count));
+    if let Some(retention_min_ms) = entry.retention_min_ms {
+        object.insert(
+            "retention_min_ms".to_string(),
+            Value::from(retention_min_ms),
+        );
+    }
+    if let Some(retention_max_ms) = entry.retention_max_ms {
+        object.insert(
+            "retention_max_ms".to_string(),
+            Value::from(retention_max_ms),
+        );
+    }
     if let Some(primary_min) = &entry.primary_min {
         object.insert(
             "primary_min".to_string(),

--- a/crates/reddb-file/tests/append_only_segment.rs
+++ b/crates/reddb-file/tests/append_only_segment.rs
@@ -2,7 +2,8 @@ use std::fs;
 
 use reddb_file::{
     decode_append_only_segment, encode_append_only_segment, AppendOnlySegmentCodec,
-    AppendOnlySegmentRow, OperationalManifest, APPEND_ONLY_SEGMENT_CHUNK_BYTES,
+    AppendOnlySegmentRow, AppendOnlySegmentState, OperationalManifest,
+    APPEND_ONLY_SEGMENT_CHUNK_BYTES,
 };
 
 #[test]
@@ -91,4 +92,71 @@ fn unpublished_append_only_segment_files_are_quarantined_on_recover() {
     assert!(manifest
         .quarantine_path_for_test("events-000000000009.raos")
         .exists());
+}
+
+#[test]
+fn interrupted_append_only_segment_retirement_recovers_without_orphaning_live_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("data.rdb");
+    let manifest = OperationalManifest::for_db_path(&db_path);
+    manifest.recover_or_bootstrap(&[]).unwrap();
+
+    let expired = encode_append_only_segment(
+        AppendOnlySegmentCodec::None,
+        &[AppendOnlySegmentRow {
+            primary_key: b"0001".to_vec(),
+            payload: b"{\"id\":1}".to_vec(),
+        }],
+    )
+    .unwrap();
+    let live = encode_append_only_segment(
+        AppendOnlySegmentCodec::None,
+        &[AppendOnlySegmentRow {
+            primary_key: b"0002".to_vec(),
+            payload: b"{\"id\":2}".to_vec(),
+        }],
+    )
+    .unwrap();
+    let expired_segment = manifest
+        .publish_append_only_segment("events", 1, AppendOnlySegmentCodec::None, &expired)
+        .unwrap();
+    let live_segment = manifest
+        .publish_append_only_segment("events", 2, AppendOnlySegmentCodec::None, &live)
+        .unwrap();
+    let expired_path = manifest.append_only_segment_path_for_test(&expired_segment.path);
+    let live_path = manifest.append_only_segment_path_for_test(&live_segment.path);
+
+    assert!(manifest
+        .begin_retire_append_only_segment("events", 1)
+        .unwrap());
+    assert!(
+        expired_path.exists(),
+        "begin phase must not remove bytes yet"
+    );
+    let pending = manifest
+        .append_only_segments_with_pending_for_test()
+        .unwrap();
+    assert_eq!(pending[0].state, AppendOnlySegmentState::PendingDrop);
+    assert_eq!(pending[1].state, AppendOnlySegmentState::Active);
+
+    manifest.recover_or_bootstrap(&[]).unwrap();
+
+    assert!(
+        !expired_path.exists(),
+        "recovery completes pending retirement"
+    );
+    assert!(live_path.exists(), "live segment must not be touched");
+    assert!(!manifest
+        .quarantine_path_for_test(&expired_segment.path)
+        .exists());
+    assert_eq!(
+        manifest.append_only_segments_for_test().unwrap(),
+        vec![live_segment]
+    );
+    assert_eq!(
+        manifest
+            .append_only_published_rows_for_test("events")
+            .unwrap(),
+        2
+    );
 }

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1068,9 +1068,9 @@ struct RuntimeInner {
     views: parking_lot::RwLock<HashMap<String, Arc<crate::storage::query::ast::CreateViewQuery>>>,
     materialized_views: parking_lot::RwLock<crate::storage::cache::result::MaterializedViewCache>,
     /// Per-collection retention sweeper state (issue #584 slice 12).
-    /// Tracks `last_sweep_at_ms`, `rows_swept_total`, and the latest
-    /// pending-rows estimate that feeds the three new columns on
-    /// `red.retention`. In-memory only; resets across restart.
+    /// Tracks `last_sweep_at_ms`, row/segment retirement totals, and
+    /// the latest pending-rows estimate that feeds `red.retention`.
+    /// In-memory only; resets across restart.
     pub(crate) retention_sweeper:
         parking_lot::RwLock<crate::runtime::retention_sweeper::RetentionSweeperState>,
     /// MVCC snapshot manager (Phase 2.3 PG parity).

--- a/crates/reddb-server/src/runtime/impl_materialized_view.rs
+++ b/crates/reddb-server/src/runtime/impl_materialized_view.rs
@@ -45,20 +45,20 @@ impl RedDBRuntime {
     /// path — failures are captured in `last_error` and the prior
     /// content stays intact. Issue #583 slice 10.
     /// Snapshot of every tracked retention sweeper state — feeds the
-    /// three extra columns on `red.retention`. Issue #584 slice 12.
+    /// sweeper observability columns on `red.retention`.
     pub(crate) fn retention_sweeper_snapshot(
         &self,
     ) -> Vec<(String, crate::runtime::retention_sweeper::SweeperState)> {
         self.inner.retention_sweeper.read().snapshot()
     }
 
-    /// Drive one tick of the retention sweeper. Iterates collections
-    /// with a retention policy set, physically deletes at most
-    /// `batch_size` expired rows per collection, and records the
-    /// `last_sweep_at_ms` / `rows_swept_total` / pending estimate that
-    /// `red.retention` exposes. Called from the background sweeper
-    /// thread; safe to invoke directly from tests with a small batch
-    /// size to drain rows deterministically. Issue #584 slice 12.
+    /// Drive one tick of the retention sweeper. Mutable collections
+    /// physically delete at most `batch_size` expired rows; append-only
+    /// collections retire whole expired segments through the operational
+    /// manifest. Records the counters that `red.retention` exposes.
+    /// Called from the background sweeper thread; safe to invoke directly
+    /// from tests with a small batch size to drain rows deterministically.
+    /// Issue #584 slice 12.
     ///
     /// Deletes are issued as `DELETE FROM <collection> WHERE
     /// <ts_column> < <cutoff>` through the standard `execute_query`
@@ -91,6 +91,10 @@ impl RedDBRuntime {
             let Some(retention_ms) = contract.retention_duration_ms else {
                 continue;
             };
+            if contract.append_only {
+                let _ = self.retire_expired_append_only_segments(now_ms);
+                continue;
+            }
             let Some(ts_column) =
                 crate::runtime::retention_filter::resolve_timestamp_column(&contract)
             else {

--- a/crates/reddb-server/src/runtime/impl_physical.rs
+++ b/crates/reddb-server/src/runtime/impl_physical.rs
@@ -363,6 +363,8 @@ impl RedDBRuntime {
 
     pub fn apply_retention_policy(&self) -> RedDBResult<()> {
         self.check_write(crate::runtime::write_gate::WriteKind::Maintenance)?;
+        let now_ms = current_unix_ms_u64();
+        self.retire_expired_append_only_segments(now_ms)?;
         let expired = self
             .inner
             .db
@@ -390,6 +392,57 @@ impl RedDBRuntime {
         self.enforce_metrics_raw_retention()?;
         self.invalidate_result_cache();
         Ok(())
+    }
+
+    pub(crate) fn retire_expired_append_only_segments(&self, now_ms: u64) -> RedDBResult<u64> {
+        let Some(path) = self.inner.db.path() else {
+            return Ok(0);
+        };
+        let manifest = reddb_file::OperationalManifest::for_db_path(path);
+        let segments = manifest
+            .append_only_segments()
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+        if segments.is_empty() {
+            return Ok(0);
+        }
+
+        let mut total_retired = 0u64;
+        for contract in self
+            .inner
+            .db
+            .collection_contracts()
+            .into_iter()
+            .filter(|contract| contract.append_only)
+        {
+            let Some(retention_ms) = contract.retention_duration_ms else {
+                continue;
+            };
+            let cutoff = (now_ms as i64).saturating_sub(retention_ms as i64);
+            let mut retired_for_collection = 0u64;
+            for segment in segments
+                .iter()
+                .filter(|segment| segment.collection == contract.name)
+                .filter(|segment| segment.retention_max_ms.is_some_and(|max| max < cutoff))
+            {
+                manifest
+                    .begin_retire_append_only_segment(&segment.collection, segment.segment_id)
+                    .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                if manifest
+                    .finish_retire_append_only_segment(&segment.collection, segment.segment_id)
+                    .map_err(|err| RedDBError::Internal(err.to_string()))?
+                {
+                    retired_for_collection = retired_for_collection.saturating_add(1);
+                }
+            }
+            if retired_for_collection > 0 {
+                self.inner
+                    .retention_sweeper
+                    .write()
+                    .record_segments_retired(&contract.name, retired_for_collection, now_ms);
+                total_retired = total_retired.saturating_add(retired_for_collection);
+            }
+        }
+        Ok(total_retired)
     }
 
     fn enforce_metrics_raw_retention(&self) -> RedDBResult<()> {
@@ -686,4 +739,11 @@ impl RedDBRuntime {
             }
         }
     }
+}
+
+fn current_unix_ms_u64() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }

--- a/crates/reddb-server/src/runtime/red_schema/mod.rs
+++ b/crates/reddb-server/src/runtime/red_schema/mod.rs
@@ -246,7 +246,7 @@ const POLICY_COLUMNS: [&str; 8] = [
 // the same four-column shape.
 const STATS_COLUMNS: [&str; 4] = ["collection", "entity", "metric", "value"];
 
-const RETENTION_COLUMNS: [&str; 7] = [
+const RETENTION_COLUMNS: [&str; 8] = [
     "name",
     "retention_duration",
     "oldest_row_ts",
@@ -254,6 +254,7 @@ const RETENTION_COLUMNS: [&str; 7] = [
     // Issue #584 slice 12 — sweeper observability columns.
     "last_sweep_at",
     "rows_swept_total",
+    "segments_retired_total",
     "current_rows_pending_sweep_estimate",
 ];
 

--- a/crates/reddb-server/src/runtime/red_schema/ops_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/ops_views.rs
@@ -342,6 +342,7 @@ pub(super) fn retention_snapshot(
                     Value::UnsignedInteger(expired_count),
                     last_sweep_at,
                     Value::UnsignedInteger(sweeper_state.rows_swept_total),
+                    Value::UnsignedInteger(sweeper_state.segments_retired_total),
                     Value::UnsignedInteger(sweeper_state.last_pending_estimate),
                 ],
             )

--- a/crates/reddb-server/src/runtime/retention_sweeper.rs
+++ b/crates/reddb-server/src/runtime/retention_sweeper.rs
@@ -1,22 +1,25 @@
 //! Issue #584 — DeclarativeRetention slice 12.
 //!
-//! Background sweeper that physically removes rows whose timestamp
-//! column has fallen beyond the collection's retention window. The
+//! Background sweeper that physically removes rows or append-only
+//! segments whose timestamp column has fallen beyond the collection's
+//! retention window. The
 //! lazy-on-scan filter from slice 11 (`retention_filter`) hides
 //! expired rows from reads the moment a policy is set; this slice
 //! complements that filter with a low-priority background task that
 //! reclaims storage in bounded batches.
 //!
-//! The sweeper executes deletes through the standard
+//! Mutable-collection sweeps execute deletes through the standard
 //! `RedDBRuntime::execute_query` chokepoint (`DELETE FROM <collection>
 //! WHERE id IN (...)`) so that WAL participation, snapshot guards and
 //! event emission ride on the same single code path as user-issued
 //! DELETEs — replicas replay sweeper deletes deterministically with
-//! no special handling on the replication side.
+//! no special handling on the replication side. Append-only sweeps
+//! retire whole expired segments through the operational manifest.
 //!
 //! Per-collection runtime state (`last_sweep_at_ms`, `rows_swept_total`,
-//! `last_pending_estimate`) lives on `RuntimeInner::retention_sweeper`
-//! and is surfaced via the three extra columns on `red.retention`.
+//! `segments_retired_total`, `last_pending_estimate`) lives on
+//! `RuntimeInner::retention_sweeper` and is surfaced via the sweeper
+//! columns on `red.retention`.
 //! State is in-memory only — counters reset across restart, mirroring
 //! the existing materialized-view scheduler state.
 
@@ -36,6 +39,8 @@ pub(crate) struct SweeperState {
     pub last_sweep_at_ms: u64,
     /// Cumulative rows reclaimed since boot.
     pub rows_swept_total: u64,
+    /// Cumulative append-only segments retired since boot.
+    pub segments_retired_total: u64,
     /// Number of rows the last tick observed as expired *but not yet
     /// swept* — i.e. either still inside the batch or queued for the
     /// next tick. Surfaced as
@@ -85,6 +90,19 @@ impl RetentionSweeperState {
         entry.last_pending_estimate = pending_estimate;
     }
 
+    pub(crate) fn record_segments_retired(
+        &mut self,
+        collection: &str,
+        segments_retired: u64,
+        at_unix_ms: u64,
+    ) {
+        let entry = self.states.entry(collection.to_string()).or_default();
+        entry.last_sweep_at_ms = at_unix_ms;
+        entry.segments_retired_total = entry
+            .segments_retired_total
+            .saturating_add(segments_retired);
+    }
+
     /// Drop bookkeeping for a collection (DROP TABLE / DROP COLLECTION).
     pub(crate) fn forget(&mut self, collection: &str) {
         self.states.remove(collection);
@@ -102,7 +120,19 @@ mod tests {
         state.record_tick("events", 50, 0, 2_000);
         let s = state.get("events");
         assert_eq!(s.rows_swept_total, 150);
+        assert_eq!(s.segments_retired_total, 0);
         assert_eq!(s.last_pending_estimate, 0);
+        assert_eq!(s.last_sweep_at_ms, 2_000);
+    }
+
+    #[test]
+    fn record_segments_retired_accumulates_without_rows() {
+        let mut state = RetentionSweeperState::new();
+        state.record_segments_retired("events", 1, 1_000);
+        state.record_segments_retired("events", 2, 2_000);
+        let s = state.get("events");
+        assert_eq!(s.rows_swept_total, 0);
+        assert_eq!(s.segments_retired_total, 3);
         assert_eq!(s.last_sweep_at_ms, 2_000);
     }
 

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_core_a.rs
@@ -635,7 +635,6 @@ impl RedDB {
 
     fn publish_append_only_segments(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
         let manifest = reddb_file::OperationalManifest::for_db_path(path);
-        let published = manifest.append_only_segments()?;
         for contract in self
             .collection_contracts()
             .into_iter()
@@ -646,24 +645,19 @@ impl RedDB {
             };
             let mut entities = manager.query_all(|_| true);
             entities.sort_by_key(|entity| entity.id.raw());
-            let published_rows = published
-                .iter()
-                .filter(|segment| segment.collection == contract.name)
-                .map(|segment| segment.row_count)
-                .sum::<u64>();
+            let published_rows = manifest.append_only_published_rows(&contract.name)?;
             if published_rows >= entities.len() as u64 {
                 continue;
             }
-            let next_segment_id = published
-                .iter()
-                .filter(|segment| segment.collection == contract.name)
-                .map(|segment| segment.segment_id)
-                .max()
-                .unwrap_or(0)
-                .saturating_add(1);
-            let rows = entities
+            let next_segment_id = manifest.next_append_only_segment_id(&contract.name)?;
+            let segment_entities = entities
                 .iter()
                 .skip(published_rows as usize)
+                .collect::<Vec<_>>();
+            let (retention_min_ms, retention_max_ms) =
+                append_only_retention_bounds(&contract, &segment_entities);
+            let rows = segment_entities
+                .iter()
                 .map(|entity| {
                     let metadata = manager.get_metadata(entity.id);
                     reddb_file::AppendOnlySegmentRow {
@@ -684,11 +678,13 @@ impl RedDB {
                 reddb_file::AppendOnlySegmentCodec::Zstd,
                 &rows,
             )?;
-            manifest.publish_append_only_segment(
+            manifest.publish_append_only_segment_with_retention_bounds(
                 &contract.name,
                 next_segment_id,
                 reddb_file::AppendOnlySegmentCodec::Zstd,
                 &bytes,
+                retention_min_ms,
+                retention_max_ms,
             )?;
         }
         Ok(())
@@ -1376,6 +1372,59 @@ impl RedDB {
             && report.state != HealthState::Unhealthy;
 
         (query_allowed, write_allowed, repair_allowed)
+    }
+}
+
+fn append_only_retention_bounds(
+    contract: &crate::physical::CollectionContract,
+    entities: &[&UnifiedEntity],
+) -> (Option<i64>, Option<i64>) {
+    let Some(ts_column) = crate::runtime::retention_filter::resolve_timestamp_column(contract)
+    else {
+        return (None, None);
+    };
+    let mut min_ts: Option<i64> = None;
+    let mut max_ts: Option<i64> = None;
+    for entity in entities {
+        let Some(ts) = append_only_entity_timestamp_ms(entity, &ts_column) else {
+            continue;
+        };
+        min_ts = Some(min_ts.map_or(ts, |min| min.min(ts)));
+        max_ts = Some(max_ts.map_or(ts, |max| max.max(ts)));
+    }
+    (min_ts, max_ts)
+}
+
+fn append_only_entity_timestamp_ms(entity: &UnifiedEntity, ts_column: &str) -> Option<i64> {
+    match ts_column {
+        "created_at" => entity
+            .data
+            .as_row()
+            .and_then(|row| row.get_field("created_at"))
+            .and_then(value_as_retention_ms)
+            .or(Some(entity.created_at as i64)),
+        "updated_at" => entity
+            .data
+            .as_row()
+            .and_then(|row| row.get_field("updated_at"))
+            .and_then(value_as_retention_ms)
+            .or(Some(entity.updated_at as i64)),
+        other => entity
+            .data
+            .as_row()
+            .and_then(|row| row.get_field(other))
+            .and_then(value_as_retention_ms),
+    }
+}
+
+fn value_as_retention_ms(value: &Value) -> Option<i64> {
+    match value {
+        Value::TimestampMs(t) => Some(*t),
+        Value::Timestamp(t) => Some(t.saturating_mul(1_000)),
+        Value::BigInt(t) => Some(*t),
+        Value::UnsignedInteger(t) => i64::try_from(*t).ok(),
+        Value::Integer(t) => Some(*t),
+        _ => None,
     }
 }
 

--- a/crates/reddb-server/tests/append_only_segment_runtime.rs
+++ b/crates/reddb-server/tests/append_only_segment_runtime.rs
@@ -1,4 +1,5 @@
 use reddb_file::OperationalManifest;
+use reddb_server::storage::schema::Value;
 use reddb_server::{RedDBOptions, RedDBRuntime};
 
 #[test]
@@ -52,4 +53,62 @@ fn append_only_flush_publishes_closed_segment_and_reopen_reads_rows() {
     assert_eq!(segments.len(), 2);
     assert_eq!(segments[0].collection, "events");
     assert_eq!(segments[1].collection, "events");
+}
+
+#[test]
+fn append_only_retention_retires_expired_segments_and_reports_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("append_only_retention.rdb");
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(&db_path)).expect("runtime boots");
+
+    rt.execute_query("CREATE TABLE events (id INT, msg TEXT) WITH timestamps = true APPEND ONLY")
+        .expect("create append-only table");
+    rt.execute_query("INSERT INTO events (id, msg) VALUES (1, 'expired')")
+        .expect("insert expired row");
+    rt.flush().expect("flush expired segment");
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+
+    rt.execute_query("ALTER COLLECTION events SET RETENTION 1 s")
+        .expect("set retention");
+    rt.execute_query("INSERT INTO events (id, msg) VALUES (2, 'live')")
+        .expect("insert live row");
+    rt.flush().expect("flush live segment");
+
+    let manifest = OperationalManifest::for_db_path(&db_path);
+    let before = manifest.append_only_segments_for_test().unwrap();
+    assert_eq!(before.len(), 2);
+    let retired_path = manifest.append_only_segment_path_for_test(&before[0].path);
+    let live_path = manifest.append_only_segment_path_for_test(&before[1].path);
+
+    rt.sweep_retention_tick(1_000);
+
+    let after = manifest.append_only_segments_for_test().unwrap();
+    assert_eq!(after.len(), 1);
+    assert_eq!(after[0].segment_id, before[1].segment_id);
+    assert!(
+        !retired_path.exists(),
+        "expired segment file should be retired"
+    );
+    assert!(live_path.exists(), "live segment file should remain");
+
+    let retention = rt
+        .execute_query(
+            "SELECT rows_swept_total, segments_retired_total \
+             FROM red.retention WHERE name = 'events'",
+        )
+        .expect("select red.retention");
+    let row = retention
+        .result
+        .records
+        .first()
+        .expect("events retention row");
+    assert_eq!(
+        row.get("rows_swept_total"),
+        Some(&Value::UnsignedInteger(0)),
+        "append-only segment retirement must not report row-level deletes",
+    );
+    assert_eq!(
+        row.get("segments_retired_total"),
+        Some(&Value::UnsignedInteger(1)),
+    );
 }


### PR DESCRIPTION
Automated AFK landing for #1817. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1817

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786031765&installation_id=129708444&pr_number=1903&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1903&signature=adca6249bc343702bf5f5781a574c28c6f5ff4adb186c9143ec8850716e7af9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->