### PR TITLE
chore: #1965 ADR 0038 Phase 2: circular in-file WAL region with checkpoint reclamation fence; retire the WAL sidecar family

### DIFF
--- a/crates/reddb-file/src/embedded.rs
+++ b/crates/reddb-file/src/embedded.rs
@@ -83,8 +83,10 @@ pub const EMBEDDED_RDB_MANIFEST_ZONE_END: u64 =
 
 const SUPERBLOCK_MAGIC: &[u8; 8] = b"RDBSBLK1";
 const MANIFEST_MAGIC: &[u8; 8] = b"RDBMNFS1";
-const SUPERBLOCK_VERSION: u32 = 1;
-const MANIFEST_VERSION: u32 = 1;
+const SUPERBLOCK_VERSION: u32 = 2;
+const MANIFEST_VERSION: u32 = 2;
+const LEGACY_SUPERBLOCK_VERSION: u32 = 1;
+const LEGACY_MANIFEST_VERSION: u32 = 1;
 const CHECKSUM_LEN: usize = 4;
 const MANIFEST_REGION_BYTES: u64 = EMBEDDED_RDB_MANIFEST_SLOT_SIZE;
 const WAL_REGION_BYTES: u64 = 64 * 1024;
@@ -102,6 +104,7 @@ pub struct EmbeddedRdbManifest {
     pub wal_region_offset: u64,
     pub wal_region_bytes: u64,
     pub wal_recovery_boundary: u64,
+    pub wal_live_bytes: u64,
     pub snapshot_offset: u64,
     pub snapshot_bytes: u64,
     pub snapshot_checksum: u32,
@@ -120,6 +123,7 @@ pub struct EmbeddedRdbSuperblock {
     pub wal_region_offset: u64,
     pub wal_region_bytes: u64,
     pub wal_recovery_boundary: u64,
+    pub wal_live_bytes: u64,
     pub snapshot_offset: u64,
     pub snapshot_bytes: u64,
     pub snapshot_checksum: u32,
@@ -167,6 +171,7 @@ impl EmbeddedRdbArtifact {
             wal_region_offset,
             wal_region_bytes: WAL_REGION_BYTES,
             wal_recovery_boundary: wal_region_offset,
+            wal_live_bytes: 0,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum: crc32(snapshot),
@@ -198,6 +203,7 @@ impl EmbeddedRdbArtifact {
             wal_region_offset,
             wal_region_bytes: WAL_REGION_BYTES,
             wal_recovery_boundary: wal_region_offset,
+            wal_live_bytes: 0,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum: crc32(snapshot),
@@ -260,6 +266,7 @@ impl EmbeddedRdbArtifact {
                 }
             })?;
             manifest.wal_recovery_boundary = selected_superblock.wal_recovery_boundary;
+            manifest.wal_live_bytes = selected_superblock.wal_live_bytes;
             if validate_snapshot_refs && !snapshot_reference_valid(&mut file, &manifest)? {
                 continue;
             }
@@ -304,13 +311,16 @@ impl EmbeddedRdbArtifact {
         lock_file.lock_exclusive()?;
 
         let open = Self::open(path)?;
+        let wal_scan = scan_wal(&open)?;
+        let checkpoint_boundary = wal_boundary_after_live_bytes(&open, wal_scan.valid_bytes)?;
         let wal_region_bytes =
             grow_wal_region_bytes(open.manifest.wal_region_bytes, min_wal_bytes)?;
         let snapshot_offset = next_snapshot_offset(path, &open, wal_region_bytes, snapshot)?;
         let snapshot_checksum = crc32(snapshot);
         let manifest = EmbeddedRdbManifest {
             wal_region_bytes,
-            wal_recovery_boundary: open.manifest.wal_region_offset,
+            wal_recovery_boundary: checkpoint_boundary,
+            wal_live_bytes: 0,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum,
@@ -351,7 +361,8 @@ impl EmbeddedRdbArtifact {
             manifest_len: manifest_bytes.len() as u64,
             manifest_checksum,
             wal_region_bytes,
-            wal_recovery_boundary: open.manifest.wal_region_offset,
+            wal_recovery_boundary: checkpoint_boundary,
+            wal_live_bytes: 0,
             snapshot_offset,
             snapshot_bytes: snapshot.len() as u64,
             snapshot_checksum,
@@ -448,25 +459,24 @@ impl EmbeddedRdbArtifact {
             sequence = sequence.saturating_add(1);
         }
 
-        let wal_start = open.manifest.wal_region_offset;
-        let wal_end = wal_start.checked_add(wal_scan.valid_bytes).ok_or_else(|| {
-            RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
-        })?;
-        let max_end = open
+        let encoded_len = encoded.len() as u64;
+        let free_bytes = open
             .manifest
-            .wal_region_offset
-            .saturating_add(open.manifest.wal_region_bytes);
-        let next_boundary = wal_end.checked_add(encoded.len() as u64).ok_or_else(|| {
-            RdbFileError::InvalidOperation("embedded wal boundary overflow".into())
-        })?;
-        if wal_end < wal_start || next_boundary > max_end {
+            .wal_region_bytes
+            .checked_sub(wal_scan.valid_bytes)
+            .ok_or_else(|| {
+                RdbFileError::InvalidOperation("embedded wal live bytes overflow".into())
+            })?;
+        if encoded_len > free_bytes {
             return Err(RdbFileError::InvalidOperation(
                 "embedded wal region full".into(),
             ));
         }
+        let next_boundary =
+            wal_boundary_after_live_bytes(&open, wal_scan.valid_bytes + encoded_len)?;
 
         let mut file = OpenOptions::new().read(true).write(true).open(path)?;
-        write_at(&mut file, wal_end, &encoded)?;
+        write_circular_wal_bytes(&mut file, &open, &encoded)?;
         crash_inject("wal_after_frame_write");
         file.sync_data()?;
         crash_inject("wal_after_frame_sync");
@@ -480,6 +490,7 @@ impl EmbeddedRdbArtifact {
             copy_index: next_copy_index,
             generation: open.selected_superblock.generation.saturating_add(1),
             wal_recovery_boundary: next_boundary,
+            wal_live_bytes: wal_scan.valid_bytes + encoded_len,
             checksum: 0,
             ..open.selected_superblock
         };
@@ -657,17 +668,22 @@ fn align_up(value: u64, alignment: u64) -> RdbFileResult<u64> {
 
 fn scan_wal(open: &EmbeddedRdbOpen) -> RdbFileResult<WalScan> {
     let wal_start = open.manifest.wal_region_offset;
-    let wal_end = open.manifest.wal_recovery_boundary;
-    let max_end = open
-        .manifest
-        .wal_region_offset
-        .saturating_add(open.manifest.wal_region_bytes);
-    if wal_end < wal_start || wal_end > max_end {
+    let wal_end = wal_start
+        .checked_add(open.manifest.wal_region_bytes)
+        .ok_or_else(|| RdbFileError::InvalidOperation("embedded wal end overflow".into()))?;
+    let append_boundary = open.manifest.wal_recovery_boundary;
+    if append_boundary < wal_start || append_boundary > wal_end {
         return Err(RdbFileError::InvalidOperation(format!(
-            "invalid embedded wal boundary {wal_end}"
+            "invalid embedded wal boundary {append_boundary}"
         )));
     }
-    if wal_end == wal_start {
+    if open.manifest.wal_live_bytes > open.manifest.wal_region_bytes {
+        return Err(RdbFileError::InvalidOperation(format!(
+            "invalid embedded wal live bytes {}",
+            open.manifest.wal_live_bytes
+        )));
+    }
+    if open.manifest.wal_live_bytes == 0 {
         return Ok(WalScan {
             next_sequence: 1,
             ..WalScan::default()
@@ -682,11 +698,93 @@ fn scan_wal(open: &EmbeddedRdbOpen) -> RdbFileResult<WalScan> {
             ..WalScan::default()
         });
     }
-    let read_end = wal_end.min(file_len);
-    file.seek(SeekFrom::Start(wal_start))?;
-    let mut bytes = vec![0u8; (read_end - wal_start) as usize];
-    file.read_exact(&mut bytes)?;
+    let bytes = read_circular_wal_bytes(&mut file, open, file_len)?;
     Ok(scan_wal_bytes(&bytes))
+}
+
+fn read_circular_wal_bytes(
+    file: &mut File,
+    open: &EmbeddedRdbOpen,
+    file_len: u64,
+) -> RdbFileResult<Vec<u8>> {
+    let live_start = wal_live_start_relative(open)?;
+    let region_bytes = open.manifest.wal_region_bytes;
+    let live_bytes = open.manifest.wal_live_bytes;
+    let mut remaining = live_bytes.min(file_len.saturating_sub(open.manifest.wal_region_offset));
+    let mut relative = live_start;
+    let mut bytes = Vec::with_capacity(remaining as usize);
+    while remaining > 0 {
+        let contiguous = (region_bytes - relative).min(remaining);
+        let offset = open.manifest.wal_region_offset + relative;
+        file.seek(SeekFrom::Start(offset))?;
+        let mut chunk = vec![0u8; contiguous as usize];
+        file.read_exact(&mut chunk)?;
+        bytes.extend_from_slice(&chunk);
+        remaining -= contiguous;
+        relative = 0;
+    }
+    Ok(bytes)
+}
+
+fn write_circular_wal_bytes(
+    file: &mut File,
+    open: &EmbeddedRdbOpen,
+    bytes: &[u8],
+) -> RdbFileResult<()> {
+    let mut written = 0usize;
+    let mut relative = wal_append_relative(open)?;
+    while written < bytes.len() {
+        if relative == open.manifest.wal_region_bytes {
+            relative = 0;
+        }
+        let contiguous = (open.manifest.wal_region_bytes - relative) as usize;
+        let chunk_len = contiguous.min(bytes.len() - written);
+        write_at(
+            file,
+            open.manifest.wal_region_offset + relative,
+            &bytes[written..written + chunk_len],
+        )?;
+        written += chunk_len;
+        relative += chunk_len as u64;
+    }
+    Ok(())
+}
+
+fn wal_append_relative(open: &EmbeddedRdbOpen) -> RdbFileResult<u64> {
+    open.manifest
+        .wal_recovery_boundary
+        .checked_sub(open.manifest.wal_region_offset)
+        .ok_or_else(|| RdbFileError::InvalidOperation("embedded wal boundary underflow".into()))
+}
+
+fn wal_live_start_relative(open: &EmbeddedRdbOpen) -> RdbFileResult<u64> {
+    let append = wal_append_relative(open)?;
+    let region = open.manifest.wal_region_bytes;
+    if region == 0 {
+        return Err(RdbFileError::InvalidOperation(
+            "embedded wal region is empty".into(),
+        ));
+    }
+    Ok((append + region - (open.manifest.wal_live_bytes % region)) % region)
+}
+
+fn wal_boundary_after_live_bytes(open: &EmbeddedRdbOpen, live_bytes: u64) -> RdbFileResult<u64> {
+    if live_bytes > open.manifest.wal_region_bytes {
+        return Err(RdbFileError::InvalidOperation(format!(
+            "embedded wal live bytes {live_bytes} exceed region size {}",
+            open.manifest.wal_region_bytes
+        )));
+    }
+    let start = if open.manifest.wal_live_bytes == 0 {
+        wal_append_relative(open)?
+    } else {
+        wal_live_start_relative(open)?
+    };
+    let relative = (start + live_bytes) % open.manifest.wal_region_bytes;
+    open.manifest
+        .wal_region_offset
+        .checked_add(relative)
+        .ok_or_else(|| RdbFileError::InvalidOperation("embedded wal boundary overflow".into()))
 }
 
 fn scan_wal_bytes(bytes: &[u8]) -> WalScan {
@@ -870,6 +968,7 @@ fn encode_superblock(superblock: EmbeddedRdbSuperblock) -> RdbFileResult<Vec<u8>
     put_u64(&mut bytes, &mut cursor, superblock.wal_region_offset);
     put_u64(&mut bytes, &mut cursor, superblock.wal_region_bytes);
     put_u64(&mut bytes, &mut cursor, superblock.wal_recovery_boundary);
+    put_u64(&mut bytes, &mut cursor, superblock.wal_live_bytes);
     put_u64(&mut bytes, &mut cursor, superblock.snapshot_offset);
     put_u64(&mut bytes, &mut cursor, superblock.snapshot_bytes);
     put_u32(&mut bytes, &mut cursor, superblock.snapshot_checksum);
@@ -902,7 +1001,7 @@ fn decode_superblock(copy_index: u8, bytes: &[u8]) -> RdbFileResult<EmbeddedRdbS
         ));
     }
     let version = take_u32(bytes, &mut cursor)?;
-    if version != SUPERBLOCK_VERSION {
+    if version != SUPERBLOCK_VERSION && version != LEGACY_SUPERBLOCK_VERSION {
         return Err(RdbFileError::InvalidOperation(format!(
             "unsupported embedded superblock version {version}"
         )));
@@ -914,16 +1013,31 @@ fn decode_superblock(copy_index: u8, bytes: &[u8]) -> RdbFileResult<EmbeddedRdbS
         ));
     }
 
+    let generation = take_u64(bytes, &mut cursor)?;
+    let format_version = take_u32(bytes, &mut cursor)?;
+    let manifest_offset = take_u64(bytes, &mut cursor)?;
+    let manifest_len = take_u64(bytes, &mut cursor)?;
+    let manifest_checksum = take_u32(bytes, &mut cursor)?;
+    let wal_region_offset = take_u64(bytes, &mut cursor)?;
+    let wal_region_bytes = take_u64(bytes, &mut cursor)?;
+    let wal_recovery_boundary = take_u64(bytes, &mut cursor)?;
+    let wal_live_bytes = if version == SUPERBLOCK_VERSION {
+        take_u64(bytes, &mut cursor)?
+    } else {
+        wal_recovery_boundary.saturating_sub(wal_region_offset)
+    };
+
     Ok(EmbeddedRdbSuperblock {
         copy_index: stored_copy_index,
-        generation: take_u64(bytes, &mut cursor)?,
-        format_version: take_u32(bytes, &mut cursor)?,
-        manifest_offset: take_u64(bytes, &mut cursor)?,
-        manifest_len: take_u64(bytes, &mut cursor)?,
-        manifest_checksum: take_u32(bytes, &mut cursor)?,
-        wal_region_offset: take_u64(bytes, &mut cursor)?,
-        wal_region_bytes: take_u64(bytes, &mut cursor)?,
-        wal_recovery_boundary: take_u64(bytes, &mut cursor)?,
+        generation,
+        format_version,
+        manifest_offset,
+        manifest_len,
+        manifest_checksum,
+        wal_region_offset,
+        wal_region_bytes,
+        wal_recovery_boundary,
+        wal_live_bytes,
         snapshot_offset: take_u64(bytes, &mut cursor)?,
         snapshot_bytes: take_u64(bytes, &mut cursor)?,
         snapshot_checksum: take_u32(bytes, &mut cursor)?,
@@ -932,13 +1046,14 @@ fn decode_superblock(copy_index: u8, bytes: &[u8]) -> RdbFileResult<EmbeddedRdbS
 }
 
 fn encode_manifest(manifest: EmbeddedRdbManifest) -> Vec<u8> {
-    let mut bytes = vec![0u8; 8 + 4 + 8 + 8 + 8 + 8 + 8 + 4 + 16 + CHECKSUM_LEN];
+    let mut bytes = vec![0u8; 8 + 4 + 8 + 8 + 8 + 8 + 8 + 8 + 4 + 16 + CHECKSUM_LEN];
     let mut cursor = 0usize;
     put_bytes(&mut bytes, &mut cursor, MANIFEST_MAGIC);
     put_u32(&mut bytes, &mut cursor, manifest.version);
     put_u64(&mut bytes, &mut cursor, manifest.wal_region_offset);
     put_u64(&mut bytes, &mut cursor, manifest.wal_region_bytes);
     put_u64(&mut bytes, &mut cursor, manifest.wal_recovery_boundary);
+    put_u64(&mut bytes, &mut cursor, manifest.wal_live_bytes);
     put_u64(&mut bytes, &mut cursor, manifest.snapshot_offset);
     put_u64(&mut bytes, &mut cursor, manifest.snapshot_bytes);
     put_u32(&mut bytes, &mut cursor, manifest.snapshot_checksum);
@@ -970,16 +1085,25 @@ fn decode_manifest(bytes: &[u8]) -> RdbFileResult<EmbeddedRdbManifest> {
         ));
     }
     let version = take_u32(bytes, &mut cursor)?;
-    if version != MANIFEST_VERSION {
+    if version != MANIFEST_VERSION && version != LEGACY_MANIFEST_VERSION {
         return Err(RdbFileError::InvalidOperation(format!(
             "unsupported embedded manifest version {version}"
         )));
     }
+    let wal_region_offset = take_u64(bytes, &mut cursor)?;
+    let wal_region_bytes = take_u64(bytes, &mut cursor)?;
+    let wal_recovery_boundary = take_u64(bytes, &mut cursor)?;
+    let wal_live_bytes = if version == MANIFEST_VERSION {
+        take_u64(bytes, &mut cursor)?
+    } else {
+        wal_recovery_boundary.saturating_sub(wal_region_offset)
+    };
     Ok(EmbeddedRdbManifest {
         version,
-        wal_region_offset: take_u64(bytes, &mut cursor)?,
-        wal_region_bytes: take_u64(bytes, &mut cursor)?,
-        wal_recovery_boundary: take_u64(bytes, &mut cursor)?,
+        wal_region_offset,
+        wal_region_bytes,
+        wal_recovery_boundary,
+        wal_live_bytes,
         snapshot_offset: take_u64(bytes, &mut cursor)?,
         snapshot_bytes: take_u64(bytes, &mut cursor)?,
         snapshot_checksum: take_u32(bytes, &mut cursor)?,

--- a/crates/reddb-file/src/embedded.rs
+++ b/crates/reddb-file/src/embedded.rs
@@ -390,6 +390,10 @@ impl EmbeddedRdbArtifact {
 
         let mut manifest = read_manifest(&mut file, selected_superblock)?;
         manifest.wal_recovery_boundary = selected_superblock.wal_recovery_boundary;
+        // The superblock is the WAL authority: appends update it without
+        // rewriting the manifest zone, so a stale manifest wal_live_bytes
+        // would make the scan see an empty region and drop live records.
+        manifest.wal_live_bytes = selected_superblock.wal_live_bytes;
         Ok(EmbeddedRdbOpen {
             path: path.to_path_buf(),
             selected_superblock,

--- a/crates/reddb-file/src/scrub.rs
+++ b/crates/reddb-file/src/scrub.rs
@@ -296,9 +296,11 @@ fn parse_superblock(copy_index: u8, bytes: &[u8]) -> Option<ParsedSuperblock> {
         manifest_len: read_u64(bytes, 33)?,
         manifest_checksum: read_u32(bytes, 41)?,
         wal_recovery_boundary: read_u64(bytes, 61)?,
-        snapshot_offset: read_u64(bytes, 69)?,
-        snapshot_bytes: read_u64(bytes, 77)?,
-        snapshot_checksum: read_u32(bytes, 85)?,
+        // offset 69..77 is wal_live_bytes (superblock v2); the census does
+        // not need it, but the snapshot fields sit 8 bytes further out.
+        snapshot_offset: read_u64(bytes, 77)?,
+        snapshot_bytes: read_u64(bytes, 85)?,
+        snapshot_checksum: read_u32(bytes, 93)?,
     })
 }
 

--- a/crates/reddb-file/tests/embedded_rdb_artifact.rs
+++ b/crates/reddb-file/tests/embedded_rdb_artifact.rs
@@ -311,8 +311,7 @@ fn embedded_wal_checkpoint_fence_allows_wrap_after_quiescing_region() {
     let checkpointed =
         EmbeddedRdbArtifact::write_snapshot(&path, b"RDST-checkpoint").expect("checkpoint");
     assert_eq!(
-        checkpointed.manifest.wal_recovery_boundary,
-        pre_checkpoint.manifest.wal_recovery_boundary,
+        checkpointed.manifest.wal_recovery_boundary, pre_checkpoint.manifest.wal_recovery_boundary,
         "checkpointing proves the old frames reclaimable but keeps the append fence at the tail"
     );
     assert_eq!(checkpointed.manifest.wal_live_bytes, 0);

--- a/crates/reddb-file/tests/embedded_rdb_artifact.rs
+++ b/crates/reddb-file/tests/embedded_rdb_artifact.rs
@@ -292,6 +292,49 @@ fn embedded_wal_recovery_ignores_corrupt_or_truncated_tail_frame() {
 }
 
 #[test]
+fn embedded_wal_checkpoint_fence_allows_wrap_after_quiescing_region() {
+    let dir = temp_dir("wal_wrap_after_checkpoint");
+    let path = dir.path().join("data.rdb");
+    let created = EmbeddedRdbArtifact::create(&path).expect("create embedded rdb");
+
+    let empty_frame_len = EmbeddedRdbArtifact::wal_payloads_encoded_len(&[Vec::new()]).unwrap();
+    let prefill_payload_len = created.manifest.wal_region_bytes - empty_frame_len - 8;
+    let prefill = vec![0xA5; prefill_payload_len as usize];
+    EmbeddedRdbArtifact::append_wal_payloads(&path, &[prefill]).expect("append prefill frame");
+
+    let pre_checkpoint = EmbeddedRdbArtifact::open(&path).expect("open before checkpoint");
+    assert_eq!(
+        pre_checkpoint.manifest.wal_recovery_boundary,
+        pre_checkpoint.manifest.wal_region_offset + pre_checkpoint.manifest.wal_region_bytes - 8
+    );
+
+    let checkpointed =
+        EmbeddedRdbArtifact::write_snapshot(&path, b"RDST-checkpoint").expect("checkpoint");
+    assert_eq!(
+        checkpointed.manifest.wal_recovery_boundary,
+        pre_checkpoint.manifest.wal_recovery_boundary,
+        "checkpointing proves the old frames reclaimable but keeps the append fence at the tail"
+    );
+    assert_eq!(checkpointed.manifest.wal_live_bytes, 0);
+
+    let wrapped = b"after-wrap".to_vec();
+    EmbeddedRdbArtifact::append_wal_payloads(&path, std::slice::from_ref(&wrapped))
+        .expect("append wrapped frame");
+
+    let artifact = EmbeddedRdbArtifact::open(&path).expect("open after wrapped append");
+    assert!(
+        artifact.manifest.wal_recovery_boundary < artifact.manifest.wal_region_offset + 64,
+        "the append boundary should wrap to the start of the region"
+    );
+    assert_eq!(
+        artifact.manifest.wal_live_bytes,
+        EmbeddedRdbArtifact::wal_payloads_encoded_len(std::slice::from_ref(&wrapped)).unwrap()
+    );
+    let payloads = EmbeddedRdbArtifact::read_wal_payloads(&artifact).expect("read wrapped wal");
+    assert_eq!(payloads, vec![wrapped]);
+}
+
+#[test]
 fn embedded_wal_crash_injection_preserves_last_published_prefix() {
     const TEST_NAME: &str = "embedded_wal_crash_injection_preserves_last_published_prefix";
     if std::env::var("REDDB_EMBEDDED_RDB_CRASH_CHILD_OP")

--- a/crates/reddb-server/tests/embedded_rdb_skeleton.rs
+++ b/crates/reddb-server/tests/embedded_rdb_skeleton.rs
@@ -103,10 +103,7 @@ fn embedded_runtime_replays_internal_wal_without_flush_or_drop() {
     rt.flush().expect("checkpoint replayed state");
 
     let checkpointed = EmbeddedRdbArtifact::open(&path).expect("open checkpointed artifact");
-    assert_eq!(
-        checkpointed.manifest.wal_recovery_boundary,
-        checkpointed.manifest.wal_region_offset
-    );
+    assert_eq!(checkpointed.manifest.wal_live_bytes, 0);
     assert!(checkpointed.manifest.snapshot_bytes > 0);
     assert_eq!(artifact_names(dir.path()), vec!["data.rdb"]);
 }


### PR DESCRIPTION
Automated AFK landing for #1965. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1965

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786284014&installation_id=129708444&pr_number=2007&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2007&signature=74b3b478427bbb90bdadfdd0d60a8776c849378b4f1fa165def944692e2792b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->