### PR TITLE
chore(config): enable the AFK PR review gate in project config

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -48,6 +48,20 @@ plugins:
         ci_aware: true
 
       # ----------------------------------------------------------------
+      # PR review gate (ADR 0064 §10, #749). A completed NON-mechanical
+      # attempt (classified tier at/above `threshold`) gets
+      # `ready-for-review` on its PR and the merge is HELD for a
+      # fresh-agent review — a different agent than the one that
+      # implemented it reviews the diff and posts inline comments.
+      # Mechanical/trivial work (fmt, bumps, one-liners) keeps the
+      # fast-merge path. Only affects PR landings (worktree_launches_
+      # pull_request: true, the default).
+      # ----------------------------------------------------------------
+      review_gate:
+        enabled: true
+        threshold: complex
+
+      # ----------------------------------------------------------------
       # Backpressure — shell gates that run AFTER the agent's automatic
       # feedback loop (`pnpm test`/cargo check/etc. on touched packages)
       # and BEFORE the merge. If any command exits non-zero, the merge


### PR DESCRIPTION
Durably enables `plugins.dev.afk.review_gate` (`enabled: true`, `threshold: complex` — ADR 0064 §10, #749) in `.red/config.yaml`, so non-mechanical AFK attempts hold their merge for a fresh-agent review once the landing flow honors the gate.

Context: the config was verified to resolve correctly; the gate is currently inert under the codex runner (diagnosed 2026-07-08). This lands the intended durable state instead of leaving it as uncommitted drift in the primary checkout.

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786129377&installation_id=129708444&pr_number=1952&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1952&signature=61d7678f1f8170b5521f4297764b1337dfdf843fb0c6d3fb2553cba8a541fede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->