### PR TITLE
chore: #1843 Replica apply rejects divergent term/epoch history with operator event

### DIFF
--- a/crates/reddb-server/src/runtime/impl_replica_loop.rs
+++ b/crates/reddb-server/src/runtime/impl_replica_loop.rs
@@ -660,10 +660,13 @@ impl RedDBRuntime {
                                     );
                                     continue;
                                 };
-                                match applier.apply(
+                                let range_authority =
+                                    self.inner.write_gate.primary_replica_range_authority();
+                                match applier.apply_fenced(
                                     self.inner.db.as_ref(),
                                     &change,
                                     ApplyMode::Replica,
+                                    range_authority.as_ref(),
                                 ) {
                                     Ok(crate::replication::logical::ApplyOutcome::Applied) => {
                                         self.invalidate_result_cache_for_table(&change.collection);
@@ -701,6 +704,19 @@ impl RedDBRuntime {
                                                 }
                                                 .emit_global();
                                             }
+                                            crate::replication::logical::LogicalApplyError::RangeFenced { range_id, lsn, .. } => {
+                                                if let Some(authority) = range_authority {
+                                                    crate::telemetry::operator_event::OperatorEvent::ReplicaAuthorityDivergence {
+                                                        range_identity: format!("system.global/{range_id}"),
+                                                        expected_term: authority.min_term,
+                                                        expected_ownership_epoch: authority.min_ownership_epoch,
+                                                        observed_term: change.term,
+                                                        observed_ownership_epoch: change.ownership_epoch.unwrap_or(0),
+                                                        lsn: *lsn,
+                                                    }
+                                                    .emit_global();
+                                                }
+                                            }
                                             _ => {}
                                         }
                                         let kind = match &err {
@@ -712,6 +728,7 @@ impl RedDBRuntime {
                                             // advance) until the legitimate primary's
                                             // current-term stream resumes.
                                             crate::replication::logical::LogicalApplyError::StaleTermFenced { .. } => "stale_term_fenced",
+                                            crate::replication::logical::LogicalApplyError::RangeFenced { .. } => "authority_divergence",
                                             _ => "apply_error",
                                         };
                                         self.persist_replication_health(

--- a/crates/reddb-server/src/runtime/write_gate.rs
+++ b/crates/reddb-server/src/runtime/write_gate.rs
@@ -29,6 +29,7 @@ use crate::cluster::{
     OwnershipEpoch, OwnershipLease, PlacementMetadata, RangeBounds, RangeId, RangeOwnership,
     ShardKeyMode, ShardOwnershipCatalog, SupervisorTerm,
 };
+use crate::replication::cdc::RangeAuthority;
 use crate::replication::flow_control::{Admission, FlowController};
 use crate::replication::ReplicationRole;
 use crate::telemetry::operator_event::OperatorEvent;
@@ -158,11 +159,13 @@ impl WriteGate {
             .and_then(|raw| raw.trim().parse::<u64>().ok())
             .unwrap_or(0);
         let ownership = match options.replication.role {
-            ReplicationRole::Primary => Some(OwnershipAdmissionGate::primary_replica(
-                DEFAULT_PRIMARY_REPLICA_OWNER,
-                options.replication.term,
-            )),
-            ReplicationRole::Standalone | ReplicationRole::Replica { .. } => None,
+            ReplicationRole::Primary | ReplicationRole::Replica { .. } => {
+                Some(OwnershipAdmissionGate::primary_replica(
+                    DEFAULT_PRIMARY_REPLICA_OWNER,
+                    options.replication.term,
+                ))
+            }
+            ReplicationRole::Standalone => None,
         };
         Self {
             read_only: AtomicBool::new(options.read_only),
@@ -415,6 +418,13 @@ impl WriteGate {
         };
         gate.promote_to(new_owner, new_term)
     }
+
+    pub fn primary_replica_range_authority(&self) -> Option<RangeAuthority> {
+        self.ownership
+            .read()
+            .as_ref()
+            .map(OwnershipAdmissionGate::range_authority)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -485,6 +495,19 @@ impl OwnershipAdmissionGate {
 
     fn is_fenced(&self) -> bool {
         self.admit().is_err()
+    }
+
+    fn range_authority(&self) -> RangeAuthority {
+        let epoch = self
+            .catalog
+            .range(&self.collection, self.range_id)
+            .map(|range| range.epoch().value())
+            .unwrap_or(0);
+        RangeAuthority {
+            range_id: self.range_id.value(),
+            min_term: self.current_term.value(),
+            min_ownership_epoch: epoch,
+        }
     }
 
     fn promote_to(&mut self, new_owner: NodeIdentity, new_term: u64) -> RedDBResult<()> {
@@ -904,6 +927,27 @@ mod tests {
     }
 
     #[test]
+    fn replica_role_carries_apply_authority_but_stays_public_read_only() {
+        let options = RedDBOptions::in_memory().with_replication(
+            crate::replication::ReplicationConfig::replica("http://primary:55055").with_term(8),
+        );
+        let g = WriteGate::from_options(&options);
+
+        let authority = g
+            .primary_replica_range_authority()
+            .expect("replica apply authority");
+        assert_eq!(authority.range_id, RESERVED_GLOBAL_SYSTEM_RANGE_ID);
+        assert_eq!(authority.min_term, 8);
+        assert_eq!(authority.min_ownership_epoch, 1);
+
+        let err = g.check(WriteKind::Dml).unwrap_err();
+        match err {
+            RedDBError::ReadOnly(msg) => assert!(msg.contains("replica"), "{msg}"),
+            other => panic!("expected replica read-only, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn ownership_admission_fences_deposed_primary() {
         let g = gate(false, ReplicationRole::Primary);
         g.install_primary_replica_ownership_gate_for_test("CN=node-a,O=reddb", 7);
@@ -921,5 +965,19 @@ mod tests {
             }
             other => panic!("expected ownership fencing ReadOnly, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn primary_replica_authority_reports_current_term_epoch_and_range() {
+        let g = gate(false, ReplicationRole::Primary);
+        g.install_primary_replica_ownership_gate_for_test("CN=node-a,O=reddb", 7);
+        g.promote_primary_replica_owner_for_test("CN=node-b,O=reddb", 8);
+
+        let authority = g
+            .primary_replica_range_authority()
+            .expect("primary-replica authority");
+        assert_eq!(authority.range_id, RESERVED_GLOBAL_SYSTEM_RANGE_ID);
+        assert_eq!(authority.min_term, 8);
+        assert_eq!(authority.min_ownership_epoch, 2);
     }
 }

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -195,6 +195,16 @@ pub enum OperatorEvent {
         ownership_epoch: u64,
         range_identity: String,
     },
+    /// Replica apply rejected a stamped record because its range authority
+    /// term/ownership epoch conflicts with the current ownership state.
+    ReplicaAuthorityDivergence {
+        range_identity: String,
+        expected_term: u64,
+        expected_ownership_epoch: u64,
+        observed_term: u64,
+        observed_ownership_epoch: u64,
+        lsn: u64,
+    },
 }
 
 impl OperatorEvent {
@@ -220,6 +230,7 @@ impl OperatorEvent {
             "QueueDlqPromoted",
             "DeposedPrimaryRollback",
             "OwnershipFenced",
+            "ReplicaAuthorityDivergence",
         ]
     }
 
@@ -245,6 +256,7 @@ impl OperatorEvent {
             Self::QueueDlqPromoted { .. } => "QueueDlqPromoted",
             Self::DeposedPrimaryRollback { .. } => "DeposedPrimaryRollback",
             Self::OwnershipFenced { .. } => "OwnershipFenced",
+            Self::ReplicaAuthorityDivergence { .. } => "ReplicaAuthorityDivergence",
         }
     }
 
@@ -544,6 +556,29 @@ impl OperatorEvent {
                     AuditFieldEscaper::field("range_identity", range_identity),
                 ];
                 ("operator/ownership_fenced", fields, summary)
+            }
+            Self::ReplicaAuthorityDivergence {
+                range_identity,
+                expected_term,
+                expected_ownership_epoch,
+                observed_term,
+                observed_ownership_epoch,
+                lsn,
+            } => {
+                let summary = format!(
+                    "replica authority divergence: range={range_identity} lsn={lsn} \
+                     expected=({expected_term},{expected_ownership_epoch}) \
+                     observed=({observed_term},{observed_ownership_epoch})"
+                );
+                let fields = vec![
+                    AuditFieldEscaper::field("range_identity", range_identity),
+                    AuditFieldEscaper::field("expected_term", expected_term),
+                    AuditFieldEscaper::field("expected_ownership_epoch", expected_ownership_epoch),
+                    AuditFieldEscaper::field("observed_term", observed_term),
+                    AuditFieldEscaper::field("observed_ownership_epoch", observed_ownership_epoch),
+                    AuditFieldEscaper::field("lsn", lsn),
+                ];
+                ("operator/replica_authority_divergence", fields, summary)
             }
         }
     }
@@ -929,6 +964,52 @@ mod tests {
             detail.get("range_identity").and_then(|x| x.as_str()),
             Some("system.global/0")
         );
+    }
+
+    #[test]
+    fn replica_authority_divergence_emits_range_and_term_epoch_pairs() {
+        let (logger, path) = make_logger();
+        OperatorEvent::ReplicaAuthorityDivergence {
+            range_identity: "system.global/0".into(),
+            expected_term: 8,
+            expected_ownership_epoch: 2,
+            observed_term: 7,
+            observed_ownership_epoch: 1,
+            lsn: 42,
+        }
+        .emit(&logger);
+        drain(&logger);
+        let v = read_last_line(&path);
+        assert_eq!(
+            v.get("action").and_then(|x| x.as_str()),
+            Some("operator/replica_authority_divergence")
+        );
+        let detail = v.get("detail").expect("event detail");
+        assert_eq!(
+            detail.get("range_identity").and_then(|x| x.as_str()),
+            Some("system.global/0")
+        );
+        assert_eq!(
+            detail.get("expected_term").and_then(|x| x.as_i64()),
+            Some(8)
+        );
+        assert_eq!(
+            detail
+                .get("expected_ownership_epoch")
+                .and_then(|x| x.as_i64()),
+            Some(2)
+        );
+        assert_eq!(
+            detail.get("observed_term").and_then(|x| x.as_i64()),
+            Some(7)
+        );
+        assert_eq!(
+            detail
+                .get("observed_ownership_epoch")
+                .and_then(|x| x.as_i64()),
+            Some(1)
+        );
+        assert_eq!(detail.get("lsn").and_then(|x| x.as_i64()), Some(42));
     }
 
     // ------------------------------------------------------------------

--- a/crates/reddb-server/src/telemetry/operator_event_router.rs
+++ b/crates/reddb-server/src/telemetry/operator_event_router.rs
@@ -694,6 +694,14 @@ mod tests {
                 dlq: "users_events_outbox_dlq".into(),
                 reason: "queue_full".into(),
             },
+            OperatorEvent::ReplicaAuthorityDivergence {
+                range_identity: "system.global/0".into(),
+                expected_term: 8,
+                expected_ownership_epoch: 2,
+                observed_term: 7,
+                observed_ownership_epoch: 1,
+                lsn: 42,
+            },
         ];
 
         // Verify count matches all_variant_names minus DanglingAdminIntent
@@ -863,6 +871,21 @@ mod tests {
                 reason: reason.clone(),
                 ownership_epoch: *ownership_epoch,
                 range_identity: range_identity.clone(),
+            },
+            OperatorEvent::ReplicaAuthorityDivergence {
+                range_identity,
+                expected_term,
+                expected_ownership_epoch,
+                observed_term,
+                observed_ownership_epoch,
+                lsn,
+            } => OperatorEvent::ReplicaAuthorityDivergence {
+                range_identity: range_identity.clone(),
+                expected_term: *expected_term,
+                expected_ownership_epoch: *expected_ownership_epoch,
+                observed_term: *observed_term,
+                observed_ownership_epoch: *observed_ownership_epoch,
+                lsn: *lsn,
             },
         }
     }

--- a/tests/grouped/replication.rs
+++ b/tests/grouped/replication.rs
@@ -54,6 +54,9 @@ mod e2e_issue_840_replication_auto_rollback;
 #[path = "replication/e2e_issue_1836_ownership_admission.rs"]
 mod e2e_issue_1836_ownership_admission;
 
+#[path = "replication/e2e_issue_1843_replica_authority_divergence.rs"]
+mod e2e_issue_1843_replica_authority_divergence;
+
 #[path = "replication/e2e_replica_readonly.rs"]
 mod e2e_replica_readonly;
 

--- a/tests/grouped/replication/e2e_issue_1843_replica_authority_divergence.rs
+++ b/tests/grouped/replication/e2e_issue_1843_replica_authority_divergence.rs
@@ -1,0 +1,75 @@
+//! Issue #1843 — replica apply rejects deposed-owner authority divergence.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use reddb::replication::cdc::{ChangeOperation, RangeAdmitError};
+use reddb::replication::logical::{
+    ApplyErrorKind, ApplyMode, LogicalApplyError, LogicalChangeApplier, ReplicaApplyMetrics,
+};
+use reddb::{RedDBOptions, RedDBRuntime, ReplicationConfig};
+use reddb_wire::replication::ChangeRecord;
+
+#[test]
+fn deposed_owner_stream_against_promoted_group_is_rejected() {
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory()
+            .with_replication(ReplicationConfig::replica("http://primary:55055").with_term(8)),
+    )
+    .expect("replica runtime boots at promoted term");
+    let authority = runtime
+        .write_gate_arc()
+        .primary_replica_range_authority()
+        .expect("replica has apply authority");
+    let applier = LogicalChangeApplier::with_metrics(0, Arc::new(ReplicaApplyMetrics::default()));
+
+    let record = ChangeRecord {
+        term: 7,
+        lsn: 1,
+        timestamp: 1,
+        operation: ChangeOperation::Delete,
+        collection: "authority_items".to_string(),
+        entity_id: 1,
+        entity_kind: "row".to_string(),
+        entity_bytes: None,
+        metadata: None,
+        refresh_records: None,
+        range_id: Some(authority.range_id),
+        ownership_epoch: Some(authority.min_ownership_epoch),
+    };
+
+    let err = applier
+        .apply_fenced(
+            runtime.db().as_ref(),
+            &record,
+            ApplyMode::Replica,
+            Some(&authority),
+        )
+        .expect_err("deposed owner stream must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            LogicalApplyError::RangeFenced {
+                range_id,
+                lsn: 1,
+                reason: RangeAdmitError::StaleTerm {
+                    record_term: 7,
+                    accepted_term: 8,
+                },
+            } if range_id == authority.range_id
+        ),
+        "got {err:?}"
+    );
+    assert_eq!(err.kind(), ApplyErrorKind::Fenced);
+    assert_eq!(
+        applier.last_applied_lsn(),
+        0,
+        "apply must halt before LSN advance"
+    );
+    assert_eq!(
+        applier.metrics().fenced_total.load(Ordering::Relaxed),
+        1,
+        "the refusal must leave a metrics trail"
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #1843. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1843

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786079583&installation_id=129708444&pr_number=1928&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1928&signature=cec1089a836b0728a50f4df02a65611b59b398ae38e69a35960845deda5d934a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer replica authority divergence reporting, including a dedicated operator event with detailed term, epoch, and LSN context.

* **Bug Fixes**
  * Improved replica write handling so fenced records are rejected with more specific feedback when authority no longer matches.
  * Updated health/error classification to distinguish authority divergence from general apply errors.

* **Tests**
  * Added regression coverage for replica fencing behavior, authority tracking, and event routing/logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->