### PR TITLE
chore: #1828 Re-home BloomSegment + HasBloom consumers onto SplitBlockBloom; bloom-segment frame v2

### DIFF
--- a/crates/reddb-file/src/bloom_segment.rs
+++ b/crates/reddb-file/src/bloom_segment.rs
@@ -2,17 +2,9 @@
 
 use std::fmt;
 
-use crate::BLOOM_SEGMENT_MAGIC;
+use crate::BLOOM_SEGMENT_V2_MAGIC;
 
-pub const BLOOM_SEGMENT_HEADER_LEN: usize = 1 + 1 + 4 + 4;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BloomSegmentFrame {
-    pub num_hashes: u8,
-    pub bit_size: u32,
-    pub inserted: u32,
-    pub bits: Vec<u8>,
-}
+pub const BLOOM_SEGMENT_HEADER_LEN: usize = 1 + 1 + 4;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BloomSegmentFrameError {
@@ -33,42 +25,42 @@ impl fmt::Display for BloomSegmentFrameError {
 
 impl std::error::Error for BloomSegmentFrameError {}
 
-pub fn encode_bloom_segment_frame(frame: &BloomSegmentFrame) -> Vec<u8> {
-    let mut out = Vec::with_capacity(BLOOM_SEGMENT_HEADER_LEN + frame.bits.len());
-    out.push(BLOOM_SEGMENT_MAGIC);
-    out.push(frame.num_hashes);
-    out.extend_from_slice(&frame.bit_size.to_be_bytes());
-    out.extend_from_slice(&frame.inserted.to_be_bytes());
-    out.extend_from_slice(&frame.bits);
+pub fn encode_bloom_segment_frame(inserted: u32, bloom_blob: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(BLOOM_SEGMENT_HEADER_LEN + bloom_blob.len());
+    out.push(BLOOM_SEGMENT_V2_MAGIC);
+    out.push(0);
+    out.extend_from_slice(&inserted.to_be_bytes());
+    out.extend_from_slice(bloom_blob);
     out
 }
 
 pub fn decode_bloom_segment_frame(
     bytes: &[u8],
-) -> Result<(BloomSegmentFrame, usize), BloomSegmentFrameError> {
+) -> Result<(u32, Vec<u8>, usize), BloomSegmentFrameError> {
     if bytes.len() < BLOOM_SEGMENT_HEADER_LEN {
         return Err(BloomSegmentFrameError::TooShort);
     }
-    if bytes[0] != BLOOM_SEGMENT_MAGIC {
+    if bytes[0] != BLOOM_SEGMENT_V2_MAGIC {
         return Err(BloomSegmentFrameError::BadMagic);
     }
 
-    let num_hashes = bytes[1];
-    let bit_size = u32::from_be_bytes(bytes[2..6].try_into().expect("len checked"));
-    let inserted = u32::from_be_bytes(bytes[6..10].try_into().expect("len checked"));
-    let byte_len = (bit_size as usize).div_ceil(8);
-    let total = BLOOM_SEGMENT_HEADER_LEN + byte_len;
+    let inserted = u32::from_be_bytes(bytes[2..6].try_into().expect("len checked"));
+    if bytes.len() < BLOOM_SEGMENT_HEADER_LEN + 4 {
+        return Err(BloomSegmentFrameError::LengthMismatch);
+    }
+    let num_blocks = u32::from_le_bytes(bytes[6..10].try_into().expect("len checked")) as usize;
+    if num_blocks == 0 || !num_blocks.is_power_of_two() {
+        return Err(BloomSegmentFrameError::LengthMismatch);
+    }
+    let payload_len = 4 + num_blocks * 32;
+    let total = BLOOM_SEGMENT_HEADER_LEN + payload_len;
     if bytes.len() < total {
         return Err(BloomSegmentFrameError::LengthMismatch);
     }
 
     Ok((
-        BloomSegmentFrame {
-            num_hashes,
-            bit_size,
-            inserted,
-            bits: bytes[BLOOM_SEGMENT_HEADER_LEN..total].to_vec(),
-        },
+        inserted,
+        bytes[BLOOM_SEGMENT_HEADER_LEN..total].to_vec(),
         total,
     ))
 }
@@ -78,23 +70,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bloom_segment_frame_round_trips_big_endian_header() {
-        let frame = BloomSegmentFrame {
-            num_hashes: 7,
-            bit_size: 17,
-            inserted: 42,
-            bits: vec![0b1010_1010, 0b0101_0101, 0xFF],
-        };
+    fn bloom_segment_frame_round_trips_v2_header() {
+        let mut bloom_blob = Vec::new();
+        bloom_blob.extend_from_slice(&1u32.to_le_bytes());
+        bloom_blob.extend_from_slice(&[0xAB; 32]);
 
-        let encoded = encode_bloom_segment_frame(&frame);
+        let encoded = encode_bloom_segment_frame(42, &bloom_blob);
 
-        assert_eq!(encoded[0], BLOOM_SEGMENT_MAGIC);
-        assert_eq!(encoded[1], 7);
-        assert_eq!(&encoded[2..6], &17u32.to_be_bytes());
-        assert_eq!(&encoded[6..10], &42u32.to_be_bytes());
+        assert_eq!(encoded[0], BLOOM_SEGMENT_V2_MAGIC);
+        assert_eq!(encoded[1], 0);
+        assert_eq!(&encoded[2..6], &42u32.to_be_bytes());
 
-        let (decoded, consumed) = decode_bloom_segment_frame(&encoded).expect("decode frame");
-        assert_eq!(decoded, frame);
+        let (inserted, decoded_blob, consumed) =
+            decode_bloom_segment_frame(&encoded).expect("decode frame");
+        assert_eq!(inserted, 42);
+        assert_eq!(decoded_blob, bloom_blob);
         assert_eq!(consumed, encoded.len());
     }
 
@@ -105,24 +95,18 @@ mod tests {
             BloomSegmentFrameError::TooShort
         );
 
-        let mut bad_magic = encode_bloom_segment_frame(&BloomSegmentFrame {
-            num_hashes: 3,
-            bit_size: 8,
-            inserted: 1,
-            bits: vec![1],
-        });
+        let mut bloom_blob = Vec::new();
+        bloom_blob.extend_from_slice(&1u32.to_le_bytes());
+        bloom_blob.extend_from_slice(&[0xAB; 32]);
+
+        let mut bad_magic = encode_bloom_segment_frame(1, &bloom_blob);
         bad_magic[0] = 0;
         assert_eq!(
             decode_bloom_segment_frame(&bad_magic).unwrap_err(),
             BloomSegmentFrameError::BadMagic
         );
 
-        let mut truncated = encode_bloom_segment_frame(&BloomSegmentFrame {
-            num_hashes: 3,
-            bit_size: 16,
-            inserted: 1,
-            bits: vec![1, 2],
-        });
+        let mut truncated = encode_bloom_segment_frame(1, &bloom_blob);
         truncated.pop();
         assert_eq!(
             decode_bloom_segment_frame(&truncated).unwrap_err(),

--- a/crates/reddb-file/src/file_format.rs
+++ b/crates/reddb-file/src/file_format.rs
@@ -444,8 +444,8 @@ pub const COLUMN_BLOCK_MAGIC: [u8; 4] = *b"RDCC";
 /// Column block on-disk format version.
 pub const COLUMN_BLOCK_VERSION_V1: u16 = 1;
 
-/// Reusable segment-level bloom header magic.
-pub const BLOOM_SEGMENT_MAGIC: u8 = 0xBF;
+/// Reusable segment-level bloom frame v2 magic.
+pub const BLOOM_SEGMENT_V2_MAGIC: u8 = 0xC0;
 
 /// Legacy vector B-tree on-disk page format.
 pub const VECTOR_BTREE_FORMAT_VERSION_V1: u16 = 1;

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -105,8 +105,8 @@ pub use blob_cache::{
     L2_FRAME_TAG_RAW, L2_FRAME_TAG_ZSTD, L2_METADATA_MAGIC,
 };
 pub use bloom_segment::{
-    decode_bloom_segment_frame, encode_bloom_segment_frame, BloomSegmentFrame,
-    BloomSegmentFrameError, BLOOM_SEGMENT_HEADER_LEN,
+    decode_bloom_segment_frame, encode_bloom_segment_frame, BloomSegmentFrameError,
+    BLOOM_SEGMENT_HEADER_LEN,
 };
 pub use btree_value_layout::{
     btree_projected_cell_len, btree_value_pointer_head, decode_btree_inline_payload,
@@ -150,7 +150,7 @@ pub use file_format::{
     set_paged_page_parent_id, set_paged_page_right_child, write_paged_cell,
     write_paged_encryption_marker_and_header, DatabaseHeader, DatabaseHeaderError, PagedDwbEntry,
     PagedDwbFrameError, PagedEncryptionHeader, PagedPageHeader, PhysicalFileHeader,
-    BLOOM_SEGMENT_MAGIC, COLUMN_BLOCK_MAGIC, COLUMN_BLOCK_VERSION_V1, DWB_MAGIC,
+    BLOOM_SEGMENT_V2_MAGIC, COLUMN_BLOCK_MAGIC, COLUMN_BLOCK_VERSION_V1, DWB_MAGIC,
     PAGED_CELL_HEADER_SIZE, PAGED_CELL_POINTER_SIZE, PAGED_DWB_ENTRY_HEADER_SIZE,
     PAGED_DWB_ENTRY_SIZE, PAGED_DWB_HEADER_SIZE, PAGED_ENCRYPTION_HEADER_SIZE,
     PAGED_ENCRYPTION_KEY_CHECK_BLOB_SIZE, PAGED_ENCRYPTION_KEY_CHECK_PLAINTEXT_SIZE,

--- a/crates/reddb-file/tests/layout_authority/storage.rs
+++ b/crates/reddb-file/tests/layout_authority/storage.rs
@@ -1109,7 +1109,7 @@ fn server_does_not_redeclare_core_file_format_constants() {
             "const DWB_MAGIC",
             "pub const COLUMN_BLOCK_MAGIC",
             "pub const COLUMN_BLOCK_VERSION_V1",
-            "const BLOOM_SEGMENT_MAGIC",
+            "const BLOOM_SEGMENT_V2_MAGIC",
             "pub const FORMAT_VERSION_V1",
             "pub const FORMAT_VERSION_V2",
             "pub const FORMAT_VERSION: u16",
@@ -1147,6 +1147,7 @@ fn server_does_not_redeclare_core_file_format_constants() {
             "[0x52, 0x44, 0x44, 0x57]",
             "*b\"RDCC\"",
             "0xBF",
+            "0xC0",
             "\"reddb-physical-v1\"",
         ] {
             assert!(
@@ -1162,7 +1163,7 @@ fn server_does_not_redeclare_core_file_format_constants() {
         "pub const DWB_MAGIC",
         "pub const COLUMN_BLOCK_MAGIC",
         "pub const COLUMN_BLOCK_VERSION_V1",
-        "pub const BLOOM_SEGMENT_MAGIC",
+        "pub const BLOOM_SEGMENT_V2_MAGIC",
         "pub const VECTOR_BTREE_FORMAT_VERSION_V1",
         "pub const VECTOR_BTREE_FORMAT_VERSION_V2",
         "pub const VECTOR_BTREE_FORMAT_VERSION",
@@ -1209,7 +1210,6 @@ fn server_does_not_redeclare_core_file_format_constants() {
         "reddb-file should own physical metadata protocol version"
     );
     for required in [
-        "pub struct BloomSegmentFrame",
         "pub enum BloomSegmentFrameError",
         "pub fn encode_bloom_segment_frame",
         "pub fn decode_bloom_segment_frame",

--- a/crates/reddb-server/src/storage/engine/graph_store/secondary_index.rs
+++ b/crates/reddb-server/src/storage/engine/graph_store/secondary_index.rs
@@ -17,7 +17,6 @@ use std::sync::RwLock;
 
 use super::LabelId;
 use crate::storage::index::{BloomSegment, HasBloom, IndexBase, IndexKind, IndexStats};
-use crate::storage::primitives::BloomFilter;
 
 /// Inverted secondary indexes on graph nodes.
 ///
@@ -208,8 +207,7 @@ impl Default for NodeSecondaryIndex {
 ///
 /// Note: this returns `None` because the underlying bloom is behind a
 /// `RwLock`. See [`NodeSecondaryIndex::may_contain_label`] for the actual
-/// fast-path. The impl exists so call-sites that only know `dyn HasBloom`
-/// can still reach the index via `IndexBase::definitely_absent`.
+/// fast-path.
 impl HasBloom for NodeSecondaryIndex {
     fn bloom_segment(&self) -> Option<&BloomSegment> {
         None
@@ -251,12 +249,6 @@ impl IndexBase for NodeSecondaryIndex {
             has_bloom: true,
             index_correlation: 0.0,
         }
-    }
-
-    fn bloom(&self) -> Option<&BloomFilter> {
-        // RwLock precludes handing out a raw reference to the inner bloom.
-        // `definitely_absent` above routes around it.
-        None
     }
 
     fn definitely_absent(&self, key_bytes: &[u8]) -> bool {

--- a/crates/reddb-server/src/storage/index/README.md
+++ b/crates/reddb-server/src/storage/index/README.md
@@ -33,8 +33,7 @@ pub trait IndexBase: Send + Sync {
     fn name(&self) -> &str;
     fn kind(&self) -> IndexKind;
     fn stats(&self) -> IndexStats;
-    fn bloom(&self) -> Option<&BloomFilter> { None }
-    fn definitely_absent(&self, key_bytes: &[u8]) -> bool { ... }
+    fn definitely_absent(&self, key_bytes: &[u8]) -> bool { false }
 }
 ```
 
@@ -56,8 +55,8 @@ The caller must follow up with a real lookup.
 **guaranteed absent**. The caller may skip the real lookup entirely.
 
 This is the only safe pruning direction. **Never** use a bloom hit as proof
-of presence. The `IndexBase::definitely_absent` default routes through the
-attached bloom; concrete impls may override with tighter signals (e.g. zone
+of presence. The `IndexBase::definitely_absent` default is conservative;
+concrete impls may override with bloom-backed or tighter signals (e.g. zone
 map min/max for range indexes — see `ZoneMap::block_skip`).
 
 ### 3. Zone maps prune iff the filter is provably disjoint

--- a/crates/reddb-server/src/storage/index/bloom_segment.rs
+++ b/crates/reddb-server/src/storage/index/bloom_segment.rs
@@ -3,23 +3,20 @@
 //! Segments (table pages, vector segments, timeseries chunks, graph
 //! partitions) all benefit from the same question: "is key X *possibly* in
 //! this segment?". Rather than reimplementing bloom wiring in every storage
-//! engine, wrap [`crate::storage::primitives::BloomFilter`] here with a
-//! serialisation header and a small trait `HasBloom` for owners to plug in.
+//! engine, wrap [`crate::storage::primitives::split_block_bloom::SplitBlockBloom`]
+//! here with a serialisation header and a small trait `HasBloom` for owners to
+//! plug in.
 //!
 //! Layout on disk / inside a segment header is:
 //!
 //! ```text
 //! [ u8  magic       ]
-//! [ u8  num_hashes   ]
-//! [ u32 bit_size     ]   // big-endian
+//! [ u8  reserved    ]   // zero
 //! [ u32 inserted     ]   // monotonic counter, best-effort
-//! [ bytes...          ]   // bit array
+//! [ bytes...          ]   // SplitBlockBloom::to_bytes()
 //! ```
-//!
-//! Readers that don't care about bloom can skip `4 + (bit_size + 7) / 8`
-//! bytes after the 10-byte header.
 
-use crate::storage::primitives::BloomFilter;
+use crate::storage::primitives::split_block_bloom::SplitBlockBloom;
 
 pub use reddb_file::BloomSegmentFrameError as BloomSegmentError;
 
@@ -42,58 +39,51 @@ pub trait HasBloom {
 
 /// Owning bloom header that can be embedded in a segment.
 pub struct BloomSegment {
-    filter: BloomFilter,
+    filter: SplitBlockBloom,
     inserted: u32,
 }
 
 impl std::fmt::Debug for BloomSegment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BloomSegment")
-            .field("bit_size", &self.filter.bit_size())
-            .field("num_hashes", &self.filter.num_hashes())
+            .field("num_blocks", &self.filter.num_blocks())
             .field("inserted", &self.inserted)
             .finish()
     }
 }
 
 impl BloomSegment {
-    /// Build a bloom sized for `expected` elements at a 1% false-positive
-    /// rate. Cheap — allocates `~9.6 * expected / 8` bytes.
+    /// Build a bloom sized for `expected` elements at the split-block
+    /// primitive's fixed ~1% false-positive rate.
     pub fn with_capacity(expected: usize) -> Self {
         Self {
-            filter: BloomFilter::with_capacity(expected.max(16), 0.01),
-            inserted: 0,
-        }
-    }
-
-    /// Custom false-positive rate.
-    pub fn with_rate(expected: usize, fp_rate: f64) -> Self {
-        Self {
-            filter: BloomFilter::with_capacity(expected.max(16), fp_rate),
+            filter: SplitBlockBloom::with_capacity(expected.max(16)),
             inserted: 0,
         }
     }
 
     /// Record `key` as possibly present.
     pub fn insert(&mut self, key: &[u8]) {
-        self.filter.insert(key);
+        self.filter.insert_bytes(key);
         self.inserted = self.inserted.saturating_add(1);
     }
 
     /// Might `key` be present? (May return a false positive, never a false
     /// negative.)
     pub fn contains(&self, key: &[u8]) -> bool {
-        self.filter.contains(key)
+        self.filter.probe_bytes(key)
     }
 
     /// Inverse of `contains` — the thing callers usually want.
     pub fn definitely_absent(&self, key: &[u8]) -> bool {
-        !self.filter.contains(key)
+        !self.filter.probe_bytes(key)
     }
 
-    /// Estimated current false-positive rate given the number of insertions.
+    /// Approximate current false-positive rate from word fill. Split-block
+    /// bloom probes require all eight salted words to match, so this is a
+    /// stats/debug estimate rather than a contract.
     pub fn estimated_fp_rate(&self) -> f64 {
-        self.filter.estimate_fp_rate(self.inserted as usize)
+        self.filter.fill_ratio().powi(8)
     }
 
     /// Number of elements recorded so far (best-effort).
@@ -101,10 +91,9 @@ impl BloomSegment {
         self.inserted
     }
 
-    /// Access the underlying bloom filter (e.g. to pass to
-    /// [`crate::storage::index::IndexBase::bloom`]).
-    pub fn filter(&self) -> &BloomFilter {
-        &self.filter
+    /// Bytes used by the underlying split-block payload.
+    pub fn byte_size(&self) -> usize {
+        self.filter.byte_size()
     }
 
     /// Merge another bloom segment into this one. Both must have the same
@@ -120,43 +109,27 @@ impl BloomSegment {
 
     /// Serialise into the header layout documented at module level.
     pub fn encode(&self) -> Vec<u8> {
-        reddb_file::encode_bloom_segment_frame(&reddb_file::BloomSegmentFrame {
-            num_hashes: self.filter.num_hashes(),
-            bit_size: self.filter.bit_size(),
-            inserted: self.inserted,
-            bits: self.filter.as_bytes().to_vec(),
-        })
+        reddb_file::encode_bloom_segment_frame(self.inserted, &self.filter.to_bytes())
     }
 
     /// Parse a previously encoded header. Returns a fresh `BloomSegment` and
     /// the number of bytes consumed.
     pub fn decode(bytes: &[u8]) -> Result<(Self, usize), BloomSegmentError> {
-        let (frame, consumed) = reddb_file::decode_bloom_segment_frame(bytes)?;
+        let (inserted, bloom_blob, consumed) = reddb_file::decode_bloom_segment_frame(bytes)?;
         let filter =
-            BloomFilter::from_bytes_with_size(frame.bits, frame.num_hashes, frame.bit_size);
-        Ok((
-            Self {
-                filter,
-                inserted: frame.inserted,
-            },
-            consumed,
-        ))
+            SplitBlockBloom::from_bytes(&bloom_blob).ok_or(BloomSegmentError::LengthMismatch)?;
+        Ok((Self { filter, inserted }, consumed))
     }
 }
 
-/// Fluent builder that mirrors `BloomFilterBuilder` but produces a
-/// `BloomSegment`.
+/// Fluent builder that produces a `BloomSegment`.
 pub struct BloomSegmentBuilder {
     expected: usize,
-    fp_rate: f64,
 }
 
 impl BloomSegmentBuilder {
     pub fn new() -> Self {
-        Self {
-            expected: 1024,
-            fp_rate: 0.01,
-        }
+        Self { expected: 1024 }
     }
 
     pub fn expected(mut self, n: usize) -> Self {
@@ -164,13 +137,8 @@ impl BloomSegmentBuilder {
         self
     }
 
-    pub fn false_positive_rate(mut self, rate: f64) -> Self {
-        self.fp_rate = rate;
-        self
-    }
-
     pub fn build(self) -> BloomSegment {
-        BloomSegment::with_rate(self.expected, self.fp_rate)
+        BloomSegment::with_capacity(self.expected)
     }
 }
 
@@ -226,7 +194,7 @@ mod tests {
 
     #[test]
     fn decode_rejects_short_buffer() {
-        let bytes = [reddb_file::BLOOM_SEGMENT_MAGIC, 3, 0, 0];
+        let bytes = [reddb_file::BLOOM_SEGMENT_V2_MAGIC, 0, 0, 0];
         assert_eq!(
             BloomSegment::decode(&bytes).unwrap_err(),
             BloomSegmentError::TooShort
@@ -245,8 +213,8 @@ mod tests {
 
     #[test]
     fn union_merges_populations() {
-        let mut a = BloomSegment::with_rate(1024, 0.01);
-        let mut b = BloomSegment::with_rate(1024, 0.01);
+        let mut a = BloomSegment::with_capacity(1024);
+        let mut b = BloomSegment::with_capacity(1024);
         a.insert(b"one");
         b.insert(b"two");
         assert!(a.union_inplace(&b));
@@ -257,8 +225,8 @@ mod tests {
 
     #[test]
     fn union_rejects_incompatible() {
-        let mut a = BloomSegment::with_rate(1024, 0.01);
-        let b = BloomSegment::with_rate(4096, 0.01);
+        let mut a = BloomSegment::with_capacity(1024);
+        let b = BloomSegment::with_capacity(4096);
         assert!(!a.union_inplace(&b));
     }
 

--- a/crates/reddb-server/src/storage/index/mod.rs
+++ b/crates/reddb-server/src/storage/index/mod.rs
@@ -78,23 +78,14 @@ pub trait IndexBase: Send + Sync {
     /// Current statistics (cardinality, estimated selectivity, memory).
     fn stats(&self) -> IndexStats;
 
-    /// Optional bloom filter for fast negative lookups. Cross-structure
-    /// pruning relies on this.
-    fn bloom(&self) -> Option<&crate::storage::primitives::BloomFilter> {
-        None
-    }
-
     /// Returns `true` iff the key is *guaranteed* to be absent from this
-    /// index. Default implementation consults [`IndexBase::bloom`] and falls
-    /// back to `false` when no bloom is available (meaning "don't know —
+    /// index. Default implementation returns `false` (meaning "don't know —
     /// caller must probe").
     ///
     /// Concrete indexes may override with tighter signals (e.g. zone map
     /// min/max for range indexes).
-    fn definitely_absent(&self, key_bytes: &[u8]) -> bool {
-        self.bloom()
-            .map(|b| !b.contains(key_bytes))
-            .unwrap_or(false)
+    fn definitely_absent(&self, _key_bytes: &[u8]) -> bool {
+        false
     }
 }
 
@@ -129,14 +120,14 @@ pub trait RangeIndex<K: ?Sized, V>: PointIndex<K, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::primitives::BloomFilter;
+    use crate::storage::index::BloomSegment;
     use std::collections::BTreeMap;
 
     /// Tiny in-memory btree to exercise the traits end-to-end.
     struct TestBTree {
         name: String,
         map: BTreeMap<Vec<u8>, Vec<u64>>,
-        bloom: BloomFilter,
+        bloom: BloomSegment,
     }
 
     impl TestBTree {
@@ -144,7 +135,7 @@ mod tests {
             Self {
                 name: name.to_string(),
                 map: BTreeMap::new(),
-                bloom: BloomFilter::with_capacity(1024, 0.01),
+                bloom: BloomSegment::with_capacity(1024),
             }
         }
     }
@@ -166,8 +157,8 @@ mod tests {
                 index_correlation: 0.0,
             }
         }
-        fn bloom(&self) -> Option<&BloomFilter> {
-            Some(&self.bloom)
+        fn definitely_absent(&self, key_bytes: &[u8]) -> bool {
+            self.bloom.definitely_absent(key_bytes)
         }
     }
 

--- a/crates/reddb-server/src/storage/index/zone_map.rs
+++ b/crates/reddb-server/src/storage/index/zone_map.rs
@@ -265,15 +265,15 @@ impl IndexBase for ZoneMap {
         IndexStats {
             entries: self.total_count as usize,
             distinct_keys: self.distinct_estimate() as usize,
-            approx_bytes: self.bloom.filter().byte_size() + 16 * 1024, // HLL fixed
+            approx_bytes: self.bloom.byte_size() + 16 * 1024, // HLL fixed
             kind: IndexKind::ZoneMap,
             has_bloom: true,
             index_correlation: 0.0,
         }
     }
 
-    fn bloom(&self) -> Option<&crate::storage::primitives::BloomFilter> {
-        Some(self.bloom.filter())
+    fn definitely_absent(&self, key_bytes: &[u8]) -> bool {
+        <Self as HasBloom>::definitely_absent(self, key_bytes)
     }
 }
 

--- a/crates/reddb-server/src/storage/primitives/split_block_bloom.rs
+++ b/crates/reddb-server/src/storage/primitives/split_block_bloom.rs
@@ -124,6 +124,42 @@ impl SplitBlockBloom {
         self.blocks.len()
     }
 
+    /// Number of bytes used by the block payload, excluding the serialized
+    /// block-count prefix.
+    pub fn byte_size(&self) -> usize {
+        self.blocks.len() * 32
+    }
+
+    /// OR-merge another split-block bloom into this filter. Returns `false`
+    /// when the filters have different block counts, because their block
+    /// routing masks are incompatible.
+    pub fn union_inplace(&mut self, other: &SplitBlockBloom) -> bool {
+        if self.blocks.len() != other.blocks.len() {
+            return false;
+        }
+        for (left, right) in self.blocks.iter_mut().zip(&other.blocks) {
+            for (left_word, right_word) in left.words.iter_mut().zip(right.words) {
+                *left_word |= right_word;
+            }
+        }
+        true
+    }
+
+    /// Fraction of block words that have at least one bit set.
+    pub fn fill_ratio(&self) -> f64 {
+        let total_words = self.blocks.len() * 8;
+        if total_words == 0 {
+            return 0.0;
+        }
+        let filled_words = self
+            .blocks
+            .iter()
+            .flat_map(|block| block.words)
+            .filter(|word| *word != 0)
+            .count();
+        filled_words as f64 / total_words as f64
+    }
+
     /// Serialize to a self-describing blob: a 4-byte LE block count followed
     /// by `num_blocks × 8` little-endian `u32` words. The block count is
     /// always a power of two, so [`from_bytes`](Self::from_bytes) can rebuild
@@ -360,6 +396,26 @@ mod tests {
             assert_eq!(a.probe_bytes(&key), b.probe_bytes(&key));
             assert!(a.probe_bytes(&key), "false negative for key {i}");
         }
+    }
+
+    #[test]
+    fn union_inplace_merges_matching_block_counts() {
+        let mut a = SplitBlockBloom::with_capacity(1024);
+        let mut b = SplitBlockBloom::with_capacity(1024);
+        a.insert_bytes(b"one");
+        b.insert_bytes(b"two");
+
+        assert!(a.union_inplace(&b));
+        assert!(a.probe_bytes(b"one"));
+        assert!(a.probe_bytes(b"two"));
+    }
+
+    #[test]
+    fn union_inplace_rejects_mismatched_block_counts() {
+        let mut a = SplitBlockBloom::with_capacity(1024);
+        let b = SplitBlockBloom::with_capacity(4096);
+
+        assert!(!a.union_inplace(&b));
     }
 
     fn byte_key(i: u64) -> [u8; 16] {


### PR DESCRIPTION
Automated AFK landing for #1828. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1828

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786066286&installation_id=129708444&pr_number=1923&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1923&signature=50cbece87872fa3b9fc4c9f70ae1147a013d01928f71c6058e9f294a6cbd4331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->