### PR TITLE
chore: #1848 Per-request read consistency levels: strong, causal, bounded-staleness, local

### DIFF
--- a/crates/reddb-client/src/bookmark_routing.rs
+++ b/crates/reddb-client/src/bookmark_routing.rs
@@ -123,6 +123,9 @@ impl ReadEndpoint {
 /// Why a causal read landed on the endpoint it did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RouteKind {
+    /// The request required a strong read, so it routed to the
+    /// primary/range-owner path.
+    StrongPrimary,
     /// The chosen target replica's snapshot frontier already covered
     /// the bookmark — no wait was needed.
     EligibleTarget,
@@ -135,6 +138,12 @@ pub enum RouteKind {
     /// No replica was past the bookmark; routed to the primary, which
     /// is always past every committed bookmark.
     FallbackPrimary,
+    /// Bounded-staleness routing found a healthy replica within the
+    /// caller's declared lag bound.
+    BoundedStalenessReplica,
+    /// Local routing selected a healthy replica without making any
+    /// freshness claim.
+    LocalReplica,
 }
 
 impl RouteKind {
@@ -176,7 +185,7 @@ pub trait BookmarkWaiter {
 }
 
 /// Options for a causal read route.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CausalReadOptions {
     /// Region the caller prefers to read from (locality). When set, a
     /// healthy replica in this region is chosen as the wait target
@@ -185,6 +194,62 @@ pub struct CausalReadOptions {
     /// Upper bound on how long to wait for the target to catch up
     /// before falling back.
     pub deadline: Duration,
+}
+
+/// Per-request read consistency level.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReadConsistency {
+    /// Route to the primary/range owner so the read never observes
+    /// state before the commit watermark.
+    Strong,
+    /// Route using the session bookmark path.
+    Causal {
+        bookmark: BookmarkTarget,
+        opts: CausalReadOptions,
+    },
+    /// Allow any healthy replica whose advertised lag is within
+    /// `max_lag`.
+    BoundedStaleness { max_lag: Duration },
+    /// Allow any healthy member; does not block or claim freshness.
+    Local,
+}
+
+/// Per-request query routing options.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryOptions {
+    pub consistency: ReadConsistency,
+}
+
+impl QueryOptions {
+    pub fn strong() -> Self {
+        Self {
+            consistency: ReadConsistency::Strong,
+        }
+    }
+
+    pub fn causal(bookmark: BookmarkTarget, opts: CausalReadOptions) -> Self {
+        Self {
+            consistency: ReadConsistency::Causal { bookmark, opts },
+        }
+    }
+
+    pub fn bounded_staleness(max_lag: Duration) -> Self {
+        Self {
+            consistency: ReadConsistency::BoundedStaleness { max_lag },
+        }
+    }
+
+    pub fn local() -> Self {
+        Self {
+            consistency: ReadConsistency::Local,
+        }
+    }
+}
+
+impl Default for QueryOptions {
+    fn default() -> Self {
+        Self::local()
+    }
 }
 
 impl CausalReadOptions {
@@ -329,6 +394,70 @@ impl RoutingTable {
         self.fall_back(bookmark, None, waiter.elapsed())
     }
 
+    /// Resolve a read for the requested per-request consistency
+    /// level. Causal delegates to the bookmark route. Strong and
+    /// fallback routes use the primary, which is the range-owner path
+    /// at the current client routing layer.
+    pub fn route_read(
+        &self,
+        options: &QueryOptions,
+        waiter: &mut dyn BookmarkWaiter,
+    ) -> RouteDecision {
+        match &options.consistency {
+            ReadConsistency::Strong => RouteDecision {
+                endpoint: self.write.endpoint(),
+                kind: RouteKind::StrongPrimary,
+                waited: Duration::ZERO,
+            },
+            ReadConsistency::Causal { bookmark, opts } => {
+                self.route_causal_read(*bookmark, opts, waiter)
+            }
+            ReadConsistency::BoundedStaleness { max_lag } => self.route_bounded_staleness(*max_lag),
+            ReadConsistency::Local => self.route_local(),
+        }
+    }
+
+    fn route_bounded_staleness(&self, max_lag: Duration) -> RouteDecision {
+        let max_lag_ms = max_lag.as_millis().min(u32::MAX as u128) as u32;
+        match self
+            .replicas
+            .iter()
+            .find(|r| r.healthy && !r.rebootstrapping && r.lag_ms <= max_lag_ms)
+        {
+            Some(r) => RouteDecision {
+                endpoint: Endpoint {
+                    addr: r.addr.clone(),
+                    region: r.region.clone(),
+                },
+                kind: RouteKind::BoundedStalenessReplica,
+                waited: Duration::ZERO,
+            },
+            None => RouteDecision {
+                endpoint: self.write.endpoint(),
+                kind: RouteKind::FallbackPrimary,
+                waited: Duration::ZERO,
+            },
+        }
+    }
+
+    fn route_local(&self) -> RouteDecision {
+        match self.replicas.iter().find(|r| r.healthy) {
+            Some(r) => RouteDecision {
+                endpoint: Endpoint {
+                    addr: r.addr.clone(),
+                    region: r.region.clone(),
+                },
+                kind: RouteKind::LocalReplica,
+                waited: Duration::ZERO,
+            },
+            None => RouteDecision {
+                endpoint: self.write.endpoint(),
+                kind: RouteKind::FallbackPrimary,
+                waited: Duration::ZERO,
+            },
+        }
+    }
+
     /// Fallback selection: a healthy replica (other than `exclude`)
     /// already past the bookmark, else the primary.
     fn fall_back(
@@ -376,6 +505,23 @@ mod tests {
             region: region.into(),
             healthy,
             lag_ms: if healthy { 5 } else { u32::MAX },
+            last_applied_lsn: frontier,
+            rebootstrapping: false,
+        }
+    }
+
+    fn lagging_replica(
+        addr: &str,
+        region: &str,
+        healthy: bool,
+        frontier: u64,
+        lag_ms: u32,
+    ) -> ReplicaInfo {
+        ReplicaInfo {
+            addr: addr.into(),
+            region: region.into(),
+            healthy,
+            lag_ms,
             last_applied_lsn: frontier,
             rebootstrapping: false,
         }
@@ -759,5 +905,64 @@ mod tests {
             );
             assert!(!decision.endpoint.addr.is_empty());
         }
+    }
+
+    #[test]
+    fn route_read_strong_uses_primary_without_polling() {
+        let table = RoutingTable::from_membership(
+            membership(vec![replica("r-ok:5050", "us-east-1", true, 150)]),
+            1,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![150], Duration::from_millis(10));
+        let decision = table.route_read(&QueryOptions::strong(), &mut waiter);
+        assert_eq!(decision.kind, RouteKind::StrongPrimary);
+        assert_eq!(decision.endpoint.addr, "primary:5050");
+        assert!(waiter.polled_addrs.is_empty());
+    }
+
+    #[test]
+    fn route_read_bounded_staleness_respects_declared_lag_bound() {
+        let table = RoutingTable::from_membership(
+            membership(vec![
+                lagging_replica("too-stale:5050", "us-east-1", true, 500, 250),
+                lagging_replica("fresh-enough:5050", "us-east-1", true, 90, 40),
+            ]),
+            1,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![], Duration::from_millis(10));
+        let decision = table.route_read(
+            &QueryOptions::bounded_staleness(Duration::from_millis(50)),
+            &mut waiter,
+        );
+        assert_eq!(decision.kind, RouteKind::BoundedStalenessReplica);
+        assert_eq!(decision.endpoint.addr, "fresh-enough:5050");
+        assert!(waiter.polled_addrs.is_empty());
+
+        let fallback = table.route_read(
+            &QueryOptions::bounded_staleness(Duration::from_millis(10)),
+            &mut waiter,
+        );
+        assert_eq!(fallback.kind, RouteKind::FallbackPrimary);
+        assert_eq!(fallback.endpoint.addr, "primary:5050");
+    }
+
+    #[test]
+    fn route_read_local_never_blocks_on_freshness() {
+        let table = RoutingTable::from_membership(
+            membership(vec![lagging_replica(
+                "very-stale:5050",
+                "us-east-1",
+                true,
+                0,
+                u32::MAX,
+            )]),
+            1,
+        );
+        let mut waiter = ScriptedWaiter::new(vec![0, 0, 0], Duration::from_millis(10));
+        let decision = table.route_read(&QueryOptions::local(), &mut waiter);
+        assert_eq!(decision.kind, RouteKind::LocalReplica);
+        assert_eq!(decision.endpoint.addr, "very-stale:5050");
+        assert_eq!(decision.waited, Duration::ZERO);
+        assert!(waiter.polled_addrs.is_empty());
     }
 }

--- a/crates/reddb-client/src/grpc.rs
+++ b/crates/reddb-client/src/grpc.rs
@@ -18,7 +18,9 @@ use std::time::{Duration, Instant};
 
 use crate::connector::RedDBClient;
 
-use crate::bookmark_routing::{BookmarkTarget, BookmarkWaiter, CausalReadOptions, RoutingTable};
+use crate::bookmark_routing::{
+    BookmarkTarget, BookmarkWaiter, CausalReadOptions, QueryOptions, RoutingTable,
+};
 use crate::error::{ClientError, ErrorCode, Result};
 use crate::params::Value as ParamValue;
 use crate::router::{HealthAwareRouter, Outcome};
@@ -367,6 +369,23 @@ impl GrpcClient {
         self.query_on_endpoint(&mut client, idx, sql).await
     }
 
+    pub async fn query_with_options(
+        &self,
+        sql: &str,
+        options: QueryOptions,
+    ) -> Result<QueryResult> {
+        let membership = self.membership.read().unwrap().clone();
+        let term = match &options.consistency {
+            crate::bookmark_routing::ReadConsistency::Causal { bookmark, .. } => bookmark.term(),
+            _ => 0,
+        };
+        let table = RoutingTable::from_membership(membership, term);
+        let mut waiter = MembershipFrontierWaiter::new(&self.membership);
+        let decision = table.route_read(&options, &mut waiter);
+        let (mut client, idx) = self.endpoint_by_addr(&decision.endpoint.addr);
+        self.query_on_endpoint(&mut client, idx, sql).await
+    }
+
     pub async fn query_causal(
         &self,
         sql: &str,
@@ -376,7 +395,8 @@ impl GrpcClient {
         let membership = self.membership.read().unwrap().clone();
         let table = RoutingTable::from_membership(membership, bookmark.term());
         let mut waiter = MembershipFrontierWaiter::new(&self.membership);
-        let decision = table.route_causal_read(bookmark, &opts, &mut waiter);
+        let options = QueryOptions::causal(bookmark, opts);
+        let decision = table.route_read(&options, &mut waiter);
         let (mut client, idx) = self.endpoint_by_addr(&decision.endpoint.addr);
         self.query_on_endpoint(&mut client, idx, sql).await
     }

--- a/crates/reddb-client/src/lib.rs
+++ b/crates/reddb-client/src/lib.rs
@@ -89,6 +89,7 @@ pub use types::{
 // crate. Workspace consumers (`reddb-server::rpc_stdio`, the `red`
 // bin's REPL launcher, the `red_client` bin) import these paths
 // directly.
+pub use bookmark_routing::{CausalReadOptions, QueryOptions, ReadConsistency};
 pub use connector::{
     repl, BulkCreateStatus, CreatedEntity, HealthStatus, OperationStatus, QueryResponse,
     RedDBClient,
@@ -200,6 +201,34 @@ impl Reddb {
             Reddb::Grpc(c) => c.query(sql).await,
             #[cfg(feature = "http")]
             Reddb::Http(c) => c.query(sql).await,
+            Reddb::Unavailable(name) => Err(ClientError::feature_disabled(name)),
+        }
+    }
+
+    pub async fn query_with_options(
+        &self,
+        sql: &str,
+        options: QueryOptions,
+    ) -> Result<QueryResult> {
+        if sql.trim().is_empty() {
+            return Err(ClientError::new(
+                ErrorCode::InvalidArgument,
+                "query SQL must not be empty",
+            ));
+        }
+        match self {
+            #[cfg(feature = "embedded")]
+            Reddb::Embedded(c) => {
+                let _ = options;
+                c.query(sql)
+            }
+            #[cfg(feature = "grpc")]
+            Reddb::Grpc(c) => c.query_with_options(sql, options).await,
+            #[cfg(feature = "http")]
+            Reddb::Http(c) => {
+                let _ = options;
+                c.query(sql).await
+            }
             Reddb::Unavailable(name) => Err(ClientError::feature_disabled(name)),
         }
     }

--- a/crates/reddb-client/tests/grpc_pool_concurrency.rs
+++ b/crates/reddb-client/tests/grpc_pool_concurrency.rs
@@ -23,13 +23,14 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use reddb_client::bookmark_routing::{BookmarkTarget, CausalReadOptions};
+use reddb_client::bookmark_routing::{BookmarkTarget, CausalReadOptions, QueryOptions};
 use reddb_client::grpc::GrpcClient;
 use reddb_client::topology::ClusterMembership;
 use reddb_client::RedDBClient;
 use reddb_client::ValueOut;
 use reddb_grpc_proto::red_db_server::{RedDb, RedDbServer};
 use reddb_grpc_proto::*;
+use reddb_wire::topology::{Endpoint as WireEndpoint, ReplicaInfo};
 use tokio::sync::{oneshot, Mutex};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{transport::Server, Request, Response, Status};
@@ -498,4 +499,101 @@ async fn causal_query_falls_back_to_primary_when_replica_is_stale_but_tokenless_
 
     let _ = primary_shutdown.send(());
     let _ = replica_shutdown.send(());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn query_options_route_each_read_consistency_level_with_lagging_replica() {
+    let (primary_addr, primary_shutdown) = spawn_labeled_mock("primary").await;
+    let (stale_addr, stale_shutdown) = spawn_labeled_mock("stale").await;
+    let (fresh_addr, fresh_shutdown) = spawn_labeled_mock("fresh").await;
+    let primary_url = format!("http://{primary_addr}");
+    let stale_url = format!("http://{stale_addr}");
+    let fresh_url = format!("http://{fresh_addr}");
+
+    let client = GrpcClient::connect_cluster_with_pool_size(
+        primary_url.clone(),
+        vec![stale_url.clone(), fresh_url.clone()],
+        false,
+        1,
+    )
+    .await
+    .expect("connect cluster");
+    client.update_membership(ClusterMembership {
+        primary: WireEndpoint {
+            addr: primary_url.clone(),
+            region: "us-east-1".into(),
+        },
+        replicas: vec![
+            ReplicaInfo {
+                addr: stale_url.clone(),
+                region: "us-east-1".into(),
+                healthy: true,
+                lag_ms: 500,
+                last_applied_lsn: 0,
+                rebootstrapping: false,
+            },
+            ReplicaInfo {
+                addr: fresh_url.clone(),
+                region: "us-east-1".into(),
+                healthy: true,
+                lag_ms: 40,
+                last_applied_lsn: 40,
+                rebootstrapping: false,
+            },
+        ],
+        epoch: 1,
+    });
+
+    let strong = client
+        .query_with_options("select endpoint", QueryOptions::strong())
+        .await
+        .expect("strong read");
+    assert_eq!(
+        endpoint_label(&strong),
+        "primary",
+        "strong reads must route to the primary/range-owner path"
+    );
+
+    let causal = client
+        .query_with_options(
+            "select endpoint",
+            QueryOptions::causal(
+                BookmarkTarget::new(1, 100),
+                CausalReadOptions::with_deadline(Duration::from_millis(1)),
+            ),
+        )
+        .await
+        .expect("causal read");
+    assert_eq!(
+        endpoint_label(&causal),
+        "primary",
+        "causal reads must not use replicas behind the session token"
+    );
+
+    let bounded = client
+        .query_with_options(
+            "select endpoint",
+            QueryOptions::bounded_staleness(Duration::from_millis(50)),
+        )
+        .await
+        .expect("bounded-staleness read");
+    assert_eq!(
+        endpoint_label(&bounded),
+        "fresh",
+        "bounded-staleness reads must skip replicas outside the lag bound"
+    );
+
+    let local = client
+        .query_with_options("select endpoint", QueryOptions::local())
+        .await
+        .expect("local read");
+    assert_eq!(
+        endpoint_label(&local),
+        "stale",
+        "local reads may use any healthy replica without blocking on freshness"
+    );
+
+    let _ = primary_shutdown.send(());
+    let _ = stale_shutdown.send(());
+    let _ = fresh_shutdown.send(());
 }


### PR DESCRIPTION
Automated AFK landing for #1848. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1848

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786072386&installation_id=129708444&pr_number=1926&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1926&signature=bd07a2180338007bad37573bc7e8043ebf12755a6318dc82a9b02c50b38c8e62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->