### PR TITLE
ci(dependabot): gate on drivers/python lockfile resolution

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -49,6 +49,14 @@ jobs:
       - name: cargo check
         run: cargo check --locked --all
 
+      - name: drivers/python lockfile still resolves
+        # drivers/python opts out of the workspace but path-depends on
+        # workspace crates; a root dependency bump can strand its separate
+        # Cargo.lock (see #1914 — ed25519-dalek 3.0 broke main post-merge).
+        # cargo metadata is resolution-only: fast, no compile.
+        working-directory: drivers/python
+        run: cargo metadata --locked --format-version 1 > /dev/null
+
       - name: Unit tests
         run: cargo test --locked --lib
 


### PR DESCRIPTION
Follow-up do #1914: bump de dependência na raiz (ex.: ed25519-dalek 3.0 no #1909) pode deixar o `drivers/python/Cargo.lock` stale — ele fica fora do workspace mas path-depende dos crates. O drift passou pelo verify do Dependabot (que só roda `cargo check --locked --all` na raiz) e quebrou a main pós-merge.

Adiciona ao verify: `cargo metadata --locked` em `drivers/python` — resolução pura, segundos, sem compile. O drift agora falha no PR do bot, onde dá pra corrigir antes do merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786046160&installation_id=129708444&pr_number=1915&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1915&signature=09c27605d197d62d33040d3f74d2d8ff219109e0a485c17b472fbaf8daa898e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->