### PR TITLE
test(docs): fix BBOX order flake in the spatial-guide parity test

### DIFF
--- a/tests/docs_spatial_guide.rs
+++ b/tests/docs_spatial_guide.rs
@@ -508,8 +508,16 @@ fn guide_promise_that_the_index_is_a_pure_optimization_holds() {
         .unwrap();
 
     for query in QUERIES {
-        let without = rows(&scan, query);
-        let with = rows(&indexed, query);
+        let mut without = rows(&scan, query);
+        let mut with = rows(&indexed, query);
+        // BBOX promises the same row SET, not an order — it has no centre to
+        // sort by, and the scan path inherits map iteration order. RADIUS and
+        // NEAREST do promise distance-ascending order, so only BBOX may be
+        // normalized before the strict comparison.
+        if query.contains("BBOX") {
+            without.sort_by_key(|row| row.0);
+            with.sort_by_key(|row| row.0);
+        }
         // Same rows, same order, bit-for-bit identical distances.
         assert_eq!(without.len(), with.len(), "{query}: row count diverged");
         for (a, b) in without.iter().zip(with.iter()) {


### PR DESCRIPTION
The docs-contract test `guide_promise_that_the_index_is_a_pure_optimization_holds` pinned byte-identical **order** for `SEARCH SPATIAL BBOX`, but BBOX promises the same row **set** (the guide itself: "a box has no centre to measure a distance from") and the scan path inherits map iteration order. ~50% flaky locally; it failed PRs #1992 and #1994 back-to-back on unrelated branches.

Fix: sort both sides by entity_id for BBOX only. RADIUS/NEAREST keep the strict distance-ascending comparison they actually promise. 0/15 failures post-fix (was ~1/2).

Same family as #1982 (HashMap scan order).

https://claude.ai/code/session_0156URehfHzsvrbeAwzGdbCy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786234296&installation_id=129708444&pr_number=1995&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1995&signature=cca0e57772fdf62a3ef78dd233faee430b2a6a19aa612d6e27b9f27e3d2987c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->