### PR TITLE
chore: #1844 MOVED-style stale-ownership redirect with driver routing-cache refresh

### DIFF
--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -58,6 +58,7 @@ pub mod connect;
 pub mod connector;
 pub mod error;
 pub mod params;
+pub mod routing_cache;
 pub mod topology;
 pub mod types;
 

--- a/crates/reddb-client/src/routing_cache.rs
+++ b/crates/reddb-client/src/routing_cache.rs
@@ -1,0 +1,125 @@
+//! Driver routing cache updates from MOVED redirects.
+
+use std::collections::BTreeMap;
+
+use reddb_wire::MovedRedirect;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CachedOwner {
+    pub owner_addr: String,
+    pub ownership_epoch: u64,
+    pub catalog_version: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct RangeKey {
+    collection: String,
+    range_id: u64,
+    slot: Option<u64>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct RoutingCache {
+    ranges: BTreeMap<RangeKey, CachedOwner>,
+}
+
+impl RoutingCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn apply_moved(&mut self, moved: &MovedRedirect) -> bool {
+        let key = RangeKey {
+            collection: moved.collection.clone(),
+            range_id: moved.range_id,
+            slot: moved.slot,
+        };
+        let incoming = CachedOwner {
+            owner_addr: moved.owner_addr.clone(),
+            ownership_epoch: moved.ownership_epoch,
+            catalog_version: moved.catalog_version,
+        };
+
+        match self.ranges.get(&key) {
+            Some(existing)
+                if existing.catalog_version > incoming.catalog_version
+                    || existing.ownership_epoch > incoming.ownership_epoch =>
+            {
+                false
+            }
+            _ => {
+                self.ranges.insert(key, incoming);
+                true
+            }
+        }
+    }
+
+    pub fn owner_for(
+        &self,
+        collection: &str,
+        range_id: u64,
+        slot: Option<u64>,
+    ) -> Option<&CachedOwner> {
+        self.ranges.get(&RangeKey {
+            collection: collection.to_string(),
+            range_id,
+            slot,
+        })
+    }
+
+    pub fn retry_owner_after_moved(&mut self, moved: &MovedRedirect) -> &str {
+        self.apply_moved(moved);
+        &self
+            .owner_for(&moved.collection, moved.range_id, moved.slot)
+            .expect("MOVED update must populate retry owner")
+            .owner_addr
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn moved(owner_addr: &str, epoch: u64, version: u64) -> MovedRedirect {
+        MovedRedirect {
+            slot: Some(12),
+            collection: "orders".to_string(),
+            range_id: 3,
+            owner_addr: owner_addr.to_string(),
+            ownership_epoch: epoch,
+            catalog_version: version,
+            reason: "transaction".to_string(),
+        }
+    }
+
+    #[test]
+    fn moved_redirect_updates_cache_and_retry_targets_current_owner() {
+        let mut cache = RoutingCache::new();
+        cache.apply_moved(&moved("node-a:5050", 1, 1));
+
+        let retry_owner = cache.retry_owner_after_moved(&moved("node-b:5050", 2, 2));
+
+        assert_eq!(retry_owner, "node-b:5050");
+        assert_eq!(
+            cache.owner_for("orders", 3, Some(12)),
+            Some(&CachedOwner {
+                owner_addr: "node-b:5050".to_string(),
+                ownership_epoch: 2,
+                catalog_version: 2,
+            })
+        );
+    }
+
+    #[test]
+    fn stale_moved_payload_does_not_replace_newer_route() {
+        let mut cache = RoutingCache::new();
+        assert!(cache.apply_moved(&moved("node-b:5050", 3, 3)));
+
+        assert!(!cache.apply_moved(&moved("node-a:5050", 2, 2)));
+
+        assert_eq!(
+            cache.owner_for("orders", 3, Some(12)).unwrap().owner_addr,
+            "node-b:5050"
+        );
+    }
+}

--- a/crates/reddb-server/src/cluster/routing.rs
+++ b/crates/reddb-server/src/cluster/routing.rs
@@ -232,6 +232,22 @@ impl RoutingHint {
     pub fn version(&self) -> CatalogVersion {
         self.version
     }
+
+    pub fn to_moved_redirect(
+        &self,
+        slot: Option<u64>,
+        reason: RedirectReason,
+    ) -> reddb_wire::MovedRedirect {
+        reddb_wire::MovedRedirect {
+            slot,
+            collection: self.collection.as_str().to_string(),
+            range_id: self.range_id.value(),
+            owner_addr: self.owner.as_str().to_string(),
+            ownership_epoch: self.epoch.value(),
+            catalog_version: self.version.value(),
+            reason: reason.code().to_string(),
+        }
+    }
 }
 
 impl std::fmt::Display for RoutingHint {
@@ -279,6 +295,18 @@ impl std::fmt::Display for RedirectReason {
             Self::ExplicitlyUnsafe => {
                 write!(f, "operation explicitly marked unsafe to forward")
             }
+        }
+    }
+}
+
+impl RedirectReason {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::ForwardingDisabled => "forwarding_disabled",
+            Self::Transaction => "transaction",
+            Self::Streaming => "streaming",
+            Self::LargePayload { .. } => "large_payload",
+            Self::ExplicitlyUnsafe => "explicitly_unsafe",
         }
     }
 }
@@ -665,6 +693,36 @@ mod tests {
                 epoch: hint.epoch(),
             }
         );
+    }
+
+    #[test]
+    fn redirect_builds_moved_payload_with_owner_epoch_and_catalog_version() {
+        let orders = collection("orders");
+        let mut catalog = catalog_with(range_with(&orders, 1, "node-a:5050", &["node-b:5050"]));
+        let v1 = catalog.range(&orders, RangeId::new(1)).unwrap().clone();
+        catalog
+            .apply_update(v1.transfer_to(ident("node-b:5050"), [ident("node-a:5050")]))
+            .unwrap();
+
+        let request =
+            RoutedRequest::new(orders.clone(), b"k".to_vec(), RequestOperation::Transaction);
+        let (hint, reason) = match catalog.plan_route(
+            &ident("node-a:5050"),
+            &request,
+            &RoutingPolicy::forwarding(),
+        ) {
+            RouteDecision::Redirect { hint, reason } => (hint, reason),
+            other => panic!("expected Redirect, got {other:?}"),
+        };
+        let payload = hint.to_moved_redirect(Some(9), reason);
+
+        assert_eq!(payload.slot, Some(9));
+        assert_eq!(payload.collection, "orders");
+        assert_eq!(payload.range_id, 1);
+        assert_eq!(payload.owner_addr, "node-b:5050");
+        assert_eq!(payload.ownership_epoch, 2);
+        assert_eq!(payload.catalog_version, 2);
+        assert_eq!(payload.reason, "transaction");
     }
 
     // A stale safe-op forward also tracks ownership: after a transfer, a safe op

--- a/crates/reddb-wire/src/lib.rs
+++ b/crates/reddb-wire/src/lib.rs
@@ -22,6 +22,7 @@ pub mod conn_string;
 pub mod jsonrpc;
 pub mod knowledge;
 pub mod legacy;
+pub mod moved;
 pub mod query_with_params;
 pub mod redwire;
 pub mod replication;
@@ -35,6 +36,10 @@ pub use conn_string::{
     SUPPORTED_SCHEMES,
 };
 pub use knowledge::*;
+pub use moved::{
+    build_moved_redirect_frame, decode_moved_redirect, encode_moved_redirect, MovedRedirect,
+    MovedRedirectError, MOVED_CODE,
+};
 pub use redwire::{BuildError, FrameBuilder};
 pub use sanitizer::{
     audit_safe_log_field, Boundary, ConnStringSanitizer, EscapeError, EscapedFor, ParsedConnString,

--- a/crates/reddb-wire/src/moved.rs
+++ b/crates/reddb-wire/src/moved.rs
@@ -1,0 +1,170 @@
+//! MOVED-style stale-ownership redirect payload.
+//!
+//! The shape is shared by transports: a non-owner returns it when routing
+//! metadata says another member currently owns the target range. Clients update
+//! their routing cache from this payload and retry once against `owner_addr`.
+
+use serde_json::{Map, Value};
+
+use crate::redwire::{Frame, MessageKind};
+
+pub const MOVED_CODE: &str = "MOVED";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MovedRedirect {
+    pub slot: Option<u64>,
+    pub collection: String,
+    pub range_id: u64,
+    pub owner_addr: String,
+    pub ownership_epoch: u64,
+    pub catalog_version: u64,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MovedRedirectError {
+    InvalidJson,
+    ExpectedObject,
+    MissingField(&'static str),
+    InvalidField(&'static str),
+}
+
+impl std::fmt::Display for MovedRedirectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidJson => write!(f, "MOVED payload is not valid JSON"),
+            Self::ExpectedObject => write!(f, "MOVED payload must be a JSON object"),
+            Self::MissingField(field) => write!(f, "MOVED payload missing field {field}"),
+            Self::InvalidField(field) => write!(f, "MOVED payload field {field} is invalid"),
+        }
+    }
+}
+
+impl std::error::Error for MovedRedirectError {}
+
+pub fn encode_moved_redirect(payload: &MovedRedirect) -> Vec<u8> {
+    let mut obj = Map::new();
+    obj.insert("code".to_string(), Value::String(MOVED_CODE.to_string()));
+    if let Some(slot) = payload.slot {
+        obj.insert("slot".to_string(), Value::Number(slot.into()));
+    }
+    obj.insert(
+        "collection".to_string(),
+        Value::String(payload.collection.clone()),
+    );
+    obj.insert(
+        "range_id".to_string(),
+        Value::Number(payload.range_id.into()),
+    );
+    obj.insert(
+        "owner_addr".to_string(),
+        Value::String(payload.owner_addr.clone()),
+    );
+    obj.insert(
+        "ownership_epoch".to_string(),
+        Value::Number(payload.ownership_epoch.into()),
+    );
+    obj.insert(
+        "catalog_version".to_string(),
+        Value::Number(payload.catalog_version.into()),
+    );
+    obj.insert("reason".to_string(), Value::String(payload.reason.clone()));
+    serde_json::to_vec(&Value::Object(obj)).expect("MOVED payload JSON encoding cannot fail")
+}
+
+pub fn decode_moved_redirect(bytes: &[u8]) -> Result<MovedRedirect, MovedRedirectError> {
+    let value: Value =
+        serde_json::from_slice(bytes).map_err(|_| MovedRedirectError::InvalidJson)?;
+    let obj = value
+        .as_object()
+        .ok_or(MovedRedirectError::ExpectedObject)?;
+    let code = required_str(obj, "code")?;
+    if code != MOVED_CODE {
+        return Err(MovedRedirectError::InvalidField("code"));
+    }
+    Ok(MovedRedirect {
+        slot: optional_u64(obj, "slot")?,
+        collection: required_str(obj, "collection")?.to_string(),
+        range_id: required_u64(obj, "range_id")?,
+        owner_addr: required_str(obj, "owner_addr")?.to_string(),
+        ownership_epoch: required_u64(obj, "ownership_epoch")?,
+        catalog_version: required_u64(obj, "catalog_version")?,
+        reason: required_str(obj, "reason")?.to_string(),
+    })
+}
+
+pub fn build_moved_redirect_frame(correlation_id: u64, payload: &MovedRedirect) -> Frame {
+    Frame::new(
+        MessageKind::MovedRedirect,
+        correlation_id,
+        encode_moved_redirect(payload),
+    )
+}
+
+fn required_str<'a>(
+    obj: &'a Map<String, Value>,
+    field: &'static str,
+) -> Result<&'a str, MovedRedirectError> {
+    obj.get(field)
+        .ok_or(MovedRedirectError::MissingField(field))?
+        .as_str()
+        .filter(|value| !value.is_empty())
+        .ok_or(MovedRedirectError::InvalidField(field))
+}
+
+fn required_u64(obj: &Map<String, Value>, field: &'static str) -> Result<u64, MovedRedirectError> {
+    obj.get(field)
+        .ok_or(MovedRedirectError::MissingField(field))?
+        .as_u64()
+        .ok_or(MovedRedirectError::InvalidField(field))
+}
+
+fn optional_u64(
+    obj: &Map<String, Value>,
+    field: &'static str,
+) -> Result<Option<u64>, MovedRedirectError> {
+    match obj.get(field) {
+        Some(value) => value
+            .as_u64()
+            .map(Some)
+            .ok_or(MovedRedirectError::InvalidField(field)),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn payload() -> MovedRedirect {
+        MovedRedirect {
+            slot: Some(42),
+            collection: "orders".to_string(),
+            range_id: 7,
+            owner_addr: "node-b:5050".to_string(),
+            ownership_epoch: 9,
+            catalog_version: 11,
+            reason: "transaction".to_string(),
+        }
+    }
+
+    #[test]
+    fn moved_payload_round_trips_owner_epoch_version_and_slot() {
+        let encoded = encode_moved_redirect(&payload());
+        let decoded = decode_moved_redirect(&encoded).expect("decode MOVED");
+
+        assert_eq!(decoded, payload());
+    }
+
+    #[test]
+    fn moved_frame_uses_server_to_client_kind() {
+        let frame = build_moved_redirect_frame(99, &payload());
+
+        assert_eq!(frame.kind, MessageKind::MovedRedirect);
+        assert_eq!(frame.correlation_id, 99);
+        assert_eq!(
+            decode_moved_redirect(&frame.payload).expect("decode frame payload"),
+            payload()
+        );
+    }
+}

--- a/crates/reddb-wire/src/redwire/frame.rs
+++ b/crates/reddb-wire/src/redwire/frame.rs
@@ -128,6 +128,9 @@ pub enum MessageKind {
     // outcome is unambiguous on the wire: not a `QueueEventPush`
     // (delivery), not a `StreamError` (cancellation / failure).
     QueueWaitTimeout = 0x30,
+    // Stale-ownership redirect. Carries a MOVED payload naming the current
+    // range owner, ownership epoch, and catalog version.
+    MovedRedirect = 0x31,
 }
 
 /// Coarse routing class for a `MessageKind`.
@@ -184,7 +187,8 @@ impl MessageKind {
             | Self::DeleteOk
             | Self::VectorSearch
             | Self::GraphTraverse
-            | Self::QueryWithParams => MessageClass::DataPlane,
+            | Self::QueryWithParams
+            | Self::MovedRedirect => MessageClass::DataPlane,
 
             // BulkStream* + RowDescription/StreamEnd describe an
             // in-flight stream rather than a single round trip.
@@ -329,7 +333,8 @@ impl MessageKind {
             // Server pushes the delivered queue message (issue #917)
             // and the distinct wait-timeout outcome (issue #919).
             | Self::QueueEventPush
-            | Self::QueueWaitTimeout => MessageDirection::ServerToClient,
+            | Self::QueueWaitTimeout
+            | Self::MovedRedirect => MessageDirection::ServerToClient,
 
             // Symmetric — either peer may initiate. (`StreamChunk` is
             // also symmetric but has its own arm above — see issue
@@ -384,6 +389,7 @@ impl MessageKind {
             0x2E => Some(Self::QueueWaitOpen),
             0x2F => Some(Self::QueueEventPush),
             0x30 => Some(Self::QueueWaitTimeout),
+            0x31 => Some(Self::MovedRedirect),
             _ => None,
         }
     }
@@ -476,6 +482,7 @@ mod catalog_tests {
         MessageKind::QueueWaitOpen,
         MessageKind::QueueEventPush,
         MessageKind::QueueWaitTimeout,
+        MessageKind::MovedRedirect,
     ];
 
     #[test]
@@ -505,6 +512,7 @@ mod catalog_tests {
             MessageKind::QueryWithParams.class(),
             MessageClass::DataPlane
         );
+        assert_eq!(MessageKind::MovedRedirect.class(), MessageClass::DataPlane);
 
         // Streamed envelopes.
         assert_eq!(MessageKind::BulkStreamStart.class(), MessageClass::Streamed);


### PR DESCRIPTION
Automated AFK landing for #1844. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1844

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786071520&installation_id=129708444&pr_number=1925&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1925&signature=502e761b6b37d1391ffed7fc3e2bc53387c5bfa24e4123c0490b15f6daf0f10c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->