### PR TITLE
chore: #1794 `SHOW STATS`: document metrics — promoted columns + top-level body-key coverage

### DIFF
--- a/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
@@ -609,6 +609,9 @@ pub(super) fn stats_snapshot(
             CollectionModel::Table => {
                 append_table_stats(&mut rows, &schema, store.as_ref(), &collection.name);
             }
+            CollectionModel::Document => {
+                append_document_stats(&mut rows, &schema, store.as_ref(), &collection.name);
+            }
             CollectionModel::Kv => {
                 append_kv_stats(&mut rows, &schema, store.as_ref(), &collection.name);
             }
@@ -953,6 +956,111 @@ fn append_table_stats(
             "most_common_values",
             Value::Array(most_common_values(column.mcv.as_ref())),
         ));
+    }
+}
+
+fn append_document_stats(
+    rows: &mut Vec<UnifiedRecord>,
+    schema: &Arc<Vec<Arc<str>>>,
+    store: &UnifiedStore,
+    collection: &str,
+) {
+    let mut entities = Vec::new();
+    let mut key_counts = BTreeMap::<String, u64>::new();
+    let mut type_counts = BTreeMap::<String, BTreeMap<&'static str, u64>>::new();
+
+    for (name, entity) in store.query_all(|_| true) {
+        if name != collection {
+            continue;
+        }
+        let EntityData::Row(row) = entity.data else {
+            continue;
+        };
+
+        let mut fields: Vec<(String, Value)> = row
+            .iter_fields()
+            .map(|(name, value)| (name.to_string(), value.clone()))
+            .collect();
+        let body_fields = row
+            .get_field("body")
+            .and_then(document_body_top_level_fields)
+            .unwrap_or_default();
+
+        for (name, value) in &body_fields {
+            *key_counts.entry(name.clone()).or_default() += 1;
+            *type_counts
+                .entry(name.clone())
+                .or_default()
+                .entry(document_value_type_name(value))
+                .or_default() += 1;
+        }
+        for (name, value) in body_fields {
+            if fields.iter().all(|(existing, _)| existing != &name) {
+                fields.push((name, value));
+            }
+        }
+
+        entities.push((entity.id, fields));
+    }
+
+    let analyzed =
+        crate::storage::query::planner::stats_catalog::analyze_entity_fields(collection, &entities);
+
+    rows.push(stats_row(
+        schema,
+        collection,
+        Value::Null,
+        "row_count",
+        Value::UnsignedInteger(analyzed.row_count),
+    ));
+    for column in &analyzed.columns {
+        rows.push(stats_row(
+            schema,
+            collection,
+            Value::text(column.name.clone()),
+            "null_count",
+            Value::UnsignedInteger(column.null_count),
+        ));
+        rows.push(stats_row(
+            schema,
+            collection,
+            Value::text(column.name.clone()),
+            "distinct_count",
+            Value::UnsignedInteger(column.distinct_count),
+        ));
+        rows.push(stats_row(
+            schema,
+            collection,
+            Value::text(column.name.clone()),
+            "most_common_values",
+            Value::Array(most_common_values(column.mcv.as_ref())),
+        ));
+    }
+
+    for (name, count) in key_counts {
+        let coverage = if analyzed.row_count == 0 {
+            0.0
+        } else {
+            count as f64 / analyzed.row_count as f64
+        };
+        rows.push(stats_row(
+            schema,
+            collection,
+            Value::text(name.clone()),
+            "coverage",
+            Value::Float(coverage),
+        ));
+        if let Some(counts) = type_counts.remove(&name) {
+            for (value_type, count) in counts {
+                rows.push(stats_row(
+                    schema,
+                    collection,
+                    Value::text(name.clone()),
+                    &format!("type_count:{value_type}"),
+                    Value::UnsignedInteger(count),
+                ));
+            }
+        }
     }
 }
 
@@ -1328,6 +1436,41 @@ fn value_type_name(value: &Value) -> &'static str {
         Value::Array(_) => "array",
         _ => "other",
     }
+}
+
+fn document_value_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Json(bytes) => match crate::json::from_slice::<crate::json::Value>(bytes) {
+            Ok(crate::json::Value::Array(_)) => "array",
+            Ok(crate::json::Value::Object(_)) => "object",
+            _ => "json",
+        },
+        Value::Array(_) => "array",
+        other => value_type_name(other),
+    }
+}
+
+fn document_body_top_level_fields(value: &Value) -> Option<Vec<(String, Value)>> {
+    let bytes = match value {
+        Value::Json(bytes) => bytes.as_slice(),
+        Value::Text(text) => text.as_bytes(),
+        _ => return None,
+    };
+    if let Some(fields) = crate::document_body::body_fields(bytes) {
+        return Some(fields);
+    }
+    let crate::json::Value::Object(map) = crate::json::from_slice(bytes).ok()? else {
+        return None;
+    };
+    Some(
+        map.iter()
+            .filter_map(|(key, value)| {
+                crate::application::entity::json_to_storage_value(value)
+                    .ok()
+                    .map(|value| (key.clone(), value))
+            })
+            .collect(),
+    )
 }
 
 fn value_estimated_bytes(value: &Value) -> u64 {

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -674,6 +674,73 @@ fn show_stats_row_table_returns_long_format_metric_set() {
 }
 
 #[test]
+fn show_stats_document_collection_returns_promoted_and_body_key_metrics() {
+    cleanup_scope();
+    let rt = runtime();
+    exec(&rt, "CREATE DOCUMENT docs");
+    exec(
+        &rt,
+        r#"INSERT INTO docs DOCUMENT VALUES ({"title":"alpha","Title":"caps","published":true,"nested":{"rank":1},"tags":["red","db"]})"#,
+    );
+    exec(
+        &rt,
+        r#"INSERT INTO docs DOCUMENT VALUES ({"title":"beta","published":false,"nested":{"rank":2},"tags":["rust"],"views":10})"#,
+    );
+    exec(
+        &rt,
+        r#"INSERT INTO docs DOCUMENT VALUES ({"Title":"only-caps","published":null,"views":20})"#,
+    );
+
+    let (columns, rows) = query_snapshot(&rt, "SHOW STATS docs");
+    assert_eq!(columns, STATS_COLUMNS.map(str::to_string));
+    assert!(
+        rows.iter().all(|row| row[0] == Value::text("docs")),
+        "every SHOW STATS row is scoped to the requested collection: {rows:?}"
+    );
+
+    assert_eq!(
+        stat_value(&rt, "docs", Value::Null, "row_count"),
+        Value::UnsignedInteger(3)
+    );
+
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("title"), "coverage"),
+        Value::Float(2.0 / 3.0)
+    );
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("Title"), "coverage"),
+        Value::Float(2.0 / 3.0)
+    );
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("nested"), "type_count:object"),
+        Value::UnsignedInteger(2)
+    );
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("tags"), "type_count:array"),
+        Value::UnsignedInteger(2)
+    );
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("published"), "type_count:null"),
+        Value::UnsignedInteger(1)
+    );
+
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("title"), "distinct_count"),
+        Value::UnsignedInteger(2)
+    );
+    assert_eq!(
+        stat_value(&rt, "docs", Value::text("Title"), "distinct_count"),
+        Value::UnsignedInteger(2)
+    );
+    assert!(
+        rows.iter().all(|row| row[1] != Value::text("rank")),
+        "nested object fields must not be descended into: {rows:?}"
+    );
+
+    cleanup_scope();
+}
+
+#[test]
 fn show_stats_returns_model_specific_metric_sets() {
     cleanup_scope();
     let rt = runtime();


### PR DESCRIPTION
Automated AFK landing for #1794. Per-attempt history lives in the issue Envelopes, the JSONL logs, and the `afk-attempts/*` snapshot branches.

Closes #1794

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786464137&installation_id=129708444&pr_number=2018&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2018&signature=ce4fd4c1917421795cc49df9d42cfaaed0422de331a6e620c84dcbbfd2343d0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->