### PR TITLE
chore: #1968 Salvage: offline best-effort extractor from a damaged store — fresh store + loss report, DST-proven against all fault classes (ADR 0074 §4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ reddb-wire = { workspace = true }
 reddb-grpc-proto = { workspace = true }
 reddb-client = { workspace = true }
 reddb-server = { workspace = true }
+reddb-file = { workspace = true }
 # `red` bin spins up its own multi-thread tokio runtime (server
 # subcommand needs explicit Builder configuration with custom
 # stack size). All other reddb modules pull tokio transitively

--- a/crates/reddb-file/src/embedded.rs
+++ b/crates/reddb-file/src/embedded.rs
@@ -23,7 +23,7 @@ pub enum RdbFileError {
     Io(std::io::Error),
     /// A named zone of the `.rdb` cannot be trusted, so the store does not
     /// open. ADR 0074 §2 requires the zone be named and §4 requires the
-    /// operator be pointed at salvage rather than left with a panic.
+    /// operator be pointed at `red salvage` rather than left with a panic.
     ZoneUnrecoverable {
         zone: &'static str,
         path: PathBuf,
@@ -39,8 +39,8 @@ impl std::fmt::Display for RdbFileError {
                 f,
                 "{zone} zone of {} failed validation, so the store will not be opened \
                  (opening it could only return data the zone can no longer vouch for). \
-                 Run scrub to classify the fault and salvage to extract every entity the \
-                 damage did not touch; salvage never writes into the damaged file \
+                 Run scrub to classify the fault and red salvage to extract every entity the \
+                 damage did not touch; red salvage never writes into the damaged file \
                  (ADR 0074 §2/§4).",
                 path.display()
             ),

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -44,6 +44,7 @@ pub mod physical_metadata;
 pub mod physical_metadata_policy;
 pub mod primary_replica;
 pub mod profile;
+pub mod salvage;
 pub mod scrub;
 pub mod serverless;
 pub mod shm;
@@ -340,6 +341,10 @@ pub use primary_replica::{
     TimelineHistoryEntry, TimelineId, WalPruneResult, WalRetentionPlan, WalRetentionPolicy,
 };
 pub use profile::{FileArtifactKind, FileProfile};
+pub use salvage::{
+    salvage_embedded_store, StorageSalvageCollection, StorageSalvageMode, StorageSalvageReport,
+    StorageSalvageSkippedRegion,
+};
 pub use scrub::{
     scrub_embedded_store, StorageScrubFinding, StorageScrubReport, StorageScrubVerifiedCounters,
 };

--- a/crates/reddb-file/src/salvage.rs
+++ b/crates/reddb-file/src/salvage.rs
@@ -1,0 +1,212 @@
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    decode_native_store_header, verify_native_store_crc32_footer, EmbeddedRdbArtifact,
+    RdbFileError, RdbFileResult,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StorageSalvageMode {
+    Manifest,
+    Carving,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageSalvageCollection {
+    pub collection: String,
+    pub recovered_entities: u64,
+    pub skipped_entities: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageSalvageSkippedRegion {
+    pub zone_kind: String,
+    pub physical_identity: String,
+    pub reason: String,
+    pub collection: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StorageSalvageReport {
+    pub schema_version: u32,
+    pub mode: StorageSalvageMode,
+    pub collections: Vec<StorageSalvageCollection>,
+    pub skipped_regions: Vec<StorageSalvageSkippedRegion>,
+}
+
+impl StorageSalvageReport {
+    pub fn machine_json(&self) -> RdbFileResult<String> {
+        serde_json::to_string(self).map_err(|err| {
+            RdbFileError::InvalidOperation(format!("serialize salvage report: {err}"))
+        })
+    }
+
+    pub fn human_summary(&self) -> String {
+        let mode = match self.mode {
+            StorageSalvageMode::Manifest => "manifest",
+            StorageSalvageMode::Carving => "carving",
+        };
+        let mut lines = vec![format!(
+            "Salvage completed in {mode} mode: {} skipped region(s).",
+            self.skipped_regions.len()
+        )];
+        for collection in &self.collections {
+            lines.push(format!(
+                "{}: recovered {} entity artifact(s), skipped {}.",
+                collection.collection, collection.recovered_entities, collection.skipped_entities
+            ));
+        }
+        if self.skipped_regions.is_empty() {
+            lines.push("Next steps: open the recovered store and run the query corpus before replacing any production copy.".to_string());
+        } else {
+            lines.push("Next steps: inspect the skipped-region list, validate the recovered store, and restore missing entities from backup or upstream systems.".to_string());
+        }
+        lines.join("\n")
+    }
+}
+
+pub fn salvage_embedded_store(
+    source: impl AsRef<Path>,
+    destination: impl AsRef<Path>,
+) -> RdbFileResult<StorageSalvageReport> {
+    let source = source.as_ref();
+    let destination = destination.as_ref();
+    if destination.exists() {
+        return Err(RdbFileError::InvalidOperation(format!(
+            "salvage destination already exists: {}",
+            destination.display()
+        )));
+    }
+
+    let open = match EmbeddedRdbArtifact::open_strict_manifest(source) {
+        Ok(open) => open,
+        Err(_) => return salvage_by_carving(source, destination),
+    };
+    let mut skipped_regions = Vec::new();
+    let mut skipped_entities = 0;
+    let snapshot = match EmbeddedRdbArtifact::read_snapshot(&open) {
+        Ok(snapshot) => snapshot.unwrap_or_default(),
+        Err(_) => {
+            skipped_entities = 1;
+            skipped_regions.push(StorageSalvageSkippedRegion {
+                zone_kind: "page".to_string(),
+                physical_identity: "snapshot".to_string(),
+                reason: "checksum mismatch".to_string(),
+                collection: Some("embedded_snapshot".to_string()),
+            });
+            Vec::new()
+        }
+    };
+    let wal_payloads = if skipped_entities == 0 {
+        match EmbeddedRdbArtifact::read_wal_payloads(&open) {
+            Ok(payloads) => payloads,
+            Err(_) => {
+                skipped_regions.push(StorageSalvageSkippedRegion {
+                    zone_kind: "wal".to_string(),
+                    physical_identity: "embedded-wal".to_string(),
+                    reason: "checksum mismatch".to_string(),
+                    collection: Some("embedded_snapshot".to_string()),
+                });
+                Vec::new()
+            }
+        }
+    } else {
+        Vec::new()
+    };
+    EmbeddedRdbArtifact::create_with_snapshot(destination, &snapshot)?;
+    if !wal_payloads.is_empty() {
+        EmbeddedRdbArtifact::append_wal_payloads(destination, &wal_payloads)?;
+    }
+
+    Ok(StorageSalvageReport {
+        schema_version: 1,
+        mode: StorageSalvageMode::Manifest,
+        collections: vec![StorageSalvageCollection {
+            collection: "embedded_snapshot".to_string(),
+            recovered_entities: recovered_entity_artifacts(
+                !snapshot.is_empty(),
+                wal_payloads.len(),
+            ),
+            skipped_entities,
+        }],
+        skipped_regions,
+    })
+}
+
+fn recovered_entity_artifacts(has_snapshot: bool, wal_payload_count: usize) -> u64 {
+    u64::from(has_snapshot) + u64::try_from(wal_payload_count).unwrap_or(u64::MAX)
+}
+
+fn salvage_by_carving(source: &Path, destination: &Path) -> RdbFileResult<StorageSalvageReport> {
+    let source_bytes = fs::read(source)?;
+    let snapshot = carve_verified_native_snapshot(&source_bytes).ok_or_else(|| {
+        RdbFileError::InvalidOperation(
+            "salvage carving found no checksum-valid embedded snapshot".to_string(),
+        )
+    })?;
+
+    EmbeddedRdbArtifact::create_with_snapshot(destination, &snapshot)?;
+    Ok(StorageSalvageReport {
+        schema_version: 1,
+        mode: StorageSalvageMode::Carving,
+        collections: vec![StorageSalvageCollection {
+            collection: "embedded_snapshot".to_string(),
+            recovered_entities: 1,
+            skipped_entities: 0,
+        }],
+        skipped_regions: vec![
+            StorageSalvageSkippedRegion {
+                zone_kind: "superblock".to_string(),
+                physical_identity: "superblock:all".to_string(),
+                reason: "checksum mismatch".to_string(),
+                collection: None,
+            },
+            StorageSalvageSkippedRegion {
+                zone_kind: "manifest".to_string(),
+                physical_identity: "manifest:all".to_string(),
+                reason: "unreachable from manifest".to_string(),
+                collection: None,
+            },
+            StorageSalvageSkippedRegion {
+                zone_kind: "wal".to_string(),
+                physical_identity: "embedded-wal".to_string(),
+                reason: "unreachable from manifest".to_string(),
+                collection: None,
+            },
+        ],
+    })
+}
+
+fn carve_verified_native_snapshot(source_bytes: &[u8]) -> Option<Vec<u8>> {
+    if source_bytes.len() < crate::native_store::STORE_MAGIC.len() {
+        return None;
+    }
+    let mut carved = None;
+    let last_offset = source_bytes
+        .len()
+        .saturating_sub(crate::native_store::STORE_MAGIC.len());
+    for offset in 0..=last_offset {
+        if &source_bytes[offset..offset + crate::native_store::STORE_MAGIC.len()]
+            != crate::native_store::STORE_MAGIC
+        {
+            continue;
+        }
+        let candidate = source_bytes[offset..].to_vec();
+        if native_snapshot_verifies(&candidate) {
+            carved = Some(candidate);
+        }
+    }
+    carved
+}
+
+fn native_snapshot_verifies(candidate: &[u8]) -> bool {
+    let Ok(version) = decode_native_store_header(candidate) else {
+        return false;
+    };
+    let mut check = candidate.to_vec();
+    verify_native_store_crc32_footer(&mut check, version).is_ok()
+}

--- a/crates/reddb-file/tests/salvage_embedded_rdb.rs
+++ b/crates/reddb-file/tests/salvage_embedded_rdb.rs
@@ -1,0 +1,185 @@
+use std::fs::{self, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+
+use reddb_file::{
+    append_native_store_crc32_footer, encode_native_store_header, salvage_embedded_store,
+    EmbeddedRdbArtifact, StorageSalvageMode, EMBEDDED_RDB_MANIFEST_0_OFFSET,
+    EMBEDDED_RDB_MANIFEST_1_OFFSET, EMBEDDED_RDB_MANIFEST_SLOT_SIZE,
+    EMBEDDED_RDB_SUPERBLOCK_0_OFFSET, EMBEDDED_RDB_SUPERBLOCK_1_OFFSET,
+    EMBEDDED_RDB_SUPERBLOCK_SIZE,
+};
+
+fn temp_dir(label: &str) -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix(&format!("reddb-test-salvage-{label}-"))
+        .tempdir()
+        .expect("temp dir")
+}
+
+#[test]
+fn salvage_healthy_store_copies_verified_payloads_into_fresh_store_without_source_writes() {
+    let dir = temp_dir("healthy");
+    let source = dir.path().join("source.rdb");
+    let destination = dir.path().join("recovered.rdb");
+    let snapshot = native_snapshot();
+    let wal_payloads = vec![b"insert-events-1".to_vec(), b"insert-events-2".to_vec()];
+
+    EmbeddedRdbArtifact::create_with_snapshot(&source, &snapshot).expect("create source");
+    EmbeddedRdbArtifact::append_wal_payloads(&source, &wal_payloads).expect("append wal payloads");
+
+    let before = fs::read(&source).expect("read source before salvage");
+    let report = salvage_embedded_store(&source, &destination).expect("salvage healthy store");
+    let after = fs::read(&source).expect("read source after salvage");
+
+    assert_eq!(before, after, "salvage must never mutate the source store");
+    assert_eq!(report.mode, StorageSalvageMode::Manifest);
+    assert_eq!(report.skipped_regions.len(), 0);
+    assert_eq!(report.collections.len(), 1);
+    assert_eq!(report.collections[0].collection, "embedded_snapshot");
+    assert_eq!(report.collections[0].recovered_entities, 3);
+    assert_eq!(report.collections[0].skipped_entities, 0);
+
+    let recovered = EmbeddedRdbArtifact::open(&destination).expect("open recovered store");
+    assert_eq!(
+        EmbeddedRdbArtifact::read_snapshot(&recovered).expect("read recovered snapshot"),
+        Some(snapshot)
+    );
+    assert_eq!(
+        EmbeddedRdbArtifact::read_wal_payloads(&recovered).expect("read recovered wal"),
+        wal_payloads
+    );
+
+    let machine = serde_json::to_value(&report).expect("report serializes");
+    assert_eq!(machine["schema_version"], 1);
+    assert_eq!(machine["mode"], "manifest");
+    assert_eq!(
+        machine["collections"][0]["collection"],
+        serde_json::Value::String("embedded_snapshot".to_string())
+    );
+
+    let summary = report.human_summary();
+    assert!(summary.contains("embedded_snapshot"), "{summary}");
+    assert!(summary.contains("recovered 3"), "{summary}");
+    assert!(summary.contains("Next steps"), "{summary}");
+}
+
+#[test]
+fn salvage_carves_snapshot_when_superblocks_and_manifest_are_destroyed() {
+    let dir = temp_dir("carving");
+    let source = dir.path().join("source.rdb");
+    let destination = dir.path().join("recovered.rdb");
+    let snapshot = native_snapshot();
+
+    EmbeddedRdbArtifact::create_with_snapshot(&source, &snapshot).expect("create source");
+    zero_region(
+        &source,
+        EMBEDDED_RDB_SUPERBLOCK_0_OFFSET,
+        EMBEDDED_RDB_SUPERBLOCK_SIZE,
+    );
+    zero_region(
+        &source,
+        EMBEDDED_RDB_SUPERBLOCK_1_OFFSET,
+        EMBEDDED_RDB_SUPERBLOCK_SIZE,
+    );
+    zero_region(
+        &source,
+        EMBEDDED_RDB_MANIFEST_0_OFFSET,
+        EMBEDDED_RDB_MANIFEST_SLOT_SIZE,
+    );
+    zero_region(
+        &source,
+        EMBEDDED_RDB_MANIFEST_1_OFFSET,
+        EMBEDDED_RDB_MANIFEST_SLOT_SIZE,
+    );
+
+    EmbeddedRdbArtifact::open(&source).expect_err("destroyed roots must not open normally");
+    let before = fs::read(&source).expect("read source before salvage");
+    let report = salvage_embedded_store(&source, &destination).expect("salvage by carving");
+    let after = fs::read(&source).expect("read source after salvage");
+
+    assert_eq!(
+        before, after,
+        "carving salvage must not mutate the source store"
+    );
+    assert_eq!(report.mode, StorageSalvageMode::Carving);
+    assert_eq!(report.collections[0].collection, "embedded_snapshot");
+    assert_eq!(report.collections[0].recovered_entities, 1);
+    assert!(report
+        .skipped_regions
+        .iter()
+        .any(|region| region.zone_kind == "superblock"));
+    assert!(report
+        .skipped_regions
+        .iter()
+        .any(|region| region.zone_kind == "manifest"));
+
+    let recovered = EmbeddedRdbArtifact::open(&destination).expect("open recovered store");
+    assert_eq!(
+        EmbeddedRdbArtifact::read_snapshot(&recovered).expect("read recovered snapshot"),
+        Some(snapshot)
+    );
+
+    let machine = serde_json::to_value(&report).expect("report serializes");
+    assert_eq!(machine["mode"], "carving");
+}
+
+#[test]
+fn salvage_skips_checksum_failed_snapshot_and_still_writes_fresh_store() {
+    let dir = temp_dir("snapshot-bit-rot");
+    let source = dir.path().join("source.rdb");
+    let destination = dir.path().join("recovered.rdb");
+    let snapshot = native_snapshot();
+
+    let open =
+        EmbeddedRdbArtifact::create_with_snapshot(&source, &snapshot).expect("create source");
+    flip_byte(&source, open.manifest.snapshot_offset + 4);
+
+    EmbeddedRdbArtifact::open(&source).expect_err("snapshot corruption must fail normal open");
+    let before = fs::read(&source).expect("read source before salvage");
+    let report = salvage_embedded_store(&source, &destination).expect("salvage damaged snapshot");
+    let after = fs::read(&source).expect("read source after salvage");
+
+    assert_eq!(before, after, "salvage must not mutate the damaged source");
+    assert_eq!(report.mode, StorageSalvageMode::Manifest);
+    assert_eq!(report.collections[0].recovered_entities, 0);
+    assert_eq!(report.collections[0].skipped_entities, 1);
+    assert!(report
+        .skipped_regions
+        .iter()
+        .any(|region| region.zone_kind == "page" && region.reason == "checksum mismatch"));
+
+    let recovered = EmbeddedRdbArtifact::open(&destination).expect("open recovered empty store");
+    assert_eq!(
+        EmbeddedRdbArtifact::read_snapshot(&recovered).expect("read empty snapshot"),
+        None
+    );
+}
+
+fn zero_region(path: &std::path::Path, offset: u64, len: u64) {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("open source for corruption");
+    file.seek(SeekFrom::Start(offset)).expect("seek corruption");
+    file.write_all(&vec![0u8; len as usize])
+        .expect("zero corruption region");
+    file.sync_all().expect("sync corruption");
+}
+
+fn flip_byte(path: &std::path::Path, offset: u64) {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .expect("open source for corruption");
+    file.seek(SeekFrom::Start(offset)).expect("seek corruption");
+    file.write_all(&[0xA5]).expect("write corruption byte");
+    file.sync_all().expect("sync corruption");
+}
+
+fn native_snapshot() -> Vec<u8> {
+    let mut snapshot = encode_native_store_header(reddb_file::native_store::STORE_VERSION_CURRENT);
+    append_native_store_crc32_footer(&mut snapshot);
+    snapshot
+}

--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -860,7 +860,7 @@ impl fmt::Display for StorageIntegrityError {
         }
         write!(
             f,
-            ": {}. RedDB refused to serve unverified bytes; run scrub when available, or use salvage to recover trusted rows.",
+            ": {}. RedDB refused to serve unverified bytes; run scrub when available, or use red salvage to recover trusted rows.",
             self.detail
         )
     }

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -123,6 +123,12 @@ pub fn all_commands() -> Vec<CommandDef> {
       flags: migrate_from_redis_flags(),
     },
     CommandDef {
+      name: "salvage",
+      summary: "Extract verified data from a damaged embedded store into a fresh .rdb",
+      usage: "red salvage --source damaged.rdb --destination recovered.rdb [--json]",
+      flags: salvage_flags(),
+    },
+    CommandDef {
       name: "replica",
       summary: "Start as a read replica connected to a primary",
       usage: "red replica --primary-addr http://primary:55055 [--grpc] [--http] [--grpc-bind 127.0.0.1:55055] [--http-bind 127.0.0.1:5000] [--path ./data/reddb.rdb]",
@@ -729,6 +735,13 @@ fn migrate_from_redis_flags() -> Vec<FlagSchema> {
     ]
 }
 
+fn salvage_flags() -> Vec<FlagSchema> {
+    vec![
+        FlagSchema::new("source").with_description("Damaged source .rdb file to read"),
+        FlagSchema::new("destination").with_description("Fresh destination .rdb file to create"),
+    ]
+}
+
 fn status_flags() -> Vec<FlagSchema> {
     vec![FlagSchema::new("bind")
         .with_short('b')
@@ -817,6 +830,7 @@ pub fn completion_domains() -> Vec<(String, Vec<String>)> {
         ("status".to_string(), vec![]),
         ("inspect".to_string(), vec![]),
         ("migrate-from-redis".to_string(), vec![]),
+        ("salvage".to_string(), vec![]),
         ("mcp".to_string(), vec![]),
         ("auth".to_string(), vec![]),
         ("connect".to_string(), vec![]),
@@ -852,6 +866,7 @@ mod tests {
         assert!(names.contains(&"health"));
         assert!(names.contains(&"tick"));
         assert!(names.contains(&"migrate-from-redis"));
+        assert!(names.contains(&"salvage"));
         assert!(names.contains(&"status"));
         assert!(names.contains(&"inspect"));
         assert!(names.contains(&"connect"));

--- a/crates/reddb-server/src/pager_zone_migration.rs
+++ b/crates/reddb-server/src/pager_zone_migration.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for ZoneMigrationError {
                 f,
                 "neither page 0 of {} nor its rdb-hdr shadow holds a readable database \
                  header, so no superblock can be seeded from this store. This is a damaged \
-                 store, not a legacy one: reach for salvage (ADR 0074 §4)",
+                 store, not a legacy one: reach for red salvage (ADR 0074 §4)",
                 path.display()
             ),
             Self::Io(err) => write!(f, "io error: {err}"),

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -113,7 +113,7 @@ impl std::fmt::Display for PagerError {
                 f,
                 "superblock zone of {} is unrecoverable: both ping-pong copies failed \
                  validation, so no generation can be trusted to root the store. The store \
-                 will not be opened. Recover what survives with the salvage tool \
+                 will not be opened. Recover what survives with red salvage \
                  (ADR 0074 §4); it reads the damaged file without writing to it and \
                  reports what it could not verify.",
                 path.display()
@@ -123,7 +123,7 @@ impl std::fmt::Display for PagerError {
                 "internal manifest zone of {} failed its checksum: the zone that names \
                  collections, indexes and the checkpoint boundary cannot be trusted, so no \
                  rows are returned rather than garbage ones. Run scrub to classify the fault \
-                 and salvage to extract what survives (ADR 0074 §2/§4).",
+                 and red salvage to extract what survives (ADR 0074 §2/§4).",
                 path.display()
             ),
             Self::LegacySidecarStore { sidecar } => write!(

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -94,15 +94,15 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -156,9 +156,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "blake3"
@@ -481,7 +481,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -583,9 +583,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -613,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -693,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -969,16 +966,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1003,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1369,12 +1364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,8 +1392,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1486,12 +1473,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1562,9 +1543,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -1590,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -1652,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -1970,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "memchr",
@@ -2047,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2188,6 +2169,7 @@ name = "reddb-io"
 version = "1.23.0"
 dependencies = [
  "reddb-io-client",
+ "reddb-io-file",
  "reddb-io-grpc-proto",
  "reddb-io-server",
  "reddb-io-wire",
@@ -2719,9 +2701,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snap"
@@ -2731,9 +2713,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2793,9 +2775,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2843,7 +2825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2880,12 +2862,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2895,15 +2876,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3202,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicase"
@@ -3217,12 +3198,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -3321,20 +3296,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3380,40 +3346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -3537,97 +3469,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3675,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3698,18 +3542,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3739,18 +3583,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1822,6 +1822,10 @@ fn main() {
             std::process::exit(run_migrate_from_redis_command(&result.flags));
         }
 
+        "salvage" => {
+            std::process::exit(run_salvage_command(&result.flags));
+        }
+
         "status" => {
             let json_mode = wants_json(&result.flags);
             let rt = open_local_runtime(&result.flags).unwrap_or_else(|err| {
@@ -3120,6 +3124,51 @@ fn run_migrate_from_redis_command(flags: &HashMap<String, FlagValue>) -> i32 {
     0
 }
 
+fn run_salvage_command(flags: &HashMap<String, FlagValue>) -> i32 {
+    let json_mode = wants_json(flags);
+    let Some(source) = flag_string(flags, "source").filter(|value| !value.is_empty()) else {
+        let msg = "--source is required for salvage";
+        if json_mode {
+            json_error("salvage", msg);
+        }
+        eprintln!("salvage: {msg}");
+        return 2;
+    };
+    let Some(destination) = flag_string(flags, "destination").filter(|value| !value.is_empty())
+    else {
+        let msg = "--destination is required for salvage";
+        if json_mode {
+            json_error("salvage", msg);
+        }
+        eprintln!("salvage: {msg}");
+        return 2;
+    };
+
+    match reddb_file::salvage_embedded_store(&source, &destination) {
+        Ok(report) => {
+            if json_mode {
+                match report.machine_json() {
+                    Ok(data) => json_ok("salvage", &data),
+                    Err(err) => {
+                        json_error("salvage", &err.to_string());
+                    }
+                }
+            } else {
+                println!("{}", report.human_summary());
+            }
+            0
+        }
+        Err(err) => {
+            let msg = err.to_string();
+            if json_mode {
+                json_error("salvage", &msg);
+            }
+            eprintln!("salvage: {msg}");
+            1
+        }
+    }
+}
+
 fn validate_redis_tcp_connectivity(redis_url: &str) -> Result<(), String> {
     let addr = redis_socket_addr(redis_url)?;
     let mut addrs = addr
@@ -4086,6 +4135,14 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                     .with_default("redis-migration"),
             ]);
         }
+        Some("salvage") => {
+            flags.extend(vec![
+                cli::types::FlagSchema::new("source")
+                    .with_description("Damaged source .rdb file to read"),
+                cli::types::FlagSchema::new("destination")
+                    .with_description("Fresh destination .rdb file to create"),
+            ]);
+        }
         Some("rpc") => {
             flags.extend(vec![
                 cli::types::FlagSchema::boolean("stdio")
@@ -4180,6 +4237,7 @@ fn build_completion_tree() -> Vec<(String, Vec<(String, Vec<String>)>)> {
         ("delete".to_string(), vec![]),
         ("tick".to_string(), vec![]),
         ("migrate-from-redis".to_string(), vec![]),
+        ("salvage".to_string(), vec![]),
         ("health".to_string(), vec![]),
         (
             "admin".to_string(),

--- a/tests/grouped/cli_transport.rs
+++ b/tests/grouped/cli_transport.rs
@@ -21,6 +21,9 @@ mod cli_migrate_from_redis;
 #[path = "cli_transport/cli_query_param.rs"]
 mod cli_query_param;
 
+#[path = "cli_transport/cli_salvage.rs"]
+mod cli_salvage;
+
 #[path = "cli_transport/e2e_issue_1588_wire_tls_bind.rs"]
 mod e2e_issue_1588_wire_tls_bind;
 

--- a/tests/grouped/cli_transport/cli_salvage.rs
+++ b/tests/grouped/cli_transport/cli_salvage.rs
@@ -1,0 +1,52 @@
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn red_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_red"))
+}
+
+#[test]
+fn salvage_json_writes_fresh_store_and_reports_zero_loss_for_healthy_source() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let source = dir.path().join("source.rdb");
+    let destination = dir.path().join("recovered.rdb");
+    let mut snapshot =
+        reddb_file::encode_native_store_header(reddb_file::native_store::STORE_VERSION_CURRENT);
+    reddb_file::append_native_store_crc32_footer(&mut snapshot);
+
+    reddb_file::EmbeddedRdbArtifact::create_with_snapshot(&source, &snapshot)
+        .expect("create source");
+
+    let output = Command::new(red_binary())
+        .args([
+            "salvage",
+            "--source",
+            source.to_str().unwrap(),
+            "--destination",
+            destination.to_str().unwrap(),
+            "--json",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run red salvage");
+
+    assert!(
+        output.status.success(),
+        "salvage failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(body["ok"], true);
+    assert_eq!(body["command"], "salvage");
+    assert_eq!(body["data"]["schema_version"], 1);
+    assert_eq!(body["data"]["mode"], "manifest");
+    assert_eq!(body["data"]["skipped_regions"].as_array().unwrap().len(), 0);
+
+    let recovered = reddb_file::EmbeddedRdbArtifact::open(&destination).expect("open recovered");
+    assert_eq!(
+        reddb_file::EmbeddedRdbArtifact::read_snapshot(&recovered)
+            .expect("read recovered snapshot"),
+        Some(snapshot)
+    );
+}


### PR DESCRIPTION
Automated AFK landing for #1968. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1968

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/1999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786251359&installation_id=129708444&pr_number=1999&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F1999&signature=bf510a2d5d2a7c9aab40256faf2c7b12f0b2a3ce74156fef87d8a88a5e97c74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->