### PR TITLE
test: #1838 TLA+ ownership-transition spec — single owner per epoch, no acked-write loss

### DIFF
--- a/.github/workflows/tla-check.yml
+++ b/.github/workflows/tla-check.yml
@@ -14,6 +14,9 @@ name: TLA+ Model Check
 #   * SafeReconfig    -- every membership change preserves quorum overlap.
 #   * CommitProtocol  -- optimistic MVCC visibility, FCW, savepoints, and
 #                        SSI dangerous-structure aborts.
+#   * OwnershipTransition
+#                     -- range ownership epochs, write-admission fencing,
+#                        handoff/failover, and no acked-write loss.
 #
 # TLC exits non-zero on a violated invariant, which fails the job (and so
 # the build). The models are sized to finish in CI seconds-to-minutes.
@@ -52,6 +55,7 @@ jobs:
           - ReplicationSafetyEnvelope
           - SafeReconfig
           - CommitProtocol
+          - OwnershipTransition
     name: model-check (${{ matrix.spec }})
     steps:
       - uses: actions/checkout@v7

--- a/specs/tla/OwnershipTransition.cfg
+++ b/specs/tla/OwnershipTransition.cfg
@@ -1,0 +1,21 @@
+\* Bounded TLC model for RedDB range ownership transitions.
+\*
+\* Runnable locally after fetching tla2tools.jar:
+\*
+\*   java -cp tools/tla2tools.jar tlc2.TLC -deadlock \
+\*     -config OwnershipTransition.cfg OwnershipTransition.tla
+\*
+\* The bounds cover one range, three candidate owners, two acknowledged
+\* writes, and enough epochs for promotion plus handoff/failover/forced
+\* transition schedules while keeping the CI state space small.
+CONSTANTS
+    Nodes = {n1, n2, n3}
+    Ranges = {r1}
+    MaxEpoch = 3
+    MaxSeq = 2
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT SingleOwnerPerEpoch
+INVARIANT NoAcknowledgedWriteLoss

--- a/specs/tla/OwnershipTransition.tla
+++ b/specs/tla/OwnershipTransition.tla
@@ -1,0 +1,263 @@
+-------------------------- MODULE OwnershipTransition --------------------------
+(***************************************************************************)
+(* Range ownership-transition safety for RedDB (issue #1838, ADR 0037).   *)
+(*                                                                         *)
+(* Property proved: a range ownership epoch has at most one owner that can *)
+(* accept durable writes, and every write acknowledged at or below the     *)
+(* range commit watermark remains present on the catalog owner across      *)
+(* normal promotion, cooperative handoff, crash failover, and forced       *)
+(* ownership transition.                                                   *)
+(*                                                                         *)
+(* Modelled mechanisms.                                                     *)
+(*                                                                         *)
+(*   * The ownership catalog is authoritative: each range has one catalog  *)
+(*     owner and a monotonically increasing ownership epoch.                *)
+(*   * The admission gate is below routing. AcceptDurableWrite requires an *)
+(*     open gate, a live holder, and a lease whose epoch equals the catalog *)
+(*     epoch, so stale owners are fenced even if clients route to them.     *)
+(*   * Cooperative handoff closes the old owner's gate before installing a *)
+(*     caught-up new owner at the next epoch.                               *)
+(*   * Crash failover installs a live caught-up owner after the old owner  *)
+(*     has crashed.                                                         *)
+(*   * Forced ownership transition skips cooperation but still bumps the   *)
+(*     epoch and requires the new owner to cover the commit watermark.      *)
+(*                                                                         *)
+(* Intentional simplifications.                                             *)
+(*                                                                         *)
+(*   * A durable write is identified only by (range, ownership epoch, seq); *)
+(*     payload bytes, WAL page shape, and collection ids are out of scope.  *)
+(*   * ReplicateCommitted abstracts catch-up, snapshot transfer, and WAL    *)
+(*     replay as copying already acknowledged entries to another live node. *)
+(*   * The model checks safety only. It does not promise that failover is   *)
+(*     always available if no live node covers the commit watermark.        *)
+(***************************************************************************)
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS
+    Nodes,
+    Ranges,
+    MaxEpoch,
+    MaxSeq
+
+ASSUME MaxEpoch \in Nat /\ MaxEpoch >= 1
+ASSUME MaxSeq \in Nat /\ MaxSeq >= 1
+
+Nil == "none"
+
+Epochs == 1..MaxEpoch
+Entries == [rng : Ranges, epoch : Epochs, seq : 1..MaxSeq]
+TransitionKinds == {"normal", "cooperative", "crash", "forced"}
+
+VARIABLES
+    catalogOwner,    \* authoritative range owner, or Nil before promotion
+    catalogEpoch,    \* authoritative range ownership epoch
+    leaseOwner,      \* current holder of the write-admission lease
+    leaseEpoch,      \* epoch attached to the current lease
+    gateOpen,        \* local write-admission gate for each range
+    up,              \* process availability
+    durable,         \* durable entries held by each node
+    acknowledged,    \* writes acknowledged to clients
+    commitWatermark, \* highest acknowledged sequence per range
+    acceptedOwners,  \* owners that accepted writes per range/epoch
+    seenTransitions  \* transition classes reached by the bounded model
+
+vars ==
+    <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, gateOpen, up,
+      durable, acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+NoAcceptedOwners == [r \in Ranges |-> [e \in Epochs |-> {}]]
+
+TypeOK ==
+    /\ catalogOwner \in [Ranges -> Nodes \union {Nil}]
+    /\ catalogEpoch \in [Ranges -> 0..MaxEpoch]
+    /\ leaseOwner \in [Ranges -> Nodes \union {Nil}]
+    /\ leaseEpoch \in [Ranges -> 0..MaxEpoch]
+    /\ gateOpen \in [Ranges -> BOOLEAN]
+    /\ up \in [Nodes -> BOOLEAN]
+    /\ durable \in [Nodes -> SUBSET Entries]
+    /\ acknowledged \subseteq Entries
+    /\ commitWatermark \in [Ranges -> 0..MaxSeq]
+    /\ acceptedOwners \in [Ranges -> [Epochs -> SUBSET Nodes]]
+    /\ seenTransitions \subseteq TransitionKinds
+    /\ \A r \in Ranges :
+        /\ catalogOwner[r] = Nil <=> catalogEpoch[r] = 0
+        /\ leaseOwner[r] = Nil <=> leaseEpoch[r] = 0
+        /\ leaseOwner[r] # Nil => leaseEpoch[r] = catalogEpoch[r]
+        /\ commitWatermark[r] <= MaxSeq
+    /\ \A e \in acknowledged :
+        /\ e.seq <= commitWatermark[e.rng]
+        /\ e.epoch <= catalogEpoch[e.rng]
+        /\ \E n \in Nodes : e \in durable[n]
+
+Init ==
+    /\ catalogOwner = [r \in Ranges |-> Nil]
+    /\ catalogEpoch = [r \in Ranges |-> 0]
+    /\ leaseOwner = [r \in Ranges |-> Nil]
+    /\ leaseEpoch = [r \in Ranges |-> 0]
+    /\ gateOpen = [r \in Ranges |-> FALSE]
+    /\ up = [n \in Nodes |-> TRUE]
+    /\ durable = [n \in Nodes |-> {}]
+    /\ acknowledged = {}
+    /\ commitWatermark = [r \in Ranges |-> 0]
+    /\ acceptedOwners = NoAcceptedOwners
+    /\ seenTransitions = {}
+
+CoversWatermark(r, n) ==
+    \A e \in acknowledged :
+        e.rng = r /\ e.seq <= commitWatermark[r] => e \in durable[n]
+
+NormalPromotion(r, n) ==
+    /\ catalogOwner[r] = Nil
+    /\ catalogEpoch[r] = 0
+    /\ up[n]
+    /\ catalogOwner' = [catalogOwner EXCEPT ![r] = n]
+    /\ catalogEpoch' = [catalogEpoch EXCEPT ![r] = 1]
+    /\ leaseOwner' = [leaseOwner EXCEPT ![r] = n]
+    /\ leaseEpoch' = [leaseEpoch EXCEPT ![r] = 1]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = TRUE]
+    /\ seenTransitions' = seenTransitions \union {"normal"}
+    /\ UNCHANGED <<up, durable, acknowledged, commitWatermark, acceptedOwners>>
+
+CloseAdmissionGate(r) ==
+    /\ catalogOwner[r] # Nil
+    /\ up[catalogOwner[r]]
+    /\ gateOpen[r]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = FALSE]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, up, durable,
+          acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+OpenAdmissionGate(r) ==
+    /\ catalogOwner[r] # Nil
+    /\ up[catalogOwner[r]]
+    /\ leaseOwner[r] = catalogOwner[r]
+    /\ leaseEpoch[r] = catalogEpoch[r]
+    /\ ~gateOpen[r]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = TRUE]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, up, durable,
+          acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+AcceptDurableWrite(r, n) ==
+    /\ catalogOwner[r] = n
+    /\ leaseOwner[r] = n
+    /\ leaseEpoch[r] = catalogEpoch[r]
+    /\ gateOpen[r]
+    /\ up[n]
+    /\ catalogEpoch[r] \in Epochs
+    /\ commitWatermark[r] < MaxSeq
+    /\ LET seq == commitWatermark[r] + 1 IN
+       LET entry == [rng |-> r, epoch |-> catalogEpoch[r], seq |-> seq] IN
+        /\ durable' = [durable EXCEPT ![n] = durable[n] \union {entry}]
+        /\ acknowledged' = acknowledged \union {entry}
+        /\ commitWatermark' = [commitWatermark EXCEPT ![r] = seq]
+        /\ acceptedOwners' =
+            [acceptedOwners EXCEPT
+                ![r][catalogEpoch[r]] =
+                    acceptedOwners[r][catalogEpoch[r]] \union {n}]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, gateOpen, up,
+          seenTransitions>>
+
+ReplicateCommitted(r, n) ==
+    /\ up[n]
+    /\ \E entry \in acknowledged :
+        /\ entry.rng = r
+        /\ entry.seq <= commitWatermark[r]
+        /\ entry \notin durable[n]
+        /\ durable' = [durable EXCEPT ![n] = durable[n] \union {entry}]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, gateOpen, up,
+          acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+CooperativeHandoff(r, old, new) ==
+    /\ catalogOwner[r] = old
+    /\ old # new
+    /\ up[old]
+    /\ up[new]
+    /\ ~gateOpen[r]
+    /\ catalogEpoch[r] < MaxEpoch
+    /\ CoversWatermark(r, new)
+    /\ catalogOwner' = [catalogOwner EXCEPT ![r] = new]
+    /\ catalogEpoch' = [catalogEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ leaseOwner' = [leaseOwner EXCEPT ![r] = new]
+    /\ leaseEpoch' = [leaseEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = TRUE]
+    /\ seenTransitions' = seenTransitions \union {"cooperative"}
+    /\ UNCHANGED <<up, durable, acknowledged, commitWatermark, acceptedOwners>>
+
+CrashFailover(r, old, new) ==
+    /\ catalogOwner[r] = old
+    /\ old # new
+    /\ ~up[old]
+    /\ up[new]
+    /\ catalogEpoch[r] < MaxEpoch
+    /\ CoversWatermark(r, new)
+    /\ catalogOwner' = [catalogOwner EXCEPT ![r] = new]
+    /\ catalogEpoch' = [catalogEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ leaseOwner' = [leaseOwner EXCEPT ![r] = new]
+    /\ leaseEpoch' = [leaseEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = TRUE]
+    /\ seenTransitions' = seenTransitions \union {"crash"}
+    /\ UNCHANGED <<up, durable, acknowledged, commitWatermark, acceptedOwners>>
+
+ForcedTransition(r, new) ==
+    /\ catalogOwner[r] # Nil
+    /\ catalogOwner[r] # new
+    /\ up[new]
+    /\ catalogEpoch[r] < MaxEpoch
+    /\ CoversWatermark(r, new)
+    /\ catalogOwner' = [catalogOwner EXCEPT ![r] = new]
+    /\ catalogEpoch' = [catalogEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ leaseOwner' = [leaseOwner EXCEPT ![r] = new]
+    /\ leaseEpoch' = [leaseEpoch EXCEPT ![r] = catalogEpoch[r] + 1]
+    /\ gateOpen' = [gateOpen EXCEPT ![r] = TRUE]
+    /\ seenTransitions' = seenTransitions \union {"forced"}
+    /\ UNCHANGED <<up, durable, acknowledged, commitWatermark, acceptedOwners>>
+
+Crash(n) ==
+    /\ up[n]
+    /\ up' = [up EXCEPT ![n] = FALSE]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, gateOpen,
+          durable, acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+Restart(n) ==
+    /\ ~up[n]
+    /\ up' = [up EXCEPT ![n] = TRUE]
+    /\ UNCHANGED
+        <<catalogOwner, catalogEpoch, leaseOwner, leaseEpoch, gateOpen,
+          durable, acknowledged, commitWatermark, acceptedOwners, seenTransitions>>
+
+Next ==
+    \/ \E r \in Ranges, n \in Nodes : NormalPromotion(r, n)
+    \/ \E r \in Ranges : CloseAdmissionGate(r)
+    \/ \E r \in Ranges : OpenAdmissionGate(r)
+    \/ \E r \in Ranges, n \in Nodes : AcceptDurableWrite(r, n)
+    \/ \E r \in Ranges, n \in Nodes : ReplicateCommitted(r, n)
+    \/ \E r \in Ranges, old \in Nodes, new \in Nodes :
+        CooperativeHandoff(r, old, new)
+    \/ \E r \in Ranges, old \in Nodes, new \in Nodes :
+        CrashFailover(r, old, new)
+    \/ \E r \in Ranges, n \in Nodes : ForcedTransition(r, n)
+    \/ \E n \in Nodes : Crash(n)
+    \/ \E n \in Nodes : Restart(n)
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* THE PROPERTIES.                                                         *)
+(***************************************************************************)
+
+SingleOwnerPerEpoch ==
+    \A r \in Ranges, e \in Epochs :
+        Cardinality(acceptedOwners[r][e]) <= 1
+
+NoAcknowledgedWriteLoss ==
+    \A r \in Ranges :
+        catalogOwner[r] # Nil =>
+            \A entry \in acknowledged :
+                entry.rng = r /\ entry.seq <= commitWatermark[r] =>
+                    entry \in durable[catalogOwner[r]]
+
+=============================================================================

--- a/specs/tla/README.md
+++ b/specs/tla/README.md
@@ -18,6 +18,7 @@ Jepsen-style cluster harness.
 | [`ReplicationSafetyEnvelope.tla`](ReplicationSafetyEnvelope.tla) | Single-writer fencing, election safety, partition behavior, and crash/recovery durability in one bounded model. | ADR 0030 / ADR 0032; writer fencing, quorum commit, crash/restart recovery. |
 | [`SafeReconfig.tla`](SafeReconfig.tla) | Every membership change preserves quorum overlap (old and new quorums intersect). | ADR 0030 membership rules; Raft single-server change. |
 | [`CommitProtocol.tla`](CommitProtocol.tla) | Optimistic MVCC commit safety: no lost update under FCW, stable snapshot reads, and SSI-admitted histories are serializable. | ADR 0065 TM v2; `SnapshotManager::begin` / `snapshot` / `commit`; `visibility::is_visible`; SQL table-row commit conflict checks; `TxnContext` savepoint sub-xids. |
+| [`OwnershipTransition.tla`](OwnershipTransition.tla) | Range ownership transitions keep one durable-write owner per ownership epoch and preserve all acknowledged writes at/below the commit watermark. | ADR 0037 ownership catalog; ADR 0058 reserved range owner fencing; current `LeaseStore` / `WriteGate` / failover promotion guard; tracked per-range follow-ups #1836, #1837, and #1843. |
 
 ## How the models mirror the implementation
 
@@ -76,6 +77,25 @@ two-row model. For local reachability checks, temporarily add
 `NoOptimisticAdmitsMoreThan2PL` as an invariant; TLC must reject the model with
 a counterexample reaching the corresponding witness state. These negated
 witness invariants are not in CI because their success condition is failure.
+
+## Ownership transition model
+
+`OwnershipTransition.tla` models ADR 0037's cataloged range ownership contract.
+The catalog owner and ownership epoch are authoritative, and `AcceptDurableWrite`
+requires the local admission gate to be open with a lease at the same epoch as
+the catalog. Cooperative handoff closes the old owner's gate before installing a
+caught-up new owner. Crash failover requires the old owner to be down. Forced
+transition skips old-owner cooperation, but still bumps the epoch and requires
+the new owner to cover every acknowledged entry at or below the range commit
+watermark. The model intentionally records transition kinds for inspection only;
+the CI invariants are the safety contract: `SingleOwnerPerEpoch` and
+`NoAcknowledgedWriteLoss`.
+
+The bounded spec is ahead of the live per-range implementation in three tracked
+places: #1836 wires the ownership admission gate into durable writes, #1837
+carries term/ownership epoch through WAL and logical spool framing, and #1843
+rejects divergent term/epoch history on replica apply. No additional divergence
+issue was opened for this model because those slices already capture the gap.
 
 ## Running locally
 


### PR DESCRIPTION
Adds `specs/tla/OwnershipTransition.tla` (+ .cfg, README) formally modelling range ownership-transition safety, and registers it in the `tla-check` model-check matrix.

**Human review (2026-07-15):** sensitive-path park cleared after review. The protected-path touch is `.github/workflows/tla-check.yml` — a minimal, pattern-consistent addition of `OwnershipTransition` to the existing spec matrix (no workflow logic/secrets/permissions change).

The spec proves the properties the ownership cluster depends on (ADR 0037):
- **SingleOwnerPerEpoch** — at most one owner per epoch can accept durable writes; the admission gate below routing fences stale owners (lease epoch must equal catalog epoch).
- **NoAcknowledgedWriteLoss** — every write acked at/below the commit watermark survives promotion, cooperative handoff, crash failover, and forced transition.

CI (`tla-check`) runs TLC over the new spec on this PR — a passing check *is* the validation.

Closes #1838

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786762767&installation_id=129708444&pr_number=2037&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2037&signature=cfa04c6da750b5cf346055be041eff7388e3a70d609534884764e1bde199dd31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->