### PR TITLE
chore: #1942 Planner accelerates GEO_DISTANCE predicates via the H3 index: candidate route, predicate intersection, byte-identical parity

### DIFF
--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::application::SearchContextInput;
+use crate::storage::query::ast::Expr;
 use crate::storage::unified::context_index::{entity_tokens_for_search, tokenize_query};
 
 const ASK_AUDIT_COLLECTION: &str = "red_ask_audit";
@@ -24,6 +25,65 @@ fn mark_table_scan_as_index_seek(
         }
     }
     false
+}
+
+fn mark_table_scan_as_geo_h3_index_seek(
+    node: &mut crate::storage::query::planner::CanonicalLogicalNode,
+) -> bool {
+    if node.operator == "table_scan" || node.operator == "index_seek" {
+        node.operator = "geo_h3_index_seek".to_string();
+        node.details.insert(
+            "reason".to_string(),
+            "GEO_DISTANCE predicate uses H3 covering-ring candidates".to_string(),
+        );
+        return true;
+    }
+    for child in &mut node.children {
+        if mark_table_scan_as_geo_h3_index_seek(child) {
+            return true;
+        }
+    }
+    false
+}
+
+fn explain_literal_f64(expr: &Expr) -> Option<f64> {
+    match expr {
+        Expr::Literal {
+            value: Value::Float(value),
+            ..
+        } => Some(*value),
+        Expr::Literal {
+            value: Value::Integer(value),
+            ..
+        } => Some(*value as f64),
+        Expr::Literal {
+            value: Value::UnsignedInteger(value),
+            ..
+        } => Some(*value as f64),
+        _ => None,
+    }
+}
+
+fn flip_geo_compare_op(op: CompareOp) -> CompareOp {
+    match op {
+        CompareOp::Eq => CompareOp::Eq,
+        CompareOp::Ne => CompareOp::Ne,
+        CompareOp::Lt => CompareOp::Gt,
+        CompareOp::Le => CompareOp::Ge,
+        CompareOp::Gt => CompareOp::Lt,
+        CompareOp::Ge => CompareOp::Le,
+    }
+}
+
+fn explain_h3_cover_is_enumerable(lat: f64, lon: f64, radius_km: f64, resolution: u8) -> bool {
+    let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
+    if cell == 0 {
+        return false;
+    }
+    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
+    const MAX_COVER_RING: u32 = 128;
+    let k_f = (radius_km / edge_km).ceil() + 1.0;
+    k_f.is_finite() && k_f <= f64::from(MAX_COVER_RING)
 }
 
 impl RedDBRuntime {
@@ -104,6 +164,10 @@ impl RedDBRuntime {
         if table.filter.is_none() && table.where_expr.is_none() {
             return;
         }
+        if self.table_filter_has_geo_h3_route(table) {
+            mark_table_scan_as_geo_h3_index_seek(node);
+            return;
+        }
         let Some(index) = self
             .inner
             .index_store
@@ -114,6 +178,74 @@ impl RedDBRuntime {
             return;
         };
         mark_table_scan_as_index_seek(node, &index.name);
+    }
+
+    fn table_filter_has_geo_h3_route(&self, table: &TableQuery) -> bool {
+        let Some(filter) = crate::storage::query::sql_lowering::effective_table_filter(table)
+        else {
+            return false;
+        };
+        self.filter_has_geo_h3_route(table.table.as_str(), &filter)
+    }
+
+    fn filter_has_geo_h3_route(&self, table: &str, filter: &Filter) -> bool {
+        match filter {
+            Filter::CompareExpr { lhs, op, rhs } => self
+                .geo_h3_route_column(lhs, *op, rhs)
+                .or_else(|| self.geo_h3_route_column(rhs, flip_geo_compare_op(*op), lhs))
+                .is_some_and(|column| {
+                    self.inner
+                        .index_store
+                        .find_index_for_column(table, column)
+                        .is_some_and(|index| {
+                            matches!(
+                                index.method,
+                                crate::runtime::index_store::IndexMethodKind::H3 { .. }
+                            )
+                        })
+                }),
+            Filter::And(left, right) => {
+                self.filter_has_geo_h3_route(table, left)
+                    || self.filter_has_geo_h3_route(table, right)
+            }
+            Filter::Or(left, right) => {
+                self.filter_has_geo_h3_route(table, left)
+                    && self.filter_has_geo_h3_route(table, right)
+            }
+            Filter::Not(_) => false,
+            _ => false,
+        }
+    }
+
+    fn geo_h3_route_column<'a>(&self, lhs: &'a Expr, op: CompareOp, rhs: &Expr) -> Option<&'a str> {
+        if !matches!(op, CompareOp::Lt | CompareOp::Le) {
+            return None;
+        }
+        let radius_km = explain_literal_f64(rhs)?;
+        if radius_km.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+            return None;
+        }
+        let Expr::FunctionCall { name, args, .. } = lhs else {
+            return None;
+        };
+        if !(name.eq_ignore_ascii_case("GEO_DISTANCE") || name.eq_ignore_ascii_case("HAVERSINE")) {
+            return None;
+        }
+        let [Expr::Column { field, .. }, lat, lon] = args.as_slice() else {
+            return None;
+        };
+        if !explain_h3_cover_is_enumerable(
+            explain_literal_f64(lat)?,
+            explain_literal_f64(lon)?,
+            radius_km,
+            9,
+        ) {
+            return None;
+        }
+        match field {
+            FieldRef::TableColumn { column, .. } => Some(column.as_str()),
+            _ => None,
+        }
     }
 
     pub fn search_similar(

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -57,6 +57,260 @@ fn projections_require_runtime_projection(projections: &[Projection]) -> bool {
     })
 }
 
+#[derive(Clone, Copy)]
+struct GeoDistancePredicate<'a> {
+    column: &'a str,
+    center_lat: f64,
+    center_lon: f64,
+    radius_km: f64,
+}
+
+fn execute_geo_distance_candidate_scan(
+    db: &RedDB,
+    query: &TableQuery,
+    filter: &Filter,
+    effective_projections: &[Projection],
+    candidate_ids: &std::collections::HashSet<u64>,
+) -> RedDBResult<Vec<UnifiedRecord>> {
+    let manager = db
+        .store()
+        .get_collection(query.table.as_str())
+        .ok_or_else(|| RedDBError::NotFound(query.table.clone()))?;
+    let table_name = query.table.as_str();
+    let table_alias = query.alias.as_deref().unwrap_or(table_name);
+    let compiled = crate::runtime::scalar_evaluator::compile_filter(
+        filter,
+        &crate::runtime::scalar_evaluator::PermissiveScope,
+    );
+
+    let table_row_resolver = TableRowMvccReadResolver::current_statement();
+    let hydrate_store = db.store();
+    let mut records = Vec::new();
+    manager.for_each_entity(|entity| {
+        if !candidate_ids.contains(&entity.id.raw()) {
+            return true;
+        }
+        if table_row_resolver.resolve_read_candidate(entity).is_none() {
+            return true;
+        }
+        if !db.replica_allows_entity_at_read(&query.table, entity) {
+            return true;
+        }
+        let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
+            hydrate_store.as_ref(),
+            entity,
+        );
+        let Some(record) = runtime_table_record_from_entity(hydrated) else {
+            return true;
+        };
+        if crate::runtime::scalar_evaluator::evaluate_compiled_filter(
+            Some(db),
+            &compiled,
+            &record,
+            Some(table_name),
+            Some(table_alias),
+        ) {
+            records.push(record);
+        }
+        true
+    });
+
+    crate::runtime::window_phase::apply(
+        Some(db),
+        &mut records,
+        effective_projections,
+        Some(table_name),
+        Some(table_alias),
+    )?;
+
+    let mut records = records
+        .iter()
+        .map(|record| {
+            project_runtime_record_with_db(
+                Some(db),
+                record,
+                effective_projections,
+                Some(table_name),
+                Some(table_alias),
+                false,
+                false,
+            )
+        })
+        .collect::<RedDBResult<Vec<_>>>()?;
+
+    if !query.order_by.is_empty() {
+        crate::runtime::materialization_limit::guard(db, "sort", records.len())?;
+        super::super::join_filter::sort_records_by_order_by_with_db(
+            Some(db),
+            &mut records,
+            &query.order_by,
+            Some(table_name),
+            Some(table_alias),
+        );
+    }
+    if let Some(offset) = query.offset {
+        let offset = offset as usize;
+        if offset < records.len() {
+            records = records.into_iter().skip(offset).collect();
+        } else {
+            records.clear();
+        }
+    }
+    if let Some(limit) = query.limit {
+        records.truncate(limit as usize);
+    }
+
+    Ok(records)
+}
+
+fn geo_distance_h3_candidate_ids(
+    filter: &Filter,
+    table: &str,
+    idx_store: &super::index_store::IndexStore,
+) -> Option<std::collections::HashSet<u64>> {
+    match filter {
+        Filter::CompareExpr { lhs, op, rhs } => {
+            let predicate = geo_distance_predicate(lhs, *op, rhs)
+                .or_else(|| geo_distance_predicate(rhs, flipped_compare_op_for_geo(*op), lhs))?;
+            geo_distance_predicate_candidate_ids(predicate, table, idx_store)
+        }
+        Filter::And(left, right) => {
+            let left_ids = geo_distance_h3_candidate_ids(left, table, idx_store);
+            let right_ids = geo_distance_h3_candidate_ids(right, table, idx_store);
+            match (left_ids, right_ids) {
+                (Some(mut left), Some(right)) => {
+                    left.retain(|id| right.contains(id));
+                    Some(left)
+                }
+                (Some(ids), None) | (None, Some(ids)) => Some(ids),
+                (None, None) => None,
+            }
+        }
+        Filter::Or(left, right) => {
+            let mut left_ids = geo_distance_h3_candidate_ids(left, table, idx_store)?;
+            let right_ids = geo_distance_h3_candidate_ids(right, table, idx_store)?;
+            left_ids.extend(right_ids);
+            Some(left_ids)
+        }
+        Filter::Not(_) => None,
+        _ => None,
+    }
+}
+
+fn geo_distance_predicate<'a>(
+    lhs: &'a Expr,
+    op: CompareOp,
+    rhs: &'a Expr,
+) -> Option<GeoDistancePredicate<'a>> {
+    if !matches!(op, CompareOp::Lt | CompareOp::Le) {
+        return None;
+    }
+    let radius_km = literal_f64(rhs)?;
+    if radius_km.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+        return None;
+    }
+    let Expr::FunctionCall { name, args, .. } = lhs else {
+        return None;
+    };
+    if !(name.eq_ignore_ascii_case("GEO_DISTANCE") || name.eq_ignore_ascii_case("HAVERSINE")) {
+        return None;
+    }
+    let [Expr::Column { field, .. }, lat, lon] = args.as_slice() else {
+        return None;
+    };
+    let column = match field {
+        FieldRef::TableColumn { column, .. } => column.as_str(),
+        _ => return None,
+    };
+    Some(GeoDistancePredicate {
+        column,
+        center_lat: literal_f64(lat)?,
+        center_lon: literal_f64(lon)?,
+        radius_km,
+    })
+}
+
+fn literal_f64(expr: &Expr) -> Option<f64> {
+    match expr {
+        Expr::Literal {
+            value: Value::Float(value),
+            ..
+        } => Some(*value),
+        Expr::Literal {
+            value: Value::Integer(value),
+            ..
+        } => Some(*value as f64),
+        Expr::Literal {
+            value: Value::UnsignedInteger(value),
+            ..
+        } => Some(*value as f64),
+        _ => None,
+    }
+}
+
+fn flipped_compare_op_for_geo(op: CompareOp) -> CompareOp {
+    match op {
+        CompareOp::Eq => CompareOp::Eq,
+        CompareOp::Ne => CompareOp::Ne,
+        CompareOp::Lt => CompareOp::Gt,
+        CompareOp::Le => CompareOp::Ge,
+        CompareOp::Gt => CompareOp::Lt,
+        CompareOp::Ge => CompareOp::Le,
+    }
+}
+
+fn geo_distance_predicate_candidate_ids(
+    predicate: GeoDistancePredicate<'_>,
+    table: &str,
+    idx_store: &super::index_store::IndexStore,
+) -> Option<std::collections::HashSet<u64>> {
+    let index = idx_store.find_index_for_column(table, predicate.column)?;
+    let super::index_store::IndexMethodKind::H3 { resolution } = index.method else {
+        return None;
+    };
+    let cells = h3_cover_cells_for_geo_predicate(
+        predicate.center_lat,
+        predicate.center_lon,
+        predicate.radius_km,
+        resolution,
+    );
+    if cells.is_empty() {
+        return None;
+    }
+    let keys: Vec<_> = cells
+        .iter()
+        .filter_map(|cell| {
+            crate::storage::schema::value_to_canonical_key(&Value::UnsignedInteger(*cell))
+        })
+        .collect();
+    if keys.is_empty() {
+        return None;
+    }
+    let ids = idx_store
+        .sorted
+        .in_lookup_limited(table, predicate.column, &keys, usize::MAX)?;
+    Some(ids.into_iter().map(|id| id.raw()).collect())
+}
+
+fn h3_cover_cells_for_geo_predicate(
+    lat: f64,
+    lon: f64,
+    radius_km: f64,
+    resolution: u8,
+) -> Vec<u64> {
+    let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, resolution);
+    if cell == 0 {
+        return Vec::new();
+    }
+    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
+    const MAX_COVER_RING: u32 = 128;
+    let k_f = (radius_km / edge_km).ceil() + 1.0;
+    if !k_f.is_finite() || k_f > f64::from(MAX_COVER_RING) {
+        return Vec::new();
+    }
+    crate::geo::h3::grid_disk(cell, k_f as u32)
+}
+
 pub(crate) fn execute_runtime_canonical_table_query_indexed(
     db: &RedDB,
     query: &TableQuery,
@@ -219,6 +473,29 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
 
     let requires_mvcc_index_fallback =
         crate::runtime::impl_core::current_snapshot_requires_index_fallback();
+
+    // ── GEO_DISTANCE H3 CANDIDATE PATH ────────────────────────────────────────
+    // `WHERE GEO_DISTANCE(col, lat, lon) < r` over an H3-indexed column can
+    // use the same covering-ring candidate set as SEARCH SPATIAL RADIUS. The
+    // full WHERE expression is still evaluated after candidate pruning, so
+    // the index remains a pure optimization.
+    if let (false, Some(idx_store), Some(ref filter)) =
+        (requires_mvcc_index_fallback, index_store, &effective_filter)
+    {
+        if !is_universal_query_source(&query.table) {
+            if let Some(candidate_ids) =
+                geo_distance_h3_candidate_ids(filter, &query.table, idx_store)
+            {
+                return execute_geo_distance_candidate_scan(
+                    db,
+                    query,
+                    filter,
+                    &effective_projections,
+                    &candidate_ids,
+                );
+            }
+        }
+    }
 
     // ── INDEX-ASSISTED PATH: sorted (BTREE) index for BETWEEN / >/>= ──
     //

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -299,6 +299,37 @@ fn float_field(record: &reddb::storage::query::UnifiedRecord, field: &str) -> f6
     }
 }
 
+fn geo_distance_select_signature(rt: &RedDBRuntime, query: &str) -> Vec<(i64, u64)> {
+    let res = rt
+        .execute_query(query)
+        .expect("geo distance SELECT executes");
+    res.result
+        .records
+        .iter()
+        .map(|record| {
+            let id = match record.get("id") {
+                Some(Value::Integer(value)) => *value,
+                other => panic!("expected id integer field, got {other:?} in {record:?}"),
+            };
+            let dist = float_field(record, "dist").to_bits();
+            (id, dist)
+        })
+        .collect()
+}
+
+fn explain_ops(rt: &RedDBRuntime, query: &str) -> Vec<String> {
+    rt.execute_query(query)
+        .expect("EXPLAIN executes")
+        .result
+        .records
+        .iter()
+        .filter_map(|record| match record.get("op") {
+            Some(Value::Text(op)) => Some(op.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// For each query: run the full scan (no index), create the H3 index, run
 /// the ring scan, and assert the two are byte-identical.
 fn assert_h3_parity(create_index: &str, queries: &[String]) {
@@ -340,6 +371,21 @@ fn assert_h3_document_parity(create_index: &str, queries: &[String]) {
             &spatial_rows(&rt, q),
             expected,
             "document H3 route diverged from full scan for: {q}"
+        );
+    }
+}
+
+fn assert_h3_geo_distance_select_parity(rt: &RedDBRuntime, create_index: &str, queries: &[&str]) {
+    let baseline: Vec<Vec<(i64, u64)>> = queries
+        .iter()
+        .map(|q| geo_distance_select_signature(rt, q))
+        .collect();
+    rt.execute_query(create_index).unwrap();
+    for (q, expected) in queries.iter().zip(&baseline) {
+        assert_eq!(
+            &geo_distance_select_signature(rt, q),
+            expected,
+            "indexed GEO_DISTANCE predicate diverged from scan for: {q}"
         );
     }
 }
@@ -433,6 +479,54 @@ fn geo_distance_predicate_projects_and_orders_row_geopoint() {
 }
 
 #[test]
+fn h3_accelerates_geo_distance_row_predicate_with_parity_and_explain() {
+    let queries = [
+        "SELECT id, GEO_DISTANCE(loc, 48.8566, 2.3522) AS dist \
+         FROM places \
+         WHERE GEO_DISTANCE(loc, 48.8566, 2.3522) < 5.0 \
+         ORDER BY dist \
+         LIMIT 4",
+        "SELECT id, GEO_DISTANCE(loc, 48.8566, 2.3522) AS dist \
+         FROM places \
+         WHERE GEO_DISTANCE(loc, 48.8566, 2.3522) < 20001.0 \
+         ORDER BY id \
+         LIMIT 10",
+    ];
+
+    let rt = seed_geo_corpus("places");
+    assert_h3_geo_distance_select_parity(
+        &rt,
+        "CREATE INDEX idx_loc ON places (loc) USING H3",
+        &queries,
+    );
+
+    let baseline = seed_geo_corpus("places");
+    let scan_ops = explain_ops(
+        &baseline,
+        "EXPLAIN SELECT id FROM places \
+         WHERE GEO_DISTANCE(loc, 48.8566, 2.3522) < 5.0",
+    );
+    assert!(
+        scan_ops.iter().all(|op| op != "geo_h3_index_seek"),
+        "unindexed plan must not advertise H3 geo acceleration: {scan_ops:?}"
+    );
+
+    let indexed = seed_geo_corpus("places");
+    indexed
+        .execute_query("CREATE INDEX idx_loc ON places (loc) USING H3")
+        .unwrap();
+    let indexed_ops = explain_ops(
+        &indexed,
+        "EXPLAIN SELECT id FROM places \
+         WHERE GEO_DISTANCE(loc, 48.8566, 2.3522) < 5.0",
+    );
+    assert!(
+        indexed_ops.iter().any(|op| op == "geo_h3_index_seek"),
+        "indexed GEO_DISTANCE predicate should explain the H3 route: {indexed_ops:?}"
+    );
+}
+
+#[test]
 fn geo_distance_predicate_resolves_document_body_and_dotted_path() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
     rt.execute_query("CREATE DOCUMENT doc_events").unwrap();
@@ -479,6 +573,21 @@ fn geo_distance_predicate_resolves_document_body_and_dotted_path() {
     assert!(
         (float_field(&dotted.result.records[1], "dist") - 1.111_949_266).abs() < 0.000_001,
         "near dotted-path distance should be the worked haversine value"
+    );
+}
+
+#[test]
+fn h3_accelerates_geo_distance_document_predicate_with_parity() {
+    let query = "SELECT id, GEO_DISTANCE(gpsLocation, 48.8566, 2.3522) AS dist \
+                 FROM events \
+                 WHERE GEO_DISTANCE(gpsLocation, 48.8566, 2.3522) < 5.0 \
+                 ORDER BY dist \
+                 LIMIT 4";
+    let rt = seed_document_geo_corpus("events");
+    assert_h3_geo_distance_select_parity(
+        &rt,
+        "CREATE INDEX idx_loc ON events (gpsLocation) USING H3",
+        &[query],
     );
 }
 


### PR DESCRIPTION
Automated AFK landing for #1942. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1942

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786149911&installation_id=129708444&pr_number=1974&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1974&signature=d075e3bdea8ed4c465ae163dfdb0234df5c81bf7c55848eba804075952c9db19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->