### PR TITLE
docs(adr): storage packaging profiles, memory budget governance, storage fault model

### DIFF
--- a/.red/adr/0038-embedded-single-file-zoned-rdb.md
+++ b/.red/adr/0038-embedded-single-file-zoned-rdb.md
@@ -1,82 +1,105 @@
-# Embedded Single-file Zoned RDB
+# Storage Packaging by Profile — Single-file Zoned RDB and Its Siblings
 
-Status: proposed
+Status: accepted
+Date: 2026-07-08 (rewritten; originally proposed as "Embedded Single-file Zoned RDB")
 
-RedDB's embedded storage profile uses a single `.rdb` file as the operator-visible
-durable artifact. The file is internally zoned so it can carry all required
-storage-engine state without mandatory sidecars.
+RedDB's physical storage packaging is a **per-profile contract**. This ADR is the
+umbrella: it names each profile's packaging and scale contract, fixes the zoned
+single-file layout as the embedded target, and — the part the original version
+lacked — attaches **phases with auditable exit criteria** so the distance between
+the promised layout and the shipped sidecars is tracked, never assumed.
+
+The 2026-07-08 rewrite was triggered by an architecture review against Cassandra
+and TigerBeetle which found the original ADR aspirational: `Status: proposed`
+while `reddb-file/src/layout.rs` carries ~15 sidecar extensions that ARE the
+shipped reality. An ADR whose status diverges from the code misleads exactly the
+way a dead syntax does; this rewrite applies the same remedy (a plan with owners
+and exit criteria, or an honest status).
 
 ## Decisions
 
-**Embedded RedDB is single-file by contract.** Embedded, local, test, plugin, and
-prototype use cases must be able to create, copy, move, back up, and delete one
-`.rdb` file containing all required durable state.
+### 1. Packaging and scale are contracted per profile
 
-**The single file is zoned internally.** The target `.rdb` layout has explicit
-zones for superblock copies, manifest/catalog state, WAL records, page/grid
-storage, free-space metadata, checksums, and future overflow/blob extents. The
-file should feel SQLite-like to users while borrowing TigerBeetle's internal
-discipline around superblocks, manifests, checksummed block references, and
-replayable state.
+- **Embedded (standalone)** — one `.rdb` file as the operator-visible durable
+  artifact: create, copy, move, back up, delete one file. **Scale contract:
+  working set ≤ the memory budget (ADR 0073).** The budget is detected or
+  declared at boot and enforced didactically; exceeding it is an operating
+  error with a named limit, never an OOM kill.
+- **Server** — same zoned grid, plus the **disk-resident roadmap**: zones for
+  entity/segment state that exceed RAM, paged through the budget-governed
+  cache hierarchy. Dataset > RAM is a committed direction for this profile
+  only; it is explicitly NOT promised for embedded.
+- **Serverless** — bounded-everything posture: strict memory/CPU budget
+  (ADR 0073), fast-boot snapshot/segment packaging (see `context/serverless.md`),
+  cold-start-aware layout. Boundedness here is a survival contract (billing,
+  host kill), not hygiene.
+- **Primary-replica / cluster** — may choose directory or segmented layouts
+  when boot speed, replication streaming, snapshot distribution, or repair
+  make them more appropriate. The single-file contract binds embedded, not
+  the fleet.
 
-**The embedded manifest is internal and authoritative.** The `.rdb` contains an
-internal manifest rooted by the file superblock. It maps internal zones and
-logical objects such as collections, indexes, WAL region, free-space state, and
-checkpoint boundary without requiring an external `red.manifest`.
+### 2. The embedded single file is zoned internally
 
-**The embedded WAL lives inside the file.** Embedded single-file storage uses a
-circular internal WAL region. WAL entries may be overwritten only after the
-checkpoint/superblock boundary proves they are no longer needed for recovery.
+Unchanged from the original decision: explicit zones for superblock copies
+(ping-pong pair with generation + checksum), internal manifest/catalog, a
+circular WAL region, page/grid storage, free-space metadata, checksums, and
+overflow/blob extents. SQLite-like to users, TigerBeetle-like inside. The
+embedded manifest is internal and authoritative; sidecars are not part of the
+promoted embedded contract.
 
-**The embedded superblock uses two ping-pong copies.** The first target design
-uses a pair of superblock copies with generation and checksum metadata. Open
-chooses the newest valid copy to root the embedded internal manifest.
+### 3. Maintenance is paced, never bursty
 
-**Embedded storage is checksummed at its recovery boundaries.** Mutable pages
-carry checksums in their page headers. Immutable internal blocks or segment-like
-regions are verified against checksums stored in manifest/index metadata.
-Superblocks, embedded manifest state, and checkpoint metadata are checksummed.
+All storage maintenance — segment consolidation (ADR 0073), scrub (ADR 0074),
+future append-only compaction (#1808 lane), archival — runs as **incremental,
+tick-paced work with a bounded per-tick cost**. Background maintenance threads
+with unbounded bursts (the Cassandra compaction model) are prohibited across
+every profile. Rationale: bursty maintenance destroys p99 on embedded, billing
+on serverless, and replica lag on the fleet; the TigerBeetle-style paced model
+is strictly more predictable and composes with the memory/CPU budget.
 
-**Sidecars are not the embedded target contract.** Existing sidecars such as WAL,
-metadata, and double-write files may remain as legacy or transitional
-implementation details while the zoned format is introduced, but the promoted
-embedded profile must not require them for normal operation.
+### 4. Phases with exit criteria (the honesty mechanism)
 
-**This does not constrain every deployment profile.** Serverless, primary-replica,
-and cluster profiles may choose different physical packaging when boot speed,
-replication streaming, snapshot distribution, range movement, or cluster repair
-make a directory or segmented layout more appropriate.
+Each sidecar family retires only when its phase's exit criteria hold. A phase
+is DONE when: (a) the promoted embedded profile creates **no** sidecar of that
+family on a fresh store, (b) the in-file zone replacing it is covered by a DST
+crash campaign with the `recover_and_check` oracle, and (c) `layout.rs` drops
+the extension (clean break — no dual-read window beyond one minor release).
+
+| Phase | Scope | Retires |
+|---|---|---|
+| 0 (now) | This rewrite: sidecar reality is documented as transitional, tracked here | — |
+| 1 | Superblock ping-pong pair + internal manifest in-file | `rdb-hdr`, `rdb-meta` (+ shadows) |
+| 2 | Circular WAL region in-file | `rdb-uwal`, `redwal`, `rdb-wal`, legacy `wal` |
+| 3 | Double-write/recovery state in-file | `rdb-dwb` (+ shadow), `shm` review |
+| 4 | Server-profile disk-resident entity/segment zones (dataset > RAM) | — (new capability, not a retirement) |
+
+Ordering within phases 1–3 may be re-sequenced by an ADR amendment with one
+line of rationale; silently skipping a phase is not allowed. Phase 4 is gated
+on ADR 0073 landing first (the cache hierarchy it pages through is
+budget-governed).
 
 ## Considered Options
 
-- **Single zoned `.rdb`.** Chosen because it preserves the embedded/SQLite-like
-  user experience while giving the engine room for formal recovery, checksums,
-  checkpointing, and future format evolution.
-- **External manifest or WAL sidecars.** Rejected for the promoted embedded
-  contract because the `.rdb` must remain self-contained.
-- **Four superblock copies.** Deferred because a two-copy ping-pong design is a
-  smaller first target while still avoiding a single fixed root copy.
-- **Manifest-only checksums.** Rejected because localized page/block corruption
-  must be detectable during reads, backup validation, and future repair.
-- **Primary `.rdb` plus mandatory sidecars.** Rejected as the embedded target
-  because it weakens copy/delete/backup ergonomics and makes local/plugin usage
-  easier to corrupt operationally.
-- **Current layout only.** Rejected as the target because it does not encode the
-  storage/deploy profile distinction and keeps embedded ergonomics tied to
-  transitional pager implementation details.
+- **Single zoned `.rdb` for embedded** — kept (unchanged rationale: ergonomics
+  + formal recovery room).
+- **Sidecars as the permanent embedded contract** — rejected again; weakens
+  copy/delete/backup ergonomics and multiplies partial-file failure modes.
+- **One packaging for all profiles** — rejected; replication/serverless have
+  structurally different boot/streaming needs (original ADR already carved
+  this out; the rewrite makes each profile's contract explicit).
+- **Keeping the ADR `proposed` with no phase plan** — rejected by this rewrite;
+  status must either be executable or say "vision".
 
 ## Consequences
 
-- The embedded storage roadmap needs a real file-level manifest/superblock model
-  rather than relying only on external path conventions.
-- WAL, metadata, DWB, and future recovery state need an in-file home before the
-  embedded profile can be considered promoted.
-- Embedded open/recovery must validate superblock generations/checksums, load the
-  internal manifest, and replay the internal WAL region from the checkpoint
-  boundary.
-- Read and validation paths must check mutable page checksums and immutable
-  block/segment checksums against their expected metadata.
-- Migration must distinguish legacy sidecar-backed databases from zoned embedded
-  `.rdb` databases.
-- Cluster and replication work must not assume the embedded single-file packaging
-  is the only valid physical store layout.
+- ADR 0073 (memory budget) and ADR 0074 (storage fault model) are companions:
+  0073 owns the scale contract enforcement, 0074 owns per-zone corruption
+  behavior. This ADR owns packaging and pacing.
+- Embedded open/recovery must validate superblock generations/checksums, load
+  the internal manifest, and replay the internal WAL region from the
+  checkpoint boundary (unchanged).
+- Every phase completion is provable in CI: fresh-store sidecar census + DST
+  campaign green. "0 sidecars created" is asserted, not eyeballed.
+- Migration must distinguish legacy sidecar-backed stores from zoned `.rdb`
+  stores; per the house no-backcompat posture, a major zoned bump reads the
+  old form only through the explicit offline migration tool, never silently.

--- a/.red/adr/0056-tigerstyle-house-style.md
+++ b/.red/adr/0056-tigerstyle-house-style.md
@@ -75,6 +75,11 @@ untrusted input, and the absence of any `[workspace.lints]`.
   on untrusted input*, not the absence of recursion. Recursive-descent parsing is natural; we
   require an explicit depth cap instead of converting it to explicit-stack iteration.
 
+  *Amended 2026-07-08 (ADR 0073 §6):* in the **storage/recovery data plane** the reframing is
+  hardened back to the literal rule — recursion is prohibited there (explicit stacks with
+  budget-sized capacity), because a stack overflow during recovery is a data-loss event, not a
+  crash. Parser/planner/query surfaces keep the depth-bounded rule above unchanged.
+
 ## Enforcement
 
 CI already runs `cargo clippy --locked --all -- -D warnings`, so any `warn`-level lint becomes a

--- a/.red/adr/0073-memory-budget-governance.md
+++ b/.red/adr/0073-memory-budget-governance.md
@@ -1,0 +1,101 @@
+# Memory Budget Governance
+
+Status: accepted
+Date: 2026-07-08
+
+RedDB becomes **system-aware about memory**: every process runs under an explicit
+memory budget, detected from the host or declared by the operator at boot, with
+the large storage structures pre-sized from it and the ceiling enforced
+didactically at runtime. This is the engine-level answer to the scale contracts
+in ADR 0038 (embedded working set ≤ budget; serverless strict boundedness) and
+the durable fix for the operational OOM class we already live with (in-RAM
+structures whose growth is O(data), e.g. the retired spatial R-tree, PRD #1574).
+
+This ADR fixes **governance and invariants**. Concrete cache topology (e.g. an
+L1 hot-page tier + larger L2 tier over WAL/file) is deliberately NOT prescribed
+here — it is a performance hypothesis and goes through a measured PRD on the
+Criterion lane, inheriting these invariants.
+
+## Decisions
+
+### 1. One budget, resolved at boot
+
+Precedence: explicit operator configuration > deployment-profile default
+(serverless profiles ship strict defaults) > host detection (cgroup/container
+limit first, then physical RAM, with a conservative fraction). The resolved
+budget is logged at boot and visible in the stats surface. There is no
+"unlimited" mode; the absence of configuration means the detected default, not
+infinity.
+
+### 2. Big structures are pre-sized from the budget
+
+Page cache, entity/segment arenas, index memory, and WAL buffers receive
+budget shares at startup and pre-allocate their slot structures (fixed page
+size → fixed-size slots → arena allocation). This is the TigerStyle spirit
+already adopted by ADR 0056 ("don't allocate per operation — pool and reuse"),
+now with a number attached. It is NOT TigerBeetle's literal static-allocation
+rule, which ADR 0056 rejected and stays rejected: dynamic structures remain
+legal outside hot paths; what changes is that their growth is accounted
+against the budget.
+
+### 3. Hot paths allocate zero per operation (ratchet)
+
+Read/write/scan hot paths must not malloc per operation; buffers come from
+pools sized in decision 2. Enforced as a ratchet on new/changed code in the
+storage data plane (same mechanism as the `.unwrap()` ban), not a big-bang
+rewrite.
+
+### 4. Enforcement is didactic, never an OOM kill
+
+An operation whose admission would exceed the budget fails with a named limit
+and the current accounting ("operation needs ~X over budget Y; largest
+consumers: …"), or triggers reclamation (decision 5) when reclamation can
+satisfy it. The process never relies on the kernel OOM killer as its limit
+mechanism. This extends the no-silent-zeros posture from the query surface to
+resource limits.
+
+### 5. Consolidation is the reclamation tool
+
+Sealed-segment consolidation — merging sealed segments and garbage-collecting
+tombstones — is a first-class, budget-driven mechanism: it runs when tombstone
+or fragmentation ratios cross thresholds, returning memory to the budget. Per
+ADR 0038 §3 it is paced (bounded per-tick cost), never bursty. This replaces
+the vestigial LSM scaffolding in the unified layer: the unused write-buffer
+memtable is DELETED (a RAM-resident store has no disk latency to amortize, so
+it buffered nothing), and the stub compaction hook either becomes this
+mechanism or is deleted with it — no aspirational code remains.
+
+### 6. Recursion is banned in the storage/recovery data plane
+
+Amendment to ADR 0056's reframed rule: inside the storage engine's data plane
+and every recovery path, recursion is prohibited outright (explicit stacks
+with capacity from the budget), because a stack overflow during recovery is a
+data-loss event, not a crash. Parser/planner/query surfaces keep the existing
+depth-bounded-recursion rule unchanged.
+
+## Considered Options
+
+- **Literal TigerBeetle static allocation** — rejected (unchanged from ADR
+  0056): arbitrary collections, variable rows, and RQL plans make it fight
+  the domain; the budget delivers the predictability without the freeze.
+- **Best-effort soft limits (log a warning, keep allocating)** — rejected:
+  a warning at 110% is an OOM kill at 130%; the limit must gate admission.
+- **Per-subsystem hard caps with no shared budget** — rejected: caps that
+  don't share one accounting pool re-create the OOM by summation (each
+  subsystem individually "within limits", the process dead).
+- **Prescribing the L1/L2 cache topology in this ADR** — rejected: topology
+  is a benchmark question (Criterion lane), and prose-first cache design is
+  the aspirational-doc disease this review is curing.
+
+## Consequences
+
+- ADR 0038 phase 4 (server-profile disk residency) builds on this: the paging
+  hierarchy that makes dataset > RAM possible is governed by the same budget.
+- A follow-up PRD designs the tiered cache (L1 hot pages / L2 / file) with
+  Criterion evidence; it inherits decisions 2–4 as constraints.
+- The unified-layer cleanup (delete memtable, wire-or-delete the compaction
+  stub into consolidation) is immediate executable work, sliceable now.
+- `red.stats` grows a budget section (resolved budget, per-pool shares, live
+  accounting, reclamation counters) so enforcement is observable.
+- ADR 0056 gains a one-line pointer to decision 6 (recursion hardening) so
+  the style doc and this ADR cannot drift.

--- a/.red/adr/0074-storage-fault-model.md
+++ b/.red/adr/0074-storage-fault-model.md
@@ -1,0 +1,99 @@
+# Storage Fault Model — Detect, Scrub, Salvage; Paranoid Cluster
+
+Status: accepted
+Date: 2026-07-08
+
+RedDB already pays for detection (page-header checksums, superblock
+generation+checksum pairs, checksummed recovery boundaries — ADR 0038) and
+already owns the right proving harness (DST with fault injection via
+`unreliable-libc` and the `recover_and_check` oracle). What has never been
+written down is the **contract after detection**: which physical faults we
+model, what each zone guarantees when corruption is found, and what the
+operator can do about it. TigerBeetle detects *and repairs from replicas*;
+single-node RedDB cannot repair from a replica, so its honest contract must be
+explicit rather than implied.
+
+## Decisions
+
+### 1. The modeled fault classes
+
+We explicitly model, and DST must exercise: torn writes (partial page/sector),
+misdirected writes (right data, wrong offset), bit rot (checksum mismatch on
+read), lost writes (fsync acknowledged, data absent), and crash at any point
+(already covered). Anything outside this list (RAM corruption, kernel page
+cache lying beyond fsync semantics) is out of model and documented as such.
+
+### 2. Per-zone detection contract (embedded)
+
+- **Superblock**: two ping-pong copies; open picks the newest valid one. Both
+  invalid → the store does not open; salvage (decision 4) is the path.
+- **Manifest/catalog**: checksummed; corruption fails open with a didactic
+  error naming the zone.
+- **WAL region**: recovery stops at the first invalid record — a torn tail is
+  normal crash truncation (recover to last valid), while corruption BEFORE the
+  checkpoint boundary is reported as corruption, never silently truncated.
+- **Pages/blocks**: checksum verified on read; a failing page fails the READ
+  didactically (named page, named collection when derivable) — it never
+  returns garbage rows.
+
+### 3. Scrub is a first-class embedded tool
+
+An operator-invocable (and paceable background, per ADR 0038 §3) integrity
+pass that verifies every checksum — superblocks, manifest, WAL region, all
+reachable pages/blocks — and reports a structured result. The SQLite
+benchmark is `PRAGMA integrity_check`; ours must additionally distinguish the
+fault classes of decision 1 where the evidence allows. Scrub findings feed
+`red.stats` and never mutate the store.
+
+### 4. Salvage is a first-class embedded tool
+
+A best-effort extractor that reads a damaged `.rdb` and exports every
+recoverable entity, skipping (and enumerating) what fails verification — the
+`.recover` of SQLite, DST-proven: campaigns corrupt stores with decision-1
+faults and assert salvage recovers everything the faults did not touch.
+Salvage never writes into the damaged file; it produces a fresh store plus a
+loss report.
+
+### 5. The cluster profile is paranoid — mandatory, not best-effort
+
+When the cluster/replica profiles come out of hold, this contract binds them:
+a node NEVER serves data whose checksum failed (fail the read, fetch from a
+peer); scrub runs continuously (paced); **repair-from-replica is a mandatory
+capability of the profile**, not an optimization — a node that detects local
+corruption heals from peers or evicts itself. Design reviews for replication
+work must cite this section.
+
+### 6. Determinism is test-scoped, by declaration
+
+Execution determinism (simulated clock, seeded randomness, `buggify!` fault
+points) is a property of the DST harness, NOT a runtime guarantee. Replication
+copies bytes (WAL/log shipping); deterministic state-machine replication in
+the TigerBeetle/VSR sense is **out of horizon** — production code is free to
+use wall clocks, hash iteration order, and thread scheduling, and no reviewer
+should reject such code "to keep SMR possible". Reversing this requires a new
+ADR, not an assumption. (Bounded/predictable behavior — pre-allocation, paced
+maintenance — is governed by ADR 0073/0038 and is orthogonal to determinism.)
+
+## Considered Options
+
+- **Detect + fail + restore-from-backup only** — rejected as the whole story:
+  cheapest, but an embedded database without scrub/salvage tooling fails the
+  operator exactly when they need it most (the SQLite bar exists for a reason).
+- **Full local self-repair (redundant zones beyond the superblock, WAL-history
+  page repair)** — rejected for embedded: buys resilience the cluster profile
+  will get structurally (peers), at high complexity now.
+- **Leaving determinism scope undeclared** — rejected: undecided architecture
+  questions fossilize into aspirational half-code (this review found three
+  such cases); the declaration is one paragraph and reversible by ADR.
+
+## Consequences
+
+- Scrub and salvage become PRD-able units with DST campaigns as their
+  acceptance tests; the fault classes of decision 1 become named `buggify!`
+  points in `unreliable-libc`.
+- The read path grows the didactic checksum-failure error (named zone/page),
+  replacing whatever implicit behavior exists today.
+- Replication design docs must carry a "decision 5 compliance" section when
+  that work resumes.
+- ADR 0038's phase exit criteria implicitly reference this ADR: an in-file
+  zone is not "done" until its decision-2 contract is DST-proven.

--- a/.red/context/persistence.md
+++ b/.red/context/persistence.md
@@ -17,6 +17,22 @@ Part of the [glossary map](../CONTEXT-MAP.md). The storage engine shared by **ev
 - **ExtendedTtlPolicy** — opt-in extension to the cache policy carrying `idle_ttl_ms`, `stale_serve_ms`, and `jitter_pct`. Off by default; per-entry rather than global.
 - **Page cache** — internal sharded SIEVE cache of database pages. Distinct from the Blob Cache. Lives at `storage/engine/page_cache.rs`.
 
+## Resource governance
+
+- **Memory budget** — per [ADR 0073](../adr/0073-memory-budget-governance.md), the explicit memory ceiling every RedDB process runs under, resolved at boot (operator config > profile default > host/cgroup detection — never "unlimited"). Big structures (page cache, segment arenas, index memory, WAL buffers) are pre-sized from it; admission that would exceed it fails didactically or triggers reclamation. The kernel OOM killer is never the limit mechanism.
+- **Budget share** — the slice of the memory budget assigned to one subsystem pool at startup. Shares draw from one shared accounting pool; per-subsystem caps that don't share accounting are explicitly rejected (OOM by summation).
+- **Segment consolidation** — budget-driven reclamation mechanism: merges sealed segments and garbage-collects tombstones, returning memory to the budget when tombstone/fragmentation ratios cross thresholds. Replaces the vestigial LSM compaction scaffolding in the unified layer. Always paced (see *Paced maintenance*).
+- **Paced maintenance** — per [ADR 0038](../adr/0038-embedded-single-file-zoned-rdb.md) §3, the rule that all storage maintenance (consolidation, scrub, append-only compaction, archival) runs as incremental tick-paced work with bounded per-tick cost. Bursty background maintenance threads (the Cassandra compaction model) are prohibited in every profile.
+- **Scale contract** — the per-profile promise about dataset size vs memory: embedded contracts working set ≤ memory budget; the server profile carries the disk-residency roadmap (dataset > RAM, ADR 0038 phase 4); serverless contracts strict boundedness. Documented in ADR 0038 §1.
+
+## Fault model & integrity tooling
+
+- **Storage fault model** — per [ADR 0074](../adr/0074-storage-fault-model.md), the explicit list of modeled physical faults: torn writes, misdirected writes, bit rot, lost writes, and crash-at-any-point. Each zone (superblock, manifest, WAL region, pages/blocks) has a written detection contract; out-of-model faults are documented as such.
+- **Scrub** — operator-invocable (and paceable background) integrity pass verifying every checksum in a store and reporting a structured result without mutating anything. RedDB's `PRAGMA integrity_check` counterpart, with fault-class attribution where evidence allows.
+- **Salvage** — best-effort extractor that reads a damaged `.rdb` and exports every recoverable entity into a fresh store plus a loss report, skipping and enumerating what fails verification. RedDB's `.recover` counterpart; DST-proven against injected fault classes. Never writes into the damaged file.
+- **Paranoid cluster clause** — ADR 0074 §5: cluster/replica profiles never serve data whose checksum failed, run scrub continuously, and treat repair-from-replica as a mandatory profile capability, not an optimization.
+- **Test-scoped determinism** — ADR 0074 §6: execution determinism (SimClock, seeded randomness, `buggify!`) is a property of the DST harness, not a runtime guarantee. Replication copies bytes (WAL shipping); deterministic state-machine replication is out of horizon unless a future ADR reverses this.
+
 ## Files & layout (operational directory)
 
 - **File/protocol ownership boundary** — per [ADR 0046](../adr/0046-wire-file-crate-authority-boundary.md), the published crate `reddb-io-file` uses Rust import `reddb_file`, and local crate `reddb-file` is the authority for file contracts: names, paths, sidecars, manifests, superblocks, WAL artifacts, checkpoint artifacts, and recovery metadata. The published crate `reddb-io-wire` uses Rust import `reddb_wire`, and local crate `reddb-wire` is the authority for communication contracts: frames, codecs, payloads, topology, connection strings, sanitizers, and replication wire messages. The published crate `reddb-io-server` uses Rust import `reddb_server`, and local crate `reddb-server` orchestrates runtime, SQL, auth, storage engine policy, and calls into those crates; it must not introduce new persistent file formats or protocol payload formats directly.


### PR DESCRIPTION
Outcome of the storage architecture grilling session (Cassandra/TigerBeetle comparison). Five doc changes, no code:

- **ADR 0038 rewritten** — per-profile packaging umbrella, `accepted`, scale contracts (embedded ≤ budget / server disk-residency roadmap / serverless bounded), paced-maintenance rule, sidecar retirement phases with exit criteria.
- **ADR 0073 (new)** — memory budget governance: boot-resolved budget, pre-sized pools, hot-path no-malloc ratchet, didactic enforcement, consolidation as reclamation, data-plane recursion ban.
- **ADR 0074 (new)** — storage fault model: fault classes, per-zone detection contract, scrub + salvage first-class, paranoid cluster clause, test-scoped determinism declaration.
- **ADR 0056 amended** — recursion-hardening pointer to 0073 §6.
- **Glossary** — persistence.md gains Resource governance + Fault model & integrity tooling terms.

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786136406&installation_id=129708444&pr_number=1955&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1955&signature=269e77a8ffc81a1e5035490227e3ea09b90a296ed55ad8a1d954b8611e85c0dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->