### PR TITLE
chore: #1947 Geo-filtered vector search: spatial pre-filter on vector metadata before similarity scoring

### DIFF
--- a/crates/reddb-rql/src/parser/vector.rs
+++ b/crates/reddb-rql/src/parser/vector.rs
@@ -200,6 +200,10 @@ impl<'a> Parser<'a> {
             return Ok(expr);
         }
 
+        if matches!(self.peek(), Token::Ident(name) if is_vector_geo_distance_function(name)) {
+            return self.parse_metadata_geo_radius();
+        }
+
         // field op value
         let field = self.expect_ident()?;
 
@@ -243,6 +247,37 @@ impl<'a> Parser<'a> {
                 self.position(),
             ))
         }
+    }
+
+    fn parse_metadata_geo_radius(&mut self) -> Result<MetadataFilter, ParseError> {
+        let function = self.expect_ident()?;
+        self.expect(Token::LParen)?;
+        let field = self.expect_ident()?;
+        self.expect(Token::Comma)?;
+        let center_lat = self.parse_float()?;
+        self.expect(Token::Comma)?;
+        let center_lon = self.parse_float()?;
+        self.expect(Token::RParen)?;
+        if !self.consume(&Token::Le)? && !self.consume(&Token::Lt)? {
+            return Err(ParseError::expected(
+                vec!["<", "<="],
+                self.peek(),
+                self.position(),
+            ));
+        }
+        let radius_km = self.parse_float()?;
+        if radius_km.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+            return Err(ParseError::new(
+                format!("{function} radius must be > 0"),
+                self.position(),
+            ));
+        }
+        Ok(MetadataFilter::GeoRadius {
+            key: field,
+            center_lat,
+            center_lon,
+            radius_km,
+        })
     }
 
     /// Parse metadata value
@@ -327,6 +362,10 @@ impl<'a> Parser<'a> {
             )),
         }
     }
+}
+
+fn is_vector_geo_distance_function(name: &str) -> bool {
+    name.eq_ignore_ascii_case("GEO_DISTANCE") || name.eq_ignore_ascii_case("HAVERSINE")
 }
 
 #[cfg(test)]
@@ -495,6 +534,40 @@ mod tests {
             }
             other => panic!("expected AND filter, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn metadata_filter_parses_geo_radius() {
+        let query = parse_query(
+            "VECTOR SEARCH restaurants SIMILAR TO [1.0, 0.0] \
+             WHERE GEO_DISTANCE(location, 48.8566, 2.3522) <= 5.0 AND cuisine = 'bistro' \
+             LIMIT 3",
+        )
+        .unwrap();
+
+        let QueryExpr::Vector(vector) = query else {
+            panic!("expected vector query");
+        };
+        let Some(MetadataFilter::And(and_parts)) = vector.filter else {
+            panic!("expected AND filter");
+        };
+        assert!(matches!(
+            &and_parts[0],
+            MetadataFilter::GeoRadius {
+                key,
+                center_lat,
+                center_lon,
+                radius_km,
+            } if key == "location"
+                && (*center_lat - 48.8566).abs() < f64::EPSILON
+                && (*center_lon - 2.3522).abs() < f64::EPSILON
+                && (*radius_km - 5.0).abs() < f64::EPSILON
+        ));
+        assert!(matches!(
+            &and_parts[1],
+            MetadataFilter::Eq(field, MetadataValue::String(value))
+                if field == "cuisine" && value == "bistro"
+        ));
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -147,6 +147,7 @@ pub(crate) fn runtime_vector_matches(
             index.search(vector, search_k, metric)
         };
         let mut results = Vec::with_capacity(raw.len());
+        let filter = effective_vector_filter(query);
         for hit in raw {
             let Some(entity) = db.store().get(&query.collection, hit.entity_id) else {
                 continue;
@@ -160,6 +161,11 @@ pub(crate) fn runtime_vector_matches(
             // version-superseded vector never reaches the results.
             if !crate::runtime::impl_core::entity_visible_under_current_snapshot(&entity) {
                 continue;
+            }
+            if let Some(filter) = filter.as_ref() {
+                if !runtime_vector_entity_matches_filter(db, &query.collection, entity.id, filter) {
+                    continue;
+                }
             }
             // Exact re-rank against the stored full-precision vector rather
             // than trusting the quantised approximate score.
@@ -209,6 +215,7 @@ pub(crate) fn runtime_vector_matches(
 
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     let mut index = BruteForceVectorIndex::default();
+    let filter = effective_vector_filter(query);
     let search_k = if effective_vector_filter(query).is_some() {
         manager.count().max(1)
     } else {
@@ -229,6 +236,11 @@ pub(crate) fn runtime_vector_matches(
         }
         crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity)
     }) {
+        if let Some(filter) = filter.as_ref() {
+            if !runtime_vector_entity_matches_filter(db, &query.collection, entity.id, filter) {
+                continue;
+            }
+        }
         if let EntityData::Vector(data) = &entity.data {
             index.upsert(VectorIndexEntry {
                 entity_id: entity.id,
@@ -271,8 +283,81 @@ pub(crate) fn runtime_vector_record_matches_filter(
         .store()
         .get_metadata(collection, entity_id)
         .unwrap_or_default();
-    let entry = runtime_metadata_entry(&metadata);
-    filter.matches(&entry)
+    runtime_metadata_matches_vector_filter(&metadata, filter)
+}
+
+fn runtime_vector_entity_matches_filter(
+    db: &RedDB,
+    collection: &str,
+    entity_id: EntityId,
+    filter: &VectorMetadataFilter,
+) -> bool {
+    let metadata = db
+        .store()
+        .get_metadata(collection, entity_id)
+        .unwrap_or_default();
+    runtime_metadata_matches_vector_filter(&metadata, filter)
+}
+
+fn runtime_metadata_matches_vector_filter(
+    metadata: &Metadata,
+    filter: &VectorMetadataFilter,
+) -> bool {
+    match filter {
+        VectorMetadataFilter::GeoRadius {
+            key,
+            center_lat,
+            center_lon,
+            radius_km,
+        } => metadata
+            .get(key)
+            .and_then(runtime_metadata_geo_point)
+            .is_some_and(|(lat, lon)| {
+                crate::geo::haversine_km(*center_lat, *center_lon, lat, lon) <= *radius_km
+            }),
+        VectorMetadataFilter::And(filters) => filters
+            .iter()
+            .all(|filter| runtime_metadata_matches_vector_filter(metadata, filter)),
+        VectorMetadataFilter::Or(filters) => filters
+            .iter()
+            .any(|filter| runtime_metadata_matches_vector_filter(metadata, filter)),
+        VectorMetadataFilter::Not(inner) => {
+            !runtime_metadata_matches_vector_filter(metadata, inner)
+        }
+        _ => {
+            let entry = runtime_metadata_entry(metadata);
+            filter.matches(&entry)
+        }
+    }
+}
+
+fn runtime_metadata_geo_point(value: &UnifiedMetadataValue) -> Option<(f64, f64)> {
+    let fields = match value {
+        UnifiedMetadataValue::Geo { lat, lon } => vec![
+            ("lat".to_string(), Value::Float(*lat)),
+            ("lon".to_string(), Value::Float(*lon)),
+        ],
+        UnifiedMetadataValue::Object(object) => object
+            .iter()
+            .filter_map(|(key, value)| {
+                runtime_metadata_geo_field_value(value).map(|value| (key.clone(), value))
+            })
+            .collect(),
+        _ => return None,
+    };
+    crate::geo::recognize_geo_fields(|key| {
+        fields
+            .iter()
+            .find_map(|(field, value)| (field == key).then_some(value))
+    })
+}
+
+fn runtime_metadata_geo_field_value(value: &UnifiedMetadataValue) -> Option<Value> {
+    match value {
+        UnifiedMetadataValue::Int(value) => Some(Value::Integer(*value)),
+        UnifiedMetadataValue::Float(value) => Some(Value::Float(*value)),
+        _ => None,
+    }
 }
 
 pub(crate) fn runtime_vector_metric(db: &RedDB, query: &VectorQuery) -> DistanceMetric {

--- a/crates/reddb-server/src/storage/query/executors/vector.rs
+++ b/crates/reddb-server/src/storage/query/executors/vector.rs
@@ -530,6 +530,7 @@ fn evaluate_filter(filter: &MetadataFilter, metadata: &HashMap<String, MetadataV
                 false
             }
         }
+        MetadataFilter::GeoRadius { .. } => false,
         MetadataFilter::Exists(field) => metadata.contains_key(field),
         MetadataFilter::NotExists(field) => !metadata.contains_key(field),
     }

--- a/crates/reddb-server/src/storage/query/planner/shape.rs
+++ b/crates/reddb-server/src/storage/query/planner/shape.rs
@@ -523,6 +523,17 @@ fn parameterize_metadata_filter(filter: &MetadataFilter, next_index: &mut usize)
             },
             format!("{STRING_PARAM_PREFIX}{}", allocate_param_index(next_index)),
         ),
+        MetadataFilter::GeoRadius {
+            key,
+            center_lat,
+            center_lon,
+            radius_km,
+        } => MetadataFilter::GeoRadius {
+            key: key.clone(),
+            center_lat: parameterize_f64(*center_lat, next_index),
+            center_lon: parameterize_f64(*center_lon, next_index),
+            radius_km: parameterize_f64(*radius_km, next_index),
+        },
         MetadataFilter::Exists(key) => MetadataFilter::Exists(key.clone()),
         MetadataFilter::NotExists(key) => MetadataFilter::NotExists(key.clone()),
         MetadataFilter::And(filters) => MetadataFilter::And(
@@ -595,6 +606,17 @@ fn bind_metadata_filter(filter: &MetadataFilter, binds: &[Value]) -> Option<Meta
             key.clone(),
             bind_placeholder_string(value, binds)?.unwrap_or_default(),
         )),
+        MetadataFilter::GeoRadius {
+            key,
+            center_lat,
+            center_lon,
+            radius_km,
+        } => Some(MetadataFilter::GeoRadius {
+            key: key.clone(),
+            center_lat: bind_placeholder_f64(*center_lat, binds)?,
+            center_lon: bind_placeholder_f64(*center_lon, binds)?,
+            radius_km: bind_placeholder_f64(*radius_km, binds)?,
+        }),
         MetadataFilter::Exists(key) => Some(MetadataFilter::Exists(key.clone())),
         MetadataFilter::NotExists(key) => Some(MetadataFilter::NotExists(key.clone())),
         MetadataFilter::And(filters) => Some(MetadataFilter::And(
@@ -1104,6 +1126,35 @@ fn bind_placeholder_f32(value: f32, binds: &[Value]) -> Option<f32> {
     }
 }
 
+fn parameterize_f64(value: f64, next_index: &mut usize) -> f64 {
+    if value.is_finite() {
+        encode_f64_placeholder(allocate_param_index(next_index))
+    } else {
+        value
+    }
+}
+
+fn encode_f64_placeholder(index: usize) -> f64 {
+    f64::from_bits(FLOAT64_PARAM_BITS_BASE | (index as u64 & 0x0007_ffff_ffff_ffff))
+}
+
+fn decode_f64_placeholder(value: f64) -> Option<usize> {
+    let bits = value.to_bits();
+    if bits & FLOAT64_PARAM_BITS_BASE == FLOAT64_PARAM_BITS_BASE {
+        Some((bits & 0x0007_ffff_ffff_ffff) as usize)
+    } else {
+        None
+    }
+}
+
+fn bind_placeholder_f64(value: f64, binds: &[Value]) -> Option<f64> {
+    if let Some(index) = decode_f64_placeholder(value) {
+        bind_value_to_f64(binds.get(index)?)
+    } else {
+        Some(value)
+    }
+}
+
 fn encode_u32_placeholder(index: usize) -> u32 {
     U32_PARAM_BASE | (index as u32 & 0x000f_ffff)
 }
@@ -1130,6 +1181,17 @@ fn bind_value_to_f32(value: &Value) -> Option<f32> {
         Value::Integer(value) => Some(*value as f32),
         Value::UnsignedInteger(value) => Some(*value as f32),
         Value::BigInt(value) => Some(*value as f32),
+        Value::Text(value) => value.parse().ok(),
+        _ => None,
+    }
+}
+
+fn bind_value_to_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::UnsignedInteger(value) => Some(*value as f64),
+        Value::BigInt(value) => Some(*value as f64),
         Value::Text(value) => value.parse().ok(),
         _ => None,
     }

--- a/crates/reddb-types/src/vector_metadata.rs
+++ b/crates/reddb-types/src/vector_metadata.rs
@@ -256,6 +256,13 @@ pub enum MetadataFilter {
     StartsWith(String, String),
     /// String ends with: key ends with suffix
     EndsWith(String, String),
+    /// Geographic radius predicate over a metadata field.
+    GeoRadius {
+        key: String,
+        center_lat: f64,
+        center_lon: f64,
+        radius_km: f64,
+    },
     /// Key exists
     Exists(String),
     /// Key does not exist
@@ -365,6 +372,7 @@ impl MetadataFilter {
             MetadataFilter::EndsWith(key, suffix) => {
                 entry.get(key).map(|v| v.ends_with(suffix)).unwrap_or(false)
             }
+            MetadataFilter::GeoRadius { .. } => false,
             MetadataFilter::Exists(key) => entry.contains_key(key),
             MetadataFilter::NotExists(key) => !entry.contains_key(key),
             MetadataFilter::And(filters) => filters.iter().all(|f| f.matches(entry)),

--- a/tests/grouped/ai_local_vector/e2e_vector_geo_filter.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_geo_filter.rs
@@ -1,0 +1,205 @@
+use reddb::storage::schema::Value;
+use reddb::{RedDBOptions, RedDBRuntime};
+
+#[derive(Clone, Copy)]
+enum TestLocation {
+    Geo { lat: f64, lon: f64 },
+    Missing,
+    NonGeo,
+}
+
+struct Restaurant {
+    content: &'static str,
+    dense: [f32; 2],
+    cuisine: &'static str,
+    location: TestLocation,
+}
+
+const CENTER_LAT: f64 = 48.8566;
+const CENTER_LON: f64 = 2.3522;
+const RADIUS_KM: f64 = 5.0;
+
+const CORPUS: &[Restaurant] = &[
+    Restaurant {
+        content: "outside-perfect",
+        dense: [1.0, 0.0],
+        cuisine: "bistro",
+        location: TestLocation::Geo {
+            lat: 41.9028,
+            lon: 12.4964,
+        },
+    },
+    Restaurant {
+        content: "inside-best",
+        dense: [0.99, 0.01],
+        cuisine: "bistro",
+        location: TestLocation::Geo {
+            lat: 48.8566,
+            lon: 2.3522,
+        },
+    },
+    Restaurant {
+        content: "non-geo-perfect",
+        dense: [1.0, 0.0],
+        cuisine: "bistro",
+        location: TestLocation::NonGeo,
+    },
+    Restaurant {
+        content: "missing-perfect",
+        dense: [1.0, 0.0],
+        cuisine: "bistro",
+        location: TestLocation::Missing,
+    },
+    Restaurant {
+        content: "wrong-cuisine-perfect",
+        dense: [1.0, 0.0],
+        cuisine: "cafe",
+        location: TestLocation::Geo {
+            lat: 48.8566,
+            lon: 2.3522,
+        },
+    },
+    Restaurant {
+        content: "inside-second",
+        dense: [0.95, 0.05],
+        cuisine: "bistro",
+        location: TestLocation::Geo {
+            lat: 48.8606,
+            lon: 2.3376,
+        },
+    },
+    Restaurant {
+        content: "inside-third",
+        dense: [0.8, 0.6],
+        cuisine: "bistro",
+        location: TestLocation::Geo {
+            lat: 48.8584,
+            lon: 2.2945,
+        },
+    },
+];
+
+fn runtime(indexed: bool) -> RedDBRuntime {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime boots");
+    rt.execute_query("CREATE VECTOR restaurants DIM 2 METRIC cosine")
+        .expect("create vector collection");
+    for row in CORPUS {
+        rt.execute_query(&insert_sql(row)).unwrap_or_else(|err| {
+            panic!("insert {} should succeed: {err:?}", row.content);
+        });
+    }
+    if indexed {
+        rt.execute_query("CREATE INDEX idx_restaurant_location ON restaurants (location) USING H3")
+            .expect("create h3 index");
+    }
+    rt
+}
+
+fn insert_sql(row: &Restaurant) -> String {
+    let metadata = match row.location {
+        TestLocation::Geo { lat, lon } => {
+            format!(
+                r#"{{"location":{{"lat":{lat},"lon":{lon}}},"cuisine":"{}"}}"#,
+                row.cuisine
+            )
+        }
+        TestLocation::Missing => format!(r#"{{"cuisine":"{}"}}"#, row.cuisine),
+        TestLocation::NonGeo => {
+            format!(r#"{{"location":"not-geo","cuisine":"{}"}}"#, row.cuisine)
+        }
+    };
+    format!(
+        "INSERT INTO restaurants VECTOR (dense, content, metadata) \
+         VALUES ([{}, {}], '{}', '{}')",
+        row.dense[0], row.dense[1], row.content, metadata
+    )
+}
+
+fn geo_query(limit: usize) -> String {
+    format!(
+        "VECTOR SEARCH restaurants SIMILAR TO [1.0, 0.0] \
+         WHERE GEO_DISTANCE(location, {CENTER_LAT}, {CENTER_LON}) <= {RADIUS_KM} \
+         AND cuisine = 'bistro' LIMIT {limit}"
+    )
+}
+
+fn hit_names(rt: &RedDBRuntime, sql: &str) -> Vec<String> {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("query should succeed: {sql}\n{err:?}"))
+        .result
+        .records
+        .iter()
+        .map(|record| match record.get("content") {
+            Some(Value::Text(value)) => value.to_string(),
+            other => panic!("expected content text, got {other:?}"),
+        })
+        .collect()
+}
+
+fn exhaustive_oracle(limit: usize) -> Vec<String> {
+    let mut scored = CORPUS
+        .iter()
+        .enumerate()
+        .filter_map(|(index, row)| {
+            if row.cuisine != "bistro" {
+                return None;
+            }
+            let TestLocation::Geo { lat, lon } = row.location else {
+                return None;
+            };
+            if reddb::geo::haversine_km(CENTER_LAT, CENTER_LON, lat, lon) > RADIUS_KM {
+                return None;
+            }
+            Some((index, cosine_score(row.dense), row.content))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|left, right| {
+        right
+            .1
+            .partial_cmp(&left.1)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, _, content)| content.to_string())
+        .collect()
+}
+
+fn cosine_score(vector: [f32; 2]) -> f32 {
+    let norm = (vector[0] * vector[0] + vector[1] * vector[1]).sqrt();
+    if norm == 0.0 {
+        0.0
+    } else {
+        vector[0] / norm
+    }
+}
+
+#[test]
+fn vector_geo_radius_filter_scores_only_entities_inside_radius() {
+    let expected = exhaustive_oracle(2);
+    let full_scan = runtime(false);
+    let indexed = runtime(true);
+
+    let full_scan_hits = hit_names(&full_scan, &geo_query(2));
+    let indexed_hits = hit_names(&indexed, &geo_query(2));
+
+    assert_eq!(full_scan_hits, expected);
+    assert_eq!(indexed_hits, full_scan_hits);
+    assert!(!full_scan_hits.contains(&"missing-perfect".to_string()));
+    assert!(!full_scan_hits.contains(&"non-geo-perfect".to_string()));
+}
+
+#[test]
+fn vector_search_without_geo_filter_keeps_existing_metadata_filter_behavior() {
+    let rt = runtime(false);
+    let hits = hit_names(
+        &rt,
+        "VECTOR SEARCH restaurants SIMILAR TO [1.0, 0.0] \
+         WHERE cuisine = 'bistro' LIMIT 3",
+    );
+    assert!(hits.contains(&"outside-perfect".to_string()));
+    assert!(hits.contains(&"missing-perfect".to_string()));
+    assert!(hits.contains(&"non-geo-perfect".to_string()));
+}

--- a/tests/grouped/ai_search.rs
+++ b/tests/grouped/ai_search.rs
@@ -60,6 +60,9 @@ mod integration_local_embedding_conformance;
 #[path = "ai_local_vector/integration_vector_query_text.rs"]
 mod integration_vector_query_text;
 
+#[path = "ai_local_vector/e2e_vector_geo_filter.rs"]
+mod e2e_vector_geo_filter;
+
 #[path = "ai_local_vector/integration_vector_query_text_local.rs"]
 mod integration_vector_query_text_local;
 


### PR DESCRIPTION
Automated AFK landing for #1947. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1947

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786159086&installation_id=129708444&pr_number=1977&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1977&signature=5e83a167872797e5e624e8c68071d38d5d1cc24d56a0babe2448b4446c494b93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->