### PR TITLE
chore: #1933 Geo-recognition seam: one authority for GeoPoint and {lat, lon} object values across index and scan sides

### DIFF
--- a/crates/reddb-server/src/geo/mod.rs
+++ b/crates/reddb-server/src/geo/mod.rs
@@ -5,6 +5,8 @@
 
 use std::f64::consts::PI;
 
+use crate::storage::schema::Value;
+
 pub mod h3;
 
 const EARTH_RADIUS_KM: f64 = 6_371.0;
@@ -35,6 +37,69 @@ pub fn micro_to_deg(micro: i32) -> f64 {
 #[inline]
 pub fn deg_to_micro(deg: f64) -> i32 {
     (deg * 1_000_000.0).round() as i32
+}
+
+/// Recognize a storage value as a geographic point in `(lat, lon)` degrees.
+pub fn recognize_geo_value(value: &Value) -> Option<(f64, f64)> {
+    match value {
+        Value::GeoPoint(lat_micro, lon_micro) => {
+            recognize_geo_degrees(micro_to_deg(*lat_micro), micro_to_deg(*lon_micro))
+        }
+        Value::Json(bytes) => recognize_geo_json(bytes),
+        _ => None,
+    }
+}
+
+/// Recognize an object-shaped value from row/node fields as `(lat, lon)` degrees.
+pub fn recognize_geo_fields<'a>(field: impl Fn(&str) -> Option<&'a Value>) -> Option<(f64, f64)> {
+    let lat = field("lat")
+        .or_else(|| field("latitude"))
+        .and_then(numeric_value_to_f64)?;
+    let lon = field("lon")
+        .or_else(|| field("lng"))
+        .or_else(|| field("longitude"))
+        .and_then(numeric_value_to_f64)?;
+    recognize_geo_degrees(lat, lon)
+}
+
+fn recognize_geo_degrees(lat: f64, lon: f64) -> Option<(f64, f64)> {
+    if lat.is_finite()
+        && lon.is_finite()
+        && (-90.0..=90.0).contains(&lat)
+        && (-180.0..=180.0).contains(&lon)
+    {
+        Some((lat, lon))
+    } else {
+        None
+    }
+}
+
+fn numeric_value_to_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::UnsignedInteger(value) => Some(*value as f64),
+        _ => None,
+    }
+}
+
+fn recognize_geo_json(bytes: &[u8]) -> Option<(f64, f64)> {
+    let json = crate::json::from_slice::<crate::json::Value>(bytes).ok()?;
+    let object = json.as_object()?;
+    let lat = object
+        .get("lat")
+        .or_else(|| object.get("latitude"))
+        .and_then(json_number_to_f64)?;
+    let lon = object
+        .get("lon")
+        .or_else(|| object.get("lng"))
+        .or_else(|| object.get("longitude"))
+        .and_then(json_number_to_f64)?;
+    recognize_geo_degrees(lat, lon)
+}
+
+fn json_number_to_f64(value: &crate::json::Value) -> Option<f64> {
+    value.as_f64()
 }
 
 // ── Haversine (spherical model) ─────────────────────────────────────────────
@@ -250,6 +315,19 @@ pub fn polygon_area_km2(vertices: &[(f64, f64)]) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
+    use std::collections::HashMap;
+
+    fn json_value(json: &str) -> Value {
+        Value::Json(json.as_bytes().to_vec())
+    }
+
+    fn fields(values: &[(&str, Value)]) -> HashMap<String, Value> {
+        values
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), value.clone()))
+            .collect()
+    }
 
     #[test]
     fn test_haversine_paris_london() {
@@ -328,5 +406,109 @@ mod tests {
         let micro = deg_to_micro(lat);
         let back = micro_to_deg(micro);
         assert!((lat - back).abs() < 0.000001);
+    }
+
+    #[test]
+    fn recognize_geo_value_accepts_geopoint_and_json_aliases() {
+        assert_eq!(
+            recognize_geo_value(&Value::GeoPoint(38_760_000, -77_150_000)),
+            Some((38.76, -77.15))
+        );
+        assert_eq!(
+            recognize_geo_value(&json_value(r#"{"lat":38.76,"lon":-77.15}"#)),
+            Some((38.76, -77.15))
+        );
+        assert_eq!(
+            recognize_geo_value(&json_value(r#"{"latitude":38,"lng":-77}"#)),
+            Some((38.0, -77.0))
+        );
+        assert_eq!(
+            recognize_geo_value(&json_value(r#"{"latitude":38.76,"longitude":-77.15}"#)),
+            Some((38.76, -77.15))
+        );
+    }
+
+    #[test]
+    fn recognize_geo_fields_accepts_numeric_aliases() {
+        let row = fields(&[
+            ("latitude", Value::Integer(38)),
+            ("longitude", Value::Float(-77.15)),
+        ]);
+        assert_eq!(
+            recognize_geo_fields(|key| row.get(key)),
+            Some((38.0, -77.15))
+        );
+
+        let node = fields(&[("lat", Value::Float(38.76)), ("lng", Value::Integer(-77))]);
+        assert_eq!(
+            recognize_geo_fields(|key| node.get(key)),
+            Some((38.76, -77.0))
+        );
+    }
+
+    #[test]
+    fn recognize_geo_rejects_non_geo_shapes() {
+        for value in [
+            json_value(r#"{"lat":"38.76","lon":"-77.15"}"#),
+            json_value(r#"{"type":"Point","coordinates":[-77.15,38.76]}"#),
+            json_value(r#"{"lat":38.76}"#),
+            json_value(r#"{"lat":91.0,"lon":0.0}"#),
+            json_value(r#"{"lat":0.0,"lon":181.0}"#),
+            json_value(r#"{"lat":null,"lon":0.0}"#),
+            json_value(r#"not json"#),
+            Value::text("38.76,-77.15".to_string()),
+        ] {
+            assert_eq!(recognize_geo_value(&value), None, "{value:?}");
+        }
+
+        let string_fields = fields(&[
+            ("lat", Value::text("38.76".to_string())),
+            ("lon", Value::Float(-77.15)),
+        ]);
+        assert_eq!(recognize_geo_fields(|key| string_fields.get(key)), None);
+
+        let missing_fields = fields(&[("lat", Value::Float(38.76))]);
+        assert_eq!(recognize_geo_fields(|key| missing_fields.get(key)), None);
+
+        let non_finite_fields = fields(&[
+            ("lat", Value::Float(f64::NAN)),
+            ("lon", Value::Float(-77.15)),
+        ]);
+        assert_eq!(recognize_geo_fields(|key| non_finite_fields.get(key)), None);
+
+        let out_of_range_fields =
+            fields(&[("lat", Value::Float(38.76)), ("lon", Value::Float(-181.0))]);
+        assert_eq!(
+            recognize_geo_fields(|key| out_of_range_fields.get(key)),
+            None
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn recognize_geo_json_and_field_maps_do_not_drift(
+            lat in -90.0f64..=90.0,
+            lon in -180.0f64..=180.0,
+        ) {
+            prop_assume!(lat.is_finite());
+            prop_assume!(lon.is_finite());
+            let json = json_value(&format!(r#"{{"lat":{lat},"lon":{lon}}}"#));
+            let fields = fields(&[("lat", Value::Float(lat)), ("lon", Value::Float(lon))]);
+            prop_assert_eq!(
+                recognize_geo_value(&json),
+                recognize_geo_fields(|key| fields.get(key))
+            );
+        }
+
+        #[test]
+        fn recognize_geo_rejects_generated_out_of_range_values(
+            lat in prop_oneof![-1000.0f64..-90.000_001, 90.000_001f64..1000.0],
+            lon in -180.0f64..=180.0,
+        ) {
+            let json = json_value(&format!(r#"{{"lat":{lat},"lon":{lon}}}"#));
+            let fields = fields(&[("lat", Value::Float(lat)), ("lon", Value::Float(lon))]);
+            prop_assert_eq!(recognize_geo_value(&json), None);
+            prop_assert_eq!(recognize_geo_fields(|key| fields.get(key)), None);
+        }
     }
 }

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -1210,84 +1210,30 @@ fn parse_components_mode(s: &str) -> RedDBResult<RuntimeGraphComponentsMode> {
 fn extract_geo_from_entity(entity: &UnifiedEntity) -> Option<(f64, f64)> {
     match &entity.data {
         EntityData::Row(row) => {
-            // Search named columns for GeoPoint or lat/lon pairs
             if let Some(ref named) = row.named {
-                // Direct GeoPoint value
                 for value in named.values() {
-                    if let Value::GeoPoint(lat_micro, lon_micro) = value {
-                        return Some((
-                            *lat_micro as f64 / 1_000_000.0,
-                            *lon_micro as f64 / 1_000_000.0,
-                        ));
+                    if let Some(point) = crate::geo::recognize_geo_value(value) {
+                        return Some(point);
                     }
                 }
-                // Try lat/lon or latitude/longitude named fields
-                let lat =
-                    named
-                        .get("lat")
-                        .or_else(|| named.get("latitude"))
-                        .and_then(|v| match v {
-                            Value::Float(f) => Some(*f),
-                            Value::Integer(i) => Some(*i as f64),
-                            _ => None,
-                        });
-                let lon = named
-                    .get("lon")
-                    .or_else(|| named.get("lng"))
-                    .or_else(|| named.get("longitude"))
-                    .and_then(|v| match v {
-                        Value::Float(f) => Some(*f),
-                        Value::Integer(i) => Some(*i as f64),
-                        _ => None,
-                    });
-                if let (Some(la), Some(lo)) = (lat, lon) {
-                    return Some((la, lo));
+                if let Some(point) = crate::geo::recognize_geo_fields(|key| named.get(key)) {
+                    return Some(point);
                 }
             }
-            // Search positional columns for GeoPoint
             for value in &row.columns {
-                if let Value::GeoPoint(lat_micro, lon_micro) = value {
-                    return Some((
-                        *lat_micro as f64 / 1_000_000.0,
-                        *lon_micro as f64 / 1_000_000.0,
-                    ));
+                if let Some(point) = crate::geo::recognize_geo_value(value) {
+                    return Some(point);
                 }
             }
             None
         }
         EntityData::Node(node) => {
-            // Search node properties
             for value in node.properties.values() {
-                if let Value::GeoPoint(lat_micro, lon_micro) = value {
-                    return Some((
-                        *lat_micro as f64 / 1_000_000.0,
-                        *lon_micro as f64 / 1_000_000.0,
-                    ));
+                if let Some(point) = crate::geo::recognize_geo_value(value) {
+                    return Some(point);
                 }
             }
-            let lat = node
-                .properties
-                .get("lat")
-                .or_else(|| node.properties.get("latitude"))
-                .and_then(|v| match v {
-                    Value::Float(f) => Some(*f),
-                    Value::Integer(i) => Some(*i as f64),
-                    _ => None,
-                });
-            let lon = node
-                .properties
-                .get("lon")
-                .or_else(|| node.properties.get("lng"))
-                .or_else(|| node.properties.get("longitude"))
-                .and_then(|v| match v {
-                    Value::Float(f) => Some(*f),
-                    Value::Integer(i) => Some(*i as f64),
-                    _ => None,
-                });
-            if let (Some(la), Some(lo)) = (lat, lon) {
-                return Some((la, lo));
-            }
-            None
+            crate::geo::recognize_geo_fields(|key| node.properties.get(key))
         }
         _ => None,
     }

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -2016,18 +2016,12 @@ fn derive_index_entities_for_column(
 /// (slice 1), which also yields an `UnsignedInteger`, so the index key
 /// family matches the query side.
 ///
-/// Returns `None` when the value is not a `GeoPoint`, or when the
+/// Returns `None` when the value is not a recognized geo value, or when the
 /// coordinate fails to encode (`lat_lng_to_cell` returns the `0`
 /// sentinel) — those rows are simply absent from the index, exactly as
 /// an `Unsupported` value is absent from a BTree index.
 fn h3_cell_value(value: &Value, resolution: u8) -> Option<Value> {
-    let (lat, lon) = match value {
-        Value::GeoPoint(lat_micro, lon_micro) => (
-            crate::geo::micro_to_deg(*lat_micro),
-            crate::geo::micro_to_deg(*lon_micro),
-        ),
-        _ => return None,
-    };
+    let (lat, lon) = crate::geo::recognize_geo_value(value)?;
     let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
     if cell == 0 {
         return None;
@@ -2104,6 +2098,28 @@ mod tests {
     fn h3_cell_value_rejects_non_geopoint() {
         assert!(h3_cell_value(&Value::Integer(5), 9).is_none());
         assert!(h3_cell_value(&Value::text("48.8,2.3".to_string()), 9).is_none());
+    }
+
+    #[test]
+    fn h3_cell_value_uses_shared_geo_recognition_for_json_objects() {
+        let value = Value::Json(br#"{"latitude":48.8566,"longitude":2.3522}"#.to_vec());
+        let cell = h3_cell_value(&value, 9).expect("json object coordinate must encode");
+        assert_eq!(
+            cell,
+            Value::UnsignedInteger(crate::geo::h3::lat_lng_to_cell(48.8566, 2.3522, 9))
+        );
+    }
+
+    #[test]
+    fn h3_cell_value_rejects_shared_geo_non_goals() {
+        for value in [
+            Value::Json(br#"{"lat":"48.8566","lon":"2.3522"}"#.to_vec()),
+            Value::Json(br#"{"type":"Point","coordinates":[2.3522,48.8566]}"#.to_vec()),
+            Value::Json(br#"{"lat":48.8566}"#.to_vec()),
+            Value::Json(br#"{"lat":91.0,"lon":2.3522}"#.to_vec()),
+        ] {
+            assert_eq!(h3_cell_value(&value, 9), None, "{value:?}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #1933. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1933

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786122860&installation_id=129708444&pr_number=1946&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1946&signature=1c8de0dc9c8ec9af6ef88edb01b186ee7b777e808f70d117b7c134d0e622da61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->