### PR TITLE
chore: #1941 GEO_DISTANCE as an ordinary RQL predicate: WHERE, projection, ORDER BY over rows and document bodies (unindexed contract)

### DIFF
--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -2140,6 +2140,10 @@ fn geo_args(args: &[Value]) -> Option<(f64, f64, f64, f64)> {
             let (lat2, lon2) = geo_point(right)?;
             Some((lat1, lon1, lat2, lon2))
         }
+        [left, lat2, lon2] => {
+            let (lat1, lon1) = geo_point(left)?;
+            Some((lat1, lon1, value_as_f64(lat2)?, value_as_f64(lon2)?))
+        }
         [lat1, lon1, lat2, lon2] => Some((
             value_as_f64(lat1)?,
             value_as_f64(lon1)?,
@@ -2151,13 +2155,7 @@ fn geo_args(args: &[Value]) -> Option<(f64, f64, f64, f64)> {
 }
 
 fn geo_point(value: &Value) -> Option<(f64, f64)> {
-    match value {
-        Value::GeoPoint(lat, lon) => Some((
-            crate::geo::micro_to_deg(*lat),
-            crate::geo::micro_to_deg(*lon),
-        )),
-        _ => None,
-    }
+    crate::geo::recognize_geo_value(value)
 }
 
 fn value_as_f64(value: &Value) -> Option<f64> {

--- a/crates/reddb-server/src/runtime/join_filter/projection_eval.rs
+++ b/crates/reddb-server/src/runtime/join_filter/projection_eval.rs
@@ -490,13 +490,26 @@ pub(in crate::runtime::join_filter) fn resolve_two_geo_points(
     args: &[Projection],
     source: &UnifiedRecord,
 ) -> Option<(f64, f64, f64, f64)> {
-    if args.len() < 2 {
-        return None;
+    match args {
+        [left, right] => {
+            let (lat1, lon1) = resolve_geo_arg(left, source)?;
+            let (lat2, lon2) = resolve_geo_arg(right, source)?;
+            Some((lat1, lon1, lat2, lon2))
+        }
+        [left, lat, lon] => {
+            let (lat1, lon1) = resolve_geo_arg(left, source)?;
+            let lat2 = resolve_geo_number(lat, source)?;
+            let lon2 = resolve_geo_number(lon, source)?;
+            Some((lat1, lon1, lat2, lon2))
+        }
+        [lat1, lon1, lat2, lon2] => Some((
+            resolve_geo_number(lat1, source)?,
+            resolve_geo_number(lon1, source)?,
+            resolve_geo_number(lat2, source)?,
+            resolve_geo_number(lon2, source)?,
+        )),
+        _ => None,
     }
-
-    let (lat1, lon1) = resolve_geo_arg(&args[0], source)?;
-    let (lat2, lon2) = resolve_geo_arg(&args[1], source)?;
-    Some((lat1, lon1, lat2, lon2))
 }
 
 /// Resolve a single geo argument — either a column (GeoPoint/Latitude/Longitude) or POINT literal.
@@ -516,12 +529,14 @@ pub(in crate::runtime::join_filter) fn resolve_geo_arg(
                 }
             }
             // Column reference → look up in record values
-            let val = source.get(col.as_str())?;
-            match val {
-                Value::GeoPoint(lat_micro, lon_micro) => Some((
-                    crate::geo::micro_to_deg(*lat_micro),
-                    crate::geo::micro_to_deg(*lon_micro),
-                )),
+            let val = source
+                .get(col.as_str())
+                .cloned()
+                .or_else(|| resolve_runtime_document_path(source, col))?;
+            match &val {
+                value if crate::geo::recognize_geo_value(value).is_some() => {
+                    crate::geo::recognize_geo_value(value)
+                }
                 Value::Float(f) => {
                     // Could be a lat or lon — check for "lat"/"lon" sibling columns
                     let lat_keys = ["lat", "latitude"];
@@ -544,6 +559,14 @@ pub(in crate::runtime::join_filter) fn resolve_geo_arg(
                 _ => None,
             }
         }
-        _ => None,
+        _ => {
+            let value = eval_projection_value(arg, source)?;
+            crate::geo::recognize_geo_value(&value)
+        }
     }
+}
+
+fn resolve_geo_number(arg: &Projection, source: &UnifiedRecord) -> Option<f64> {
+    let value = eval_projection_value(arg, source)?;
+    value_as_number(&value).map(NumOperand::as_f64)
 }

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -285,6 +285,20 @@ fn spatial_rows(rt: &RedDBRuntime, query: &str) -> Vec<(u64, u64)> {
         .collect()
 }
 
+fn text_field<'a>(record: &'a reddb::storage::query::UnifiedRecord, field: &str) -> &'a str {
+    match record.get(field) {
+        Some(Value::Text(value)) => value.as_ref(),
+        other => panic!("expected {field} text field, got {other:?} in {record:?}"),
+    }
+}
+
+fn float_field(record: &reddb::storage::query::UnifiedRecord, field: &str) -> f64 {
+    match record.get(field) {
+        Some(Value::Float(value)) => *value,
+        other => panic!("expected {field} float field, got {other:?} in {record:?}"),
+    }
+}
+
 /// For each query: run the full scan (no index), create the H3 index, run
 /// the ring scan, and assert the two are byte-identical.
 fn assert_h3_parity(create_index: &str, queries: &[String]) {
@@ -377,6 +391,94 @@ fn spatial_full_scan_reads_document_body_column() {
         nearest[0].1,
         0.0_f64.to_bits(),
         "exact centre nearest hit must report zero distance"
+    );
+}
+
+#[test]
+fn geo_distance_predicate_projects_and_orders_row_geopoint() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query(
+        "CREATE TABLE events (id INT, name TEXT, event_kind TEXT, gpsLocation GEOPOINT)",
+    )
+    .unwrap();
+    rt.execute_query(
+        "INSERT INTO events (id, name, event_kind, gpsLocation) VALUES \
+         (1, 'centre', 'signup', '38.760000,-77.150000'), \
+         (2, 'near', 'signup', '38.770000,-77.150000'), \
+         (3, 'wrong-kind', 'purchase', '38.760000,-77.150000'), \
+         (4, 'far', 'signup', '39.200000,-77.150000'), \
+         (5, 'missing', 'signup', NULL)",
+    )
+    .unwrap();
+
+    let res = rt
+        .execute_query(
+            "SELECT name, GEO_DISTANCE(gpsLocation, 38.76, -77.15) AS dist \
+             FROM events \
+             WHERE GEO_DISTANCE(gpsLocation, 38.76, -77.15) < 10.0 \
+               AND event_kind = 'signup' \
+             ORDER BY dist \
+             LIMIT 2",
+        )
+        .expect("GEO_DISTANCE predicate query over row GEOPOINT should execute");
+
+    assert_eq!(res.result.records.len(), 2);
+    assert_eq!(text_field(&res.result.records[0], "name"), "centre");
+    assert_eq!(float_field(&res.result.records[0], "dist"), 0.0);
+    assert_eq!(text_field(&res.result.records[1], "name"), "near");
+    assert!(
+        (float_field(&res.result.records[1], "dist") - 1.111_949_266).abs() < 0.000_001,
+        "near distance should be the worked haversine value"
+    );
+}
+
+#[test]
+fn geo_distance_predicate_resolves_document_body_and_dotted_path() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT doc_events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO doc_events DOCUMENT VALUES
+        ({"name":"centre","category":"signup","gpsLocation":{"lat":38.76,"lon":-77.15},"location":{"gps":{"lat":38.76,"lon":-77.15}}}),
+        ({"name":"near","category":"signup","gpsLocation":{"lat":38.77,"lon":-77.15},"location":{"gps":{"lat":38.77,"lon":-77.15}}}),
+        ({"name":"wrong-category","category":"purchase","gpsLocation":{"lat":38.76,"lon":-77.15},"location":{"gps":{"lat":38.76,"lon":-77.15}}}),
+        ({"name":"far","category":"signup","gpsLocation":{"lat":39.20,"lon":-77.15},"location":{"gps":{"lat":39.20,"lon":-77.15}}}),
+        ({"name":"missing","category":"signup"}),
+        ({"name":"not-geo","category":"signup","gpsLocation":"not-geo","location":{"gps":"not-geo"}})"#,
+    )
+    .unwrap();
+
+    let bare = rt
+        .execute_query(
+            "SELECT name, GEO_DISTANCE(gpsLocation, 38.76, -77.15) AS dist \
+             FROM doc_events \
+             WHERE GEO_DISTANCE(gpsLocation, 38.76, -77.15) < 10.0 \
+               AND category = 'signup' \
+             ORDER BY dist \
+             LIMIT 2",
+        )
+        .expect("GEO_DISTANCE should resolve a bare document body field");
+    assert_eq!(bare.result.records.len(), 2);
+    assert_eq!(text_field(&bare.result.records[0], "name"), "centre");
+    assert_eq!(text_field(&bare.result.records[1], "name"), "near");
+
+    let dotted = rt
+        .execute_query(
+            "SELECT name, GEO_DISTANCE(body.location.gps, 38.76, -77.15) AS dist \
+             FROM doc_events \
+             WHERE (GEO_DISTANCE(body.location.gps, 38.76, -77.15) = 0.0 \
+                    OR GEO_DISTANCE(body.location.gps, 38.76, -77.15) < 2.0) \
+               AND category = 'signup' \
+             ORDER BY dist \
+             LIMIT 2",
+        )
+        .expect("GEO_DISTANCE should resolve a dotted document body field");
+    assert_eq!(dotted.result.records.len(), 2);
+    assert_eq!(text_field(&dotted.result.records[0], "name"), "centre");
+    assert_eq!(float_field(&dotted.result.records[0], "dist"), 0.0);
+    assert_eq!(text_field(&dotted.result.records[1], "name"), "near");
+    assert!(
+        (float_field(&dotted.result.records[1], "dist") - 1.111_949_266).abs() < 0.000_001,
+        "near dotted-path distance should be the worked haversine value"
     );
 }
 


### PR DESCRIPTION
Automated AFK landing for #1941. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1941

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786144369&installation_id=129708444&pr_number=1973&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1973&signature=6266b978e56a3ee83b0f119f48f0619d0fd10049e936729b81776eb204a81dd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->