### PR TITLE
chore: #1779 Decimal-text representation for beyond-native-range numerics

### DIFF
--- a/crates/reddb-rql/src/expr_typing.rs
+++ b/crates/reddb-rql/src/expr_typing.rs
@@ -400,6 +400,7 @@ fn literal_type(v: &Value) -> DataType {
         Value::Float(_) => DataType::Float,
         Value::BigInt(_) => DataType::BigInt,
         Value::Decimal(_) => DataType::Decimal,
+        Value::DecimalText(_) => DataType::DecimalText,
         Value::Text(_) => DataType::Text,
         Value::Blob(_) => DataType::Blob,
         Value::Timestamp(_) => DataType::Timestamp,

--- a/crates/reddb-rql/src/parser/tree.rs
+++ b/crates/reddb-rql/src/parser/tree.rs
@@ -297,6 +297,7 @@ fn tree_json_value_to_storage_value(value: &JsonValue) -> Result<Value, ParseErr
                 Value::Float(*value)
             }
         }
+        JsonValue::Decimal(value) => Value::DecimalText(value.clone()),
         JsonValue::String(value) => Value::text(value.clone()),
         JsonValue::Array(_) | JsonValue::Object(_) => {
             Value::Json(reddb_types::json::to_vec(value).map_err(|err| {

--- a/crates/reddb-server/src/application/entity.rs
+++ b/crates/reddb-server/src/application/entity.rs
@@ -347,6 +347,7 @@ pub(crate) fn json_to_storage_value(value: &JsonValue) -> RedDBResult<Value> {
                 Ok(Value::Float(*value))
             }
         }
+        JsonValue::Decimal(value) => Ok(Value::DecimalText(value.clone())),
         JsonValue::String(value) => Ok(Value::text(value.clone())),
         JsonValue::Array(_) | JsonValue::Object(_) => json_to_vec(value)
             .map(Value::Json)
@@ -366,6 +367,7 @@ pub(crate) fn json_to_metadata_value(value: &JsonValue) -> RedDBResult<MetadataV
                 Ok(MetadataValue::Float(*value))
             }
         }
+        JsonValue::Decimal(value) => Ok(MetadataValue::String(value.clone())),
         JsonValue::String(value) => Ok(MetadataValue::String(value.clone())),
         JsonValue::Array(values) => {
             let mut items = Vec::with_capacity(values.len());
@@ -695,6 +697,7 @@ fn metadata_value_from_json(value: &JsonValue) -> RedDBResult<MetadataValue> {
                 Ok(MetadataValue::Float(*value))
             }
         }
+        JsonValue::Decimal(value) => Ok(MetadataValue::String(value.clone())),
         JsonValue::String(value) => Ok(MetadataValue::String(value.clone())),
         JsonValue::Array(values) => {
             let mut out = Vec::with_capacity(values.len());

--- a/crates/reddb-server/src/application/json_input.rs
+++ b/crates/reddb-server/src/application/json_input.rs
@@ -28,6 +28,7 @@ pub(crate) fn json_metadata_value_to_string(value: &JsonValue) -> String {
         JsonValue::Bool(value) => value.to_string(),
         JsonValue::Integer(value) => value.to_string(),
         JsonValue::Number(value) => value.to_string(),
+        JsonValue::Decimal(value) => value.clone(),
         JsonValue::String(value) => value.clone(),
         JsonValue::Array(_) | JsonValue::Object(_) => {
             json_to_string(value).unwrap_or_else(|_| "".to_string())

--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1107,6 +1107,7 @@ fn data_type_name(data_type: DataType) -> &'static str {
         DataType::Date => "date",
         DataType::Time => "time",
         DataType::Decimal => "decimal",
+        DataType::DecimalText => "decimal_text",
         DataType::Enum => "enum",
         DataType::Array => "array",
         DataType::TimestampMs => "timestamp_ms",
@@ -1167,6 +1168,7 @@ fn value_matches_declared_type(value: &Value, target: DataType) -> bool {
             | (Value::Date(_), DataType::Date)
             | (Value::Time(_), DataType::Time)
             | (Value::Decimal(_), DataType::Decimal)
+            | (Value::DecimalText(_), DataType::DecimalText)
             | (Value::EnumValue(_), DataType::Enum)
             | (Value::Array(_), DataType::Array)
             | (Value::TimestampMs(_), DataType::TimestampMs)
@@ -1222,6 +1224,7 @@ fn value_to_coercion_input(value: &Value) -> Option<String> {
         Value::Date(value) => Some(value.to_string()),
         Value::Time(value) => Some(value.to_string()),
         Value::Decimal(value) => Some(value.to_string()),
+        Value::DecimalText(value) => Some(value.clone()),
         Value::TimestampMs(value) => Some(value.to_string()),
         Value::Ipv4(value) => Some(format!(
             "{}.{}.{}.{}",

--- a/crates/reddb-server/src/application/query_payload.rs
+++ b/crates/reddb-server/src/application/query_payload.rs
@@ -685,6 +685,7 @@ fn json_filter_value(value: &JsonValue) -> RedDBResult<RuntimeFilterValue> {
                 RuntimeFilterValue::Float(*value)
             }
         }
+        JsonValue::Decimal(value) => RuntimeFilterValue::String(value.clone()),
         JsonValue::String(value) => RuntimeFilterValue::String(value.clone()),
         JsonValue::Array(values) => RuntimeFilterValue::List(
             values

--- a/crates/reddb-server/src/cli/bootstrap_manifest.rs
+++ b/crates/reddb-server/src/cli/bootstrap_manifest.rs
@@ -1014,6 +1014,7 @@ fn json_to_storage_value(value: &JsonValue) -> Result<Value, String> {
                 Value::Float(*value)
             }
         }
+        JsonValue::Decimal(value) => Value::DecimalText(value.clone()),
         JsonValue::String(value) => Value::text(value.clone()),
         JsonValue::Array(_) | JsonValue::Object(_) => Value::Json(
             crate::serde_json::to_vec(value)

--- a/crates/reddb-server/src/document_body.rs
+++ b/crates/reddb-server/src/document_body.rs
@@ -150,6 +150,22 @@ mod tests {
     }
 
     #[test]
+    fn high_precision_decimal_body_field_round_trips_exactly() {
+        let original = parse(r#"{"amount":3.14159265358979323846,"big":18446744073709551616}"#);
+        let bytes = serialize_document_body(&original, true).expect("serialize");
+        let decoded = decode_container_to_json(&bytes).expect("decode");
+        assert_eq!(decoded, original);
+        assert_eq!(
+            read_body_field(&bytes, "amount"),
+            Some(Value::DecimalText("3.14159265358979323846".to_string()))
+        );
+        assert_eq!(
+            decoded.to_string_compact(),
+            r#"{"amount":3.14159265358979323846,"big":18446744073709551616}"#
+        );
+    }
+
+    #[test]
     fn non_object_body_falls_back_to_json_even_with_binary_on() {
         let scalar = JsonValue::String("just-a-string".to_string());
         let bytes = serialize_document_body(&scalar, true).expect("serialize");

--- a/crates/reddb-server/src/grpc/input_support.rs
+++ b/crates/reddb-server/src/grpc/input_support.rs
@@ -16,6 +16,7 @@ pub(crate) fn parse_json_bind_value(s: &str) -> Result<Value, String> {
                 Value::Float(n)
             }
         }
+        JsonValue::Decimal(n) => Value::DecimalText(n),
         JsonValue::String(s) => Value::text(s),
         JsonValue::Array(_) | JsonValue::Object(_) => {
             Value::text(json_to_string(&json_val).unwrap_or_default())

--- a/crates/reddb-server/src/mcp/server.rs
+++ b/crates/reddb-server/src/mcp/server.rs
@@ -1658,6 +1658,7 @@ fn mcp_value_literal(value: &JsonValue) -> Result<String, String> {
         JsonValue::String(value) => Ok(format!("'{}'", value.replace('\'', "''"))),
         JsonValue::Integer(value) => Ok(value.to_string()),
         JsonValue::Number(value) => Ok(value.to_string()),
+        JsonValue::Decimal(value) => Ok(value.clone()),
         JsonValue::Bool(value) => Ok(value.to_string()),
         JsonValue::Null => Ok("NULL".to_string()),
         JsonValue::Array(_) | JsonValue::Object(_) => {

--- a/crates/reddb-server/src/presentation/catalog_json.rs
+++ b/crates/reddb-server/src/presentation/catalog_json.rs
@@ -1600,6 +1600,7 @@ fn schema_data_type_str(data_type: crate::storage::schema::DataType) -> &'static
         crate::storage::schema::DataType::Date => "date",
         crate::storage::schema::DataType::Time => "time",
         crate::storage::schema::DataType::Decimal => "decimal",
+        crate::storage::schema::DataType::DecimalText => "decimal_text",
         crate::storage::schema::DataType::Enum => "enum",
         crate::storage::schema::DataType::Array => "array",
         crate::storage::schema::DataType::TimestampMs => "timestamp_ms",

--- a/crates/reddb-server/src/presentation/entity_json.rs
+++ b/crates/reddb-server/src/presentation/entity_json.rs
@@ -125,6 +125,7 @@ pub(crate) fn storage_value_to_json(value: &Value) -> JsonValue {
         Value::Date(days) => JsonValue::Number(*days as f64),
         Value::Time(ms) => JsonValue::Number(*ms as f64),
         Value::Decimal(v) => JsonValue::Number(*v as f64 / 10_000.0),
+        Value::DecimalText(v) => JsonValue::Decimal(v.clone()),
         Value::EnumValue(i) => JsonValue::Number(*i as f64),
         Value::Array(elems) => JsonValue::Array(elems.iter().map(storage_value_to_json).collect()),
         Value::TimestampMs(ms) => JsonValue::Number(*ms as f64),

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -322,6 +322,7 @@ fn coarse_type_for(value: &StorageValue) -> &'static str {
         | StorageValue::UnsignedInteger(_)
         | StorageValue::Float(_)
         | StorageValue::Decimal(_)
+        | StorageValue::DecimalText(_)
         | StorageValue::BigInt(_)
         | StorageValue::Port(_)
         | StorageValue::Latitude(_)

--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -1526,6 +1526,7 @@ pub(crate) fn json_value_to_schema_value(v: &Value) -> SchemaValue {
                 SchemaValue::Float(*n)
             }
         }
+        Value::Decimal(n) => SchemaValue::DecimalText(n.clone()),
         Value::String(s) => SchemaValue::text(s.clone()),
         Value::Array(items) => {
             // A JSON array of numbers (or empty) is taken as `Vector`

--- a/crates/reddb-server/src/runtime/ai/ner.rs
+++ b/crates/reddb-server/src/runtime/ai/ner.rs
@@ -543,6 +543,7 @@ fn json_kind(v: &JsonValue) -> &'static str {
         JsonValue::Bool(_) => "bool",
         JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
+        JsonValue::Decimal(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",
         JsonValue::Object(_) => "object",

--- a/crates/reddb-server/src/runtime/analytics_schema_registry.rs
+++ b/crates/reddb-server/src/runtime/analytics_schema_registry.rs
@@ -481,6 +481,7 @@ fn json_type_name(v: &JsonValue) -> &'static str {
         JsonValue::Bool(_) => "boolean",
         JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
+        JsonValue::Decimal(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",
         JsonValue::Object(_) => "object",

--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -1821,6 +1821,7 @@ fn dispatch_builtin_function(name: &str, args: &[Value]) -> Option<Value> {
                 crate::serde_json::Value::Bool(_) => "boolean",
                 crate::serde_json::Value::Integer(_) => "number",
                 crate::serde_json::Value::Number(_) => "number",
+                crate::serde_json::Value::Decimal(_) => "number",
                 crate::serde_json::Value::String(_) => "string",
                 crate::serde_json::Value::Array(_) => "array",
                 crate::serde_json::Value::Object(_) => "object",
@@ -1923,6 +1924,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
+        crate::serde_json::Value::Decimal(value) => value == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null => false,
     }

--- a/crates/reddb-server/src/runtime/join_filter/field_resolution.rs
+++ b/crates/reddb-server/src/runtime/join_filter/field_resolution.rs
@@ -221,6 +221,7 @@ pub(in crate::runtime) fn runtime_json_value_to_runtime_value(value: &JsonValue)
         JsonValue::Bool(value) => Some(Value::Boolean(*value)),
         JsonValue::Integer(value) => Some(Value::Integer(*value)),
         JsonValue::Number(value) => Some(Value::Float(*value)),
+        JsonValue::Decimal(value) => Some(Value::DecimalText(value.clone())),
         JsonValue::String(value) => Some(Value::text(value.clone())),
         JsonValue::Array(values) => Some(Value::Array(
             values

--- a/crates/reddb-server/src/runtime/join_filter/filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter/filter.rs
@@ -166,6 +166,7 @@ fn json_value_contains(value: &JsonValue, needle: &str) -> bool {
         JsonValue::String(value) => value == needle,
         JsonValue::Integer(value) => value.to_string() == needle,
         JsonValue::Number(value) => value.to_string() == needle,
+        JsonValue::Decimal(value) => value == needle,
         JsonValue::Bool(value) => value.to_string() == needle,
         JsonValue::Null | JsonValue::Object(_) => false,
     }

--- a/crates/reddb-server/src/runtime/join_filter/value_compare.rs
+++ b/crates/reddb-server/src/runtime/join_filter/value_compare.rs
@@ -191,6 +191,7 @@ pub(in crate::runtime) fn runtime_value_text(value: &Value) -> Option<String> {
             ))
         }
         Value::Decimal(v) => Some(Value::Decimal(*v).display_string()),
+        Value::DecimalText(v) => Some(v.clone()),
         Value::EnumValue(i) => Some(format!("enum({})", i)),
         Value::Array(_) => None,
         Value::TimestampMs(ms) => Some(ms.to_string()),

--- a/crates/reddb-server/src/runtime/mutation.rs
+++ b/crates/reddb-server/src/runtime/mutation.rs
@@ -845,6 +845,7 @@ fn json_id_for_hash(value: &JsonValue) -> String {
         JsonValue::String(value) => value.clone(),
         JsonValue::Integer(value) => value.to_string(),
         JsonValue::Number(value) => value.to_string(),
+        JsonValue::Decimal(value) => value.clone(),
         JsonValue::Bool(value) => value.to_string(),
         JsonValue::Null => "null".to_string(),
         JsonValue::Array(_) | JsonValue::Object(_) => {
@@ -1358,6 +1359,7 @@ fn compare_json_to_store_value(
                 Value::Float(n)
             }
         }
+        Some(JsonValue::Decimal(n)) => Value::DecimalText(n.clone()),
         Some(JsonValue::String(s)) => Value::text(s.clone()),
         Some(JsonValue::Array(_) | JsonValue::Object(_)) => return false,
     };

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -818,6 +818,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
+        crate::serde_json::Value::Decimal(value) => value == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,
     }

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -695,6 +695,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
+        crate::serde_json::Value::Decimal(value) => value == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null | crate::serde_json::Value::Object(_) => false,
     }

--- a/crates/reddb-server/src/runtime/query_exec/json_writers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/json_writers.rs
@@ -226,6 +226,7 @@ pub(crate) fn write_value_bytes(buf: &mut Vec<u8>, value: &Value) {
                 buf.extend_from_slice(b"null");
             }
         }
+        Value::DecimalText(value) => buf.extend_from_slice(value.as_bytes()),
         Value::Text(s) => write_json_bytes(buf, s.as_bytes()),
         Value::Array(values) => {
             buf.push(b'[');

--- a/crates/reddb-server/src/server/handlers_keyed.rs
+++ b/crates/reddb-server/src/server/handlers_keyed.rs
@@ -402,6 +402,7 @@ fn keyed_value_literal(value: &JsonValue) -> Result<String, HttpResponse> {
         JsonValue::String(value) => Ok(format!("'{}'", value.replace('\'', "''"))),
         JsonValue::Integer(value) => Ok(value.to_string()),
         JsonValue::Number(value) => Ok(value.to_string()),
+        JsonValue::Decimal(value) => Ok(value.clone()),
         JsonValue::Bool(value) => Ok(value.to_string()),
         JsonValue::Null => Ok("NULL".to_string()),
         JsonValue::Array(_) | JsonValue::Object(_) => crate::json::to_string(value)

--- a/crates/reddb-server/src/server/handlers_log.rs
+++ b/crates/reddb-server/src/server/handlers_log.rs
@@ -104,6 +104,7 @@ fn json_to_value(v: &JsonValue) -> Value {
         JsonValue::Bool(b) => Value::Boolean(*b),
         JsonValue::Integer(n) => Value::Integer(*n),
         JsonValue::Number(n) => Value::Float(*n),
+        JsonValue::Decimal(n) => Value::DecimalText(n.clone()),
         JsonValue::String(s) => Value::text(s.clone()),
         JsonValue::Array(arr) => Value::Array(arr.iter().map(json_to_value).collect()),
         JsonValue::Object(_) => Value::text(format!("{:?}", v)),

--- a/crates/reddb-server/src/server/ingest_pipeline.rs
+++ b/crates/reddb-server/src/server/ingest_pipeline.rs
@@ -234,6 +234,7 @@ fn json_type_name(v: &JsonValue) -> &'static str {
         JsonValue::Bool(_) => "bool",
         JsonValue::Integer(_) => "number",
         JsonValue::Number(_) => "number",
+        JsonValue::Decimal(_) => "number",
         JsonValue::String(_) => "string",
         JsonValue::Array(_) => "array",
         JsonValue::Object(_) => "object",
@@ -255,6 +256,7 @@ fn json_to_value(v: &JsonValue) -> Value {
                 Value::Float(*n)
             }
         }
+        JsonValue::Decimal(n) => Value::DecimalText(n.clone()),
         JsonValue::String(s) => Value::text(s.clone()),
         JsonValue::Array(arr) => Value::Array(arr.iter().map(json_to_value).collect()),
         JsonValue::Object(_) => Value::text(v.to_string_compact()),

--- a/crates/reddb-server/src/storage/columnar_projection.rs
+++ b/crates/reddb-server/src/storage/columnar_projection.rs
@@ -656,6 +656,7 @@ fn value_kind(value: &Value) -> &'static str {
         Value::Date(_) => "Date",
         Value::Time(_) => "Time",
         Value::Decimal(_) => "Decimal",
+        Value::DecimalText(_) => "DecimalText",
         Value::EnumValue(_) => "Enum",
         Value::Array(_) => "Array",
         Value::TimestampMs(_) => "TimestampMs",

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -981,6 +981,7 @@ fn json_value_contains(value: &crate::serde_json::Value, needle: &str) -> bool {
         crate::serde_json::Value::String(value) => value == needle,
         crate::serde_json::Value::Integer(value) => value.to_string() == needle,
         crate::serde_json::Value::Number(value) => value.to_string() == needle,
+        crate::serde_json::Value::Decimal(value) => value == needle,
         crate::serde_json::Value::Bool(value) => value.to_string() == needle,
         crate::serde_json::Value::Null => false,
     }

--- a/crates/reddb-server/src/storage/query/executors/cte.rs
+++ b/crates/reddb-server/src/storage/query/executors/cte.rs
@@ -428,6 +428,10 @@ where
                 26u8.hash(hasher);
                 v.hash(hasher);
             }
+            Value::DecimalText(v) => {
+                52u8.hash(hasher);
+                v.hash(hasher);
+            }
             Value::EnumValue(i) => {
                 27u8.hash(hasher);
                 i.hash(hasher);

--- a/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
@@ -949,6 +949,7 @@ pub(crate) fn summarize_value(value: &Value) -> String {
         Value::Date(days) => format!("date({})", days),
         Value::Time(ms) => format!("time({})", ms),
         Value::Decimal(v) => Value::Decimal(*v).display_string(),
+        Value::DecimalText(v) => v.clone(),
         Value::EnumValue(i) => format!("enum({})", i),
         Value::Array(elems) => format!("array({})", elems.len()),
         Value::TimestampMs(ms) => format!("timestamp_ms({})", ms),

--- a/crates/reddb-server/src/storage/query/planner/stats_catalog.rs
+++ b/crates/reddb-server/src/storage/query/planner/stats_catalog.rs
@@ -644,6 +644,7 @@ fn approximate_value_size(value: &Value) -> usize {
         | Value::PageRef(_) => 8,
         Value::Boolean(_) | Value::EnumValue(_) => 1,
         Value::Text(v) => v.len(),
+        Value::DecimalText(v) => v.len(),
         Value::Email(v)
         | Value::Url(v)
         | Value::NodeRef(v)

--- a/crates/reddb-server/src/storage/unified/devx/builders.rs
+++ b/crates/reddb-server/src/storage/unified/devx/builders.rs
@@ -800,6 +800,7 @@ fn json_value_to_storage_value(value: &JsonValue) -> Value {
                 Value::Float(*n)
             }
         }
+        JsonValue::Decimal(n) => Value::DecimalText(n.clone()),
         JsonValue::String(s) => Value::text(s.clone()),
         JsonValue::Array(_) | JsonValue::Object(_) => match json_to_vec(value) {
             Ok(bytes) => Value::Json(bytes),

--- a/crates/reddb-server/src/storage/unified/devx/reddb/impl_access.rs
+++ b/crates/reddb-server/src/storage/unified/devx/reddb/impl_access.rs
@@ -532,6 +532,7 @@ impl RedDB {
             JsonValue::Bool(value) => Some(value.to_string()),
             JsonValue::Integer(value) => Some(value.to_string()),
             JsonValue::Number(value) => Some(value.to_string()),
+            JsonValue::Decimal(value) => Some(value.clone()),
             JsonValue::String(value) => Some(value.clone()),
             JsonValue::Array(_) | JsonValue::Object(_) => None,
         }
@@ -619,6 +620,7 @@ impl RedDB {
                 ))
             }
             Value::Decimal(v) => Some(Value::Decimal(*v).display_string()),
+            Value::DecimalText(v) => Some(v.clone()),
             Value::EnumValue(i) => Some(format!("enum({})", i)),
             Value::Array(_) => None,
             Value::TimestampMs(ms) => Some(ms.to_string()),

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -1694,6 +1694,9 @@ fn flatten_config_json(
                 out.push((prefix.to_string(), Value::Float(*n)));
             }
         }
+        crate::serde_json::Value::Decimal(n) => {
+            out.push((prefix.to_string(), Value::DecimalText(n.clone())));
+        }
         crate::serde_json::Value::Bool(b) => {
             out.push((prefix.to_string(), Value::Boolean(*b)));
         }

--- a/crates/reddb-server/src/storage/unified/store/impl_file.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_file.rs
@@ -1292,6 +1292,12 @@ impl UnifiedStore {
                     scale,
                 }
             }
+            52 => {
+                let len = Self::read_varu32_safe(buf, pos)?;
+                let value = String::from_utf8(buf[*pos..*pos + len].to_vec())?;
+                *pos += len;
+                Value::DecimalText(value)
+            }
             // C3 TOAST: compressed Text (0x85) and Blob (0x86).
             0x85 => {
                 let orig_len = Self::read_varu32_safe(buf, pos)?;
@@ -1603,6 +1609,11 @@ impl UnifiedStore {
                 buf.push(49);
                 write_varu32(buf, hash.len() as u32);
                 buf.extend_from_slice(hash.as_bytes());
+            }
+            Value::DecimalText(value) => {
+                buf.push(52);
+                write_varu32(buf, value.len() as u32);
+                buf.extend_from_slice(value.as_bytes());
             }
         }
     }

--- a/crates/reddb-server/src/storage/unified/tokenization.rs
+++ b/crates/reddb-server/src/storage/unified/tokenization.rs
@@ -93,6 +93,10 @@ pub fn push_json_tokens(tokens: &mut BTreeSet<String>, bytes: &[u8]) {
                 push_text_tokens(tokens, &v.to_string(), false);
                 *budget = budget.saturating_sub(1);
             }
+            crate::serde_json::Value::Decimal(v) => {
+                push_text_tokens(tokens, v, false);
+                *budget = budget.saturating_sub(1);
+            }
             crate::serde_json::Value::String(v) => {
                 push_text_tokens(tokens, v, true);
                 *budget = budget.saturating_sub(1);

--- a/crates/reddb-types/src/canonical_key.rs
+++ b/crates/reddb-types/src/canonical_key.rs
@@ -324,6 +324,7 @@ pub fn value_to_canonical_key(value: &Value) -> Option<CanonicalKey> {
         )),
         Value::Time(v) => Some(CanonicalKey::Unsigned(CanonicalKeyFamily::Time, *v as u64)),
         Value::Decimal(v) => Some(CanonicalKey::Signed(CanonicalKeyFamily::Decimal, *v)),
+        Value::DecimalText(_) => None,
         Value::EnumValue(v) => Some(CanonicalKey::Unsigned(
             CanonicalKeyFamily::EnumValue,
             *v as u64,

--- a/crates/reddb-types/src/knowledge.rs
+++ b/crates/reddb-types/src/knowledge.rs
@@ -395,6 +395,7 @@ pub fn infer_literal_type(value: &JsonValue) -> DataType {
                 DataType::Float
             }
         }
+        JsonValue::Decimal(_) => DataType::DecimalText,
         JsonValue::String(_) => DataType::Text,
         JsonValue::Array(_) => DataType::Array,
         JsonValue::Object(_) => DataType::Json,

--- a/crates/reddb-types/src/serde_json.rs
+++ b/crates/reddb-types/src/serde_json.rs
@@ -11,6 +11,7 @@ pub enum Value {
     Bool(bool),
     Integer(i64),
     Number(f64),
+    Decimal(String),
     String(String),
     Array(Vec<Value>),
     Object(Map<String, Value>),
@@ -34,6 +35,7 @@ impl Value {
         match self {
             Value::Number(n) => Some(*n),
             Value::Integer(n) => Some(*n as f64),
+            Value::Decimal(n) => n.parse::<f64>().ok(),
             _ => None,
         }
     }
@@ -42,6 +44,7 @@ impl Value {
         match self {
             Value::Integer(n) => Some(*n),
             Value::Number(n) => Some(*n as i64),
+            Value::Decimal(n) => n.parse::<i64>().ok(),
             _ => None,
         }
     }
@@ -50,6 +53,7 @@ impl Value {
         match self {
             Value::Integer(n) if *n >= 0 => Some(*n as u64),
             Value::Number(n) if *n >= 0.0 => Some(*n as u64),
+            Value::Decimal(n) => n.parse::<u64>().ok(),
             _ => None,
         }
     }
@@ -107,6 +111,7 @@ impl Value {
                     out.push_str(&format!("{}", n));
                 }
             }
+            Value::Decimal(n) => out.push_str(n),
             Value::String(s) => {
                 out.push('"');
                 out.push_str(&escape_string(s));
@@ -145,6 +150,7 @@ impl Value {
             | Value::Bool(_)
             | Value::Integer(_)
             | Value::Number(_)
+            | Value::Decimal(_)
             | Value::String(_) => {
                 out.push_str(&self.to_string_compact());
             }
@@ -300,6 +306,10 @@ mod tests {
         object.insert("null".to_string(), Value::Null);
         object.insert("bool".to_string(), Value::Bool(true));
         object.insert("number".to_string(), Value::Number(42.5));
+        object.insert(
+            "decimal".to_string(),
+            Value::Decimal("3.14159265358979323846".to_string()),
+        );
         object.insert("string".to_string(), Value::String("reddb".to_string()));
         object.insert(
             "array".to_string(),
@@ -316,7 +326,11 @@ mod tests {
             value.get("array").and_then(Value::as_array).map(<[_]>::len),
             Some(2)
         );
-        assert_eq!(value.as_object().map(Map::len), Some(5));
+        assert_eq!(value.as_object().map(Map::len), Some(6));
+        assert_eq!(
+            value.get("decimal").and_then(Value::as_f64),
+            Some(3.141592653589793)
+        );
         assert!(Value::Number(-1.0).as_u64().is_none());
         assert!(Value::Null.as_str().is_none());
 
@@ -327,6 +341,10 @@ mod tests {
         assert!(pretty.contains("\"array\": ["));
         assert_eq!(Value::Array(Vec::new()).to_string_pretty(), "[]");
         assert_eq!(Value::Object(Map::new()).to_string_pretty(), "{}");
+        assert_eq!(
+            value.get("decimal").unwrap().to_string_compact(),
+            "3.14159265358979323846"
+        );
 
         let mut created_from_index = Value::Null;
         created_from_index["created"] = Value::Bool(true);
@@ -446,6 +464,7 @@ impl From<JsonValue> for Value {
             JsonValue::Bool(b) => Value::Bool(b),
             JsonValue::Integer(n) => Value::Integer(n),
             JsonValue::Number(n) => Value::Number(n),
+            JsonValue::Decimal(n) => Value::Decimal(n),
             JsonValue::String(s) => Value::String(s),
             JsonValue::Array(values) => Value::Array(values.into_iter().map(Value::from).collect()),
             JsonValue::Object(entries) => {

--- a/crates/reddb-types/src/types.rs
+++ b/crates/reddb-types/src/types.rs
@@ -313,6 +313,8 @@ pub enum DataType {
     AssetCode = 53,
     /// Monetary amount represented as minor units + scale + asset code
     Money = 54,
+    /// Exact JSON numeric literal stored as canonical decimal text
+    DecimalText = 55,
 }
 
 /// Type categories used by the Fase 3 coercion resolver. Mirrors
@@ -382,6 +384,7 @@ impl DataType {
             | DataType::UnsignedInteger
             | DataType::Float
             | DataType::Decimal
+            | DataType::DecimalText
             | DataType::BigInt
             | DataType::Port
             | DataType::Latitude
@@ -524,6 +527,7 @@ impl DataType {
             52 => Some(DataType::BlobZstd),
             53 => Some(DataType::AssetCode),
             54 => Some(DataType::Money),
+            55 => Some(DataType::DecimalText),
             _ => None,
         }
     }
@@ -585,6 +589,7 @@ impl DataType {
             "CURRENCY" => DataType::Currency,
             "ASSETCODE" | "ASSET_CODE" | "ASSET" => DataType::AssetCode,
             "MONEY" => DataType::Money,
+            "DECIMAL_TEXT" | "DECIMALTEXT" => DataType::DecimalText,
             "ENUM" => DataType::Enum,
             "ARRAY" => DataType::Array,
             "KEYREF" => DataType::KeyRef,
@@ -631,6 +636,7 @@ impl DataType {
             DataType::Date => Some(4),        // i32
             DataType::Time => Some(4),        // u32
             DataType::Decimal => Some(8),     // i64
+            DataType::DecimalText => None,    // variable-length exact decimal text
             DataType::Enum => Some(1),        // u8
             DataType::Array => None,          // variable-length
             DataType::TimestampMs => Some(8), // i64
@@ -683,6 +689,7 @@ impl DataType {
                 | DataType::Date
                 | DataType::Time
                 | DataType::Decimal
+                | DataType::DecimalText
                 | DataType::Enum
                 | DataType::TimestampMs
                 | DataType::Ipv4
@@ -718,6 +725,7 @@ impl DataType {
                 | DataType::Date
                 | DataType::Time
                 | DataType::Decimal
+                | DataType::DecimalText
                 | DataType::Semver
                 | DataType::TimestampMs
                 | DataType::Port
@@ -777,6 +785,7 @@ impl fmt::Display for DataType {
             DataType::Currency => write!(f, "CURRENCY"),
             DataType::AssetCode => write!(f, "ASSET_CODE"),
             DataType::Money => write!(f, "MONEY"),
+            DataType::DecimalText => write!(f, "DECIMAL_TEXT"),
             DataType::ColorAlpha => write!(f, "COLOR_ALPHA"),
             DataType::BigInt => write!(f, "BIGINT"),
             DataType::KeyRef => write!(f, "KEY_REF"),
@@ -848,6 +857,8 @@ pub enum Value {
     Time(u32),
     /// Fixed-point decimal (value * 10^precision)
     Decimal(i64),
+    /// Exact JSON numeric literal stored as decimal text
+    DecimalText(String),
     /// Enum variant index
     EnumValue(u8),
     /// Homogeneous array
@@ -960,6 +971,7 @@ impl std::hash::Hash for Value {
             Value::Date(v) => v.hash(state),
             Value::Time(v) => v.hash(state),
             Value::Decimal(v) => v.hash(state),
+            Value::DecimalText(v) => v.hash(state),
             Value::EnumValue(v) => v.hash(state),
             Value::Array(v) => {
                 v.len().hash(state);
@@ -1054,6 +1066,7 @@ impl Value {
             Value::Date(_) => DataType::Date,
             Value::Time(_) => DataType::Time,
             Value::Decimal(_) => DataType::Decimal,
+            Value::DecimalText(_) => DataType::DecimalText,
             Value::EnumValue(_) => DataType::Enum,
             Value::Array(_) => DataType::Array,
             Value::TimestampMs(_) => DataType::TimestampMs,
@@ -1196,6 +1209,7 @@ impl Value {
                 )
             }
             Value::Decimal(v) => format_scaled_i64(*v, 4),
+            Value::DecimalText(v) => v.clone(),
             Value::EnumValue(i) => format!("enum({})", i),
             Value::Array(elems) => {
                 let items: Vec<String> = elems.iter().map(|e| e.display_string()).collect();
@@ -1378,6 +1392,7 @@ impl fmt::Display for Value {
                 )
             }
             Value::Decimal(v) => write!(f, "{}", format_scaled_i64(*v, 4)),
+            Value::DecimalText(v) => write!(f, "{v}"),
             Value::EnumValue(i) => write!(f, "enum({})", i),
             Value::Array(elems) => {
                 write!(f, "[")?;
@@ -2867,6 +2882,14 @@ mod tests {
                 false,
                 false,
             ),
+            (
+                DataType::DecimalText,
+                TypeCategory::Numeric,
+                "DECIMAL_TEXT",
+                None,
+                true,
+                true,
+            ),
         ];
 
         for (data_type, category, display, fixed, indexable, orderable) in cases {
@@ -2908,6 +2931,7 @@ mod tests {
             ("COLOR_ALPHA", DataType::ColorAlpha),
             ("GEO_POINT", DataType::GeoPoint),
             ("ASSET_CODE", DataType::AssetCode),
+            ("DECIMAL_TEXT", DataType::DecimalText),
             ("KEYREF", DataType::KeyRef),
             ("DOCREF", DataType::DocRef),
             ("TABLEREF", DataType::TableRef),
@@ -2921,7 +2945,7 @@ mod tests {
         }
         assert_eq!(DataType::from_sql_name("definitely_not_a_type"), None);
         assert_eq!(DataType::from_byte(0), None);
-        assert_eq!(DataType::from_byte(55), None);
+        assert_eq!(DataType::from_byte(56), None);
     }
 
     #[test]
@@ -2955,6 +2979,7 @@ mod tests {
             Value::Date(20_000),
             Value::Time(43_200_000),
             Value::Decimal(123_456),
+            Value::DecimalText("3.14159265358979323846".to_string()),
             Value::EnumValue(3),
             Value::Array(vec![Value::Integer(1), Value::text("two")]),
             Value::TimestampMs(123_456),

--- a/crates/reddb-types/src/utils/json.rs
+++ b/crates/reddb-types/src/utils/json.rs
@@ -10,6 +10,7 @@ pub enum JsonValue {
     Bool(bool),
     Integer(i64),
     Number(f64),
+    Decimal(String),
     String(String),
     Array(Vec<JsonValue>),
     Object(Vec<(String, JsonValue)>),
@@ -29,6 +30,7 @@ impl JsonValue {
         match self {
             JsonValue::Number(n) => Some(*n),
             JsonValue::Integer(n) => Some(*n as f64),
+            JsonValue::Decimal(n) => n.parse::<f64>().ok(),
             _ => None,
         }
     }
@@ -147,6 +149,7 @@ impl JsonValue {
                     out.push_str(&format!("{}", n));
                 }
             }
+            JsonValue::Decimal(n) => out.push_str(n),
             JsonValue::String(s) => {
                 out.push('"');
                 for ch in s.chars() {
@@ -345,10 +348,17 @@ impl<'a> JsonParser<'a> {
             if let Ok(value) = s.parse::<i64>() {
                 return Ok(JsonValue::Integer(value));
             }
+            return Ok(JsonValue::Decimal(s.to_string()));
+        }
+        if should_preserve_decimal_text(s) {
+            return Ok(JsonValue::Decimal(s.to_string()));
         }
         let value = s
             .parse::<f64>()
             .map_err(|_| "failed to parse number".to_string())?;
+        if !value.is_finite() {
+            return Ok(JsonValue::Decimal(s.to_string()));
+        }
         Ok(JsonValue::Number(value))
     }
 
@@ -575,6 +585,11 @@ impl<'a> JsonParser<'a> {
     }
 }
 
+fn should_preserve_decimal_text(input: &str) -> bool {
+    let significant_digits = input.bytes().filter(u8::is_ascii_digit).count();
+    significant_digits > 15
+}
+
 /// Parses the provided JSON string into a [`JsonValue`].
 pub fn parse_json(input: &str) -> Result<JsonValue, String> {
     let mut parser = JsonParser::new(input);
@@ -590,6 +605,7 @@ pub fn parse_json(input: &str) -> Result<JsonValue, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
 
     #[test]
     fn parse_simple_object() {
@@ -674,6 +690,14 @@ mod tests {
         assert_eq!(parse_json("true").unwrap(), JsonValue::Bool(true));
         assert_eq!(parse_json("false").unwrap(), JsonValue::Bool(false));
         assert_eq!(parse_json("-12.5e+2").unwrap(), JsonValue::Number(-1250.0));
+        assert_eq!(
+            parse_json("3.14159265358979323846").unwrap(),
+            JsonValue::Decimal("3.14159265358979323846".to_string())
+        );
+        assert_eq!(
+            parse_json("18446744073709551616").unwrap(),
+            JsonValue::Decimal("18446744073709551616".to_string())
+        );
         assert_eq!(parse_json("[]").unwrap(), JsonValue::Array(Vec::new()));
         assert_eq!(parse_json("{}").unwrap(), JsonValue::Object(Vec::new()));
 
@@ -718,6 +742,21 @@ mod tests {
 
         for case in cases {
             assert!(parse_json(case).is_err(), "{case:?}");
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn beyond_native_decimal_text_round_trips(
+            prefix in "[1-9][0-9]{18,36}",
+            suffix in "[0-9]{1,24}"
+        ) {
+            let input = format!("{prefix}.{suffix}");
+            let parsed = parse_json(&input).expect("generated decimal parses");
+            prop_assert_eq!(&parsed, &JsonValue::Decimal(input.clone()));
+            #[allow(deprecated)]
+            let output = parsed.to_json_string();
+            prop_assert_eq!(output, input);
         }
     }
 }

--- a/crates/reddb-types/src/value_codec.rs
+++ b/crates/reddb-types/src/value_codec.rs
@@ -247,6 +247,12 @@ pub fn encode(value: &Value, out: &mut Vec<u8>) {
             out.push(DataType::Decimal.to_byte());
             out.extend_from_slice(&v.to_le_bytes());
         }
+        Value::DecimalText(s) => {
+            out.push(DataType::DecimalText.to_byte());
+            let bytes = s.as_bytes();
+            write_varint(out, bytes.len() as u64);
+            out.extend_from_slice(bytes);
+        }
         Value::EnumValue(idx) => {
             out.push(DataType::Enum.to_byte());
             out.push(*idx);
@@ -656,6 +662,17 @@ pub fn decode(data: &[u8]) -> Result<(Value, usize), ValueError> {
             let v = i64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
             offset += 8;
             Value::Decimal(v)
+        }
+        DataType::DecimalText => {
+            let (len, varint_size) = read_varint(&data[offset..])?;
+            offset += varint_size;
+            if data.len() < offset + len as usize {
+                return Err(ValueError::TruncatedData);
+            }
+            let value = String::from_utf8(data[offset..offset + len as usize].to_vec())
+                .map_err(|_| ValueError::InvalidUtf8)?;
+            offset += len as usize;
+            Value::DecimalText(value)
         }
         DataType::Enum => {
             if data.len() < offset + 1 {
@@ -1108,6 +1125,7 @@ mod tests {
             Value::Date(20_000),
             Value::Time(43_200_000),
             Value::Decimal(123_456),
+            Value::DecimalText("18446744073709551616.00000000000000000001".to_string()),
             Value::EnumValue(3),
             Value::Array(vec![Value::Integer(1), Value::text("two")]),
             Value::TimestampMs(123_456),
@@ -1196,6 +1214,7 @@ mod tests {
             DataType::Date,
             DataType::Time,
             DataType::Decimal,
+            DataType::DecimalText,
             DataType::Enum,
             DataType::Array,
             DataType::TimestampMs,
@@ -1302,6 +1321,7 @@ mod tests {
                 Just(f64::from_bits(1)),
             ]
             .prop_map(Value::Float),
+            "[1-9][0-9]{18,36}\\.[0-9]{1,24}".prop_map(Value::DecimalText),
             proptest::collection::vec(any::<u8>(), 0..4096).prop_map(Value::Blob),
             prop_oneof![
                 Just(br#"{"a":null,"b":[1,true]}"#.to_vec()),

--- a/crates/reddb-types/src/value_compare.rs
+++ b/crates/reddb-types/src/value_compare.rs
@@ -22,6 +22,8 @@ pub fn partial_compare_values(a: &Value, b: &Value) -> Option<Ordering> {
         (Value::Integer(a), Value::Integer(b)) => Some(a.cmp(b)),
         (Value::UnsignedInteger(a), Value::UnsignedInteger(b)) => Some(a.cmp(b)),
         (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+        (Value::Decimal(a), Value::Decimal(b)) => Some(a.cmp(b)),
+        (Value::DecimalText(a), Value::DecimalText(b)) => compare_decimal_text(a, b),
         (Value::Text(a), Value::Text(b)) => Some(a.cmp(b)),
         (Value::Boolean(a), Value::Boolean(b)) => Some(a.cmp(b)),
         (Value::Timestamp(a), Value::Timestamp(b)) => Some(a.cmp(b)),
@@ -34,12 +36,168 @@ pub fn partial_compare_values(a: &Value, b: &Value) -> Option<Ordering> {
         (Value::Float(a), Value::UnsignedInteger(b)) => a.partial_cmp(&(*b as f64)),
         (Value::Integer(a), Value::UnsignedInteger(b)) => Some((*a as i128).cmp(&(*b as i128))),
         (Value::UnsignedInteger(a), Value::Integer(b)) => Some((*a as i128).cmp(&(*b as i128))),
+        (Value::Decimal(a), other) => {
+            compare_decimal_text(&format_scaled_i64(*a, 4), &numeric_value_text(other)?)
+        }
+        (other, Value::Decimal(b)) => {
+            compare_decimal_text(&numeric_value_text(other)?, &format_scaled_i64(*b, 4))
+        }
+        (Value::DecimalText(a), other) => compare_decimal_text(a, &numeric_value_text(other)?),
+        (other, Value::DecimalText(b)) => compare_decimal_text(&numeric_value_text(other)?, b),
         _ => None,
     }
 }
 
 pub fn total_compare_values(a: &Value, b: &Value) -> Ordering {
     partial_compare_values(a, b).unwrap_or_else(|| value_type_tag(a).cmp(&value_type_tag(b)))
+}
+
+fn numeric_value_text(value: &Value) -> Option<String> {
+    match value {
+        Value::Integer(n) => Some(n.to_string()),
+        Value::UnsignedInteger(n) => Some(n.to_string()),
+        Value::Float(n) if n.is_finite() => Some(n.to_string()),
+        Value::Decimal(n) => Some(format_scaled_i64(*n, 4)),
+        Value::DecimalText(n) => Some(n.clone()),
+        _ => None,
+    }
+}
+
+fn format_scaled_i64(value: i64, scale: usize) -> String {
+    let sign = if value < 0 { "-" } else { "" };
+    let abs = value.unsigned_abs();
+    let factor = 10u64.pow(scale as u32);
+    let whole = abs / factor;
+    let frac = abs % factor;
+    format!("{sign}{whole}.{frac:0scale$}")
+}
+
+fn compare_decimal_text(left: &str, right: &str) -> Option<Ordering> {
+    let left = ParsedDecimal::parse(left)?;
+    let right = ParsedDecimal::parse(right)?;
+    Some(left.cmp(&right))
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ParsedDecimal {
+    negative: bool,
+    digits: String,
+    scale: i32,
+}
+
+impl ParsedDecimal {
+    fn parse(input: &str) -> Option<Self> {
+        let mut s = input.trim();
+        let mut negative = false;
+        if let Some(rest) = s.strip_prefix('-') {
+            negative = true;
+            s = rest;
+        } else if let Some(rest) = s.strip_prefix('+') {
+            s = rest;
+        }
+
+        let (base, exponent) = split_exponent(s)?;
+        let (int_part, frac_part) = split_decimal_base(base)?;
+        if int_part.is_empty() && frac_part.is_empty() {
+            return None;
+        }
+        if !int_part.bytes().all(|b| b.is_ascii_digit())
+            || !frac_part.bytes().all(|b| b.is_ascii_digit())
+        {
+            return None;
+        }
+
+        let mut digits = String::with_capacity(int_part.len() + frac_part.len());
+        digits.push_str(int_part);
+        digits.push_str(frac_part);
+        let mut scale = frac_part.len() as i32 - exponent;
+        trim_decimal(&mut digits, &mut scale);
+        if digits == "0" {
+            negative = false;
+        }
+        Some(Self {
+            negative,
+            digits,
+            scale,
+        })
+    }
+
+    fn cmp_abs(&self, other: &Self) -> Ordering {
+        let left_int = self.digits.len() as i32 - self.scale;
+        let right_int = other.digits.len() as i32 - other.scale;
+        match left_int.cmp(&right_int) {
+            Ordering::Equal => {}
+            ord => return ord,
+        }
+
+        let scale = self.scale.max(other.scale).max(0) as usize;
+        let mut left = self.digits.clone();
+        let mut right = other.digits.clone();
+        left.extend(std::iter::repeat_n(
+            '0',
+            scale.saturating_sub(self.scale.max(0) as usize),
+        ));
+        right.extend(std::iter::repeat_n(
+            '0',
+            scale.saturating_sub(other.scale.max(0) as usize),
+        ));
+        left.cmp(&right)
+    }
+}
+
+impl Ord for ParsedDecimal {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self.negative, other.negative) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            (true, true) => other.cmp_abs(self),
+            (false, false) => self.cmp_abs(other),
+        }
+    }
+}
+
+impl PartialOrd for ParsedDecimal {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn split_exponent(input: &str) -> Option<(&str, i32)> {
+    let Some(index) = input.find(['e', 'E']) else {
+        return Some((input, 0));
+    };
+    let exponent = input[index + 1..].parse::<i32>().ok()?;
+    Some((&input[..index], exponent))
+}
+
+fn split_decimal_base(input: &str) -> Option<(&str, &str)> {
+    if let Some(index) = input.find('.') {
+        if input[index + 1..].contains('.') {
+            return None;
+        }
+        Some((&input[..index], &input[index + 1..]))
+    } else {
+        Some((input, ""))
+    }
+}
+
+fn trim_decimal(digits: &mut String, scale: &mut i32) {
+    while digits.len() > 1 && digits.starts_with('0') {
+        digits.remove(0);
+    }
+    while *scale > 0 && digits.len() > 1 && digits.ends_with('0') {
+        digits.pop();
+        *scale -= 1;
+    }
+    if digits.is_empty() || digits.bytes().all(|b| b == b'0') {
+        digits.clear();
+        digits.push('0');
+        *scale = 0;
+    }
+    if *scale < 0 {
+        digits.extend(std::iter::repeat_n('0', (-*scale) as usize));
+        *scale = 0;
+    }
 }
 
 #[cfg(test)]
@@ -60,6 +218,8 @@ mod tests {
             Value::Integer(0),
             Value::UnsignedInteger(0),
             Value::Float(0.0),
+            Value::Decimal(0),
+            Value::DecimalText("0".to_string()),
             Value::text(""),
             Value::Blob(Vec::new()),
             Value::Timestamp(0),
@@ -97,6 +257,12 @@ mod tests {
                 Ordering::Greater,
             ),
             (Value::Float(1.0), Value::Float(1.0), Ordering::Equal),
+            (Value::Decimal(10000), Value::Decimal(20000), Ordering::Less),
+            (
+                Value::DecimalText("3.14".to_string()),
+                Value::DecimalText("3.1400".to_string()),
+                Ordering::Equal,
+            ),
             (Value::text("a"), Value::text("b"), Ordering::Less),
             (Value::Boolean(false), Value::Boolean(true), Ordering::Less),
             (Value::Timestamp(10), Value::Timestamp(9), Ordering::Greater),
@@ -134,6 +300,26 @@ mod tests {
             (
                 Value::UnsignedInteger(9),
                 Value::Integer(8),
+                Ordering::Greater,
+            ),
+            (
+                Value::DecimalText("18446744073709551616".to_string()),
+                Value::UnsignedInteger(u64::MAX),
+                Ordering::Greater,
+            ),
+            (
+                Value::DecimalText("3.14159265358979323846".to_string()),
+                Value::DecimalText("3.14159265358979323847".to_string()),
+                Ordering::Less,
+            ),
+            (
+                Value::DecimalText("-0.00000000000000000001".to_string()),
+                Value::Integer(0),
+                Ordering::Less,
+            ),
+            (
+                Value::DecimalText("1e30".to_string()),
+                Value::DecimalText("999999999999999999999999999999".to_string()),
                 Ordering::Greater,
             ),
         ];

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -316,6 +316,7 @@ fn schema_value_to_value_out(value: &reddb::storage::schema::Value) -> ValueOut 
             .map(ValueOut::Integer)
             .unwrap_or_else(|_| ValueOut::String(value.to_string())),
         Value::Float(value) => ValueOut::Float(*value),
+        Value::DecimalText(value) => ValueOut::String(value.clone()),
         Value::BigInt(value) => ValueOut::Integer(*value),
         Value::TimestampMs(value)
         | Value::Timestamp(value)
@@ -1039,6 +1040,7 @@ fn auto_type_param(s: &str) -> reddb::storage::schema::Value {
                     Value::Float(n)
                 }
             }
+            J::Decimal(n) => Value::DecimalText(n),
             J::String(t) => Value::text(t),
             J::Array(items) => {
                 if items
@@ -1072,6 +1074,7 @@ fn value_to_json_fragment(value: &reddb::storage::schema::Value) -> String {
         Value::Integer(n) => n.to_string(),
         Value::UnsignedInteger(n) => n.to_string(),
         Value::Float(n) => n.to_string(),
+        Value::DecimalText(n) => n.clone(),
         Value::BigInt(n) => n.to_string(),
         Value::TimestampMs(n) | Value::Timestamp(n) | Value::Duration(n) | Value::Decimal(n) => {
             n.to_string()
@@ -5764,6 +5767,7 @@ fn admin_json_value_display(value: &reddb::json::Value) -> String {
         reddb::json::Value::Integer(n) => n.to_string(),
         reddb::json::Value::Number(n) if n.fract() == 0.0 => (*n as i64).to_string(),
         reddb::json::Value::Number(n) => n.to_string(),
+        reddb::json::Value::Decimal(n) => n.clone(),
         reddb::json::Value::Array(_) | reddb::json::Value::Object(_) => value.to_string_compact(),
     }
 }


### PR DESCRIPTION
Automated AFK landing for #1779. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1779

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786757627&installation_id=129708444&pr_number=2034&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2034&signature=e1a8f9dc7ef72ecc25ae2fb09eaa5dbd1d791c9c37ea718a1424f2e3ff7035f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->