### PR TITLE
chore: #1840 Per-request commit-policy strengthening above the collection HA floor

### DIFF
--- a/crates/reddb-server/src/cluster/commit_resolution.rs
+++ b/crates/reddb-server/src/cluster/commit_resolution.rs
@@ -149,6 +149,8 @@ pub enum ResolutionSource {
     ClusterDefault,
     /// The collection's own override applied.
     CollectionOverride,
+    /// A per-request override strengthened the already-resolved floor.
+    RequestOverride,
 }
 
 impl ResolutionSource {
@@ -156,6 +158,7 @@ impl ResolutionSource {
         match self {
             Self::ClusterDefault => "cluster_default",
             Self::CollectionOverride => "collection_override",
+            Self::RequestOverride => "request_override",
         }
     }
 }
@@ -228,6 +231,11 @@ pub enum CommitPolicyViolation {
         model: CollectionDataModel,
         source: ResolutionSource,
     },
+    /// A per-request override attempted to weaken the already-resolved floor.
+    RequestBelowResolvedFloor {
+        floor: CommitPolicy,
+        requested: CommitPolicy,
+    },
 }
 
 impl CommitPolicyViolation {
@@ -239,6 +247,18 @@ impl CommitPolicyViolation {
                 model.label(),
                 source.label()
             ),
+            Self::RequestBelowResolvedFloor { floor, requested } => format!(
+                "per-request commit policy '{}' is weaker than resolved floor '{}'",
+                requested.detail_label(),
+                floor.detail_label()
+            ),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::DurableLocalUnderHa { .. } => "DURABLE_LOCAL_UNDER_HA",
+            Self::RequestBelowResolvedFloor { .. } => "COMMIT_POLICY_BELOW_FLOOR",
         }
     }
 }
@@ -255,6 +275,42 @@ impl std::error::Error for CommitPolicyViolation {}
 /// `Local`, or the degenerate `AckN(0)` the policy docs define as equivalent.
 pub fn is_local_ack(policy: CommitPolicy) -> bool {
     matches!(policy, CommitPolicy::Local | CommitPolicy::AckN(0))
+}
+
+fn durability_rank(policy: CommitPolicy) -> u64 {
+    match policy {
+        CommitPolicy::Local | CommitPolicy::AckN(0) => 0,
+        CommitPolicy::RemoteWal => 10,
+        CommitPolicy::AckN(n) => 100 + u64::from(n),
+        CommitPolicy::Quorum => 10_000,
+    }
+}
+
+/// Apply an optional per-request override to an already-resolved floor.
+///
+/// The request may strengthen durability for one write, but it may not weaken
+/// the floor chosen by collection/HA resolution. Weakening is rejected rather
+/// than clamped so callers can surface a typed client error.
+pub fn resolve_request_commit_policy(
+    floor: CommitPolicyResolution,
+    request_override: Option<CommitPolicy>,
+) -> Result<CommitPolicyResolution, CommitPolicyViolation> {
+    let Some(requested) = request_override else {
+        return Ok(floor);
+    };
+
+    if durability_rank(requested) < durability_rank(floor.effective) {
+        return Err(CommitPolicyViolation::RequestBelowResolvedFloor {
+            floor: floor.effective,
+            requested,
+        });
+    }
+
+    Ok(CommitPolicyResolution {
+        effective: requested,
+        source: ResolutionSource::RequestOverride,
+        guardrail: floor.guardrail,
+    })
 }
 
 /// Deterministically resolve the effective commit policy for one collection.
@@ -365,6 +421,44 @@ mod tests {
         assert_eq!(r.effective, CommitPolicy::Quorum);
         assert_eq!(r.source, ResolutionSource::CollectionOverride);
         assert_eq!(r.guardrail, GuardrailDisposition::Satisfied);
+    }
+
+    #[test]
+    fn request_override_can_strengthen_above_resolved_floor() {
+        let floor = resolve_commit_policy(
+            CommitPolicy::Local,
+            None,
+            CollectionDataModel::Transactional,
+            HaIntent::None,
+        )
+        .expect("non-HA local floor resolves");
+
+        let r = resolve_request_commit_policy(floor, Some(CommitPolicy::Quorum))
+            .expect("request may strengthen local floor to quorum");
+        assert_eq!(r.effective, CommitPolicy::Quorum);
+        assert_eq!(r.source, ResolutionSource::RequestOverride);
+    }
+
+    #[test]
+    fn request_override_rejects_weaker_than_resolved_floor() {
+        let floor = resolve_commit_policy(
+            CommitPolicy::Quorum,
+            None,
+            CollectionDataModel::Transactional,
+            HaIntent::Declared,
+        )
+        .expect("quorum floor resolves");
+
+        let err = resolve_request_commit_policy(floor, Some(CommitPolicy::AckN(1)))
+            .expect_err("request may not weaken quorum floor");
+        assert_eq!(
+            err,
+            CommitPolicyViolation::RequestBelowResolvedFloor {
+                floor: CommitPolicy::Quorum,
+                requested: CommitPolicy::AckN(1),
+            }
+        );
+        assert_eq!(err.code(), "COMMIT_POLICY_BELOW_FLOOR");
     }
 
     // AC: local commit allowed for ephemeral/cache-like data under HA intent.

--- a/crates/reddb-server/src/cluster/mod.rs
+++ b/crates/reddb-server/src/cluster/mod.rs
@@ -31,8 +31,9 @@ pub use bootstrap_authority::{
     plan_vault_bootstrap, AuthBootstrapInput, BootstrapDisposition, VaultBootstrapPlan,
 };
 pub use commit_resolution::{
-    is_local_ack, resolve_commit_policy, CollectionDataModel, CommitPolicyResolution,
-    CommitPolicyViolation, FailoverEligibility, GuardrailDisposition, HaIntent, ResolutionSource,
+    is_local_ack, resolve_commit_policy, resolve_request_commit_policy, CollectionDataModel,
+    CommitPolicyResolution, CommitPolicyViolation, FailoverEligibility, GuardrailDisposition,
+    HaIntent, ResolutionSource,
 };
 pub use control_plane::{
     ControlPlaneConsensus, ControlPlaneEntry, ControlPlaneError, ControlPlaneIndex,

--- a/crates/reddb-server/src/replication/commit_policy.rs
+++ b/crates/reddb-server/src/replication/commit_policy.rs
@@ -38,6 +38,30 @@ impl CommitPolicy {
         }
     }
 
+    pub fn detail_label(self) -> String {
+        match self {
+            Self::AckN(n) => format!("ack_n={n}"),
+            _ => self.label().to_string(),
+        }
+    }
+
+    pub fn parse_strict(raw: &str) -> Option<Self> {
+        let lower = raw.trim().to_ascii_lowercase();
+        if lower == "local" {
+            return Some(Self::Local);
+        }
+        if lower == "remote_wal" {
+            return Some(Self::RemoteWal);
+        }
+        if lower == "quorum" {
+            return Some(Self::Quorum);
+        }
+        if let Some(n_str) = lower.strip_prefix("ack_n=") {
+            return n_str.parse::<u32>().ok().map(Self::AckN);
+        }
+        None
+    }
+
     /// Parse from `RED_PRIMARY_COMMIT_POLICY` env var. Accepts:
     /// `local` (default), `remote_wal`, `ack_n=N` (decimal),
     /// `quorum`. Unknown values fall back to `Local` with a warning.
@@ -105,5 +129,15 @@ mod tests {
         assert_eq!(CommitPolicy::RemoteWal.label(), "remote_wal");
         assert_eq!(CommitPolicy::AckN(5).label(), "ack_n");
         assert_eq!(CommitPolicy::Quorum.label(), "quorum");
+    }
+
+    #[test]
+    fn strict_parse_rejects_unknown_values() {
+        assert_eq!(
+            CommitPolicy::parse_strict("ack_n=2"),
+            Some(CommitPolicy::AckN(2))
+        );
+        assert_eq!(CommitPolicy::parse_strict("nonsense"), None);
+        assert_eq!(CommitPolicy::parse_strict(""), None);
     }
 }

--- a/crates/reddb-server/src/runtime/impl_replication_commit.rs
+++ b/crates/reddb-server/src/runtime/impl_replication_commit.rs
@@ -151,6 +151,18 @@ impl RedDBRuntime {
         )
     }
 
+    pub fn resolve_request_commit_policy(
+        &self,
+        request_override: Option<crate::replication::CommitPolicy>,
+    ) -> Result<crate::cluster::CommitPolicyResolution, crate::cluster::CommitPolicyViolation> {
+        let floor = crate::cluster::CommitPolicyResolution {
+            effective: self.commit_policy(),
+            source: crate::cluster::ResolutionSource::ClusterDefault,
+            guardrail: crate::cluster::GuardrailDisposition::NotApplicable,
+        };
+        crate::cluster::resolve_request_commit_policy(floor, request_override)
+    }
+
     pub fn primary_replica_durability(&self) -> reddb_file::ReplicationDurability {
         Self::primary_replica_durability_for_policy(self.commit_policy())
     }
@@ -285,7 +297,25 @@ impl RedDBRuntime {
         &self,
         post_lsn: u64,
     ) -> RedDBResult<crate::replication::AwaitOutcome> {
-        let policy = self.commit_policy();
+        self.enforce_commit_policy_for_policy(post_lsn, self.commit_policy())
+    }
+
+    pub fn enforce_commit_policy_for_request(
+        &self,
+        post_lsn: u64,
+        request_override: Option<crate::replication::CommitPolicy>,
+    ) -> RedDBResult<crate::replication::AwaitOutcome> {
+        let resolution = self
+            .resolve_request_commit_policy(request_override)
+            .map_err(commit_policy_violation_error)?;
+        self.enforce_commit_policy_for_policy(post_lsn, resolution.effective)
+    }
+
+    fn enforce_commit_policy_for_policy(
+        &self,
+        post_lsn: u64,
+        policy: crate::replication::CommitPolicy,
+    ) -> RedDBResult<crate::replication::AwaitOutcome> {
         if matches!(policy, crate::replication::CommitPolicy::Quorum) {
             return match self.inner.db.wait_for_replication_quorum(post_lsn) {
                 Ok(()) => Ok(crate::replication::AwaitOutcome::Reached(0)),
@@ -410,5 +440,23 @@ impl RedDBRuntime {
             }
         }
         Ok(outcome)
+    }
+}
+
+fn commit_policy_violation_error(violation: crate::cluster::CommitPolicyViolation) -> RedDBError {
+    let code = violation.code();
+    let detail = violation.message();
+    let mut validation = crate::json::Map::new();
+    validation.insert(
+        "code".to_string(),
+        crate::json::Value::String(code.to_string()),
+    );
+    validation.insert(
+        "message".to_string(),
+        crate::json::Value::String(detail.clone()),
+    );
+    RedDBError::Validation {
+        message: format!("{code}: {detail}"),
+        validation: crate::json::Value::Object(validation),
     }
 }

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -403,6 +403,7 @@ struct ParsedQueryRequest {
     query: String,
     entity_types: Option<Vec<String>>,
     capabilities: Option<Vec<String>>,
+    commit_policy: Option<crate::replication::CommitPolicy>,
     /// Optional positional `$N` bind parameters (#358). When `Some`, the
     /// query handler runs the user_params binder before executing.
     /// Absence preserves the legacy `query`-only behavior.

--- a/crates/reddb-server/src/server/handlers_query.rs
+++ b/crates/reddb-server/src/server/handlers_query.rs
@@ -10,6 +10,7 @@ impl RedDBServer {
             query,
             entity_types,
             capabilities,
+            commit_policy,
             params,
         } = request;
         let stream_ask = is_stream_ask_query(&query);
@@ -35,13 +36,33 @@ impl RedDBServer {
                 let is_mutation = matches!(result.statement_type, "insert" | "update" | "delete");
                 if is_mutation {
                     let post_lsn = self.runtime.cdc_current_lsn();
-                    if let Err(err) = self.runtime.enforce_commit_policy(post_lsn) {
-                        // Only fired when RED_COMMIT_FAIL_ON_TIMEOUT=true
-                        // — operator opted into hard-blocking. 504
-                        // is the right code: the local write
-                        // succeeded, but the configured durability
-                        // contract didn't.
-                        return json_error(504, err.to_string());
+                    if let Err(err) = self
+                        .runtime
+                        .enforce_commit_policy_for_request(post_lsn, commit_policy)
+                    {
+                        match err {
+                            crate::api::RedDBError::Validation {
+                                message,
+                                validation,
+                            } => {
+                                let mut object = crate::json::Map::new();
+                                object.insert("ok".to_string(), crate::json::Value::Bool(false));
+                                object.insert(
+                                    "error".to_string(),
+                                    crate::json_field::SerializedJsonField::tainted(&message),
+                                );
+                                object.insert("validation".to_string(), validation);
+                                return json_response(422, crate::json::Value::Object(object));
+                            }
+                            other => {
+                                // Only fired when RED_COMMIT_FAIL_ON_TIMEOUT=true
+                                // — operator opted into hard-blocking. 504
+                                // is the right code: the local write
+                                // succeeded, but the configured durability
+                                // contract didn't.
+                                return json_error(504, other.to_string());
+                            }
+                        }
                     }
                 }
                 json_response(

--- a/crates/reddb-server/src/server/request_body.rs
+++ b/crates/reddb-server/src/server/request_body.rs
@@ -24,11 +24,13 @@ pub(crate) fn extract_query_request(body: &[u8]) -> Result<ParsedQueryRequest, H
             let (entity_types, capabilities) =
                 crate::application::query_payload::parse_json_search_selection(&json)
                     .map_err(|err| json_error(400, err.to_string()))?;
+            let commit_policy = parse_commit_policy_field(&json)?;
             let params = parse_params_field(&json)?;
             return Ok(ParsedQueryRequest {
                 query: query.to_string(),
                 entity_types,
                 capabilities,
+                commit_policy,
                 params,
             });
         }
@@ -42,8 +44,31 @@ pub(crate) fn extract_query_request(body: &[u8]) -> Result<ParsedQueryRequest, H
         query: trimmed.to_string(),
         entity_types: None,
         capabilities: None,
+        commit_policy: None,
         params: None,
     })
+}
+
+fn parse_commit_policy_field(
+    json: &JsonValue,
+) -> Result<Option<crate::replication::CommitPolicy>, HttpResponse> {
+    match json.get("commit_policy") {
+        None => Ok(None),
+        Some(JsonValue::String(value)) => crate::replication::CommitPolicy::parse_strict(value)
+            .map(Some)
+            .ok_or_else(|| {
+                json_error_code(
+                    400,
+                    "INVALID_COMMIT_POLICY",
+                    format!("invalid commit_policy value '{value}'"),
+                )
+            }),
+        Some(_) => Err(json_error_code(
+            400,
+            "INVALID_COMMIT_POLICY",
+            "'commit_policy' must be a string",
+        )),
+    }
 }
 
 /// Parse the optional `params` JSON array on a query request body.

--- a/crates/reddb-server/src/wire/redwire/session.rs
+++ b/crates/reddb-server/src/wire/redwire/session.rs
@@ -20,7 +20,7 @@ use crate::auth::Role;
 use crate::runtime::RedDBRuntime;
 use crate::serde_json::{self, Value as JsonValue};
 use reddb_wire::query_with_params::{
-    decode_query_with_params, ParamValue as RedWireParamValue, FEATURE_PARAMS,
+    decode_query_with_params_request, ParamValue as RedWireParamValue, FEATURE_PARAMS,
 };
 use reddb_wire::redwire::operations::{
     decode_delete_payload, decode_get_payload, decode_insert_dispatch_payload,
@@ -1152,20 +1152,27 @@ fn run_query(runtime: &RedDBRuntime, frame: &Frame) -> Frame {
 }
 
 fn run_query_with_params(runtime: &RedDBRuntime, frame: &Frame) -> Frame {
-    let (sql, params) = match decode_query_with_params(&frame.payload) {
+    let request = match decode_query_with_params_request(&frame.payload) {
         Ok(decoded) => decoded,
         Err(err) => return build_error_frame_lossy(frame.correlation_id, &err.to_string()),
     };
-    let params = params
+    let commit_policy = match parse_redwire_commit_policy(request.options.commit_policy.as_deref())
+    {
+        Ok(policy) => policy,
+        Err(err) => return build_error_frame_lossy(frame.correlation_id, &err),
+    };
+    let params = request
+        .params
         .into_iter()
         .map(param_to_schema_value)
         .collect::<Vec<_>>();
-    match runtime.execute_query_with_params(&sql, &params) {
+    match runtime.execute_query_with_params(&request.sql, &params) {
         Ok(result) => {
             let is_mutation = matches!(result.statement_type, "insert" | "update" | "delete");
             if is_mutation {
                 let post_lsn = runtime.cdc_current_lsn();
-                if let Err(err) = runtime.enforce_commit_policy(post_lsn) {
+                if let Err(err) = runtime.enforce_commit_policy_for_request(post_lsn, commit_policy)
+                {
                     return build_error_frame_lossy(frame.correlation_id, &err.to_string());
                 }
             }
@@ -1177,6 +1184,17 @@ fn run_query_with_params(runtime: &RedDBRuntime, frame: &Frame) -> Frame {
         }
         Err(err) => build_error_frame_lossy(frame.correlation_id, &err.to_string()),
     }
+}
+
+fn parse_redwire_commit_policy(
+    value: Option<&str>,
+) -> Result<Option<crate::replication::CommitPolicy>, String> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    crate::replication::CommitPolicy::parse_strict(value)
+        .map(Some)
+        .ok_or_else(|| format!("invalid commit_policy value '{value}'"))
 }
 
 fn param_to_schema_value(value: RedWireParamValue) -> crate::storage::schema::Value {
@@ -1426,7 +1444,52 @@ mod tests {
     use super::*;
 
     use crate::runtime::RedDBRuntime;
+    use std::sync::{Mutex, OnceLock};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvGuard {
+        previous: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvGuard {
+        fn set(vars: &[(&'static str, &'static str)]) -> Self {
+            let previous = vars
+                .iter()
+                .map(|(key, _)| (*key, std::env::var(key).ok()))
+                .collect();
+            for (key, value) in vars {
+                std::env::set_var(key, value);
+            }
+            Self { previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.previous.iter().rev() {
+                match value {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    fn temp_data_path(name: &str) -> std::path::PathBuf {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "reddb-redwire-{name}-{}-{}.rdb",
+            std::process::id(),
+            crate::utils::now_unix_millis()
+        ));
+        let _ = std::fs::remove_file(&path);
+        path
+    }
 
     fn bulk_insert_frame(correlation_id: u64, payload: Vec<u8>) -> Frame {
         reddb_wire::redwire::build_bulk_insert_frame(correlation_id, payload)
@@ -1578,6 +1641,68 @@ mod tests {
                 .and_then(|b| b.get("e"))
                 .and_then(JsonValue::as_str),
             Some("x")
+        );
+    }
+
+    #[test]
+    fn redwire_query_with_params_request_policy_strengthens_to_ack_n() {
+        let _env_lock = env_lock().lock().expect("env lock");
+        let _env = EnvGuard::set(&[
+            ("RED_PRIMARY_COMMIT_POLICY", "local"),
+            ("RED_REPLICATION_ACK_TIMEOUT_MS", "20"),
+            ("RED_COMMIT_FAIL_ON_TIMEOUT", "true"),
+        ]);
+        let data_path = temp_data_path("request-ack-n");
+        let runtime = RedDBRuntime::with_options(
+            crate::api::RedDBOptions::persistent(&data_path)
+                .with_replication(crate::replication::ReplicationConfig::primary()),
+        )
+        .expect("runtime");
+
+        let payload = reddb_wire::query_with_params::encode_query_with_params_request(
+            "INSERT INTO redwire_request_ack (id, name) VALUES (1, 'alpha')",
+            &[],
+            &reddb_wire::query_with_params::QueryWithParamsOptions {
+                commit_policy: Some("ack_n=1".to_string()),
+            },
+        )
+        .expect("encode query with request policy");
+        let frame = reddb_wire::redwire::build_query_with_params_frame(100, payload)
+            .expect("query-with-params frame");
+        let reply = run_query_with_params(&runtime, &frame);
+
+        assert_eq!(reply.kind, MessageKind::Error);
+        let body = String::from_utf8_lossy(&reply.payload);
+        assert!(
+            body.contains("commit policy timed out") && body.contains("RED_COMMIT_FAIL_ON_TIMEOUT"),
+            "request ack_n should wait for replica ack, got {body}"
+        );
+        let _ = std::fs::remove_file(data_path);
+    }
+
+    #[test]
+    fn redwire_query_with_params_rejects_request_policy_below_floor() {
+        let _env_lock = env_lock().lock().expect("env lock");
+        let _env = EnvGuard::set(&[("RED_PRIMARY_COMMIT_POLICY", "quorum")]);
+        let runtime = RedDBRuntime::in_memory().expect("runtime");
+
+        let payload = reddb_wire::query_with_params::encode_query_with_params_request(
+            "INSERT INTO redwire_request_floor (id, name) VALUES (1, 'alpha')",
+            &[],
+            &reddb_wire::query_with_params::QueryWithParamsOptions {
+                commit_policy: Some("local".to_string()),
+            },
+        )
+        .expect("encode query with request policy");
+        let frame = reddb_wire::redwire::build_query_with_params_frame(101, payload)
+            .expect("query-with-params frame");
+        let reply = run_query_with_params(&runtime, &frame);
+
+        assert_eq!(reply.kind, MessageKind::Error);
+        let body = String::from_utf8_lossy(&reply.payload);
+        assert!(
+            body.contains("COMMIT_POLICY_BELOW_FLOOR"),
+            "typed floor violation should be surfaced, got {body}"
         );
     }
 

--- a/crates/reddb-server/tests/primary_replica_slot_catalog.rs
+++ b/crates/reddb-server/tests/primary_replica_slot_catalog.rs
@@ -77,14 +77,27 @@ impl Drop for EnvGuard {
 }
 
 fn post_query_once(runtime: &RedDBRuntime, sql: &str) -> (u16, String) {
+    post_query_once_with_commit_policy(runtime, sql, None)
+}
+
+fn post_query_once_with_commit_policy(
+    runtime: &RedDBRuntime,
+    sql: &str,
+    commit_policy: Option<&str>,
+) -> (u16, String) {
     let server = RedDBServer::new(runtime.clone());
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind query listener");
     let addr = listener.local_addr().expect("query addr");
     let handle = thread::spawn(move || server.serve_one_on(listener));
-    let body = format!(
-        "{{\"query\":\"{}\"}}",
-        sql.replace('\\', "\\\\").replace('"', "\\\"")
-    );
+    let escaped_sql = sql.replace('\\', "\\\\").replace('"', "\\\"");
+    let body = match commit_policy {
+        Some(policy) => format!(
+            "{{\"query\":\"{}\",\"commit_policy\":\"{}\"}}",
+            escaped_sql,
+            policy.replace('\\', "\\\\").replace('"', "\\\"")
+        ),
+        None => format!("{{\"query\":\"{}\"}}", escaped_sql),
+    };
     let request = format!(
         "POST /query HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         body.len(),
@@ -361,6 +374,57 @@ fn http_mutation_ack_n_commit_policy_fails_closed_without_replica_ack() {
     assert!(
         runtime.cdc_current_lsn() > 0,
         "local mutation should have advanced CDC before the response failed"
+    );
+}
+
+#[test]
+fn http_request_commit_policy_can_strengthen_and_wait_for_ack() {
+    let _env_lock = env_lock().lock().expect("env lock");
+    let _env = EnvGuard::set(&[
+        ("RED_PRIMARY_COMMIT_POLICY", "local"),
+        ("RED_REPLICATION_ACK_TIMEOUT_MS", "20"),
+        ("RED_COMMIT_FAIL_ON_TIMEOUT", "true"),
+    ]);
+    let data_path = temp_data_path("primary_replica_http_request_ack_n_timeout");
+
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::persistent(&data_path).with_replication(ReplicationConfig::primary()),
+    )
+    .expect("runtime boots");
+
+    let (status, body) = post_query_once_with_commit_policy(
+        &runtime,
+        "INSERT INTO request_ack_items (id, name) VALUES (1, 'alpha')",
+        Some("ack_n=1"),
+    );
+    assert_eq!(
+        status, 504,
+        "request ack_n without replica ack must fail closed, body={body}"
+    );
+    assert!(
+        body.contains("commit policy timed out") && body.contains("RED_COMMIT_FAIL_ON_TIMEOUT"),
+        "error body should identify request commit wait, got {body}"
+    );
+}
+
+#[test]
+fn http_request_commit_policy_rejects_weaker_than_floor() {
+    let _env_lock = env_lock().lock().expect("env lock");
+    let _env = EnvGuard::set(&[("RED_PRIMARY_COMMIT_POLICY", "quorum")]);
+    let runtime = RedDBRuntime::in_memory().expect("runtime boots");
+
+    let (status, body) = post_query_once_with_commit_policy(
+        &runtime,
+        "INSERT INTO request_floor_items (id, name) VALUES (1, 'alpha')",
+        Some("local"),
+    );
+    assert_eq!(
+        status, 422,
+        "weaker request policy must be rejected: {body}"
+    );
+    assert!(
+        body.contains("COMMIT_POLICY_BELOW_FLOOR"),
+        "typed floor violation should be surfaced, got {body}"
     );
 }
 

--- a/crates/reddb-wire/src/query_with_params.rs
+++ b/crates/reddb-wire/src/query_with_params.rs
@@ -8,6 +8,8 @@ use std::fmt;
 pub const FEATURE_PARAMS: u32 = 0x0000_0001;
 pub const MAX_PARAM_COUNT: usize = 65_536;
 
+const OPTIONS_MAGIC: &[u8; 4] = b"RQP1";
+
 const TAG_NULL: u8 = 0x00;
 const TAG_BOOL: u8 = 0x01;
 const TAG_INT: u8 = 0x02;
@@ -41,6 +43,7 @@ pub enum ParamCodecError {
     InvalidUtf8(&'static str),
     InvalidBool(u8),
     UnknownTag(u8),
+    InvalidOptionsMagic,
     TrailingBytes(usize),
 }
 
@@ -55,6 +58,7 @@ impl fmt::Display for ParamCodecError {
             Self::InvalidUtf8(field) => write!(f, "{field} must be valid UTF-8"),
             Self::InvalidBool(byte) => write!(f, "invalid bool payload byte {byte}"),
             Self::UnknownTag(tag) => write!(f, "unknown parameter value tag 0x{tag:02x}"),
+            Self::InvalidOptionsMagic => write!(f, "invalid QueryWithParams options extension"),
             Self::TrailingBytes(count) => write!(f, "{count} trailing bytes after payload"),
         }
     }
@@ -62,9 +66,29 @@ impl fmt::Display for ParamCodecError {
 
 impl std::error::Error for ParamCodecError {}
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct QueryWithParamsOptions {
+    pub commit_policy: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct QueryWithParamsRequest {
+    pub sql: String,
+    pub params: Vec<ParamValue>,
+    pub options: QueryWithParamsOptions,
+}
+
 pub fn encode_query_with_params(
     sql: &str,
     params: &[ParamValue],
+) -> Result<Vec<u8>, ParamCodecError> {
+    encode_query_with_params_request(sql, params, &QueryWithParamsOptions::default())
+}
+
+pub fn encode_query_with_params_request(
+    sql: &str,
+    params: &[ParamValue],
+    options: &QueryWithParamsOptions,
 ) -> Result<Vec<u8>, ParamCodecError> {
     if sql.len() > u32::MAX as usize {
         return Err(ParamCodecError::LengthOverflow("sql"));
@@ -83,12 +107,26 @@ pub fn encode_query_with_params(
     for value in params {
         encode_value(value, &mut out)?;
     }
+    if let Some(policy) = &options.commit_policy {
+        if policy.len() > u32::MAX as usize {
+            return Err(ParamCodecError::LengthOverflow("commit_policy"));
+        }
+        out.extend_from_slice(OPTIONS_MAGIC);
+        write_len_prefixed(policy.as_bytes(), &mut out, "commit_policy")?;
+    }
     Ok(out)
 }
 
 pub fn decode_query_with_params(
     payload: &[u8],
 ) -> Result<(String, Vec<ParamValue>), ParamCodecError> {
+    let request = decode_query_with_params_request(payload)?;
+    Ok((request.sql, request.params))
+}
+
+pub fn decode_query_with_params_request(
+    payload: &[u8],
+) -> Result<QueryWithParamsRequest, ParamCodecError> {
     let mut pos = 0;
     let sql_len = read_u32(payload, &mut pos, "sql_len")? as usize;
     let sql_bytes = read_bytes(payload, &mut pos, sql_len, "sql")?;
@@ -103,10 +141,37 @@ pub fn decode_query_with_params(
     for _ in 0..param_count {
         params.push(decode_value(payload, &mut pos)?);
     }
+    let options = if pos == payload.len() {
+        QueryWithParamsOptions::default()
+    } else {
+        decode_options(payload, &mut pos)?
+    };
     if pos != payload.len() {
         return Err(ParamCodecError::TrailingBytes(payload.len() - pos));
     }
-    Ok((sql, params))
+    Ok(QueryWithParamsRequest {
+        sql,
+        params,
+        options,
+    })
+}
+
+fn decode_options(
+    payload: &[u8],
+    pos: &mut usize,
+) -> Result<QueryWithParamsOptions, ParamCodecError> {
+    let magic = read_bytes(payload, pos, OPTIONS_MAGIC.len(), "options_magic")?;
+    if magic != OPTIONS_MAGIC {
+        return Err(ParamCodecError::InvalidOptionsMagic);
+    }
+    let len = read_u32(payload, pos, "commit_policy_len")? as usize;
+    let bytes = read_bytes(payload, pos, len, "commit_policy")?;
+    let commit_policy = std::str::from_utf8(bytes)
+        .map_err(|_| ParamCodecError::InvalidUtf8("commit_policy"))?
+        .to_string();
+    Ok(QueryWithParamsOptions {
+        commit_policy: Some(commit_policy),
+    })
 }
 
 pub fn encode_value(value: &ParamValue, out: &mut Vec<u8>) -> Result<(), ParamCodecError> {


### PR DESCRIPTION
Automated AFK landing for #1840. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1840

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786053206&installation_id=129708444&pr_number=1918&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1918&signature=e24f7018a169bca0ac2eb4404844585faa564189ff2feb578cf095a4294c0f31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->