### PR TITLE
chore: #1822 inverted tag index — tag key/value to series posting lists

### DIFF
--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -62,6 +62,20 @@ use crate::storage::{
     UnifiedStore,
 };
 
+static TIMESERIES_TAG_INDEX_OBSERVED_POINTS: AtomicU64 = AtomicU64::new(0);
+
+pub fn reset_timeseries_tag_index_observability() {
+    TIMESERIES_TAG_INDEX_OBSERVED_POINTS.store(0, AtomicOrdering::Relaxed);
+}
+
+pub fn timeseries_tag_index_observed_points() -> u64 {
+    TIMESERIES_TAG_INDEX_OBSERVED_POINTS.load(AtomicOrdering::Relaxed)
+}
+
+pub(crate) fn observe_timeseries_tag_index_point() {
+    TIMESERIES_TAG_INDEX_OBSERVED_POINTS.fetch_add(1, AtomicOrdering::Relaxed);
+}
+
 #[derive(Debug, Clone)]
 pub struct ConnectionPoolConfig {
     pub max_connections: usize,

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -1,12 +1,13 @@
 //! Time-series DDL execution
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use super::*;
 
 const TIMESERIES_META_COLLECTION: &str = "red_timeseries_meta";
 const TIMESERIES_SERIES_COLLECTION: &str = "red_timeseries_series";
+const TIMESERIES_TAG_INDEX_COLLECTION: &str = "red_timeseries_tag_index";
 const DEFAULT_TIMESERIES_CHUNK_INTERVAL_NS: u64 = 86_400_000_000_000;
 const TIMESERIES_MAX_SERIES_GLOBAL_CONFIG: &str = "storage.time_series.max_series_per_collection";
 const DEFAULT_TIMESERIES_MAX_SERIES_PER_COLLECTION: usize = 1_000_000;
@@ -201,6 +202,7 @@ impl RedDBRuntime {
             .map_err(|err| RedDBError::Internal(err.to_string()))?;
         remove_timeseries_metadata(store.as_ref(), &query.name);
         remove_timeseries_series_dictionary(store.as_ref(), &query.name);
+        remove_timeseries_tag_index(store.as_ref(), &query.name);
         self.invalidate_result_cache();
         self.inner
             .db
@@ -603,7 +605,258 @@ pub(crate) fn intern_timeseries_series(
         )
         .map_err(|err| RedDBError::Internal(err.to_string()))?;
 
+    maintain_timeseries_tag_index(store, collection, series_id, tags)?;
+
     Ok(series_id)
+}
+
+pub(crate) fn timeseries_tag_index_series_candidates(
+    store: &crate::storage::unified::UnifiedStore,
+    collection: &str,
+    filter: &Filter,
+) -> Option<HashSet<u64>> {
+    match filter {
+        Filter::Compare { field, op, value } if *op == CompareOp::Eq => {
+            let tag_key = timeseries_tag_field(field)?;
+            let tag_values = value_to_tag_index_texts(value)?;
+            lookup_timeseries_tag_index(store, collection, tag_key, &tag_values)
+        }
+        Filter::In { field, values } => {
+            let tag_key = timeseries_tag_field(field)?;
+            let tag_values = values
+                .iter()
+                .map(value_to_tag_index_texts)
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>();
+            lookup_timeseries_tag_index(store, collection, tag_key, &tag_values)
+        }
+        Filter::And(left, right) => {
+            match (
+                timeseries_tag_index_series_candidates(store, collection, left),
+                timeseries_tag_index_series_candidates(store, collection, right),
+            ) {
+                (Some(left), Some(right)) => {
+                    Some(left.intersection(&right).copied().collect::<HashSet<_>>())
+                }
+                (Some(candidates), None) | (None, Some(candidates)) => Some(candidates),
+                (None, None) => None,
+            }
+        }
+        Filter::Or(left, right) => {
+            let mut left = timeseries_tag_index_series_candidates(store, collection, left)?;
+            let right = timeseries_tag_index_series_candidates(store, collection, right)?;
+            left.extend(right);
+            Some(left)
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn strip_indexed_timeseries_tag_filter(filter: &Filter) -> Option<Filter> {
+    match filter {
+        Filter::Compare { field, op, value }
+            if *op == CompareOp::Eq
+                && timeseries_tag_field(field).is_some()
+                && value_to_tag_index_texts(value).is_some() =>
+        {
+            None
+        }
+        Filter::In { field, values }
+            if timeseries_tag_field(field).is_some()
+                && values
+                    .iter()
+                    .all(|value| value_to_tag_index_texts(value).is_some()) =>
+        {
+            None
+        }
+        Filter::And(left, right) => match (
+            strip_indexed_timeseries_tag_filter(left),
+            strip_indexed_timeseries_tag_filter(right),
+        ) {
+            (Some(left), Some(right)) => Some(Filter::And(Box::new(left), Box::new(right))),
+            (Some(filter), None) | (None, Some(filter)) => Some(filter),
+            (None, None) => None,
+        },
+        _ => Some(filter.clone()),
+    }
+}
+
+fn maintain_timeseries_tag_index(
+    store: &crate::storage::unified::UnifiedStore,
+    collection: &str,
+    series_id: u64,
+    tags: &HashMap<String, String>,
+) -> RedDBResult<()> {
+    let _ = store.get_or_create_collection(TIMESERIES_TAG_INDEX_COLLECTION);
+    let manager = store
+        .get_collection(TIMESERIES_TAG_INDEX_COLLECTION)
+        .ok_or_else(|| RedDBError::Internal("timeseries tag index missing".to_string()))?;
+
+    for (tag_key, tag_value) in tags {
+        let existing = manager
+            .query_all(|entity| tag_index_row_matches(entity, collection, tag_key, tag_value))
+            .into_iter()
+            .next();
+
+        if let Some(mut entity) = existing {
+            let EntityData::Row(row) = &mut entity.data else {
+                continue;
+            };
+            let mut ids = row
+                .get_field("series_ids")
+                .map(series_ids_from_value)
+                .unwrap_or_default();
+            if !ids.contains(&series_id) {
+                ids.push(series_id);
+                ids.sort_unstable();
+                set_row_field(row, "series_ids", series_ids_value(&ids));
+                manager
+                    .update(entity)
+                    .map_err(|err| RedDBError::Internal(err.to_string()))?;
+            }
+            continue;
+        }
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "collection".to_string(),
+            Value::text(collection.to_string()),
+        );
+        fields.insert("tag_key".to_string(), Value::text(tag_key.clone()));
+        fields.insert("tag_value".to_string(), Value::text(tag_value.clone()));
+        fields.insert("series_ids".to_string(), series_ids_value(&[series_id]));
+
+        store
+            .insert_auto(
+                TIMESERIES_TAG_INDEX_COLLECTION,
+                UnifiedEntity::new(
+                    EntityId::new(0),
+                    EntityKind::TableRow {
+                        table: Arc::from(TIMESERIES_TAG_INDEX_COLLECTION),
+                        row_id: 0,
+                    },
+                    EntityData::Row(crate::storage::RowData {
+                        columns: Vec::new(),
+                        named: Some(fields),
+                        schema: None,
+                    }),
+                ),
+            )
+            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+    }
+
+    Ok(())
+}
+
+fn lookup_timeseries_tag_index(
+    store: &crate::storage::unified::UnifiedStore,
+    collection: &str,
+    tag_key: &str,
+    tag_values: &[String],
+) -> Option<HashSet<u64>> {
+    let Some(manager) = store.get_collection(TIMESERIES_TAG_INDEX_COLLECTION) else {
+        return None;
+    };
+    let wanted = tag_values
+        .iter()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let rows = manager.query_all(|entity| {
+        entity.data.as_row().is_some_and(|row| {
+            row_text(row, "collection").is_some_and(|value| value == collection)
+                && row_text(row, "tag_key").is_some_and(|value| value == tag_key)
+                && row_text(row, "tag_value").is_some_and(|value| wanted.contains(value))
+        })
+    });
+
+    Some(
+        rows.iter()
+            .filter_map(|entity| entity.data.as_row())
+            .flat_map(|row| {
+                row.get_field("series_ids")
+                    .map(series_ids_from_value)
+                    .unwrap_or_default()
+            })
+            .collect(),
+    )
+}
+
+fn timeseries_tag_field(field: &FieldRef) -> Option<&str> {
+    match field {
+        FieldRef::TableColumn { table, column } if table == "tags" && !column.is_empty() => {
+            Some(column.as_str())
+        }
+        FieldRef::TableColumn { column, .. } => {
+            column.strip_prefix("tags.").filter(|key| !key.is_empty())
+        }
+        _ => None,
+    }
+}
+
+fn value_to_tag_index_texts(value: &Value) -> Option<Vec<String>> {
+    match value {
+        Value::Text(value) => {
+            let raw = value.to_string();
+            let encoded = encoded_json_tag_probe(&raw);
+            if encoded == raw {
+                Some(vec![raw])
+            } else {
+                Some(vec![raw, encoded])
+            }
+        }
+        _ => None,
+    }
+}
+
+fn encoded_json_tag_probe(value: &str) -> String {
+    let mut encoded = String::new();
+    encoded.push(crate::runtime::query_exec::TIMESERIES_TAG_JSON_PREFIX);
+    encoded.push_str(&crate::json::Value::String(value.to_string()).to_string_compact());
+    encoded
+}
+
+fn tag_index_row_matches(
+    entity: &UnifiedEntity,
+    collection: &str,
+    tag_key: &str,
+    tag_value: &str,
+) -> bool {
+    entity.data.as_row().is_some_and(|row| {
+        row_text(row, "collection").is_some_and(|value| value == collection)
+            && row_text(row, "tag_key").is_some_and(|value| value == tag_key)
+            && row_text(row, "tag_value").is_some_and(|value| value == tag_value)
+    })
+}
+
+fn series_ids_value(ids: &[u64]) -> Value {
+    Value::Array(
+        ids.iter()
+            .copied()
+            .map(Value::UnsignedInteger)
+            .collect::<Vec<_>>(),
+    )
+}
+
+fn series_ids_from_value(value: &Value) -> Vec<u64> {
+    let Value::Array(values) = value else {
+        return Vec::new();
+    };
+    values
+        .iter()
+        .filter_map(|value| match value {
+            Value::UnsignedInteger(value) => Some(*value),
+            Value::Integer(value) if *value >= 0 => Some(*value as u64),
+            _ => None,
+        })
+        .collect()
+}
+
+fn set_row_field(row: &mut crate::storage::RowData, name: &str, value: Value) {
+    if let Some(named) = &mut row.named {
+        named.insert(name.to_string(), value);
+    }
 }
 
 pub(crate) fn hydrate_timeseries_entity(
@@ -883,6 +1136,22 @@ fn remove_timeseries_series_dictionary(
     });
     for row in rows {
         let _ = store.delete(TIMESERIES_SERIES_COLLECTION, row.id);
+    }
+}
+
+fn remove_timeseries_tag_index(store: &crate::storage::unified::UnifiedStore, collection: &str) {
+    let Some(manager) = store.get_collection(TIMESERIES_TAG_INDEX_COLLECTION) else {
+        return;
+    };
+    let rows = manager.query_all(|entity| {
+        entity.data.as_row().is_some_and(|row| {
+            row.get_field("collection").is_some_and(
+                |value| matches!(value, Value::Text(candidate) if &**candidate == collection),
+            )
+        })
+    });
+    for row in rows {
+        let _ = store.delete(TIMESERIES_TAG_INDEX_COLLECTION, row.id);
     }
 }
 

--- a/crates/reddb-server/src/runtime/impl_timeseries.rs
+++ b/crates/reddb-server/src/runtime/impl_timeseries.rs
@@ -756,9 +756,7 @@ fn lookup_timeseries_tag_index(
     tag_key: &str,
     tag_values: &[String],
 ) -> Option<HashSet<u64>> {
-    let Some(manager) = store.get_collection(TIMESERIES_TAG_INDEX_COLLECTION) else {
-        return None;
-    };
+    let manager = store.get_collection(TIMESERIES_TAG_INDEX_COLLECTION)?;
     let wanted = tag_values
         .iter()
         .map(String::as_str)

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1208,10 +1208,26 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     // Evaluates the filter directly on raw entity data to avoid materializing
     // UnifiedRecord for every entity in the collection.
     // Excludes universal entity sources (e.g. "any") which span all collections.
+    let tag_series_candidates_for_filter = db
+        .collection_contract(&query.table)
+        .filter(|contract| contract.declared_model == crate::catalog::CollectionModel::TimeSeries)
+        .and_then(|_| {
+            effective_filter.as_ref().and_then(|filter| {
+                let store = db.store();
+                super::super::impl_timeseries::timeseries_tag_index_series_candidates(
+                    store.as_ref(),
+                    &query.table,
+                    filter,
+                )
+            })
+        });
+    let tag_index_can_filter = tag_series_candidates_for_filter.is_some();
+
     if effective_filter.is_some()
-        && !effective_filter
+        && (!effective_filter
             .as_ref()
             .is_some_and(|filter| runtime_filter_uses_document_path(filter, query))
+            || tag_index_can_filter)
         && effective_group_by.is_empty()
         && effective_having.is_none()
         && query.expand.is_none()
@@ -1223,10 +1239,18 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             .store()
             .get_collection(query.table.as_str())
             .ok_or_else(|| RedDBError::NotFound(query.table.clone()))?;
+        let store = db.store();
 
         let filter = effective_filter.as_ref().ok_or_else(|| {
             RedDBError::Internal("filtered runtime scan selected without a WHERE clause".into())
         })?;
+        let tag_series_candidates = tag_series_candidates_for_filter;
+        if tag_series_candidates
+            .as_ref()
+            .is_some_and(std::collections::HashSet::is_empty)
+        {
+            return Ok(Vec::new());
+        }
         let table_name = query.table.as_str();
         let table_alias = query.alias.as_deref().unwrap_or(table_name);
         let explicit_limit = query.limit;
@@ -1253,6 +1277,12 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             }
         }
 
+        let residual_filter = if tag_series_candidates.is_some() {
+            super::super::impl_timeseries::strip_indexed_timeseries_tag_filter(filter)
+        } else {
+            Some(filter.clone())
+        };
+
         // Zone map: extract range/equality predicates for segment-level pruning.
         // Sealed segments whose column min/max proves no row can match are skipped.
         let mut zone_raw: Vec<(
@@ -1260,7 +1290,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             crate::storage::schema::Value,
             crate::storage::unified::segment::ZoneColPredKind,
         )> = Vec::new();
-        extract_zone_predicates(filter, &mut zone_raw);
+        if let Some(filter) = residual_filter.as_ref() {
+            extract_zone_predicates(filter, &mut zone_raw);
+        }
         // Reconstruct lifetime-bound ZoneColPred refs from the owned Vec.
         let zone_preds: Vec<(&str, crate::storage::unified::segment::ZoneColPred<'_>)> = zone_raw
             .iter()
@@ -1285,20 +1317,24 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         // user column names to positional indices — O(1) access per field
         // per row instead of O(n schema search) for bulk-inserted entities.
         let schema_arc = manager.column_schema();
-        let compiled = match schema_arc.as_ref() {
-            Some(schema) => super::filter_compiled::CompiledEntityFilter::compile_with_schema(
-                filter,
-                table_name,
-                table_alias,
-                schema.as_ref(),
-            ),
-            None => super::filter_compiled::CompiledEntityFilter::compile(
-                filter,
-                table_name,
-                table_alias,
-            ),
-        };
-        let requires_filter_recheck = compiled.has_fallback();
+        let compiled = residual_filter
+            .as_ref()
+            .map(|filter| match schema_arc.as_ref() {
+                Some(schema) => super::filter_compiled::CompiledEntityFilter::compile_with_schema(
+                    filter,
+                    table_name,
+                    table_alias,
+                    schema.as_ref(),
+                ),
+                None => super::filter_compiled::CompiledEntityFilter::compile(
+                    filter,
+                    table_name,
+                    table_alias,
+                ),
+            });
+        let requires_filter_recheck = compiled
+            .as_ref()
+            .is_some_and(|filter| filter.has_fallback());
 
         // Pre-filter at entity level, only materialize records that pass.
         // Uses zone-map-aware iteration: sealed segments whose column zones
@@ -1338,7 +1374,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         let lean_select_star = select_cols.is_empty();
 
         let mut records: Vec<UnifiedRecord> = Vec::new();
-        let hydrate_store = db.store();
+        let hydrate_store = store;
         if use_parallel {
             // Parallel scan spawns worker threads that don't inherit the
             // main thread's CURRENT_SNAPSHOT thread-local. Capture the
@@ -1348,13 +1384,24 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             let table_row_resolver = TableRowMvccReadResolver::captured(snap_ctx);
             let (matching, scan_stats) =
                 manager.query_all_zoned_with_stats(&zone_preds, |entity| {
+                    if let Some(candidates) = tag_series_candidates.as_ref() {
+                        let EntityData::TimeSeries(point) = &entity.data else {
+                            return false;
+                        };
+                        if !point.series_id.is_some_and(|id| candidates.contains(&id)) {
+                            return false;
+                        }
+                        crate::runtime::observe_timeseries_tag_index_point();
+                    }
                     let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
                         hydrate_store.as_ref(),
                         entity,
                     );
                     table_row_resolver.resolve_read_candidate(entity).is_some()
                         && db.replica_allows_entity_at_read(&query.table, entity)
-                        && compiled.evaluate(&hydrated)
+                        && compiled.as_ref().is_none_or(|filter| {
+                            requires_filter_recheck || filter.evaluate(&hydrated)
+                        })
                 });
             record_segment_scan_stats(scan_stats);
             for entity in &matching {
@@ -1399,6 +1446,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 };
                 if let Some(record) = record {
                     if requires_filter_recheck {
+                        let Some(filter) = residual_filter.as_ref() else {
+                            continue;
+                        };
                         let Some(filter_record) =
                             runtime_table_record_from_entity(hydrated.clone())
                         else {
@@ -1430,11 +1480,23 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 if !db.replica_allows_entity_at_read(&query.table, entity) {
                     return true;
                 }
+                if let Some(candidates) = tag_series_candidates.as_ref() {
+                    let EntityData::TimeSeries(point) = &entity.data else {
+                        return true;
+                    };
+                    if !point.series_id.is_some_and(|id| candidates.contains(&id)) {
+                        return true;
+                    }
+                    crate::runtime::observe_timeseries_tag_index_point();
+                }
                 let hydrated = super::super::impl_timeseries::hydrate_timeseries_entity(
                     hydrate_store.as_ref(),
                     entity,
                 );
-                if compiled.evaluate(&hydrated) {
+                if compiled
+                    .as_ref()
+                    .is_none_or(|filter| requires_filter_recheck || filter.evaluate(&hydrated))
+                {
                     let record = if !select_cols.is_empty() {
                         // Fast columnar path: use pre-computed schema indices when available.
                         if let Some(ref idx_map) = schema_col_indices {
@@ -1470,6 +1532,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         };
                     if let Some(record) = record {
                         if requires_filter_recheck {
+                            let Some(filter) = residual_filter.as_ref() else {
+                                return true;
+                            };
                             let Some(filter_record) =
                                 runtime_table_record_from_entity(hydrated.clone())
                             else {

--- a/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
+++ b/tests/grouped/docs_kv_queue/integration_queue_timeseries.rs
@@ -1341,6 +1341,98 @@ fn test_timeseries_series_dictionary_interns_canonical_tags() {
 }
 
 #[test]
+fn test_timeseries_tag_index_filters_series_for_equality_and_in_after_reopen() {
+    let path = PersistentDbPath::new("timeseries_tag_index");
+    let rt = path.open_runtime();
+
+    exec(&rt, "CREATE TIMESERIES cpu_metrics RETENTION 7 d");
+    exec(
+        &rt,
+        "INSERT INTO cpu_metrics (metric, value, tags, timestamp) VALUES ('cpu.idle', 94.8, {host: 'srv1', region: 'us-east'}, 1)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO cpu_metrics (metric, value, tags, timestamp) VALUES ('cpu.idle', 95.2, {host: 'srv2', region: 'us-west'}, 2)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO cpu_metrics (metric, value, tags, timestamp) VALUES ('cpu.idle', 96.0, {host: 'srv3', region: 'us-east'}, 3)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO cpu_metrics (metric, value, tags, timestamp) VALUES ('cpu.idle', 97.0, {host: 'srv1', region: 'us-east'}, 4)",
+    );
+
+    {
+        let store = rt.db().store();
+        let tag_index = store
+            .get_collection("red_timeseries_tag_index")
+            .expect("tag index collection should be maintained at series creation");
+        let host_rows = tag_index.query_all(|entity| {
+            entity.data.as_row().is_some_and(|row| {
+                matches!(row.get_field("collection"), Some(Value::Text(name)) if &**name == "cpu_metrics")
+                    && matches!(row.get_field("tag_key"), Some(Value::Text(key)) if &**key == "host")
+            })
+        });
+        assert_eq!(
+            host_rows.len(),
+            3,
+            "one posting list row should exist per distinct host tag value"
+        );
+    }
+
+    let equal = exec(
+        &rt,
+        "SELECT timestamp FROM cpu_metrics WHERE tags.host = 'srv1' ORDER BY timestamp ASC",
+    );
+    assert_eq!(
+        equal
+            .result
+            .records
+            .iter()
+            .map(|row| uint(row, "timestamp"))
+            .collect::<Vec<_>>(),
+        vec![1, 4]
+    );
+
+    reddb::runtime::reset_timeseries_tag_index_observability();
+    let in_filter = exec(
+        &rt,
+        "SELECT timestamp FROM cpu_metrics WHERE tags.host IN ('srv1', 'srv3') ORDER BY timestamp ASC",
+    );
+    assert_eq!(
+        in_filter
+            .result
+            .records
+            .iter()
+            .map(|row| uint(row, "timestamp"))
+            .collect::<Vec<_>>(),
+        vec![1, 3, 4]
+    );
+    assert_eq!(
+        reddb::runtime::timeseries_tag_index_observed_points(),
+        3,
+        "indexed tag scan should only hydrate points from matching series"
+    );
+
+    let rt = checkpoint_and_reopen(&path, rt);
+    let reopened = exec(
+        &rt,
+        "SELECT timestamp FROM cpu_metrics WHERE tags.region = 'us-east' ORDER BY timestamp ASC",
+    );
+    assert_eq!(
+        reopened
+            .result
+            .records
+            .iter()
+            .map(|row| uint(row, "timestamp"))
+            .collect::<Vec<_>>(),
+        vec![1, 3, 4],
+        "tag index should survive restart with the series dictionary"
+    );
+}
+
+#[test]
 fn test_timeseries_time_bucket_aggregate_query() {
     let rt = rt();
 


### PR DESCRIPTION
Inverted tag index for TimeSeries: maintains tag key/value → series posting lists and prefilters tag equality/`IN` predicates, with scan observability.

Completed by the AFK worker (4 commits, +460/−20). One follow-up commit applies the `clippy::question-mark` fix the backpressure gate flagged in `impl_timeseries.rs` (behaviour-identical `?` rewrite) — the only thing that had blocked the merge; the merge conflict with #1818 is gone now that #1818 is on main.

Closes #1822

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786754293&installation_id=129708444&pr_number=2033&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2033&signature=f1f617f575e3fce4a21e766d332eea39d93deb3b177c9b96370927ef3c50f568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->