### PR TITLE
chore: #1799 Funnel demo e2e: load → SHOW STATS → query → format → save → reopen

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -176,6 +176,51 @@ handles. The aliases and stem names are real collections in the
 ephemeral store, so they work in queries and catalog commands such as
 `SHOW STATS t1`.
 
+#### Canonical funnel demo
+
+This is the canonical copy-pasteable file-to-store funnel. The same
+sequence is pinned by
+`tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs`.
+
+```bash
+cat > users.csv <<'CSV'
+id,name
+1,Ada
+2,Linus
+CSV
+
+cat > orders.json <<'JSON'
+[
+  {"id":100,"user_id":1,"total":42},
+  {"id":101,"user_id":2,"total":7}
+]
+JSON
+
+red query users.csv orders.json "SHOW STATS users" --json
+red query users.csv orders.json "SHOW STATS orders" --json
+
+red query users.csv orders.json \
+  "SELECT users.name AS name, orders.total AS total \
+   FROM users JOIN orders ON users.id = orders.user_id \
+   WHERE orders.total > 20" \
+  --format csv
+
+red query users.csv orders.json \
+  "SELECT users.name AS name, orders.total AS total \
+   FROM users JOIN orders ON users.id = orders.user_id \
+   WHERE orders.total > 20" \
+  --format json \
+  --save funnel.rdb
+
+red query --path funnel.rdb \
+  "SELECT users.name AS name, orders.total AS total \
+   FROM users JOIN orders ON users.id = orders.user_id \
+   WHERE orders.total > 20" \
+  --format json
+
+red query --path funnel.rdb "SHOW STATS orders" --json
+```
+
 ### Parameterized queries
 
 `--param <value>` (or `-p <value>`) binds positionally — the first

--- a/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1786_ephemeral_query.rs
@@ -326,6 +326,96 @@ fn red_query_multiple_files_join_by_alias_and_stem() {
 }
 
 #[test]
+fn red_query_funnel_demo_load_stats_join_format_save_reopen() {
+    let dir = temp_dir("funnel-demo");
+    let users = dir.path().join("users.csv");
+    let orders = dir.path().join("orders.json");
+    let saved = dir.path().join("funnel.rdb");
+    fs::write(&users, "id,name\n1,Ada\n2,Linus\n").expect("write users");
+    fs::write(
+        &orders,
+        r#"[
+  {"id":100,"user_id":1,"total":42},
+  {"id":101,"user_id":2,"total":7}
+]"#,
+    )
+    .expect("write orders");
+    let users_str = users.display().to_string();
+    let orders_str = orders.display().to_string();
+    let saved_str = saved.display().to_string();
+
+    let (code, stdout, stderr) =
+        run_query_files(&[&users_str, &orders_str], "SHOW STATS users", &["--json"]);
+    assert_eq!(code, 0, "users stats failed; stderr: {stderr}");
+    assert!(stdout.contains("\"ok\":true"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("\"collection\":\"users\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"entity\":null") && stdout.contains("\"metric\":\"row_count\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"entity\":\"name\"") && stdout.contains("\"metric\":\"distinct_count\""),
+        "stdout: {stdout}"
+    );
+
+    let (code, stdout, stderr) =
+        run_query_files(&[&users_str, &orders_str], "SHOW STATS orders", &["--json"]);
+    assert_eq!(code, 0, "orders stats failed; stderr: {stderr}");
+    assert!(
+        stdout.contains("\"collection\":\"orders\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"entity\":null") && stdout.contains("\"metric\":\"row_count\""),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("\"entity\":\"user_id\"") && stdout.contains("\"metric\":\"coverage\""),
+        "stdout: {stdout}"
+    );
+
+    let join_sql = "SELECT users.name AS name, orders.total AS total \
+        FROM users JOIN orders ON users.id = orders.user_id \
+        WHERE orders.total > 20";
+    let (code, stdout, stderr) =
+        run_query_files(&[&users_str, &orders_str], join_sql, &["--format", "csv"]);
+    assert_eq!(code, 0, "join/csv failed; stderr: {stderr}");
+    assert_eq!(stdout, "name,total\nAda,42\n");
+
+    let (code, _stdout, stderr) = run_query_files(
+        &[&users_str, &orders_str],
+        join_sql,
+        &["--save", &saved_str, "--format", "json"],
+    );
+    assert_eq!(code, 0, "save failed; stderr: {stderr}");
+    assert!(saved.exists(), "--save should create the embedded store");
+
+    let (code, stdout, stderr) = run_red(&[
+        "query",
+        "--path",
+        &saved_str,
+        "SELECT users.name AS name, orders.total AS total \
+         FROM users JOIN orders ON users.id = orders.user_id \
+         WHERE orders.total > 20",
+        "--format",
+        "json",
+    ]);
+    assert_eq!(code, 0, "reopen join failed; stderr: {stderr}");
+    assert_eq!(stdout, "[{\"name\":\"Ada\",\"total\":42}]\n");
+
+    let (code, stdout, stderr) =
+        run_red(&["query", "--path", &saved_str, "SHOW STATS orders", "--json"]);
+    assert_eq!(code, 0, "reopen stats failed; stderr: {stderr}");
+    assert!(
+        stdout.contains("\"collection\":\"orders\"") && stdout.contains("\"metric\":\"row_count\""),
+        "stdout: {stdout}"
+    );
+}
+
+#[test]
 fn red_query_multiple_files_collision_uses_deterministic_stems_and_aliases() {
     let dir = temp_dir("collision");
     let plain = dir.path().join("items.csv");


### PR DESCRIPTION
Automated AFK landing for #1799. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1799

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786759355&installation_id=129708444&pr_number=2035&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2035&signature=14b9a5c1dda66139ab42e0c64098c5f0d5f96d7984a8c997f90b68e5684d07e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->