### PR TITLE
chore: #1823 Per-collection series cardinality guard with descriptive ingest error

### DIFF
--- a/crates/reddb-server/src/runtime/config_matrix.rs
+++ b/crates/reddb-server/src/runtime/config_matrix.rs
@@ -248,6 +248,12 @@ pub const MATRIX: &[ConfigDefault] = &[
         tier: Tier::Optional,
         default: || num(32.0),
     },
+    // storage.time_series.*
+    ConfigDefault {
+        key: "storage.time_series.max_series_per_collection",
+        tier: Tier::Optional,
+        default: || num(1_000_000.0),
+    },
     // storage.btree.*
     ConfigDefault {
         key: "storage.btree.lehman_yao",
@@ -440,6 +446,7 @@ mod tests {
             "storage.bulk_insert.max_buffered_rows",
             "storage.bulk_insert.max_buffered_bytes",
             "storage.hot_update.max_chain_hops",
+            "storage.time_series.max_series_per_collection",
         ];
         for key in must_be_optional {
             assert_eq!(tier_for(key), Some(Tier::Optional), "{key} tier mismatch");

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -8,6 +8,8 @@ use super::*;
 const TIMESERIES_META_COLLECTION: &str = "red_timeseries_meta";
 const TIMESERIES_SERIES_COLLECTION: &str = "red_timeseries_series";
 const DEFAULT_TIMESERIES_CHUNK_INTERVAL_NS: u64 = 86_400_000_000_000;
+const TIMESERIES_MAX_SERIES_GLOBAL_CONFIG: &str = "storage.time_series.max_series_per_collection";
+const DEFAULT_TIMESERIES_MAX_SERIES_PER_COLLECTION: usize = 1_000_000;
 
 #[derive(Default)]
 struct SealHypertableChunksOutcome {
@@ -562,6 +564,13 @@ pub(crate) fn intern_timeseries_series(
         }
     }
 
+    let ceiling = timeseries_max_series_per_collection(store, collection);
+    if rows.len() >= ceiling {
+        return Err(RedDBError::Query(format!(
+            "timeseries collection '{collection}' has reached its distinct series ceiling of {ceiling}"
+        )));
+    }
+
     let series_id = next_id;
     let mut fields = HashMap::new();
     fields.insert(
@@ -682,6 +691,49 @@ fn row_u64(row: &crate::storage::RowData, field: &str) -> Option<u64> {
         Some(Value::Integer(value)) if *value >= 0 => Some(*value as u64),
         _ => None,
     }
+}
+
+fn timeseries_max_series_per_collection(
+    store: &crate::storage::unified::UnifiedStore,
+    collection: &str,
+) -> usize {
+    let collection_key = format!("storage.time_series.collections.{collection}.max_series");
+    latest_usize_config(store, &collection_key)
+        .or_else(|| latest_usize_config(store, TIMESERIES_MAX_SERIES_GLOBAL_CONFIG))
+        .unwrap_or(DEFAULT_TIMESERIES_MAX_SERIES_PER_COLLECTION)
+}
+
+fn latest_usize_config(store: &crate::storage::unified::UnifiedStore, key: &str) -> Option<usize> {
+    let manager = store.get_collection("red_config")?;
+    let mut newest: Option<(u64, usize)> = None;
+    manager.for_each_entity(|entity| {
+        let Some(row) = entity.data.as_row() else {
+            return true;
+        };
+        if !row_text(row, "key").is_some_and(|value| value.eq_ignore_ascii_case(key)) {
+            return true;
+        }
+        let Some(value) = row.get_field("value").and_then(value_as_usize) else {
+            return true;
+        };
+        let id = entity.id.raw();
+        if newest.is_none_or(|(best_id, _)| id >= best_id) {
+            newest = Some((id, value));
+        }
+        true
+    });
+    newest.map(|(_, value)| value)
+}
+
+fn value_as_usize(value: &Value) -> Option<usize> {
+    let value = match value {
+        Value::UnsignedInteger(value) => *value,
+        Value::Integer(value) if *value >= 0 => *value as u64,
+        Value::Float(value) if *value >= 0.0 => *value as u64,
+        Value::Text(value) => value.trim().parse().ok()?,
+        _ => return None,
+    };
+    usize::try_from(value).ok()
 }
 
 /// Materialise `(timestamp_ns, value)` rows from the entity/row store for

--- a/tests/grouped/analytics_metrics.rs
+++ b/tests/grouped/analytics_metrics.rs
@@ -90,6 +90,9 @@ mod e2e_probabilistic_public_contract;
 #[path = "timeseries_remaining/e2e_sessionize_operator.rs"]
 mod e2e_sessionize_operator;
 
+#[path = "timeseries_remaining/e2e_timeseries_series_cardinality_guard.rs"]
+mod e2e_timeseries_series_cardinality_guard;
+
 #[path = "sql_window/e2e_window_aggregate.rs"]
 mod e2e_window_aggregate;
 

--- a/tests/grouped/timeseries_remaining/e2e_timeseries_series_cardinality_guard.rs
+++ b/tests/grouped/timeseries_remaining/e2e_timeseries_series_cardinality_guard.rs
@@ -1,0 +1,65 @@
+use reddb::application::{
+    CreateTimeSeriesInput, CreateTimeSeriesPointInput, EntityUseCases, SchemaUseCases,
+};
+use reddb::runtime::RedDBRuntime;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::in_memory().expect("in-memory runtime")
+}
+
+fn create_timeseries(rt: &RedDBRuntime, name: &str) {
+    SchemaUseCases::new(rt)
+        .create_timeseries(CreateTimeSeriesInput {
+            name: name.to_string(),
+            retention_ms: Some(86_400_000),
+            chunk_size: None,
+            downsample_policies: Vec::new(),
+            if_not_exists: false,
+        })
+        .expect("create timeseries");
+}
+
+fn write_point(rt: &RedDBRuntime, collection: &str, host: &str, timestamp_ns: u64) {
+    EntityUseCases::new(rt)
+        .create_timeseries_point(CreateTimeSeriesPointInput {
+            collection: collection.to_string(),
+            metric: "cpu.usage".to_string(),
+            value: 1.0,
+            timestamp_ns: Some(timestamp_ns),
+            tags: vec![("host".to_string(), host.to_string())],
+            metadata: Vec::new(),
+        })
+        .expect("create timeseries point");
+}
+
+#[test]
+fn per_collection_series_ceiling_rejects_only_new_series_and_can_be_raised() {
+    let rt = runtime();
+    create_timeseries(&rt, "metrics");
+    rt.execute_query("SET CONFIG storage.time_series.collections.metrics.max_series = 2")
+        .expect("set series ceiling");
+
+    write_point(&rt, "metrics", "a", 1);
+    write_point(&rt, "metrics", "b", 2);
+    write_point(&rt, "metrics", "a", 3);
+
+    let err = EntityUseCases::new(&rt)
+        .create_timeseries_point(CreateTimeSeriesPointInput {
+            collection: "metrics".to_string(),
+            metric: "cpu.usage".to_string(),
+            value: 1.0,
+            timestamp_ns: Some(4),
+            tags: vec![("host".to_string(), "c".to_string())],
+            metadata: Vec::new(),
+        })
+        .expect_err("new series beyond the ceiling must fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("metrics") && message.contains('2'),
+        "error must name collection and ceiling, got {message}"
+    );
+
+    rt.execute_query("SET CONFIG storage.time_series.collections.metrics.max_series = 3")
+        .expect("raise series ceiling");
+    write_point(&rt, "metrics", "c", 5);
+}


### PR DESCRIPTION
Automated AFK landing for #1823. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1823

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786063288&installation_id=129708444&pr_number=1922&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1922&signature=79e8dd40d8d6d2c9b768d6a9a8ad047c92df81a67fd4cba620883dd15b32a772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for limiting the number of timeseries series per collection with a configurable maximum.
  * Collection-specific settings can now override the default limit, with a fallback to a global value.

* **Bug Fixes**
  * Prevented new series from being created once the configured ceiling is reached.
  * Allowed series creation again after increasing the configured limit.

* **Tests**
  * Added end-to-end coverage for per-collection series limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->