### PR TITLE
chore: #1948 H3 cell aggregation: H3_CELL and H3_PARENT scalars for GROUP BY heatmaps and hierarchical rollups

### DIFF
--- a/crates/reddb-server/src/geo/h3.rs
+++ b/crates/reddb-server/src/geo/h3.rs
@@ -12,6 +12,17 @@
 
 use h3o::{CellIndex, LatLng, Resolution};
 
+pub const MIN_RESOLUTION: i64 = 0;
+pub const MAX_RESOLUTION: i64 = 15;
+
+pub fn valid_resolution(res: i64) -> Option<u8> {
+    if (MIN_RESOLUTION..=MAX_RESOLUTION).contains(&res) {
+        Some(res as u8)
+    } else {
+        None
+    }
+}
+
 /// Clamp an arbitrary resolution byte into h3o's valid `0..=15` range.
 ///
 /// H3 has 16 resolutions; anything coarser/finer than the bounds is

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1694,6 +1694,34 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
                 lat, lon, res,
             )))
         }
+        "H3_CELL" => {
+            let Some((lat, lon)) = geo_point(args.first()?) else {
+                return Some(Value::Null);
+            };
+            let res_value = value_as_i64(args.get(1)?)?;
+            let Some(res) = crate::geo::h3::valid_resolution(res_value) else {
+                return Some(Value::Null);
+            };
+            let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, res);
+            if cell == 0 {
+                Some(Value::Null)
+            } else {
+                Some(Value::UnsignedInteger(cell))
+            }
+        }
+        "H3_PARENT" => {
+            let cell = value_as_u64(args.first()?)?;
+            let res_value = value_as_i64(args.get(1)?)?;
+            let Some(res) = crate::geo::h3::valid_resolution(res_value) else {
+                return Some(Value::Null);
+            };
+            let parent = crate::geo::h3::cell_to_parent(cell, res);
+            if parent == 0 {
+                Some(Value::Null)
+            } else {
+                Some(Value::UnsignedInteger(parent))
+            }
+        }
         "H3_TO_LATLNG" => {
             let cell = value_as_u64(args.first()?)?;
             let (lat, lon) = crate::geo::h3::cell_to_lat_lng(cell);

--- a/crates/reddb-server/src/runtime/join_filter/scalar_functions.rs
+++ b/crates/reddb-server/src/runtime/join_filter/scalar_functions.rs
@@ -313,6 +313,34 @@ fn evaluate_scalar_function_legacy(
                 lat, lon, res,
             )))
         }
+        "H3_CELL" => {
+            let Some((lat, lon)) = resolve_geo_arg(args.first()?, source) else {
+                return Some(Value::Null);
+            };
+            let res_value = value_as_i64(&resolve_scalar_arg(args, 1, source)?)?;
+            let Some(res) = crate::geo::h3::valid_resolution(res_value) else {
+                return Some(Value::Null);
+            };
+            let cell = crate::geo::h3::lat_lng_to_cell(lat, lon, res);
+            if cell == 0 {
+                Some(Value::Null)
+            } else {
+                Some(Value::UnsignedInteger(cell))
+            }
+        }
+        "H3_PARENT" => {
+            let cell = value_as_u64(&resolve_scalar_arg(args, 0, source)?)?;
+            let res_value = value_as_i64(&resolve_scalar_arg(args, 1, source)?)?;
+            let Some(res) = crate::geo::h3::valid_resolution(res_value) else {
+                return Some(Value::Null);
+            };
+            let parent = crate::geo::h3::cell_to_parent(cell, res);
+            if parent == 0 {
+                Some(Value::Null)
+            } else {
+                Some(Value::UnsignedInteger(parent))
+            }
+        }
         "H3_TO_LATLNG" => {
             let cell = value_as_u64(&resolve_scalar_arg(args, 0, source)?)?;
             let (lat, lon) = crate::geo::h3::cell_to_lat_lng(cell);

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -25,6 +25,7 @@ use crate::storage::query::ast::{
 use crate::storage::query::sql_lowering::{
     effective_table_filter, effective_table_group_by_exprs, effective_table_having_filter,
     effective_table_projections, expr_to_projection as lower_expr_to_projection,
+    projection_to_expr,
 };
 use crate::storage::query::unified::{UnifiedRecord, UnifiedResult};
 use crate::storage::schema::{value_to_canonical_key, CanonicalKey, Value};
@@ -159,7 +160,7 @@ pub(crate) fn execute_aggregate_query(
 
     let effective_projections = effective_table_projections(query);
     let effective_filter = effective_table_filter(query);
-    let effective_group_by = effective_table_group_by_exprs(query);
+    let effective_group_by = resolve_group_by_aliases(query, effective_table_group_by_exprs(query));
     let runtime_plan = prepare_aggregate_runtime_plan(query);
     let mut all_aggregate_projections = effective_projections
         .iter()
@@ -1401,10 +1402,12 @@ fn aggregate_output_name(projection: &Projection, func_name: &str, column_name: 
 
 fn validate_aggregate_projection_shape(query: &TableQuery) -> RedDBResult<()> {
     let effective_projections = effective_table_projections(query);
-    let effective_group_by = effective_table_group_by_exprs(query);
+    let effective_group_by = resolve_group_by_aliases(query, effective_table_group_by_exprs(query));
     let has_group_by = !effective_group_by.is_empty();
 
     for projection in &effective_projections {
+        validate_h3_projection_resolutions(projection)?;
+
         if matches!(
             projection,
             Projection::Function(name, _)
@@ -1435,7 +1438,168 @@ fn validate_aggregate_projection_shape(query: &TableQuery) -> RedDBResult<()> {
         return Err(RedDBError::Query(message));
     }
 
+    for group_expr in &effective_group_by {
+        validate_h3_expr_resolutions(group_expr)?;
+    }
+
     Ok(())
+}
+
+fn resolve_group_by_aliases(query: &TableQuery, group_by: Vec<Expr>) -> Vec<Expr> {
+    let projections = effective_table_projections(query);
+    group_by
+        .into_iter()
+        .map(|expr| {
+            let Expr::Column {
+                field: FieldRef::TableColumn { table, column },
+                ..
+            } = &expr
+            else {
+                return expr;
+            };
+            if !table.is_empty() {
+                return expr;
+            }
+            projections
+                .iter()
+                .find(|projection| projection_name(projection).eq_ignore_ascii_case(column))
+                .and_then(|projection| projection_to_expr(projection).map(|(expr, _)| expr))
+                .unwrap_or(expr)
+        })
+        .collect()
+}
+
+fn validate_h3_projection_resolutions(projection: &Projection) -> RedDBResult<()> {
+    match projection {
+        Projection::Function(name, args) => {
+            validate_h3_function_projection_resolution(base_function_name(name), args)?;
+            for arg in args {
+                validate_h3_projection_resolutions(arg)?;
+            }
+        }
+        Projection::Expression(filter, _) => validate_h3_filter_resolutions(filter)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_h3_filter_resolutions(filter: &Filter) -> RedDBResult<()> {
+    match filter {
+        Filter::And(left, right) | Filter::Or(left, right) => {
+            validate_h3_filter_resolutions(left)?;
+            validate_h3_filter_resolutions(right)?;
+        }
+        Filter::Not(inner) => validate_h3_filter_resolutions(inner)?,
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_h3_expr_resolutions(expr: &Expr) -> RedDBResult<()> {
+    match expr {
+        Expr::FunctionCall { name, args, .. } => {
+            validate_h3_function_expr_resolution(name, args)?;
+            for arg in args {
+                validate_h3_expr_resolutions(arg)?;
+            }
+        }
+        Expr::BinaryOp { lhs, rhs, .. } => {
+            validate_h3_expr_resolutions(lhs)?;
+            validate_h3_expr_resolutions(rhs)?;
+        }
+        Expr::UnaryOp { operand, .. } | Expr::Cast { inner: operand, .. } => {
+            validate_h3_expr_resolutions(operand)?;
+        }
+        Expr::Case {
+            branches, else_, ..
+        } => {
+            for (cond, value) in branches {
+                validate_h3_expr_resolutions(cond)?;
+                validate_h3_expr_resolutions(value)?;
+            }
+            if let Some(else_expr) = else_ {
+                validate_h3_expr_resolutions(else_expr)?;
+            }
+        }
+        Expr::IsNull { operand, .. } => validate_h3_expr_resolutions(operand)?,
+        Expr::InList { target, values, .. } => {
+            validate_h3_expr_resolutions(target)?;
+            for value in values {
+                validate_h3_expr_resolutions(value)?;
+            }
+        }
+        Expr::Between {
+            target, low, high, ..
+        } => {
+            validate_h3_expr_resolutions(target)?;
+            validate_h3_expr_resolutions(low)?;
+            validate_h3_expr_resolutions(high)?;
+        }
+        Expr::Literal { .. }
+        | Expr::Column { .. }
+        | Expr::Parameter { .. }
+        | Expr::Subquery { .. }
+        | Expr::WindowFunctionCall { .. } => {}
+    }
+    Ok(())
+}
+
+fn validate_h3_function_projection_resolution(name: &str, args: &[Projection]) -> RedDBResult<()> {
+    let Some(res_arg) = h3_resolution_projection_arg(name, args) else {
+        return Ok(());
+    };
+    let Some(res) = literal_projection_i64(res_arg) else {
+        return Ok(());
+    };
+    validate_h3_resolution_value(name, res)
+}
+
+fn validate_h3_function_expr_resolution(name: &str, args: &[Expr]) -> RedDBResult<()> {
+    let upper = name.to_ascii_uppercase();
+    let res_arg = match upper.as_str() {
+        "H3_CELL" | "H3_PARENT" => args.get(1),
+        _ => None,
+    };
+    let Some(Expr::Literal { value, .. }) = res_arg else {
+        return Ok(());
+    };
+    let Some(res) = value_i64(value) else {
+        return Ok(());
+    };
+    validate_h3_resolution_value(&upper, res)
+}
+
+fn h3_resolution_projection_arg<'a>(name: &str, args: &'a [Projection]) -> Option<&'a Projection> {
+    match name.to_ascii_uppercase().as_str() {
+        "H3_CELL" | "H3_PARENT" => args.get(1),
+        _ => None,
+    }
+}
+
+fn literal_projection_i64(projection: &Projection) -> Option<i64> {
+    let record = UnifiedRecord::new();
+    let value = eval_projection_value_with_db(None, projection, &record)?;
+    value_i64(&value).or_else(|| match value {
+        Value::Float(value) if value.fract() == 0.0 => Some(value as i64),
+        _ => None,
+    })
+}
+
+fn value_i64(value: &Value) -> Option<i64> {
+    match value {
+        Value::Integer(value) | Value::BigInt(value) => Some(*value),
+        Value::UnsignedInteger(value) => i64::try_from(*value).ok(),
+        _ => None,
+    }
+}
+
+fn validate_h3_resolution_value(function_name: &str, resolution: i64) -> RedDBResult<()> {
+    if crate::geo::h3::valid_resolution(resolution).is_some() {
+        return Ok(());
+    }
+    Err(RedDBError::Query(format!(
+        "{function_name} H3 resolution {resolution} is invalid; expected H3 resolution in range 0..=15"
+    )))
 }
 
 fn render_aggregate_argument_key(arg: &Projection) -> String {
@@ -1502,6 +1666,7 @@ fn projection_group_key(projection: &Projection) -> Option<String> {
         Projection::Function(name, args) if base_function_name(name) == "TIME_BUCKET" => {
             render_time_bucket_group_expr(args)
         }
+        Projection::Function(_, _) => Some(render_projection_signature(projection)),
         _ => None,
     }
 }
@@ -1543,9 +1708,22 @@ fn resolve_group_by_value(db: &RedDB, group_expr: &Expr, record: &UnifiedRecord)
         Expr::Column { field, .. } => resolve_runtime_field(record, field, None, None),
         _ => {
             let projection = projection_from_expr(group_expr)?;
-            eval_projection_value_with_db(Some(db), &projection, record)
+            let value = eval_projection_value_with_db(Some(db), &projection, record)?;
+            if h3_group_expr_yields_null_drop(group_expr) && matches!(value, Value::Null) {
+                None
+            } else {
+                Some(value)
+            }
         }
     }
+}
+
+fn h3_group_expr_yields_null_drop(group_expr: &Expr) -> bool {
+    matches!(
+        group_expr,
+        Expr::FunctionCall { name, .. }
+            if matches!(name.to_ascii_uppercase().as_str(), "H3_CELL" | "H3_PARENT")
+    )
 }
 
 fn group_expr_key(expr: &Expr) -> Option<String> {

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -299,6 +299,16 @@ fn float_field(record: &reddb::storage::query::UnifiedRecord, field: &str) -> f6
     }
 }
 
+fn uint_field(record: &reddb::storage::query::UnifiedRecord, field: &str) -> u64 {
+    match record.get(field) {
+        Some(Value::UnsignedInteger(value)) => *value,
+        Some(Value::Integer(value)) => {
+            u64::try_from(*value).unwrap_or_else(|_| panic!("{field} must be non-negative"))
+        }
+        other => panic!("expected {field} uint field, got {other:?} in {record:?}"),
+    }
+}
+
 /// For each query: run the full scan (no index), create the H3 index, run
 /// the ring scan, and assert the two are byte-identical.
 fn assert_h3_parity(create_index: &str, queries: &[String]) {
@@ -392,6 +402,191 @@ fn spatial_full_scan_reads_document_body_column() {
         0.0_f64.to_bits(),
         "exact centre nearest hit must report zero distance"
     );
+}
+
+#[test]
+fn h3_cell_projects_and_groups_row_geopoints() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE events (id INT, gpsLocation GEOPOINT, event_kind TEXT)")
+        .unwrap();
+    rt.execute_query(
+        "INSERT INTO events (id, gpsLocation, event_kind) VALUES \
+         (1, '38.760000,-77.150000', 'seen'), \
+         (2, '38.760100,-77.150100', 'seen'), \
+         (3, '40.712800,-74.006000', 'seen'), \
+         (4, NULL, 'seen')",
+    )
+    .unwrap();
+
+    let expected_dc_cell = reddb::geo::h3::lat_lng_to_cell(38.76, -77.15, 7);
+    let expected_ny_cell = reddb::geo::h3::lat_lng_to_cell(40.7128, -74.006, 7);
+
+    let projected = rt
+        .execute_query(
+            "SELECT H3_CELL(gpsLocation, 7) AS cell \
+             FROM events WHERE id = 1",
+        )
+        .expect("H3_CELL should project over row GEOPOINT");
+    assert_eq!(projected.result.records.len(), 1);
+    assert_eq!(
+        uint_field(&projected.result.records[0], "cell"),
+        expected_dc_cell
+    );
+
+    let heatmap = rt
+        .execute_query(
+            "SELECT H3_CELL(gpsLocation, 7) AS cell, COUNT(*) AS events \
+             FROM events \
+             GROUP BY cell \
+             ORDER BY events DESC \
+             LIMIT 50",
+        )
+        .expect("issue heatmap query should run as written over rows");
+    let rows = heatmap
+        .result
+        .records
+        .iter()
+        .map(|record| (uint_field(record, "cell"), uint_field(record, "events")))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        rows,
+        vec![(expected_dc_cell, 2), (expected_ny_cell, 1)],
+        "NULL row cells must drop out of GROUP BY"
+    );
+}
+
+#[test]
+fn h3_cell_groups_document_body_and_dotted_path_values() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+        ({"id":1,"gpsLocation":{"lat":38.76,"lon":-77.15},"location":{"gps":{"lat":38.76,"lon":-77.15}}}),
+        ({"id":2,"gpsLocation":{"lat":38.7601,"lon":-77.1501},"location":{"gps":{"lat":38.7601,"lon":-77.1501}}}),
+        ({"id":3,"gpsLocation":{"lat":40.7128,"lon":-74.0060},"location":{"gps":{"lat":40.7128,"lon":-74.0060}}}),
+        ({"id":4,"gpsLocation":"not-geo","location":{"gps":"not-geo"}}),
+        ({"id":5})"#,
+    )
+    .unwrap();
+
+    let expected_dc_cell = reddb::geo::h3::lat_lng_to_cell(38.76, -77.15, 7);
+    let expected_ny_cell = reddb::geo::h3::lat_lng_to_cell(40.7128, -74.006, 7);
+
+    let bare = rt
+        .execute_query(
+            "SELECT H3_CELL(gpsLocation, 7) AS cell, COUNT(*) AS events \
+             FROM events \
+             GROUP BY cell \
+             ORDER BY events DESC \
+             LIMIT 50",
+        )
+        .expect("issue heatmap query should run as written over documents");
+    let bare_rows = bare
+        .result
+        .records
+        .iter()
+        .map(|record| (uint_field(record, "cell"), uint_field(record, "events")))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        bare_rows,
+        vec![(expected_dc_cell, 2), (expected_ny_cell, 1)]
+    );
+
+    let dotted = rt
+        .execute_query(
+            "SELECT H3_CELL(body.location.gps, 7) AS cell, COUNT(*) AS events \
+             FROM events \
+             GROUP BY cell \
+             ORDER BY events DESC \
+             LIMIT 50",
+        )
+        .expect("H3_CELL should resolve dotted document body paths");
+    let dotted_rows = dotted
+        .result
+        .records
+        .iter()
+        .map(|record| (uint_field(record, "cell"), uint_field(record, "events")))
+        .collect::<Vec<_>>();
+    assert_eq!(dotted_rows, bare_rows);
+}
+
+#[test]
+fn h3_parent_rolls_child_cells_up_to_documented_parent() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE events (id INT, gpsLocation GEOPOINT)")
+        .unwrap();
+    rt.execute_query(
+        "INSERT INTO events (id, gpsLocation) VALUES \
+         (1, '38.760000,-77.150000'), \
+         (2, '38.760100,-77.150100'), \
+         (3, '38.761000,-77.151000'), \
+         (4, '40.712800,-74.006000')",
+    )
+    .unwrap();
+
+    let expected_dc_region =
+        reddb::geo::h3::cell_to_parent(reddb::geo::h3::lat_lng_to_cell(38.76, -77.15, 9), 4);
+    let expected_ny_region =
+        reddb::geo::h3::cell_to_parent(reddb::geo::h3::lat_lng_to_cell(40.7128, -74.006, 9), 4);
+
+    let rollup = rt
+        .execute_query(
+            "SELECT H3_PARENT(H3_CELL(gpsLocation, 9), 4) AS region, COUNT(*) AS events \
+             FROM events \
+             GROUP BY region \
+             ORDER BY events DESC",
+        )
+        .expect("issue rollup query should run as written");
+    let rows = rollup
+        .result
+        .records
+        .iter()
+        .map(|record| (uint_field(record, "region"), uint_field(record, "events")))
+        .collect::<Vec<_>>();
+    assert_eq!(rows, vec![(expected_dc_region, 3), (expected_ny_region, 1)]);
+
+    let fine = rt
+        .execute_query(
+            "SELECT H3_CELL(gpsLocation, 9) AS cell, COUNT(*) AS events \
+             FROM events \
+             GROUP BY cell \
+             ORDER BY events DESC",
+        )
+        .expect("child-cell heatmap should execute");
+    let dc_child_total = fine
+        .result
+        .records
+        .iter()
+        .map(|record| (uint_field(record, "cell"), uint_field(record, "events")))
+        .filter(|(cell, _)| reddb::geo::h3::cell_to_parent(*cell, 4) == expected_dc_region)
+        .map(|(_, count)| count)
+        .sum::<u64>();
+    assert_eq!(
+        dc_child_total, 3,
+        "rollup count should equal the sum of child-cell counts"
+    );
+}
+
+#[test]
+fn h3_cell_and_parent_reject_invalid_resolutions() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE events (id INT, gpsLocation GEOPOINT)")
+        .unwrap();
+    rt.execute_query("INSERT INTO events (id, gpsLocation) VALUES (1, '38.76,-77.15')")
+        .unwrap();
+
+    for query in [
+        "SELECT H3_CELL(gpsLocation, -1) AS cell, COUNT(*) AS events FROM events GROUP BY cell",
+        "SELECT H3_PARENT(H3_CELL(gpsLocation, 9), 16) AS region, COUNT(*) AS events FROM events GROUP BY region",
+    ] {
+        let err = match rt.execute_query(query) {
+            Ok(_) => panic!("invalid H3 resolution should reject: {query}"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("H3 resolution"), "{msg}");
+        assert!(msg.contains("0..=15"), "{msg}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
Automated AFK landing for #1948. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1948

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786151206&installation_id=129708444&pr_number=1975&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1975&signature=92ab66d5f52b0245527ff3635fc47013c70593a26ef6bf579f3972ea4ac92fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->