### PR TITLE
chore: #1945 GEO_WITHIN predicate: composable geofencing in WHERE, planner-accelerated, one inside-test authority with the verb

### DIFF
--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -609,6 +609,22 @@ impl<'a> Parser<'a> {
             });
         }
 
+        if function_name.eq_ignore_ascii_case("POLYGON") {
+            let vertices = self.parse_polygon_expr_vertices()?;
+            super::search_commands::validate_search_spatial_polygon(&vertices, self.position())?;
+            let value = Value::Array(
+                vertices
+                    .into_iter()
+                    .map(|(lat, lon)| Value::Array(vec![Value::Float(lat), Value::Float(lon)]))
+                    .collect(),
+            );
+            let end = self.position();
+            return Ok(Expr::Literal {
+                value,
+                span: Span::new(start, end),
+            });
+        }
+
         if function_name.eq_ignore_ascii_case("COUNT") {
             if self.consume(&Token::Distinct)? {
                 let arg = self.parse_expr_prec(0)?;
@@ -684,6 +700,26 @@ impl<'a> Parser<'a> {
             args,
             span: Span::new(start, end),
         })
+    }
+
+    fn parse_polygon_expr_vertices(&mut self) -> Result<Vec<(f64, f64)>, ParseError> {
+        let mut vertices = Vec::new();
+        if self.check(&Token::RParen) {
+            self.expect(Token::RParen)?;
+            return Ok(vertices);
+        }
+        loop {
+            self.expect(Token::LParen)?;
+            let lat = self.parse_float()?;
+            let lon = self.parse_float()?;
+            self.expect(Token::RParen)?;
+            vertices.push((lat, lon));
+            if !self.consume(&Token::Comma)? {
+                break;
+            }
+        }
+        self.expect(Token::RParen)?;
+        Ok(vertices)
     }
 
     /// Parse a single CONFIG()/KV() argument. A bare identifier or

--- a/crates/reddb-rql/src/parser/search_commands.rs
+++ b/crates/reddb-rql/src/parser/search_commands.rs
@@ -674,7 +674,7 @@ impl<'a> Parser<'a> {
     }
 }
 
-fn validate_search_spatial_polygon(
+pub(super) fn validate_search_spatial_polygon(
     vertices: &[(f64, f64)],
     pos: crate::lexer::Position,
 ) -> Result<(), ParseError> {

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1673,6 +1673,13 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
                 lat1, lon1, lat2, lon2,
             )))
         }
+        "GEO_WITHIN" => {
+            let (lat, lon) = geo_point(args.first()?)?;
+            let vertices = polygon_vertices(args.get(1)?)?;
+            Some(Value::Boolean(crate::geo::point_in_polygon_even_odd(
+                lat, lon, &vertices,
+            )))
+        }
         "VINCENTY" => {
             let (lat1, lon1, lat2, lon2) = geo_args(args)?;
             Some(Value::Float(crate::geo::vincenty_km(
@@ -2184,6 +2191,24 @@ fn geo_args(args: &[Value]) -> Option<(f64, f64, f64, f64)> {
 
 fn geo_point(value: &Value) -> Option<(f64, f64)> {
     crate::geo::recognize_geo_value(value)
+}
+
+fn polygon_vertices(value: &Value) -> Option<Vec<(f64, f64)>> {
+    let Value::Array(vertices) = value else {
+        return None;
+    };
+    vertices
+        .iter()
+        .map(|vertex| {
+            let Value::Array(pair) = vertex else {
+                return None;
+            };
+            let [lat, lon] = pair.as_slice() else {
+                return None;
+            };
+            Some((value_as_f64(lat)?, value_as_f64(lon)?))
+        })
+        .collect()
 }
 
 fn value_as_f64(value: &Value) -> Option<f64> {

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -34,7 +34,7 @@ fn mark_table_scan_as_geo_h3_index_seek(
         node.operator = "geo_h3_index_seek".to_string();
         node.details.insert(
             "reason".to_string(),
-            "GEO_DISTANCE predicate uses H3 covering-ring candidates".to_string(),
+            "geo predicate uses H3 covering candidates".to_string(),
         );
         return true;
     }
@@ -64,6 +64,47 @@ fn explain_literal_f64(expr: &Expr) -> Option<f64> {
     }
 }
 
+fn explain_literal_bool(expr: &Expr) -> Option<bool> {
+    match expr {
+        Expr::Literal {
+            value: Value::Boolean(value),
+            ..
+        } => Some(*value),
+        _ => None,
+    }
+}
+
+fn explain_polygon_vertices(expr: &Expr) -> Option<Vec<(f64, f64)>> {
+    let Expr::Literal {
+        value: Value::Array(vertices),
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    vertices
+        .iter()
+        .map(|vertex| {
+            let Value::Array(pair) = vertex else {
+                return None;
+            };
+            let [lat, lon] = pair.as_slice() else {
+                return None;
+            };
+            Some((explain_value_f64(lat)?, explain_value_f64(lon)?))
+        })
+        .collect()
+}
+
+fn explain_value_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::UnsignedInteger(value) => Some(*value as f64),
+        _ => None,
+    }
+}
+
 fn flip_geo_compare_op(op: CompareOp) -> CompareOp {
     match op {
         CompareOp::Eq => CompareOp::Eq,
@@ -84,6 +125,11 @@ fn explain_h3_cover_is_enumerable(lat: f64, lon: f64, radius_km: f64, resolution
     const MAX_COVER_RING: u32 = 128;
     let k_f = (radius_km / edge_km).ceil() + 1.0;
     k_f.is_finite() && k_f <= f64::from(MAX_COVER_RING)
+}
+
+fn explain_h3_polygon_cover_is_enumerable(vertices: &[(f64, f64)], resolution: u8) -> bool {
+    const MAX_POLYGON_COVER_CELLS: usize = 50_000;
+    crate::geo::h3::polygon_to_cover_cells(vertices, resolution, MAX_POLYGON_COVER_CELLS).is_some()
 }
 
 impl RedDBRuntime {
@@ -218,30 +264,46 @@ impl RedDBRuntime {
     }
 
     fn geo_h3_route_column<'a>(&self, lhs: &'a Expr, op: CompareOp, rhs: &Expr) -> Option<&'a str> {
-        if !matches!(op, CompareOp::Lt | CompareOp::Le) {
-            return None;
-        }
-        let radius_km = explain_literal_f64(rhs)?;
-        if radius_km.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
-            return None;
-        }
         let Expr::FunctionCall { name, args, .. } = lhs else {
             return None;
         };
-        if !(name.eq_ignore_ascii_case("GEO_DISTANCE") || name.eq_ignore_ascii_case("HAVERSINE")) {
-            return None;
-        }
-        let [Expr::Column { field, .. }, lat, lon] = args.as_slice() else {
+        let field = if name.eq_ignore_ascii_case("GEO_DISTANCE")
+            || name.eq_ignore_ascii_case("HAVERSINE")
+        {
+            if !matches!(op, CompareOp::Lt | CompareOp::Le) {
+                return None;
+            }
+            let radius_km = explain_literal_f64(rhs)?;
+            if radius_km.partial_cmp(&0.0) != Some(std::cmp::Ordering::Greater) {
+                return None;
+            }
+            let [Expr::Column { field, .. }, lat, lon] = args.as_slice() else {
+                return None;
+            };
+            if !explain_h3_cover_is_enumerable(
+                explain_literal_f64(lat)?,
+                explain_literal_f64(lon)?,
+                radius_km,
+                9,
+            ) {
+                return None;
+            }
+            field
+        } else if name.eq_ignore_ascii_case("GEO_WITHIN") {
+            if !matches!(op, CompareOp::Eq) || !explain_literal_bool(rhs)? {
+                return None;
+            }
+            let [Expr::Column { field, .. }, polygon] = args.as_slice() else {
+                return None;
+            };
+            let vertices = explain_polygon_vertices(polygon)?;
+            if !explain_h3_polygon_cover_is_enumerable(&vertices, 9) {
+                return None;
+            }
+            field
+        } else {
             return None;
         };
-        if !explain_h3_cover_is_enumerable(
-            explain_literal_f64(lat)?,
-            explain_literal_f64(lon)?,
-            radius_km,
-            9,
-        ) {
-            return None;
-        }
         match field {
             FieldRef::TableColumn { column, .. } => Some(column.as_str()),
             _ => None,

--- a/crates/reddb-server/src/runtime/join_filter/scalar_functions.rs
+++ b/crates/reddb-server/src/runtime/join_filter/scalar_functions.rs
@@ -283,6 +283,13 @@ fn evaluate_scalar_function_legacy(
                 lat1, lon1, lat2, lon2,
             )))
         }
+        "GEO_WITHIN" => {
+            let (lat, lon) = resolve_geo_arg(args.first()?, source)?;
+            let vertices = polygon_vertices_from_value(&resolve_scalar_arg(args, 1, source)?)?;
+            Some(Value::Boolean(crate::geo::point_in_polygon_even_odd(
+                lat, lon, &vertices,
+            )))
+        }
         "TIME_BUCKET" => {
             let bucket_ns = resolve_time_bucket_duration(args, 0)?;
             let timestamp_ns = resolve_time_bucket_timestamp(args, source)?;
@@ -820,6 +827,27 @@ pub(super) fn value_as_number(v: &Value) -> Option<NumOperand> {
         }
         _ => None,
     }
+}
+
+fn polygon_vertices_from_value(value: &Value) -> Option<Vec<(f64, f64)>> {
+    let Value::Array(vertices) = value else {
+        return None;
+    };
+    vertices
+        .iter()
+        .map(|vertex| {
+            let Value::Array(pair) = vertex else {
+                return None;
+            };
+            let [lat, lon] = pair.as_slice() else {
+                return None;
+            };
+            Some((
+                value_as_number(lat)?.as_f64(),
+                value_as_number(lon)?.as_f64(),
+            ))
+        })
+        .collect()
 }
 
 /// Convert a `Value` to a new `Value` of the requested `DataType`. Used

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -65,7 +65,12 @@ struct GeoDistancePredicate<'a> {
     radius_km: f64,
 }
 
-fn execute_geo_distance_candidate_scan(
+struct GeoWithinPredicate<'a> {
+    column: &'a str,
+    vertices: Vec<(f64, f64)>,
+}
+
+fn execute_geo_h3_candidate_scan(
     db: &RedDB,
     query: &TableQuery,
     filter: &Filter,
@@ -163,20 +168,25 @@ fn execute_geo_distance_candidate_scan(
     Ok(records)
 }
 
-fn geo_distance_h3_candidate_ids(
+fn geo_h3_candidate_ids(
     filter: &Filter,
     table: &str,
     idx_store: &super::index_store::IndexStore,
 ) -> Option<std::collections::HashSet<u64>> {
     match filter {
         Filter::CompareExpr { lhs, op, rhs } => {
-            let predicate = geo_distance_predicate(lhs, *op, rhs)
-                .or_else(|| geo_distance_predicate(rhs, flipped_compare_op_for_geo(*op), lhs))?;
-            geo_distance_predicate_candidate_ids(predicate, table, idx_store)
+            if let Some(predicate) = geo_distance_predicate(lhs, *op, rhs)
+                .or_else(|| geo_distance_predicate(rhs, flipped_compare_op_for_geo(*op), lhs))
+            {
+                return geo_distance_predicate_candidate_ids(predicate, table, idx_store);
+            }
+            let predicate = geo_within_predicate(lhs, *op, rhs)
+                .or_else(|| geo_within_predicate(rhs, flipped_compare_op_for_geo(*op), lhs))?;
+            geo_within_predicate_candidate_ids(predicate, table, idx_store)
         }
         Filter::And(left, right) => {
-            let left_ids = geo_distance_h3_candidate_ids(left, table, idx_store);
-            let right_ids = geo_distance_h3_candidate_ids(right, table, idx_store);
+            let left_ids = geo_h3_candidate_ids(left, table, idx_store);
+            let right_ids = geo_h3_candidate_ids(right, table, idx_store);
             match (left_ids, right_ids) {
                 (Some(mut left), Some(right)) => {
                     left.retain(|id| right.contains(id));
@@ -187,8 +197,8 @@ fn geo_distance_h3_candidate_ids(
             }
         }
         Filter::Or(left, right) => {
-            let mut left_ids = geo_distance_h3_candidate_ids(left, table, idx_store)?;
-            let right_ids = geo_distance_h3_candidate_ids(right, table, idx_store)?;
+            let mut left_ids = geo_h3_candidate_ids(left, table, idx_store)?;
+            let right_ids = geo_h3_candidate_ids(right, table, idx_store)?;
             left_ids.extend(right_ids);
             Some(left_ids)
         }
@@ -230,6 +240,33 @@ fn geo_distance_predicate<'a>(
     })
 }
 
+fn geo_within_predicate<'a>(
+    lhs: &'a Expr,
+    op: CompareOp,
+    rhs: &Expr,
+) -> Option<GeoWithinPredicate<'a>> {
+    if !matches!(op, CompareOp::Eq) || !literal_bool(rhs)? {
+        return None;
+    }
+    let Expr::FunctionCall { name, args, .. } = lhs else {
+        return None;
+    };
+    if !name.eq_ignore_ascii_case("GEO_WITHIN") {
+        return None;
+    }
+    let [Expr::Column { field, .. }, polygon] = args.as_slice() else {
+        return None;
+    };
+    let column = match field {
+        FieldRef::TableColumn { column, .. } => column.as_str(),
+        _ => return None,
+    };
+    Some(GeoWithinPredicate {
+        column,
+        vertices: polygon_vertices_from_expr(polygon)?,
+    })
+}
+
 fn literal_f64(expr: &Expr) -> Option<f64> {
     match expr {
         Expr::Literal {
@@ -244,6 +281,47 @@ fn literal_f64(expr: &Expr) -> Option<f64> {
             value: Value::UnsignedInteger(value),
             ..
         } => Some(*value as f64),
+        _ => None,
+    }
+}
+
+fn literal_bool(expr: &Expr) -> Option<bool> {
+    match expr {
+        Expr::Literal {
+            value: Value::Boolean(value),
+            ..
+        } => Some(*value),
+        _ => None,
+    }
+}
+
+fn polygon_vertices_from_expr(expr: &Expr) -> Option<Vec<(f64, f64)>> {
+    let Expr::Literal {
+        value: Value::Array(vertices),
+        ..
+    } = expr
+    else {
+        return None;
+    };
+    vertices
+        .iter()
+        .map(|vertex| {
+            let Value::Array(pair) = vertex else {
+                return None;
+            };
+            let [lat, lon] = pair.as_slice() else {
+                return None;
+            };
+            Some((value_f64(lat)?, value_f64(lon)?))
+        })
+        .collect()
+}
+
+fn value_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Float(value) => Some(*value),
+        Value::Integer(value) => Some(*value as f64),
+        Value::UnsignedInteger(value) => Some(*value as f64),
         _ => None,
     }
 }
@@ -274,6 +352,39 @@ fn geo_distance_predicate_candidate_ids(
         predicate.radius_km,
         resolution,
     );
+    if cells.is_empty() {
+        return None;
+    }
+    let keys: Vec<_> = cells
+        .iter()
+        .filter_map(|cell| {
+            crate::storage::schema::value_to_canonical_key(&Value::UnsignedInteger(*cell))
+        })
+        .collect();
+    if keys.is_empty() {
+        return None;
+    }
+    let ids = idx_store
+        .sorted
+        .in_lookup_limited(table, predicate.column, &keys, usize::MAX)?;
+    Some(ids.into_iter().map(|id| id.raw()).collect())
+}
+
+fn geo_within_predicate_candidate_ids(
+    predicate: GeoWithinPredicate<'_>,
+    table: &str,
+    idx_store: &super::index_store::IndexStore,
+) -> Option<std::collections::HashSet<u64>> {
+    let index = idx_store.find_index_for_column(table, predicate.column)?;
+    let super::index_store::IndexMethodKind::H3 { resolution } = index.method else {
+        return None;
+    };
+    const MAX_POLYGON_COVER_CELLS: usize = 50_000;
+    let cells = crate::geo::h3::polygon_to_cover_cells(
+        &predicate.vertices,
+        resolution,
+        MAX_POLYGON_COVER_CELLS,
+    )?;
     if cells.is_empty() {
         return None;
     }
@@ -474,19 +585,16 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     let requires_mvcc_index_fallback =
         crate::runtime::impl_core::current_snapshot_requires_index_fallback();
 
-    // ── GEO_DISTANCE H3 CANDIDATE PATH ────────────────────────────────────────
-    // `WHERE GEO_DISTANCE(col, lat, lon) < r` over an H3-indexed column can
-    // use the same covering-ring candidate set as SEARCH SPATIAL RADIUS. The
-    // full WHERE expression is still evaluated after candidate pruning, so
-    // the index remains a pure optimization.
+    // ── GEO H3 CANDIDATE PATH ────────────────────────────────────────────────
+    // Geo predicates over H3-indexed columns can reuse the same candidate
+    // covers as SEARCH SPATIAL. The full WHERE expression is still evaluated
+    // after candidate pruning, so the index remains a pure optimization.
     if let (false, Some(idx_store), Some(ref filter)) =
         (requires_mvcc_index_fallback, index_store, &effective_filter)
     {
         if !is_universal_query_source(&query.table) {
-            if let Some(candidate_ids) =
-                geo_distance_h3_candidate_ids(filter, &query.table, idx_store)
-            {
-                return execute_geo_distance_candidate_scan(
+            if let Some(candidate_ids) = geo_h3_candidate_ids(filter, &query.table, idx_store) {
+                return execute_geo_h3_candidate_scan(
                     db,
                     query,
                     filter,

--- a/crates/reddb-types/src/function_catalog.rs
+++ b/crates/reddb-types/src/function_catalog.rs
@@ -110,6 +110,7 @@ const ARGS_TEXT_TWO_INT: &[DataType] = &[DataType::Text, DataType::Integer, Data
 const ARGS_NONE: &[DataType] = &[];
 const ARGS_TWO_FLOATS: &[DataType] = &[DataType::Float, DataType::Float];
 const ARGS_GEO_PAIR: &[DataType] = &[DataType::GeoPoint, DataType::GeoPoint];
+const ARGS_GEO_POLYGON: &[DataType] = &[DataType::GeoPoint, DataType::Array];
 const ARGS_FOUR_FLOATS: &[DataType] = &[
     DataType::Float,
     DataType::Float,
@@ -757,6 +758,13 @@ pub const FUNCTION_CATALOG: &[FunctionEntry] = &[
         "GEO_DISTANCE",
         ARGS_FOUR_FLOATS,
         DataType::Float,
+        FunctionKind::Scalar,
+        false,
+    ),
+    entry(
+        "GEO_WITHIN",
+        ARGS_GEO_POLYGON,
+        DataType::Boolean,
         FunctionKind::Scalar,
         false,
     ),

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -317,6 +317,21 @@ fn geo_distance_select_signature(rt: &RedDBRuntime, query: &str) -> Vec<(i64, u6
         .collect()
 }
 
+fn id_name_signature(rt: &RedDBRuntime, query: &str) -> Vec<(i64, String)> {
+    let res = rt.execute_query(query).expect("SELECT executes");
+    res.result
+        .records
+        .iter()
+        .map(|record| {
+            let id = match record.get("id") {
+                Some(Value::Integer(value)) => *value,
+                other => panic!("expected id integer field, got {other:?} in {record:?}"),
+            };
+            (id, text_field(record, "name").to_string())
+        })
+        .collect()
+}
+
 fn explain_ops(rt: &RedDBRuntime, query: &str) -> Vec<String> {
     rt.execute_query(query)
         .expect("EXPLAIN executes")
@@ -837,6 +852,97 @@ fn h3_accelerates_geo_distance_document_predicate_with_parity() {
         &rt,
         "CREATE INDEX idx_loc ON events (gpsLocation) USING H3",
         &[query],
+    );
+}
+
+#[test]
+fn geo_within_predicate_composes_over_rows_documents_and_h3_explain() {
+    let row_query = "SELECT id, name \
+                     FROM couriers \
+                     WHERE GEO_WITHIN(current, POLYGON((38.70 -77.20), (38.80 -77.20), (38.80 -77.05), (38.70 -77.05))) \
+                       AND status = 'available' \
+                       AND shift = 'night' \
+                     ORDER BY name \
+                     LIMIT 2";
+
+    let rows = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rows.execute_query(
+        "CREATE TABLE couriers (id INT, name TEXT, status TEXT, shift TEXT, current GEOPOINT)",
+    )
+    .unwrap();
+    rows.execute_query(
+        "INSERT INTO couriers (id, name, status, shift, current) VALUES \
+         (1, 'Ada', 'available', 'night', '38.75,-77.15'), \
+         (2, 'Bea', 'available', 'day', '38.75,-77.15'), \
+         (3, 'Cid', 'busy', 'night', '38.75,-77.15'), \
+         (4, 'Dee', 'available', 'night', '38.69,-77.15'), \
+         (5, 'Eli', 'available', 'night', '38.79,-77.19'), \
+         (6, 'Fay', 'available', 'night', NULL)",
+    )
+    .unwrap();
+
+    let baseline = id_name_signature(&rows, row_query);
+    assert_eq!(
+        baseline,
+        vec![(1, "Ada".to_string()), (5, "Eli".to_string())]
+    );
+
+    let verb = "SEARCH SPATIAL WITHIN POLYGON ((38.70 -77.20), (38.80 -77.20), (38.80 -77.05), (38.70 -77.05)) COLLECTION couriers COLUMN current";
+    assert_eq!(
+        spatial_entity_ids(&rows, verb),
+        vec![1, 2, 3, 5],
+        "GEO_WITHIN must agree with the verb before extra boolean predicates"
+    );
+
+    let scan_ops = explain_ops(&rows, &format!("EXPLAIN {row_query}"));
+    assert!(
+        scan_ops.iter().all(|op| op != "geo_h3_index_seek"),
+        "unindexed GEO_WITHIN plan must stay on the scan path: {scan_ops:?}"
+    );
+
+    rows.execute_query("CREATE INDEX idx_current ON couriers (current) USING H3")
+        .unwrap();
+    assert_eq!(
+        id_name_signature(&rows, row_query),
+        baseline,
+        "indexed GEO_WITHIN row predicate must match the scan path"
+    );
+    let indexed_ops = explain_ops(&rows, &format!("EXPLAIN {row_query}"));
+    assert!(
+        indexed_ops.iter().any(|op| op == "geo_h3_index_seek"),
+        "indexed GEO_WITHIN predicate should explain the H3 route: {indexed_ops:?}"
+    );
+
+    let docs = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    docs.execute_query("CREATE DOCUMENT couriers").unwrap();
+    docs.execute_query(
+        r#"INSERT INTO couriers DOCUMENT VALUES
+        ({"id":1,"name":"Ada","status":"available","shift":"night","current":{"lat":38.75,"lon":-77.15}}),
+        ({"id":2,"name":"Bea","status":"available","shift":"day","current":{"lat":38.75,"lon":-77.15}}),
+        ({"id":3,"name":"Cid","status":"busy","shift":"night","current":{"lat":38.75,"lon":-77.15}}),
+        ({"id":4,"name":"Dee","status":"available","shift":"night","current":{"lat":38.69,"lon":-77.15}}),
+        ({"id":5,"name":"Eli","status":"available","shift":"night","current":{"lat":38.79,"lon":-77.19}}),
+        ({"id":6,"name":"Fay","status":"available","shift":"night"})"#,
+    )
+    .unwrap();
+    let doc_baseline = id_name_signature(&docs, row_query);
+    assert_eq!(doc_baseline, baseline);
+    docs.execute_query("CREATE INDEX idx_current ON couriers (current) USING H3")
+        .unwrap();
+    assert_eq!(
+        id_name_signature(&docs, row_query),
+        doc_baseline,
+        "indexed GEO_WITHIN document predicate must match the scan path"
+    );
+
+    let non_constant_ops = explain_ops(
+        &rows,
+        "EXPLAIN SELECT id FROM couriers \
+         WHERE GEO_WITHIN(current, current)",
+    );
+    assert!(
+        non_constant_ops.iter().all(|op| op != "geo_h3_index_seek"),
+        "non-constant polygon expressions must keep the scan path: {non_constant_ops:?}"
     );
 }
 


### PR DESCRIPTION
Automated AFK landing for #1945. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1945

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786163413&installation_id=129708444&pr_number=1979&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1979&signature=8add9942b684e69fcf633ed87fffcadba42cce5862d31c6ca992bd82102a1a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->