### PR TITLE
chore: #1965 ADR 0038 Phase 2: circular in-file WAL region with checkpoint reclamation fence; retire the WAL sidecar family

### DIFF
--- a/crates/reddb-file/src/embedded.rs
+++ b/crates/reddb-file/src/embedded.rs
@@ -101,6 +101,7 @@ pub struct EmbeddedRdbManifest {
     pub version: u32,
     pub wal_region_offset: u64,
     pub wal_region_bytes: u64,
+    pub wal_checkpoint_boundary: u64,
     pub wal_recovery_boundary: u64,
     pub snapshot_offset: u64,
     pub snapshot_bytes: u64,
@@ -119,6 +120,7 @@ pub struct EmbeddedRdbSuperblock {
     pub manifest_checksum: u32,
     pub wal_region_offset: u64,
     pub wal_region_bytes: u64,
+    pub wal_checkpoint_boundary: u64,
     pub wal_recovery_boundary: u64,
     pub snapshot_offset: u64,
     pub snapshot_bytes: u64,
@@ -166,6 +168,7 @@ impl EmbeddedRdbArtifact {
             version: MANIFEST_VERSION,
             wal_region_offset,
             wal_region_bytes: WAL_REGION_BYTES,
+            wal_checkpoint_boundary: wal_region_offset,
             wal_recovery_boundary: wal_region_offset,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
@@ -197,6 +200,7 @@ impl EmbeddedRdbArtifact {
             manifest_checksum,
             wal_region_offset,
             wal_region_bytes: WAL_REGION_BYTES,
+            wal_checkpoint_boundary: wal_region_offset,
             wal_recovery_boundary: wal_region_offset,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
@@ -259,6 +263,7 @@ impl EmbeddedRdbArtifact {
                     path: path.to_path_buf(),
                 }
             })?;
+            manifest.wal_checkpoint_boundary = selected_superblock.wal_checkpoint_boundary;
             manifest.wal_recovery_boundary = selected_superblock.wal_recovery_boundary;
             if validate_snapshot_refs && !snapshot_reference_valid(&mut file, &manifest)? {
                 continue;
@@ -293,7 +298,7 @@ impl EmbeddedRdbArtifact {
     pub fn write_snapshot_with_wal_capacity(
         path: impl AsRef<Path>,
         snapshot: &[u8],
-        min_wal_bytes: u64,
+        _min_wal_bytes: u64,
     ) -> RdbFileResult<EmbeddedRdbOpen> {
         let path = path.as_ref();
         let path_lock = embedded_path_lock(path);
@@ -304,13 +309,13 @@ impl EmbeddedRdbArtifact {
         lock_file.lock_exclusive()?;
 
         let open = Self::open(path)?;
-        let wal_region_bytes =
-            grow_wal_region_bytes(open.manifest.wal_region_bytes, min_wal_bytes)?;
+        let wal_region_bytes = open.manifest.wal_region_bytes;
         let snapshot_offset = next_snapshot_offset(path, &open, wal_region_bytes, snapshot)?;
         let snapshot_checksum = crc32(snapshot);
         let manifest = EmbeddedRdbManifest {
             wal_region_bytes,
-            wal_recovery_boundary: open.manifest.wal_region_offset,
+            wal_checkpoint_boundary: open.manifest.wal_recovery_boundary,
+            wal_recovery_boundary: open.manifest.wal_recovery_boundary,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum,
@@ -351,7 +356,8 @@ impl EmbeddedRdbArtifact {
             manifest_len: manifest_bytes.len() as u64,
             manifest_checksum,
             wal_region_bytes,
-            wal_recovery_boundary: open.manifest.wal_region_offset,
+            wal_checkpoint_boundary: open.manifest.wal_recovery_boundary,
+            wal_recovery_boundary: open.manifest.wal_recovery_boundary,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum,
@@ -378,6 +384,7 @@ impl EmbeddedRdbArtifact {
         .ok_or_else(|| RdbFileError::InvalidOperation("no valid embedded superblock".into()))?;
 
         let mut manifest = read_manifest(&mut file, selected_superblock)?;
+        manifest.wal_checkpoint_boundary = selected_superblock.wal_checkpoint_boundary;
         manifest.wal_recovery_boundary = selected_superblock.wal_recovery_boundary;
         Ok(EmbeddedRdbOpen {
             path: path.to_path_buf(),
@@ -448,28 +455,34 @@ impl EmbeddedRdbArtifact {
             sequence = sequence.saturating_add(1);
         }
 
-        let wal_start = open.manifest.wal_region_offset;
-        let wal_end = wal_start.checked_add(wal_scan.valid_bytes).ok_or_else(|| {
+        let encoded_len = encoded.len() as u64;
+        let live_bytes = wal_scan.valid_bytes;
+        let next_live_bytes = live_bytes.checked_add(encoded_len).ok_or_else(|| {
             RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
         })?;
-        let max_end = open
-            .manifest
-            .wal_region_offset
-            .saturating_add(open.manifest.wal_region_bytes);
-        let next_boundary = wal_end.checked_add(encoded.len() as u64).ok_or_else(|| {
-            RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
-        })?;
-        if wal_end < wal_start || next_boundary > max_end {
-            return Err(RdbFileError::InvalidOperation(
-                "embedded wal region full".into(),
-            ));
+        if next_live_bytes > open.manifest.wal_region_bytes {
+            return Err(RdbFileError::InvalidOperation(format!(
+                "embedded circular wal region full: write requires {encoded_len} bytes with \
+                 {live_bytes} bytes still ahead of the checkpoint fence; region size {} bytes",
+                open.manifest.wal_region_bytes
+            )));
         }
 
         let mut file = OpenOptions::new().read(true).write(true).open(path)?;
-        write_at(&mut file, wal_end, &encoded)?;
+        let write_boundary = open
+            .manifest
+            .wal_checkpoint_boundary
+            .checked_add(wal_scan.valid_bytes)
+            .ok_or_else(|| {
+                RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
+            })?;
+        write_circular_wal_bytes(&mut file, &open.manifest, write_boundary, &encoded)?;
         crash_inject("wal_after_frame_write");
         file.sync_data()?;
         crash_inject("wal_after_frame_sync");
+        let next_boundary = write_boundary.checked_add(encoded_len).ok_or_else(|| {
+            RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
+        })?;
 
         let next_copy_index = if open.selected_superblock.copy_index == 0 {
             1
@@ -590,16 +603,6 @@ fn snapshot_reference_valid(
     Ok(true)
 }
 
-fn grow_wal_region_bytes(current: u64, min_required: u64) -> RdbFileResult<u64> {
-    let mut next = current.max(WAL_REGION_BYTES);
-    while next < min_required {
-        next = next.checked_mul(2).ok_or_else(|| {
-            RdbFileError::InvalidOperation("embedded wal region size overflow".into())
-        })?;
-    }
-    Ok(next)
-}
-
 fn embedded_path_lock(path: &Path) -> Arc<Mutex<()>> {
     static LOCKS: OnceLock<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> = OnceLock::new();
     let key = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -657,17 +660,24 @@ fn align_up(value: u64, alignment: u64) -> RdbFileResult<u64> {
 
 fn scan_wal(open: &EmbeddedRdbOpen) -> RdbFileResult<WalScan> {
     let wal_start = open.manifest.wal_region_offset;
+    let wal_checkpoint = open.manifest.wal_checkpoint_boundary;
     let wal_end = open.manifest.wal_recovery_boundary;
-    let max_end = open
-        .manifest
-        .wal_region_offset
-        .saturating_add(open.manifest.wal_region_bytes);
-    if wal_end < wal_start || wal_end > max_end {
+    if wal_checkpoint < wal_start || wal_end < wal_checkpoint {
         return Err(RdbFileError::InvalidOperation(format!(
             "invalid embedded wal boundary {wal_end}"
         )));
     }
-    if wal_end == wal_start {
+    let live_bytes = wal_end
+        .checked_sub(wal_checkpoint)
+        .ok_or_else(|| RdbFileError::InvalidOperation("embedded wal boundary overflow".into()))?;
+    if live_bytes > open.manifest.wal_region_bytes {
+        return Err(RdbFileError::InvalidOperation(format!(
+            "embedded circular wal region overran its checkpoint fence: live bytes {live_bytes}, \
+             region size {} bytes",
+            open.manifest.wal_region_bytes
+        )));
+    }
+    if live_bytes == 0 {
         return Ok(WalScan {
             next_sequence: 1,
             ..WalScan::default()
@@ -682,11 +692,57 @@ fn scan_wal(open: &EmbeddedRdbOpen) -> RdbFileResult<WalScan> {
             ..WalScan::default()
         });
     }
-    let read_end = wal_end.min(file_len);
-    file.seek(SeekFrom::Start(wal_start))?;
-    let mut bytes = vec![0u8; (read_end - wal_start) as usize];
-    file.read_exact(&mut bytes)?;
+    let mut bytes = vec![0u8; live_bytes as usize];
+    read_circular_wal_bytes(&mut file, &open.manifest, wal_checkpoint, &mut bytes)?;
     Ok(scan_wal_bytes(&bytes))
+}
+
+fn circular_wal_physical_offset(
+    manifest: &EmbeddedRdbManifest,
+    logical_boundary: u64,
+) -> RdbFileResult<u64> {
+    if logical_boundary < manifest.wal_region_offset {
+        return Err(RdbFileError::InvalidOperation(format!(
+            "embedded wal logical boundary precedes region: {logical_boundary}"
+        )));
+    }
+    let relative = logical_boundary - manifest.wal_region_offset;
+    Ok(manifest.wal_region_offset + (relative % manifest.wal_region_bytes))
+}
+
+fn read_circular_wal_bytes(
+    file: &mut File,
+    manifest: &EmbeddedRdbManifest,
+    logical_boundary: u64,
+    out: &mut [u8],
+) -> RdbFileResult<()> {
+    let mut copied = 0usize;
+    while copied < out.len() {
+        let physical = circular_wal_physical_offset(manifest, logical_boundary + copied as u64)?;
+        let region_remaining = (manifest.wal_region_offset + manifest.wal_region_bytes) - physical;
+        let chunk_len = (out.len() - copied).min(region_remaining as usize);
+        file.seek(SeekFrom::Start(physical))?;
+        file.read_exact(&mut out[copied..copied + chunk_len])?;
+        copied += chunk_len;
+    }
+    Ok(())
+}
+
+fn write_circular_wal_bytes(
+    file: &mut File,
+    manifest: &EmbeddedRdbManifest,
+    logical_boundary: u64,
+    bytes: &[u8],
+) -> RdbFileResult<()> {
+    let mut copied = 0usize;
+    while copied < bytes.len() {
+        let physical = circular_wal_physical_offset(manifest, logical_boundary + copied as u64)?;
+        let region_remaining = (manifest.wal_region_offset + manifest.wal_region_bytes) - physical;
+        let chunk_len = (bytes.len() - copied).min(region_remaining as usize);
+        write_at(file, physical, &bytes[copied..copied + chunk_len])?;
+        copied += chunk_len;
+    }
+    Ok(())
 }
 
 fn scan_wal_bytes(bytes: &[u8]) -> WalScan {
@@ -869,6 +925,7 @@ fn encode_superblock(superblock: EmbeddedRdbSuperblock) -> RdbFileResult<Vec<u8>
     put_u32(&mut bytes, &mut cursor, superblock.manifest_checksum);
     put_u64(&mut bytes, &mut cursor, superblock.wal_region_offset);
     put_u64(&mut bytes, &mut cursor, superblock.wal_region_bytes);
+    put_u64(&mut bytes, &mut cursor, superblock.wal_checkpoint_boundary);
     put_u64(&mut bytes, &mut cursor, superblock.wal_recovery_boundary);
     put_u64(&mut bytes, &mut cursor, superblock.snapshot_offset);
     put_u64(&mut bytes, &mut cursor, superblock.snapshot_bytes);
@@ -923,6 +980,7 @@ fn decode_superblock(copy_index: u8, bytes: &[u8]) -> RdbFileResult<EmbeddedRdbS
         manifest_checksum: take_u32(bytes, &mut cursor)?,
         wal_region_offset: take_u64(bytes, &mut cursor)?,
         wal_region_bytes: take_u64(bytes, &mut cursor)?,
+        wal_checkpoint_boundary: take_u64(bytes, &mut cursor)?,
         wal_recovery_boundary: take_u64(bytes, &mut cursor)?,
         snapshot_offset: take_u64(bytes, &mut cursor)?,
         snapshot_bytes: take_u64(bytes, &mut cursor)?,
@@ -932,12 +990,13 @@ fn decode_superblock(copy_index: u8, bytes: &[u8]) -> RdbFileResult<EmbeddedRdbS
 }
 
 fn encode_manifest(manifest: EmbeddedRdbManifest) -> Vec<u8> {
-    let mut bytes = vec![0u8; 8 + 4 + 8 + 8 + 8 + 8 + 8 + 4 + 16 + CHECKSUM_LEN];
+    let mut bytes = vec![0u8; 8 + 4 + 8 + 8 + 8 + 8 + 8 + 8 + 4 + 16 + CHECKSUM_LEN];
     let mut cursor = 0usize;
     put_bytes(&mut bytes, &mut cursor, MANIFEST_MAGIC);
     put_u32(&mut bytes, &mut cursor, manifest.version);
     put_u64(&mut bytes, &mut cursor, manifest.wal_region_offset);
     put_u64(&mut bytes, &mut cursor, manifest.wal_region_bytes);
+    put_u64(&mut bytes, &mut cursor, manifest.wal_checkpoint_boundary);
     put_u64(&mut bytes, &mut cursor, manifest.wal_recovery_boundary);
     put_u64(&mut bytes, &mut cursor, manifest.snapshot_offset);
     put_u64(&mut bytes, &mut cursor, manifest.snapshot_bytes);
@@ -979,6 +1038,7 @@ fn decode_manifest(bytes: &[u8]) -> RdbFileResult<EmbeddedRdbManifest> {
         version,
         wal_region_offset: take_u64(bytes, &mut cursor)?,
         wal_region_bytes: take_u64(bytes, &mut cursor)?,
+        wal_checkpoint_boundary: take_u64(bytes, &mut cursor)?,
         wal_recovery_boundary: take_u64(bytes, &mut cursor)?,
         snapshot_offset: take_u64(bytes, &mut cursor)?,
         snapshot_bytes: take_u64(bytes, &mut cursor)?,

--- a/crates/reddb-server/src/storage/unified/store/commit.rs
+++ b/crates/reddb-server/src/storage/unified/store/commit.rs
@@ -931,10 +931,19 @@ impl UnifiedStore {
         let payloads: Vec<Vec<u8>> = actions.iter().map(StoreWalAction::encode).collect();
         let encoded_len = crate::storage::EmbeddedRdbArtifact::wal_payloads_encoded_len(&payloads)
             .map_err(|err| StoreError::Io(std::io::Error::other(err.to_string())))?;
+        let artifact = crate::storage::EmbeddedRdbArtifact::open(path)
+            .map_err(|err| StoreError::Io(std::io::Error::other(err.to_string())))?;
+        if encoded_len > artifact.manifest.wal_region_bytes {
+            return Err(StoreError::Io(std::io::Error::other(format!(
+                "embedded circular wal region full: write requires {encoded_len} bytes; \
+                 region size {} bytes",
+                artifact.manifest.wal_region_bytes
+            ))));
+        }
         match crate::storage::EmbeddedRdbArtifact::append_wal_payloads(path, &payloads) {
             Ok(_) => Ok(()),
             Err(crate::api::RedDBError::InvalidOperation(msg))
-                if msg.contains("embedded wal region full") =>
+                if msg.contains("embedded circular wal region full") =>
             {
                 let snapshot = self.to_binary_dump_bytes();
                 crate::storage::EmbeddedRdbArtifact::write_snapshot_with_wal_capacity(

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -105,15 +105,15 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
     let checkpointed = EmbeddedRdbArtifact::open(&path).expect("open checkpointed artifact");
     assert_eq!(
         checkpointed.manifest.wal_recovery_boundary,
-        checkpointed.manifest.wal_region_offset
+        checkpointed.manifest.wal_checkpoint_boundary
     );
     assert!(checkpointed.manifest.snapshot_bytes > 0);
     assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
 }
 
 #[test]
-fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
-    let dir = temp_dir("internal_wal_expand");
+fn embedded_runtime_checkpoints_and_retries_when_internal_wal_fills() {
+    let dir = temp_dir("internal_wal_checkpoint_retry");
     let path = dir.path().join("data.rdb");
 
     EmbeddedRdbArtifact::create(&path).expect("create embedded artifact");
@@ -121,7 +121,7 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
         UnifiedStore::with_config(UnifiedStoreConfig::default().with_embedded_wal_path(&path));
     store.create_collection("blobs").expect("create collection");
     let mut seed = 0xD00D_F00D_CAFE_BABEu64;
-    let body: Vec<u8> = (0..100_000)
+    let body: Vec<u8> = (0..40_000)
         .map(|_| {
             seed ^= seed << 7;
             seed ^= seed >> 9;
@@ -129,20 +129,22 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
             (seed & 0xFF) as u8
         })
         .collect();
-    let entity = reddb_server::storage::UnifiedEntity::table_row(
-        EntityId::new(1),
-        "blobs",
-        1,
-        vec![Value::Blob(body)],
-    );
-    store
-        .insert_auto("blobs", entity)
-        .expect("insert large row");
+    for id in 1..=2 {
+        let entity = reddb_server::storage::UnifiedEntity::table_row(
+            EntityId::new(id),
+            "blobs",
+            id as u64,
+            vec![Value::Blob(body.clone())],
+        );
+        store
+            .insert_auto("blobs", entity)
+            .expect("insert large row");
+    }
 
     assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
     let artifact = EmbeddedRdbArtifact::open(&path).expect("open embedded artifact");
     assert!(artifact.manifest.snapshot_bytes > 0);
-    assert!(artifact.manifest.wal_region_bytes > 64 * 1024);
+    assert_eq!(artifact.manifest.wal_region_bytes, 64 * 1024);
     assert!(
         artifact.manifest.wal_recovery_boundary > artifact.manifest.wal_region_offset,
         "expected retried frame after checkpoint"
@@ -150,4 +152,68 @@ fn embedded_runtime_checkpoints_expands_and_retries_when_internal_wal_fills() {
 
     let frames = EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read wal payloads");
     assert!(!frames.is_empty(), "expected retried wal frame");
+}
+
+#[test]
+fn embedded_runtime_wraps_internal_wal_without_sidecars() {
+    let dir = temp_dir("internal_wal_wrap");
+    let path = dir.path().join("data.rdb");
+
+    EmbeddedRdbArtifact::create(&path).expect("create embedded artifact");
+    let store =
+        UnifiedStore::with_config(UnifiedStoreConfig::default().with_embedded_wal_path(&path));
+    store
+        .create_collection("events")
+        .expect("create collection");
+
+    let mut seed = 0xA11C_E5ED_1234_5678u64;
+    let body: Vec<u8> = (0..40 * 1024)
+        .map(|_| {
+            seed ^= seed << 7;
+            seed ^= seed >> 9;
+            seed ^= seed << 8;
+            (seed & 0xFF) as u8
+        })
+        .collect();
+    for id in 1..=2 {
+        let entity = reddb_server::storage::UnifiedEntity::table_row(
+            EntityId::new(id),
+            "events",
+            id as u64,
+            vec![Value::Blob(body.clone())],
+        );
+        store.insert_auto("events", entity).expect("insert row");
+    }
+
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
+    let artifact = EmbeddedRdbArtifact::open(&path).expect("open embedded artifact");
+    assert!(
+        artifact.manifest.wal_recovery_boundary
+            > artifact.manifest.wal_region_offset + artifact.manifest.wal_region_bytes,
+        "expected logical wal boundary to wrap past the physical region"
+    );
+
+    let replayed =
+        RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("reopen runtime");
+    let rows = replayed
+        .execute_query("SELECT * FROM events")
+        .expect("select replayed rows");
+    assert_eq!(rows.result.records.len(), 2);
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
+}
+
+#[test]
+fn embedded_runtime_reports_region_size_when_internal_wal_remains_full_after_checkpoint() {
+    let dir = temp_dir("internal_wal_full");
+    let path = dir.path().join("data.rdb");
+
+    EmbeddedRdbArtifact::create(&path).expect("create embedded artifact");
+    let err = EmbeddedRdbArtifact::append_wal_payloads(&path, &[vec![b'z'; 80 * 1024]])
+        .expect_err("oversized write should not silently grow the wal region");
+    let msg = err.to_string();
+    assert!(msg.contains("embedded circular wal region full"), "{msg}");
+    assert!(msg.contains("region size 65536 bytes"), "{msg}");
+    assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
+
+    EmbeddedRdbArtifact::open(&path).expect("store remains readable after full wal failure");
 }


### PR DESCRIPTION
Automated AFK landing for #1965. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1965

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786241600&installation_id=129708444&pr_number=1996&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1996&signature=90e516bfc42d7b741591825c45d466e7ef0b57cc0fd2124145f6b71ce9017db9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->