### PR TITLE
chore: #1827 Canonical byte-key bloom: stable 64-bit front end on SplitBlockBloom + criterion bench

### DIFF
--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -172,6 +172,10 @@ name = "blob_cache_bench"
 harness = false
 
 [[bench]]
+name = "bloom_byte_key_bench"
+harness = false
+
+[[bench]]
 name = "column_policy_gate_bench"
 harness = false
 

--- a/crates/reddb-server/benches/bloom_byte_key_bench.rs
+++ b/crates/reddb-server/benches/bloom_byte_key_bench.rs
@@ -1,0 +1,124 @@
+//! Byte-key bloom benchmark (#1827).
+//!
+//! Run:
+//!   cargo bench -p reddb-io-server --bench bloom_byte_key_bench
+//!
+//! Compares the legacy byte-slice `BloomFilter` against the byte-key front end
+//! on `SplitBlockBloom` within one Criterion run. Cross-run comparisons are
+//! not valid.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use reddb_server::storage::primitives::bloom::BloomFilter;
+use reddb_server::storage::primitives::split_block_bloom::SplitBlockBloom;
+use std::hint::black_box;
+
+const CAPACITY: usize = 100_000;
+
+fn key(i: u64) -> [u8; 16] {
+    let mut key = [0u8; 16];
+    key[..8].copy_from_slice(&i.to_le_bytes());
+    key[8..].copy_from_slice(&i.wrapping_mul(0x9e37_79b9_7f4a_7c15).to_le_bytes());
+    key
+}
+
+fn keys(start: u64) -> Vec<[u8; 16]> {
+    (start..start + CAPACITY as u64).map(key).collect()
+}
+
+fn legacy_filter(keys: &[[u8; 16]]) -> BloomFilter {
+    let mut filter = BloomFilter::with_capacity(CAPACITY, 0.01);
+    for key in keys {
+        filter.insert(black_box(key));
+    }
+    filter
+}
+
+fn split_filter(keys: &[[u8; 16]]) -> SplitBlockBloom {
+    let mut filter = SplitBlockBloom::with_capacity(CAPACITY);
+    for key in keys {
+        filter.insert_bytes(black_box(key));
+    }
+    filter
+}
+
+fn bench_bloom_byte_keys(c: &mut Criterion) {
+    let present = keys(0);
+    let absent = keys(CAPACITY as u64);
+    let legacy = legacy_filter(&present);
+    let split = split_filter(&present);
+
+    let mut group = c.benchmark_group("bloom-byte-key");
+    group.sample_size(20);
+    group.throughput(Throughput::Elements(CAPACITY as u64));
+
+    group.bench_function("legacy-insert", |b| {
+        b.iter_batched(
+            || BloomFilter::with_capacity(CAPACITY, 0.01),
+            |mut filter| {
+                for key in &present {
+                    filter.insert(black_box(key));
+                }
+                black_box(filter)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("legacy-contains-present", |b| {
+        b.iter(|| {
+            let mut matches = 0usize;
+            for key in &present {
+                matches += usize::from(legacy.contains(black_box(key)));
+            }
+            black_box(matches)
+        });
+    });
+
+    group.bench_function("legacy-contains-absent", |b| {
+        b.iter(|| {
+            let mut matches = 0usize;
+            for key in &absent {
+                matches += usize::from(legacy.contains(black_box(key)));
+            }
+            black_box(matches)
+        });
+    });
+
+    group.bench_function("split-insert-bytes", |b| {
+        b.iter_batched(
+            || SplitBlockBloom::with_capacity(CAPACITY),
+            |mut filter| {
+                for key in &present {
+                    filter.insert_bytes(black_box(key));
+                }
+                black_box(filter)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("split-probe-bytes-present", |b| {
+        b.iter(|| {
+            let mut matches = 0usize;
+            for key in &present {
+                matches += usize::from(split.probe_bytes(black_box(key)));
+            }
+            black_box(matches)
+        });
+    });
+
+    group.bench_function("split-probe-bytes-absent", |b| {
+        b.iter(|| {
+            let mut matches = 0usize;
+            for key in &absent {
+                matches += usize::from(split.probe_bytes(black_box(key)));
+            }
+            black_box(matches)
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_bloom_byte_keys);
+criterion_main!(benches);

--- a/crates/reddb-server/src/storage/primitives/split_block_bloom.rs
+++ b/crates/reddb-server/src/storage/primitives/split_block_bloom.rs
@@ -74,6 +74,19 @@ impl SplitBlockBloom {
         }
     }
 
+    /// Insert an arbitrary byte key into the filter using one stable hash pass.
+    #[inline]
+    pub fn insert_bytes(&mut self, key: &[u8]) {
+        let h = stable_hash64(key);
+        let block_idx = ((h >> 32) as usize) & self.mask;
+        let probe_word = h as u32;
+        let block = &mut self.blocks[block_idx];
+        for (i, &salt) in SALTS.iter().enumerate() {
+            let bit = probe_word.wrapping_mul(salt) >> 27;
+            block.words[i] |= 1u32 << bit;
+        }
+    }
+
     /// Return `true` if `key` **may** be in the set (false positives possible).
     /// Return `false` if `key` is **definitely absent** (no false negatives).
     #[inline]
@@ -82,6 +95,23 @@ impl SplitBlockBloom {
         let block = &self.blocks[block_idx];
         for (i, &salt) in SALTS.iter().enumerate() {
             let bit = key.wrapping_mul(salt) >> 27;
+            if block.words[i] & (1u32 << bit) == 0 {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Return `true` if `key` **may** be in the set (false positives possible).
+    /// Return `false` if `key` is **definitely absent** (no false negatives).
+    #[inline]
+    pub fn probe_bytes(&self, key: &[u8]) -> bool {
+        let h = stable_hash64(key);
+        let block_idx = ((h >> 32) as usize) & self.mask;
+        let probe_word = h as u32;
+        let block = &self.blocks[block_idx];
+        for (i, &salt) in SALTS.iter().enumerate() {
+            let bit = probe_word.wrapping_mul(salt) >> 27;
             if block.words[i] & (1u32 << bit) == 0 {
                 return false;
             }
@@ -140,6 +170,25 @@ impl SplitBlockBloom {
             mask: num_blocks - 1,
         })
     }
+}
+
+/// Hash a raw byte slice to a stable `u64` for byte-key bloom-filter use.
+///
+/// This hasher is seedless, dependency-free, and deterministic across
+/// processes and restarts. Persisted filters that store byte-key bloom bits
+/// MUST use this same function for both writers and readers so the stored
+/// bloom and probe key agree bit-for-bit across the persisted boundary.
+pub fn stable_hash64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for &byte in bytes {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash ^= hash >> 33;
+    hash = hash.wrapping_mul(0xff51_afd7_ed55_8ccd);
+    hash ^= hash >> 33;
+    hash = hash.wrapping_mul(0xc4ce_b9fe_1a85_ec53);
+    hash ^ (hash >> 33)
 }
 
 /// Hash a raw byte slice to a `u32` for bloom-filter use. The writer and the
@@ -242,5 +291,81 @@ mod tests {
         let fpr = fp as f64 / probes as f64;
         // Allow up to 5% FPR — the theoretical ~1% varies with data patterns.
         assert!(fpr < 0.05, "FPR too high: {fpr:.3}");
+    }
+
+    #[test]
+    fn insert_bytes_has_no_false_negatives() {
+        const N: usize = 10_000;
+        let mut bloom = SplitBlockBloom::with_capacity(N);
+        for i in 0..N as u64 {
+            bloom.insert_bytes(&byte_key(i));
+        }
+        for i in 0..N as u64 {
+            assert!(
+                bloom.probe_bytes(&byte_key(i)),
+                "false negative for key {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn insert_bytes_false_positive_rate_stays_below_two_percent() {
+        const N: usize = 10_000;
+        let mut bloom = SplitBlockBloom::with_capacity(N);
+        for i in 0..N as u64 {
+            bloom.insert_bytes(&byte_key(i));
+        }
+        let mut fp = 0usize;
+        let probes = 10_000usize;
+        for i in N as u64..(N + probes) as u64 {
+            if bloom.probe_bytes(&byte_key(i)) {
+                fp += 1;
+            }
+        }
+        let fpr = fp as f64 / probes as f64;
+        assert!(fpr < 0.02, "FPR too high: {fpr:.3}");
+    }
+
+    #[test]
+    fn bytes_round_trip_keeps_no_false_negatives() {
+        const N: usize = 10_000;
+        let mut bloom = SplitBlockBloom::with_capacity(N);
+        for i in 0..N as u64 {
+            bloom.insert_bytes(&byte_key(i));
+        }
+        let blob = bloom.to_bytes();
+        let restored = SplitBlockBloom::from_bytes(&blob).expect("round-trips");
+        assert_eq!(restored, bloom);
+        for i in 0..N as u64 {
+            assert!(
+                restored.probe_bytes(&byte_key(i)),
+                "false negative for key {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn bytes_hashing_agrees_across_filters() {
+        const N: usize = 10_000;
+        let mut a = SplitBlockBloom::with_capacity(N);
+        let mut b = SplitBlockBloom::with_capacity(N);
+        for i in 0..N as u64 {
+            let key = byte_key(i);
+            a.insert_bytes(&key);
+            b.insert_bytes(&key);
+        }
+        assert_eq!(a, b);
+        for i in 0..N as u64 {
+            let key = byte_key(i);
+            assert_eq!(a.probe_bytes(&key), b.probe_bytes(&key));
+            assert!(a.probe_bytes(&key), "false negative for key {i}");
+        }
+    }
+
+    fn byte_key(i: u64) -> [u8; 16] {
+        let mut key = [0u8; 16];
+        key[..8].copy_from_slice(&i.to_le_bytes());
+        key[8..].copy_from_slice(&i.wrapping_mul(0x9e37_79b9_7f4a_7c15).to_le_bytes());
+        key
     }
 }


### PR DESCRIPTION
Automated AFK landing for #1827. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1827

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786040136&installation_id=129708444&pr_number=1911&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1911&signature=5cf464926c1adbd6fcbb68d74f0dba4d8604ab4b3570e75445af808132ec9fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using byte-slice keys with bloom filters, including insert and lookup operations.
  * Improved bloom filter consistency for persisted data by using a deterministic hash for byte keys.

* **Tests**
  * Expanded coverage for byte-key bloom behavior, including round-trip storage, correctness after reload, and false-positive rate checks.

* **Chores**
  * Added a new benchmark to measure bloom performance with byte keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->