### PR TITLE
chore: #1937 Didactic spatial zeros: H3 index coverage reporting, zero-geo search hint, Documents walkthrough spatial section

### DIFF
--- a/crates/reddb-client/src/embedded.rs
+++ b/crates/reddb-client/src/embedded.rs
@@ -300,6 +300,7 @@ fn map_query_result(qr: &reddb_server::runtime::RuntimeQueryResult) -> QueryResu
         affected: qr.affected_rows,
         columns,
         rows,
+        notice: qr.notice.clone(),
     }
 }
 

--- a/crates/reddb-client/src/grpc.rs
+++ b/crates/reddb-client/src/grpc.rs
@@ -640,6 +640,10 @@ fn parse_query_json(s: &str) -> Result<QueryResult> {
         affected,
         columns,
         rows,
+        notice: parsed
+            .get("notice")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned),
     })
 }
 

--- a/crates/reddb-client/src/row_format.rs
+++ b/crates/reddb-client/src/row_format.rs
@@ -59,7 +59,13 @@ fn value_at<'a>(row: &'a [(String, ValueOut)], column: &str) -> Option<&'a Value
 fn format_table(result: &QueryResult) -> String {
     let columns = columns(result);
     if result.rows.is_empty() {
-        return "(no rows)\n".to_string();
+        let mut out = "(no rows)\n".to_string();
+        if let Some(notice) = result.notice.as_deref() {
+            out.push_str("Note: ");
+            out.push_str(notice);
+            out.push('\n');
+        }
+        return out;
     }
 
     let mut widths: Vec<usize> = columns.iter().map(|column| column.len()).collect();
@@ -353,6 +359,7 @@ mod tests {
                     ),
                 ],
             ],
+            notice: None,
         }
     }
 
@@ -433,6 +440,7 @@ mod tests {
                 ("count".to_string(), ValueOut::Integer(7)),
                 ("enabled".to_string(), ValueOut::Bool(false)),
             ]],
+            notice: None,
         };
 
         assert_eq!(

--- a/crates/reddb-client/src/types.rs
+++ b/crates/reddb-client/src/types.rs
@@ -150,6 +150,7 @@ pub struct QueryResult {
     pub affected: u64,
     pub columns: Vec<String>,
     pub rows: Vec<Vec<(String, ValueOut)>>,
+    pub notice: Option<String>,
 }
 
 pub type Row = Vec<(String, ValueOut)>;
@@ -233,6 +234,7 @@ impl QueryResult {
                 affected: 0,
                 columns: Vec::new(),
                 rows: Vec::new(),
+                notice: None,
             };
         };
         let result_obj = obj.get("result").and_then(|v| v.as_object()).unwrap_or(obj);
@@ -273,6 +275,10 @@ impl QueryResult {
             affected,
             columns,
             rows,
+            notice: obj
+                .get("notice")
+                .and_then(|v| v.as_str())
+                .map(ToOwned::to_owned),
         }
     }
 }

--- a/crates/reddb-server/src/geo/mod.rs
+++ b/crates/reddb-server/src/geo/mod.rs
@@ -17,6 +17,8 @@ const WGS84_A: f64 = 6_378_137.0; // semi-major axis (meters)
 const WGS84_F: f64 = 1.0 / 298.257_223_563; // flattening
 const WGS84_B: f64 = WGS84_A * (1.0 - WGS84_F); // semi-minor axis
 
+pub const RECOGNIZED_GEO_SHAPES: &str = "GEO_POINT or {lat, lon} object";
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 #[inline]

--- a/crates/reddb-server/src/grpc.rs
+++ b/crates/reddb-server/src/grpc.rs
@@ -863,6 +863,7 @@ mod grpc_ask_query_reply_tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         }
     }
 
@@ -940,6 +941,7 @@ mod grpc_ask_query_reply_tests {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             },
             &None,
             &None,
@@ -977,6 +979,7 @@ mod grpc_ask_query_reply_tests {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             },
             &None,
             &None,

--- a/crates/reddb-server/src/grpc/service_impl.rs
+++ b/crates/reddb-server/src/grpc/service_impl.rs
@@ -4034,6 +4034,7 @@ mod tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         }
     }
 

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -81,6 +81,9 @@ pub(crate) fn runtime_query_json(
             JsonValue::String(bookmark.to_string()),
         );
     }
+    if let Some(notice) = result.notice.as_deref() {
+        object.insert("notice".to_string(), JsonValue::String(notice.to_string()));
+    }
     object.insert(
         "result".to_string(),
         unified_result_json_with_records(&result.result, &records),
@@ -1131,6 +1134,7 @@ mod descriptor_tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         };
 
         let json = runtime_query_json(&runtime_result, &None, &None);

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -2360,6 +2360,7 @@ mod tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         });
 
         let payload = json
@@ -2546,6 +2547,7 @@ mod tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         });
 
         assert_eq!(

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -483,6 +483,7 @@ pub struct RuntimeQueryResult {
     /// High-level statement type: "select", "insert", "update", "delete", "create", "drop", "alter"
     pub statement_type: &'static str,
     pub bookmark: Option<String>,
+    pub notice: Option<String>,
 }
 
 impl RuntimeQueryResult {
@@ -502,6 +503,7 @@ impl RuntimeQueryResult {
             affected_rows: affected,
             statement_type,
             bookmark: None,
+            notice: None,
         }
     }
 
@@ -522,6 +524,7 @@ impl RuntimeQueryResult {
             affected_rows: 0,
             statement_type,
             bookmark: None,
+            notice: None,
         }
     }
 
@@ -553,6 +556,7 @@ impl RuntimeQueryResult {
             affected_rows: 0,
             statement_type,
             bookmark: None,
+            notice: None,
         }
     }
 

--- a/crates/reddb-server/src/runtime/authz/statements.rs
+++ b/crates/reddb-server/src/runtime/authz/statements.rs
@@ -688,6 +688,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -763,6 +764,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -860,6 +862,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -1031,6 +1034,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -1109,6 +1113,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 }

--- a/crates/reddb-server/src/runtime/impl_config.rs
+++ b/crates/reddb-server/src/runtime/impl_config.rs
@@ -290,6 +290,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             Err(err) => {
@@ -722,6 +723,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -775,6 +777,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -837,6 +840,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -889,6 +893,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "stream",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -1624,6 +1629,7 @@ fn config_write_output(
             "update"
         },
         bookmark: None,
+        notice: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_config_secret.rs
+++ b/crates/reddb-server/src/runtime/impl_config_secret.rs
@@ -136,6 +136,7 @@ pub(crate) fn show_config_json_result(
         affected_rows: 0,
         statement_type: "select",
         bookmark: None,
+        notice: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -723,6 +723,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueryExpr::Table(table) => {
@@ -755,6 +756,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     };
                     frame.write_result_cache(self, &tvf_result, result_cache_scopes.clone());
                     return Ok(tvf_result);
@@ -787,6 +789,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     };
                     frame.write_result_cache(self, &inline_result, result_cache_scopes);
                     return Ok(inline_result);
@@ -806,6 +809,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
 
@@ -825,6 +829,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
 
@@ -838,6 +843,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
 
@@ -864,6 +870,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
 
@@ -898,6 +905,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -920,6 +928,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueryExpr::Join(join) => {
@@ -946,6 +955,7 @@ impl RedDBRuntime {
                             affected_rows: 0,
                             statement_type: "select",
                             bookmark: None,
+                            notice: None,
                         });
                     }
                 };
@@ -958,6 +968,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueryExpr::Vector(vector) => Ok(RuntimeQueryResult {
@@ -969,6 +980,7 @@ impl RedDBRuntime {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             }),
             QueryExpr::Hybrid(hybrid) => Ok(RuntimeQueryResult {
                 query: query.to_string(),
@@ -979,6 +991,7 @@ impl RedDBRuntime {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             }),
             QueryExpr::RankOf(ref rank) => self.execute_rank_of(query, rank),
             QueryExpr::ApproxRankOf(ref rank) => self.execute_approx_rank_of(query, rank),
@@ -1263,6 +1276,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             // SHOW CONFIG [prefix] [AS JSON|FORMAT JSON]
@@ -1291,6 +1305,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 let manager = store
@@ -1357,6 +1372,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             // Session-local multi-tenancy handle (Phase 2.5.3).
@@ -1395,6 +1411,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             // Transaction control (Phase 2.3 PG parity).
@@ -2955,6 +2972,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 // Inline-graph TVF (issue #799) on the prepared-statement /
@@ -2981,6 +2999,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 if super::red_schema::is_virtual_table(&table.table) {
@@ -2998,6 +3017,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 // `<graph>.<output>` analytics virtual view (issue #800).
@@ -3014,6 +3034,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 let Some(table_with_rls) = self.authorize_relational_table_select(
@@ -3030,6 +3051,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -3045,6 +3067,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueryExpr::Join(join) => {
@@ -3063,6 +3086,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 };
                 Ok(RuntimeQueryResult {
@@ -3074,6 +3098,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueryExpr::Vector(vector) => Ok(RuntimeQueryResult {
@@ -3085,6 +3110,7 @@ impl RedDBRuntime {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             }),
             QueryExpr::Hybrid(hybrid) => Ok(RuntimeQueryResult {
                 query: query_str.to_string(),
@@ -3095,6 +3121,7 @@ impl RedDBRuntime {
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             }),
             QueryExpr::Insert(ref insert) if super::red_schema::is_virtual_table(&insert.table) => {
                 Err(RedDBError::Query(
@@ -3249,6 +3276,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -3320,6 +3348,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 }

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -1643,12 +1643,30 @@ impl RedDBRuntime {
         let method_str = format!("{}", query.method);
         let unique_str = if query.unique { "unique " } else { "" };
         let cols = query.columns.join(", ");
+        let total_count = entity_fields.len();
+        let coverage_detail =
+            if matches!(method_kind, super::index_store::IndexMethodKind::H3 { .. })
+                && total_count > 0
+                && indexed_count == 0
+            {
+                format!(
+                    "{} of {} entities indexed — no indexable geo value in '{}'; expected {}",
+                    indexed_count,
+                    total_count,
+                    cols,
+                    crate::geo::RECOGNIZED_GEO_SHAPES
+                )
+            } else if matches!(method_kind, super::index_store::IndexMethodKind::H3 { .. }) {
+                format!("{} of {} entities indexed", indexed_count, total_count)
+            } else {
+                format!("{} entities indexed", indexed_count)
+            };
 
         Ok(RuntimeQueryResult::ok_message(
             raw_query.to_string(),
             &format!(
-                "{}index '{}' created on '{}' ({}) using {} ({} entities indexed)",
-                unique_str, query.name, query.table, cols, method_str, indexed_count
+                "{}index '{}' created on '{}' ({}) using {} ({})",
+                unique_str, query.name, query.table, cols, method_str, coverage_detail
             ),
             "create",
         ))

--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -242,5 +242,6 @@ fn backfill_result(
         affected_rows: enqueued,
         statement_type: "insert",
         bookmark: None,
+        notice: None,
     }
 }

--- a/crates/reddb-server/src/runtime/impl_fast_path.rs
+++ b/crates/reddb-server/src/runtime/impl_fast_path.rs
@@ -95,6 +95,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         }))
     }
 

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -53,6 +53,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::ShortestPath {
@@ -111,6 +112,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Properties { source } => {
@@ -178,6 +180,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
                 let res = self.graph_properties(None)?;
@@ -206,6 +209,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Traverse {
@@ -248,6 +252,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Centrality {
@@ -303,6 +308,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Community {
@@ -364,6 +370,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Components {
@@ -396,6 +403,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Cycles { max_length } => {
@@ -417,6 +425,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::Clustering => {
@@ -448,6 +457,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             GraphCommand::TopologicalSort => {
@@ -473,6 +483,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
         }
@@ -599,6 +610,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::Text {
@@ -657,6 +669,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::Hybrid {
@@ -702,6 +715,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::Multimodal {
@@ -736,6 +750,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::Index {
@@ -779,6 +794,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::Context {
@@ -857,6 +873,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::SpatialRadius {
@@ -892,10 +909,12 @@ impl RedDBRuntime {
                 let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
+                let mut geo_values_seen = 0usize;
                 for entity in &entities {
                     if let Some((lat, lon)) =
                         self.extract_spatial_column(entity, collection, column)
                     {
+                        geo_values_seen += 1;
                         let dist = haversine_km(*center_lat, *center_lon, lat, lon);
                         if dist <= *radius_km {
                             hits.push((entity.id.raw(), dist));
@@ -913,6 +932,13 @@ impl RedDBRuntime {
                     record.set("distance_km", Value::Float(*dist));
                     result.push(record);
                 }
+                let notice = self.spatial_zero_geo_notice(
+                    collection,
+                    column,
+                    &entities,
+                    geo_values_seen,
+                    result.records.is_empty(),
+                );
                 Ok(RuntimeQueryResult {
                     query: raw_query.to_string(),
                     mode: QueryMode::Sql,
@@ -922,6 +948,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice,
                 })
             }
             SearchCommand::SpatialBbox {
@@ -952,6 +979,7 @@ impl RedDBRuntime {
 
                 let mut result = UnifiedResult::with_columns(vec!["entity_id".into()]);
                 let mut count = 0;
+                let mut geo_values_seen = 0usize;
                 for entity in &entities {
                     if count >= *limit {
                         break;
@@ -959,6 +987,7 @@ impl RedDBRuntime {
                     if let Some((lat, lon)) =
                         self.extract_spatial_column(entity, collection, column)
                     {
+                        geo_values_seen += 1;
                         if lat >= *min_lat && lat <= *max_lat && lon >= *min_lon && lon <= *max_lon
                         {
                             let mut record = UnifiedRecord::new();
@@ -968,6 +997,13 @@ impl RedDBRuntime {
                         }
                     }
                 }
+                let notice = self.spatial_zero_geo_notice(
+                    collection,
+                    column,
+                    &entities,
+                    geo_values_seen,
+                    result.records.is_empty(),
+                );
                 Ok(RuntimeQueryResult {
                     query: raw_query.to_string(),
                     mode: QueryMode::Sql,
@@ -977,6 +1013,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice,
                 })
             }
             SearchCommand::SpatialNearest {
@@ -1006,10 +1043,12 @@ impl RedDBRuntime {
                 let entities = scan_collection_with_candidates(&store, collection, &h3_candidates);
 
                 let mut hits: Vec<(u64, f64)> = Vec::new();
+                let mut geo_values_seen = 0usize;
                 for entity in &entities {
                     if let Some((elat, elon)) =
                         self.extract_spatial_column(entity, collection, column)
                     {
+                        geo_values_seen += 1;
                         let dist = haversine_km(*lat, *lon, elat, elon);
                         hits.push((entity.id.raw(), dist));
                     }
@@ -1025,6 +1064,13 @@ impl RedDBRuntime {
                     record.set("distance_km", Value::Float(*dist));
                     result.push(record);
                 }
+                let notice = self.spatial_zero_geo_notice(
+                    collection,
+                    column,
+                    &entities,
+                    geo_values_seen,
+                    result.records.is_empty(),
+                );
                 Ok(RuntimeQueryResult {
                     query: raw_query.to_string(),
                     mode: QueryMode::Sql,
@@ -1034,6 +1080,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice,
                 })
             }
         }
@@ -1347,6 +1394,42 @@ impl RedDBRuntime {
             EntityData::Row(_) | EntityData::Node(_) => extract_geo_from_entity(entity),
             _ => None,
         }
+    }
+
+    fn spatial_zero_geo_notice(
+        &self,
+        collection: &str,
+        column: &str,
+        scanned_entities: &[UnifiedEntity],
+        geo_values_seen: usize,
+        result_is_empty: bool,
+    ) -> Option<String> {
+        if !result_is_empty || geo_values_seen > 0 {
+            return None;
+        }
+        let (entity_count, geo_count) = if scanned_entities.is_empty() {
+            let store = self.inner.db.store();
+            let entities = scan_collection_with_candidates(&store, collection, &None);
+            let geo_count = entities
+                .iter()
+                .filter(|entity| {
+                    self.extract_spatial_column(entity, collection, column)
+                        .is_some()
+                })
+                .count();
+            (entities.len(), geo_count)
+        } else {
+            (scanned_entities.len(), geo_values_seen)
+        };
+        if entity_count == 0 || geo_count > 0 {
+            return None;
+        }
+        Some(format!(
+            "no entity in '{}' has an indexable geo value in column '{}' (expected {}).",
+            collection,
+            column,
+            crate::geo::RECOGNIZED_GEO_SHAPES
+        ))
     }
 
     /// Resolution of the H3 index registered on `(collection, column)`, if

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -1059,6 +1059,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             SearchCommand::SpatialNearest {

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -1634,6 +1634,7 @@ impl RedDBRuntime {
                     affected_rows: 1,
                     statement_type: if created { "insert" } else { "update" },
                     bookmark: None,
+                    notice: None,
                 })
             }
             KvCommand::InvalidateTags { collection, tags } => {
@@ -1661,6 +1662,7 @@ impl RedDBRuntime {
                     affected_rows: invalidated as u64,
                     statement_type: "delete",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -1797,6 +1799,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     })
                 } else {
                     let mut result = UnifiedResult::with_columns(vec![
@@ -1867,6 +1870,7 @@ impl RedDBRuntime {
                             affected_rows: 0,
                             statement_type: "select",
                             bookmark: None,
+                            notice: None,
                         })
                     }
                 }
@@ -1911,6 +1915,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -1981,6 +1986,7 @@ impl RedDBRuntime {
                     affected_rows: purged as u64,
                     statement_type: "delete",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -2028,6 +2034,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     });
                 }
 
@@ -2077,6 +2084,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             KvCommand::Watch {
@@ -2132,6 +2140,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "stream",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -2261,6 +2270,7 @@ impl RedDBRuntime {
                             affected_rows: 0,
                             statement_type: "select",
                             bookmark: None,
+                            notice: None,
                         })
                     }
                     Err(err) => {
@@ -2319,6 +2329,7 @@ impl RedDBRuntime {
                     affected_rows: 1,
                     statement_type: "update",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -2365,6 +2376,7 @@ impl RedDBRuntime {
                     affected_rows: if ok { 1 } else { 0 },
                     statement_type: "update",
                     bookmark: None,
+                    notice: None,
                 })
             }
 
@@ -2436,6 +2448,7 @@ impl RedDBRuntime {
                     affected_rows: if deleted { 1 } else { 0 },
                     statement_type: "delete",
                     bookmark: None,
+                    notice: None,
                 })
             }
         }
@@ -2583,6 +2596,7 @@ fn vault_write_result(
         affected_rows,
         statement_type,
         bookmark: None,
+        notice: None,
     }
 }
 
@@ -2925,6 +2939,7 @@ fn kv_list_json_result(
         affected_rows: 0,
         statement_type: "select",
         bookmark: None,
+        notice: None,
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_probabilistic.rs
+++ b/crates/reddb-server/src/runtime/impl_probabilistic.rs
@@ -816,6 +816,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     })
                 } else {
                     // Multi-HLL count = union count
@@ -858,6 +859,7 @@ impl RedDBRuntime {
                         affected_rows: 0,
                         statement_type: "select",
                         bookmark: None,
+                        notice: None,
                     })
                 }
             }
@@ -938,6 +940,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::DropHll { name, if_exists } => {
@@ -1060,6 +1063,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::SketchMerge { dest, sources } => {
@@ -1140,6 +1144,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::DropSketch { name, if_exists } => {
@@ -1257,6 +1262,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::FilterDelete { name, element } => {
@@ -1304,6 +1310,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::FilterInfo { name } => {
@@ -1338,6 +1345,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             ProbabilisticCommand::DropFilter { name, if_exists } => {

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -993,6 +993,7 @@ impl RedDBRuntime {
                             affected_rows: 1,
                             statement_type: "insert",
                             bookmark: None,
+                            notice: None,
                         });
                     }
                 }
@@ -1104,6 +1105,7 @@ impl RedDBRuntime {
                     affected_rows: 1,
                     statement_type: "insert",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Pop { queue, side, count } => {
@@ -1139,6 +1141,7 @@ impl RedDBRuntime {
                     affected_rows: popped_count,
                     statement_type: "delete",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Peek { queue, count } => {
@@ -1168,6 +1171,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Len { queue } => {
@@ -1190,6 +1194,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Purge { queue } => {
@@ -1325,6 +1330,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Pending { queue, group } => {
@@ -1375,6 +1381,7 @@ impl RedDBRuntime {
                     affected_rows: 0,
                     statement_type: "select",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Claim {
@@ -1428,6 +1435,7 @@ impl RedDBRuntime {
                     affected_rows,
                     statement_type: "update",
                     bookmark: None,
+                    notice: None,
                 })
             }
             QueueCommand::Ack {
@@ -1664,6 +1672,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -1795,6 +1804,7 @@ impl RedDBRuntime {
             affected_rows: selected_count,
             statement_type: "update",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -1928,6 +1938,7 @@ impl RedDBRuntime {
             affected_rows,
             statement_type: "update",
             bookmark: None,
+            notice: None,
         })
     }
 }

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -1722,6 +1722,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2116,6 +2117,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2339,6 +2341,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2404,6 +2407,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2519,6 +2523,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2585,6 +2590,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2667,6 +2673,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 
@@ -2851,6 +2858,7 @@ impl RedDBRuntime {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         })
     }
 

--- a/crates/reddb-server/src/runtime/result_cache_runtime.rs
+++ b/crates/reddb-server/src/runtime/result_cache_runtime.rs
@@ -277,6 +277,7 @@ fn decode_result_cache_payload(mut input: &[u8]) -> Option<(RuntimeQueryResult, 
             affected_rows,
             statement_type,
             bookmark: None,
+            notice: None,
         },
         scopes,
     ))

--- a/crates/reddb-server/src/wire/postgres/server.rs
+++ b/crates/reddb-server/src/wire/postgres/server.rs
@@ -740,6 +740,7 @@ fn execute_pg_query_result(
                 affected_rows: 0,
                 statement_type: "select",
                 bookmark: None,
+                notice: None,
             }),
             Ok(None) => run_runtime_blocking(|| {
                 execute_with_pg_auth_context(auth_context, || runtime.execute_query(sql))
@@ -776,6 +777,7 @@ fn try_execute_pg_scalar_select(
         affected_rows: 0,
         statement_type: "select",
         bookmark: None,
+        notice: None,
     })
 }
 
@@ -1104,6 +1106,7 @@ where
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         }),
         Ok(None) => run_runtime_blocking(|| {
             execute_with_pg_auth_context(auth_context, || runtime.execute_query(sql))
@@ -1943,6 +1946,7 @@ mod tests {
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         };
 
         let mut out = Vec::new();

--- a/docs/data-models/documents.md
+++ b/docs/data-models/documents.md
@@ -236,6 +236,68 @@ curl -X POST http://127.0.0.1:5000/query \
   -d '{"query":"SELECT event_type, user_id, body FROM events WHERE event_type = '\''login'\'' LIMIT 20"}'
 ```
 
+## Spatial on documents
+
+Document fields can participate in `SEARCH SPATIAL` when the named field is a
+recognized geographic point. RedDB recognizes the same shapes for full scans,
+H3 indexes, and diagnostics:
+
+| Shape | Example | Indexed by H3 |
+|:------|:--------|:--------------|
+| `GeoPoint` value | A typed `GEOPOINT` value such as `POINT(38.76, -77.15)` | Yes |
+| `{lat, lon}` JSON object | `{"gpsLocation":{"lat":38.76,"lon":-77.15}}` | Yes |
+| Alias object | `{"gpsLocation":{"latitude":38.76,"longitude":-77.15}}` or `{"gpsLocation":{"latitude":38.76,"lng":-77.15}}` | Yes |
+| GeoJSON object | `{"gpsLocation":{"type":"Point","coordinates":[-77.15,38.76]}}` | No, not yet |
+| String coordinate | `{"gpsLocation":"38.76,-77.15"}` | No |
+| Array coordinate | `{"gpsLocation":[38.76,-77.15]}` | No |
+
+Create the H3 index on the document field you search:
+
+```sql
+CREATE DOCUMENT events
+CREATE INDEX idx_loc ON events (gpsLocation) USING H3
+```
+
+Dotted paths work for nested document bodies:
+
+```sql
+CREATE INDEX idx_nested_loc ON events (location.gps) USING H3
+
+SEARCH SPATIAL RADIUS 38.76 -77.15 10.0
+COLLECTION events
+COLUMN location.gps
+```
+
+You can create the index before data arrives:
+
+```sql
+CREATE DOCUMENT events
+CREATE INDEX idx_loc ON events (gpsLocation) USING H3
+
+INSERT INTO events DOCUMENT VALUES
+  ({"name":"gate","gpsLocation":{"lat":38.76,"lon":-77.15}})
+
+SEARCH SPATIAL RADIUS 38.76 -77.15 10.0
+COLLECTION events
+COLUMN gpsLocation
+```
+
+Or backfill an index after documents already exist:
+
+```sql
+CREATE DOCUMENT events
+
+INSERT INTO events DOCUMENT VALUES
+  ({"name":"gate","gpsLocation":{"lat":38.76,"lon":-77.15}}),
+  ({"name":"bad","gpsLocation":"38.76,-77.15"})
+
+CREATE INDEX idx_loc ON events (gpsLocation) USING H3
+```
+
+The create-index message reports how many existing entities were indexed. If a
+non-empty collection reports `0 of N`, the message names the field and expected
+shape so a document-shape mismatch is visible at index time.
+
 ## Updating Documents
 
 Patch specific nested fields in a document with JSON-pointer-style paths under `body`:

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -302,6 +302,7 @@ fn runtime_query_result_to_client(result: &reddb::runtime::RuntimeQueryResult) -
         affected: result.affected_rows,
         columns,
         rows,
+        notice: result.notice.clone(),
     }
 }
 
@@ -1103,6 +1104,11 @@ fn format_result_pretty(result: &reddb::runtime::RuntimeQueryResult) -> String {
     }
     if result.result.records.is_empty() {
         out.push_str("(no rows)\n");
+        if let Some(notice) = result.notice.as_deref() {
+            out.push_str("Note: ");
+            out.push_str(notice);
+            out.push('\n');
+        }
         return out;
     }
     for (i, record) in result.result.records.iter().enumerate() {
@@ -1161,7 +1167,13 @@ fn format_result_json(result: &reddb::runtime::RuntimeQueryResult) -> String {
         }
         out.push('}');
     }
-    out.push_str("]}");
+    out.push(']');
+    if let Some(notice) = result.notice.as_deref() {
+        out.push_str(",\"notice\":\"");
+        out.push_str(&json_escape(notice));
+        out.push('"');
+    }
+    out.push('}');
     out
 }
 
@@ -7603,6 +7615,7 @@ reddb_replica_lag_records{replica_id=\"b\"} 250\n";
             affected_rows: 0,
             statement_type: "select",
             bookmark: None,
+            notice: None,
         };
 
         let out = format_result_json(&query);

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -285,6 +285,18 @@ fn spatial_rows(rt: &RedDBRuntime, query: &str) -> Vec<(u64, u64)> {
         .collect()
 }
 
+fn result_message(res: &reddb::runtime::RuntimeQueryResult) -> String {
+    match res
+        .result
+        .records
+        .first()
+        .and_then(|record| record.get("message"))
+    {
+        Some(Value::Text(message)) => message.to_string(),
+        other => panic!("missing message row: {other:?}"),
+    }
+}
+
 /// For each query: run the full scan (no index), create the H3 index, run
 /// the ring scan, and assert the two are byte-identical.
 fn assert_h3_parity(create_index: &str, queries: &[String]) {
@@ -450,6 +462,123 @@ fn spatial_full_scan_skips_non_geo_named_document_values() {
         hits.is_empty(),
         "non-geo, missing, and GeoJSON named document values must be skipped"
     );
+}
+
+#[test]
+fn h3_create_index_reports_existing_geo_coverage() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":38.76,"lon":-77.15}})"#,
+    )
+    .unwrap();
+
+    let res = rt
+        .execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+    assert_eq!(
+        result_message(&res),
+        "index 'idx_loc' created on 'events' (gpsLocation) using H3 (1 of 1 entities indexed)"
+    );
+}
+
+#[test]
+fn h3_create_index_reports_zero_coverage_shape_hint_for_non_empty_collection() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+           ({"gpsLocation":"not-geo"}),
+           ({"name":"missing"}),
+           ({"gpsLocation":{"type":"Point","coordinates":[-77.15,38.76]}})"#,
+    )
+    .unwrap();
+
+    let res = rt
+        .execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+    assert_eq!(
+        result_message(&res),
+        "index 'idx_loc' created on 'events' (gpsLocation) using H3 (0 of 3 entities indexed — no indexable geo value in 'gpsLocation'; expected GEO_POINT or {lat, lon} object)"
+    );
+}
+
+#[test]
+fn h3_create_index_reports_plain_zero_for_empty_collection() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+
+    let res = rt
+        .execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+    assert_eq!(
+        result_message(&res),
+        "index 'idx_loc' created on 'events' (gpsLocation) using H3 (0 of 0 entities indexed)"
+    );
+}
+
+#[test]
+fn spatial_search_reports_zero_geo_notice_only_for_shape_mismatch() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES
+           ({"gpsLocation":"not-geo"}),
+           ({"name":"missing"}),
+           ({"gpsLocation":{"type":"Point","coordinates":[-77.15,38.76]}})"#,
+    )
+    .unwrap();
+
+    let res = rt
+        .execute_query(
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .unwrap();
+    assert!(res.result.records.is_empty());
+    assert_eq!(
+        res.notice.as_deref(),
+        Some(
+            "no entity in 'events' has an indexable geo value in column 'gpsLocation' (expected GEO_POINT or {lat, lon} object)."
+        )
+    );
+    rt.execute_query("CREATE INDEX idx_loc ON events (gpsLocation) USING H3")
+        .unwrap();
+    let res = rt
+        .execute_query(
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .unwrap();
+    assert!(res.result.records.is_empty());
+    assert_eq!(
+        res.notice.as_deref(),
+        Some(
+            "no entity in 'events' has an indexable geo value in column 'gpsLocation' (expected GEO_POINT or {lat, lon} object)."
+        )
+    );
+
+    let empty = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    empty.execute_query("CREATE DOCUMENT events").unwrap();
+    let res = empty
+        .execute_query(
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 10.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .unwrap();
+    assert!(res.result.records.is_empty());
+    assert_eq!(res.notice, None);
+
+    let miss = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    miss.execute_query("CREATE DOCUMENT events").unwrap();
+    miss.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":40.7,"lon":-74.0}})"#,
+    )
+    .unwrap();
+    let res = miss
+        .execute_query(
+            "SEARCH SPATIAL RADIUS 38.76 -77.15 1.0 COLLECTION events COLUMN gpsLocation",
+        )
+        .unwrap();
+    assert!(res.result.records.is_empty());
+    assert_eq!(res.notice, None);
 }
 
 #[test]


### PR DESCRIPTION
Lands the completed worker branch for #1937 (worker wY5FL finished coding but parked blocked:merge-conflict when sibling geo slices merged into the same grouped H3 e2e suite first). Conflicts resolved by keeping both sides' helper functions.

Closes #1937

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786160014&installation_id=129708444&pr_number=1978&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1978&signature=a487564aebbacc7c14aade7d144b32fcec56d8597024420cc806ceace1f69d9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->