### PR TITLE
chore: #1837 WAL and logical spool v3 framing: term and ownership epoch end-to-end

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -386,8 +386,11 @@ pub use wal_header::{
     WAL_FILE_VERSION_V2,
 };
 pub use wal_record::{
-    decode_main_wal_record_frame, encode_main_wal_record_frame, encode_main_wal_record_frame_into,
-    MainWalCompression, MainWalRecordFrame, MainWalRecordType, MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD,
+    decode_main_wal_record_frame, decode_main_wal_record_frame_with_authority,
+    encode_main_wal_record_frame, encode_main_wal_record_frame_into,
+    encode_main_wal_record_frame_with_authority, encode_main_wal_record_frame_with_authority_into,
+    MainWalCompression, MainWalRecordAuthority, MainWalRecordFrame, MainWalRecordType,
+    MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD,
 };
 pub use zone_map::{
     read_zone_map_sidecar, write_zone_map_sidecar, PersistedZone, ZoneMapPersistError,

--- a/crates/reddb-file/src/logical_wal.rs
+++ b/crates/reddb-file/src/logical_wal.rs
@@ -11,11 +11,12 @@
 //! [magic     4 bytes  = b"RDLW"]
 //! [version   1 byte   = 0x03]
 //! [term      8 bytes  little-endian u64]
+//! [ownership_epoch 8 bytes little-endian u64, 0 when absent]
 //! [lsn       8 bytes  little-endian u64]
 //! [timestamp 8 bytes  little-endian u64, wall-clock millis since UNIX epoch]
 //! [payload_len 4 bytes little-endian u32]
 //! [payload   payload_len bytes]
-//! [crc32     4 bytes  little-endian u32 over version, term, lsn, timestamp, len, payload]
+//! [crc32     4 bytes  little-endian u32 over version, term, ownership_epoch, lsn, timestamp, len, payload]
 //! ```
 //!
 //! ## Version 2, legacy read-only
@@ -49,7 +50,7 @@ pub const LOGICAL_WAL_SPOOL_VERSION_V1: u8 = 1;
 pub const LOGICAL_WAL_SPOOL_VERSION_V2: u8 = 2;
 pub const LOGICAL_WAL_SPOOL_VERSION_V3: u8 = 3;
 pub const LOGICAL_WAL_SPOOL_VERSION_CURRENT: u8 = LOGICAL_WAL_SPOOL_VERSION_V3;
-pub const LOGICAL_WAL_V3_HEADER_LEN: u64 = 4 + 1 + 8 + 8 + 8 + 4;
+pub const LOGICAL_WAL_V3_HEADER_LEN: u64 = 4 + 1 + 8 + 8 + 8 + 8 + 4;
 pub const LOGICAL_WAL_CRC_LEN: u64 = 4;
 pub const LOGICAL_WAL_SEEK_INDEX_INTERVAL: u64 = 64;
 
@@ -58,6 +59,7 @@ const MAX_PLAUSIBLE_PAYLOAD: usize = 256 * 1024 * 1024;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogicalWalEntry {
     pub term: u64,
+    pub ownership_epoch: Option<u64>,
     pub lsn: u64,
     pub timestamp_ms: u64,
     pub data: Vec<u8>,
@@ -66,6 +68,7 @@ pub struct LogicalWalEntry {
 
 pub fn encode_logical_wal_v3(
     term: u64,
+    ownership_epoch: Option<u64>,
     lsn: u64,
     timestamp_ms: u64,
     data: &[u8],
@@ -86,6 +89,7 @@ pub fn encode_logical_wal_v3(
     frame.extend_from_slice(LOGICAL_WAL_SPOOL_MAGIC);
     frame.push(LOGICAL_WAL_SPOOL_VERSION_CURRENT);
     frame.extend_from_slice(&term.to_le_bytes());
+    frame.extend_from_slice(&ownership_epoch.unwrap_or(0).to_le_bytes());
     frame.extend_from_slice(&lsn.to_le_bytes());
     frame.extend_from_slice(&timestamp_ms.to_le_bytes());
     frame.extend_from_slice(&(data.len() as u32).to_le_bytes());
@@ -93,6 +97,7 @@ pub fn encode_logical_wal_v3(
     let crc = compute_logical_v3_crc(
         LOGICAL_WAL_SPOOL_VERSION_CURRENT,
         term,
+        ownership_epoch,
         lsn,
         timestamp_ms,
         data,
@@ -245,7 +250,13 @@ pub fn rewrite_logical_wal_entries(
     let mut temp = File::create(temp_path)?;
     let mut current_lsn = 0;
     for entry in entries {
-        let frame = encode_logical_wal_v3(entry.term, entry.lsn, entry.timestamp_ms, &entry.data)?;
+        let frame = encode_logical_wal_v3(
+            entry.term,
+            entry.ownership_epoch,
+            entry.lsn,
+            entry.timestamp_ms,
+            &entry.data,
+        )?;
         temp.write_all(&frame)?;
         current_lsn = current_lsn.max(entry.lsn);
     }
@@ -284,6 +295,7 @@ fn read_logical_wal_frame(
 
 fn read_one_v3(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, String> {
     let term = read_u64(file, "term", record_start)?;
+    let ownership_epoch = read_u64(file, "ownership epoch", record_start)?;
     let lsn = read_u64(file, "lsn", record_start)?;
     let timestamp_ms = read_u64(file, "timestamp", record_start)?;
     let payload_len = read_u32(file, "payload length", record_start)? as usize;
@@ -292,6 +304,11 @@ fn read_one_v3(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     let expected_crc = compute_logical_v3_crc(
         LOGICAL_WAL_SPOOL_VERSION_V3,
         term,
+        if ownership_epoch == 0 {
+            None
+        } else {
+            Some(ownership_epoch)
+        },
         lsn,
         timestamp_ms,
         &payload,
@@ -303,6 +320,11 @@ fn read_one_v3(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     }
     Ok(LogicalWalEntry {
         term,
+        ownership_epoch: if ownership_epoch == 0 {
+            None
+        } else {
+            Some(ownership_epoch)
+        },
         lsn,
         timestamp_ms,
         data: payload,
@@ -325,6 +347,7 @@ fn read_one_v2(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     }
     Ok(LogicalWalEntry {
         term: 0,
+        ownership_epoch: None,
         lsn,
         timestamp_ms,
         data: payload,
@@ -338,6 +361,7 @@ fn read_one_v1(file: &mut File, record_start: u64) -> Result<LogicalWalEntry, St
     let payload = read_payload(file, payload_len, record_start)?;
     Ok(LogicalWalEntry {
         term: 0,
+        ownership_epoch: None,
         lsn,
         timestamp_ms: 0,
         data: payload,
@@ -385,6 +409,7 @@ fn compute_logical_v2_crc(version: u8, lsn: u64, timestamp_ms: u64, payload: &[u
 fn compute_logical_v3_crc(
     version: u8,
     term: u64,
+    ownership_epoch: Option<u64>,
     lsn: u64,
     timestamp_ms: u64,
     payload: &[u8],
@@ -392,6 +417,7 @@ fn compute_logical_v3_crc(
     let mut hasher = crc32fast::Hasher::new();
     hasher.update(&[version]);
     hasher.update(&term.to_le_bytes());
+    hasher.update(&ownership_epoch.unwrap_or(0).to_le_bytes());
     hasher.update(&lsn.to_le_bytes());
     hasher.update(&timestamp_ms.to_le_bytes());
     hasher.update(&(payload.len() as u32).to_le_bytes());
@@ -415,7 +441,7 @@ mod tests {
     #[test]
     fn v3_roundtrip_preserves_framing_term_and_timestamp() {
         let path = temp_path("v3");
-        let frame = encode_logical_wal_v3(7, 42, 99, b"payload").expect("encode");
+        let frame = encode_logical_wal_v3(7, None, 42, 99, b"payload").expect("encode");
         std::fs::write(&path, frame).expect("write");
 
         let entries = read_and_repair_logical_wal_entries(&path).expect("read");
@@ -432,9 +458,11 @@ mod tests {
     #[test]
     fn repair_truncates_torn_tail_to_last_valid_record() {
         let path = temp_path("repair");
-        let first = encode_logical_wal_v3(1, 1, 10, b"ok").expect("first");
+        let first = encode_logical_wal_v3(1, None, 1, 10, b"ok").expect("first");
         let mut bytes = first.clone();
-        bytes.extend_from_slice(&encode_logical_wal_v3(1, 2, 11, b"torn").expect("second")[..12]);
+        bytes.extend_from_slice(
+            &encode_logical_wal_v3(1, None, 2, 11, b"torn").expect("second")[..12],
+        );
         std::fs::write(&path, bytes).expect("write");
 
         let entries = read_and_repair_logical_wal_entries(&path).expect("repair");
@@ -465,6 +493,29 @@ mod tests {
     }
 
     #[test]
+    fn mixed_v2_v3_readback_surfaces_framing_term_and_epoch() {
+        let path = temp_path("mixed-v2-v3-authority");
+        let mut frames = encode_logical_wal_v2_for_compat(3, 44, b"legacy").expect("encode v2");
+        frames.extend_from_slice(
+            &encode_logical_wal_v3(7, Some(11), 4, 45, b"current").expect("encode v3"),
+        );
+        std::fs::write(&path, frames).expect("write");
+
+        let entries = read_and_repair_logical_wal_entries(&path).expect("read");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].term, 0);
+        assert_eq!(entries[0].ownership_epoch, None);
+        assert_eq!(entries[0].version, LOGICAL_WAL_SPOOL_VERSION_V2);
+        assert_eq!(entries[1].term, 7);
+        assert_eq!(entries[1].ownership_epoch, Some(11));
+        assert_eq!(entries[1].lsn, 4);
+        assert_eq!(entries[1].data, b"current");
+        assert_eq!(entries[1].version, LOGICAL_WAL_SPOOL_VERSION_V3);
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
     fn missing_paths_read_as_empty_wal() {
         let path = temp_path("missing");
         assert!(read_and_repair_logical_wal_entries(&path)
@@ -487,7 +538,8 @@ mod tests {
                 offset_64 = bytes.len() as u64;
             }
             bytes.extend_from_slice(
-                &encode_logical_wal_v3(2, lsn, 1_000 + lsn, format!("p{lsn}").as_bytes()).unwrap(),
+                &encode_logical_wal_v3(2, None, lsn, 1_000 + lsn, format!("p{lsn}").as_bytes())
+                    .unwrap(),
             );
         }
         std::fs::write(&path, bytes).unwrap();
@@ -534,7 +586,7 @@ mod tests {
 
     #[test]
     fn corruption_modes_truncate_to_last_good_record() {
-        let valid = encode_logical_wal_v3(1, 1, 1, b"ok").unwrap();
+        let valid = encode_logical_wal_v3(1, None, 1, 1, b"ok").unwrap();
 
         for (name, tail) in [
             ("bad-magic", b"NOPE".to_vec()),
@@ -557,11 +609,11 @@ mod tests {
 
     #[test]
     fn checksum_and_implausible_payload_are_repaired_away() {
-        let valid = encode_logical_wal_v3(1, 1, 1, b"ok").unwrap();
+        let valid = encode_logical_wal_v3(1, None, 1, 1, b"ok").unwrap();
 
         let path = temp_path("bad-crc");
         let mut bad_crc = valid.clone();
-        let mut corrupt = encode_logical_wal_v3(1, 2, 2, b"bad").unwrap();
+        let mut corrupt = encode_logical_wal_v3(1, None, 2, 2, b"bad").unwrap();
         let last = corrupt.len() - 1;
         corrupt[last] ^= 0xff;
         bad_crc.extend_from_slice(&corrupt);
@@ -576,6 +628,7 @@ mod tests {
         implausible.extend_from_slice(LOGICAL_WAL_SPOOL_MAGIC);
         implausible.push(LOGICAL_WAL_SPOOL_VERSION_V3);
         implausible.extend_from_slice(&1u64.to_le_bytes());
+        implausible.extend_from_slice(&0u64.to_le_bytes());
         implausible.extend_from_slice(&2u64.to_le_bytes());
         implausible.extend_from_slice(&3u64.to_le_bytes());
         implausible.extend_from_slice(&(MAX_PLAUSIBLE_PAYLOAD as u32 + 1).to_le_bytes());

--- a/crates/reddb-file/src/wal_record.rs
+++ b/crates/reddb-file/src/wal_record.rs
@@ -12,6 +12,8 @@ use crate::{WAL_FILE_VERSION, WAL_FILE_VERSION_V2};
 use std::io::{self, Read};
 
 pub const MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD: usize = 256;
+const MAX_MAIN_WAL_PAYLOAD: usize = 256 * 1024 * 1024;
+const MAX_MAIN_WAL_ITEMS: usize = 1_000_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
@@ -337,6 +339,7 @@ pub fn decode_main_wal_record_frame_with_authority<R: Read>(
             let page_id = read_u32_tracked(reader, &mut checksum_bytes)?;
             let compression = read_compression_tracked(reader, &mut checksum_bytes)?;
             let original_len = read_u32_tracked(reader, &mut checksum_bytes)? as usize;
+            validate_len(original_len, "main WAL original page length")?;
             let compressed = read_bytes_tracked(reader, &mut checksum_bytes)?;
             let data = match compression {
                 MainWalCompression::Zstd => {
@@ -360,6 +363,7 @@ pub fn decode_main_wal_record_frame_with_authority<R: Read>(
         MainWalRecordType::TxCommitBatch => {
             let tx_id = read_u64_tracked(reader, &mut checksum_bytes)?;
             let count = read_u32_tracked(reader, &mut checksum_bytes)? as usize;
+            validate_count(count, "main WAL action count")?;
             let mut actions = Vec::with_capacity(count);
             for _ in 0..count {
                 actions.push(read_bytes_tracked(reader, &mut checksum_bytes)?);
@@ -388,6 +392,7 @@ pub fn decode_main_wal_record_frame_with_authority<R: Read>(
                 })?;
             let entity_id = read_u64_tracked(reader, &mut checksum_bytes)?;
             let count = read_u32_tracked(reader, &mut checksum_bytes)? as usize;
+            validate_count(count, "main WAL vector length")?;
             let mut vector = Vec::with_capacity(count);
             for _ in 0..count {
                 vector.push(f32::from_le_bytes(read_array_tracked(
@@ -412,6 +417,7 @@ pub fn decode_main_wal_record_frame_with_authority<R: Read>(
                     )
                 })?;
             let count = read_u32_tracked(reader, &mut checksum_bytes)? as usize;
+            validate_count(count, "main WAL probabilistic operand count")?;
             let mut operands = Vec::with_capacity(count);
             for _ in 0..count {
                 operands.push(read_bytes_tracked(reader, &mut checksum_bytes)?);
@@ -484,10 +490,31 @@ fn read_bytes_tracked<R: Read>(
     checksum_bytes: &mut Vec<u8>,
 ) -> io::Result<Vec<u8>> {
     let len = read_u32_tracked(reader, checksum_bytes)? as usize;
+    validate_len(len, "main WAL payload length")?;
     let mut bytes = vec![0u8; len];
     reader.read_exact(&mut bytes)?;
     checksum_bytes.extend_from_slice(&bytes);
     Ok(bytes)
+}
+
+fn validate_len(len: usize, label: &'static str) -> io::Result<()> {
+    if len > MAX_MAIN_WAL_PAYLOAD {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("implausible {label}: {len}"),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_count(count: usize, label: &'static str) -> io::Result<()> {
+    if count > MAX_MAIN_WAL_ITEMS {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("implausible {label}: {count}"),
+        ));
+    }
+    Ok(())
 }
 
 fn read_u64_tracked<R: Read>(reader: &mut R, checksum_bytes: &mut Vec<u8>) -> io::Result<u64> {
@@ -646,6 +673,53 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "WAL record checksum mismatch"
+        );
+    }
+
+    #[test]
+    fn main_wal_record_rejects_implausible_payload_before_allocating() {
+        let mut encoded = Vec::new();
+        write_type_and_authority(
+            &mut encoded,
+            MainWalRecordType::PageWrite,
+            MainWalRecordAuthority {
+                term: 1,
+                ownership_epoch: None,
+            },
+        );
+        encoded.extend_from_slice(&7u64.to_le_bytes());
+        encoded.extend_from_slice(&3u32.to_le_bytes());
+        encoded.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let mut cursor = Cursor::new(encoded);
+        assert_eq!(
+            decode_main_wal_record_frame(&mut cursor, WAL_FILE_VERSION, 1)
+                .unwrap_err()
+                .to_string(),
+            "implausible main WAL payload length: 4294967295"
+        );
+    }
+
+    #[test]
+    fn main_wal_record_rejects_implausible_count_before_allocating() {
+        let mut encoded = Vec::new();
+        write_type_and_authority(
+            &mut encoded,
+            MainWalRecordType::TxCommitBatch,
+            MainWalRecordAuthority {
+                term: 1,
+                ownership_epoch: None,
+            },
+        );
+        encoded.extend_from_slice(&7u64.to_le_bytes());
+        encoded.extend_from_slice(&u32::MAX.to_le_bytes());
+
+        let mut cursor = Cursor::new(encoded);
+        assert_eq!(
+            decode_main_wal_record_frame(&mut cursor, WAL_FILE_VERSION, 1)
+                .unwrap_err()
+                .to_string(),
+            "implausible main WAL action count: 4294967295"
         );
     }
 

--- a/crates/reddb-file/src/wal_record.rs
+++ b/crates/reddb-file/src/wal_record.rs
@@ -105,9 +105,28 @@ pub enum MainWalRecordFrame {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MainWalRecordAuthority {
+    pub term: u64,
+    pub ownership_epoch: Option<u64>,
+}
+
 pub fn encode_main_wal_record_frame(frame: &MainWalRecordFrame, term: u64) -> io::Result<Vec<u8>> {
+    encode_main_wal_record_frame_with_authority(
+        frame,
+        MainWalRecordAuthority {
+            term,
+            ownership_epoch: None,
+        },
+    )
+}
+
+pub fn encode_main_wal_record_frame_with_authority(
+    frame: &MainWalRecordFrame,
+    authority: MainWalRecordAuthority,
+) -> io::Result<Vec<u8>> {
     let mut out = Vec::new();
-    encode_main_wal_record_frame_into(frame, term, &mut out)?;
+    encode_main_wal_record_frame_with_authority_into(frame, authority, &mut out)?;
     Ok(out)
 }
 
@@ -116,18 +135,33 @@ pub fn encode_main_wal_record_frame_into(
     term: u64,
     out: &mut Vec<u8>,
 ) -> io::Result<()> {
+    encode_main_wal_record_frame_with_authority_into(
+        frame,
+        MainWalRecordAuthority {
+            term,
+            ownership_epoch: None,
+        },
+        out,
+    )
+}
+
+pub fn encode_main_wal_record_frame_with_authority_into(
+    frame: &MainWalRecordFrame,
+    authority: MainWalRecordAuthority,
+    out: &mut Vec<u8>,
+) -> io::Result<()> {
     let start = out.len();
     match frame {
         MainWalRecordFrame::Begin { tx_id } => {
-            write_type_and_term(out, MainWalRecordType::Begin, term);
+            write_type_and_authority(out, MainWalRecordType::Begin, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
         MainWalRecordFrame::Commit { tx_id } => {
-            write_type_and_term(out, MainWalRecordType::Commit, term);
+            write_type_and_authority(out, MainWalRecordType::Commit, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
         MainWalRecordFrame::Rollback { tx_id } => {
-            write_type_and_term(out, MainWalRecordType::Rollback, term);
+            write_type_and_authority(out, MainWalRecordType::Rollback, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
         MainWalRecordFrame::PageWrite {
@@ -138,7 +172,11 @@ pub fn encode_main_wal_record_frame_into(
             if data.len() >= MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD {
                 if let Ok(compressed) = zstd::bulk::compress(data.as_slice(), 3) {
                     if compressed.len() < data.len() {
-                        write_type_and_term(out, MainWalRecordType::PageWriteCompressed, term);
+                        write_type_and_authority(
+                            out,
+                            MainWalRecordType::PageWriteCompressed,
+                            authority,
+                        );
                         out.extend_from_slice(&tx_id.to_le_bytes());
                         out.extend_from_slice(&page_id.to_le_bytes());
                         out.push(MainWalCompression::Zstd as u8);
@@ -151,14 +189,14 @@ pub fn encode_main_wal_record_frame_into(
                 }
             }
 
-            write_type_and_term(out, MainWalRecordType::PageWrite, term);
+            write_type_and_authority(out, MainWalRecordType::PageWrite, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
             out.extend_from_slice(&page_id.to_le_bytes());
             write_u32_len(out, data.len(), "main wal page length")?;
             out.extend_from_slice(data);
         }
         MainWalRecordFrame::TxCommitBatch { tx_id, actions } => {
-            write_type_and_term(out, MainWalRecordType::TxCommitBatch, term);
+            write_type_and_authority(out, MainWalRecordType::TxCommitBatch, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
             write_u32_len(out, actions.len(), "main wal action count")?;
             for action in actions {
@@ -172,7 +210,7 @@ pub fn encode_main_wal_record_frame_into(
             ckpt_epoch,
             data,
         } => {
-            write_type_and_term(out, MainWalRecordType::FullPageImage, term);
+            write_type_and_authority(out, MainWalRecordType::FullPageImage, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
             out.extend_from_slice(&page_id.to_le_bytes());
             out.extend_from_slice(&ckpt_epoch.to_le_bytes());
@@ -184,7 +222,7 @@ pub fn encode_main_wal_record_frame_into(
             entity_id,
             vector,
         } => {
-            write_type_and_term(out, MainWalRecordType::VectorInsert, term);
+            write_type_and_authority(out, MainWalRecordType::VectorInsert, authority);
             write_u32_len(out, collection.len(), "main wal collection name length")?;
             out.extend_from_slice(collection.as_bytes());
             out.extend_from_slice(&entity_id.to_le_bytes());
@@ -199,7 +237,7 @@ pub fn encode_main_wal_record_frame_into(
             name,
             operands,
         } => {
-            write_type_and_term(out, MainWalRecordType::ProbabilisticDelta, term);
+            write_type_and_authority(out, MainWalRecordType::ProbabilisticDelta, authority);
             out.push(*kind);
             out.push(*operation);
             write_u32_len(out, name.len(), "main wal probabilistic name length")?;
@@ -211,7 +249,7 @@ pub fn encode_main_wal_record_frame_into(
             }
         }
         MainWalRecordFrame::Checkpoint { lsn } => {
-            write_type_and_term(out, MainWalRecordType::Checkpoint, term);
+            write_type_and_authority(out, MainWalRecordType::Checkpoint, authority);
             out.extend_from_slice(&lsn.to_le_bytes());
         }
     }
@@ -225,6 +263,22 @@ pub fn decode_main_wal_record_frame<R: Read>(
     format_version: u8,
     default_term: u64,
 ) -> io::Result<Option<(u64, MainWalRecordFrame)>> {
+    Ok(decode_main_wal_record_frame_with_authority(
+        reader,
+        format_version,
+        MainWalRecordAuthority {
+            term: default_term,
+            ownership_epoch: None,
+        },
+    )?
+    .map(|(authority, frame)| (authority.term, frame)))
+}
+
+pub fn decode_main_wal_record_frame_with_authority<R: Read>(
+    reader: &mut R,
+    format_version: u8,
+    default_authority: MainWalRecordAuthority,
+) -> io::Result<Option<(MainWalRecordAuthority, MainWalRecordFrame)>> {
     let mut checksum_bytes = Vec::new();
     let mut type_buf = [0u8; 1];
     match reader.read_exact(&mut type_buf) {
@@ -236,9 +290,20 @@ pub fn decode_main_wal_record_frame<R: Read>(
     let record_type = MainWalRecordType::from_u8(type_buf[0])
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "Invalid record type"))?;
 
-    let term = match format_version {
-        WAL_FILE_VERSION => read_u64_tracked(reader, &mut checksum_bytes)?,
-        WAL_FILE_VERSION_V2 => default_term,
+    let authority = match format_version {
+        WAL_FILE_VERSION => {
+            let term = read_u64_tracked(reader, &mut checksum_bytes)?;
+            let ownership_epoch = read_u64_tracked(reader, &mut checksum_bytes)?;
+            MainWalRecordAuthority {
+                term,
+                ownership_epoch: if ownership_epoch == 0 {
+                    None
+                } else {
+                    Some(ownership_epoch)
+                },
+            }
+        }
+        WAL_FILE_VERSION_V2 => default_authority,
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -371,12 +436,17 @@ pub fn decode_main_wal_record_frame<R: Read>(
         ));
     }
 
-    Ok(Some((term, frame)))
+    Ok(Some((authority, frame)))
 }
 
-fn write_type_and_term(out: &mut Vec<u8>, record_type: MainWalRecordType, term: u64) {
+fn write_type_and_authority(
+    out: &mut Vec<u8>,
+    record_type: MainWalRecordType,
+    authority: MainWalRecordAuthority,
+) {
     out.push(record_type as u8);
-    out.extend_from_slice(&term.to_le_bytes());
+    out.extend_from_slice(&authority.term.to_le_bytes());
+    out.extend_from_slice(&authority.ownership_epoch.unwrap_or(0).to_le_bytes());
 }
 
 fn write_u32_len(out: &mut Vec<u8>, len: usize, label: &'static str) -> io::Result<()> {
@@ -520,6 +590,31 @@ mod tests {
             assert_eq!(term, 42);
             assert_eq!(decoded, frame);
         }
+    }
+
+    #[test]
+    fn main_wal_record_round_trip_current_format_authority_epoch() {
+        let frame = MainWalRecordFrame::Begin { tx_id: 42 };
+        let authority = MainWalRecordAuthority {
+            term: 7,
+            ownership_epoch: Some(11),
+        };
+        let encoded = encode_main_wal_record_frame_with_authority(&frame, authority).unwrap();
+
+        let mut cursor = Cursor::new(encoded);
+        let (decoded_authority, decoded) = decode_main_wal_record_frame_with_authority(
+            &mut cursor,
+            WAL_FILE_VERSION,
+            MainWalRecordAuthority {
+                term: 1,
+                ownership_epoch: None,
+            },
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(decoded_authority, authority);
+        assert_eq!(decoded, frame);
     }
 
     #[test]

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -26,6 +26,12 @@ fn term_from_payload(payload: &[u8]) -> u64 {
         .unwrap_or(crate::replication::DEFAULT_REPLICATION_TERM)
 }
 
+fn authority_from_payload(payload: &[u8]) -> (u64, Option<u64>) {
+    crate::replication::cdc::ChangeRecord::decode(payload)
+        .map(|record| (record.term, record.ownership_epoch))
+        .unwrap_or((crate::replication::DEFAULT_REPLICATION_TERM, None))
+}
+
 /// In-memory WAL buffer for replication.
 /// Primary appends records here; replicas consume from it.
 ///
@@ -122,8 +128,11 @@ fn logical_wal_entry_term(entry: &reddb_file::LogicalWalEntry) -> u64 {
 fn logical_wal_data_with_framing_term(entry: &reddb_file::LogicalWalEntry) -> Vec<u8> {
     let term = logical_wal_entry_term(entry);
     match crate::replication::cdc::ChangeRecord::decode(&entry.data) {
-        Ok(mut record) if record.term != term => {
+        Ok(mut record) if record.term != term || record.ownership_epoch != entry.ownership_epoch => {
             record.term = term;
+            if entry.ownership_epoch.is_some() {
+                record.ownership_epoch = entry.ownership_epoch;
+            }
             record.encode()
         }
         _ => entry.data.clone(),
@@ -243,12 +252,25 @@ impl LogicalWalSpool {
         timestamp_ms: u64,
         data: &[u8],
     ) -> io::Result<()> {
-        self.append_with_term_and_timestamp(term_from_payload(data), lsn, timestamp_ms, data)
+        let (term, ownership_epoch) = authority_from_payload(data);
+        self.append_with_term_epoch_and_timestamp(term, ownership_epoch, lsn, timestamp_ms, data)
     }
 
     pub fn append_with_term_and_timestamp(
         &self,
         term: u64,
+        lsn: u64,
+        timestamp_ms: u64,
+        data: &[u8],
+    ) -> io::Result<()> {
+        let (_, ownership_epoch) = authority_from_payload(data);
+        self.append_with_term_epoch_and_timestamp(term, ownership_epoch, lsn, timestamp_ms, data)
+    }
+
+    pub fn append_with_term_epoch_and_timestamp(
+        &self,
+        term: u64,
+        ownership_epoch: Option<u64>,
         lsn: u64,
         timestamp_ms: u64,
         data: &[u8],
@@ -266,7 +288,7 @@ impl LogicalWalSpool {
         //   (b) crc32 is computed exactly once over the same bytes the
         //       reader will checksum, with zero risk of header/payload
         //       drift from a partial flush.
-        let frame = reddb_file::encode_logical_wal_v3(term, lsn, timestamp_ms, data)?;
+        let frame = reddb_file::encode_logical_wal_v3(term, ownership_epoch, lsn, timestamp_ms, data)?;
 
         file.write_all(&frame)?;
         // PLAN.md Phase 2 mandates `sync_all` for logical WAL durability.

--- a/crates/reddb-server/src/replication/primary.rs
+++ b/crates/reddb-server/src/replication/primary.rs
@@ -128,7 +128,9 @@ fn logical_wal_entry_term(entry: &reddb_file::LogicalWalEntry) -> u64 {
 fn logical_wal_data_with_framing_term(entry: &reddb_file::LogicalWalEntry) -> Vec<u8> {
     let term = logical_wal_entry_term(entry);
     match crate::replication::cdc::ChangeRecord::decode(&entry.data) {
-        Ok(mut record) if record.term != term || record.ownership_epoch != entry.ownership_epoch => {
+        Ok(mut record)
+            if record.term != term || record.ownership_epoch != entry.ownership_epoch =>
+        {
             record.term = term;
             if entry.ownership_epoch.is_some() {
                 record.ownership_epoch = entry.ownership_epoch;
@@ -288,7 +290,8 @@ impl LogicalWalSpool {
         //   (b) crc32 is computed exactly once over the same bytes the
         //       reader will checksum, with zero risk of header/payload
         //       drift from a partial flush.
-        let frame = reddb_file::encode_logical_wal_v3(term, ownership_epoch, lsn, timestamp_ms, data)?;
+        let frame =
+            reddb_file::encode_logical_wal_v3(term, ownership_epoch, lsn, timestamp_ms, data)?;
 
         file.write_all(&frame)?;
         // PLAN.md Phase 2 mandates `sync_all` for logical WAL durability.

--- a/crates/reddb-server/src/replication/primary/tests.rs
+++ b/crates/reddb-server/src/replication/primary/tests.rs
@@ -110,6 +110,12 @@ fn logical_wal_spool_preserves_range_authority() {
     assert_eq!(derived.ownership_epoch, Some(4));
     assert_eq!(derived.term, 5);
 
+    let framed =
+        reddb_file::read_and_repair_logical_wal_entries(&spool_path).expect("read framed entries");
+    assert_eq!(framed[0].term, 5);
+    assert_eq!(framed[0].ownership_epoch, Some(4));
+    assert_eq!(framed[0].version, reddb_file::LOGICAL_WAL_SPOOL_VERSION_V3);
+
     let _ = fs::remove_file(spool_path);
 }
 
@@ -136,6 +142,7 @@ fn logical_wal_spool_reads_v2_without_term() {
     let framed = reddb_file::read_and_repair_logical_wal_entries(&spool_path)
         .expect("read framed v2 entries");
     assert_eq!(framed[0].term, 0);
+    assert_eq!(framed[0].ownership_epoch, None);
 
     let _ = fs::remove_file(spool_path);
 }

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -6,8 +6,8 @@ use std::io::{self, Read};
 
 pub const WAL_DEFAULT_TERM: u64 = crate::replication::DEFAULT_REPLICATION_TERM;
 
-pub use reddb_file::MainWalRecordType as RecordType;
 pub use reddb_file::MainWalRecordAuthority as WalRecordAuthority;
+pub use reddb_file::MainWalRecordType as RecordType;
 
 /// A single entry in the write-ahead log
 #[derive(Debug, Clone, PartialEq)]
@@ -128,25 +128,25 @@ impl WalRecord {
         reader: &mut R,
         format_version: u8,
     ) -> io::Result<Option<(u64, WalRecord)>> {
-        Ok(Self::read_with_authority_format_version(reader, format_version)?
-            .map(|(authority, record)| (authority.term, record)))
+        Ok(
+            Self::read_with_authority_format_version(reader, format_version)?
+                .map(|(authority, record)| (authority.term, record)),
+        )
     }
 
     pub(crate) fn read_with_authority_format_version<R: Read>(
         reader: &mut R,
         format_version: u8,
     ) -> io::Result<Option<(WalRecordAuthority, WalRecord)>> {
-        Ok(
-            decode_main_wal_record_frame_with_authority(
-                reader,
-                format_version,
-                WalRecordAuthority {
-                    term: WAL_DEFAULT_TERM,
-                    ownership_epoch: None,
-                },
-            )?
-            .map(|(authority, frame)| (authority, WalRecord::from_file_frame(frame))),
-        )
+        Ok(decode_main_wal_record_frame_with_authority(
+            reader,
+            format_version,
+            WalRecordAuthority {
+                term: WAL_DEFAULT_TERM,
+                ownership_epoch: None,
+            },
+        )?
+        .map(|(authority, frame)| (authority, WalRecord::from_file_frame(frame))))
     }
 }
 
@@ -362,8 +362,9 @@ mod tests {
         original.encode_with_authority_into(&mut encoded, authority);
 
         let mut cursor = Cursor::new(encoded);
-        let (decoded_authority, decoded) =
-            WalRecord::read_with_authority(&mut cursor).unwrap().unwrap();
+        let (decoded_authority, decoded) = WalRecord::read_with_authority(&mut cursor)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(decoded_authority, authority);
         assert_eq!(decoded, original);

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -1,12 +1,13 @@
 use reddb_file::{
-    decode_main_wal_record_frame, encode_main_wal_record_frame_into, MainWalRecordFrame,
-    WAL_FILE_VERSION,
+    decode_main_wal_record_frame_with_authority, encode_main_wal_record_frame_into,
+    encode_main_wal_record_frame_with_authority_into, MainWalRecordFrame, WAL_FILE_VERSION,
 };
 use std::io::{self, Read};
 
 pub const WAL_DEFAULT_TERM: u64 = crate::replication::DEFAULT_REPLICATION_TERM;
 
 pub use reddb_file::MainWalRecordType as RecordType;
+pub use reddb_file::MainWalRecordAuthority as WalRecordAuthority;
 
 /// A single entry in the write-ahead log
 #[derive(Debug, Clone, PartialEq)]
@@ -97,6 +98,11 @@ impl WalRecord {
             .expect("main WAL record cannot be encoded");
     }
 
+    pub fn encode_with_authority_into(&self, out: &mut Vec<u8>, authority: WalRecordAuthority) {
+        encode_main_wal_record_frame_with_authority_into(&self.to_file_frame(), authority, out)
+            .expect("main WAL record cannot be encoded");
+    }
+
     /// Read a record from a reader.
     ///
     /// Handles both v1 (`PageWrite`) and v2 (`PageWriteCompressed`) record
@@ -110,13 +116,36 @@ impl WalRecord {
         Self::read_with_format_version(reader, WAL_FILE_VERSION)
     }
 
+    /// Read a record and return the term + ownership epoch stamped into
+    /// its physical envelope.
+    pub fn read_with_authority<R: Read>(
+        reader: &mut R,
+    ) -> io::Result<Option<(WalRecordAuthority, WalRecord)>> {
+        Self::read_with_authority_format_version(reader, WAL_FILE_VERSION)
+    }
+
     pub(crate) fn read_with_format_version<R: Read>(
         reader: &mut R,
         format_version: u8,
     ) -> io::Result<Option<(u64, WalRecord)>> {
+        Ok(Self::read_with_authority_format_version(reader, format_version)?
+            .map(|(authority, record)| (authority.term, record)))
+    }
+
+    pub(crate) fn read_with_authority_format_version<R: Read>(
+        reader: &mut R,
+        format_version: u8,
+    ) -> io::Result<Option<(WalRecordAuthority, WalRecord)>> {
         Ok(
-            decode_main_wal_record_frame(reader, format_version, WAL_DEFAULT_TERM)?
-                .map(|(term, frame)| (term, WalRecord::from_file_frame(frame))),
+            decode_main_wal_record_frame_with_authority(
+                reader,
+                format_version,
+                WalRecordAuthority {
+                    term: WAL_DEFAULT_TERM,
+                    ownership_epoch: None,
+                },
+            )?
+            .map(|(authority, frame)| (authority, WalRecord::from_file_frame(frame))),
         )
     }
 }
@@ -319,6 +348,24 @@ mod tests {
         let (term, decoded) = WalRecord::read_with_term(&mut cursor).unwrap().unwrap();
 
         assert_eq!(term, 9);
+        assert_eq!(decoded, original);
+    }
+
+    #[test]
+    fn test_read_begin_roundtrip_preserves_authority_epoch() {
+        let original = WalRecord::Begin { tx_id: 42 };
+        let authority = WalRecordAuthority {
+            term: 9,
+            ownership_epoch: Some(12),
+        };
+        let mut encoded = Vec::new();
+        original.encode_with_authority_into(&mut encoded, authority);
+
+        let mut cursor = Cursor::new(encoded);
+        let (decoded_authority, decoded) =
+            WalRecord::read_with_authority(&mut cursor).unwrap().unwrap();
+
+        assert_eq!(decoded_authority, authority);
         assert_eq!(decoded, original);
     }
 

--- a/crates/reddb-server/src/storage/wal/writer.rs
+++ b/crates/reddb-server/src/storage/wal/writer.rs
@@ -506,8 +506,9 @@ mod tests {
         assert_eq!(lsn, 8);
 
         // Next record should start after encoded size
-        // Begin record: 1 (type) + 8 (term) + 8 (tx_id) + 4 (checksum) = 21 bytes
-        assert_eq!(writer.current_lsn(), 8 + 21);
+        // Begin record (v3 framing): 1 (type) + 8 (term) + 8 (ownership_epoch)
+        //   + 8 (tx_id) + 4 (checksum) = 29 bytes
+        assert_eq!(writer.current_lsn(), 8 + 29);
     }
 
     #[test]
@@ -526,8 +527,8 @@ mod tests {
             .expect("append() should succeed");
 
         assert_eq!(lsn1, 8);
-        assert_eq!(lsn2, 8 + 21);
-        assert_eq!(lsn3, 8 + 21 + 21);
+        assert_eq!(lsn2, 8 + 29);
+        assert_eq!(lsn3, 8 + 29 + 29);
     }
 
     #[test]
@@ -541,7 +542,7 @@ mod tests {
             .expect("append() should succeed");
         assert_eq!(lsn1, 8);
 
-        // PageWrite record: 1 + 8 + 4 + 4 + data_len + 4 = 21 + data_len
+        // PageWrite record (v3 framing): +8 bytes for ownership_epoch vs v2
         let data = vec![1, 2, 3, 4, 5];
         let lsn2 = writer
             .append(&WalRecord::PageWrite {
@@ -551,10 +552,10 @@ mod tests {
             })
             .expect("value is present");
 
-        assert_eq!(lsn2, 8 + 21); // after Begin
+        assert_eq!(lsn2, 8 + 29); // after Begin
 
-        // Next LSN = lsn2 + (1 + 8 + 8 + 4 + 4 + 5 + 4) = lsn2 + 34
-        assert_eq!(writer.current_lsn(), 8 + 21 + 34);
+        // Next LSN = lsn2 + (1 + 8 + 8 + 8 + 4 + 4 + 5 + 4) = lsn2 + 42
+        assert_eq!(writer.current_lsn(), 8 + 29 + 42);
     }
 
     #[test]
@@ -637,12 +638,12 @@ mod tests {
         let (_guard, path) = temp_wal("checkpoint");
         let mut writer = WalWriter::open(&path).expect("open() should succeed");
 
-        // Checkpoint is same size as Begin (1 + 8 + 8 + 4 = 21)
+        // Checkpoint is same size as Begin (v3: 1 + 8 + 8 + 8 + 4 = 29)
         let lsn = writer
             .append(&WalRecord::Checkpoint { lsn: 12345 })
             .expect("value is present");
         assert_eq!(lsn, 8);
-        assert_eq!(writer.current_lsn(), 8 + 21);
+        assert_eq!(writer.current_lsn(), 8 + 29);
     }
 
     // -----------------------------------------------------------------
@@ -875,8 +876,10 @@ mod tests {
                 .append(&WalRecord::Begin { tx_id: tx })
                 .expect("append() should succeed");
         }
-        // current_lsn reflects the in-buffer position.
-        assert_eq!(writer.current_lsn(), 8 + 100 * 21);
+        // current_lsn reflects the in-buffer position. Each v3 Begin record is
+        // 29 bytes: 1 (type) + 8 (term) + 8 (ownership_epoch) + 8 (tx_id)
+        //   + 4 (checksum).
+        assert_eq!(writer.current_lsn(), 8 + 100 * 29);
         // But the file on disk only has the header.
         let on_disk = std::fs::metadata(&path)
             .expect("metadata() should succeed")
@@ -967,7 +970,7 @@ mod tests {
             std::fs::metadata(&path)
                 .expect("metadata() should succeed")
                 .len(),
-            8 + 21
+            8 + 29
         );
     }
 
@@ -1089,7 +1092,7 @@ mod tests {
         let logical = std::fs::metadata(&path)
             .expect("metadata() should succeed")
             .len();
-        assert_eq!(logical, 8 + 50 * 21, "preallocation inflated i_size");
+        assert_eq!(logical, 8 + 50 * 29, "preallocation inflated i_size");
         assert_eq!(writer.current_lsn(), logical);
     }
 


### PR DESCRIPTION
Automated AFK landing for #1837. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1837

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786048618&installation_id=129708444&pr_number=1916&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1916&signature=1cc2027449dbe6071788940269d30c61aa9e710acb03bc5be11b17ebab4462c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->