### PR TITLE
fix(query): deterministic ORDER BY over computed GEO_DISTANCE aliases

### DIFF
--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1530,6 +1530,77 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     execute_runtime_canonical_table_node(db, &plan.root, &context)
 }
 
+/// Materialize computed SELECT-alias values referenced by ORDER BY onto the
+/// records before sorting (#1982). The planner places the sort node *below*
+/// the projection node, so a computed alias such as `GEO_DISTANCE(...) AS dist`
+/// is not yet a column when the sort runs — resolving the bare name yields
+/// `None` for every row, the comparator treats all rows as equal, and the
+/// stable sort leaves them in nondeterministic scan order (ORDER BY silently
+/// no-ops). We compute the alias with the same `project_runtime_record_with_db`
+/// the projection node uses — which resolves document-body fields correctly on
+/// the lean records — and inject it as a virtual column; the sort then finds
+/// it, and the projection node re-projects it idempotently. Re-evaluating the
+/// expression directly at sort time does NOT work: the lean records do not
+/// expose document-body fields to the bare expression evaluator.
+fn materialize_order_by_computed_keys(
+    db: &RedDB,
+    records: &mut [UnifiedRecord],
+    order_by: &[OrderByClause],
+    projections: &[Projection],
+    table_name: &str,
+    table_alias: &str,
+    document_projection: bool,
+    entity_projection: bool,
+) {
+    let referenced: Vec<String> = order_by
+        .iter()
+        .filter(|clause| clause.expr.is_none())
+        .filter_map(|clause| match &clause.field {
+            FieldRef::TableColumn { table, column } if table.is_empty() => Some(column.clone()),
+            _ => None,
+        })
+        .collect();
+    if referenced.is_empty() {
+        return;
+    }
+    let needed: Vec<&Projection> = projections
+        .iter()
+        .filter(|projection| {
+            matches!(
+                projection,
+                Projection::Function(..) | Projection::Expression(..)
+            ) && referenced
+                .iter()
+                .any(|name| *name == projection_name(projection))
+        })
+        .collect();
+    if needed.is_empty() {
+        return;
+    }
+    for record in records.iter_mut() {
+        for projection in &needed {
+            let name = projection_name(projection);
+            if record.get(name.as_str()).is_some() {
+                continue;
+            }
+            if let Ok(projected) = project_runtime_record_with_db(
+                Some(db),
+                record,
+                std::slice::from_ref(*projection),
+                Some(table_name),
+                Some(table_alias),
+                document_projection,
+                entity_projection,
+            ) {
+                if let Some(value) = projected.get(name.as_str()) {
+                    let value = value.clone();
+                    record.set(name.as_str(), value);
+                }
+            }
+        }
+    }
+}
+
 pub(crate) fn execute_runtime_canonical_table_node(
     db: &RedDB,
     node: &crate::storage::query::planner::CanonicalLogicalNode,
@@ -1797,6 +1868,23 @@ pub(crate) fn execute_runtime_canonical_table_node(
             if !context.query.order_by.is_empty() {
                 // Issue #769 — cap the materialized sort buffer.
                 crate::runtime::materialization_limit::guard(db, "sort", records.len())?;
+                // #1982 — materialize computed SELECT aliases referenced by
+                // ORDER BY before sorting, so the sort finds the column instead
+                // of resolving it to None and leaving rows unordered.
+                let effective_projections = effective_table_projections(context.query);
+                let document_projection = node.operator == "document_sort"
+                    || runtime_projections_use_document_path(&effective_projections, context.query);
+                let entity_projection = node.operator == "entity_sort";
+                materialize_order_by_computed_keys(
+                    db,
+                    &mut records,
+                    &context.query.order_by,
+                    &effective_projections,
+                    context.table_name,
+                    context.table_alias,
+                    document_projection,
+                    entity_projection,
+                );
                 super::super::join_filter::sort_records_by_order_by_with_db(
                     Some(db),
                     &mut records,


### PR DESCRIPTION
## What

Fixes the nondeterministic `ORDER BY` on a computed `GEO_DISTANCE(...) AS dist` alias over document collections (#1982). Distances were computed correctly, but the sort silently failed to order by them — rows came out in HashMap scan order, wrong ~20% of runs.

## Root cause

The planner places the sort node **below** the projection node, so a computed SELECT alias isn't a materialized column when the sort runs. `resolve_runtime_field("dist")` returned `None` for every row → the comparator saw all rows equal → the stable sort preserved nondeterministic scan order. Pinned to `table.rs:1800` (the canonical `sort` node) via backtrace.

## Fix

Materialize the ORDER BY-referenced computed projection aliases onto the records **before** the sort, reusing `project_runtime_record_with_db` — the same routine the projection node uses, which resolves document-body fields correctly on lean records. A rejected first approach (binding the alias to its expression and re-evaluating at sort time) regressed the flake to 22/40 because lean records don't expose document-body fields to the bare expression evaluator; details in #1982.

## Validation

- Target module `e2e_h3_index` under nextest, serial, **40 consecutive runs: 0 failures** (baseline ~8/40; rejected approach 22/40).
- Full `grouped_sql_core` suite: **279/279 pass**.
- Designed gate green: `cargo clippy --locked -- -D warnings`, `cargo fmt`.

Unblocks #1943, #1945, #1938 (all exercised ORDER BY / parity over geo document bodies and hit this flake).

Closes #1982

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786195875&installation_id=129708444&pr_number=1983&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1983&signature=dd4ec7fe35a9a968dcf7090f69a22355cf939e8f61c6be3fd5b36f0f75d89fd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->