### PR TITLE
chore: #1784 DST campaign: crash safety across the store-fork lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test-chaos-all:
 	$(MAKE) test-dst-storage
 
 test-dst-storage:
-	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery --test tm_commit_path_recovery
+	cargo test --locked -p unreliable-libc --test sim_power_cut_recovery --test value_equivalence_recovery --test power_cut_recovery --test tm_commit_path_recovery --test store_fork_lifecycle_recovery
 
 test-dst-sweep:
 	cargo test --locked -p reddb-io-server replication::dst::tests::dst_seed_sweep -- --ignored

--- a/crates/reddb-file/src/operational_manifest/fork.rs
+++ b/crates/reddb-file/src/operational_manifest/fork.rs
@@ -411,7 +411,7 @@ impl OperationalManifest {
         }
     }
 
-    fn archived_parent_handle(&self, name: &str) -> Self {
+    pub(super) fn archived_parent_handle(&self, name: &str) -> Self {
         let root_name = self
             .root
             .file_name()
@@ -425,7 +425,7 @@ impl OperationalManifest {
         }
     }
 
-    fn promoting_fork_handle(&self, name: &str) -> Self {
+    pub(super) fn promoting_fork_handle(&self, name: &str) -> Self {
         let root_name = self
             .root
             .file_name()
@@ -462,6 +462,65 @@ impl OperationalManifest {
         Ok(())
     }
 
+    pub(super) fn recover_interrupted_fork_promotions(&self) -> io::Result<()> {
+        let Some(staging) = self.interrupted_promotion_staging()? else {
+            self.clear_promoted_primary_origin()?;
+            return Ok(());
+        };
+        let origin = staging
+            .fork_origin()?
+            .ok_or_else(|| invalid_data("promoting store fork is missing origin"))?;
+        if origin.parent_store != self.store_identity() {
+            return Err(invalid_data(format!(
+                "promoting store fork {} belongs to {}, not {}",
+                origin.name,
+                origin.parent_store,
+                self.store_identity()
+            )));
+        }
+
+        let fork = self.fork_handle(&origin.name);
+        if fork.root.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "store fork exists alongside promotion staging: {}",
+                    origin.name
+                ),
+            ));
+        }
+
+        let archived_parent = self.archived_parent_handle(&origin.name);
+        if archived_parent.root.exists() {
+            if self.root.exists() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AlreadyExists,
+                    format!(
+                        "active store and retired parent both exist during fork promotion: {}",
+                        origin.name
+                    ),
+                ));
+            }
+        } else {
+            if !self.root.exists() {
+                return Err(invalid_data(format!(
+                    "store fork promotion lost active parent before archive: {}",
+                    origin.name
+                )));
+            }
+            fs::rename(&self.root, &archived_parent.root)?;
+            if let Some(parent) = self.root.parent() {
+                sync_dir(parent)?;
+            }
+        }
+
+        fs::rename(&staging.root, &self.root)?;
+        if let Some(parent) = self.root.parent() {
+            sync_dir(parent)?;
+        }
+        self.clear_fork_origin()
+    }
+
     fn clear_fork_origin(&self) -> io::Result<()> {
         let mut manifest = match self.load_current()? {
             Some(manifest) => manifest,
@@ -473,6 +532,49 @@ impl OperationalManifest {
         manifest.fork_origin = None;
         manifest.generation += 1;
         self.publish(&manifest)
+    }
+
+    fn clear_promoted_primary_origin(&self) -> io::Result<()> {
+        let Some(origin) = self.fork_origin()? else {
+            return Ok(());
+        };
+        if origin.parent_store == self.store_identity()
+            && self.archived_parent_handle(&origin.name).root.exists()
+        {
+            self.clear_fork_origin()?;
+        }
+        Ok(())
+    }
+
+    fn interrupted_promotion_staging(&self) -> io::Result<Option<Self>> {
+        let Some(parent) = self.root.parent() else {
+            return Ok(None);
+        };
+        let Some(root_name) = self.root.file_name() else {
+            return Ok(None);
+        };
+        let prefix = format!("{}.promoting-", root_name.to_string_lossy());
+        let entries = match fs::read_dir(parent) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let mut staging = None;
+        for entry in entries {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let file_name = entry.file_name().to_string_lossy().into_owned();
+            if !file_name.starts_with(&prefix) {
+                continue;
+            }
+            if staging.is_some() {
+                return Err(invalid_data("multiple interrupted store fork promotions"));
+            }
+            staging = Some(Self { root: entry.path() });
+        }
+        Ok(staging)
     }
 
     pub(super) fn fork_referenced_collection_paths(&self) -> io::Result<BTreeSet<String>> {

--- a/crates/reddb-file/src/operational_manifest/mod.rs
+++ b/crates/reddb-file/src/operational_manifest/mod.rs
@@ -143,6 +143,7 @@ impl OperationalManifest {
     }
 
     pub fn recover_or_bootstrap(&self, existing_collections: &[String]) -> io::Result<Vec<String>> {
+        self.recover_interrupted_fork_promotions()?;
         self.ensure_dirs()?;
         let mut manifest = match self.load_current()? {
             Some(manifest) => manifest,
@@ -174,6 +175,7 @@ impl OperationalManifest {
         let protected_paths = self.protected_collection_paths(&manifest)?;
         self.quarantine_unreferenced_collection_files(&protected_paths)?;
         self.quarantine_unreferenced_append_only_segments(&manifest)?;
+        self.validate_manifest_artifacts(&manifest)?;
 
         let pending_drops = manifest
             .collections
@@ -200,6 +202,7 @@ impl OperationalManifest {
             let protected_paths = self.protected_collection_paths(&manifest)?;
             self.quarantine_unreferenced_collection_files(&protected_paths)?;
             self.quarantine_unreferenced_append_only_segments(&manifest)?;
+            self.validate_manifest_artifacts(&manifest)?;
         }
         let pending_segments = manifest
             .append_only_segments
@@ -220,6 +223,7 @@ impl OperationalManifest {
             let protected_paths = self.protected_collection_paths(&manifest)?;
             self.quarantine_unreferenced_collection_files(&protected_paths)?;
             self.quarantine_unreferenced_append_only_segments(&manifest)?;
+            self.validate_manifest_artifacts(&manifest)?;
         }
 
         Ok(completed_pending_drops)
@@ -603,6 +607,44 @@ impl OperationalManifest {
         sync_dir(&self.quarantine_dir())
     }
 
+    fn validate_manifest_artifacts(&self, manifest: &Manifest) -> io::Result<()> {
+        for (name, entry) in &manifest.collections {
+            if entry.state != CollectionState::Active {
+                continue;
+            }
+            if let Some(source) = &entry.source {
+                if !Path::new(source).is_file() {
+                    return Err(invalid_data(format!(
+                        "missing collection artifact for shared fork source {name}: {source}"
+                    )));
+                }
+                continue;
+            }
+            let path = self.collections_dir().join(&entry.path);
+            if !path.is_file() {
+                return Err(invalid_data(format!(
+                    "missing collection artifact for {name}: {}",
+                    path.display()
+                )));
+            }
+        }
+        for entry in &manifest.append_only_segments {
+            if entry.state != AppendOnlySegmentState::Active {
+                continue;
+            }
+            let path = self.append_only_segments_dir().join(&entry.path);
+            if !path.is_file() {
+                return Err(invalid_data(format!(
+                    "missing append-only artifact for {}/{}: {}",
+                    entry.collection,
+                    entry.segment_id,
+                    path.display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
     fn collections_dir(&self) -> PathBuf {
         self.root.join(COLLECTIONS_DIR)
     }
@@ -648,7 +690,7 @@ fn active_collection_paths(manifest: &Manifest) -> BTreeSet<String> {
     manifest
         .collections
         .values()
-        .filter(|entry| entry.state == CollectionState::Active)
+        .filter(|entry| entry.state == CollectionState::Active && entry.source.is_none())
         .map(|entry| entry.path.clone())
         .collect()
 }
@@ -1382,6 +1424,44 @@ mod tests {
     }
 
     #[test]
+    fn fork_recovery_quarantines_partial_hydration_artifact() {
+        let path = temp_db_path("fork_partial_hydration");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"complete-parent-copy");
+        parent.create_fork("exp", 1).unwrap();
+        let fork = parent.fork_handle("exp");
+
+        write_collection(&fork, "users", b"partial");
+
+        fork.recover_or_bootstrap(&[]).unwrap();
+
+        assert!(
+            !fork.collection_path_for_test("users").exists(),
+            "shared-by-reference fork recovery must not keep half-hydrated local artifacts"
+        );
+        assert_eq!(read_collection(&parent, "users"), b"complete-parent-copy");
+        let forks = parent.list_forks().unwrap();
+        assert_eq!(forks.len(), 1);
+        assert_eq!(
+            forks[0].hydration_state,
+            ForkHydrationState::SharedByReference
+        );
+    }
+
+    #[test]
+    fn recovery_rejects_manifest_referencing_missing_artifact() {
+        let path = temp_db_path("missing_artifact");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        fs::remove_file(parent.collection_path_for_test("users")).unwrap();
+
+        let err = parent.recover_or_bootstrap(&[]).unwrap_err();
+
+        assert!(err.to_string().contains("missing collection artifact"));
+    }
+
+    #[test]
     fn parent_writes_after_fork_are_invisible_to_fork() {
         let path = temp_db_path("parent_to_fork");
         let parent = OperationalManifest::for_db_path(&path);
@@ -1506,6 +1586,30 @@ mod tests {
         assert!(parent.list_forks().unwrap().is_empty());
         assert_eq!(
             read_collection(&outcome.archived_parent, "users"),
+            b"old-primary"
+        );
+    }
+
+    #[test]
+    fn promotion_recovery_resumes_after_fork_moves_to_staging() {
+        let path = temp_db_path("promote_fork_resume_staging");
+        let parent = OperationalManifest::for_db_path(&path);
+        parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
+        write_collection(&parent, "users", b"old-primary");
+        parent.create_fork("exp", 21).unwrap();
+        let fork = parent.fork_handle("exp");
+        fork.hydrate_collection("users").unwrap();
+        write_collection(&fork, "users", b"new-primary");
+        let staging = parent.promoting_fork_handle("exp");
+        fs::rename(&fork.root, &staging.root).unwrap();
+
+        parent.recover_or_bootstrap(&[]).unwrap();
+
+        assert_eq!(read_collection(&parent, "users"), b"new-primary");
+        assert!(parent.fork_origin().unwrap().is_none());
+        assert!(parent.list_forks().unwrap().is_empty());
+        assert_eq!(
+            read_collection(&parent.archived_parent_handle("exp"), "users"),
             b"old-primary"
         );
     }

--- a/crates/unreliable-libc/Cargo.toml
+++ b/crates/unreliable-libc/Cargo.toml
@@ -37,6 +37,12 @@ path = "src/bin/typed_workload.rs"
 name = "tm_commit_path_workload"
 path = "src/bin/tm_commit_path_workload.rs"
 
+# Store-fork lifecycle workload (#1784), driven under the shim after the test
+# harness prepares the operation-specific pre-state.
+[[bin]]
+name = "store_fork_workload"
+path = "src/bin/store_fork_workload.rs"
+
 [dependencies]
 reddb-file = { workspace = true }
 reddb-types = { workspace = true }

--- a/crates/unreliable-libc/src/bin/store_fork_workload.rs
+++ b/crates/unreliable-libc/src/bin/store_fork_workload.rs
@@ -1,0 +1,58 @@
+//! Store-fork lifecycle workload, driven under the `unreliable-libc` shim.
+
+#![allow(clippy::unwrap_used)]
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use reddb_file::OperationalManifest;
+
+const DB_FILE: &str = "store.rdb";
+const FORK_NAME: &str = "exp";
+
+fn main() -> ExitCode {
+    let stage = match std::env::args().nth(1).as_deref() {
+        Some("create") => Stage::Create,
+        Some("hydrate") => Stage::Hydrate,
+        Some("promote") => Stage::Promote,
+        Some(other) => {
+            eprintln!("unknown store-fork stage: {other}");
+            return ExitCode::from(2);
+        }
+        None => {
+            eprintln!("store-fork stage is required");
+            return ExitCode::from(2);
+        }
+    };
+    let dir = match std::env::var_os("UNRELIABLE_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => {
+            eprintln!("UNRELIABLE_DIR is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    match run_stage(&dir, stage) {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("store-fork workload stopped on durability error: {err}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Stage {
+    Create,
+    Hydrate,
+    Promote,
+}
+
+fn run_stage(dir: &Path, stage: Stage) -> std::io::Result<()> {
+    let parent = OperationalManifest::for_db_path(&dir.join(DB_FILE));
+    match stage {
+        Stage::Create => parent.create_fork(FORK_NAME, 42),
+        Stage::Hydrate => parent.fork_handle(FORK_NAME).hydrate_collection("users"),
+        Stage::Promote => parent.promote_fork(FORK_NAME).map(|_| ()),
+    }
+}

--- a/crates/unreliable-libc/tests/store_fork_lifecycle_recovery.rs
+++ b/crates/unreliable-libc/tests/store_fork_lifecycle_recovery.rs
@@ -1,0 +1,187 @@
+//! Store-fork lifecycle power-cut campaign (#1784).
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used)]
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use reddb_file::{ForkHydrationState, OperationalManifest};
+use unreliable_libc::recover_and_check;
+
+const SHIM_SO: &str = env!("UNRELIABLE_LIBC_SO");
+const WORKLOAD_BIN: &str = env!("CARGO_BIN_EXE_store_fork_workload");
+const DB_FILE: &str = "store.rdb";
+const FORK_NAME: &str = "exp";
+const OLD_PRIMARY: &[u8] = b"old-primary";
+const NEW_PRIMARY: &[u8] = b"new-primary";
+const KILL_AFTER_LIMIT: u64 = 64;
+
+#[derive(Clone, Copy, Debug)]
+enum Stage {
+    Create,
+    Hydrate,
+    Promote,
+}
+
+impl Stage {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Create => "create",
+            Self::Hydrate => "hydrate",
+            Self::Promote => "promote",
+        }
+    }
+
+    fn all() -> [Self; 3] {
+        [Self::Create, Self::Hydrate, Self::Promote]
+    }
+}
+
+#[test]
+fn store_fork_lifecycle_power_cuts_recover_consistently() {
+    assert!(Path::new(SHIM_SO).exists(), "shim .so missing at {SHIM_SO}");
+
+    for stage in Stage::all() {
+        for kill_after in crash_points() {
+            let dir = tempfile::tempdir().unwrap();
+            prepare_stage(dir.path(), stage);
+            spawn_stage(stage, dir.path(), kill_after);
+            assert_recovered(stage, dir.path(), kill_after);
+        }
+    }
+}
+
+fn crash_points() -> Vec<u64> {
+    match std::env::var("SEED") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(seed) => vec![seed.max(1)],
+            Err(_) => documented_crash_points(),
+        },
+        Err(_) => documented_crash_points(),
+    }
+}
+
+fn documented_crash_points() -> Vec<u64> {
+    (1..=KILL_AFTER_LIMIT).collect()
+}
+
+fn prepare_stage(dir: &Path, stage: Stage) {
+    let parent = manifest(dir);
+    parent
+        .recover_or_bootstrap(&["users".to_string(), "orders".to_string()])
+        .unwrap();
+    write_collection(&parent, "users", OLD_PRIMARY);
+    write_collection(&parent, "orders", b"orders");
+
+    match stage {
+        Stage::Create => {}
+        Stage::Hydrate => parent.create_fork(FORK_NAME, 42).unwrap(),
+        Stage::Promote => {
+            parent.create_fork(FORK_NAME, 42).unwrap();
+            let fork = parent.fork_handle(FORK_NAME);
+            fork.hydrate_collection("users").unwrap();
+            fork.hydrate_collection("orders").unwrap();
+            write_collection(&fork, "users", NEW_PRIMARY);
+        }
+    }
+}
+
+fn spawn_stage(stage: Stage, dir: &Path, kill_after: u64) {
+    Command::new(WORKLOAD_BIN)
+        .arg(stage.name())
+        .env("LD_PRELOAD", SHIM_SO)
+        .env("UNRELIABLE_SEED", kill_after.to_string())
+        .env("UNRELIABLE_DIR", dir)
+        .env("UNRELIABLE_POWERCUT", "1")
+        .env("UNRELIABLE_KILL_AFTER", kill_after.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|err| {
+            panic!(
+                "failed to spawn store_fork_workload stage={} kill_after={kill_after}: {err}",
+                stage.name()
+            )
+        });
+}
+
+fn assert_recovered(stage: Stage, dir: &Path, kill_after: u64) {
+    recover_and_check(dir).unwrap_or_else(|err| {
+        panic!(
+            "WAL oracle failed for stage={} kill_after={kill_after}: {err}",
+            stage.name()
+        )
+    });
+
+    let parent = manifest(dir);
+    parent.recover_or_bootstrap(&[]).unwrap_or_else(|err| {
+        panic!(
+            "manifest recovery failed for stage={} kill_after={kill_after}: {err}",
+            stage.name()
+        )
+    });
+
+    match stage {
+        Stage::Create => assert_create_recovered(&parent),
+        Stage::Hydrate => assert_hydrate_recovered(&parent),
+        Stage::Promote => assert_promote_recovered(&parent),
+    }
+}
+
+fn assert_create_recovered(parent: &OperationalManifest) {
+    assert_eq!(read_collection(parent, "users"), OLD_PRIMARY);
+    let forks = parent.list_forks().unwrap();
+    assert!(
+        forks.len() <= 1,
+        "create crash must leave zero or one live fork, got {forks:?}"
+    );
+    if forks.is_empty() {
+        return;
+    }
+    let fork = parent.fork_handle(FORK_NAME);
+    fork.recover_or_bootstrap(&[]).unwrap();
+    fork.hydrate_collection("users").unwrap();
+    assert_eq!(read_collection(&fork, "users"), OLD_PRIMARY);
+}
+
+fn assert_hydrate_recovered(parent: &OperationalManifest) {
+    assert_eq!(read_collection(parent, "users"), OLD_PRIMARY);
+    let forks = parent.list_forks().unwrap();
+    assert_eq!(forks.len(), 1, "hydrate crash must retain the live fork");
+    let fork = parent.fork_handle(FORK_NAME);
+    fork.recover_or_bootstrap(&[]).unwrap();
+    if forks[0].hydration_state != ForkHydrationState::Hydrated {
+        fork.hydrate_collection("users").unwrap();
+    }
+    assert_eq!(read_collection(&fork, "users"), OLD_PRIMARY);
+}
+
+fn assert_promote_recovered(parent: &OperationalManifest) {
+    let forks = parent.list_forks().unwrap();
+    match forks.len() {
+        0 => {
+            assert_eq!(read_collection(parent, "users"), NEW_PRIMARY);
+            assert!(parent.fork_origin().unwrap().is_none());
+        }
+        1 => {
+            assert_eq!(read_collection(parent, "users"), OLD_PRIMARY);
+            let fork = parent.fork_handle(FORK_NAME);
+            fork.recover_or_bootstrap(&[]).unwrap();
+            assert_eq!(read_collection(&fork, "users"), NEW_PRIMARY);
+        }
+        other => panic!("promote crash must leave zero or one live fork, got {other}"),
+    }
+}
+
+fn manifest(dir: &Path) -> OperationalManifest {
+    OperationalManifest::for_db_path(&dir.join(DB_FILE))
+}
+
+fn write_collection(manifest: &OperationalManifest, name: &str, bytes: &[u8]) {
+    std::fs::write(manifest.collection_path_for_test(name), bytes).unwrap();
+}
+
+fn read_collection(manifest: &OperationalManifest, name: &str) -> Vec<u8> {
+    std::fs::read(manifest.collection_path_for_test(name)).unwrap()
+}

--- a/docs/testing/dst-storage-fault-lane.md
+++ b/docs/testing/dst-storage-fault-lane.md
@@ -29,6 +29,9 @@ The lane currently runs these suites:
   scenario families:
   `fcw_before_wal_append`, `wal_append_before_finalize`,
   `savepoint_release_rollback`, and `concurrent_writers`.
+- `store_fork_lifecycle_recovery`: store-fork lifecycle campaign for #1784,
+  injecting power cuts during fork creation, first-touch hydration, and
+  promotion.
 
 ## Documented Seeds
 
@@ -45,6 +48,14 @@ WAL truncation, the in-process `SimVfs` power-cut path, and on Linux the
 then asserts the TM-specific invariant: single-transaction scenarios recover as
 fully absent or fully committed, the concurrent-writer scenario recovers only a
 transaction prefix, and savepoint sub-xids are never orphan-visible.
+
+The store-fork lifecycle campaign prepares the operation-specific parent/fork
+state outside the shim, then runs exactly one lifecycle operation under
+`LD_PRELOAD` while enumerating deterministic kill points. Recovery runs the
+shared WAL oracle and the operational-manifest checks so interrupted create,
+hydrate, and promote stages leave either the pre-crash state or the completed
+state, never a manifest that silently points at a missing or half-hydrated
+artifact.
 
 ## CI Signal
 


### PR DESCRIPTION
Automated AFK landing for #1784. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1784

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786074008&installation_id=129708444&pr_number=1927&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1927&signature=402a02bd1fdb93d470343ba1b195bc20462df612d5e9afd747bbf1231c86de6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new recovery test scenario for store-fork lifecycles, covering creation, hydration, and promotion under simulated power loss.
  * Expanded recovery handling so interrupted fork promotions can resume automatically after a restart.

* **Bug Fixes**
  * Improved recovery validation to detect missing or incomplete storage artifacts during startup.
  * Tightened quarantine behavior so partially hydrated fork data is no longer left behind.

* **Documentation**
  * Updated fault-recovery testing docs to include the new store-fork lifecycle campaign.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->