### PR TITLE
chore: #1944 Geofencing verb: SEARCH SPATIAL WITHIN POLYGON via H3 polyfill candidates and exact point-in-polygon post-filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1240,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "earcut",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+ "spade",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+ "spade",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1384,8 @@ dependencies = [
  "ahash",
  "either",
  "float_eq",
+ "geo",
+ "geo-traits",
  "h3o-bit",
  "libm",
  "ordered-float",
@@ -1333,6 +1409,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,6 +1432,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -1368,6 +1455,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
  "hashbrown 0.17.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1542,6 +1639,52 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "icu_collections"
@@ -2503,6 +2646,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,6 +2697,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -2713,6 +2874,7 @@ dependencies = [
  "flate2",
  "fs2",
  "futures-util",
+ "geo",
  "h3o",
  "hex",
  "hmac 0.13.0",
@@ -2906,6 +3068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3101,17 @@ checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -3204,6 +3383,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3464,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -2897,6 +2897,17 @@ pub enum SearchCommand {
         /// and clears this back to `None`.
         limit_param: Option<usize>,
     },
+    /// SEARCH SPATIAL WITHIN POLYGON ((lat lon), ...) COLLECTION col COLUMN col [LIMIT n]
+    SpatialWithinPolygon {
+        vertices: Vec<(f64, f64)>,
+        collection: String,
+        column: String,
+        limit: usize,
+        /// `$N` placeholder for the `LIMIT` slot. The binder
+        /// substitutes the user-supplied positive integer into `limit`
+        /// and clears this back to `None`.
+        limit_param: Option<usize>,
+    },
     /// SEARCH SPATIAL NEAREST lat lon K n COLLECTION col COLUMN col
     SpatialNearest {
         lat: f64,

--- a/crates/reddb-rql/src/parser/search_commands.rs
+++ b/crates/reddb-rql/src/parser/search_commands.rs
@@ -375,11 +375,12 @@ impl<'a> Parser<'a> {
         }))
     }
 
-    /// Parse: SEARCH SPATIAL (RADIUS | BBOX | NEAREST) ...
+    /// Parse: SEARCH SPATIAL (RADIUS | BBOX | WITHIN POLYGON | NEAREST) ...
     ///
     /// Syntax:
     /// - SEARCH SPATIAL RADIUS lat lon radius_km COLLECTION col COLUMN col [LIMIT n]
     /// - SEARCH SPATIAL BBOX min_lat min_lon max_lat max_lon COLLECTION col COLUMN col [LIMIT n]
+    /// - SEARCH SPATIAL WITHIN POLYGON ((lat lon), ...) COLLECTION col COLUMN col [LIMIT n]
     /// - SEARCH SPATIAL NEAREST lat lon K n COLLECTION col COLUMN col
     fn parse_search_spatial(&mut self) -> Result<QueryExpr, ParseError> {
         self.advance()?; // consume SPATIAL
@@ -511,6 +512,40 @@ impl<'a> Parser<'a> {
                     limit_param,
                 }))
             }
+            Token::Ident(ref name) if name.eq_ignore_ascii_case("WITHIN") => {
+                self.advance()?; // consume WITHIN
+                self.expect_search_ident("POLYGON")?;
+                let vertices = self.parse_search_spatial_polygon_vertices()?;
+                validate_search_spatial_polygon(&vertices, self.position())?;
+
+                self.expect(Token::Collection)?;
+                let collection = self.expect_ident()?;
+
+                let _ = self.consume(&Token::Column)? || self.consume_search_ident("COLUMN")?;
+                let column = self.parse_search_spatial_column()?;
+
+                let mut limit_param: Option<usize> = None;
+                let limit = if self.consume(&Token::Limit)? {
+                    if matches!(self.peek(), Token::Dollar | Token::Question) {
+                        limit_param = Some(self.parse_param_slot("LIMIT")?);
+                        0
+                    } else {
+                        self.parse_integer()? as usize
+                    }
+                } else {
+                    100
+                };
+
+                Ok(QueryExpr::SearchCommand(
+                    SearchCommand::SpatialWithinPolygon {
+                        vertices,
+                        collection,
+                        column,
+                        limit,
+                        limit_param,
+                    },
+                ))
+            }
             Token::Ident(ref name) if name.eq_ignore_ascii_case("NEAREST") => {
                 self.advance()?; // consume NEAREST
                 let lat_pos = self.position();
@@ -558,11 +593,28 @@ impl<'a> Parser<'a> {
                 }))
             }
             _ => Err(ParseError::expected(
-                vec!["RADIUS", "BBOX", "NEAREST"],
+                vec!["RADIUS", "BBOX", "WITHIN", "NEAREST"],
                 self.peek(),
                 self.position(),
             )),
         }
+    }
+
+    fn parse_search_spatial_polygon_vertices(&mut self) -> Result<Vec<(f64, f64)>, ParseError> {
+        self.expect(Token::LParen)?;
+        let mut vertices = Vec::new();
+        loop {
+            self.expect(Token::LParen)?;
+            let lat = self.parse_float()?;
+            let lon = self.parse_float()?;
+            self.expect(Token::RParen)?;
+            vertices.push((lat, lon));
+            if !self.consume(&Token::Comma)? {
+                break;
+            }
+        }
+        self.expect(Token::RParen)?;
+        Ok(vertices)
     }
 
     fn parse_search_spatial_column(&mut self) -> Result<String, ParseError> {
@@ -620,6 +672,46 @@ impl<'a> Parser<'a> {
         self.expect(Token::RBracket)?;
         Ok(items)
     }
+}
+
+fn validate_search_spatial_polygon(
+    vertices: &[(f64, f64)],
+    pos: crate::lexer::Position,
+) -> Result<(), ParseError> {
+    if vertices.len() < 3 {
+        return Err(ParseError::new(
+            "SEARCH SPATIAL WITHIN POLYGON requires at least 3 vertices".to_string(),
+            pos,
+        ));
+    }
+    for (lat, lon) in vertices {
+        if !lat.is_finite() || !(-90.0..=90.0).contains(lat) {
+            return Err(ParseError::value_out_of_range(
+                "lat",
+                "must be in -90.0..=90.0",
+                pos,
+            ));
+        }
+        if !lon.is_finite() || !(-180.0..=180.0).contains(lon) {
+            return Err(ParseError::value_out_of_range(
+                "lon",
+                "must be in -180.0..=180.0",
+                pos,
+            ));
+        }
+    }
+    let (min_lon, max_lon) = vertices.iter().map(|(_, lon)| *lon).fold(
+        (f64::INFINITY, f64::NEG_INFINITY),
+        |(min_lon, max_lon), lon| (min_lon.min(lon), max_lon.max(lon)),
+    );
+    if max_lon - min_lon > 180.0 {
+        return Err(ParseError::new(
+            "SEARCH SPATIAL WITHIN POLYGON does not support polygons crossing the antimeridian"
+                .to_string(),
+            pos,
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/reddb-server/Cargo.toml
+++ b/crates/reddb-server/Cargo.toml
@@ -91,7 +91,8 @@ rayon = "1.12"
 # Pure-Rust H3 hexagonal geospatial index (no C FFI; ADR 0061
 # source-consumable). Wrapped behind `crate::geo::h3` so no other
 # module depends on h3o directly (PRD #1574 slice 1, #1575).
-h3o = "0.10"
+h3o = { version = "0.10", features = ["geo"] }
+geo = "0.33"
 regex = "1"
 fs2 = "0.4"
 tokio-rustls = { version = "0.26", default-features = false, features = ["tls12", "logging", "ring"] }

--- a/crates/reddb-server/src/geo/h3.rs
+++ b/crates/reddb-server/src/geo/h3.rs
@@ -10,7 +10,11 @@
 //! (`grid_disk`) and parent truncation only. No on-disk index is
 //! touched here — that arrives in later slices.
 
-use h3o::{CellIndex, LatLng, Resolution};
+use geo::{LineString, Polygon};
+use h3o::{
+    geom::{ContainmentMode, TilerBuilder},
+    CellIndex, LatLng, Resolution,
+};
 
 /// Clamp an arbitrary resolution byte into h3o's valid `0..=15` range.
 ///
@@ -81,6 +85,45 @@ pub fn cell_to_parent(cell: u64, res: u8) -> u64 {
         Ok(c) => c.parent(clamp_resolution(res)).map(u64::from).unwrap_or(0),
         Err(_) => 0,
     }
+}
+
+/// Cover a polygon with every H3 cell whose boundary intersects or covers the
+/// polygon at `res`.
+///
+/// Input vertices are `(lat, lon)` degrees. Returns `None` when the geometry
+/// cannot be tiled or when the caller-supplied cap would be exceeded, so query
+/// execution can fall back to an exact full scan.
+pub fn polygon_to_cover_cells(
+    vertices: &[(f64, f64)],
+    res: u8,
+    max_cells: usize,
+) -> Option<Vec<u64>> {
+    if vertices.len() < 3 {
+        return None;
+    }
+    let mut coords: Vec<(f64, f64)> = vertices.iter().map(|(lat, lon)| (*lon, *lat)).collect();
+    if coords.first() != coords.last() {
+        coords.push(*coords.first()?);
+    }
+    let polygon = Polygon::new(LineString::from(coords), vec![]);
+    let mut tiler = TilerBuilder::new(clamp_resolution(res))
+        .containment_mode(ContainmentMode::Covers)
+        .disable_transmeridian_heuristic()
+        .build();
+    tiler.add(polygon).ok()?;
+    if tiler.coverage_size_hint() > max_cells {
+        return None;
+    }
+    let mut cells = Vec::new();
+    for cell in tiler.into_coverage() {
+        if cells.len() >= max_cells {
+            return None;
+        }
+        cells.push(u64::from(cell));
+    }
+    cells.sort_unstable();
+    cells.dedup();
+    Some(cells)
 }
 
 #[cfg(test)]

--- a/crates/reddb-server/src/geo/mod.rs
+++ b/crates/reddb-server/src/geo/mod.rs
@@ -310,6 +310,43 @@ pub fn polygon_area_km2(vertices: &[(f64, f64)]) -> f64 {
     (total.abs() / 2.0) * EARTH_RADIUS_KM * EARTH_RADIUS_KM
 }
 
+/// Exact planar even-odd point-in-polygon test over `(lat, lon)` degrees.
+///
+/// Boundary ties are included: a point exactly on a polygon vertex or edge is
+/// considered inside. Self-intersections are accepted and resolved by the
+/// standard even-odd rule.
+pub fn point_in_polygon_even_odd(lat: f64, lon: f64, vertices: &[(f64, f64)]) -> bool {
+    if vertices.len() < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = vertices.len() - 1;
+    for i in 0..vertices.len() {
+        let (yi, xi) = vertices[i];
+        let (yj, xj) = vertices[j];
+        if point_on_segment(lat, lon, yi, xi, yj, xj) {
+            return true;
+        }
+        if ((yi > lat) != (yj > lat)) && (lon < (xj - xi) * (lat - yi) / (yj - yi) + xi) {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+fn point_on_segment(py: f64, px: f64, ay: f64, ax: f64, by: f64, bx: f64) -> bool {
+    const EPS: f64 = 1e-12;
+    let cross = (px - ax) * (by - ay) - (py - ay) * (bx - ax);
+    if cross.abs() > EPS {
+        return false;
+    }
+    px >= ax.min(bx) - EPS
+        && px <= ax.max(bx) + EPS
+        && py >= ay.min(by) - EPS
+        && py <= ay.max(by) + EPS
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/crates/reddb-server/src/runtime/impl_core_result_cache_scopes.rs
+++ b/crates/reddb-server/src/runtime/impl_core_result_cache_scopes.rs
@@ -155,6 +155,7 @@ fn collect_query_expr_result_cache_scopes(scopes: &mut HashSet<String>, expr: &Q
             | SearchCommand::Hybrid { collection, .. }
             | SearchCommand::SpatialRadius { collection, .. }
             | SearchCommand::SpatialBbox { collection, .. }
+            | SearchCommand::SpatialWithinPolygon { collection, .. }
             | SearchCommand::SpatialNearest { collection, .. } => {
                 cache_scope_insert(scopes, collection);
             }

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -979,6 +979,51 @@ impl RedDBRuntime {
                     bookmark: None,
                 })
             }
+            SearchCommand::SpatialWithinPolygon {
+                vertices,
+                collection,
+                column,
+                limit,
+                limit_param,
+            } => {
+                if limit_param.is_some() {
+                    return Err(RedDBError::Query(
+                        "SEARCH SPATIAL WITHIN POLYGON LIMIT $N parameter was not bound before execution"
+                            .to_string(),
+                    ));
+                }
+                let h3_candidates = self.h3_polygon_candidate_ids(collection, column, vertices);
+                let store = self.inner.db.store();
+                let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
+
+                let mut result = UnifiedResult::with_columns(vec!["entity_id".into()]);
+                let mut count = 0;
+                for entity in &entities {
+                    if count >= *limit {
+                        break;
+                    }
+                    if let Some((lat, lon)) =
+                        self.extract_spatial_column(entity, collection, column)
+                    {
+                        if crate::geo::point_in_polygon_even_odd(lat, lon, vertices) {
+                            let mut record = UnifiedRecord::new();
+                            record.set("entity_id", Value::UnsignedInteger(entity.id.raw()));
+                            result.push(record);
+                            count += 1;
+                        }
+                    }
+                }
+                Ok(RuntimeQueryResult {
+                    query: raw_query.to_string(),
+                    mode: QueryMode::Sql,
+                    statement: "search_spatial_within_polygon",
+                    engine: "runtime-spatial",
+                    result,
+                    affected_rows: 0,
+                    statement_type: "select",
+                    bookmark: None,
+                })
+            }
             SearchCommand::SpatialNearest {
                 lat,
                 lon,
@@ -1425,6 +1470,23 @@ impl RedDBRuntime {
         .map(|(la, lo)| crate::geo::haversine_km(center_lat, center_lon, la, lo))
         .fold(0.0_f64, f64::max);
         let cells = h3_cover_cells(center_lat, center_lon, radius_km, resolution);
+        self.h3_cell_candidate_ids(collection, column, &cells)
+    }
+
+    /// Native H3 polygon-to-cells candidate ids for a WITHIN POLYGON query.
+    /// The H3 cover is only a pruning superset; exact even-odd
+    /// point-in-polygon filtering decides correctness. `None` falls back to
+    /// the full scan when there is no H3 index or the cover is too large.
+    fn h3_polygon_candidate_ids(
+        &self,
+        collection: &str,
+        column: &str,
+        vertices: &[(f64, f64)],
+    ) -> Option<std::collections::HashSet<u64>> {
+        let resolution = self.h3_index_resolution(collection, column)?;
+        const MAX_POLYGON_COVER_CELLS: usize = 50_000;
+        let cells =
+            crate::geo::h3::polygon_to_cover_cells(vertices, resolution, MAX_POLYGON_COVER_CELLS)?;
         self.h3_cell_candidate_ids(collection, column, &cells)
     }
 

--- a/crates/reddb-server/src/storage/query/user_params.rs
+++ b/crates/reddb-server/src/storage/query/user_params.rs
@@ -312,6 +312,11 @@ fn collect_non_expr_indices(expr: &QueryExpr, out: &mut Vec<usize>) {
                 out.push(*idx);
             }
         }
+        QueryExpr::SearchCommand(SearchCommand::SpatialWithinPolygon { limit_param, .. }) => {
+            if let Some(idx) = limit_param {
+                out.push(*idx);
+            }
+        }
         QueryExpr::SearchCommand(SearchCommand::Text { limit_param, .. }) => {
             if let Some(idx) = limit_param {
                 out.push(*idx);
@@ -679,6 +684,50 @@ pub fn bind(expr: &QueryExpr, params: &[Value]) -> Result<QueryExpr, UserParamEr
             limit: bound_limit,
             limit_param: None,
         }));
+    }
+
+    if let QueryExpr::SearchCommand(SearchCommand::SpatialWithinPolygon {
+        vertices,
+        collection,
+        column,
+        limit,
+        limit_param,
+    }) = expr
+    {
+        let bound_limit = if let Some(idx) = limit_param {
+            let value = params.get(*idx).ok_or(UserParamError::Arity {
+                expected: idx + 1,
+                got: params.len(),
+            })?;
+            match value {
+                Value::Integer(n) if *n > 0 => *n as usize,
+                Value::UnsignedInteger(n) if *n > 0 => *n as usize,
+                Value::BigInt(n) if *n > 0 => *n as usize,
+                Value::Integer(_) | Value::UnsignedInteger(_) | Value::BigInt(_) => {
+                    return Err(UserParamError::TypeMismatch {
+                        slot: "SEARCH SPATIAL WITHIN POLYGON LIMIT parameter (must be > 0)",
+                        got: value_variant_name(value),
+                    });
+                }
+                other => {
+                    return Err(UserParamError::TypeMismatch {
+                        slot: "SEARCH SPATIAL WITHIN POLYGON LIMIT parameter",
+                        got: value_variant_name(other),
+                    });
+                }
+            }
+        } else {
+            *limit
+        };
+        return Ok(QueryExpr::SearchCommand(
+            SearchCommand::SpatialWithinPolygon {
+                vertices: vertices.clone(),
+                collection: collection.clone(),
+                column: column.clone(),
+                limit: bound_limit,
+                limit_param: None,
+            },
+        ));
     }
 
     if let QueryExpr::SearchCommand(SearchCommand::Text {

--- a/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_eof_after_search_spatial.snap
+++ b/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_eof_after_search_spatial.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SEARCH SPATIAL\")"
 ---
 input: "SEARCH SPATIAL"
 kind:  Syntax
-error: Parse error at 1:15: Unexpected token: EOF (expected: RADIUS, BBOX, NEAREST)
+error: Parse error at 1:15: Unexpected token: EOF (expected: RADIUS, BBOX, WITHIN, NEAREST)

--- a/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_unknown_subcommand.snap
+++ b/crates/reddb-server/tests/snapshots/geo_parser_snapshots__geo_unknown_subcommand.snap
@@ -4,4 +4,4 @@ expression: "fmt_parse_error(\"SEARCH SPATIAL POLYGON 0.0 0.0 COLLECTION c COLUM
 ---
 input: "SEARCH SPATIAL POLYGON 0.0 0.0 COLLECTION c COLUMN col"
 kind:  Syntax
-error: Parse error at 1:16: Unexpected token: POLYGON (expected: RADIUS, BBOX, NEAREST)
+error: Parse error at 1:16: Unexpected token: POLYGON (expected: RADIUS, BBOX, WITHIN, NEAREST)

--- a/docs/query/spatial-search.md
+++ b/docs/query/spatial-search.md
@@ -1,13 +1,13 @@
 # Spatial Search
 
-RedDB supports spatial queries on `GeoPoint`, `Latitude`, and `Longitude` columns using an R-tree index. Find points within a radius, bounding box, or nearest neighbors.
+RedDB supports spatial queries on `GeoPoint`, `Latitude`, and `Longitude` columns using an H3 index. Find points within a radius, bounding box, polygon, or nearest neighbors. Without an index, RedDB falls back to an exact full scan.
 
 ## Prerequisites
 
-Create an R-tree index on the spatial column:
+Create an H3 index on the spatial column:
 
 ```sql
-CREATE INDEX idx_location ON sites (location) USING RTREE
+CREATE INDEX idx_location ON sites (location) USING H3
 ```
 
 ## Radius Search
@@ -64,6 +64,30 @@ SEARCH SPATIAL NEAREST 50.8503 4.3517 K 5 COLLECTION sites COLUMN location
 
 Returns results sorted by distance ascending.
 
+## Polygon Search
+
+Find all points inside a polygon. H3 polygon coverage is used only to prune candidates; an exact even-odd point-in-polygon post-filter decides correctness, so indexed and full-scan results are identical.
+
+```sql
+SEARCH SPATIAL WITHIN POLYGON ((<lat> <lon>), (<lat> <lon>), (<lat> <lon>)[, ...])
+  COLLECTION <collection> COLUMN <column> [LIMIT <n>]
+```
+
+**Example:** Find couriers inside a zone:
+
+```sql
+SEARCH SPATIAL WITHIN POLYGON ((38.70 -77.20), (38.80 -77.20), (38.80 -77.05), (38.70 -77.05))
+  COLLECTION couriers COLUMN current
+```
+
+Polygon rules:
+
+- At least three vertices are required.
+- Latitude must be in `-90..=90`; longitude must be in `-180..=180`.
+- Points exactly on a vertex or edge are treated as inside.
+- Self-intersecting polygons are accepted and resolved with the standard even-odd rule.
+- Polygons crossing the antimeridian are rejected.
+
 ## Distance Calculation
 
 RedDB uses the **Haversine formula** for accurate great-circle distances on the Earth's surface. All distances are in kilometers.
@@ -76,6 +100,6 @@ RedDB uses the **Haversine formula** for accurate great-circle distances on the 
 
 ## See Also
 
-- [CREATE INDEX](/query/create-index.md) -- Creating R-tree indexes
+- [CREATE INDEX](/query/create-index.md) -- Creating H3 indexes
 - [Geo Types](/types/geo.md) -- GeoPoint, Latitude, Longitude types
 - [Search Commands](/query/search-commands.md) -- Other search types

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -78,6 +78,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcut"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88459a2a8e3a514b6e6de38cf3aaa9250a894cb098f74a932db77fcc8341b6d0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +801,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
+name = "float_next_after"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37007738a80ea34f969af54a3390dd72cacdef654974cfd449c9f6f72dbaac10"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,6 +895,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30eb1fdc57c1e5cfd11826fe0caec4b9dc7901f3758263bb506228d88c8d9e9a"
+dependencies = [
+ "earcut",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "rand 0.10.2",
+ "rand_pcg",
+ "robust",
+ "rstar",
+ "sif-itree",
+ "spade",
+]
+
+[[package]]
+name = "geo-traits"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
+
+[[package]]
+name = "geo-types"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94776032c45f950d30a13af6113c2ad5625316c9abfbccee4dd5a6695f8fe0f5"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rayon",
+ "rstar",
+ "serde",
+ "spade",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +1029,8 @@ dependencies = [
  "ahash",
  "either",
  "float_eq",
+ "geo",
+ "geo-traits",
  "h3o-bit",
  "libm",
  "ordered-float",
@@ -967,12 +1043,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -984,6 +1080,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1133,6 +1239,52 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "i_float"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "813145bb0ad5b60f55cbbf3c74cdceda1c0a9d253b35c4cc36ae0df7887cb78f"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d73d122b937fca067feb0ad74f62388920272b27c356d4df2d0cfdd59e044cf0"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
+name = "i_overlay"
+version = "4.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd314b4668e2b3a12508f2e125558c82a6c0a8636fa5107a900f79ce414e450"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa9eac533d7509a8ab87672b60ac610c17240f9ea4851d26227689fdfe349c8"
+dependencies = [
+ "i_float",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4804bdc1dc124eb7e1aa9e144ecc04096bcf787a10a15fa44af682b51f0f6cce"
 
 [[package]]
 name = "icu_collections"
@@ -1936,6 +2088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +2139,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rayon"
@@ -2119,6 +2289,7 @@ dependencies = [
  "ed25519-dalek 3.0.0",
  "flate2",
  "fs2",
+ "geo",
  "h3o",
  "hex",
  "hmac 0.13.0",
@@ -2256,6 +2427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2273,6 +2450,17 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
 ]
 
 [[package]]
@@ -2474,6 +2662,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "sif-itree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f45b8998ced5134fb1d75732c77842a3e888f19c1ff98481822e8fbfbf930b"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,6 +2737,18 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -285,6 +285,13 @@ fn spatial_rows(rt: &RedDBRuntime, query: &str) -> Vec<(u64, u64)> {
         .collect()
 }
 
+fn spatial_entity_ids(rt: &RedDBRuntime, query: &str) -> Vec<u64> {
+    spatial_rows(rt, query)
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect()
+}
+
 /// For each query: run the full scan (no index), create the H3 index, run
 /// the ring scan, and assert the two are byte-identical.
 fn assert_h3_parity(create_index: &str, queries: &[String]) {
@@ -296,6 +303,41 @@ fn assert_h3_parity(create_index: &str, queries: &[String]) {
             &spatial_rows(&rt, q),
             expected,
             "H3 ring scan diverged from full scan for: {q}"
+        );
+    }
+}
+
+fn seed_geofence_rows() -> RedDBRuntime {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE couriers (id INT, loc GEOPOINT)")
+        .unwrap();
+    for (id, loc) in [
+        (1, "38.75,-77.15"), // inside rectangle
+        (2, "38.70,-77.20"), // vertex tie: inside
+        (3, "38.80,-77.12"), // edge tie: inside
+        (4, "38.74,-77.06"), // inside non-convex test
+        (5, "38.79,-77.19"), // inside rectangle
+        (6, "38.69,-77.15"), // outside south
+        (7, "38.75,-77.04"), // outside east
+        (8, "39.00,-77.15"), // outside north
+    ] {
+        rt.execute_query(&format!(
+            "INSERT INTO couriers (id, loc) VALUES ({id}, '{loc}')"
+        ))
+        .unwrap();
+    }
+    rt
+}
+
+fn assert_polygon_parity(create_index: &str, queries: &[String]) {
+    let rt = seed_geofence_rows();
+    let baseline: Vec<Vec<u64>> = queries.iter().map(|q| spatial_entity_ids(&rt, q)).collect();
+    rt.execute_query(create_index).unwrap();
+    for (q, expected) in queries.iter().zip(&baseline) {
+        assert_eq!(
+            &spatial_entity_ids(&rt, q),
+            expected,
+            "H3 polygon cover diverged from full scan for: {q}"
         );
     }
 }
@@ -519,6 +561,102 @@ fn h3_bbox_parity_with_full_scan() {
     })
     .collect();
     assert_h3_parity("CREATE INDEX idx ON places (loc) USING H3", &queries);
+}
+
+#[test]
+fn h3_polygon_parity_with_full_scan_for_adversarial_shapes() {
+    let queries = vec![
+        // Rectangle from the issue: includes interior points plus documented
+        // vertex/edge ties.
+        "SEARCH SPATIAL WITHIN POLYGON ((38.70 -77.20), (38.80 -77.20), (38.80 -77.05), (38.70 -77.05)) COLLECTION couriers COLUMN loc".to_string(),
+        // Tiny polygon inside one H3 cell: H3 covers only prunes; exact
+        // point-in-polygon decides the answer.
+        "SEARCH SPATIAL WITHIN POLYGON ((38.7499 -77.1501), (38.7501 -77.1501), (38.7501 -77.1499), (38.7499 -77.1499)) COLLECTION couriers COLUMN loc".to_string(),
+        // Non-convex shape handled by the exact even-odd post-filter.
+        "SEARCH SPATIAL WITHIN POLYGON ((38.70 -77.20), (38.80 -77.20), (38.74 -77.12), (38.80 -77.05), (38.70 -77.05)) COLLECTION couriers COLUMN loc".to_string(),
+        // Region-scale polygon at fine resolution exceeds the cover cap and
+        // falls back to the full scan; results must still be identical.
+        "SEARCH SPATIAL WITHIN POLYGON ((-80.0 -80.0), (80.0 -80.0), (80.0 80.0), (-80.0 80.0)) COLLECTION couriers COLUMN loc".to_string(),
+    ];
+    assert_polygon_parity("CREATE INDEX idx ON couriers (loc) USING H3 (15)", &queries);
+}
+
+#[test]
+fn spatial_within_polygon_reads_document_body_column_with_and_without_h3() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT couriers").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO couriers DOCUMENT VALUES
+        ({"current":{"lat":38.75,"lon":-77.15},"name":"inside"}),
+        ({"current":{"lat":38.69,"lon":-77.15},"name":"outside"}),
+        ({"home":{"lat":38.75,"lon":-77.15},"name":"wrong-field"})"#,
+    )
+    .unwrap();
+
+    let q = "SEARCH SPATIAL WITHIN POLYGON ((38.70 -77.20), (38.80 -77.20), (38.80 -77.05), (38.70 -77.05)) COLLECTION couriers COLUMN current";
+    let baseline = spatial_entity_ids(&rt, q);
+    assert_eq!(
+        baseline.len(),
+        1,
+        "full scan must read only the named document body field"
+    );
+
+    rt.execute_query("CREATE INDEX idx_current ON couriers (current) USING H3")
+        .unwrap();
+    assert_eq!(
+        spatial_entity_ids(&rt, q),
+        baseline,
+        "indexed document polygon search must match full scan"
+    );
+}
+
+#[test]
+fn spatial_within_polygon_rejects_degenerate_and_antimeridian_inputs() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE TABLE places (id INT, loc GEOPOINT)")
+        .unwrap();
+    for (sql, needle) in [
+        (
+            "SEARCH SPATIAL WITHIN POLYGON ((0 0), (1 1)) COLLECTION places COLUMN loc",
+            "at least 3 vertices",
+        ),
+        (
+            "SEARCH SPATIAL WITHIN POLYGON ((91 0), (0 0), (1 1)) COLLECTION places COLUMN loc",
+            "lat",
+        ),
+        (
+            "SEARCH SPATIAL WITHIN POLYGON ((0 170), (10 -170), (0 -160)) COLLECTION places COLUMN loc",
+            "antimeridian",
+        ),
+    ] {
+        let err = rt
+            .execute_query(sql)
+            .expect_err("invalid polygon must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains(needle),
+            "expected {needle:?} in error message, got {msg:?}"
+        );
+    }
+}
+
+#[test]
+fn h3_polygon_cover_is_superset_for_generated_rectangles() {
+    let queries: Vec<String> = [
+        (38.73, -77.18, 38.77, -77.12),
+        (38.69, -77.21, 38.76, -77.14),
+        (38.76, -77.18, 38.81, -77.10),
+        (38.70, -77.20, 38.80, -77.05),
+        (38.68, -77.22, 38.82, -77.03),
+    ]
+    .iter()
+    .map(|(min_lat, min_lon, max_lat, max_lon)| {
+        format!(
+            "SEARCH SPATIAL WITHIN POLYGON (({min_lat} {min_lon}), ({max_lat} {min_lon}), ({max_lat} {max_lon}), ({min_lat} {max_lon})) COLLECTION couriers COLUMN loc"
+        )
+    })
+    .collect();
+    assert_polygon_parity("CREATE INDEX idx ON couriers (loc) USING H3 (9)", &queries);
 }
 
 // ── Slice 4 (PRD #1574 / #1578): H3 is the DEFAULT spatial index ─────────────


### PR DESCRIPTION
Lands the completed worker branch for #1944 (worker wI170 passed validation but parked blocked:merge-conflict when #1948/#1942 merged into the same test file first). Conflict resolved by keeping both sides' helper functions in the grouped H3 e2e suite.

Closes #1944

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786156792&installation_id=129708444&pr_number=1976&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1976&signature=aed968c049b7d3f89bb5b0ac3d1603c0799d2778fbaccb8c71f161e01ccb7bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->