### PR TITLE
chore: #1963 didactic checksum-failure read errors — named zone/page/collection, fail-closed reads (ADR 0074 §2)

### DIFF
--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -825,6 +825,48 @@ impl SchemaManifest {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StorageIntegrityError {
+    pub zone: String,
+    pub id: String,
+    pub collection: Option<String>,
+    pub detail: String,
+}
+
+impl StorageIntegrityError {
+    pub fn new(
+        zone: impl Into<String>,
+        id: impl Into<String>,
+        collection: Option<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            zone: zone.into(),
+            id: id.into(),
+            collection,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl fmt::Display for StorageIntegrityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "storage integrity failure: zone={} id={}",
+            self.zone, self.id
+        )?;
+        if let Some(collection) = &self.collection {
+            write!(f, " collection={collection}")?;
+        }
+        write!(
+            f,
+            ": {}. RedDB refused to serve unverified bytes; run scrub when available, or use salvage to recover trusted rows.",
+            self.detail
+        )
+    }
+}
+
 #[derive(Debug)]
 pub enum RedDBError {
     InvalidConfig(String),
@@ -838,6 +880,7 @@ pub enum RedDBError {
     InvalidOperation(String),
     Engine(String),
     Catalog(String),
+    StorageIntegrity(StorageIntegrityError),
     Query(String),
     Validation {
         message: String,
@@ -883,6 +926,7 @@ impl fmt::Display for RedDBError {
             Self::InvalidOperation(msg) => write!(f, "INVALID_OPERATION: {msg}"),
             Self::Engine(msg) => write!(f, "engine error: {msg}"),
             Self::Catalog(msg) => write!(f, "catalog error: {msg}"),
+            Self::StorageIntegrity(err) => write!(f, "{err}"),
             Self::Query(msg) => write!(f, "query error: {msg}"),
             Self::Validation { message, .. } => write!(f, "validation error: {message}"),
             Self::Io(err) => write!(f, "io error: {err}"),
@@ -923,7 +967,10 @@ impl From<crate::storage::wal::TxError> for RedDBError {
 
 impl From<crate::storage::StoreError> for RedDBError {
     fn from(err: crate::storage::StoreError) -> Self {
-        Self::Catalog(err.to_string())
+        match err {
+            crate::storage::StoreError::StorageIntegrity(err) => Self::StorageIntegrity(err),
+            other => Self::Catalog(other.to_string()),
+        }
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -197,10 +197,12 @@ impl RedDBRuntime {
         let embedded_single_file = options.storage_profile.deploy_profile
             == crate::storage::DeployProfile::Embedded
             && options.storage_profile.packaging == crate::storage::StoragePackaging::SingleFile;
-        let db = Arc::new(
-            RedDB::open_with_options(&options)
-                .map_err(|err| RedDBError::Internal(err.to_string()))?,
-        );
+        let db = Arc::new(RedDB::open_with_options(&options).map_err(|err| {
+            match err.downcast::<crate::storage::StoreError>() {
+                Ok(store_err) => RedDBError::from(*store_err),
+                Err(err) => RedDBError::Internal(err.to_string()),
+            }
+        })?);
         let result_blob_cache_config = if embedded_single_file {
             crate::storage::cache::BlobCacheConfig::default()
         } else {

--- a/crates/reddb-server/src/server/handlers_query.rs
+++ b/crates/reddb-server/src/server/handlers_query.rs
@@ -1791,6 +1791,7 @@ pub(crate) fn ndjson_error_code(err: &crate::api::RedDBError) -> &'static str {
         Validation { .. } => "validation_failed",
         FeatureNotEnabled(_) => "feature_not_enabled",
         SchemaVersionMismatch { .. } => "schema_version_mismatch",
+        StorageIntegrity(_) => "storage_integrity_failed",
         QuotaExceeded(_) => "quota_exceeded",
         MaterializationLimitExceeded { .. } => "materialization_limit_exceeded",
         Engine(_) | Catalog(_) | Io(_) | VersionUnavailable | Internal(_) => "internal_error",

--- a/crates/reddb-server/src/server/transport.rs
+++ b/crates/reddb-server/src/server/transport.rs
@@ -298,6 +298,7 @@ pub(crate) fn map_runtime_error(err: &crate::api::RedDBError) -> (u16, String) {
         Query(msg) if msg.starts_with("ask_primary_sync_unavailable:") => 503,
         Query(_) => 400,
         Validation { .. } => 422,
+        StorageIntegrity(_) => 500,
         FeatureNotEnabled(_) => 501,
         SchemaVersionMismatch { .. } => 409,
         QuotaExceeded(payload) => {

--- a/crates/reddb-server/src/sqlstate.rs
+++ b/crates/reddb-server/src/sqlstate.rs
@@ -185,6 +185,7 @@ pub fn sqlstate_for_reddb_error(err: &crate::api::RedDBError) -> SqlState {
         E::InvalidOperation(_) => WRONG_OBJECT_TYPE,
         E::Engine(_) => INTERNAL_ERROR,
         E::Catalog(_) => INTERNAL_ERROR,
+        E::StorageIntegrity(_) => DATA_CORRUPTED,
         E::Query(_) => SYNTAX_ERROR,
         E::Validation { .. } => SYNTAX_ERROR_OR_ACCESS_RULE_VIOLATION,
         E::Io(_) => IO_ERROR,

--- a/crates/reddb-server/src/storage/unified/store.rs
+++ b/crates/reddb-server/src/storage/unified/store.rs
@@ -198,6 +198,8 @@ pub enum StoreError {
     Segment(SegmentError),
     /// I/O error
     Io(std::io::Error),
+    /// Checksummed storage bytes failed validation.
+    StorageIntegrity(crate::api::StorageIntegrityError),
     /// Serialization error
     Serialization(String),
     /// Internal error (lock poisoning, invariant violation)
@@ -213,6 +215,7 @@ impl std::fmt::Display for StoreError {
             Self::TooManyRefs(id) => write!(f, "Too many cross-references for entity: {}", id),
             Self::Segment(e) => write!(f, "Segment error: {:?}", e),
             Self::Io(e) => write!(f, "I/O error: {}", e),
+            Self::StorageIntegrity(e) => write!(f, "{e}"),
             Self::Serialization(msg) => write!(f, "Serialization error: {}", msg),
             Self::Internal(msg) => write!(f, "Internal error: {}", msg),
         }

--- a/crates/reddb-server/src/storage/unified/store/impl_pages.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_pages.rs
@@ -148,24 +148,57 @@ fn build_meta_page1_with_overflow(
 /// metadata parser would see starting from the content offset of page 1.
 /// Single-page metadata returns the raw page content (including trailing
 /// zero-pad), so the legacy parser sees the same bytes it always saw.
-fn read_meta_payload(pager: &Pager) -> Option<Vec<u8>> {
+fn storage_integrity(
+    zone: &str,
+    id: impl Into<String>,
+    collection: Option<String>,
+    detail: impl Into<String>,
+) -> StoreError {
+    StoreError::StorageIntegrity(crate::api::StorageIntegrityError::new(
+        zone, id, collection, detail,
+    ))
+}
+
+fn page_integrity(
+    page_id: u32,
+    collection: Option<String>,
+    detail: impl Into<String>,
+) -> StoreError {
+    storage_integrity("page", page_id.to_string(), collection, detail)
+}
+
+fn read_meta_payload(pager: &Pager) -> Result<Option<Vec<u8>>, StoreError> {
     let cs = crate::storage::engine::HEADER_SIZE;
-    let meta_page = pager
-        .read_page(1)
-        .or_else(|_| pager.recover_meta_from_shadow())
-        .ok()?;
+    let meta_page = match pager.read_page(1) {
+        Ok(page) => page,
+        Err(read_err) => pager.recover_meta_from_shadow().map_err(|shadow_err| {
+            page_integrity(
+                1,
+                None,
+                format!(
+                    "metadata page checksum/read failed ({read_err}); shadow recovery also failed ({shadow_err})"
+                ),
+            )
+        })?,
+    };
     let bytes = meta_page.as_bytes();
     if bytes.len() < cs + 4 {
-        return Some(bytes.get(cs..).unwrap_or(&[]).to_vec());
+        return Ok(Some(bytes.get(cs..).unwrap_or(&[]).to_vec()));
     }
-    let header = match reddb_file::decode_native_metadata_overflow_header(&bytes[cs..]).ok()? {
+    let header = match reddb_file::decode_native_metadata_overflow_header(&bytes[cs..])
+        .map_err(|err| page_integrity(1, None, err.to_string()))?
+    {
         Some(header) => header,
         None => {
-            return Some(bytes[cs..].to_vec());
+            return Ok(Some(bytes[cs..].to_vec()));
         }
     };
     if bytes.len() < cs + META_V3_PAGE1_HEADER {
-        return None;
+        return Err(page_integrity(
+            1,
+            None,
+            "metadata overflow header is truncated",
+        ));
     }
     let total = header.total_payload_bytes as usize;
     let mut next = header.next_overflow_page_id;
@@ -175,13 +208,20 @@ fn read_meta_payload(pager: &Pager) -> Option<Vec<u8>> {
         &bytes[cs + META_V3_PAGE1_HEADER..cs + META_V3_PAGE1_HEADER + first_take],
     );
     while next != 0 && payload.len() < total {
-        let ov = pager.read_page(next).ok()?;
+        let ov = pager
+            .read_page(next)
+            .map_err(|err| page_integrity(next, None, err.to_string()))?;
         let ob = ov.as_bytes();
         if ob.len() < cs + META_V3_OVERFLOW_HEADER {
-            return None;
+            return Err(page_integrity(
+                next,
+                None,
+                "metadata overflow continuation is truncated",
+            ));
         }
         let continuation =
-            reddb_file::decode_native_metadata_overflow_continuation_header(&ob[cs..]).ok()?;
+            reddb_file::decode_native_metadata_overflow_continuation_header(&ob[cs..])
+                .map_err(|err| page_integrity(next, None, err.to_string()))?;
         let nn = continuation.next_overflow_page_id;
         let len = continuation.chunk_bytes as usize;
         let remaining = total - payload.len();
@@ -191,7 +231,7 @@ fn read_meta_payload(pager: &Pager) -> Option<Vec<u8>> {
         );
         next = nn;
     }
-    Some(payload)
+    Ok(Some(payload))
 }
 
 impl UnifiedStore {
@@ -439,7 +479,7 @@ impl UnifiedStore {
         let pending_drops =
             crate::storage::operational_manifest::OperationalManifest::for_db_path(path)
                 .recover_or_bootstrap(&collections)
-                .map_err(StoreError::Io)?;
+                .map_err(|err| storage_integrity("manifest", "current", None, err.to_string()))?;
         for name in pending_drops {
             if self.get_collection(&name).is_some() {
                 self.drop_collection(&name)?;
@@ -509,7 +549,7 @@ impl UnifiedStore {
         // helper transparently follows the `RDM3` overflow chain when the
         // metadata blob spans multiple pages and falls back to the legacy
         // `<data>-meta` shadow when page 1 itself is corrupted.
-        if let Some(content_vec) = read_meta_payload(pager) {
+        if let Some(content_vec) = read_meta_payload(pager)? {
             let content: &[u8] = &content_vec;
             if content.len() >= 4 {
                 let mut pos = 0;
@@ -558,30 +598,34 @@ impl UnifiedStore {
                             let btree = BTree::with_root(Arc::clone(pager), root_page);
 
                             // Load all entities from B-tree into the collection
-                            if let Ok(mut cursor) = btree.cursor_first() {
-                                let manager = self.get_collection(&name);
-                                while let Ok(Some((key, value))) = cursor.next() {
-                                    // Deserialize entity from value bytes
-                                    if let Ok((entity, metadata)) = Self::deserialize_entity_record(
-                                        &value,
-                                        self.format_version(),
-                                    ) {
-                                        if let Some(m) = &manager {
-                                            let id = entity.id;
-                                            if let EntityKind::TableRow { row_id, .. } =
-                                                &entity.kind
-                                            {
-                                                m.register_row_id(*row_id);
-                                            }
-                                            self.context_index.index_entity(&name, &entity);
-                                            let _ = m.insert(entity.clone());
-                                            if let Some(metadata) = metadata {
-                                                let _ = m.set_metadata(id, metadata);
-                                            }
-                                            self.register_entity_id(id);
-                                            if self.config.auto_index_refs {
-                                                self.index_cross_refs(&entity, &name)?;
-                                            }
+                            let mut cursor = btree.cursor_first().map_err(|err| {
+                                page_integrity(root_page, Some(name.clone()), err.to_string())
+                            })?;
+                            let manager = self.get_collection(&name);
+                            loop {
+                                let next = cursor.next().map_err(|err| {
+                                    page_integrity(root_page, Some(name.clone()), err.to_string())
+                                })?;
+                                let Some((key, value)) = next else {
+                                    break;
+                                };
+                                // Deserialize entity from value bytes
+                                if let Ok((entity, metadata)) =
+                                    Self::deserialize_entity_record(&value, self.format_version())
+                                {
+                                    if let Some(m) = &manager {
+                                        let id = entity.id;
+                                        if let EntityKind::TableRow { row_id, .. } = &entity.kind {
+                                            m.register_row_id(*row_id);
+                                        }
+                                        self.context_index.index_entity(&name, &entity);
+                                        let _ = m.insert(entity.clone());
+                                        if let Some(metadata) = metadata {
+                                            let _ = m.set_metadata(id, metadata);
+                                        }
+                                        self.register_entity_id(id);
+                                        if self.config.auto_index_refs {
+                                            self.index_cross_refs(&entity, &name)?;
                                         }
                                     }
                                 }

--- a/tests/grouped/chaos_drill_persistence.rs
+++ b/tests/grouped/chaos_drill_persistence.rs
@@ -69,6 +69,9 @@ mod e2e_logical_wal_crash;
 #[path = "storage_durability/e2e_migrations_bootstrap.rs"]
 mod e2e_migrations_bootstrap;
 
+#[path = "storage_durability/e2e_storage_integrity_errors.rs"]
+mod e2e_storage_integrity_errors;
+
 #[path = "runtime_persistence/e2e_seqn_journal_policy.rs"]
 mod e2e_seqn_journal_policy;
 

--- a/tests/grouped/storage_durability/e2e_storage_integrity_errors.rs
+++ b/tests/grouped/storage_durability/e2e_storage_integrity_errors.rs
@@ -1,0 +1,140 @@
+#[allow(dead_code)]
+#[path = "../../support/mod.rs"]
+mod support;
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use reddb::storage::engine::PAGE_SIZE;
+use reddb::{RedDBError, RedDBOptions, RedDBRuntime, StorageDeployPreset};
+
+fn persistent_operational_options(path: &Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
+        .expect("primary-replica production storage profile is valid")
+}
+
+fn exec(rt: &RedDBRuntime, sql: &str) {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("query failed: {sql}: {err:?}"));
+}
+
+fn corrupt_page(path: &Path, page_id: u64) {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("open database file");
+    let offset = page_id * PAGE_SIZE as u64 + 128;
+    file.seek(SeekFrom::Start(offset)).expect("seek page byte");
+    let mut byte = [0u8; 1];
+    file.read_exact(&mut byte).expect("read page byte");
+    file.seek(SeekFrom::Start(offset))
+        .expect("seek page byte again");
+    file.write_all(&[byte[0] ^ 0x01]).expect("flip page byte");
+    file.sync_all().expect("sync corrupted page");
+}
+
+fn page_containing(path: &Path, needle: &[u8]) -> u64 {
+    let bytes = fs::read(path).expect("read database file");
+    let pos = bytes
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .unwrap_or_else(|| panic!("needle {needle:?} not found in database file"));
+    (pos / PAGE_SIZE) as u64
+}
+
+fn assert_integrity_error(err: RedDBError, zone: &str, id: &str, collection: Option<&str>) {
+    let RedDBError::StorageIntegrity(integrity) = err else {
+        panic!("expected storage integrity error, got {err:?}");
+    };
+    assert_eq!(integrity.zone, zone);
+    assert_eq!(integrity.id, id);
+    assert_eq!(integrity.collection.as_deref(), collection);
+    let rendered = integrity.to_string();
+    assert!(rendered.contains("refused to serve unverified bytes"));
+    assert!(rendered.contains("scrub"));
+    assert!(rendered.contains("salvage"));
+}
+
+fn expect_runtime_open_err(result: Result<RedDBRuntime, RedDBError>) -> RedDBError {
+    match result {
+        Ok(_) => panic!("corrupted store must fail closed"),
+        Err(err) => err,
+    }
+}
+
+#[test]
+fn data_page_checksum_failure_reports_page_id_and_collection() {
+    let db = support::temp_db_file("storage-integrity-page");
+    {
+        let rt = RedDBRuntime::with_options(persistent_operational_options(db.path()))
+            .expect("runtime opens");
+        exec(&rt, "CREATE TABLE bad_rows (id INT, label TEXT)");
+        exec(&rt, "CREATE TABLE healthy_rows (id INT, label TEXT)");
+        exec(
+            &rt,
+            "INSERT INTO bad_rows (id, label) VALUES (1, 'needle-row-1963')",
+        );
+        exec(
+            &rt,
+            "INSERT INTO healthy_rows (id, label) VALUES (1, 'still-ok')",
+        );
+        rt.checkpoint().expect("checkpoint fixture");
+    }
+
+    let page_id = page_containing(db.path(), b"needle-row-1963");
+    corrupt_page(db.path(), page_id);
+
+    let err = expect_runtime_open_err(RedDBRuntime::with_options(persistent_operational_options(
+        db.path(),
+    )));
+    assert_integrity_error(err, "page", &page_id.to_string(), Some("bad_rows"));
+}
+
+#[test]
+fn manifest_checksum_failure_reports_manifest_zone() {
+    let db = support::temp_db_file("storage-integrity-manifest");
+    {
+        let rt = RedDBRuntime::with_options(persistent_operational_options(db.path()))
+            .expect("runtime opens");
+        exec(&rt, "CREATE TABLE manifest_probe (id INT)");
+        rt.checkpoint().expect("checkpoint fixture");
+    }
+
+    let manifest =
+        reddb_file::OperationalManifest::for_db_path(db.path()).current_manifest_path_for_test();
+    let mut bytes = fs::read(&manifest).expect("read manifest");
+    let checksum_pos = bytes
+        .windows(b"checksum".len())
+        .position(|window| window == b"checksum")
+        .expect("manifest has checksum field");
+    bytes[checksum_pos] ^= 0x01;
+    fs::write(&manifest, bytes).expect("write corrupted manifest");
+
+    let err = expect_runtime_open_err(RedDBRuntime::with_options(persistent_operational_options(
+        db.path(),
+    )));
+    assert_integrity_error(err, "manifest", "current", None);
+}
+
+#[test]
+fn append_only_segment_chunk_checksum_failure_is_detected_before_rows_decode() {
+    let rows = vec![reddb_file::AppendOnlySegmentRow {
+        primary_key: b"1".to_vec(),
+        payload: b"segment-row-1963".to_vec(),
+    }];
+    let mut bytes =
+        reddb_file::encode_append_only_segment(reddb_file::AppendOnlySegmentCodec::None, &rows)
+            .expect("encode segment");
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0x01;
+
+    let err = reddb_file::decode_append_only_segment(&bytes)
+        .expect_err("corrupted segment chunk must fail before row decode");
+    assert!(
+        err.to_string().contains("segment") && err.to_string().contains("checksum"),
+        "unexpected segment error: {err}"
+    );
+}


### PR DESCRIPTION
Closes #1963 (PRD #1956).

Worker w1BIO completed with DONE and pushed the exit barrier, but the fleet supervisor died before opening the PR — this is the finish-from-branch recovery, branch untouched (receipt head 93d8b06a6).

- storage: fail closed on corrupt page reads; integrity carried through store errors
- runtime: preserve storage integrity on open
- wire/http: integrity mapped to data-corrupted sqlstate / operating error, named ndjson errors
- tests: didactic integrity-failure assertions (named zone/page/collection)

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226539&installation_id=129708444&pr_number=1991&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1991&signature=2dc15703fae4f85b58452b43bcb95366b4ab8b5dee5698d1148aabf2a109bbfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->