### PR TITLE
chore: #1768 Lossless JSON numbers tracer: exact integers through the document body

### DIFF
--- a/crates/reddb-rql/src/parser/tree.rs
+++ b/crates/reddb-rql/src/parser/tree.rs
@@ -289,6 +289,7 @@ fn tree_json_value_to_storage_value(value: &JsonValue) -> Result<Value, ParseErr
     Ok(match value {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(value) => Value::Boolean(*value),
+        JsonValue::Integer(value) => Value::Integer(*value),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON {
                 Value::Integer(*value as i64)

--- a/crates/reddb-server/src/application/entity.rs
+++ b/crates/reddb-server/src/application/entity.rs
@@ -339,6 +339,7 @@ pub(crate) fn json_to_storage_value(value: &JsonValue) -> RedDBResult<Value> {
     match value {
         JsonValue::Null => Ok(Value::Null),
         JsonValue::Bool(value) => Ok(Value::Boolean(*value)),
+        JsonValue::Integer(value) => Ok(Value::Integer(*value)),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON {
                 Ok(Value::Integer(*value as i64))
@@ -357,6 +358,7 @@ pub(crate) fn json_to_metadata_value(value: &JsonValue) -> RedDBResult<MetadataV
     match value {
         JsonValue::Null => Ok(MetadataValue::Null),
         JsonValue::Bool(value) => Ok(MetadataValue::Bool(*value)),
+        JsonValue::Integer(value) => Ok(MetadataValue::Int(*value)),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON {
                 Ok(MetadataValue::Int(*value as i64))
@@ -685,6 +687,7 @@ fn metadata_value_from_json(value: &JsonValue) -> RedDBResult<MetadataValue> {
     match value {
         JsonValue::Null => Ok(MetadataValue::Null),
         JsonValue::Bool(value) => Ok(MetadataValue::Bool(*value)),
+        JsonValue::Integer(value) => Ok(MetadataValue::Int(*value)),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON {
                 Ok(MetadataValue::Int(*value as i64))

--- a/crates/reddb-server/src/application/json_input.rs
+++ b/crates/reddb-server/src/application/json_input.rs
@@ -26,6 +26,7 @@ pub(crate) fn json_metadata_value_to_string(value: &JsonValue) -> String {
     match value {
         JsonValue::Null => "null".to_string(),
         JsonValue::Bool(value) => value.to_string(),
+        JsonValue::Integer(value) => value.to_string(),
         JsonValue::Number(value) => value.to_string(),
         JsonValue::String(value) => value.clone(),
         JsonValue::Array(_) | JsonValue::Object(_) => {

--- a/crates/reddb-server/src/application/query_payload.rs
+++ b/crates/reddb-server/src/application/query_payload.rs
@@ -677,6 +677,7 @@ fn json_filter_value(value: &JsonValue) -> RedDBResult<RuntimeFilterValue> {
     Ok(match value {
         JsonValue::Null => RuntimeFilterValue::Null,
         JsonValue::Bool(value) => RuntimeFilterValue::Bool(*value),
+        JsonValue::Integer(value) => RuntimeFilterValue::Int(*value),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON {
                 RuntimeFilterValue::Int(*value as i64)

--- a/crates/reddb-server/src/cli/bootstrap_manifest.rs
+++ b/crates/reddb-server/src/cli/bootstrap_manifest.rs
@@ -1004,6 +1004,7 @@ fn json_to_storage_value(value: &JsonValue) -> Result<Value, String> {
     Ok(match value {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(value) => Value::Boolean(*value),
+        JsonValue::Integer(value) => Value::Integer(*value),
         JsonValue::Number(value) => {
             if value.fract().abs() < f64::EPSILON && *value >= 0.0 {
                 Value::UnsignedInteger(*value as u64)

--- a/crates/reddb-server/src/document_body.rs
+++ b/crates/reddb-server/src/document_body.rs
@@ -39,7 +39,11 @@ pub(crate) fn decode_container_to_json(bytes: &[u8]) -> Option<JsonValue> {
     let fields = document_body_codec::decode(bytes).ok()?;
     let mut map = Map::new();
     for (key, value) in fields {
-        map.insert(key, storage_value_to_json(&value));
+        let json = match &value {
+            Value::Integer(n) => JsonValue::Integer(*n),
+            other => storage_value_to_json(other),
+        };
+        map.insert(key, json);
     }
     Some(JsonValue::Object(map))
 }

--- a/crates/reddb-server/src/grpc/input_support.rs
+++ b/crates/reddb-server/src/grpc/input_support.rs
@@ -8,6 +8,7 @@ pub(crate) fn parse_json_bind_value(s: &str) -> Result<Value, String> {
     Ok(match json_val {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(b) => Value::Boolean(b),
+        JsonValue::Integer(n) => Value::Integer(n),
         JsonValue::Number(n) => {
             if n.fract() == 0.0 && n.abs() < i64::MAX as f64 {
                 Value::Integer(n as i64)

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -1655,6 +1655,7 @@ fn mcp_keyed_ident(value: &str) -> Result<String, String> {
 fn mcp_value_literal(value: &JsonValue) -> Result<String, String> {
     match value {
         JsonValue::String(value) => Ok(format!("'{}'", value.replace('\'', "''"))),
+        JsonValue::Integer(value) => Ok(value.to_string()),
         JsonValue::Number(value) => Ok(value.to_string()),
         JsonValue::Bool(value) => Ok(value.to_string()),
         JsonValue::Null => Ok("NULL".to_string()),

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -1517,6 +1517,7 @@ pub(crate) fn json_value_to_schema_value(v: &Value) -> SchemaValue {
     match v {
         Value::Null => SchemaValue::Null,
         Value::Bool(b) => SchemaValue::Boolean(*b),
+        Value::Integer(n) => SchemaValue::Integer(*n),
         Value::Number(n) => {
             if n.is_finite() && n.fract() == 0.0 && *n >= i64::MIN as f64 && *n <= i64::MAX as f64 {
                 SchemaValue::Integer(*n as i64)
@@ -1529,7 +1530,10 @@ pub(crate) fn json_value_to_schema_value(v: &Value) -> SchemaValue {
             // A JSON array of numbers (or empty) is taken as `Vector`
             // for the #355 query-param contract. Other arrays are
             // JSON values, so JSON columns can bind array payloads.
-            if items.iter().all(|v| matches!(v, Value::Number(_))) {
+            if items
+                .iter()
+                .all(|v| matches!(v, Value::Integer(_) | Value::Number(_)))
+            {
                 let floats: Vec<f32> = items
                     .iter()
                     .map(|v| v.as_f64().unwrap_or(0.0) as f32)

--- a/crates/reddb-server/src/runtime/ai/ner.rs
+++ b/crates/reddb-server/src/runtime/ai/ner.rs
@@ -541,6 +541,7 @@ fn json_kind(v: &JsonValue) -> &'static str {
     match v {
         JsonValue::Null => "null",
         JsonValue::Bool(_) => "bool",
+        JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",

--- a/crates/reddb-server/src/runtime/analytics_schema_registry.rs
+++ b/crates/reddb-server/src/runtime/analytics_schema_registry.rs
@@ -479,6 +479,7 @@ fn json_type_name(v: &JsonValue) -> &'static str {
     match v {
         JsonValue::Null => "null",
         JsonValue::Bool(_) => "boolean",
+        JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",
@@ -493,8 +494,9 @@ fn type_matches(expected: &str, got: &JsonValue) -> bool {
         "array" => matches!(got, JsonValue::Array(_)),
         "object" => matches!(got, JsonValue::Object(_)),
         "null" => matches!(got, JsonValue::Null),
-        "number" => matches!(got, JsonValue::Number(_)),
+        "number" => matches!(got, JsonValue::Integer(_) | JsonValue::Number(_)),
         "integer" => match got {
+            JsonValue::Integer(_) => true,
             JsonValue::Number(n) => *n == n.trunc(),
             _ => false,
         },

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1819,6 +1819,7 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
             let name = match v {
                 crate::serde_json::Value::Null => "null",
                 crate::serde_json::Value::Bool(_) => "boolean",
+                crate::serde_json::Value::Integer(_) => "number",
                 crate::serde_json::Value::Number(_) => "number",
                 crate::serde_json::Value::String(_) => "string",
                 crate::serde_json::Value::Array(_) => "array",
@@ -1920,6 +1921,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
             map.values().any(|value| json_value_contains(value, needle))
         }
         crate::serde_json::Value::String(value) => value == needle,
+        crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null => false,
@@ -2034,6 +2036,7 @@ fn json_extract_impl(input: &Value, path: &Value, as_text: bool) -> Option<Value
             crate::serde_json::Value::String(s) => Some(Value::text(s.clone())),
             crate::serde_json::Value::Null => Some(Value::Null),
             crate::serde_json::Value::Bool(b) => Some(Value::text(b.to_string())),
+            crate::serde_json::Value::Integer(n) => Some(Value::text(n.to_string())),
             crate::serde_json::Value::Number(n) => Some(Value::text(n.to_string())),
             other => Some(Value::text(other.to_string_compact())),
         }

--- a/crates/reddb-server/src/runtime/join_filter/field_resolution.rs
+++ b/crates/reddb-server/src/runtime/join_filter/field_resolution.rs
@@ -219,6 +219,7 @@ pub(in crate::runtime) fn runtime_json_value_to_runtime_value(value: &JsonValue)
     match value {
         JsonValue::Null => Some(Value::Null),
         JsonValue::Bool(value) => Some(Value::Boolean(*value)),
+        JsonValue::Integer(value) => Some(Value::Integer(*value)),
         JsonValue::Number(value) => Some(Value::Float(*value)),
         JsonValue::String(value) => Some(Value::text(value.clone())),
         JsonValue::Array(values) => Some(Value::Array(

--- a/crates/reddb-server/src/runtime/join_filter/filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter/filter.rs
@@ -164,6 +164,7 @@ fn json_value_contains(value: &JsonValue, needle: &str) -> bool {
             .iter()
             .any(|value| json_value_contains(value, needle)),
         JsonValue::String(value) => value == needle,
+        JsonValue::Integer(value) => value.to_string() == needle,
         JsonValue::Number(value) => value.to_string() == needle,
         JsonValue::Bool(value) => value.to_string() == needle,
         JsonValue::Null | JsonValue::Object(_) => false,

--- a/crates/reddb-server/src/runtime/mutation.rs
+++ b/crates/reddb-server/src/runtime/mutation.rs
@@ -843,6 +843,7 @@ fn event_item_kind_for_entity(
 fn json_id_for_hash(value: &JsonValue) -> String {
     match value {
         JsonValue::String(value) => value.clone(),
+        JsonValue::Integer(value) => value.to_string(),
         JsonValue::Number(value) => value.to_string(),
         JsonValue::Bool(value) => value.to_string(),
         JsonValue::Null => "null".to_string(),
@@ -1348,6 +1349,7 @@ fn compare_json_to_store_value(
     let lhs: Value = match json {
         None | Some(JsonValue::Null) => Value::Null,
         Some(JsonValue::Bool(b)) => Value::Boolean(*b),
+        Some(JsonValue::Integer(n)) => Value::Integer(*n),
         Some(JsonValue::Number(n)) => {
             let n = *n;
             if n.fract() == 0.0 && n >= i64::MIN as f64 && n <= i64::MAX as f64 {

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -816,6 +816,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
             .iter()
             .any(|value| json_value_contains(value, needle)),
         crate::serde_json::Value::String(value) => value == needle,
+        crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -693,6 +693,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
             .iter()
             .any(|value| json_value_contains(value, needle)),
         crate::serde_json::Value::String(value) => value == needle,
+        crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,

--- a/crates/reddb-server/src/server/handlers_keyed.rs
+++ b/crates/reddb-server/src/server/handlers_keyed.rs
@@ -400,6 +400,7 @@ fn list_sql(domain: &str, collection: &str, query: &BTreeMap<String, String>) ->
 fn keyed_value_literal(value: &JsonValue) -> Result<String, HttpResponse> {
     match value {
         JsonValue::String(value) => Ok(format!("'{}'", value.replace('\'', "''"))),
+        JsonValue::Integer(value) => Ok(value.to_string()),
         JsonValue::Number(value) => Ok(value.to_string()),
         JsonValue::Bool(value) => Ok(value.to_string()),
         JsonValue::Null => Ok("NULL".to_string()),

--- a/crates/reddb-server/src/server/handlers_log.rs
+++ b/crates/reddb-server/src/server/handlers_log.rs
@@ -102,6 +102,7 @@ fn json_to_value(v: &JsonValue) -> Value {
     match v {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(b) => Value::Boolean(*b),
+        JsonValue::Integer(n) => Value::Integer(*n),
         JsonValue::Number(n) => Value::Float(*n),
         JsonValue::String(s) => Value::text(s.clone()),
         JsonValue::Array(arr) => Value::Array(arr.iter().map(json_to_value).collect()),

--- a/crates/reddb-server/src/server/ingest_pipeline.rs
+++ b/crates/reddb-server/src/server/ingest_pipeline.rs
@@ -232,6 +232,7 @@ fn json_type_name(v: &JsonValue) -> &'static str {
     match v {
         JsonValue::Null => "null",
         JsonValue::Bool(_) => "bool",
+        JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",
@@ -243,6 +244,7 @@ fn json_to_value(v: &JsonValue) -> Value {
     match v {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(b) => Value::Boolean(*b),
+        JsonValue::Integer(n) => Value::Integer(*n),
         JsonValue::Number(n) => {
             // Preserve integer-ness when the number has no fraction —
             // downstream codecs pick T64 / Delta on i64 columns and

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -924,6 +924,7 @@ fn json_extract_value(input: &Value, path: &Value, as_text: bool) -> Value {
             crate::serde_json::Value::String(value) => Value::text(value.clone()),
             crate::serde_json::Value::Null => Value::Null,
             crate::serde_json::Value::Bool(value) => Value::text(value.to_string()),
+            crate::serde_json::Value::Integer(value) => Value::text(value.to_string()),
             crate::serde_json::Value::Number(value) => Value::text(value.to_string()),
             other => Value::text(other.to_string_compact()),
         }
@@ -978,6 +979,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
             map.values().any(|value| json_value_contains(value, needle))
         }
         crate::serde_json::Value::String(value) => value == needle,
+        crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null => false,

--- a/crates/reddb-server/src/storage/unified/devx/builders.rs
+++ b/crates/reddb-server/src/storage/unified/devx/builders.rs
@@ -792,6 +792,7 @@ fn json_value_to_storage_value(value: &JsonValue) -> Value {
     match value {
         JsonValue::Null => Value::Null,
         JsonValue::Bool(b) => Value::Boolean(*b),
+        JsonValue::Integer(n) => Value::Integer(*n),
         JsonValue::Number(n) => {
             if n.fract().abs() < f64::EPSILON {
                 Value::Integer(*n as i64)

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_access.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_access.rs
@@ -530,6 +530,7 @@ impl RedDB {
         match value {
             JsonValue::Null => None,
             JsonValue::Bool(value) => Some(value.to_string()),
+            JsonValue::Integer(value) => Some(value.to_string()),
             JsonValue::Number(value) => Some(value.to_string()),
             JsonValue::String(value) => Some(value.clone()),
             JsonValue::Array(_) | JsonValue::Object(_) => None,

--- a/crates/reddb-server/src/storage/unified/dsl/cross_modal.rs
+++ b/crates/reddb-server/src/storage/unified/dsl/cross_modal.rs
@@ -237,6 +237,13 @@ pub(crate) fn cross_modal_value_tokens(value: &crate::storage::schema::Value) ->
                         }
                         *budget = budget.saturating_sub(1);
                     }
+                    crate::serde_json::Value::Integer(value) => {
+                        push(tokens, seen, value.to_string());
+                        if *value >= 0 {
+                            push(tokens, seen, format!("e{value}"));
+                        }
+                        *budget = budget.saturating_sub(1);
+                    }
                     crate::serde_json::Value::Number(value) => {
                         let i = *value as i64;
                         if *value >= 0.0 && value.fract().abs() < f64::EPSILON {

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -1684,6 +1684,9 @@ fn flatten_config_json(
         crate::serde_json::Value::String(s) => {
             out.push((prefix.to_string(), Value::text(s.clone())));
         }
+        crate::serde_json::Value::Integer(n) => {
+            out.push((prefix.to_string(), Value::Integer(*n)));
+        }
         crate::serde_json::Value::Number(n) => {
             if n.fract().abs() < f64::EPSILON {
                 out.push((prefix.to_string(), Value::UnsignedInteger(*n as u64)));

--- a/crates/reddb-server/src/storage/unified/tokenization.rs
+++ b/crates/reddb-server/src/storage/unified/tokenization.rs
@@ -85,6 +85,10 @@ pub fn push_json_tokens(tokens: &mut BTreeSet<String>, bytes: &[u8]) {
                 push_text_tokens(tokens, if *v { "true" } else { "false" }, false);
                 *budget = budget.saturating_sub(1);
             }
+            crate::serde_json::Value::Integer(v) => {
+                push_text_tokens(tokens, &v.to_string(), false);
+                *budget = budget.saturating_sub(1);
+            }
             crate::serde_json::Value::Number(v) => {
                 push_text_tokens(tokens, &v.to_string(), false);
                 *budget = budget.saturating_sub(1);

--- a/crates/reddb-types/src/document_body_codec.rs
+++ b/crates/reddb-types/src/document_body_codec.rs
@@ -4,11 +4,11 @@
 //! container with a **header offset table** that enables O(1) access to any
 //! top-level field value without decoding the entire document.
 //!
-//! ## Format — version 1
+//! ## Format — version 3
 //!
 //! ```text
 //! [0..4]  magic        = b"RDOC"
-//! [4]     version      = 0x01
+//! [4]     version      = 0x03
 //! [5..7]  num_fields   : u16 LE          (max 65 535 fields per document)
 //! [7..]   offset table : num_fields × [key_len: u16 LE, val_offset: u32 LE]
 //!         keys section : concatenated UTF-8 field name bytes (key_len[i] each)
@@ -32,14 +32,17 @@ use crate::value_codec;
 pub const MAGIC: &[u8; 4] = b"RDOC";
 
 /// Format version byte for the plain (inline-keys-only) container.
-pub const VERSION: u8 = 0x01;
+pub const VERSION: u8 = 0x03;
 
 /// Format version byte for the dictionary-aware container (PRD-1398).
 ///
-/// Identical layout to v1 except each offset-table entry carries a key *kind*
+/// Identical layout to the plain container except each offset-table entry carries a key *kind*
 /// tag: a field name is either a key-id into the per-collection
 /// [`KeyDictionary`] (common keys) or stored inline (rare/unique keys).
-pub const VERSION_DICT: u8 = 0x02;
+pub const VERSION_DICT: u8 = 0x04;
+
+const SUPERSEDED_VERSION: u8 = 0x01;
+const SUPERSEDED_VERSION_DICT: u8 = 0x02;
 
 /// Byte size of one entry in the offset table: u16 key_len + u32 val_offset.
 const ENTRY_SIZE: usize = 6;
@@ -70,8 +73,10 @@ pub enum DocBodyError {
     TruncatedData,
     /// First 4 bytes do not match `b"RDOC"`.
     BadMagic,
-    /// Version byte is not `0x01`.
+    /// Version byte is not a version this codec understands.
     UnsupportedVersion(u8),
+    /// Version byte is from a pre-lossless-integer format that must not be reinterpreted.
+    SupersededVersion(u8),
     /// A field name or value points outside the container buffer.
     OffsetOutOfBounds,
     /// A field name is not valid UTF-8.
@@ -98,6 +103,13 @@ impl std::fmt::Display for DocBodyError {
             Self::TruncatedData => write!(f, "document body: truncated data"),
             Self::BadMagic => write!(f, "document body: bad magic bytes (expected RDOC)"),
             Self::UnsupportedVersion(v) => write!(f, "document body: unsupported version {v}"),
+            Self::SupersededVersion(v) => write!(
+                f,
+                "document body: format version {v} is superseded by version {VERSION} for the \
+                 lossless-integer clean break (#1768). Pre-bump bodies stored numbers as f64, \
+                 so they are refused rather than silently reinterpreted; re-insert the document \
+                 to rewrite it in the current format."
+            ),
             Self::OffsetOutOfBounds => write!(f, "document body: offset points outside buffer"),
             Self::InvalidFieldName => write!(f, "document body: field name is not valid UTF-8"),
             Self::FieldLimitExceeded => {
@@ -265,6 +277,14 @@ pub fn decode_value_at_offset(data: &[u8], val_offset: u32) -> Result<Value, Doc
     Ok(value)
 }
 
+fn version_error(version: u8) -> DocBodyError {
+    if version == SUPERSEDED_VERSION || version == SUPERSEDED_VERSION_DICT {
+        DocBodyError::SupersededVersion(version)
+    } else {
+        DocBodyError::UnsupportedVersion(version)
+    }
+}
+
 /// Parse the container header and return `(num_fields, offset_table)`.
 ///
 /// Each table entry is `(key_len: u16, val_offset: u32)`.  The table may be
@@ -280,7 +300,7 @@ pub fn parse_header(data: &[u8]) -> Result<(usize, Vec<(u16, u32)>), DocBodyErro
         return Err(DocBodyError::BadMagic);
     }
     if data[4] != VERSION {
-        return Err(DocBodyError::UnsupportedVersion(data[4]));
+        return Err(version_error(data[4]));
     }
 
     let n = u16::from_le_bytes([data[5], data[6]]) as usize;
@@ -430,7 +450,7 @@ pub fn parse_dict_header(data: &[u8]) -> Result<(usize, Vec<DictEntry>), DocBody
         return Err(DocBodyError::BadMagic);
     }
     if data[4] != VERSION_DICT {
-        return Err(DocBodyError::UnsupportedVersion(data[4]));
+        return Err(version_error(data[4]));
     }
 
     let n = u16::from_le_bytes([data[5], data[6]]) as usize;
@@ -606,6 +626,41 @@ mod tests {
         buf[0..4].copy_from_slice(MAGIC);
         buf[4] = 0x99;
         assert_eq!(decode(&buf), Err(DocBodyError::UnsupportedVersion(0x99)));
+    }
+
+    #[test]
+    fn superseded_plain_version_is_rejected_didactically() {
+        let fields = [("id", Value::Integer(1))];
+        let refs: Vec<(&str, &Value)> = fields.iter().map(|(k, v)| (*k, v)).collect();
+        let mut buf = Vec::new();
+        encode(&refs, &mut buf).expect("encode");
+        assert_eq!(buf[4], VERSION);
+
+        buf[4] = SUPERSEDED_VERSION;
+        let err = decode(&buf).expect_err("pre-bump body must be refused");
+        assert_eq!(err, DocBodyError::SupersededVersion(SUPERSEDED_VERSION));
+
+        let msg = err.to_string();
+        assert!(msg.contains("superseded"), "{msg}");
+        assert!(msg.contains("#1768"), "{msg}");
+        assert!(msg.contains("re-insert"), "{msg}");
+    }
+
+    #[test]
+    fn superseded_dict_version_is_rejected_didactically() {
+        let fields = [("id", Value::Integer(1))];
+        let refs: Vec<(&str, &Value)> = fields.iter().map(|(k, v)| (*k, v)).collect();
+        let mut dict = KeyDictionary::new();
+        let mut buf = Vec::new();
+        encode_with_dictionary(&refs, &mut dict, |_| true, &mut buf).expect("encode");
+        assert_eq!(buf[4], VERSION_DICT);
+
+        buf[4] = SUPERSEDED_VERSION_DICT;
+        let err = decode_with_dictionary(&buf, &dict).expect_err("pre-bump body must be refused");
+        assert_eq!(
+            err,
+            DocBodyError::SupersededVersion(SUPERSEDED_VERSION_DICT)
+        );
     }
 
     #[test]

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -387,6 +387,7 @@ pub fn infer_literal_type(value: &JsonValue) -> DataType {
     match value {
         JsonValue::Null => DataType::Nullable,
         JsonValue::Bool(_) => DataType::Boolean,
+        JsonValue::Integer(_) => DataType::Integer,
         JsonValue::Number(n) => {
             if n.fract() == 0.0 && *n >= i64::MIN as f64 && *n <= i64::MAX as f64 {
                 DataType::Integer

--- a/crates/reddb-types/src/serde_json.rs
+++ b/crates/reddb-types/src/serde_json.rs
@@ -9,6 +9,7 @@ pub type Map<K, V> = BTreeMap<K, V>;
 pub enum Value {
     Null,
     Bool(bool),
+    Integer(i64),
     Number(f64),
     String(String),
     Array(Vec<Value>),
@@ -32,12 +33,14 @@ impl Value {
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             Value::Number(n) => Some(*n),
+            Value::Integer(n) => Some(*n as f64),
             _ => None,
         }
     }
 
     pub fn as_i64(&self) -> Option<i64> {
         match self {
+            Value::Integer(n) => Some(*n),
             Value::Number(n) => Some(*n as i64),
             _ => None,
         }
@@ -45,6 +48,7 @@ impl Value {
 
     pub fn as_u64(&self) -> Option<u64> {
         match self {
+            Value::Integer(n) if *n >= 0 => Some(*n as u64),
             Value::Number(n) if *n >= 0.0 => Some(*n as u64),
             _ => None,
         }
@@ -95,6 +99,7 @@ impl Value {
         match self {
             Value::Null => out.push_str("null"),
             Value::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            Value::Integer(n) => out.push_str(&format!("{n}")),
             Value::Number(n) => {
                 if n.fract() == 0.0 {
                     out.push_str(&format!("{}", *n as i64));
@@ -136,7 +141,11 @@ impl Value {
 
     fn write_pretty(&self, out: &mut String, indent: usize) {
         match self {
-            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+            Value::Null
+            | Value::Bool(_)
+            | Value::Integer(_)
+            | Value::Number(_)
+            | Value::String(_) => {
                 out.push_str(&self.to_string_compact());
             }
             Value::Array(values) => {
@@ -435,6 +444,7 @@ impl From<JsonValue> for Value {
         match value {
             JsonValue::Null => Value::Null,
             JsonValue::Bool(b) => Value::Bool(b),
+            JsonValue::Integer(n) => Value::Integer(n),
             JsonValue::Number(n) => Value::Number(n),
             JsonValue::String(s) => Value::String(s),
             JsonValue::Array(values) => Value::Array(values.into_iter().map(Value::from).collect()),
@@ -638,6 +648,7 @@ impl JsonDecode for bool {
 impl JsonDecode for u8 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as u8),
             Value::Number(n) => Ok(n as u8),
             _ => Err("expected number".to_string()),
         }
@@ -647,6 +658,7 @@ impl JsonDecode for u8 {
 impl JsonDecode for u16 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as u16),
             Value::Number(n) => Ok(n as u16),
             _ => Err("expected number".to_string()),
         }
@@ -656,6 +668,7 @@ impl JsonDecode for u16 {
 impl JsonDecode for u32 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as u32),
             Value::Number(n) => Ok(n as u32),
             _ => Err("expected number".to_string()),
         }
@@ -665,6 +678,7 @@ impl JsonDecode for u32 {
 impl JsonDecode for u64 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as u64),
             Value::Number(n) => Ok(n as u64),
             _ => Err("expected number".to_string()),
         }
@@ -674,6 +688,7 @@ impl JsonDecode for u64 {
 impl JsonDecode for usize {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as usize),
             Value::Number(n) => Ok(n as usize),
             _ => Err("expected number".to_string()),
         }
@@ -683,6 +698,7 @@ impl JsonDecode for usize {
 impl JsonDecode for i64 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n),
             Value::Number(n) => Ok(n as i64),
             _ => Err("expected number".to_string()),
         }
@@ -692,6 +708,7 @@ impl JsonDecode for i64 {
 impl JsonDecode for i32 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as i32),
             Value::Number(n) => Ok(n as i32),
             _ => Err("expected number".to_string()),
         }
@@ -701,6 +718,7 @@ impl JsonDecode for i32 {
 impl JsonDecode for f32 {
     fn from_json_value(value: Value) -> Result<Self, String> {
         match value {
+            Value::Integer(n) => Ok(n as f32),
             Value::Number(n) => Ok(n as f32),
             _ => Err("expected number".to_string()),
         }

--- a/crates/reddb-types/src/utils/json.rs
+++ b/crates/reddb-types/src/utils/json.rs
@@ -8,6 +8,7 @@ use std::fmt;
 pub enum JsonValue {
     Null,
     Bool(bool),
+    Integer(i64),
     Number(f64),
     String(String),
     Array(Vec<JsonValue>),
@@ -27,6 +28,15 @@ impl JsonValue {
     pub fn as_f64(&self) -> Option<f64> {
         match self {
             JsonValue::Number(n) => Some(*n),
+            JsonValue::Integer(n) => Some(*n as f64),
+            _ => None,
+        }
+    }
+
+    /// Returns the value as i64 if it is an exact integer.
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            JsonValue::Integer(n) => Some(*n),
             _ => None,
         }
     }
@@ -129,6 +139,7 @@ impl JsonValue {
         match self {
             JsonValue::Null => out.push_str("null"),
             JsonValue::Bool(b) => out.push_str(if *b { "true" } else { "false" }),
+            JsonValue::Integer(n) => out.push_str(&format!("{n}")),
             JsonValue::Number(n) => {
                 if n.fract() == 0.0 {
                     out.push_str(&format!("{}", *n as i64));
@@ -205,13 +216,15 @@ impl From<f64> for JsonValue {
 
 impl From<i64> for JsonValue {
     fn from(value: i64) -> JsonValue {
-        JsonValue::Number(value as f64)
+        JsonValue::Integer(value)
     }
 }
 
 impl From<usize> for JsonValue {
     fn from(value: usize) -> JsonValue {
-        JsonValue::Number(value as f64)
+        i64::try_from(value)
+            .map(JsonValue::Integer)
+            .unwrap_or_else(|_| JsonValue::Number(value as f64))
     }
 }
 
@@ -299,7 +312,10 @@ impl<'a> JsonParser<'a> {
             _ => return Err("invalid number literal".to_string()),
         }
 
+        let mut is_float = false;
+
         if !self.eof() && self.current_char() == b'.' {
+            is_float = true;
             self.pos += 1;
             if self.eof() || !self.current_char().is_ascii_digit() {
                 return Err("invalid number literal".to_string());
@@ -310,6 +326,7 @@ impl<'a> JsonParser<'a> {
         }
 
         if !self.eof() && (self.current_char() == b'e' || self.current_char() == b'E') {
+            is_float = true;
             self.pos += 1;
             if !self.eof() && (self.current_char() == b'+' || self.current_char() == b'-') {
                 self.pos += 1;
@@ -324,6 +341,11 @@ impl<'a> JsonParser<'a> {
 
         let slice = &self.input[start..self.pos];
         let s = std::str::from_utf8(slice).map_err(|_| "invalid UTF-8 in number".to_string())?;
+        if !is_float {
+            if let Ok(value) = s.parse::<i64>() {
+                return Ok(JsonValue::Integer(value));
+            }
+        }
         let value = s
             .parse::<f64>()
             .map_err(|_| "failed to parse number".to_string())?;

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1031,6 +1031,7 @@ fn auto_type_param(s: &str) -> reddb::storage::schema::Value {
         return match parsed {
             J::Null => Value::Null,
             J::Bool(b) => Value::Boolean(b),
+            J::Integer(n) => Value::Integer(n),
             J::Number(n) => {
                 if n.fract() == 0.0 && n.abs() < i64::MAX as f64 {
                     Value::Integer(n as i64)
@@ -1040,7 +1041,10 @@ fn auto_type_param(s: &str) -> reddb::storage::schema::Value {
             }
             J::String(t) => Value::text(t),
             J::Array(items) => {
-                if items.iter().all(|v| matches!(v, J::Number(_))) {
+                if items
+                    .iter()
+                    .all(|v| matches!(v, J::Integer(_) | J::Number(_)))
+                {
                     let floats: Vec<f32> = items
                         .iter()
                         .map(|v| v.as_f64().unwrap_or(0.0) as f32)
@@ -5757,6 +5761,7 @@ fn admin_json_value_display(value: &reddb::json::Value) -> String {
         reddb::json::Value::Null => "".to_string(),
         reddb::json::Value::String(s) => s.clone(),
         reddb::json::Value::Bool(b) => b.to_string(),
+        reddb::json::Value::Integer(n) => n.to_string(),
         reddb::json::Value::Number(n) if n.fract() == 0.0 => (*n as i64).to_string(),
         reddb::json::Value::Number(n) => n.to_string(),
         reddb::json::Value::Array(_) | reddb::json::Value::Object(_) => value.to_string_compact(),

--- a/tests/grouped/docs_kv_queue/e2e_issue_1404_document_migration.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1404_document_migration.rs
@@ -48,6 +48,7 @@ fn open(store_dir: &Path) -> RedDBRuntime {
 fn json_field_to_storage(value: &reddb::json::Value) -> Value {
     match value {
         reddb::json::Value::String(text) => Value::text(text.clone()),
+        reddb::json::Value::Integer(number) => Value::Integer(*number),
         reddb::json::Value::Number(number) => {
             if number.fract() == 0.0 && *number >= i64::MIN as f64 && *number <= i64::MAX as f64 {
                 Value::Integer(*number as i64)

--- a/tests/grouped/docs_kv_queue/e2e_issue_1768_lossless_json_integers.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1768_lossless_json_integers.rs
@@ -1,0 +1,97 @@
+use proptest::prelude::*;
+use reddb::storage::schema::Value;
+use reddb::RedDBRuntime;
+
+fn runtime() -> RedDBRuntime {
+    RedDBRuntime::in_memory().expect("runtime")
+}
+
+fn select_one(rt: &RedDBRuntime, sql: &str, alias: &str) -> Value {
+    let page = rt.execute_query(sql).expect("SELECT should succeed");
+    let record = page
+        .result
+        .records
+        .first()
+        .unwrap_or_else(|| panic!("no records for `{sql}`"));
+    record
+        .get(alias)
+        .unwrap_or_else(|| panic!("no `{alias}` field in {record:?}"))
+        .clone()
+}
+
+#[test]
+fn large_integer_round_trips_exactly_through_document_body() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT issue1768_big")
+        .expect("CREATE DOCUMENT");
+
+    let big = 9_007_199_254_740_993_i64;
+    let max = i64::MAX;
+    rt.execute_query(&format!(
+        "INSERT INTO issue1768_big DOCUMENT VALUES ({{\"big\":{big},\"edge\":{max}}})"
+    ))
+    .expect("INSERT DOCUMENT");
+
+    assert_eq!(
+        select_one(
+            &rt,
+            "SELECT body.big AS big_val FROM issue1768_big",
+            "big_val",
+        ),
+        Value::Integer(big)
+    );
+    assert_eq!(
+        select_one(
+            &rt,
+            "SELECT body.edge AS edge_val FROM issue1768_big",
+            "edge_val",
+        ),
+        Value::Integer(max)
+    );
+}
+
+#[test]
+fn genuine_float_keeps_float_behaviour() {
+    let rt = runtime();
+    rt.execute_query("CREATE DOCUMENT issue1768_float")
+        .expect("CREATE DOCUMENT");
+    rt.execute_query("INSERT INTO issue1768_float DOCUMENT VALUES ({\"ratio\":3.5,\"exp\":5e-1})")
+        .expect("INSERT DOCUMENT");
+
+    assert_eq!(
+        select_one(
+            &rt,
+            "SELECT body.ratio AS ratio_val FROM issue1768_float",
+            "ratio_val",
+        ),
+        Value::Float(3.5)
+    );
+    assert_eq!(
+        select_one(
+            &rt,
+            "SELECT body.exp AS exp_val FROM issue1768_float",
+            "exp_val",
+        ),
+        Value::Float(0.5)
+    );
+}
+
+proptest! {
+    #[test]
+    fn integer_extremes_round_trip_through_rql_surface(n in any::<i64>()) {
+        let rt = runtime();
+        rt.execute_query("CREATE DOCUMENT issue1768_prop")
+            .expect("CREATE DOCUMENT");
+        rt.execute_query(&format!(
+            "INSERT INTO issue1768_prop DOCUMENT VALUES ({{\"n\":{n}}})"
+        ))
+        .expect("INSERT DOCUMENT");
+
+        let got = select_one(
+            &rt,
+            "SELECT body.n AS n_val FROM issue1768_prop",
+            "n_val",
+        );
+        prop_assert_eq!(got, Value::Integer(n));
+    }
+}

--- a/tests/grouped/documents_kv_queues.rs
+++ b/tests/grouped/documents_kv_queues.rs
@@ -24,6 +24,9 @@ mod e2e_issue_540_documents_basics;
 #[path = "docs_kv_queue/e2e_issue_1721_strict_json_coercion.rs"]
 mod e2e_issue_1721_strict_json_coercion;
 
+#[path = "docs_kv_queue/e2e_issue_1768_lossless_json_integers.rs"]
+mod e2e_issue_1768_lossless_json_integers;
+
 #[path = "docs_kv_queue/e2e_issue_1402_document_binary_body.rs"]
 mod e2e_issue_1402_document_binary_body;
 


### PR DESCRIPTION
Automated AFK landing for #1768. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1768

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786288961&installation_id=129708444&pr_number=2008&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2008&signature=40c0018f830999c31ef032dfa27ca86742d0fdeada37d529b89c6ea7c17b15d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->