### PR TITLE
chore: #1935 SEARCH SPATIAL honors COLUMN and reads document bodies: full-scan correctness before any index

### DIFF
--- a/crates/reddb-rql/src/lexer.rs
+++ b/crates/reddb-rql/src/lexer.rs
@@ -641,6 +641,13 @@ pub struct Lexer<'a> {
 }
 
 impl<'a> Lexer<'a> {
+    /// Raw source text. Lets parsers recover a keyword-colliding
+    /// identifier's typed spelling from its token span (keywords are
+    /// matched case-insensitively, so the token alone has lost it).
+    pub(crate) fn source(&self) -> &'a str {
+        self.input
+    }
+
     /// Create a new lexer for the given input
     pub fn new(input: &'a str) -> Self {
         Self::with_limits(input, crate::limits::ParserLimits::default())

--- a/crates/reddb-rql/src/parser/search_commands.rs
+++ b/crates/reddb-rql/src/parser/search_commands.rs
@@ -566,11 +566,42 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_search_spatial_column(&mut self) -> Result<String, ParseError> {
-        let mut segments = vec![self.expect_ident_or_keyword()?];
+        let mut segments = vec![self.expect_spatial_column_segment()?];
         while self.consume(&Token::Dot)? {
-            segments.push(self.expect_ident_or_keyword()?);
+            segments.push(self.expect_spatial_column_segment()?);
         }
         Ok(segments.join("."))
+    }
+
+    /// One dotted-path segment of a `SEARCH SPATIAL ... COLUMN` argument.
+    ///
+    /// Column names are user data, not grammar: a document field named
+    /// `current` lexes (case-insensitively) into the window-frame keyword
+    /// token, whose display form would silently rewrite the column to
+    /// `CURRENT` and break the case-sensitive body-field lookup. Recover
+    /// the typed spelling by slicing the token's source span; only
+    /// word-shaped tokens qualify as segments.
+    fn expect_spatial_column_segment(&mut self) -> Result<String, ParseError> {
+        if let Token::Ident(name) = &self.current.token {
+            let name = name.clone();
+            self.advance()?;
+            return Ok(name);
+        }
+        let start = self.current.start.offset as usize;
+        let end = self.current.end.offset as usize;
+        let raw = self.lexer.source().get(start..end).unwrap_or("");
+        let word_shaped = !raw.is_empty()
+            && raw.chars().all(|c| c.is_alphanumeric() || c == '_')
+            && !raw.chars().next().is_some_and(|c| c.is_ascii_digit());
+        if word_shaped {
+            let name = raw.to_string();
+            self.advance()?;
+            return Ok(name);
+        }
+        Err(ParseError::new(
+            format!("expected column name, found {}", self.current.token),
+            self.position(),
+        ))
     }
 
     /// Parse a vector literal: [0.1, 0.2, 0.3]

--- a/crates/reddb-rql/src/parser/search_commands.rs
+++ b/crates/reddb-rql/src/parser/search_commands.rs
@@ -419,7 +419,7 @@ impl<'a> Parser<'a> {
                 let collection = self.expect_ident()?;
 
                 let _ = self.consume(&Token::Column)? || self.consume_search_ident("COLUMN")?;
-                let column = self.expect_ident()?;
+                let column = self.parse_search_spatial_column()?;
 
                 let mut limit_param: Option<usize> = None;
                 let limit = if self.consume(&Token::Limit)? {
@@ -486,7 +486,7 @@ impl<'a> Parser<'a> {
                 let collection = self.expect_ident()?;
 
                 let _ = self.consume(&Token::Column)? || self.consume_search_ident("COLUMN")?;
-                let column = self.expect_ident()?;
+                let column = self.parse_search_spatial_column()?;
 
                 let mut limit_param: Option<usize> = None;
                 let limit = if self.consume(&Token::Limit)? {
@@ -546,7 +546,7 @@ impl<'a> Parser<'a> {
                 let collection = self.expect_ident()?;
 
                 let _ = self.consume(&Token::Column)? || self.consume_search_ident("COLUMN")?;
-                let column = self.expect_ident()?;
+                let column = self.parse_search_spatial_column()?;
 
                 Ok(QueryExpr::SearchCommand(SearchCommand::SpatialNearest {
                     lat,
@@ -563,6 +563,14 @@ impl<'a> Parser<'a> {
                 self.position(),
             )),
         }
+    }
+
+    fn parse_search_spatial_column(&mut self) -> Result<String, ParseError> {
+        let mut segments = vec![self.expect_ident_or_keyword()?];
+        while self.consume(&Token::Dot)? {
+            segments.push(self.expect_ident_or_keyword()?);
+        }
+        Ok(segments.join("."))
     }
 
     /// Parse a vector literal: [0.1, 0.2, 0.3]

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -893,8 +893,9 @@ impl RedDBRuntime {
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
                 for entity in &entities {
-                    // Extract lat/lon from GeoPoint values in entity data
-                    if let Some((lat, lon)) = extract_geo_from_entity(entity) {
+                    if let Some((lat, lon)) =
+                        self.extract_spatial_column(entity, collection, column)
+                    {
                         let dist = haversine_km(*center_lat, *center_lon, lat, lon);
                         if dist <= *radius_km {
                             hits.push((entity.id.raw(), dist));
@@ -955,7 +956,9 @@ impl RedDBRuntime {
                     if count >= *limit {
                         break;
                     }
-                    if let Some((lat, lon)) = extract_geo_from_entity(entity) {
+                    if let Some((lat, lon)) =
+                        self.extract_spatial_column(entity, collection, column)
+                    {
                         if lat >= *min_lat && lat <= *max_lat && lon >= *min_lon && lon <= *max_lon
                         {
                             let mut record = UnifiedRecord::new();
@@ -1004,7 +1007,9 @@ impl RedDBRuntime {
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
                 for entity in &entities {
-                    if let Some((elat, elon)) = extract_geo_from_entity(entity) {
+                    if let Some((elat, elon)) =
+                        self.extract_spatial_column(entity, collection, column)
+                    {
                         let dist = haversine_km(*lat, *lon, elat, elon);
                         hits.push((entity.id.raw(), dist));
                     }
@@ -1239,6 +1244,26 @@ fn extract_geo_from_entity(entity: &UnifiedEntity) -> Option<(f64, f64)> {
     }
 }
 
+fn index_fields_from_entity(entity: &UnifiedEntity) -> Vec<(String, Value)> {
+    match &entity.data {
+        EntityData::Row(row) => row
+            .iter_fields()
+            .map(|(field, value)| (field.to_string(), value.clone()))
+            .collect(),
+        EntityData::Node(node) => node
+            .properties
+            .iter()
+            .map(|(field, value)| (field.clone(), value.clone()))
+            .collect(),
+        EntityData::Edge(edge) => edge
+            .properties
+            .iter()
+            .map(|(field, value)| (field.clone(), value.clone()))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Collect the entities a spatial post-filter runs over. With an H3 cover
 /// (`Some`), the collection scan is restricted to the candidate entity ids
 /// while preserving `query_all` order, so the downstream stable sort and
@@ -1286,6 +1311,38 @@ fn h3_cover_cells(lat: f64, lon: f64, radius_km: f64, resolution: u8) -> Vec<u64
 }
 
 impl RedDBRuntime {
+    fn extract_spatial_column(
+        &self,
+        entity: &UnifiedEntity,
+        collection: &str,
+        column: &str,
+    ) -> Option<(f64, f64)> {
+        let fields = index_fields_from_entity(entity);
+        if let Some(value) = self
+            .inner
+            .index_store
+            .resolve_index_field_value(&fields, column)
+        {
+            return crate::geo::recognize_geo_value(&value);
+        }
+
+        let is_document_collection =
+            self.inner
+                .db
+                .collection_contract(collection)
+                .is_some_and(|contract| {
+                    contract.declared_model == crate::catalog::CollectionModel::Document
+                });
+        if is_document_collection {
+            return None;
+        }
+
+        match entity.data {
+            EntityData::Row(_) | EntityData::Node(_) => extract_geo_from_entity(entity),
+            _ => None,
+        }
+    }
+
     /// Resolution of the H3 index registered on `(collection, column)`, if
     /// the column is covered by one. `None` for any other (or no) index.
     fn h3_index_resolution(&self, collection: &str, column: &str) -> Option<u8> {

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1944,14 +1944,27 @@ impl IndexStore {
 }
 
 fn index_field_value<'a>(fields: &'a [(String, Value)], column: &str) -> Option<Cow<'a, Value>> {
-    if let Some((_, body)) = fields.iter().find(|(field, _)| field == "body") {
+    if let Some((_, Value::Json(bytes))) = fields.iter().find(|(field, _)| field == "body") {
         // Single-source document: an index on a bare or dotted document field
         // (`score`, `location.gps`) is backed by the body, not a stored column.
-        let path = super::join_filter::parse_runtime_document_path(column);
-        if let Some(value) =
-            super::join_filter::resolve_runtime_document_path_from_value(body, &path)
-        {
-            return Some(Cow::Owned(value));
+        // The ROOT segment must be offset-read from the binary `body`
+        // container (`read_body_field` is the binary-container-aware,
+        // storage-typed read); the generic document-path resolver does not
+        // decode binary containers, so resolving the whole path against the
+        // raw `body` value silently yields nothing and builds an empty
+        // index. Descend into nested structure only AFTER the offset-read.
+        let segments = super::join_filter::parse_runtime_document_path(column);
+        if let Some((root, tail)) = segments.split_first() {
+            if let Some(root_value) = crate::document_body::read_body_field(bytes, root) {
+                if tail.is_empty() {
+                    return Some(Cow::Owned(root_value));
+                }
+                if let Some(value) =
+                    super::join_filter::resolve_runtime_document_path_from_value(&root_value, tail)
+                {
+                    return Some(Cow::Owned(value));
+                }
+            }
         }
     }
     if let Some((_, value)) = fields.iter().find(|(field, _)| field == column) {

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1944,12 +1944,14 @@ impl IndexStore {
 }
 
 fn index_field_value<'a>(fields: &'a [(String, Value)], column: &str) -> Option<Cow<'a, Value>> {
-    if !column.contains('.') {
-        // Single-source document: an index on a bare document field (`score`)
-        // is backed by the body.
-        // Offset-read it from the binary `body` container (inert otherwise).
-        if let Some((_, Value::Json(bytes))) = fields.iter().find(|(field, _)| field == "body") {
-            return crate::document_body::read_body_field(bytes, column).map(Cow::Owned);
+    if let Some((_, body)) = fields.iter().find(|(field, _)| field == "body") {
+        // Single-source document: an index on a bare or dotted document field
+        // (`score`, `location.gps`) is backed by the body, not a stored column.
+        let path = super::join_filter::parse_runtime_document_path(column);
+        if let Some(value) =
+            super::join_filter::resolve_runtime_document_path_from_value(body, &path)
+        {
+            return Some(Cow::Owned(value));
         }
     }
     if let Some((_, value)) = fields.iter().find(|(field, _)| field == column) {

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -301,6 +301,168 @@ fn assert_h3_parity(create_index: &str, queries: &[String]) {
 }
 
 #[test]
+fn spatial_full_scan_reads_document_body_column() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":38.76,"lon":-77.15}})"#,
+    )
+    .unwrap();
+
+    let radius = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(
+        radius.len(),
+        1,
+        "RADIUS must read gpsLocation from the document body"
+    );
+    assert_eq!(
+        radius[0].1,
+        0.0_f64.to_bits(),
+        "exact centre hit must report zero distance"
+    );
+
+    let bbox = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL BBOX 38.75 -77.16 38.77 -77.14 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(
+        bbox.len(),
+        1,
+        "BBOX must read gpsLocation from the document body"
+    );
+
+    let nearest = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL NEAREST 38.76 -77.15 K 5 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(
+        nearest.len(),
+        1,
+        "NEAREST must read gpsLocation from the document body"
+    );
+    assert_eq!(
+        nearest[0].1,
+        0.0_f64.to_bits(),
+        "exact centre nearest hit must report zero distance"
+    );
+}
+
+#[test]
+fn spatial_full_scan_document_column_discriminates_geo_fields() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT couriers").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO couriers DOCUMENT VALUES ({"home":{"lat":38.7,"lon":-77.1},"current":{"lat":40.7,"lon":-74.0}})"#,
+    )
+    .unwrap();
+
+    let current = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 40.7 -74.0 1.0 COLLECTION couriers COLUMN current",
+    );
+    assert_eq!(current.len(), 1, "COLUMN current must hit the near field");
+
+    let home = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 40.7 -74.0 1.0 COLLECTION couriers COLUMN home",
+    );
+    assert!(
+        home.is_empty(),
+        "COLUMN home must not be overridden by the near current field"
+    );
+}
+
+#[test]
+fn spatial_full_scan_document_column_resolves_dotted_path() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"location":{"gps":{"lat":38.76,"lon":-77.15}}})"#,
+    )
+    .unwrap();
+
+    let nearest = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL NEAREST 38.76 -77.15 K 5 COLLECTION events COLUMN location.gps",
+    );
+    assert_eq!(
+        nearest.len(),
+        1,
+        "dotted COLUMN path must resolve into the document body"
+    );
+    assert_eq!(
+        nearest[0].1,
+        0.0_f64.to_bits(),
+        "exact dotted-path hit must report zero distance"
+    );
+}
+
+#[test]
+fn spatial_full_scan_skips_non_geo_named_document_values() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+        ({"gpsLocation":"not-geo","fallback":{"lat":38.76,"lon":-77.15}}),
+        ({"fallback":{"lat":38.76,"lon":-77.15}}),
+        ({"gpsLocation":{"type":"Point","coordinates":[-77.15,38.76]}})"#,
+    )
+    .unwrap();
+
+    let hits = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+    );
+    assert!(
+        hits.is_empty(),
+        "non-geo, missing, and GeoJSON named document values must be skipped"
+    );
+}
+
+#[test]
+fn spatial_row_named_column_wins_and_missing_column_uses_legacy_fallback() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE vehicles (id INT, home GEOPOINT, live_loc GEOPOINT)")
+        .unwrap();
+    rt.execute_query(
+        "INSERT INTO vehicles (id, home, live_loc) VALUES (1, '38.76,-77.15', '40.7,-74.0')",
+    )
+    .unwrap();
+
+    let home = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION vehicles COLUMN home",
+    );
+    assert_eq!(home.len(), 1, "resolvable named row column must hit");
+
+    let current = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION vehicles COLUMN live_loc",
+    );
+    assert!(
+        current.is_empty(),
+        "legacy any-geo fallback must not override a resolvable row column"
+    );
+
+    rt.execute_query("CREATE TABLE fallback_places (id INT, loc GEOPOINT)")
+        .unwrap();
+    rt.execute_query("INSERT INTO fallback_places (id, loc) VALUES (1, '38.76,-77.15')")
+        .unwrap();
+    let missing = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION fallback_places COLUMN missing_geo",
+    );
+    assert_eq!(
+        missing.len(),
+        1,
+        "legacy any-geo fallback must remain for row entities when COLUMN is absent"
+    );
+}
+
+#[test]
 fn h3_radius_parity_with_full_scan() {
     // Tight radii land on res-9 cell boundaries (the +1 ring margin must
     // still find the neighbouring in-radius points); large radii exceed the


### PR DESCRIPTION
Automated AFK landing for #1935. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1935

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786133483&installation_id=129708444&pr_number=1954&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1954&signature=022811d7a3fc632e6155bbfa9b8d1e1f4fdc196487ace34d7f9046155d0951d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->