### PR TITLE
chore: #1818 Append-only segment skip metadata: min/max and bloom pruning on scans

### DIFF
--- a/crates/reddb-file/src/append_only_segment.rs
+++ b/crates/reddb-file/src/append_only_segment.rs
@@ -38,6 +38,14 @@ pub struct AppendOnlySegmentChunkChecksum {
     pub checksum: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppendOnlySegmentBloom {
+    pub num_hashes: u8,
+    pub bit_size: u32,
+    pub inserted: u32,
+    pub bits_hex: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AppendOnlySegment {
     pub version: u32,
@@ -46,6 +54,7 @@ pub struct AppendOnlySegment {
     pub rows: Vec<AppendOnlySegmentRow>,
     pub primary_min: Option<Vec<u8>>,
     pub primary_max: Option<Vec<u8>>,
+    pub primary_bloom: Option<AppendOnlySegmentBloom>,
     pub chunk_checksums: Vec<AppendOnlySegmentChunkChecksum>,
 }
 
@@ -58,6 +67,7 @@ struct SegmentHeader {
     uncompressed_len: u64,
     primary_min_hex: Option<String>,
     primary_max_hex: Option<String>,
+    primary_bloom: Option<AppendOnlySegmentBloom>,
     chunk_checksums: Vec<AppendOnlySegmentChunkChecksum>,
 }
 
@@ -102,6 +112,7 @@ pub fn encode_append_only_segment(
             .map(|row| row.primary_key.as_slice())
             .max()
             .map(hex::encode),
+        primary_bloom: build_primary_bloom(rows),
         chunk_checksums,
     };
     let header_bytes = serde_json::to_vec(&header).map_err(invalid_operation)?;
@@ -217,12 +228,82 @@ pub fn decode_append_only_segment(bytes: &[u8]) -> RdbFileResult<AppendOnlySegme
         rows,
         primary_min,
         primary_max,
+        primary_bloom: header.primary_bloom,
         chunk_checksums: header.chunk_checksums,
     })
 }
 
 pub fn append_only_segment_chunk_checksums(bytes: &[u8]) -> Vec<AppendOnlySegmentChunkChecksum> {
     chunk_checksums(bytes)
+}
+
+pub fn append_only_segment_primary_bloom_might_contain(
+    bloom: &AppendOnlySegmentBloom,
+    key: &[u8],
+) -> bool {
+    if bloom.bit_size == 0 || bloom.num_hashes == 0 {
+        return true;
+    }
+    let Ok(bits) = hex::decode(&bloom.bits_hex) else {
+        return true;
+    };
+    for idx in primary_bloom_indexes(key, bloom.bit_size, bloom.num_hashes) {
+        let byte = (idx / 8) as usize;
+        let mask = 1u8 << (idx % 8);
+        if bits
+            .get(byte)
+            .map(|value| value & mask == 0)
+            .unwrap_or(true)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn build_primary_bloom(rows: &[AppendOnlySegmentRow]) -> Option<AppendOnlySegmentBloom> {
+    if rows.is_empty() {
+        return None;
+    }
+    let inserted = u32::try_from(rows.len()).ok()?;
+    let bit_size = inserted.saturating_mul(10).max(64);
+    let num_hashes = 3;
+    let mut bits = vec![0u8; (bit_size as usize).div_ceil(8)];
+    for row in rows {
+        for idx in primary_bloom_indexes(&row.primary_key, bit_size, num_hashes) {
+            bits[(idx / 8) as usize] |= 1u8 << (idx % 8);
+        }
+    }
+    Some(AppendOnlySegmentBloom {
+        num_hashes,
+        bit_size,
+        inserted,
+        bits_hex: hex::encode(bits),
+    })
+}
+
+fn primary_bloom_indexes(key: &[u8], bit_size: u32, num_hashes: u8) -> impl Iterator<Item = u32> {
+    let h1 = fnv1a64(key);
+    let h2 = djb2_64(key).max(1);
+    (0..num_hashes)
+        .map(move |idx| h1.wrapping_add(u64::from(idx).wrapping_mul(h2)) as u32 % bit_size)
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100_0000_01b3);
+    }
+    hash
+}
+
+fn djb2_64(bytes: &[u8]) -> u64 {
+    let mut hash = 5381u64;
+    for byte in bytes {
+        hash = hash.wrapping_mul(33).wrapping_add(u64::from(*byte));
+    }
+    hash
 }
 
 fn chunk_checksums(bytes: &[u8]) -> Vec<AppendOnlySegmentChunkChecksum> {

--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -73,8 +73,9 @@ pub use ai_model_cache::{
     AI_MODEL_CACHE_STAGING_DIR_NAME,
 };
 pub use append_only_segment::{
-    append_only_segment_chunk_checksums, decode_append_only_segment, encode_append_only_segment,
-    AppendOnlySegment, AppendOnlySegmentChunkChecksum, AppendOnlySegmentCodec,
+    append_only_segment_chunk_checksums, append_only_segment_primary_bloom_might_contain,
+    decode_append_only_segment, encode_append_only_segment, AppendOnlySegment,
+    AppendOnlySegmentBloom, AppendOnlySegmentChunkChecksum, AppendOnlySegmentCodec,
     AppendOnlySegmentRow, APPEND_ONLY_SEGMENT_CHUNK_BYTES, APPEND_ONLY_SEGMENT_VERSION,
 };
 pub use audit_log::{rotate_audit_log, AuditLogRotation};

--- a/crates/reddb-file/src/operational_manifest/mod.rs
+++ b/crates/reddb-file/src/operational_manifest/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use serde_json::{Map, Value};
 
 use crate::append_only_segment::{
-    append_only_segment_chunk_checksums, decode_append_only_segment,
+    append_only_segment_chunk_checksums, decode_append_only_segment, AppendOnlySegmentBloom,
     AppendOnlySegmentChunkChecksum, AppendOnlySegmentCodec, APPEND_ONLY_SEGMENT_CHUNK_BYTES,
 };
 
@@ -119,6 +119,7 @@ pub struct AppendOnlySegmentManifestEntry {
     pub retention_max_ms: Option<i64>,
     pub primary_min: Option<String>,
     pub primary_max: Option<String>,
+    pub primary_bloom: Option<AppendOnlySegmentBloom>,
     pub chunk_checksums: Vec<AppendOnlySegmentChunkChecksum>,
 }
 
@@ -361,6 +362,7 @@ impl OperationalManifest {
             retention_max_ms,
             primary_min: decoded.primary_min.as_ref().map(hex::encode),
             primary_max: decoded.primary_max.as_ref().map(hex::encode),
+            primary_bloom: decoded.primary_bloom.clone(),
             chunk_checksums: append_only_segment_chunk_checksums(bytes),
         };
         manifest.append_only_segments.push(entry.clone());
@@ -923,6 +925,10 @@ fn append_only_segment_from_value(value: &Value) -> io::Result<AppendOnlySegment
         .get("primary_max")
         .and_then(Value::as_str)
         .map(str::to_string);
+    let primary_bloom = object
+        .get("primary_bloom")
+        .map(append_only_segment_bloom_from_value)
+        .transpose()?;
     let retention_min_ms = object.get("retention_min_ms").and_then(Value::as_i64);
     let retention_max_ms = object.get("retention_max_ms").and_then(Value::as_i64);
     let chunk_checksums = object
@@ -944,7 +950,40 @@ fn append_only_segment_from_value(value: &Value) -> io::Result<AppendOnlySegment
         retention_max_ms,
         primary_min,
         primary_max,
+        primary_bloom,
         chunk_checksums,
+    })
+}
+
+fn append_only_segment_bloom_from_value(value: &Value) -> io::Result<AppendOnlySegmentBloom> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| invalid_data("append-only segment bloom must be an object"))?;
+    let num_hashes = object
+        .get("num_hashes")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("append-only segment bloom num_hashes is missing"))
+        .and_then(u8_from_u64)?;
+    let bit_size = object
+        .get("bit_size")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("append-only segment bloom bit_size is missing"))
+        .and_then(u32_from_u64)?;
+    let inserted = object
+        .get("inserted")
+        .and_then(Value::as_u64)
+        .ok_or_else(|| invalid_data("append-only segment bloom inserted is missing"))
+        .and_then(u32_from_u64)?;
+    let bits_hex = object
+        .get("bits_hex")
+        .and_then(Value::as_str)
+        .ok_or_else(|| invalid_data("append-only segment bloom bits_hex is missing"))?
+        .to_string();
+    Ok(AppendOnlySegmentBloom {
+        num_hashes,
+        bit_size,
+        inserted,
+        bits_hex,
     })
 }
 
@@ -1121,6 +1160,12 @@ fn append_only_segment_to_value(entry: &AppendOnlySegmentManifestEntry) -> Value
             Value::String(primary_max.clone()),
         );
     }
+    if let Some(primary_bloom) = &entry.primary_bloom {
+        object.insert(
+            "primary_bloom".to_string(),
+            append_only_segment_bloom_to_value(primary_bloom),
+        );
+    }
     object.insert(
         "chunk_checksums".to_string(),
         Value::Array(
@@ -1130,6 +1175,18 @@ fn append_only_segment_to_value(entry: &AppendOnlySegmentManifestEntry) -> Value
                 .map(chunk_checksum_to_value)
                 .collect(),
         ),
+    );
+    Value::Object(object)
+}
+
+fn append_only_segment_bloom_to_value(bloom: &AppendOnlySegmentBloom) -> Value {
+    let mut object = Map::new();
+    object.insert("num_hashes".to_string(), Value::from(bloom.num_hashes));
+    object.insert("bit_size".to_string(), Value::from(bloom.bit_size));
+    object.insert("inserted".to_string(), Value::from(bloom.inserted));
+    object.insert(
+        "bits_hex".to_string(),
+        Value::String(bloom.bits_hex.clone()),
     );
     Value::Object(object)
 }
@@ -1147,6 +1204,10 @@ fn chunk_checksum_to_value(chunk: &AppendOnlySegmentChunkChecksum) -> Value {
 
 fn u32_from_u64(value: u64) -> io::Result<u32> {
     u32::try_from(value).map_err(|_| invalid_data(format!("value does not fit u32: {value}")))
+}
+
+fn u8_from_u64(value: u64) -> io::Result<u8> {
+    u8::try_from(value).map_err(|_| invalid_data(format!("value does not fit u8: {value}")))
 }
 
 fn unique_quarantine_path(dir: &Path, file_name: &str) -> PathBuf {

--- a/crates/reddb-file/tests/append_only_segment.rs
+++ b/crates/reddb-file/tests/append_only_segment.rs
@@ -1,9 +1,9 @@
 use std::fs;
 
 use reddb_file::{
-    decode_append_only_segment, encode_append_only_segment, AppendOnlySegmentCodec,
-    AppendOnlySegmentRow, AppendOnlySegmentState, OperationalManifest,
-    APPEND_ONLY_SEGMENT_CHUNK_BYTES,
+    append_only_segment_primary_bloom_might_contain, decode_append_only_segment,
+    encode_append_only_segment, AppendOnlySegmentCodec, AppendOnlySegmentRow,
+    AppendOnlySegmentState, OperationalManifest, APPEND_ONLY_SEGMENT_CHUNK_BYTES,
 };
 
 #[test]
@@ -28,6 +28,16 @@ fn append_only_segment_frame_round_trips_metadata_and_checksums() {
     assert_eq!(decoded.rows, rows);
     assert_eq!(decoded.primary_min.as_deref(), Some(&b"0001"[..]));
     assert_eq!(decoded.primary_max.as_deref(), Some(&b"0002"[..]));
+    let bloom = decoded.primary_bloom.as_ref().expect("primary bloom");
+    assert!(append_only_segment_primary_bloom_might_contain(
+        bloom, b"0001"
+    ));
+    assert!(append_only_segment_primary_bloom_might_contain(
+        bloom, b"0002"
+    ));
+    assert!(!append_only_segment_primary_bloom_might_contain(
+        bloom, b"9999"
+    ));
     assert!(!decoded.chunk_checksums.is_empty());
     assert!(decoded
         .chunk_checksums
@@ -56,6 +66,9 @@ fn operational_manifest_publishes_closed_append_only_segment_once() {
     assert_eq!(segment.codec, AppendOnlySegmentCodec::None);
     assert_eq!(segment.chunk_size, APPEND_ONLY_SEGMENT_CHUNK_BYTES);
     assert_eq!(segment.row_count, 1);
+    assert!(segment.primary_min.is_some());
+    assert!(segment.primary_max.is_some());
+    assert!(segment.primary_bloom.is_some());
     assert!(!segment.chunk_checksums.is_empty());
     assert!(segment.path.ends_with(".raos"));
     assert!(manifest

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -411,6 +411,18 @@ pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
         JsonValue::Number(stats.rows_scanned as f64),
     );
     object.insert(
+        "segments_total".to_string(),
+        JsonValue::Number(stats.segments_total as f64),
+    );
+    object.insert(
+        "segments_scanned".to_string(),
+        JsonValue::Number(stats.segments_scanned as f64),
+    );
+    object.insert(
+        "segments_pruned".to_string(),
+        JsonValue::Number(stats.segments_pruned as f64),
+    );
+    object.insert(
         "exec_time_us".to_string(),
         JsonValue::Number(stats.exec_time_us as f64),
     );

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -42,7 +42,7 @@ pub(super) use vector::execute_runtime_vector_query;
 use aggregate::{execute_aggregate_query, has_aggregate_projections};
 use table::{
     execute_runtime_canonical_table_node, execute_runtime_canonical_table_query_indexed,
-    RuntimeTableExecutionContext,
+    take_last_segment_scan_stats, RuntimeTableExecutionContext,
 };
 
 pub(crate) use row_stream::{RowBufferArena, RowStream, DEFAULT_HIGH_WATER_MARK};
@@ -213,7 +213,9 @@ fn execute_runtime_table_query_materialized(
         }
     }
 
+    let _ = take_last_segment_scan_stats();
     let mut records = execute_runtime_canonical_table_query_indexed(db, query, index_store)?;
+    let segment_scan_stats = take_last_segment_scan_stats();
     // Issue #580 — DeclarativeRetention slice 1. Lazy-on-scan: drop
     // rows older than `now - retention_duration_ms` after the scan
     // assembles them, before the result reaches the caller. No-op for
@@ -244,7 +246,12 @@ fn execute_runtime_table_query_materialized(
     Ok(UnifiedResult {
         columns,
         records,
-        stats: Default::default(),
+        stats: crate::storage::query::unified::QueryStats {
+            segments_total: segment_scan_stats.segments_total,
+            segments_scanned: segment_scan_stats.segments_scanned,
+            segments_pruned: segment_scan_stats.segments_pruned,
+            ..Default::default()
+        },
         pre_serialized_json: None,
     })
 }

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -27,6 +27,24 @@ use crate::storage::query::sql_lowering::{
     effective_table_filter, effective_table_group_by_exprs, effective_table_having_filter,
     effective_table_projections,
 };
+use crate::storage::unified::manager::SegmentScanStats;
+
+thread_local! {
+    static LAST_SEGMENT_SCAN_STATS: std::cell::Cell<SegmentScanStats> =
+        const { std::cell::Cell::new(SegmentScanStats {
+            segments_total: 0,
+            segments_scanned: 0,
+            segments_pruned: 0,
+        }) };
+}
+
+pub(crate) fn take_last_segment_scan_stats() -> SegmentScanStats {
+    LAST_SEGMENT_SCAN_STATS.with(|stats| stats.replace(SegmentScanStats::default()))
+}
+
+fn record_segment_scan_stats(stats: SegmentScanStats) {
+    LAST_SEGMENT_SCAN_STATS.with(|slot| slot.set(stats));
+}
 
 /// Build the JSON result from a set of entity IDs (from index lookup).
 /// Scan entities sequentially but only process those in the candidate set (from hash index).
@@ -1328,15 +1346,17 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             // the same MVCC visibility gate.
             let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
             let table_row_resolver = TableRowMvccReadResolver::captured(snap_ctx);
-            let matching = manager.query_all_zoned(&zone_preds, |entity| {
-                let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
-                    hydrate_store.as_ref(),
-                    entity,
-                );
-                table_row_resolver.resolve_read_candidate(entity).is_some()
-                    && db.replica_allows_entity_at_read(&query.table, entity)
-                    && compiled.evaluate(&hydrated)
-            });
+            let (matching, scan_stats) =
+                manager.query_all_zoned_with_stats(&zone_preds, |entity| {
+                    let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
+                        hydrate_store.as_ref(),
+                        entity,
+                    );
+                    table_row_resolver.resolve_read_candidate(entity).is_some()
+                        && db.replica_allows_entity_at_read(&query.table, entity)
+                        && compiled.evaluate(&hydrated)
+                });
+            record_segment_scan_stats(scan_stats);
             for entity in &matching {
                 let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
                     hydrate_store.as_ref(),
@@ -1400,7 +1420,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             }
         } else {
             let table_row_resolver = TableRowMvccReadResolver::current_statement();
-            manager.for_each_entity_zoned(&zone_preds, |entity| {
+            let scan_stats = manager.for_each_entity_zoned_with_stats(&zone_preds, |entity| {
                 if records.len() >= limit {
                     return false; // stop iteration
                 }
@@ -1471,6 +1491,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 }
                 true // continue
             });
+            record_segment_scan_stats(scan_stats);
         }
 
         // Apply ORDER BY — Schwartzian transform extracts keys once (O(n))

--- a/crates/reddb-server/src/runtime/result_cache_runtime.rs
+++ b/crates/reddb-server/src/runtime/result_cache_runtime.rs
@@ -193,6 +193,9 @@ fn encode_result_cache_payload(entry: &RuntimeResultCacheEntry) -> Option<Vec<u8
     out.extend_from_slice(&result.result.stats.nodes_scanned.to_le_bytes());
     out.extend_from_slice(&result.result.stats.edges_scanned.to_le_bytes());
     out.extend_from_slice(&result.result.stats.rows_scanned.to_le_bytes());
+    out.extend_from_slice(&result.result.stats.segments_total.to_le_bytes());
+    out.extend_from_slice(&result.result.stats.segments_scanned.to_le_bytes());
+    out.extend_from_slice(&result.result.stats.segments_pruned.to_le_bytes());
     out.extend_from_slice(&result.result.stats.exec_time_us.to_le_bytes());
 
     write_u32(&mut out, result.result.records.len())?;
@@ -237,6 +240,9 @@ fn decode_result_cache_payload(mut input: &[u8]) -> Option<(RuntimeQueryResult, 
         nodes_scanned: read_u64(&mut input)?,
         edges_scanned: read_u64(&mut input)?,
         rows_scanned: read_u64(&mut input)?,
+        segments_total: read_u64(&mut input)?,
+        segments_scanned: read_u64(&mut input)?,
+        segments_pruned: read_u64(&mut input)?,
         exec_time_us: read_u64(&mut input)?,
     };
 

--- a/crates/reddb-server/src/storage/query/executors/hybrid.rs
+++ b/crates/reddb-server/src/storage/query/executors/hybrid.rs
@@ -533,6 +533,9 @@ impl QueryStats {
             nodes_scanned: a.nodes_scanned + b.nodes_scanned,
             edges_scanned: a.edges_scanned + b.edges_scanned,
             rows_scanned: a.rows_scanned + b.rows_scanned,
+            segments_total: a.segments_total + b.segments_total,
+            segments_scanned: a.segments_scanned + b.segments_scanned,
+            segments_pruned: a.segments_pruned + b.segments_pruned,
             exec_time_us: a.exec_time_us + b.exec_time_us,
         }
     }

--- a/crates/reddb-server/src/storage/query/executors/vector.rs
+++ b/crates/reddb-server/src/storage/query/executors/vector.rs
@@ -147,6 +147,7 @@ impl VectorExecutor {
             edges_scanned: 0,
             rows_scanned: result.len() as u64,
             exec_time_us: start.elapsed().as_micros() as u64,
+            ..Default::default()
         };
 
         Ok(result)
@@ -409,6 +410,7 @@ impl InMemoryVectorExecutor {
             edges_scanned: 0,
             rows_scanned: self.vectors.len() as u64,
             exec_time_us: start.elapsed().as_micros() as u64,
+            ..Default::default()
         };
 
         Ok(result)

--- a/crates/reddb-server/src/storage/query/unified/types.rs
+++ b/crates/reddb-server/src/storage/query/unified/types.rs
@@ -640,6 +640,12 @@ pub struct QueryStats {
     pub edges_scanned: u64,
     /// Number of rows scanned
     pub rows_scanned: u64,
+    /// Number of queryable segments considered by the scan
+    pub segments_total: u64,
+    /// Number of queryable segments actually scanned
+    pub segments_scanned: u64,
+    /// Number of queryable segments skipped by metadata pruning
+    pub segments_pruned: u64,
     /// Execution time in microseconds
     pub exec_time_us: u64,
 }

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -116,6 +116,13 @@ pub struct ManagerStats {
     pub consolidation: ConsolidationStats,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SegmentScanStats {
+    pub segments_total: u64,
+    pub segments_scanned: u64,
+    pub segments_pruned: u64,
+}
+
 /// Lifecycle events for monitoring
 #[derive(Debug, Clone)]
 pub enum LifecycleEvent {
@@ -1321,33 +1328,51 @@ impl SegmentManager {
     where
         F: FnMut(&UnifiedEntity) -> bool,
     {
+        let _ = self.for_each_entity_zoned_with_stats(zone_preds, &mut callback);
+    }
+
+    pub fn for_each_entity_zoned_with_stats<F>(
+        &self,
+        zone_preds: &[(&str, ZoneColPred<'_>)],
+        mut callback: F,
+    ) -> SegmentScanStats
+    where
+        F: FnMut(&UnifiedEntity) -> bool,
+    {
+        let mut scan_stats = SegmentScanStats::default();
         // Growing segment — never skip (it's receiving writes, zones are partial).
         // Try a non-blocking read first: if a writer is currently inserting
         // (holding the write lock), try_read() returns None and we fall back to
         // the blocking read.  In low-contention workloads (reads far outnumber
         // writes) the try_read() almost always succeeds and readers never stall.
         if let Some(growing_arc) = self.growing.read().as_ref() {
+            scan_stats.segments_total += 1;
+            scan_stats.segments_scanned += 1;
             let growing = if let Some(g) = growing_arc.try_read() {
                 g
             } else {
                 growing_arc.read()
             };
             if !growing.for_each_fast(&mut callback) {
-                return;
+                return scan_stats;
             }
         }
 
         // Sealed segments — check zone maps before iterating
         let sealed = self.sealed.read();
         for segment_arc in sealed.iter() {
+            scan_stats.segments_total += 1;
             let segment = segment_arc.read();
             if !zone_preds.is_empty() && segment.can_skip_zone_preds(zone_preds) {
+                scan_stats.segments_pruned += 1;
                 continue; // entire segment pruned
             }
+            scan_stats.segments_scanned += 1;
             if !segment.for_each_fast(&mut callback) {
-                return;
+                return scan_stats;
             }
         }
+        scan_stats
     }
 
     /// Zone-map-aware parallel query.
@@ -1367,11 +1392,25 @@ impl SegmentManager {
     where
         F: Fn(&UnifiedEntity) -> bool + Sync,
     {
+        self.query_all_zoned_with_stats(zone_preds, filter).0
+    }
+
+    pub fn query_all_zoned_with_stats<F>(
+        &self,
+        zone_preds: &[(&str, ZoneColPred<'_>)],
+        filter: F,
+    ) -> (Vec<UnifiedEntity>, SegmentScanStats)
+    where
+        F: Fn(&UnifiedEntity) -> bool + Sync,
+    {
         let mut results = Vec::new();
+        let mut scan_stats = SegmentScanStats::default();
 
         // Growing segment — always scan, no zone skip (zones are partial).
         // Non-blocking try_read() avoids stalling behind in-progress inserts.
         if let Some(growing_arc) = self.growing.read().as_ref() {
+            scan_stats.segments_total += 1;
+            scan_stats.segments_scanned += 1;
             let growing = if let Some(g) = growing_arc.try_read() {
                 g
             } else {
@@ -1386,11 +1425,19 @@ impl SegmentManager {
         let surviving: Vec<_> = sealed
             .iter()
             .filter(|seg_arc| {
+                scan_stats.segments_total += 1;
                 if zone_preds.is_empty() {
+                    scan_stats.segments_scanned += 1;
                     return true;
                 }
                 let seg = seg_arc.read();
-                !seg.can_skip_zone_preds(zone_preds)
+                if seg.can_skip_zone_preds(zone_preds) {
+                    scan_stats.segments_pruned += 1;
+                    false
+                } else {
+                    scan_stats.segments_scanned += 1;
+                    true
+                }
             })
             .collect();
 
@@ -1426,7 +1473,7 @@ impl SegmentManager {
             }
         }
 
-        results
+        (results, scan_stats)
     }
 
     /// Query across all segments. Uses parallel scanning for sealed segments
@@ -2072,6 +2119,7 @@ impl UnifiedSegment for Arc<RwLock<GrowingSegment>> {
 mod tests {
     use super::*;
     use crate::storage::schema::Value;
+    use crate::storage::unified::entity::{EntityData, EntityKind, RowData};
 
     #[test]
     fn test_manager_basic() {
@@ -2104,6 +2152,52 @@ mod tests {
 
         assert!(manager.bloom_may_contain_key(&id.raw().to_le_bytes()));
         assert!(!manager.bloom_may_contain_key(&u64::MAX.to_le_bytes()));
+    }
+
+    #[test]
+    fn zoned_scan_reports_pruned_segments_and_preserves_results() {
+        let config = ManagerConfig {
+            segment_config: SegmentConfig {
+                max_entities: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let manager = SegmentManager::with_config("events", config);
+
+        for (idx, value) in [10, 20, 100, 110, 200].into_iter().enumerate() {
+            let row = RowData::with_names(vec![Value::Integer(value)], vec!["ts".to_string()]);
+            let entity = UnifiedEntity::new(
+                manager.next_entity_id(),
+                EntityKind::TableRow {
+                    table: "events".into(),
+                    row_id: (idx + 1) as u64,
+                },
+                EntityData::Row(row),
+            );
+            manager.insert(entity).unwrap();
+        }
+
+        let full = manager.query_all(|entity| match &entity.data {
+            EntityData::Row(row) => matches!(row.get_field("ts"), Some(Value::Integer(100))),
+            _ => false,
+        });
+        let probe = Value::Integer(100);
+        let (pruned, stats) =
+            manager.query_all_zoned_with_stats(&[("ts", ZoneColPred::Eq(&probe))], |entity| {
+                match &entity.data {
+                    EntityData::Row(row) => {
+                        matches!(row.get_field("ts"), Some(Value::Integer(100)))
+                    }
+                    _ => false,
+                }
+            });
+
+        assert_eq!(pruned.len(), full.len());
+        assert_eq!(pruned[0].id, full[0].id);
+        assert_eq!(stats.segments_total, 3);
+        assert_eq!(stats.segments_scanned, 2);
+        assert_eq!(stats.segments_pruned, 1);
     }
 
     #[test]

--- a/crates/reddb-server/tests/append_only_segment_runtime.rs
+++ b/crates/reddb-server/tests/append_only_segment_runtime.rs
@@ -22,6 +22,9 @@ fn append_only_flush_publishes_closed_segment_and_reopen_reads_rows() {
         assert_eq!(segments[0].collection, "events");
         assert_eq!(segments[0].codec, reddb_file::AppendOnlySegmentCodec::Zstd);
         assert_eq!(segments[0].row_count, 2);
+        assert!(segments[0].primary_min.is_some());
+        assert!(segments[0].primary_max.is_some());
+        assert!(segments[0].primary_bloom.is_some());
         assert!(!segments[0].chunk_checksums.is_empty());
         manifest.append_only_segment_path_for_test(&segments[0].path)
     };


### PR DESCRIPTION
Automated AFK landing for #1818. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1818

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786740781&installation_id=129708444&pr_number=2028&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2028&signature=48e064990542a1d6e8f7563798cac4c210fbb6ebe5a0da44a2c8309f9a77ae01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->