### PR TITLE
chore: #1936 H3 index over document bodies: backfill, live maintenance, and parity with full scan through the RQL surface

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -3337,6 +3337,9 @@ impl RuntimeEntityPort for RedDBRuntime {
         let id = builder.save()?;
         // Phase 1.1 MVCC universal: stamp xmin on the document.
         self.stamp_xmin_if_in_txn(&input.collection, id);
+        self.index_store_ref()
+            .index_entity_insert(&input.collection, id, &fields)
+            .map_err(crate::RedDBError::Internal)?;
         refresh_context_index(&db, &input.collection, id)?;
         self.cdc_emit(
             crate::replication::cdc::ChangeOperation::Insert,

--- a/crates/reddb-server/src/runtime/impl_dml_batch.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_batch.rs
@@ -35,6 +35,7 @@ impl RedDBRuntime {
         let mut tombstoned_ids = Vec::new();
         let mut tombstoned_entities = Vec::new();
         let mut physical_delete_ids = Vec::new();
+        let mut index_delete_fields: Vec<(EntityId, Vec<(String, Value)>)> = Vec::new();
         let table_row_resolver =
             crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
         // Phase 3: versioned graph collections tombstone node/edge
@@ -96,15 +97,22 @@ impl RedDBRuntime {
                         }
                     },
                 };
+                let pre_delete_fields = entity_row_fields_snapshot(&entity);
                 entity.set_xmax(xid);
                 if manager.update(entity.clone()).is_ok() {
                     if active_xid.is_some() {
                         self.record_pending_tombstone(conn_id, collection, id, xid, previous_xmax);
+                    } else if !pre_delete_fields.is_empty() {
+                        index_delete_fields.push((id, pre_delete_fields));
                     }
                     tombstoned_entities.push(entity);
                     tombstoned_ids.push(id);
                 }
             } else {
+                let pre_delete_fields = entity_row_fields_snapshot(&entity);
+                if !pre_delete_fields.is_empty() {
+                    index_delete_fields.push((id, pre_delete_fields));
+                }
                 physical_delete_ids.push(id);
             }
         }
@@ -124,6 +132,14 @@ impl RedDBRuntime {
                 .persist_entities_to_pager(collection, &tombstoned_entities)
                 .map_err(|err| RedDBError::Internal(err.to_string()))?;
             for id in &tombstoned_ids {
+                if let Some((_, fields)) = index_delete_fields
+                    .iter()
+                    .find(|(indexed_id, _)| indexed_id == id)
+                {
+                    self.index_store_ref()
+                        .index_entity_delete(collection, *id, fields)
+                        .map_err(RedDBError::Internal)?;
+                }
                 store.context_index().remove_entity(*id);
                 let lsn = self.cdc_emit(
                     crate::replication::cdc::ChangeOperation::Delete,
@@ -140,6 +156,14 @@ impl RedDBRuntime {
             .map_err(|err| RedDBError::Internal(err.to_string()))?;
         affected += deleted_ids.len() as u64;
         for id in &deleted_ids {
+            if let Some((_, fields)) = index_delete_fields
+                .iter()
+                .find(|(indexed_id, _)| indexed_id == id)
+            {
+                self.index_store_ref()
+                    .index_entity_delete(collection, *id, fields)
+                    .map_err(RedDBError::Internal)?;
+            }
             store.context_index().remove_entity(*id);
             let lsn = self.cdc_emit(
                 crate::replication::cdc::ChangeOperation::Delete,

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -1274,14 +1274,20 @@ fn scan_collection_with_candidates(
     collection: &str,
     candidates: &Option<std::collections::HashSet<u64>>,
 ) -> Vec<UnifiedEntity> {
+    let resolver =
+        crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
     match candidates {
         Some(ids) => store
             .get_collection(collection)
-            .map(|m| m.query_all(|e| ids.contains(&e.id.raw())))
+            .map(|m| {
+                m.query_all(|e| {
+                    ids.contains(&e.id.raw()) && resolver.resolve_read_candidate(e).is_some()
+                })
+            })
             .unwrap_or_default(),
         None => store
             .get_collection(collection)
-            .map(|m| m.query_all(|_| true))
+            .map(|m| m.query_all(|e| resolver.resolve_read_candidate(e).is_some()))
             .unwrap_or_default(),
     }
 }

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -300,6 +300,36 @@ fn assert_h3_parity(create_index: &str, queries: &[String]) {
     }
 }
 
+fn seed_document_geo_corpus(collection: &str) -> RedDBRuntime {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query(&format!("CREATE DOCUMENT {collection}"))
+        .unwrap();
+    for (id, loc) in GEO_CORPUS {
+        let (lat, lon) = loc
+            .split_once(',')
+            .unwrap_or_else(|| panic!("invalid test coordinate: {loc}"));
+        rt.execute_query(&format!(
+            r#"INSERT INTO {collection} DOCUMENT VALUES
+               ({{"id":{id},"gpsLocation":{{"lat":{lat},"lon":{lon}}}}})"#
+        ))
+        .unwrap();
+    }
+    rt
+}
+
+fn assert_h3_document_parity(create_index: &str, queries: &[String]) {
+    let rt = seed_document_geo_corpus("events");
+    let baseline: Vec<Vec<(u64, u64)>> = queries.iter().map(|q| spatial_rows(&rt, q)).collect();
+    rt.execute_query(create_index).unwrap();
+    for (q, expected) in queries.iter().zip(&baseline) {
+        assert_eq!(
+            &spatial_rows(&rt, q),
+            expected,
+            "document H3 route diverged from full scan for: {q}"
+        );
+    }
+}
+
 #[test]
 fn spatial_full_scan_reads_document_body_column() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
@@ -459,6 +489,210 @@ fn spatial_row_named_column_wins_and_missing_column_uses_legacy_fallback() {
         missing.len(),
         1,
         "legacy any-geo fallback must remain for row entities when COLUMN is absent"
+    );
+}
+
+#[test]
+fn h3_document_body_repro_backfills_existing_documents() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":38.76,"lon":-77.15}})"#,
+    )
+    .unwrap();
+
+    rt.execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+
+    let (kind, entries) = show_index(&rt, "events", "idx_loc")
+        .expect("document H3 index must appear in red.show_indexes");
+    assert_eq!(kind, "H3");
+    assert_eq!(
+        entries, 1,
+        "document H3 backfill must index the existing body field"
+    );
+
+    let hits = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(hits.len(), 1, "the #1866 document repro must return a hit");
+    assert_eq!(
+        hits[0].1,
+        0.0_f64.to_bits(),
+        "exact document hit must report zero distance"
+    );
+}
+
+#[test]
+fn h3_document_body_indexes_live_inserts() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":38.76,"lon":-77.15}})"#,
+    )
+    .unwrap();
+
+    let (_, entries) = show_index(&rt, "events", "idx_loc").unwrap();
+    assert_eq!(
+        entries, 1,
+        "document H3 live maintenance must index inserts after CREATE INDEX"
+    );
+    let hits = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].1, 0.0_f64.to_bits());
+}
+
+#[test]
+fn h3_document_body_update_delete_and_missing_value_lifecycle() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+           ({"name":"moving","gpsLocation":{"lat":38.76,"lon":-77.15}}),
+           ({"name":"missing"}),
+           ({"name":"bad","gpsLocation":"not-geo"})"#,
+    )
+    .unwrap();
+    rt.execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+
+    let (_, entries) = show_index(&rt, "events", "idx_loc").unwrap();
+    assert_eq!(
+        entries, 1,
+        "missing and non-geo document values must be absent from H3"
+    );
+
+    rt.execute_query(
+        r#"UPDATE events SET gpsLocation = JSON_PARSE('{"lat":40.7,"lon":-74.0}') WHERE name = 'moving'"#,
+    )
+    .unwrap();
+    assert!(
+        spatial_rows(
+            &rt,
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .is_empty(),
+        "document UPDATE must remove the old H3 cell"
+    );
+    assert_eq!(
+        spatial_rows(
+            &rt,
+            "SEARCH SPATIAL RADIUS 40.7 -74.0 1.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .len(),
+        1,
+        "document UPDATE must insert the new H3 cell"
+    );
+
+    rt.execute_query(
+        r#"UPDATE events SET gpsLocation = JSON_PARSE('{"lat":38.76,"lon":-77.15}') WHERE name = 'missing'"#,
+    )
+    .unwrap();
+    assert_eq!(
+        spatial_rows(
+            &rt,
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .len(),
+        1,
+        "a document that gains a valid geo field must appear in H3"
+    );
+
+    rt.execute_query("DELETE FROM events WHERE name = 'moving'")
+        .unwrap();
+    assert!(
+        spatial_rows(
+            &rt,
+            "SEARCH SPATIAL RADIUS 40.7 -74.0 1.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .is_empty(),
+        "document DELETE must remove the H3 index entry"
+    );
+}
+
+#[test]
+fn h3_document_body_dotted_path_backfills_and_searches() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+           ({"location":{"gps":{"lat":38.76,"lon":-77.15}}})"#,
+    )
+    .unwrap();
+
+    rt.execute_query("CREATE INDEX idx_loc ON events (location.gps) USING H3")
+        .unwrap();
+
+    let (_, entries) = show_index(&rt, "events", "idx_loc").unwrap();
+    assert_eq!(entries, 1, "dotted document H3 path must backfill");
+    let hits = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION events COLUMN location.gps",
+    );
+    assert_eq!(hits.len(), 1, "dotted document H3 path must search");
+    assert_eq!(hits[0].1, 0.0_f64.to_bits());
+}
+
+#[test]
+fn h3_document_radius_parity_with_full_scan() {
+    let queries: Vec<String> = [
+        (48.8566, 2.3522, 0.5),
+        (48.8566, 2.3522, 5.0),
+        (48.8566, 2.3522, 50.0),
+    ]
+    .iter()
+    .map(|(clat, clon, r)| {
+        format!("SEARCH SPATIAL RADIUS {clat} {clon} {r} COLLECTION events COLUMN gpsLocation")
+    })
+    .collect();
+    assert_h3_document_parity(
+        "CREATE INDEX idx_loc ON events (gpsLocation) USING H3",
+        &queries,
+    );
+}
+
+#[test]
+fn h3_document_nearest_parity_with_full_scan() {
+    let queries: Vec<String> = [
+        (48.8566, 2.3522, 1),
+        (48.8566, 2.3522, 4),
+        (48.8584, 2.2945, 3),
+    ]
+    .iter()
+    .map(|(lat, lon, k)| {
+        format!("SEARCH SPATIAL NEAREST {lat} {lon} K {k} COLLECTION events COLUMN gpsLocation")
+    })
+    .collect();
+    assert_h3_document_parity(
+        "CREATE INDEX idx_loc ON events (gpsLocation) USING H3 (9)",
+        &queries,
+    );
+}
+
+#[test]
+fn h3_document_bbox_parity_with_full_scan() {
+    let queries: Vec<String> = [
+        (48.84, 2.33, 48.87, 2.36),
+        (48.80, 2.25, 48.90, 2.40),
+        (-90.0, -180.0, 90.0, 180.0),
+    ]
+    .iter()
+    .map(|(min_lat, min_lon, max_lat, max_lon)| {
+        format!(
+            "SEARCH SPATIAL BBOX {min_lat} {min_lon} {max_lat} {max_lon} COLLECTION events COLUMN gpsLocation"
+        )
+    })
+    .collect();
+    assert_h3_document_parity(
+        "CREATE INDEX idx_loc ON events (gpsLocation) USING H3",
+        &queries,
     );
 }
 


### PR DESCRIPTION
Automated AFK landing for #1936. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1936

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786143907&installation_id=129708444&pr_number=1972&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1972&signature=d59e253332e84e830848c094c3a61cc721d972c9825f936c8066990d0251cf12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->