### PR TITLE
chore: #1839 Replica reads honor causal session tokens with catch-up and fallback

### DIFF
--- a/crates/reddb-client/src/grpc.rs
+++ b/crates/reddb-client/src/grpc.rs
@@ -14,10 +14,11 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use crate::connector::RedDBClient;
 
+use crate::bookmark_routing::{BookmarkTarget, BookmarkWaiter, CausalReadOptions, RoutingTable};
 use crate::error::{ClientError, ErrorCode, Result};
 use crate::params::Value as ParamValue;
 use crate::router::{HealthAwareRouter, Outcome};
@@ -63,6 +64,9 @@ pub struct GrpcClient {
     /// endpoint. Behind an `RwLock` so [`update_membership`] can
     /// swap the membership snapshot without poisoning hot reads.
     router: RwLock<HealthAwareRouter>,
+    /// Latest topology snapshot, including each replica's contiguous
+    /// applied frontier for causal-read routing.
+    membership: RwLock<ClusterMembership>,
 }
 
 /// One remote endpoint plus a fixed pool of `RedDBClient` clones.
@@ -137,7 +141,10 @@ impl GrpcClient {
     pub async fn connect_with_pool_size(endpoint: String, pool_size: usize) -> Result<Self> {
         let primary = Endpoint::connect(endpoint, pool_size).await?;
         let membership = ClusterMembership::from_uri_addresses(primary.url.clone(), Vec::new());
-        let router = RwLock::new(HealthAwareRouter::with_force_primary(membership, true));
+        let router = RwLock::new(HealthAwareRouter::with_force_primary(
+            membership.clone(),
+            true,
+        ));
         Ok(Self {
             primary,
             replicas: RwLock::new(Vec::new()),
@@ -145,6 +152,7 @@ impl GrpcClient {
             force_primary: true,
             pool_size,
             router,
+            membership: RwLock::new(membership),
         })
     }
 
@@ -179,7 +187,7 @@ impl GrpcClient {
             replica_eps.iter().map(|e| e.url.clone()).collect(),
         );
         let router = RwLock::new(HealthAwareRouter::with_force_primary(
-            membership,
+            membership.clone(),
             force_primary,
         ));
         Ok(Self {
@@ -189,6 +197,7 @@ impl GrpcClient {
             force_primary,
             pool_size,
             router,
+            membership: RwLock::new(membership),
         })
     }
 
@@ -232,12 +241,24 @@ impl GrpcClient {
         }
     }
 
+    fn endpoint_by_addr(&self, addr: &str) -> (RedDBClient, usize) {
+        if addr == self.primary.url {
+            return (self.primary.pick(), 0);
+        }
+        let replicas = self.replicas.read().unwrap();
+        match replicas.iter().enumerate().find(|(_, ep)| ep.url == addr) {
+            Some((idx, ep)) => (ep.pick(), idx + 1),
+            None => (self.primary.pick(), 0),
+        }
+    }
+
     /// Refresh routing state from a new canonical cluster membership.
     pub fn update_membership(&self, new_membership: ClusterMembership) {
         self.router
             .write()
             .unwrap()
-            .update_membership(new_membership);
+            .update_membership(new_membership.clone());
+        *self.membership.write().unwrap() = new_membership;
     }
 
     /// Refresh the live replica pool from a topology advertisement.
@@ -306,6 +327,7 @@ impl GrpcClient {
             .write()
             .unwrap()
             .update_membership(membership.clone());
+        *self.membership.write().unwrap() = membership.clone();
         Ok(())
     }
 
@@ -342,6 +364,29 @@ impl GrpcClient {
 
     pub async fn query(&self, sql: &str) -> Result<QueryResult> {
         let (mut client, idx) = self.read_endpoint();
+        self.query_on_endpoint(&mut client, idx, sql).await
+    }
+
+    pub async fn query_causal(
+        &self,
+        sql: &str,
+        bookmark: BookmarkTarget,
+        opts: CausalReadOptions,
+    ) -> Result<QueryResult> {
+        let membership = self.membership.read().unwrap().clone();
+        let table = RoutingTable::from_membership(membership, bookmark.term());
+        let mut waiter = MembershipFrontierWaiter::new(&self.membership);
+        let decision = table.route_causal_read(bookmark, &opts, &mut waiter);
+        let (mut client, idx) = self.endpoint_by_addr(&decision.endpoint.addr);
+        self.query_on_endpoint(&mut client, idx, sql).await
+    }
+
+    async fn query_on_endpoint(
+        &self,
+        client: &mut RedDBClient,
+        idx: usize,
+        sql: &str,
+    ) -> Result<QueryResult> {
         let started = Instant::now();
         let reply = match client.query_reply(sql).await {
             Ok(r) => {
@@ -508,6 +553,38 @@ impl GrpcClient {
     ) -> std::result::Result<crate::topology::ClusterMembership, crate::topology::ConsumeError>
     {
         crate::topology::TopologyConsumer::consume_bytes(bytes, uri_seed)
+    }
+}
+
+struct MembershipFrontierWaiter<'a> {
+    membership: &'a RwLock<ClusterMembership>,
+    started: Instant,
+}
+
+impl<'a> MembershipFrontierWaiter<'a> {
+    fn new(membership: &'a RwLock<ClusterMembership>) -> Self {
+        Self {
+            membership,
+            started: Instant::now(),
+        }
+    }
+}
+
+impl BookmarkWaiter for MembershipFrontierWaiter<'_> {
+    fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+
+    fn poll(&mut self, target_addr: &str) -> u64 {
+        std::thread::sleep(Duration::from_millis(1));
+        self.membership
+            .read()
+            .unwrap()
+            .replicas
+            .iter()
+            .find(|replica| replica.addr == target_addr)
+            .map(|replica| replica.last_applied_lsn)
+            .unwrap_or(0)
     }
 }
 

--- a/crates/reddb-client/tests/grpc_pool_concurrency.rs
+++ b/crates/reddb-client/tests/grpc_pool_concurrency.rs
@@ -23,7 +23,10 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use reddb_client::bookmark_routing::{BookmarkTarget, CausalReadOptions};
 use reddb_client::grpc::GrpcClient;
+use reddb_client::topology::ClusterMembership;
+use reddb_client::ValueOut;
 use reddb_client::RedDBClient;
 use reddb_grpc_proto::red_db_server::{RedDb, RedDbServer};
 use reddb_grpc_proto::*;
@@ -69,7 +72,9 @@ macro_rules! stub_rpc {
     };
 }
 
-struct SlowMock;
+struct SlowMock {
+    endpoint_label: &'static str,
+}
 
 #[tonic::async_trait]
 impl RedDb for SlowMock {
@@ -105,11 +110,15 @@ impl RedDb for SlowMock {
             mode: "select".into(),
             statement: "select".into(),
             engine: "mock".into(),
-            columns: vec![],
-            record_count: 0,
+            columns: vec!["endpoint".into()],
+            record_count: 1,
             // Minimal valid JSON the client's `parse_query_json`
-            // accepts. Empty rows + columns is fine.
-            result_json: r#"{"statement":"select","affected":0,"columns":[],"rows":[]}"#.into(),
+            // accepts. Include the endpoint so routing assertions
+            // observe which server handled the read.
+            result_json: format!(
+                r#"{{"statement":"select","affected":0,"columns":["endpoint"],"rows":[{{"endpoint":"{}"}}]}}"#,
+                self.endpoint_label
+            ),
             affected_rows: 0,
         }))
     }
@@ -285,13 +294,17 @@ impl RedDb for SlowMock {
 /// plus a shutdown trigger. The caller should drop the trigger to
 /// stop the server.
 async fn spawn_slow_mock() -> (SocketAddr, oneshot::Sender<()>) {
+    spawn_labeled_mock("slow").await
+}
+
+async fn spawn_labeled_mock(endpoint_label: &'static str) -> (SocketAddr, oneshot::Sender<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let incoming = TcpListenerStream::new(listener);
     let (tx, rx) = oneshot::channel::<()>();
     tokio::spawn(async move {
         Server::builder()
-            .add_service(RedDbServer::new(SlowMock))
+            .add_service(RedDbServer::new(SlowMock { endpoint_label }))
             .serve_with_incoming_shutdown(incoming, async {
                 let _ = rx.await;
             })
@@ -302,6 +315,18 @@ async fn spawn_slow_mock() -> (SocketAddr, oneshot::Sender<()>) {
     // accepting before we connect.
     tokio::time::sleep(Duration::from_millis(20)).await;
     (addr, tx)
+}
+
+fn endpoint_label(result: &reddb_client::QueryResult) -> &str {
+    let row = result.rows.first().expect("one row");
+    let (_, value) = row
+        .iter()
+        .find(|(name, _)| name == "endpoint")
+        .expect("endpoint column");
+    match value {
+        ValueOut::String(s) => s,
+        other => panic!("endpoint should be a string, got {other:?}"),
+    }
 }
 
 /// Drive `N` concurrent `query` calls through the new `GrpcClient`
@@ -424,4 +449,50 @@ async fn pool_runs_queries_in_parallel_vs_legacy_mutex_baseline() {
     // don't pin its timing; tonic's underlying channel multiplexing
     // means observed parallelism varies.
     let _ = single_pool_elapsed;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn causal_query_falls_back_to_primary_when_replica_is_stale_but_tokenless_read_stays_replica_default(
+) {
+    let (primary_addr, primary_shutdown) = spawn_labeled_mock("primary").await;
+    let (replica_addr, replica_shutdown) = spawn_labeled_mock("replica").await;
+    let primary_url = format!("http://{primary_addr}");
+    let replica_url = format!("http://{replica_addr}");
+
+    let client = GrpcClient::connect_cluster_with_pool_size(
+        primary_url.clone(),
+        vec![replica_url.clone()],
+        false,
+        1,
+    )
+    .await
+    .expect("connect cluster");
+    client.update_membership(ClusterMembership::from_uri_addresses(
+        primary_url.clone(),
+        vec![replica_url.clone()],
+    ));
+
+    let tokenless = client.query("select endpoint").await.expect("tokenless read");
+    assert_eq!(
+        endpoint_label(&tokenless),
+        "replica",
+        "ordinary reads keep the eventual-consistency replica default"
+    );
+
+    let causal = client
+        .query_causal(
+            "select endpoint",
+            BookmarkTarget::new(1, 100),
+            CausalReadOptions::with_deadline(Duration::from_millis(1)),
+        )
+        .await
+        .expect("causal read");
+    assert_eq!(
+        endpoint_label(&causal),
+        "primary",
+        "stale replica must not serve a read carrying a causal token"
+    );
+
+    let _ = primary_shutdown.send(());
+    let _ = replica_shutdown.send(());
 }

--- a/crates/reddb-client/tests/grpc_pool_concurrency.rs
+++ b/crates/reddb-client/tests/grpc_pool_concurrency.rs
@@ -26,8 +26,8 @@ use std::time::{Duration, Instant};
 use reddb_client::bookmark_routing::{BookmarkTarget, CausalReadOptions};
 use reddb_client::grpc::GrpcClient;
 use reddb_client::topology::ClusterMembership;
-use reddb_client::ValueOut;
 use reddb_client::RedDBClient;
+use reddb_client::ValueOut;
 use reddb_grpc_proto::red_db_server::{RedDb, RedDbServer};
 use reddb_grpc_proto::*;
 use tokio::sync::{oneshot, Mutex};
@@ -472,7 +472,10 @@ async fn causal_query_falls_back_to_primary_when_replica_is_stale_but_tokenless_
         vec![replica_url.clone()],
     ));
 
-    let tokenless = client.query("select endpoint").await.expect("tokenless read");
+    let tokenless = client
+        .query("select endpoint")
+        .await
+        .expect("tokenless read");
     assert_eq!(
         endpoint_label(&tokenless),
         "replica",


### PR DESCRIPTION
Automated AFK landing for #1839. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1839

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786051822&installation_id=129708444&pr_number=1917&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1917&signature=96c529e781de07ff0b371e5640e00f72ffb3e623c3b61f01b9c080f4ee30e587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added causal read support over gRPC, letting reads wait for fresher replica state when needed.
  * Improved endpoint routing so requests can be directed to the best available node based on live cluster state.

* **Bug Fixes**
  * Kept routing decisions in sync with topology changes for more reliable read behavior.
  * Added coverage for fallback behavior when a replica is too stale, ensuring reads can switch to the primary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->