### PR TITLE
chore: #1959 Named DST fault classes: torn_write, misdirected_write, bit_rot, lost_write as seeded buggify knobs (ADR 0074 §1)

### DIFF
--- a/crates/reddb-file/src/dst.rs
+++ b/crates/reddb-file/src/dst.rs
@@ -2,16 +2,162 @@
 //!
 //! `buggify!()` is intentionally debug-only. Release builds compile the macro
 //! to `false`, so production crash hooks keep their legacy env-var behavior.
+//!
+//! # Named fault classes (ADR 0074 §1)
+//!
+//! Beyond the crash/delay boundaries `buggify!` guards, the context owns the
+//! vocabulary for the four modeled storage fault classes — [`FaultClass`]. Each
+//! is individually addressable by name with its own probability (ppm), is **off
+//! by default** (`0` ppm), and is release-inert exactly like `buggify!`: the
+//! [`buggify_fault!`] macro compiles to `None` outside `debug_assertions`.
+//!
+//! A fired knob yields a [`FaultDecision`] whose parameters are drawn from the
+//! same seeded stream as every other simulation decision, so a seed reproduces
+//! the whole fault schedule byte for byte. Every applied injection is appended
+//! to the campaign's **fault log** ([`FaultRecord`]) with class, target file,
+//! offset and length, so an oracle can compute which durable objects a campaign
+//! actually touched.
 
 use crate::clock::{Clock, SimClock};
 use std::cell::RefCell;
+use std::fmt;
 use std::rc::Rc;
 
 const DEFAULT_BUGGIFY_PPM: u64 = 10_000;
 const PPM_DENOMINATOR: u64 = 1_000_000;
 
+/// The simulated sector size a torn write is cut at.
+pub const SECTOR_BYTES: u64 = 512;
+
+/// The `env` label the fault-class knobs record under in the buggify trace.
+pub const FAULT_ENV: &str = "REDDB_DST_FAULT";
+
 thread_local! {
     static ACTIVE: RefCell<Option<Rc<RefCell<ActiveSimulation>>>> = const { RefCell::new(None) };
+}
+
+/// The four modeled storage fault classes (ADR 0074 §1). Crash-at-any-point is
+/// modeled separately by the existing `buggify!` crash boundaries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum FaultClass {
+    /// A write persists only a prefix of its buffer, cut at a sector boundary.
+    TornWrite,
+    /// A write persists the correct bytes at a wrong offset, reporting success.
+    MisdirectedWrite,
+    /// Stored bytes acquire a flipped bit between the write and a later read.
+    BitRot,
+    /// The write (or its fsync effect) is dropped entirely; success is reported.
+    LostWrite,
+}
+
+impl FaultClass {
+    /// Every class, in a stable order (the order knobs are rolled in).
+    pub const ALL: [Self; 4] = [
+        Self::TornWrite,
+        Self::MisdirectedWrite,
+        Self::BitRot,
+        Self::LostWrite,
+    ];
+
+    /// The stable, machine-readable name a campaign selects the knob by.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::TornWrite => "torn_write",
+            Self::MisdirectedWrite => "misdirected_write",
+            Self::BitRot => "bit_rot",
+            Self::LostWrite => "lost_write",
+        }
+    }
+
+    /// Parse a class from its [`name`](Self::name).
+    pub fn from_name(name: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|class| class.name() == name)
+    }
+
+    const fn index(self) -> usize {
+        match self {
+            Self::TornWrite => 0,
+            Self::MisdirectedWrite => 1,
+            Self::BitRot => 2,
+            Self::LostWrite => 3,
+        }
+    }
+}
+
+impl fmt::Display for FaultClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// A fired knob's deterministic parameters — what the backend must actually do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FaultDecision {
+    /// Persist only `persisted` bytes of the buffer, then report the full length.
+    TornWrite { persisted: u64 },
+    /// Persist the whole buffer at `actual_offset` instead of the requested one.
+    MisdirectedWrite { actual_offset: u64 },
+    /// Flip bit `bit` of the byte at absolute `byte_offset` when it is read back.
+    BitRot { byte_offset: u64, bit: u8 },
+    /// Persist nothing; report success.
+    LostWrite,
+}
+
+impl FaultDecision {
+    /// The class this decision belongs to.
+    pub const fn class(self) -> FaultClass {
+        match self {
+            Self::TornWrite { .. } => FaultClass::TornWrite,
+            Self::MisdirectedWrite { .. } => FaultClass::MisdirectedWrite,
+            Self::BitRot { .. } => FaultClass::BitRot,
+            Self::LostWrite => FaultClass::LostWrite,
+        }
+    }
+}
+
+/// One applied injection, as an oracle consumes it: which class hit which file,
+/// at which offset, over how many bytes, with the class-specific parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FaultRecord {
+    pub class: FaultClass,
+    pub file: String,
+    pub offset: u64,
+    pub length: u64,
+    pub decision: FaultDecision,
+}
+
+impl FaultRecord {
+    /// Build a record for a decision applied to `file` over `[offset, offset + length)`.
+    pub fn new(file: impl Into<String>, offset: u64, length: u64, decision: FaultDecision) -> Self {
+        Self {
+            class: decision.class(),
+            file: file.into(),
+            offset,
+            length,
+            decision,
+        }
+    }
+}
+
+/// One `key=value` line per injection: the machine-readable fault-log form.
+impl fmt::Display for FaultRecord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "class={} file={} offset={} length={}",
+            self.class, self.file, self.offset, self.length
+        )?;
+        match self.decision {
+            FaultDecision::TornWrite { persisted } => write!(f, " persisted={persisted}"),
+            FaultDecision::MisdirectedWrite { actual_offset } => {
+                write!(f, " actual_offset={actual_offset}")
+            }
+            FaultDecision::BitRot { byte_offset, bit } => {
+                write!(f, " byte_offset={byte_offset} bit={bit}")
+            }
+            FaultDecision::LostWrite => Ok(()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -19,6 +165,9 @@ pub struct SimulationContext {
     seed: u64,
     clock_start_ms: u64,
     buggify_ppm: u64,
+    /// Per-class probability in parts-per-million, indexed by [`FaultClass::index`].
+    /// All zero: every named fault class is off unless a campaign asks for it.
+    fault_ppm: [u64; 4],
 }
 
 impl SimulationContext {
@@ -27,6 +176,7 @@ impl SimulationContext {
             seed,
             clock_start_ms: seed,
             buggify_ppm: DEFAULT_BUGGIFY_PPM,
+            fault_ppm: [0; 4],
         }
     }
 
@@ -35,6 +185,18 @@ impl SimulationContext {
             buggify_ppm: buggify_ppm.min(PPM_DENOMINATOR),
             ..Self::new(seed)
         }
+    }
+
+    /// Arm one named fault class at `ppm`. `0` leaves it off (the default).
+    #[must_use]
+    pub fn with_fault_class(mut self, class: FaultClass, ppm: u64) -> Self {
+        self.fault_ppm[class.index()] = ppm.min(PPM_DENOMINATOR);
+        self
+    }
+
+    /// The probability currently armed for `class`.
+    pub fn fault_ppm(&self, class: FaultClass) -> u64 {
+        self.fault_ppm[class.index()]
     }
 
     pub fn install(self) -> SimulationGuard {
@@ -53,6 +215,19 @@ impl SimulationGuard {
     pub fn trace(&self) -> Vec<u8> {
         self.active.borrow().trace.clone()
     }
+
+    /// Every injection applied under this context, in order.
+    pub fn fault_log(&self) -> Vec<FaultRecord> {
+        self.active.borrow().fault_log.clone()
+    }
+
+    /// The fault log as newline-terminated `key=value` lines.
+    pub fn fault_log_lines(&self) -> String {
+        self.fault_log()
+            .iter()
+            .map(|record| format!("{record}\n"))
+            .collect()
+    }
 }
 
 impl Drop for SimulationGuard {
@@ -68,8 +243,10 @@ struct ActiveSimulation {
     clock: SimClock,
     rng: SplitMix64,
     buggify_ppm: u64,
+    fault_ppm: [u64; 4],
     tick: u64,
     trace: Vec<u8>,
+    fault_log: Vec<FaultRecord>,
 }
 
 impl ActiveSimulation {
@@ -80,8 +257,10 @@ impl ActiveSimulation {
             clock: SimClock::from_seed(context.clock_start_ms),
             rng: SplitMix64::new(context.seed ^ 0x4255_4747_4946_595F), // "BUGGIFY_"
             buggify_ppm: context.buggify_ppm,
+            fault_ppm: context.fault_ppm,
             tick: 0,
             trace,
+            fault_log: Vec::new(),
         }
     }
 
@@ -133,6 +312,96 @@ pub fn is_active() -> bool {
     ACTIVE.with(|slot| slot.borrow().is_some())
 }
 
+/// Roll the seeded coin for one named fault class over `[offset, offset + length)`.
+///
+/// Returns `None` when no simulation is installed, when the class is not armed
+/// (`0` ppm — the default), or when the coin simply did not fire. A fired knob
+/// consumes further draws from the same stream to derive its parameters, so the
+/// whole schedule is a pure function of the seed and the armed probabilities.
+///
+/// This only *decides*; the backend that applies the fault calls
+/// [`record_fault`] with the target file so the log names a durable object.
+pub fn roll_fault(class: FaultClass, offset: u64, length: u64) -> Option<FaultDecision> {
+    ACTIVE.with(|slot| {
+        let active = slot.borrow().clone()?;
+        let mut active = active.borrow_mut();
+        let ppm = active.fault_ppm[class.index()];
+        // An unarmed class draws nothing: "off by default" must not perturb the
+        // stream a campaign without it would have seen.
+        if ppm == 0 || !active.boundary(FAULT_ENV, class.name(), ppm) {
+            return None;
+        }
+        let decision = derive_fault(class, offset, length, &mut || active.rng.next_u64());
+        Some(decision)
+    })
+}
+
+/// Append an applied injection to the active campaign's fault log. A no-op when
+/// no simulation is installed.
+pub fn record_fault(record: FaultRecord) {
+    ACTIVE.with(|slot| {
+        if let Some(active) = slot.borrow().clone() {
+            active.borrow_mut().fault_log.push(record);
+        }
+    });
+}
+
+/// Derive a fired knob's parameters from `next`, the campaign's seeded stream.
+///
+/// Pure and stream-driven so both the simulation context and an out-of-context
+/// backend (a `SimVfs` rolling its own coins) produce the same fault shapes.
+///
+/// A [`FaultClass::TornWrite`] is cut at the first simulated sector boundary the
+/// write crosses, choosing uniformly among them. A write that never crosses one
+/// — the common case for small WAL frames — is cut at a byte prefix instead,
+/// modeling sub-sector tearing; the cut is always a strict prefix, so a fired
+/// knob always loses bytes.
+pub fn derive_fault(
+    class: FaultClass,
+    offset: u64,
+    length: u64,
+    next: &mut dyn FnMut() -> u64,
+) -> FaultDecision {
+    match class {
+        FaultClass::TornWrite => FaultDecision::TornWrite {
+            persisted: torn_prefix(offset, length, next),
+        },
+        FaultClass::MisdirectedWrite => {
+            let delta = SECTOR_BYTES * (1 + next() % 4);
+            let backwards = next() % 2 == 1;
+            let actual_offset = if backwards && offset >= delta {
+                offset - delta
+            } else {
+                offset.saturating_add(delta)
+            };
+            FaultDecision::MisdirectedWrite { actual_offset }
+        }
+        FaultClass::BitRot => {
+            let byte_offset = offset + if length == 0 { 0 } else { next() % length };
+            let bit = u8::try_from(next() % 8).unwrap_or(0);
+            FaultDecision::BitRot { byte_offset, bit }
+        }
+        FaultClass::LostWrite => FaultDecision::LostWrite,
+    }
+}
+
+/// How many bytes of a torn write reach the platter: a sector-aligned cut when
+/// the write crosses a sector boundary, otherwise a strict byte prefix.
+fn torn_prefix(offset: u64, length: u64, next: &mut dyn FnMut() -> u64) -> u64 {
+    if length == 0 {
+        return 0;
+    }
+    let end = offset + length;
+    let first_boundary = (offset / SECTOR_BYTES + 1) * SECTOR_BYTES;
+    if first_boundary >= end {
+        // Entirely inside one sector: tear at a strict byte prefix (0..length-1).
+        return next() % length;
+    }
+    let boundaries = (end - 1 - first_boundary) / SECTOR_BYTES + 1;
+    let chosen = first_boundary + (next() % boundaries) * SECTOR_BYTES;
+    chosen - offset
+}
+
 #[derive(Debug, Clone)]
 struct SplitMix64 {
     state: u64,
@@ -175,8 +444,28 @@ macro_rules! buggify {
     }};
 }
 
+/// Roll one named fault class, release-inert like [`buggify!`].
+///
+/// Debug builds consult the installed simulation context; release builds
+/// compile to `None`, so no production write path can ever be perturbed.
+#[macro_export]
+macro_rules! buggify_fault {
+    ($class:expr, $offset:expr, $length:expr) => {{
+        #[cfg(debug_assertions)]
+        {
+            $crate::dst::roll_fault($class, $offset, $length)
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = ($class, $offset, $length);
+            ::core::option::Option::<$crate::dst::FaultDecision>::None
+        }
+    }};
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::dst::{FaultClass, FaultDecision, FaultRecord, SECTOR_BYTES};
     use crate::SimulationContext;
 
     const ENV: &str = "REDDB_EMBEDDED_RDB_CRASH_AT";
@@ -206,5 +495,190 @@ mod tests {
         assert!(trace.contains("env=REDDB_EMBEDDED_RDB_CRASH_AT"));
         assert!(trace.contains("point=snapshot_after_manifest_write"));
         assert!(trace.contains("fired=true"));
+    }
+
+    #[test]
+    fn fault_classes_round_trip_through_their_names() {
+        for class in FaultClass::ALL {
+            assert_eq!(FaultClass::from_name(class.name()), Some(class));
+        }
+        assert_eq!(FaultClass::from_name("not_a_class"), None);
+    }
+
+    #[test]
+    fn every_fault_class_is_off_by_default() {
+        let context = SimulationContext::new(7);
+        for class in FaultClass::ALL {
+            assert_eq!(context.fault_ppm(class), 0, "{class} must default to off");
+        }
+        let guard = context.install();
+        for class in FaultClass::ALL {
+            assert_eq!(crate::buggify_fault!(class, 0, 64), None);
+        }
+        assert!(guard.fault_log().is_empty());
+        // An unarmed class draws nothing, so it cannot perturb the seed stream.
+        assert!(!String::from_utf8(guard.trace())
+            .unwrap()
+            .contains("env=REDDB_DST_FAULT"));
+    }
+
+    #[test]
+    fn each_class_is_individually_triggerable_by_name_and_ppm() {
+        for armed in FaultClass::ALL {
+            let guard = SimulationContext::new(99)
+                .with_fault_class(armed, 1_000_000)
+                .install();
+            for class in FaultClass::ALL {
+                let decision = crate::buggify_fault!(class, SECTOR_BYTES + 8, 64);
+                if class == armed {
+                    let decision = decision.unwrap_or_else(|| panic!("{armed} must fire at 1e6"));
+                    assert_eq!(decision.class(), armed);
+                } else {
+                    assert_eq!(decision, None, "{class} must stay off while {armed} is armed");
+                }
+            }
+            let trace = String::from_utf8(guard.trace()).unwrap();
+            assert!(trace.contains(&format!("point={armed}")));
+        }
+    }
+
+    #[test]
+    fn a_torn_write_crossing_a_sector_is_cut_at_a_sector_boundary() {
+        let guard = SimulationContext::new(5)
+            .with_fault_class(FaultClass::TornWrite, 1_000_000)
+            .install();
+        // Spans sectors 0..=2, so the cut must land on 512 or 1024.
+        let offset = 8;
+        let Some(FaultDecision::TornWrite { persisted }) =
+            crate::buggify_fault!(FaultClass::TornWrite, offset, 1_200)
+        else {
+            panic!("torn_write must fire at 1e6")
+        };
+        assert!((offset + persisted) % SECTOR_BYTES == 0, "cut at {persisted}");
+        assert!(persisted < 1_200, "a torn write always loses bytes");
+        drop(guard);
+    }
+
+    #[test]
+    fn a_torn_write_inside_one_sector_is_cut_at_a_strict_byte_prefix() {
+        let _guard = SimulationContext::new(6)
+            .with_fault_class(FaultClass::TornWrite, 1_000_000)
+            .install();
+        // A 48-byte WAL frame never crosses a sector: sub-sector tearing.
+        let Some(FaultDecision::TornWrite { persisted }) =
+            crate::buggify_fault!(FaultClass::TornWrite, 64, 48)
+        else {
+            panic!("torn_write must fire at 1e6")
+        };
+        assert!(persisted < 48, "a torn write always loses bytes");
+    }
+
+    #[test]
+    fn a_misdirected_write_lands_a_whole_number_of_sectors_away() {
+        let _guard = SimulationContext::new(11)
+            .with_fault_class(FaultClass::MisdirectedWrite, 1_000_000)
+            .install();
+        for offset in [0, 64, 4_096, 10_000] {
+            let Some(FaultDecision::MisdirectedWrite { actual_offset }) =
+                crate::buggify_fault!(FaultClass::MisdirectedWrite, offset, 64)
+            else {
+                panic!("misdirected_write must fire at 1e6")
+            };
+            assert_ne!(actual_offset, offset, "the write must land elsewhere");
+            assert_eq!(actual_offset.abs_diff(offset) % SECTOR_BYTES, 0);
+        }
+    }
+
+    #[test]
+    fn bit_rot_targets_a_byte_inside_the_read_region() {
+        let _guard = SimulationContext::new(13)
+            .with_fault_class(FaultClass::BitRot, 1_000_000)
+            .install();
+        for _ in 0..32 {
+            let Some(FaultDecision::BitRot { byte_offset, bit }) =
+                crate::buggify_fault!(FaultClass::BitRot, 100, 40)
+            else {
+                panic!("bit_rot must fire at 1e6")
+            };
+            assert!((100..140).contains(&byte_offset));
+            assert!(bit < 8);
+        }
+    }
+
+    #[test]
+    fn the_fault_log_records_class_file_offset_and_length() {
+        let guard = SimulationContext::new(21)
+            .with_fault_class(FaultClass::LostWrite, 1_000_000)
+            .install();
+        let decision = crate::buggify_fault!(FaultClass::LostWrite, 4_096, 512)
+            .expect("lost_write must fire at 1e6");
+        crate::dst::record_fault(FaultRecord::new("/db/wal.log", 4_096, 512, decision));
+
+        let log = guard.fault_log();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].class, FaultClass::LostWrite);
+        assert_eq!(log[0].file, "/db/wal.log");
+        assert_eq!(log[0].offset, 4_096);
+        assert_eq!(log[0].length, 512);
+        assert_eq!(
+            guard.fault_log_lines(),
+            "class=lost_write file=/db/wal.log offset=4096 length=512\n"
+        );
+    }
+
+    #[test]
+    fn same_seed_produces_an_identical_fault_schedule() {
+        fn schedule(seed: u64) -> Vec<String> {
+            let mut context = SimulationContext::new(seed);
+            for class in FaultClass::ALL {
+                context = context.with_fault_class(class, 300_000);
+            }
+            let guard = context.install();
+            for step in 0..64u64 {
+                for class in FaultClass::ALL {
+                    let offset = step * 97;
+                    if let Some(decision) = crate::buggify_fault!(class, offset, 64) {
+                        crate::dst::record_fault(FaultRecord::new(
+                            "/db/wal.log",
+                            offset,
+                            64,
+                            decision,
+                        ));
+                    }
+                }
+            }
+            guard.fault_log().iter().map(ToString::to_string).collect()
+        }
+
+        let first = schedule(0xDEAD);
+        assert!(!first.is_empty(), "the sweep must inject something");
+        assert_eq!(first, schedule(0xDEAD), "same seed → same fault schedule");
+        assert_ne!(first, schedule(0xBEEF), "different seeds must diverge");
+    }
+
+    #[test]
+    fn fault_classes_compose_with_the_crash_knob_deterministically() {
+        fn run(seed: u64) -> Vec<u8> {
+            let guard = SimulationContext::with_buggify_ppm(seed, 500_000)
+                .with_fault_class(FaultClass::TornWrite, 400_000)
+                .install();
+            for _ in 0..32 {
+                let _crashed = crate::buggify!(ENV, "wal_after_frame_write");
+                if let Some(decision) = crate::buggify_fault!(FaultClass::TornWrite, 64, 48) {
+                    crate::dst::record_fault(FaultRecord::new("/db/wal.log", 64, 48, decision));
+                }
+            }
+            let mut out = guard.trace();
+            out.extend_from_slice(guard.fault_log_lines().as_bytes());
+            out
+        }
+        assert_eq!(run(1234), run(1234), "crash + torn_write must replay exactly");
+    }
+
+    #[test]
+    fn no_fault_fires_without_an_installed_context() {
+        for class in FaultClass::ALL {
+            assert_eq!(crate::buggify_fault!(class, 0, 64), None);
+        }
     }
 }

--- a/crates/reddb-file/src/dst.rs
+++ b/crates/reddb-file/src/dst.rs
@@ -534,7 +534,10 @@ mod tests {
                     let decision = decision.unwrap_or_else(|| panic!("{armed} must fire at 1e6"));
                     assert_eq!(decision.class(), armed);
                 } else {
-                    assert_eq!(decision, None, "{class} must stay off while {armed} is armed");
+                    assert_eq!(
+                        decision, None,
+                        "{class} must stay off while {armed} is armed"
+                    );
                 }
             }
             let trace = String::from_utf8(guard.trace()).unwrap();
@@ -554,7 +557,10 @@ mod tests {
         else {
             panic!("torn_write must fire at 1e6")
         };
-        assert!((offset + persisted) % SECTOR_BYTES == 0, "cut at {persisted}");
+        assert!(
+            (offset + persisted) % SECTOR_BYTES == 0,
+            "cut at {persisted}"
+        );
         assert!(persisted < 1_200, "a torn write always loses bytes");
         drop(guard);
     }
@@ -672,7 +678,11 @@ mod tests {
             out.extend_from_slice(guard.fault_log_lines().as_bytes());
             out
         }
-        assert_eq!(run(1234), run(1234), "crash + torn_write must replay exactly");
+        assert_eq!(
+            run(1234),
+            run(1234),
+            "crash + torn_write must replay exactly"
+        );
     }
 
     #[test]

--- a/crates/reddb-file/src/dst.rs
+++ b/crates/reddb-file/src/dst.rs
@@ -691,4 +691,21 @@ mod tests {
             assert_eq!(crate::buggify_fault!(class, 0, 64), None);
         }
     }
+
+    /// The `buggify_fault!` posture matches `buggify!`: debug builds consult the
+    /// installed context, release builds compile the call away to `None`, so no
+    /// production write path can be perturbed. Written to hold under both
+    /// profiles, which also type-checks the release arm of the macro.
+    #[test]
+    fn the_fault_macro_is_release_inert() {
+        let _guard = SimulationContext::new(3)
+            .with_fault_class(FaultClass::LostWrite, 1_000_000)
+            .install();
+        let fired = crate::buggify_fault!(FaultClass::LostWrite, 0, 8);
+        if cfg!(debug_assertions) {
+            assert_eq!(fired, Some(FaultDecision::LostWrite));
+        } else {
+            assert_eq!(fired, None, "release builds must never inject a fault");
+        }
+    }
 }

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -127,7 +127,7 @@ pub use control_store::{
     DurableLastVote, FileLastVoteStore, FileTermStore, DEFAULT_FILE_TERM, LAST_VOTE_TEMP_EXTENSION,
     TERM_TEMP_EXTENSION,
 };
-pub use dst::SimulationContext;
+pub use dst::{FaultClass, FaultDecision, FaultRecord, SimulationContext};
 pub use embedded::{
     EmbeddedRdbArtifact, EmbeddedRdbManifest, EmbeddedRdbOpen, EmbeddedRdbSuperblock, RdbFileError,
     RdbFileResult, DEFAULT_FORMAT_VERSION, EMBEDDED_RDB_MANIFEST_OFFSET,

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -338,9 +338,19 @@ impl SimState {
 
     /// Collapse every file to its post-crash durable image (torn unsynced tail)
     /// and mark the device gone.
+    ///
+    /// Files are torn in path order: each one draws from the seeded stream, so
+    /// hash iteration order would otherwise make the crash image differ between
+    /// two runs of the same seed.
     fn trip_power_cut(&mut self) {
-        for file in self.files.values_mut() {
-            let image = crash_image(file, &mut self.rng);
+        let mut paths: Vec<PathBuf> = self.files.keys().cloned().collect();
+        paths.sort();
+        for path in paths {
+            let Self { files, rng, .. } = self;
+            let Some(file) = files.get_mut(&path) else {
+                continue;
+            };
+            let image = crash_image(file, rng);
             file.durable = image.clone();
             file.live = image;
             file.dirty.clear();

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -920,7 +920,10 @@ mod tests {
 
     /// A device with one named class armed at certainty, and nothing else.
     fn armed(seed: u64, class: FaultClass) -> SimVfs {
-        SimVfs::new(seed, SimFaultConfig::none().with_fault_class(class, 1_000_000))
+        SimVfs::new(
+            seed,
+            SimFaultConfig::none().with_fault_class(class, 1_000_000),
+        )
     }
 
     #[test]

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -35,14 +35,34 @@
 //!   became durable, so the old target survives) or leave a torn target when
 //!   the source was not fully durable. A `sync_dir` after the rename is what
 //!   makes it durable.
+//!
+//! # Named fault classes (#1959, ADR 0074 §1)
+//!
+//! On top of the families above, [`SimVfs`] applies the four modeled storage
+//! fault classes — [`FaultClass::TornWrite`], [`FaultClass::MisdirectedWrite`],
+//! [`FaultClass::BitRot`] and [`FaultClass::LostWrite`] — each armed by name at
+//! its own ppm through [`SimFaultConfig`], each off by default, and each
+//! composing freely with the crash/delay knobs. Write-side classes are rolled on
+//! every `write_all`; `bit_rot` is rolled on the read side ([`VfsFile::read`]
+//! and [`SimVfs::crash_image`], the recovery reader's read) so the original
+//! write path is untouched.
+//!
+//! Every applied injection is appended to the device's [`fault log`](SimVfs::fault_log)
+//! — class, target file, offset, length — and mirrored into the campaign's
+//! [`SimulationContext`](reddb_file::SimulationContext) log when one is
+//! installed. Exactly as with the crash knobs, an installed simulation context
+//! takes over the coin flips (and their probabilities) so `buggify!`-driven
+//! campaigns stay on the seed's single decision stream.
 
 use crate::prng::SplitMix64;
+use reddb_file::dst::{self, FaultClass, FaultDecision, FaultRecord};
 use std::collections::HashMap;
 use std::io::{self, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const TURBO_CRASH_INJECT_ENV: &str = "REDDB_TURBO_CRASH_AT";
+const PPM_DENOMINATOR: u64 = 1_000_000;
 
 /// How a file is opened. Mirrors the subset of `OpenOptions` the durable
 /// writers actually use.
@@ -171,6 +191,21 @@ pub struct SimFaultConfig {
     pub revert_rename_ppm: u64,
     /// A `rename` leaves a torn (byte-prefix) target on crash.
     pub torn_rename_ppm: u64,
+    /// ADR 0074 §1 `torn_write`: a `write` persists only a prefix of its buffer,
+    /// cut at a simulated sector boundary, then reports the full length.
+    pub torn_write_ppm: u64,
+    /// Whether a fired `torn_write` also cuts power instead of reporting the
+    /// full length — the campaign's choice between the two modeled outcomes.
+    pub torn_write_crashes: bool,
+    /// ADR 0074 §1 `misdirected_write`: a `write` persists the correct bytes at
+    /// a wrong (seed-derived) offset and reports success.
+    pub misdirected_write_ppm: u64,
+    /// ADR 0074 §1 `bit_rot`: stored bytes come back with a flipped bit on a
+    /// later read. Rolled on the read side, so the write path is untouched.
+    pub bit_rot_ppm: u64,
+    /// ADR 0074 §1 `lost_write`: the `write` is dropped entirely while success
+    /// is reported.
+    pub lost_write_ppm: u64,
     /// Force a power-cut after this many durability syscalls (`None` = run to
     /// completion). A power-cut torns the unsynced tail of every file.
     pub power_cut_after: Option<u64>,
@@ -185,7 +220,34 @@ impl SimFaultConfig {
             reorder_fsync_ppm: 0,
             revert_rename_ppm: 0,
             torn_rename_ppm: 0,
+            torn_write_ppm: 0,
+            torn_write_crashes: false,
+            misdirected_write_ppm: 0,
+            bit_rot_ppm: 0,
+            lost_write_ppm: 0,
             power_cut_after: None,
+        }
+    }
+
+    /// Arm one named fault class at `ppm`, leaving every other knob alone.
+    #[must_use]
+    pub fn with_fault_class(mut self, class: FaultClass, ppm: u64) -> Self {
+        match class {
+            FaultClass::TornWrite => self.torn_write_ppm = ppm,
+            FaultClass::MisdirectedWrite => self.misdirected_write_ppm = ppm,
+            FaultClass::BitRot => self.bit_rot_ppm = ppm,
+            FaultClass::LostWrite => self.lost_write_ppm = ppm,
+        }
+        self
+    }
+
+    /// The probability armed for `class`.
+    pub fn fault_ppm(&self, class: FaultClass) -> u64 {
+        match class {
+            FaultClass::TornWrite => self.torn_write_ppm,
+            FaultClass::MisdirectedWrite => self.misdirected_write_ppm,
+            FaultClass::BitRot => self.bit_rot_ppm,
+            FaultClass::LostWrite => self.lost_write_ppm,
         }
     }
 }
@@ -213,14 +275,49 @@ struct SimState {
     syscalls: u64,
     /// Set once a power-cut fires; all further durable calls fail.
     crashed: bool,
+    /// Every named-fault-class injection applied to this device, in order.
+    fault_log: Vec<FaultRecord>,
 }
 
 impl SimState {
     fn fires(&mut self, point: &str, ppm: u64) -> bool {
-        if reddb_file::dst::is_active() {
-            return reddb_file::dst::buggify_at(TURBO_CRASH_INJECT_ENV, point, ppm);
+        if dst::is_active() {
+            return dst::buggify_at(TURBO_CRASH_INJECT_ENV, point, ppm);
         }
-        ppm != 0 && self.rng.below(1_000_000) < ppm
+        ppm != 0 && self.rng.below(PPM_DENOMINATOR) < ppm
+    }
+
+    /// Roll the coin for one named fault class over `[offset, offset + length)`.
+    ///
+    /// An installed [`SimulationContext`](reddb_file::SimulationContext) owns the
+    /// decision (and the probability), mirroring how `fires` defers the crash
+    /// knobs; otherwise the device rolls its own seeded coin against
+    /// [`SimFaultConfig`]. Both paths derive the fault's parameters through the
+    /// same [`dst::derive_fault`], so a class behaves identically either way.
+    fn roll(&mut self, class: FaultClass, offset: u64, length: u64) -> Option<FaultDecision> {
+        if length == 0 {
+            return None;
+        }
+        if dst::is_active() {
+            return dst::roll_fault(class, offset, length);
+        }
+        let ppm = self.cfg.fault_ppm(class);
+        if ppm == 0 || self.rng.below(PPM_DENOMINATOR) >= ppm {
+            return None;
+        }
+        let rng = &mut self.rng;
+        Some(dst::derive_fault(class, offset, length, &mut || {
+            rng.next_u64()
+        }))
+    }
+
+    /// Log an injection the device actually applied. When several classes fire on
+    /// one call only the applied one is recorded, so the log names exactly the
+    /// durable bytes that were touched.
+    fn record(&mut self, path: &Path, offset: u64, length: u64, decision: FaultDecision) {
+        let record = FaultRecord::new(path.display().to_string(), offset, length, decision);
+        dst::record_fault(record.clone());
+        self.fault_log.push(record);
     }
 
     /// Charge one durability syscall and trip the power-cut once the budget is
@@ -285,6 +382,31 @@ fn apply_write(image: &mut Vec<u8>, offset: usize, bytes: &[u8]) {
     image[offset..end].copy_from_slice(bytes);
 }
 
+/// Apply read-side [`FaultClass::BitRot`] to bytes leaving the device: roll the
+/// class over the served region and, if it fires, flip the chosen bit in the
+/// caller's copy. The stored image is never touched — the corruption is
+/// *observed* on read, exactly as a rotted sector is.
+///
+/// `base` is the absolute file offset the buffer starts at, so the logged offset
+/// names a real durable location.
+fn rot_bits(state: &mut SimState, path: &Path, base: u64, bytes: &mut [u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    let length = bytes.len() as u64;
+    let Some(decision @ FaultDecision::BitRot { byte_offset, bit }) =
+        state.roll(FaultClass::BitRot, base, length)
+    else {
+        return;
+    };
+    let index = as_usize(byte_offset.saturating_sub(base));
+    let Some(byte) = bytes.get_mut(index) else {
+        return;
+    };
+    *byte ^= 1u8 << bit;
+    state.record(path, base, length, decision);
+}
+
 fn power_cut_error() -> io::Error {
     io::Error::other(POWER_CUT_MESSAGE)
 }
@@ -319,8 +441,23 @@ impl SimVfs {
                 cfg,
                 syscalls: 0,
                 crashed: false,
+                fault_log: Vec::new(),
             })),
         }
+    }
+
+    /// Every named-fault-class injection applied to this device, in order — the
+    /// campaign's machine-readable fault log (class, file, offset, length).
+    pub fn fault_log(&self) -> Vec<FaultRecord> {
+        self.lock().fault_log.clone()
+    }
+
+    /// The fault log as newline-terminated `key=value` lines.
+    pub fn fault_log_lines(&self) -> String {
+        self.fault_log()
+            .iter()
+            .map(|record| format!("{record}\n"))
+            .collect()
     }
 
     /// Trigger a power-cut now (torns every unsynced tail). Idempotent.
@@ -344,24 +481,37 @@ impl SimVfs {
     /// Snapshot every file's post-crash durable image. If no power-cut has
     /// fired, this is the current durable state; otherwise it is the torn image
     /// left by the crash. Use this to materialize the device for the oracle.
+    ///
+    /// This is the recovery reader's read of the device, so it is where
+    /// [`FaultClass::BitRot`] surfaces: the stored bytes are handed back with a
+    /// flipped bit while the device itself keeps what the write path put there.
+    /// Files are visited in path order so the seeded fault schedule does not
+    /// depend on hash iteration order.
     pub fn crash_image(&self) -> HashMap<PathBuf, Vec<u8>> {
         let mut state = self.lock();
-        if !state.crashed {
-            // Compute a torn image without mutating state, so callers can both
-            // inspect and keep simulating.
-            let mut out = HashMap::new();
-            let SimState { files, rng, .. } = &mut *state;
-            for (path, file) in files.iter() {
-                out.insert(path.clone(), crash_image(file, rng));
+        let crashed = state.crashed;
+        let mut paths: Vec<PathBuf> = state.files.keys().cloned().collect();
+        paths.sort();
+
+        let mut images: Vec<(PathBuf, Vec<u8>)> = Vec::with_capacity(paths.len());
+        for path in paths {
+            let image = if crashed {
+                state.files.get(&path).map(|f| f.durable.clone())
+            } else {
+                // Compute a torn image without mutating state, so callers can
+                // both inspect and keep simulating.
+                let SimState { files, rng, .. } = &mut *state;
+                files.get(&path).map(|file| crash_image(file, rng))
+            };
+            if let Some(image) = image {
+                images.push((path, image));
             }
-            out
-        } else {
-            state
-                .files
-                .iter()
-                .map(|(p, f)| (p.clone(), f.durable.clone()))
-                .collect()
         }
+
+        for (path, bytes) in &mut images {
+            rot_bits(&mut state, path, 0, bytes);
+        }
+        images.into_iter().collect()
     }
 
     /// Materialize the post-crash device into a real directory so the
@@ -396,6 +546,15 @@ impl SimFileHandle {
 }
 
 impl VfsFile for SimFileHandle {
+    /// Apply one write, subject to `ENOSPC` and the three write-side named fault
+    /// classes.
+    ///
+    /// All three classes are rolled on every call, in a fixed order, so the seed
+    /// stream never depends on which of them fired. When more than one fires the
+    /// most destructive wins: a `lost_write` persists nothing, so it subsumes a
+    /// misdirected or torn one; a `misdirected_write` moves the whole buffer, so
+    /// it subsumes a tear of the buffer at its requested offset. Only the applied
+    /// class reaches the fault log.
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
         let mut state = self.lock();
         state.charge()?;
@@ -403,20 +562,58 @@ impl VfsFile for SimFileHandle {
         if state.fires("simvfs_enospc", enospc_ppm) {
             return Err(enospc_error());
         }
-        let offset = usize::try_from(self.pos).unwrap_or(usize::MAX);
-        if let Some(file) = state.files.get_mut(&self.path) {
-            apply_write(&mut file.live, offset, buf);
-            file.dirty.push((offset, buf.to_vec()));
-        } else {
+        if !state.files.contains_key(&self.path) {
             return Err(io::Error::new(io::ErrorKind::NotFound, "file not open"));
         }
+
+        let offset = self.pos;
+        let length = buf.len() as u64;
+        let lost = state.roll(FaultClass::LostWrite, offset, length);
+        let misdirected = state.roll(FaultClass::MisdirectedWrite, offset, length);
+        let torn = state.roll(FaultClass::TornWrite, offset, length);
+
+        // The writer is told the full buffer landed in every one of these cases;
+        // only the durable bytes differ. The cursor therefore always advances.
+        let (target, persisted, decision) = match (lost, misdirected, torn) {
+            (Some(decision), _, _) => (offset, 0, Some(decision)),
+            (_, Some(decision @ FaultDecision::MisdirectedWrite { actual_offset }), _) => {
+                (actual_offset, buf.len(), Some(decision))
+            }
+            (_, _, Some(decision @ FaultDecision::TornWrite { persisted })) => {
+                (offset, as_usize(persisted).min(buf.len()), Some(decision))
+            }
+            _ => (offset, buf.len(), None),
+        };
+
+        if persisted > 0 {
+            let at = as_usize(target);
+            if let Some(file) = state.files.get_mut(&self.path) {
+                apply_write(&mut file.live, at, &buf[..persisted]);
+                file.dirty.push((at, buf[..persisted].to_vec()));
+            }
+        }
+        if let Some(decision) = decision {
+            state.record(&self.path, offset, length, decision);
+        }
+
+        // A torn write may also take the power with it, per campaign choice.
+        let crashing_tear = state.cfg.torn_write_crashes
+            && matches!(decision, Some(FaultDecision::TornWrite { .. }));
+        if crashing_tear {
+            state.trip_power_cut();
+            return Err(power_cut_error());
+        }
+
         drop(state);
-        self.pos += buf.len() as u64;
+        self.pos += length;
         Ok(())
     }
 
+    /// Read at the cursor. Bytes leaving the device pass through read-side
+    /// [`FaultClass::BitRot`], so a rotted sector is observed here rather than
+    /// having been written wrong.
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let state = self.lock();
+        let mut state = self.lock();
         let file = state
             .files
             .get(&self.path)
@@ -427,6 +624,7 @@ impl VfsFile for SimFileHandle {
         let end = (start + buf.len()).min(file.live.len());
         let n = end - start;
         buf[..n].copy_from_slice(&file.live[start..end]);
+        rot_bits(&mut state, &self.path, start as u64, &mut buf[..n]);
         drop(state);
         self.pos += n as u64;
         Ok(n)
@@ -708,6 +906,167 @@ mod tests {
             vfs.crash_image().get(Path::new("dst")).unwrap().as_slice(),
             b"NEWVALUE"
         );
+    }
+
+    /// A device with one named class armed at certainty, and nothing else.
+    fn armed(seed: u64, class: FaultClass) -> SimVfs {
+        SimVfs::new(seed, SimFaultConfig::none().with_fault_class(class, 1_000_000))
+    }
+
+    #[test]
+    fn no_named_fault_class_fires_by_default() {
+        let vfs = SimVfs::new(17, SimFaultConfig::none());
+        let path = Path::new("clean.bin");
+        let mut f = vfs.open(path, OpenMode::create_truncate()).unwrap();
+        f.write_all(b"untouched").unwrap();
+        f.sync_all().unwrap();
+        assert_eq!(read_back(&vfs, path), b"untouched");
+        assert!(vfs.fault_log().is_empty(), "classes must be off by default");
+    }
+
+    #[test]
+    fn lost_write_reports_success_and_persists_nothing() {
+        let vfs = armed(31, FaultClass::LostWrite);
+        let path = Path::new("lost.bin");
+        let mut f = vfs.open(path, OpenMode::create_truncate()).unwrap();
+        // The writer is told the write landed...
+        f.write_all(b"acknowledged").unwrap();
+        f.sync_all().unwrap();
+        // ...but nothing reached the platter.
+        assert!(vfs.crash_image().get(path).unwrap().is_empty());
+
+        let log = vfs.fault_log();
+        assert_eq!(log.len(), 1);
+        assert_eq!(log[0].class, FaultClass::LostWrite);
+        assert_eq!(log[0].file, "lost.bin");
+        assert_eq!(log[0].offset, 0);
+        assert_eq!(log[0].length, b"acknowledged".len() as u64);
+    }
+
+    #[test]
+    fn torn_write_persists_only_a_prefix_but_reports_the_full_length() {
+        let vfs = armed(37, FaultClass::TornWrite);
+        let path = Path::new("torn.bin");
+        let mut f = vfs.open(path, OpenMode::create_truncate()).unwrap();
+        let payload = [0xABu8; 64];
+        f.write_all(&payload).unwrap();
+        f.sync_all().unwrap();
+
+        let durable = vfs.crash_image().get(path).unwrap().clone();
+        assert!(durable.len() < payload.len(), "the tear must lose bytes");
+        assert!(payload.starts_with(&durable), "what landed is a prefix");
+        let log = vfs.fault_log();
+        assert_eq!(log[0].class, FaultClass::TornWrite);
+        assert_eq!(
+            log[0].decision,
+            FaultDecision::TornWrite {
+                persisted: durable.len() as u64
+            }
+        );
+    }
+
+    #[test]
+    fn torn_write_can_take_the_power_with_it() {
+        let cfg = SimFaultConfig {
+            torn_write_crashes: true,
+            ..SimFaultConfig::none().with_fault_class(FaultClass::TornWrite, 1_000_000)
+        };
+        let vfs = SimVfs::new(41, cfg);
+        let mut f = vfs
+            .open(Path::new("crash.bin"), OpenMode::create_truncate())
+            .unwrap();
+        let err = f.write_all(&[7u8; 32]).unwrap_err();
+        assert!(err.to_string().contains(POWER_CUT_MESSAGE));
+        assert!(vfs.is_crashed());
+    }
+
+    #[test]
+    fn misdirected_write_lands_the_right_bytes_at_the_wrong_offset() {
+        let vfs = armed(43, FaultClass::MisdirectedWrite);
+        let path = Path::new("misdirected.bin");
+        let mut f = vfs.open(path, OpenMode::create_keep()).unwrap();
+        f.seek(SeekFrom::Start(4_096)).unwrap();
+        f.write_all(b"PAYLOAD").unwrap();
+        f.sync_all().unwrap();
+
+        let log = vfs.fault_log();
+        assert_eq!(log[0].class, FaultClass::MisdirectedWrite);
+        let FaultDecision::MisdirectedWrite { actual_offset } = log[0].decision else {
+            panic!("expected a misdirected write")
+        };
+        assert_ne!(actual_offset, 4_096);
+
+        let durable = vfs.crash_image().get(path).unwrap().clone();
+        let at = as_usize(actual_offset);
+        assert_eq!(&durable[at..at + 7], b"PAYLOAD", "right bytes, wrong place");
+        // The requested offset never received the bytes.
+        assert_ne!(durable.get(4_096..4_103), Some(&b"PAYLOAD"[..]));
+    }
+
+    #[test]
+    fn bit_rot_flips_a_bit_on_read_without_touching_the_write_path() {
+        let vfs = armed(47, FaultClass::BitRot);
+        let path = Path::new("rot.bin");
+        let mut f = vfs.open(path, OpenMode::create_truncate()).unwrap();
+        let payload = [0u8; 32];
+        f.write_all(&payload).unwrap();
+        f.sync_all().unwrap();
+        // The write path is untouched: every fault so far is a read-side rot.
+        assert!(vfs.fault_log().is_empty());
+
+        let served = read_back(&vfs, path);
+        assert_eq!(served.len(), payload.len());
+        let flipped: Vec<usize> = (0..payload.len()).filter(|&i| served[i] != 0).collect();
+        assert_eq!(flipped.len(), 1, "exactly one byte rots per read");
+        assert_eq!(served[flipped[0]].count_ones(), 1, "exactly one bit flips");
+
+        let log = vfs.fault_log();
+        assert_eq!(log[0].class, FaultClass::BitRot);
+        assert_eq!(log[0].file, "rot.bin");
+    }
+
+    #[test]
+    fn a_fired_class_is_the_only_one_logged_for_that_write() {
+        // Every write-side class armed at certainty: `lost_write` dominates, so
+        // the log names exactly the bytes that were (not) touched.
+        let mut cfg = SimFaultConfig::none();
+        for class in FaultClass::ALL {
+            cfg = cfg.with_fault_class(class, 1_000_000);
+        }
+        let vfs = SimVfs::new(53, cfg);
+        let mut f = vfs
+            .open(Path::new("all.bin"), OpenMode::create_truncate())
+            .unwrap();
+        f.write_all(b"gone").unwrap();
+        let log = vfs.fault_log();
+        assert_eq!(log.len(), 1, "one applied injection, one record");
+        assert_eq!(log[0].class, FaultClass::LostWrite);
+    }
+
+    #[test]
+    fn same_seed_produces_an_identical_fault_log() {
+        let mut cfg = SimFaultConfig {
+            power_cut_after: Some(24),
+            ..SimFaultConfig::none()
+        };
+        for class in FaultClass::ALL {
+            cfg = cfg.with_fault_class(class, 120_000);
+        }
+        let run = || {
+            let vfs = SimVfs::new(0xC0FFEE, cfg);
+            for i in 0..16u8 {
+                let Ok(mut f) = vfs.open(Path::new("s.bin"), OpenMode::create_keep()) else {
+                    break;
+                };
+                let _ = f.write_all(&[i; 40]);
+                let _ = f.sync_all();
+            }
+            let _ = vfs.crash_image();
+            vfs.fault_log_lines()
+        };
+        let first = run();
+        assert!(!first.is_empty(), "the sweep must inject something");
+        assert_eq!(first, run(), "same seed → identical fault schedule");
     }
 
     #[test]

--- a/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
+++ b/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
@@ -10,21 +10,31 @@
 //! [`recover_and_check`]. Because everything is in-process and in-memory, this
 //! lane runs on every OS and enumerates many more seeds per second than the
 //! shim — a failing seed prints and reproduces exactly via `SEED=<n>`.
+//!
+//! Since #1959 the same campaign also arms the four **named fault classes** of
+//! ADR 0074 §1 (`torn_write`, `misdirected_write`, `bit_rot`, `lost_write`) at
+//! low ppm, asserts the fault log records every injection, and checks that a
+//! checksum-detectable injection surfaces as a *detection event* rather than as
+//! silent corruption.
 
 #![allow(clippy::unwrap_used)]
 
-use reddb_file::SimulationContext;
+use reddb_file::{FaultClass, FaultRecord, SimulationContext};
+use std::collections::BTreeSet;
 use std::path::Path;
 use unreliable_libc::vfs::POWER_CUT_MESSAGE;
-use unreliable_libc::wal_workload::{MANIFEST_FILE_NAME, MANIFEST_TEMP_NAME};
+use unreliable_libc::wal_workload::{MANIFEST_FILE_NAME, MANIFEST_TEMP_NAME, WAL_FILE_NAME};
 use unreliable_libc::{
-    decode_manifest, recover_and_check, run_wal_workload_on, RecoveryReport, SimFaultConfig, SimVfs,
+    decode_manifest, recover_and_check, run_wal_workload_on, RecoveryError, RecoveryReport,
+    SimFaultConfig, SimVfs,
 };
 
 /// Working directory inside the simulated device (paths are virtual).
 const SIM_DIR: &str = "/db";
 /// How many seeds to enumerate when `SEED` is not pinned.
 const SEED_COUNT: u64 = 256;
+/// How many seeds the (slower, materializing) fault-class sweep enumerates.
+const FAULT_SEED_COUNT: u64 = 64;
 
 /// Derive a fault config from the seed so each seed exercises a different
 /// interleaving of every fault family, including a power-cut budget.
@@ -37,6 +47,7 @@ fn config_for(seed: u64) -> SimFaultConfig {
         torn_rename_ppm: 80_000 + (seed % 6) * 20_000,    // 8%..18%
         // Cut power somewhere inside the workload's durability syscalls.
         power_cut_after: Some(4 + seed % 60),
+        ..SimFaultConfig::none()
     }
 }
 
@@ -203,5 +214,246 @@ fn pinned_regression_seed_1337() {
     let report = run_seed(1337, config_for(1337));
     if let Some(sb_lsn) = report.superblock_committed_lsn {
         assert!(sb_lsn <= report.last_committed_lsn);
+    }
+}
+
+// --------------------------------------------------------------------------
+// Named fault classes (#1959, ADR 0074 §1)
+// --------------------------------------------------------------------------
+
+/// The same crash campaign, additionally arming all four named classes at low
+/// ppm. `bit_rot` gets a higher ppm than the write-side classes because it is
+/// rolled once per file when the recovery reader reads the crash image, not once
+/// per write — a few rolls per seed instead of a hundred.
+fn fault_class_config_for(seed: u64) -> SimFaultConfig {
+    SimFaultConfig {
+        torn_write_ppm: 20_000,        // 2% per write
+        misdirected_write_ppm: 15_000, // 1.5% per write
+        lost_write_ppm: 15_000,        // 1.5% per write
+        bit_rot_ppm: 150_000,          // 15% per file read back
+        power_cut_after: Some(6 + seed % 60),
+        ..SimFaultConfig::none()
+    }
+}
+
+/// What one fault-class campaign seed produced: which injections landed, and
+/// what recovery made of the resulting device.
+struct FaultOutcome {
+    faults: Vec<FaultRecord>,
+    recovery: Result<RecoveryReport, RecoveryError>,
+}
+
+impl FaultOutcome {
+    fn classes(&self) -> BTreeSet<FaultClass> {
+        self.faults.iter().map(|record| record.class).collect()
+    }
+
+    /// Whether any injection hit a file the recovery oracle reads.
+    fn touched_a_recovered_object(&self) -> bool {
+        self.faults
+            .iter()
+            .any(|record| !record.file.ends_with(MANIFEST_TEMP_NAME))
+    }
+}
+
+/// Run one seed of the fault-class campaign. Unlike [`run_seed`], a recovery
+/// error is *not* a test failure here: corruption injected by a named class is
+/// meant to be detected, and detection is what an error means. The caller
+/// decides whether the error was attributable.
+fn run_fault_seed(seed: u64, cfg: SimFaultConfig) -> FaultOutcome {
+    let vfs = SimVfs::new(seed, cfg);
+    if let Err(err) = run_wal_workload_on(&vfs, Path::new(SIM_DIR), seed) {
+        let msg = err.to_string();
+        let os = err.raw_os_error();
+        assert!(
+            msg.contains(POWER_CUT_MESSAGE) || os == Some(28) || os == Some(5),
+            "SEED={seed}: unexpected workload error: {err}"
+        );
+    }
+
+    let crash_dir = tempfile::tempdir().unwrap();
+    // `materialize` reads the device, which is where `bit_rot` is injected.
+    vfs.materialize(crash_dir.path()).unwrap();
+    let recovery = recover_and_check(crash_dir.path());
+
+    FaultOutcome {
+        faults: vfs.fault_log(),
+        recovery,
+    }
+}
+
+/// The campaign exercises every class, logs every injection with a target the
+/// oracle can attribute, and never fails the oracle without a fault to explain
+/// it — the no-false-negative contract. A seed whose faults all missed (or were
+/// overwritten before any read) must still recover cleanly.
+#[test]
+fn all_four_fault_classes_are_injected_logged_and_attributable() {
+    let mut observed: BTreeSet<FaultClass> = BTreeSet::new();
+
+    for seed in fault_seeds() {
+        let outcome = run_fault_seed(seed, fault_class_config_for(seed));
+        observed.extend(outcome.classes());
+
+        for record in &outcome.faults {
+            assert!(!record.file.is_empty(), "SEED={seed}: fault names no file");
+            assert!(
+                record.length > 0,
+                "SEED={seed}: fault covers no bytes: {record}"
+            );
+        }
+
+        match &outcome.recovery {
+            // The faults landed where the checksum contract truncates them away,
+            // or in bytes overwritten before any read.
+            Ok(report) => {
+                if let Some(sb_lsn) = report.superblock_committed_lsn {
+                    assert!(sb_lsn <= report.last_committed_lsn, "SEED={seed}");
+                }
+            }
+            // A detection event. It must be explained by an injection: a crash
+            // alone can never violate a recovery invariant.
+            Err(err) => {
+                assert!(
+                    !outcome.faults.is_empty(),
+                    "SEED={seed}: oracle violated with no injected fault: {err}\n\
+                     reproduce with: SEED={seed} cargo nextest run -p unreliable-libc \
+                     --test sim_power_cut_recovery"
+                );
+                assert!(
+                    outcome.touched_a_recovered_object(),
+                    "SEED={seed}: oracle violated but every fault hit a staging file: {err}\n\
+                     fault log:\n{}",
+                    outcome
+                        .faults
+                        .iter()
+                        .map(|record| format!("  {record}\n"))
+                        .collect::<String>()
+                );
+            }
+        }
+    }
+
+    if std::env::var("SEED").is_err() {
+        assert_eq!(
+            observed,
+            FaultClass::ALL.into_iter().collect::<BTreeSet<_>>(),
+            "the campaign must exercise every named class across the sweep"
+        );
+    }
+}
+
+/// A crash-only campaign injects nothing: the classes are off by default, so the
+/// pre-#1959 behavior of this lane is unchanged.
+#[test]
+fn named_classes_are_off_in_the_crash_only_campaign() {
+    for seed in fault_seeds() {
+        let outcome = run_fault_seed(seed, config_for(seed));
+        assert!(
+            outcome.faults.is_empty(),
+            "SEED={seed}: a crash-only campaign must inject no named fault"
+        );
+        outcome
+            .recovery
+            .unwrap_or_else(|err| panic!("SEED={seed}: crash-only recovery must hold: {err}"));
+    }
+}
+
+/// Determinism: the same seed replays the identical fault schedule — class,
+/// target and offset, byte for byte.
+#[test]
+fn same_seed_produces_an_identical_fault_schedule() {
+    let schedule = |seed: u64| {
+        run_fault_seed(seed, fault_class_config_for(seed))
+            .faults
+            .iter()
+            .map(|record| format!("{record}\n"))
+            .collect::<String>()
+    };
+
+    let first = schedule(4242);
+    assert!(!first.is_empty(), "seed 4242 must inject something");
+    assert_eq!(first, schedule(4242), "same seed → same fault schedule");
+    assert_ne!(first, schedule(4243), "different seeds must diverge");
+}
+
+/// Composition: `torn_write` alongside the crash knob stays deterministic and
+/// reproducible, both in what it injected and in what recovery saw.
+#[test]
+fn crash_plus_torn_write_composes_deterministically() {
+    let cfg = SimFaultConfig {
+        torn_write_ppm: 60_000,
+        power_cut_after: Some(30),
+        ..SimFaultConfig::none()
+    };
+    let run = |seed: u64| {
+        let outcome = run_fault_seed(seed, cfg);
+        let log = outcome
+            .faults
+            .iter()
+            .map(|record| format!("{record}\n"))
+            .collect::<String>();
+        (log, format!("{:?}", outcome.recovery))
+    };
+
+    for seed in 0..16u64 {
+        let first = run(seed);
+        assert!(
+            first.0.contains("class=torn_write") || first.1.contains("Ok"),
+            "SEED={seed}: a torn write must either land or leave recovery clean"
+        );
+        assert_eq!(first, run(seed), "SEED={seed}: crash + torn_write must replay");
+    }
+}
+
+/// Checksum-detectable corruption surfaces as a detection event, never as a
+/// silently-accepted commit frontier: bit rot inside the WAL either fails the
+/// oracle outright or shows up as a truncated (torn) recovery.
+#[test]
+fn bit_rot_in_the_wal_is_detected_not_silently_accepted() {
+    let cfg = SimFaultConfig::none().with_fault_class(FaultClass::BitRot, 1_000_000);
+
+    for seed in 0..32u64 {
+        let outcome = run_fault_seed(seed, cfg);
+
+        let rotted_wal = outcome
+            .faults
+            .iter()
+            .any(|record| record.class == FaultClass::BitRot && record.file.ends_with(WAL_FILE_NAME));
+        assert!(rotted_wal, "SEED={seed}: bit_rot at 1e6 must rot the WAL");
+
+        match outcome.recovery {
+            Err(_) => {} // detected
+            Ok(report) => assert!(
+                report.torn_tail_bytes > 0,
+                "SEED={seed}: a rotted WAL recovered clean — silent corruption"
+            ),
+        }
+    }
+}
+
+/// A `lost_write` on the WAL can only ever lose the tail: recovery may see fewer
+/// commits, never a commit the workload had not durably made.
+#[test]
+fn lost_writes_never_resurrect_a_commit() {
+    let cfg = SimFaultConfig::none().with_fault_class(FaultClass::LostWrite, 80_000);
+    for seed in 0..32u64 {
+        let outcome = run_fault_seed(seed, cfg);
+        if let Ok(report) = outcome.recovery {
+            if let Some(sb_lsn) = report.superblock_committed_lsn {
+                assert!(sb_lsn <= report.last_committed_lsn, "SEED={seed}");
+            }
+        }
+    }
+}
+
+/// Which seeds the fault-class sweep enumerates: a single pinned seed when
+/// `SEED` is set, otherwise the sweep.
+fn fault_seeds() -> Vec<u64> {
+    match std::env::var("SEED") {
+        Ok(raw) => match raw.parse::<u64>() {
+            Ok(seed) => vec![seed],
+            Err(_) => (0..FAULT_SEED_COUNT).collect(),
+        },
+        Err(_) => (0..FAULT_SEED_COUNT).collect(),
     }
 }

--- a/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
+++ b/crates/unreliable-libc/tests/sim_power_cut_recovery.rs
@@ -401,7 +401,11 @@ fn crash_plus_torn_write_composes_deterministically() {
             first.0.contains("class=torn_write") || first.1.contains("Ok"),
             "SEED={seed}: a torn write must either land or leave recovery clean"
         );
-        assert_eq!(first, run(seed), "SEED={seed}: crash + torn_write must replay");
+        assert_eq!(
+            first,
+            run(seed),
+            "SEED={seed}: crash + torn_write must replay"
+        );
     }
 }
 
@@ -415,10 +419,9 @@ fn bit_rot_in_the_wal_is_detected_not_silently_accepted() {
     for seed in 0..32u64 {
         let outcome = run_fault_seed(seed, cfg);
 
-        let rotted_wal = outcome
-            .faults
-            .iter()
-            .any(|record| record.class == FaultClass::BitRot && record.file.ends_with(WAL_FILE_NAME));
+        let rotted_wal = outcome.faults.iter().any(|record| {
+            record.class == FaultClass::BitRot && record.file.ends_with(WAL_FILE_NAME)
+        });
         assert!(rotted_wal, "SEED={seed}: bit_rot at 1e6 must rot the WAL");
 
         match outcome.recovery {

--- a/docs/testing/dst-storage-fault-lane.md
+++ b/docs/testing/dst-storage-fault-lane.md
@@ -20,7 +20,8 @@ SEED=<n> make test-dst-storage
 The lane currently runs these suites:
 
 - `sim_power_cut_recovery`: in-process `SimVfs` coverage for torn writes,
-  dropped or reordered fsync, ENOSPC, partial rename, and seeded power cuts.
+  dropped or reordered fsync, ENOSPC, partial rename, seeded power cuts, and the
+  four named ADR 0074 §1 fault classes (see [Fault Classes](#fault-classes)).
 - `value_equivalence_recovery`: typed-value crash recovery, asserting recovered
   committed values match the model's committed prefix.
 - `power_cut_recovery`: Linux `LD_PRELOAD` shim coverage for real process kills,
@@ -32,6 +33,70 @@ The lane currently runs these suites:
 - `store_fork_lifecycle_recovery`: store-fork lifecycle campaign for #1784,
   injecting power cuts during fork creation, first-touch hydration, and
   promotion.
+
+## Fault Classes
+
+ADR 0074 §1 names the storage faults RedDB models. Four of them are injectable
+knobs; crash-at-any-point is modeled separately by the existing `buggify!` crash
+boundaries and the `power_cut_after` budget.
+
+Each class is selected **by name** with its own probability in parts-per-million,
+is **off by default** (`0` ppm), and composes freely with the crash and delay
+knobs. Every decision is drawn from the campaign's seeded stream, so the same
+seed reproduces the same fault schedule byte for byte. In release builds the
+`buggify_fault!` macro compiles to `None`, exactly like `buggify!` — no
+production write path can be perturbed.
+
+| Knob | Semantics |
+| --- | --- |
+| `torn_write` | The write persists only a prefix of its buffer, cut at a simulated 512-byte sector boundary, then reports the full length. A write that never crosses a sector — the common case for small WAL frames — is cut at a strict byte prefix instead (sub-sector tearing). Set `torn_write_crashes` to cut the power after the tear rather than report success. |
+| `misdirected_write` | The write persists the correct bytes at a wrong offset — a seed-derived whole number of sectors before or after the requested one — and reports success. |
+| `bit_rot` | Stored bytes come back with one flipped bit on a later read. Rolled on the **read** side (`VfsFile::read` and `SimVfs::crash_image`, the recovery reader's read), so the write path is untouched and the device keeps what was written. |
+| `lost_write` | The write, or its fsync effect, is dropped entirely while success is reported. |
+
+Arm them through `SimFaultConfig`, or through the `SimulationContext` when a
+campaign drives its decisions off `buggify!`:
+
+```rust
+let cfg = SimFaultConfig::none()
+    .with_fault_class(FaultClass::TornWrite, 20_000)   // 2% per write
+    .with_fault_class(FaultClass::BitRot, 150_000);    // 15% per file read back
+
+let context = SimulationContext::new(seed)
+    .with_fault_class(FaultClass::LostWrite, 15_000);
+```
+
+An installed `SimulationContext` takes over the coin flips and their
+probabilities, so a `buggify!`-driven campaign stays on the seed's single
+decision stream. `bit_rot` wants a higher ppm than the write-side classes to
+appear as often across a sweep: it is rolled once per file when the recovery
+reader reads the crash image, not once per write.
+
+### Fault Log
+
+Every *applied* injection is appended to a machine-readable fault log — reachable
+as `SimVfs::fault_log()` (device-scoped) and `SimulationGuard::fault_log()`
+(campaign-scoped). When several classes fire on one write only the applied one is
+recorded, so the log names exactly the durable bytes that were touched. An oracle
+consumes the `FaultRecord` structs directly; `fault_log_lines()` renders the same
+data as `key=value` lines:
+
+```text
+class=torn_write file=/db/wal.log offset=1088 length=48 persisted=12
+class=misdirected_write file=/db/wal.log offset=4096 length=64 actual_offset=3584
+class=bit_rot file=/db/wal.log offset=0 length=2048 byte_offset=917 bit=3
+class=lost_write file=/db/super.block offset=64 length=64
+```
+
+The `sim_power_cut_recovery` campaign uses this to hold two contracts: a recovery
+invariant is never violated without an injected fault to explain it (a crash
+alone must always recover cleanly), and a checksum-detectable injection — bit rot
+or a torn write on a checksummed region — surfaces as a **detection event** (an
+oracle error, or a truncated recovery with a non-zero torn tail) rather than as a
+silently-accepted commit frontier.
+
+Scrub and salvage (ADR 0074 §3–4) build on this vocabulary; they are later
+slices.
 
 ## Documented Seeds
 


### PR DESCRIPTION
Automated AFK landing for #1959. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1959

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786208146&installation_id=129708444&pr_number=1987&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1987&signature=ccca7b593590f96b0923aadd4af71057dab302ae6c51f3ad3fb102c5b8f90691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->