### PR TITLE
chore: #2013 /go: Resolver os follow-ups remanescentes da varredura de performance (pos-PR

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -401,8 +401,8 @@ pub use wal_record::{
     decode_main_wal_record_frame, decode_main_wal_record_frame_with_authority,
     encode_main_wal_record_frame, encode_main_wal_record_frame_into,
     encode_main_wal_record_frame_with_authority, encode_main_wal_record_frame_with_authority_into,
-    MainWalCompression, MainWalRecordAuthority, MainWalRecordFrame, MainWalRecordType,
-    MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD,
+    MainWalCompression, MainWalRecordAuthority, MainWalRecordFrame, MainWalRecordFrameRef,
+    MainWalRecordType, MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD,
 };
 pub use zone_map::{
     read_zone_map_sidecar, write_zone_map_sidecar, PersistedZone, ZoneMapPersistError,

--- a/crates/reddb-file/src/wal_record.rs
+++ b/crates/reddb-file/src/wal_record.rs
@@ -107,6 +107,116 @@ pub enum MainWalRecordFrame {
     },
 }
 
+/// Borrowed view of a [`MainWalRecordFrame`].
+///
+/// The append path encodes straight out of the runtime record, so the payload
+/// of a `PageWrite`, `FullPageImage` or `TxCommitBatch` never has to be cloned
+/// into an owned frame first. The encoder works exclusively on this view — the
+/// owned frame encodes by borrowing itself — so both paths emit the same bytes
+/// by construction, not by convention.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum MainWalRecordFrameRef<'a> {
+    Begin {
+        tx_id: u64,
+    },
+    Commit {
+        tx_id: u64,
+    },
+    Rollback {
+        tx_id: u64,
+    },
+    PageWrite {
+        tx_id: u64,
+        page_id: u32,
+        data: &'a [u8],
+    },
+    TxCommitBatch {
+        tx_id: u64,
+        actions: &'a [Vec<u8>],
+    },
+    FullPageImage {
+        tx_id: u64,
+        page_id: u32,
+        ckpt_epoch: u64,
+        data: &'a [u8],
+    },
+    VectorInsert {
+        collection: &'a str,
+        entity_id: u64,
+        vector: &'a [f32],
+    },
+    ProbabilisticDelta {
+        kind: u8,
+        operation: u8,
+        name: &'a str,
+        operands: &'a [Vec<u8>],
+    },
+    Checkpoint {
+        lsn: u64,
+    },
+}
+
+impl<'a> From<&'a MainWalRecordFrame> for MainWalRecordFrameRef<'a> {
+    fn from(frame: &'a MainWalRecordFrame) -> Self {
+        match frame {
+            MainWalRecordFrame::Begin { tx_id } => MainWalRecordFrameRef::Begin { tx_id: *tx_id },
+            MainWalRecordFrame::Commit { tx_id } => MainWalRecordFrameRef::Commit { tx_id: *tx_id },
+            MainWalRecordFrame::Rollback { tx_id } => {
+                MainWalRecordFrameRef::Rollback { tx_id: *tx_id }
+            }
+            MainWalRecordFrame::PageWrite {
+                tx_id,
+                page_id,
+                data,
+            } => MainWalRecordFrameRef::PageWrite {
+                tx_id: *tx_id,
+                page_id: *page_id,
+                data,
+            },
+            MainWalRecordFrame::TxCommitBatch { tx_id, actions } => {
+                MainWalRecordFrameRef::TxCommitBatch {
+                    tx_id: *tx_id,
+                    actions,
+                }
+            }
+            MainWalRecordFrame::FullPageImage {
+                tx_id,
+                page_id,
+                ckpt_epoch,
+                data,
+            } => MainWalRecordFrameRef::FullPageImage {
+                tx_id: *tx_id,
+                page_id: *page_id,
+                ckpt_epoch: *ckpt_epoch,
+                data,
+            },
+            MainWalRecordFrame::VectorInsert {
+                collection,
+                entity_id,
+                vector,
+            } => MainWalRecordFrameRef::VectorInsert {
+                collection,
+                entity_id: *entity_id,
+                vector,
+            },
+            MainWalRecordFrame::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
+            } => MainWalRecordFrameRef::ProbabilisticDelta {
+                kind: *kind,
+                operation: *operation,
+                name,
+                operands,
+            },
+            MainWalRecordFrame::Checkpoint { lsn } => {
+                MainWalRecordFrameRef::Checkpoint { lsn: *lsn }
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MainWalRecordAuthority {
     pub term: u64,
@@ -132,8 +242,11 @@ pub fn encode_main_wal_record_frame_with_authority(
     Ok(out)
 }
 
-pub fn encode_main_wal_record_frame_into(
-    frame: &MainWalRecordFrame,
+/// Encode a frame into `out`. Accepts an owned `&MainWalRecordFrame` or a
+/// borrowed [`MainWalRecordFrameRef`] — the append path passes the latter, so
+/// the payload is written straight from the caller's buffers with no copy.
+pub fn encode_main_wal_record_frame_into<'a>(
+    frame: impl Into<MainWalRecordFrameRef<'a>>,
     term: u64,
     out: &mut Vec<u8>,
 ) -> io::Result<()> {
@@ -147,32 +260,34 @@ pub fn encode_main_wal_record_frame_into(
     )
 }
 
-pub fn encode_main_wal_record_frame_with_authority_into(
-    frame: &MainWalRecordFrame,
+/// The single encoder. Every other encode entry point funnels here, so the
+/// owned and borrowed paths cannot drift in the bytes they persist.
+pub fn encode_main_wal_record_frame_with_authority_into<'a>(
+    frame: impl Into<MainWalRecordFrameRef<'a>>,
     authority: MainWalRecordAuthority,
     out: &mut Vec<u8>,
 ) -> io::Result<()> {
     let start = out.len();
-    match frame {
-        MainWalRecordFrame::Begin { tx_id } => {
+    match frame.into() {
+        MainWalRecordFrameRef::Begin { tx_id } => {
             write_type_and_authority(out, MainWalRecordType::Begin, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
-        MainWalRecordFrame::Commit { tx_id } => {
+        MainWalRecordFrameRef::Commit { tx_id } => {
             write_type_and_authority(out, MainWalRecordType::Commit, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
-        MainWalRecordFrame::Rollback { tx_id } => {
+        MainWalRecordFrameRef::Rollback { tx_id } => {
             write_type_and_authority(out, MainWalRecordType::Rollback, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
         }
-        MainWalRecordFrame::PageWrite {
+        MainWalRecordFrameRef::PageWrite {
             tx_id,
             page_id,
             data,
         } => {
             if data.len() >= MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD {
-                if let Ok(compressed) = zstd::bulk::compress(data.as_slice(), 3) {
+                if let Ok(compressed) = zstd::bulk::compress(data, 3) {
                     if compressed.len() < data.len() {
                         write_type_and_authority(
                             out,
@@ -197,7 +312,7 @@ pub fn encode_main_wal_record_frame_with_authority_into(
             write_u32_len(out, data.len(), "main wal page length")?;
             out.extend_from_slice(data);
         }
-        MainWalRecordFrame::TxCommitBatch { tx_id, actions } => {
+        MainWalRecordFrameRef::TxCommitBatch { tx_id, actions } => {
             write_type_and_authority(out, MainWalRecordType::TxCommitBatch, authority);
             out.extend_from_slice(&tx_id.to_le_bytes());
             write_u32_len(out, actions.len(), "main wal action count")?;
@@ -206,7 +321,7 @@ pub fn encode_main_wal_record_frame_with_authority_into(
                 out.extend_from_slice(action);
             }
         }
-        MainWalRecordFrame::FullPageImage {
+        MainWalRecordFrameRef::FullPageImage {
             tx_id,
             page_id,
             ckpt_epoch,
@@ -219,7 +334,7 @@ pub fn encode_main_wal_record_frame_with_authority_into(
             write_u32_len(out, data.len(), "main wal full-page image length")?;
             out.extend_from_slice(data);
         }
-        MainWalRecordFrame::VectorInsert {
+        MainWalRecordFrameRef::VectorInsert {
             collection,
             entity_id,
             vector,
@@ -233,15 +348,15 @@ pub fn encode_main_wal_record_frame_with_authority_into(
                 out.extend_from_slice(&value.to_le_bytes());
             }
         }
-        MainWalRecordFrame::ProbabilisticDelta {
+        MainWalRecordFrameRef::ProbabilisticDelta {
             kind,
             operation,
             name,
             operands,
         } => {
             write_type_and_authority(out, MainWalRecordType::ProbabilisticDelta, authority);
-            out.push(*kind);
-            out.push(*operation);
+            out.push(kind);
+            out.push(operation);
             write_u32_len(out, name.len(), "main wal probabilistic name length")?;
             out.extend_from_slice(name.as_bytes());
             write_u32_len(out, operands.len(), "main wal probabilistic operand count")?;
@@ -250,7 +365,7 @@ pub fn encode_main_wal_record_frame_with_authority_into(
                 out.extend_from_slice(operand);
             }
         }
-        MainWalRecordFrame::Checkpoint { lsn } => {
+        MainWalRecordFrameRef::Checkpoint { lsn } => {
             write_type_and_authority(out, MainWalRecordType::Checkpoint, authority);
             out.extend_from_slice(&lsn.to_le_bytes());
         }

--- a/crates/reddb-server/src/storage/columnar_projection.rs
+++ b/crates/reddb-server/src/storage/columnar_projection.rs
@@ -589,6 +589,14 @@ impl ColumnarProjection {
             out.push(Vec::with_capacity(self.schema.columns.len()));
         }
         for column in decoded_columns {
+            // `decode_column` yields exactly `row_count` values; the drain below
+            // relies on that to keep rows rectangular. Fail loud in debug if the
+            // decoder ever breaks the invariant.
+            debug_assert_eq!(
+                column.len(),
+                row_count,
+                "decoded column is not row_count long"
+            );
             for (r, value) in column.into_iter().take(row_count).enumerate() {
                 out[base + r].push(value);
             }

--- a/crates/reddb-server/src/storage/no_malloc_hot_paths.rs
+++ b/crates/reddb-server/src/storage/no_malloc_hot_paths.rs
@@ -414,9 +414,12 @@ fn measure_hash_join_probe_key_lookup() -> AllocationCount {
     let keys = [Var::new("x"), Var::new("y")];
     // The build side owns its key; only the probe side must stay allocation-free.
     let build_key = join_extract_key(&binding, &keys);
+    // One seeded state per join, created outside the measured probe (as in
+    // `hash_join` itself, where it is per-call, not per-row).
+    let hash_state = std::collections::hash_map::RandomState::new();
 
     let (hit, count) = measure_allocations(|| {
-        let hash = join_key_hash(&binding, &keys);
+        let hash = join_key_hash(&hash_state, &binding, &keys);
         (hash, join_key_matches(&build_key, &binding, &keys))
     });
 
@@ -630,11 +633,12 @@ fn structural_hot_path_report() {
 
     let probe_lookup = measure_hash_join_probe_key_lookup();
     let build_key = join_extract_key(&binding, &group_vars);
+    let hash_state = std::collections::hash_map::RandomState::new();
     eprintln!(
         "hash-join-probe-key-lookup(new),{},{:.1},#2013 after: borrowed hash + element-wise match — includes the hashing the row above excludes (0-alloc, ratcheted)",
         probe_lookup.allocs,
         time_ns(iters, || {
-            let hash = join_key_hash(&binding, &group_vars);
+            let hash = join_key_hash(&hash_state, &binding, &group_vars);
             let hit = join_key_matches(&build_key, &binding, &group_vars);
             std::hint::black_box((hash, hit));
         })

--- a/crates/reddb-server/src/storage/no_malloc_hot_paths.rs
+++ b/crates/reddb-server/src/storage/no_malloc_hot_paths.rs
@@ -6,6 +6,10 @@ use super::engine::page::{Page, PageType};
 use super::engine::page_cache::PageCacheShard;
 use super::query::ast::{Projection, QueryExpr, TableQuery};
 use super::query::engine::binding::{Binding, Value as BindingValue, Var};
+use super::query::executors::aggregation::write_group_key;
+use super::query::executors::join::{
+    extract_key as join_extract_key, key_hash as join_key_hash, key_matches as join_key_matches,
+};
 use super::query::planner::cache::{CachedPlan, PlanCache};
 use super::query::planner::cost::PlanCost;
 use super::query::planner::QueryPlan;
@@ -184,6 +188,36 @@ const COVERED_OPERATIONS: &[CoveredOperation] = &[
         exception: None,
         measure: measure_plan_cache_hit,
     },
+    // Ratchet additions from the #2013 follow-up sweep. `encode_into` now
+    // encodes straight out of the borrowed record, so a page payload is no
+    // longer cloned into an owned file frame on every append.
+    CoveredOperation {
+        name: "wal-pagewrite-encode",
+        allowed_allocs: 0,
+        exception: None,
+        measure: measure_wal_pagewrite_encode,
+    },
+    CoveredOperation {
+        name: "wal-pagewrite-encode-compressed",
+        allowed_allocs: 1,
+        exception: Some(AllocationException {
+            reason: "zstd::bulk::compress returns an owned buffer for pages at or above the compression threshold; the payload itself is no longer cloned",
+            follow_up_issue: 2013,
+        }),
+        measure: measure_wal_pagewrite_encode_compressed,
+    },
+    CoveredOperation {
+        name: "wal-tx-commit-batch-encode",
+        allowed_allocs: 0,
+        exception: None,
+        measure: measure_wal_tx_commit_batch_encode,
+    },
+    CoveredOperation {
+        name: "hash-join-probe-key-lookup",
+        allowed_allocs: 0,
+        exception: None,
+        measure: measure_hash_join_probe_key_lookup,
+    },
 ];
 
 #[test]
@@ -322,6 +356,77 @@ fn measure_wal_record_encode_into_group_commit_buffer() -> AllocationCount {
     count
 }
 
+/// A `PageWrite` append below the compression threshold: the frame is written
+/// literally, straight out of the record's own payload buffer. Since #2013 the
+/// page bytes are borrowed rather than cloned into an owned file frame, so a
+/// warmed group-commit buffer absorbs the whole record with zero allocations.
+fn measure_wal_pagewrite_encode() -> AllocationCount {
+    let record = WalRecord::PageWrite {
+        tx_id: 1,
+        page_id: 2,
+        // Below MAIN_WAL_DEFAULT_COMPRESS_THRESHOLD (256) → literal frame.
+        data: vec![7u8; 200],
+    };
+    let mut group_commit_buffer = Vec::with_capacity(1024);
+
+    let ((), count) = measure_allocations(|| record.encode_into(&mut group_commit_buffer));
+
+    assert!(!group_commit_buffer.is_empty());
+    count
+}
+
+/// The same append for a page at/above the compression threshold. The payload
+/// clone is gone, but `zstd::bulk::compress` still hands back an owned buffer —
+/// that single allocation is the documented residual floor.
+fn measure_wal_pagewrite_encode_compressed() -> AllocationCount {
+    let record = WalRecord::PageWrite {
+        tx_id: 1,
+        page_id: 2,
+        data: vec![7u8; 4096],
+    };
+    let mut group_commit_buffer = Vec::with_capacity(8192);
+
+    let ((), count) = measure_allocations(|| record.encode_into(&mut group_commit_buffer));
+
+    assert!(!group_commit_buffer.is_empty());
+    count
+}
+
+/// A logical commit batch append. Its action payloads are borrowed too, so the
+/// record encodes into a warmed buffer without allocating.
+fn measure_wal_tx_commit_batch_encode() -> AllocationCount {
+    let record = WalRecord::TxCommitBatch {
+        tx_id: 9,
+        actions: vec![b"insert:orders:1".to_vec(), b"update:orders:2".to_vec()],
+    };
+    let mut group_commit_buffer = Vec::with_capacity(512);
+
+    let ((), count) = measure_allocations(|| record.encode_into(&mut group_commit_buffer));
+
+    assert!(!group_commit_buffer.is_empty());
+    count
+}
+
+/// The hash-join probe hot path (#2013): hash the probe row's join key in place
+/// and confirm the bucket match element-wise. Neither step clones a `Value`.
+fn measure_hash_join_probe_key_lookup() -> AllocationCount {
+    let binding = two_var_binding();
+    let keys = [Var::new("x"), Var::new("y")];
+    // The build side owns its key; only the probe side must stay allocation-free.
+    let build_key = join_extract_key(&binding, &keys);
+
+    let (hit, count) = measure_allocations(|| {
+        let hash = join_key_hash(&binding, &keys);
+        (hash, join_key_matches(&build_key, &binding, &keys))
+    });
+
+    assert!(
+        hit.1,
+        "probe key must match the build key it was derived from"
+    );
+    count
+}
+
 /// Two-variable binding used across the structural hot-path fixtures.
 fn two_var_binding() -> Binding {
     Binding::two(
@@ -332,60 +437,24 @@ fn two_var_binding() -> Binding {
     )
 }
 
-/// Mirrors the hot body of `executors::aggregation::write_group_key`: a row
-/// that lands in an *existing* group reuses one scratch `String`, so no
-/// allocation happens once the buffer has grown. This measures a steady-state
-/// row (buffer already sized, cleared before the call).
+/// Measures the *real* `executors::aggregation::write_group_key`: a row that
+/// lands in an *existing* group reuses one scratch `String`, so no allocation
+/// happens once the buffer has grown. This measures a steady-state row (buffer
+/// already sized, cleared before the call).
 fn measure_group_by_existing_group_key_write() -> AllocationCount {
     let binding = two_var_binding();
     let group_vars = [Var::new("x"), Var::new("y")];
     let mut key = String::with_capacity(64);
     // Warm the buffer so its backing allocation already exists.
-    write_group_key_into(&binding, &group_vars, &mut key);
+    write_group_key(&binding, &group_vars, &mut key);
 
     let ((), count) = measure_allocations(|| {
         key.clear();
-        write_group_key_into(&binding, &group_vars, &mut key);
+        write_group_key(&binding, &group_vars, &mut key);
     });
 
     assert!(!key.is_empty());
     count
-}
-
-/// Faithful copy of `write_group_key`'s hot loop, kept local so the manifest
-/// does not need to widen that helper's visibility.
-fn write_group_key_into(binding: &Binding, group_vars: &[Var], key: &mut String) {
-    use std::fmt::Write as _;
-    for (i, var) in group_vars.iter().enumerate() {
-        if i > 0 {
-            key.push('|');
-        }
-        key.push_str(var.name());
-        key.push('=');
-        match binding.get(var) {
-            None => key.push_str("NULL"),
-            Some(BindingValue::Null) => key.push_str("null"),
-            Some(BindingValue::String(s)) => key.push_str(s),
-            Some(BindingValue::Integer(n)) => {
-                let _ = write!(key, "{n}");
-            }
-            Some(BindingValue::Float(f)) => {
-                let _ = write!(key, "{f}");
-            }
-            Some(BindingValue::Boolean(b)) => {
-                let _ = write!(key, "{b}");
-            }
-            Some(BindingValue::Node(id)) => {
-                key.push_str("node:");
-                key.push_str(id);
-            }
-            Some(BindingValue::Edge(id)) => {
-                key.push_str("edge:");
-                key.push_str(id);
-            }
-            Some(BindingValue::Uri(u)) => key.push_str(u),
-        }
-    }
 }
 
 /// Minimal `QueryPlan` fixture (parameter-free) used only as cache ballast.
@@ -432,10 +501,9 @@ fn measure_plan_cache_hit() -> AllocationCount {
     count
 }
 
-/// Mirrors the probe side of `executors::join::extract_key`: the values behind
-/// the join keys are cloned into an owned key vector on *every* probe row. This
-/// is the item-3 candidate (skipped as too invasive); measured here to record
-/// its baseline cost.
+/// The *retired* probe-key shape: the values behind the join keys were cloned
+/// into an owned key vector on every probe row. Kept as the before-number the
+/// borrowed lookup (#2013) is compared against in the report.
 #[cfg(test)]
 fn measure_hash_join_probe_key_extract() -> AllocationCount {
     let binding = two_var_binding();
@@ -535,7 +603,7 @@ fn structural_hot_path_report() {
     let binding = two_var_binding();
     let group_vars = [Var::new("x"), Var::new("y")];
     let mut scratch = String::with_capacity(64);
-    write_group_key_into(&binding, &group_vars, &mut scratch);
+    write_group_key(&binding, &group_vars, &mut scratch);
     eprintln!(
         "binding-merge-per-joined-row,{},{:.1},item-1 Var interned (Arc<str>)",
         merge.allocs,
@@ -548,7 +616,7 @@ fn structural_hot_path_report() {
 
     let probe = measure_hash_join_probe_key_extract();
     eprintln!(
-        "hash-join-probe-key-extract,{},{:.1},item-3 SKIPPED (invasive HashKey change)",
+        "hash-join-probe-key-extract(old),{},{:.1},#2013 before: key cloned into an owned HashKey (clone only; the map then hashed it too)",
         probe.allocs,
         time_ns(iters, || {
             let _ = std::hint::black_box(
@@ -560,13 +628,25 @@ fn structural_hot_path_report() {
         })
     );
 
+    let probe_lookup = measure_hash_join_probe_key_lookup();
+    let build_key = join_extract_key(&binding, &group_vars);
+    eprintln!(
+        "hash-join-probe-key-lookup(new),{},{:.1},#2013 after: borrowed hash + element-wise match — includes the hashing the row above excludes (0-alloc, ratcheted)",
+        probe_lookup.allocs,
+        time_ns(iters, || {
+            let hash = join_key_hash(&binding, &group_vars);
+            let hit = join_key_matches(&build_key, &binding, &group_vars);
+            std::hint::black_box((hash, hit));
+        })
+    );
+
     let gbk = measure_group_by_existing_group_key_write();
     eprintln!(
         "group-by-existing-group-key-write,{},{:.1},steady-state buffer reuse (0-alloc, ratcheted)",
         gbk.allocs,
         time_ns(iters, || {
             scratch.clear();
-            write_group_key_into(&binding, &group_vars, &mut scratch);
+            write_group_key(&binding, &group_vars, &mut scratch);
             std::hint::black_box(&scratch);
         })
     );
@@ -585,7 +665,7 @@ fn structural_hot_path_report() {
 
     let wal = measure_wal_record_encode_into_group_commit_buffer();
     eprintln!(
-        "wal-commit-encode-into,{},{:.1},item-2 SKIPPED (PageWrite path clones; guard covers Commit only)",
+        "wal-commit-encode-into,{},{:.1},0-alloc, ratcheted",
         wal.allocs,
         time_ns(iters, || {
             let record = WalRecord::Commit { tx_id: 9 };
@@ -595,18 +675,33 @@ fn structural_hot_path_report() {
         })
     );
 
-    // Item 2 evidence: the PageWrite append path clones its page payload, which
-    // the existing zero-alloc guard (Commit-only) does not cover.
-    let page_write = WalRecord::PageWrite {
-        tx_id: 1,
-        page_id: 2,
-        data: vec![7u8; 256],
-    };
-    let mut buf = Vec::with_capacity(512);
-    let ((), page_count) = measure_allocations(|| page_write.encode_into(&mut buf));
+    // #2013: the PageWrite append path no longer clones its page payload. The
+    // literal frame is fully allocation-free; the compressed frame keeps one
+    // allocation for zstd's owned output buffer (documented in the manifest).
+    let page_literal = measure_wal_pagewrite_encode();
     eprintln!(
-        "wal-pagewrite-encode-into,{},-,item-2 evidence: page payload cloned into file frame",
-        page_count.allocs
+        "wal-pagewrite-encode(literal),{},{:.1},#2013 after: payload borrowed (0-alloc, ratcheted)",
+        page_literal.allocs,
+        time_ns(iters, || {
+            let record = WalRecord::PageWrite {
+                tx_id: 1,
+                page_id: 2,
+                data: vec![7u8; 200],
+            };
+            let mut buf = Vec::with_capacity(1024);
+            record.encode_into(&mut buf);
+            std::hint::black_box(&buf);
+        })
+    );
+    let page_compressed = measure_wal_pagewrite_encode_compressed();
+    eprintln!(
+        "wal-pagewrite-encode(compressed),{},-,#2013 after: 1 residual alloc = zstd output buffer",
+        page_compressed.allocs
+    );
+    let commit_batch = measure_wal_tx_commit_batch_encode();
+    eprintln!(
+        "wal-tx-commit-batch-encode,{},-,#2013 after: actions borrowed (0-alloc, ratcheted)",
+        commit_batch.allocs
     );
 
     let (clone_count, move_count) = measure_columnar_transpose_variants();

--- a/crates/reddb-server/src/storage/query/executors/aggregation.rs
+++ b/crates/reddb-server/src/storage/query/executors/aggregation.rs
@@ -786,7 +786,7 @@ fn value_to_string(value: &Value) -> String {
 /// the buffer is only cloned when a *new* group is inserted. Everything
 /// for one key is written into the shared buffer with no intermediate
 /// per-value String allocations.
-fn write_group_key(binding: &Binding, group_vars: &[Var], key: &mut String) {
+pub(crate) fn write_group_key(binding: &Binding, group_vars: &[Var], key: &mut String) {
     use std::fmt::Write;
     for (i, var) in group_vars.iter().enumerate() {
         if i > 0 {

--- a/crates/reddb-server/src/storage/query/executors/join.rs
+++ b/crates/reddb-server/src/storage/query/executors/join.rs
@@ -25,6 +25,7 @@
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 
@@ -154,46 +155,75 @@ pub fn choose_strategy(stats: &JoinStats, condition: &JoinCondition) -> JoinStra
 
 /// Hash key for join matching
 #[derive(Clone, PartialEq, Eq)]
-struct HashKey(Vec<Option<Value>>);
+pub(crate) struct HashKey(Vec<Option<Value>>);
 
 impl Hash for HashKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         for value in &self.0 {
-            match value {
-                Some(Value::String(s)) => {
-                    1u8.hash(state);
-                    s.hash(state);
-                }
-                Some(Value::Integer(i)) => {
-                    2u8.hash(state);
-                    i.hash(state);
-                }
-                Some(Value::Float(f)) => {
-                    3u8.hash(state);
-                    f.to_bits().hash(state);
-                }
-                Some(Value::Boolean(b)) => {
-                    4u8.hash(state);
-                    b.hash(state);
-                }
-                Some(Value::Uri(u)) => {
-                    5u8.hash(state);
-                    u.hash(state);
-                }
-                Some(Value::Node(n)) => {
-                    6u8.hash(state);
-                    n.hash(state);
-                }
-                Some(Value::Edge(e)) => {
-                    7u8.hash(state);
-                    e.hash(state);
-                }
-                Some(Value::Null) | None => {
-                    0u8.hash(state);
-                }
-            }
+            hash_key_value(value.as_ref(), state);
         }
     }
+}
+
+/// Hash one join-key column. `NULL` and an absent binding hash alike (tag 0) —
+/// they are also equal-by-absence nowhere, so a null key still finds its bucket
+/// and is then rejected by the element-wise equality check.
+fn hash_key_value<H: Hasher>(value: Option<&Value>, state: &mut H) {
+    match value {
+        Some(Value::String(s)) => {
+            1u8.hash(state);
+            s.hash(state);
+        }
+        Some(Value::Integer(i)) => {
+            2u8.hash(state);
+            i.hash(state);
+        }
+        Some(Value::Float(f)) => {
+            3u8.hash(state);
+            f.to_bits().hash(state);
+        }
+        Some(Value::Boolean(b)) => {
+            4u8.hash(state);
+            b.hash(state);
+        }
+        Some(Value::Uri(u)) => {
+            5u8.hash(state);
+            u.hash(state);
+        }
+        Some(Value::Node(n)) => {
+            6u8.hash(state);
+            n.hash(state);
+        }
+        Some(Value::Edge(e)) => {
+            7u8.hash(state);
+            e.hash(state);
+        }
+        Some(Value::Null) | None => {
+            0u8.hash(state);
+        }
+    }
+}
+
+/// Hash a row's join key *in place* — without materializing an owned `HashKey`.
+/// This is the probe-side hot path: one hash per probe row, zero allocations.
+pub(crate) fn key_hash(binding: &Binding, vars: &[Var]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for var in vars {
+        hash_key_value(binding.get(var), &mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Element-wise equality between a stored build key and a probe row's key,
+/// compared through references so the probe key is never cloned. Identical to
+/// `extract_key(binding, vars) == *key`, including `None`/`NULL` columns.
+pub(crate) fn key_matches(key: &HashKey, binding: &Binding, vars: &[Var]) -> bool {
+    key.0.len() == vars.len()
+        && key
+            .0
+            .iter()
+            .zip(vars)
+            .all(|(stored, var)| stored.as_ref() == binding.get(var))
 }
 
 /// Execute a hash join
@@ -219,11 +249,23 @@ pub fn hash_join(
             (&right, &left, &right_keys, &left_keys, false)
         };
 
-    // Build hash table
-    let mut hash_table: HashMap<HashKey, Vec<&Binding>> = HashMap::new();
+    // Build hash table, bucketed by the key's precomputed hash. The build side
+    // owns its keys; collisions inside a bucket are resolved by element-wise
+    // equality, exactly as the `HashMap<HashKey, _>` it replaces did. Keeping
+    // the hash explicit is what lets the probe side look a row up *without*
+    // cloning its key values (see `key_hash` / `key_matches`).
+    #[allow(clippy::type_complexity)]
+    let mut hash_table: HashMap<u64, Vec<(HashKey, Vec<&Binding>)>> = HashMap::new();
     for binding in build_side {
-        let key = extract_key(binding, build_keys);
-        hash_table.entry(key).or_default().push(binding);
+        let hash = key_hash(binding, build_keys);
+        let bucket = hash_table.entry(hash).or_default();
+        match bucket
+            .iter_mut()
+            .find(|(key, _)| key_matches(key, binding, build_keys))
+        {
+            Some((_, bindings)) => bindings.push(binding),
+            None => bucket.push((extract_key(binding, build_keys), vec![binding])),
+        }
     }
 
     // Probe phase
@@ -231,8 +273,16 @@ pub fn hash_join(
     let mut matched_build: std::collections::HashSet<usize> = std::collections::HashSet::new();
 
     for (probe_idx, probe_binding) in probe_side.iter().enumerate() {
-        let key = extract_key(probe_binding, probe_keys);
-        let matches = hash_table.get(&key);
+        // Probe with a borrowed key: hash the row's join columns in place, then
+        // confirm the match element-wise. No `Value` is cloned per probe row.
+        let matches = hash_table
+            .get(&key_hash(probe_binding, probe_keys))
+            .and_then(|bucket: &Vec<(HashKey, Vec<&Binding>)>| {
+                bucket
+                    .iter()
+                    .find(|(key, _)| key_matches(key, probe_binding, probe_keys))
+                    .map(|(_, bindings)| bindings)
+            });
 
         let mut had_match = false;
         if let Some(build_bindings) = matches {
@@ -331,7 +381,7 @@ pub fn hash_join(
     results
 }
 
-fn extract_key(binding: &Binding, vars: &[Var]) -> HashKey {
+pub(crate) fn extract_key(binding: &Binding, vars: &[Var]) -> HashKey {
     HashKey(vars.iter().map(|v| binding.get(v).cloned()).collect())
 }
 
@@ -782,5 +832,130 @@ mod tests {
             choose_strategy(&stats, &JoinCondition::Eq(Var::new("a"), Var::new("b"))),
             JoinStrategy::Merge
         );
+    }
+
+    // ===================== borrowed probe-key equivalence (#2013) ============
+
+    /// Bind `k` to the given value (or leave `k` unbound when `None`), plus a
+    /// side-local tag var so merged rows stay distinguishable and never conflict.
+    fn key_row(k: Option<Value>, tag_var: &str, tag: &str) -> Binding {
+        let row = Binding::one(Var::new(tag_var), Value::String(tag.to_string()));
+        match k {
+            Some(value) => row
+                .merge(&Binding::one(Var::new("k"), value))
+                .expect("no conflicting binding"),
+            None => row,
+        }
+    }
+
+    fn left_row(k: Option<Value>, tag: &str) -> Binding {
+        key_row(k, "lt", tag)
+    }
+
+    fn right_row(k: Option<Value>, tag: &str) -> Binding {
+        key_row(k, "rt", tag)
+    }
+
+    /// Order-independent fingerprint of a joined row (`Binding` is backed by a
+    /// `HashMap`, so its `Debug` order is not stable).
+    fn fingerprint(binding: &Binding) -> String {
+        let field = |name: &str| match binding.get(&Var::new(name)) {
+            Some(value) => format!("{value:?}"),
+            None => "-".to_string(),
+        };
+        format!("lt={} rt={} k={}", field("lt"), field("rt"), field("k"))
+    }
+
+    /// Reference semantics for an inner equi-join: every (left, right) pair
+    /// whose *owned* join keys compare equal. This is deliberately independent
+    /// of the hash table under test.
+    fn reference_inner_matches(left: &[Binding], right: &[Binding], keys: &[Var]) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for l in left {
+            for r in right {
+                if extract_key(l, keys) == extract_key(r, keys) {
+                    out.push(fingerprint(&merge_bindings(l, r)));
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// An absent column and an explicit `NULL` hash to the same bucket, so the
+    /// probe path *must* resolve the collision by element-wise equality — which
+    /// keeps them distinct, exactly as the old owned-`HashKey` map did.
+    #[test]
+    fn null_and_absent_keys_collide_in_hash_but_stay_distinct_in_equality() {
+        let keys = [Var::new("k")];
+        let null_row = left_row(Some(Value::Null), "null");
+        let absent_row = left_row(None, "absent");
+
+        assert_eq!(
+            key_hash(&null_row, &keys),
+            key_hash(&absent_row, &keys),
+            "NULL and an absent column are expected to share a hash bucket"
+        );
+        assert!(key_matches(
+            &extract_key(&null_row, &keys),
+            &null_row,
+            &keys
+        ));
+        assert!(!key_matches(
+            &extract_key(&null_row, &keys),
+            &absent_row,
+            &keys
+        ));
+        assert!(!key_matches(
+            &extract_key(&absent_row, &keys),
+            &null_row,
+            &keys
+        ));
+    }
+
+    /// The borrowed probe key produces exactly the matches the owned key does —
+    /// over string keys, explicit `NULL`s, absent columns, and rows that share a
+    /// hash bucket while holding different values.
+    #[test]
+    fn hash_join_matches_are_identical_to_the_owned_key_reference() {
+        let left = vec![
+            left_row(Some(Value::String("a".into())), "L-a"),
+            left_row(Some(Value::Integer(1)), "L-1"),
+            left_row(Some(Value::Null), "L-null"),
+            left_row(None, "L-absent"),
+            left_row(Some(Value::String("a".into())), "L-a2"),
+        ];
+        let right = vec![
+            right_row(Some(Value::String("a".into())), "R-a"),
+            right_row(Some(Value::Null), "R-null"),
+            right_row(None, "R-absent"),
+            right_row(Some(Value::Boolean(true)), "R-true"),
+            right_row(Some(Value::Integer(1)), "R-1"),
+            right_row(Some(Value::Integer(1)), "R-1b"),
+        ];
+        let keys = [Var::new("k")];
+        let condition = JoinCondition::Eq(Var::new("k"), Var::new("k"));
+
+        // Cover both build-side choices: `left` is the smaller side (built), the
+        // swapped call builds on the right input, and equal-size inputs exercise
+        // the `<=` tie rule.
+        for (l, r) in [
+            (left.clone(), right.clone()),
+            (right.clone(), left.clone()),
+            (left.clone(), right[..left.len()].to_vec()),
+        ] {
+            let expected = reference_inner_matches(&l, &r, &keys);
+
+            let mut actual: Vec<String> = hash_join(l, r, &condition, JoinType::Inner)
+                .iter()
+                .map(fingerprint)
+                .collect();
+            actual.sort();
+
+            assert_eq!(
+                actual, expected,
+                "hash join diverged from the owned-key reference"
+            );
+        }
     }
 }

--- a/crates/reddb-server/src/storage/query/executors/join.rs
+++ b/crates/reddb-server/src/storage/query/executors/join.rs
@@ -25,9 +25,9 @@
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 
-use std::collections::hash_map::DefaultHasher;
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 
 use super::super::engine::binding::{Binding, Value, Var};
 use super::value_compare::total_compare_values;
@@ -206,8 +206,12 @@ fn hash_key_value<H: Hasher>(value: Option<&Value>, state: &mut H) {
 
 /// Hash a row's join key *in place* — without materializing an owned `HashKey`.
 /// This is the probe-side hot path: one hash per probe row, zero allocations.
-pub(crate) fn key_hash(binding: &Binding, vars: &[Var]) -> u64 {
-    let mut hasher = DefaultHasher::new();
+///
+/// The caller supplies a `RandomState` (one per join) so bucket hashes stay
+/// randomly seeded like the `HashMap<HashKey, _>` this replaced — a fixed-key
+/// hasher would let precomputed collisions degrade the build to O(n²).
+pub(crate) fn key_hash(state: &RandomState, binding: &Binding, vars: &[Var]) -> u64 {
+    let mut hasher = state.build_hasher();
     for var in vars {
         hash_key_value(binding.get(var), &mut hasher);
     }
@@ -256,8 +260,9 @@ pub fn hash_join(
     // cloning its key values (see `key_hash` / `key_matches`).
     #[allow(clippy::type_complexity)]
     let mut hash_table: HashMap<u64, Vec<(HashKey, Vec<&Binding>)>> = HashMap::new();
+    let hash_state = RandomState::new();
     for binding in build_side {
-        let hash = key_hash(binding, build_keys);
+        let hash = key_hash(&hash_state, binding, build_keys);
         let bucket = hash_table.entry(hash).or_default();
         match bucket
             .iter_mut()
@@ -276,7 +281,7 @@ pub fn hash_join(
         // Probe with a borrowed key: hash the row's join columns in place, then
         // confirm the match element-wise. No `Value` is cloned per probe row.
         let matches = hash_table
-            .get(&key_hash(probe_binding, probe_keys))
+            .get(&key_hash(&hash_state, probe_binding, probe_keys))
             .and_then(|bucket: &Vec<(HashKey, Vec<&Binding>)>| {
                 bucket
                     .iter()
@@ -891,9 +896,10 @@ mod tests {
         let null_row = left_row(Some(Value::Null), "null");
         let absent_row = left_row(None, "absent");
 
+        let state = RandomState::new();
         assert_eq!(
-            key_hash(&null_row, &keys),
-            key_hash(&absent_row, &keys),
+            key_hash(&state, &null_row, &keys),
+            key_hash(&state, &absent_row, &keys),
             "NULL and an absent column are expected to share a hash bucket"
         );
         assert!(key_matches(

--- a/crates/reddb-server/src/storage/query/planner/cache.rs
+++ b/crates/reddb-server/src/storage/query/planner/cache.rs
@@ -161,7 +161,12 @@ pub struct PlanCache {
 
 impl PlanCache {
     /// Create a new plan cache with the given capacity
+    ///
+    /// A capacity of 0 is meaningless and unreachable from every call site
+    /// today. If one ever appears, the LRU keeps a single entry rather than
+    /// evicting forever (the pre-#2012 code looped indefinitely on it).
     pub fn new(capacity: usize) -> Self {
+        debug_assert!(capacity > 0, "plan cache capacity must be positive");
         Self {
             entries: HashMap::with_capacity(capacity),
             clock: 0,

--- a/crates/reddb-server/src/storage/wal/record.rs
+++ b/crates/reddb-server/src/storage/wal/record.rs
@@ -1,6 +1,7 @@
 use reddb_file::{
     decode_main_wal_record_frame_with_authority, encode_main_wal_record_frame_into,
-    encode_main_wal_record_frame_with_authority_into, MainWalRecordFrame, WAL_FILE_VERSION,
+    encode_main_wal_record_frame_with_authority_into, MainWalRecordFrame, MainWalRecordFrameRef,
+    WAL_FILE_VERSION,
 };
 use std::io::{self, Read};
 
@@ -93,13 +94,17 @@ impl WalRecord {
     /// The checksum is computed over only the bytes this call appends (the slice
     /// starting at the buffer's prior length), so appending after existing
     /// records leaves them untouched and keeps each record's CRC self-contained.
+    ///
+    /// The payload is written straight from this record's own buffers — the
+    /// append path never clones a page image or a commit batch into an owned
+    /// file frame first.
     pub fn encode_with_term_into(&self, out: &mut Vec<u8>, term: u64) {
-        encode_main_wal_record_frame_into(&self.to_file_frame(), term, out)
+        encode_main_wal_record_frame_into(self.to_file_frame_ref(), term, out)
             .expect("main WAL record cannot be encoded");
     }
 
     pub fn encode_with_authority_into(&self, out: &mut Vec<u8>, authority: WalRecordAuthority) {
-        encode_main_wal_record_frame_with_authority_into(&self.to_file_frame(), authority, out)
+        encode_main_wal_record_frame_with_authority_into(self.to_file_frame_ref(), authority, out)
             .expect("main WAL record cannot be encoded");
     }
 
@@ -151,6 +156,65 @@ impl WalRecord {
 }
 
 impl WalRecord {
+    /// Borrow this record as a file frame. Every payload is passed through by
+    /// reference, so encoding a `PageWrite`, `FullPageImage` or `TxCommitBatch`
+    /// costs no copy of the payload.
+    fn to_file_frame_ref(&self) -> MainWalRecordFrameRef<'_> {
+        match self {
+            WalRecord::Begin { tx_id } => MainWalRecordFrameRef::Begin { tx_id: *tx_id },
+            WalRecord::Commit { tx_id } => MainWalRecordFrameRef::Commit { tx_id: *tx_id },
+            WalRecord::Rollback { tx_id } => MainWalRecordFrameRef::Rollback { tx_id: *tx_id },
+            WalRecord::PageWrite {
+                tx_id,
+                page_id,
+                data,
+            } => MainWalRecordFrameRef::PageWrite {
+                tx_id: *tx_id,
+                page_id: *page_id,
+                data,
+            },
+            WalRecord::TxCommitBatch { tx_id, actions } => MainWalRecordFrameRef::TxCommitBatch {
+                tx_id: *tx_id,
+                actions,
+            },
+            WalRecord::FullPageImage {
+                tx_id,
+                page_id,
+                ckpt_epoch,
+                data,
+            } => MainWalRecordFrameRef::FullPageImage {
+                tx_id: *tx_id,
+                page_id: *page_id,
+                ckpt_epoch: *ckpt_epoch,
+                data,
+            },
+            WalRecord::VectorInsert {
+                collection,
+                entity_id,
+                vector,
+            } => MainWalRecordFrameRef::VectorInsert {
+                collection,
+                entity_id: *entity_id,
+                vector,
+            },
+            WalRecord::ProbabilisticDelta {
+                kind,
+                operation,
+                name,
+                operands,
+            } => MainWalRecordFrameRef::ProbabilisticDelta {
+                kind: *kind,
+                operation: *operation,
+                name,
+                operands,
+            },
+            WalRecord::Checkpoint { lsn } => MainWalRecordFrameRef::Checkpoint { lsn: *lsn },
+        }
+    }
+
+    /// The pre-#2013 owning conversion, kept as the baseline the borrowed
+    /// encode path is proven byte-identical against.
+    #[cfg(test)]
     fn to_file_frame(&self) -> MainWalRecordFrame {
         match self {
             WalRecord::Begin { tx_id } => MainWalRecordFrame::Begin { tx_id: *tx_id },
@@ -687,6 +751,117 @@ mod tests {
             assert_eq!(&decoded, expected);
         }
         assert!(WalRecord::read(&mut cursor).unwrap().is_none());
+    }
+
+    /// Every record variant, including empty/large/compressible payloads and
+    /// the edge cases each variant can carry.
+    fn every_record_variant() -> Vec<WalRecord> {
+        vec![
+            WalRecord::Begin { tx_id: 12345 },
+            WalRecord::Commit { tx_id: 99999 },
+            WalRecord::Rollback { tx_id: 54321 },
+            WalRecord::Checkpoint { lsn: 1_000_000 },
+            // Below the compression threshold → literal PageWrite frame.
+            WalRecord::PageWrite {
+                tx_id: 100,
+                page_id: 42,
+                data: vec![1, 2, 3, 4, 5],
+            },
+            WalRecord::PageWrite {
+                tx_id: 1,
+                page_id: 0,
+                data: Vec::new(),
+            },
+            // Compressible and above the threshold → PageWriteCompressed frame.
+            WalRecord::PageWrite {
+                tx_id: 7,
+                page_id: 3,
+                data: vec![0xABu8; 1024],
+            },
+            // Above the threshold but incompressible → stays a literal PageWrite.
+            WalRecord::PageWrite {
+                tx_id: 8,
+                page_id: 4,
+                data: (0..300u32)
+                    .map(|i| i.wrapping_mul(2_654_435_761) as u8)
+                    .collect(),
+            },
+            WalRecord::TxCommitBatch {
+                tx_id: 7,
+                actions: vec![b"insert".to_vec(), Vec::new(), b"update".to_vec()],
+            },
+            WalRecord::TxCommitBatch {
+                tx_id: 8,
+                actions: Vec::new(),
+            },
+            WalRecord::FullPageImage {
+                tx_id: 11,
+                page_id: 9,
+                ckpt_epoch: 42,
+                data: (0..4096).map(|i| (i % 251) as u8).collect(),
+            },
+            WalRecord::VectorInsert {
+                collection: "turbo".to_string(),
+                entity_id: 42,
+                vector: vec![1.0, -0.5, 0.25],
+            },
+            WalRecord::ProbabilisticDelta {
+                kind: 1,
+                operation: 2,
+                name: "visitors".to_string(),
+                operands: vec![b"alice".to_vec(), b"bob".to_vec()],
+            },
+        ]
+    }
+
+    /// The borrowed encode path (#2013) must persist *exactly* the bytes the
+    /// pre-#2013 owning path persisted, for every record variant and for both
+    /// the term-only and the full-authority envelope. The on-disk format is
+    /// frozen; only the in-memory representation changed.
+    #[test]
+    fn borrowed_encode_is_byte_identical_to_the_owning_frame_path() {
+        for record in every_record_variant() {
+            // Old path: clone the payload into an owned frame, then encode.
+            let mut owned_bytes = Vec::new();
+            encode_main_wal_record_frame_into(&record.to_file_frame(), 17, &mut owned_bytes)
+                .expect("owning encode");
+
+            // New path: encode straight from the borrowed record.
+            let mut borrowed_bytes = Vec::new();
+            record.encode_with_term_into(&mut borrowed_bytes, 17);
+
+            assert_eq!(
+                borrowed_bytes, owned_bytes,
+                "borrowed encode diverged from the owning baseline for {record:?}"
+            );
+
+            // Same again through the authority envelope (with an ownership epoch).
+            let authority = WalRecordAuthority {
+                term: 17,
+                ownership_epoch: Some(5),
+            };
+            let mut owned_auth = Vec::new();
+            encode_main_wal_record_frame_with_authority_into(
+                &record.to_file_frame(),
+                authority,
+                &mut owned_auth,
+            )
+            .expect("owning authority encode");
+
+            let mut borrowed_auth = Vec::new();
+            record.encode_with_authority_into(&mut borrowed_auth, authority);
+
+            assert_eq!(
+                borrowed_auth, owned_auth,
+                "borrowed authority encode diverged from the owning baseline for {record:?}"
+            );
+
+            // And the persisted bytes still decode back to the original record.
+            let mut cursor = Cursor::new(borrowed_bytes);
+            let (term, decoded) = WalRecord::read_with_term(&mut cursor).unwrap().unwrap();
+            assert_eq!(term, 17);
+            assert_eq!(decoded, record);
+        }
     }
 
     /// `encode_with_term_into` honours the term and matches the allocating


### PR DESCRIPTION
Automated AFK landing for #2013. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #2013

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786414678&installation_id=129708444&pr_number=2014&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2014&signature=1b9881b63ce8980a6923dbce05b3b08fc502c5c00d92ccfb63ecb181ccf3c4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->