### PR TITLE
chore: #1845 Named failover profiles: lease window, health thresholds, grace by deployment posture

### DIFF
--- a/crates/reddb-server/src/replication/mod.rs
+++ b/crates/reddb-server/src/replication/mod.rs
@@ -85,6 +85,181 @@ pub use witness::{RuntimeProfile, WitnessSupervisor};
 pub const DEFAULT_REPLICATION_TERM: u64 = reddb_wire::replication::DEFAULT_REPLICATION_TERM;
 pub const DEFAULT_SLOT_RETENTION_MAX_LAG_LSN: u64 = 100_000;
 pub const DEFAULT_SLOT_IDLE_TIMEOUT_MS: u64 = 86_400_000;
+pub const SHIPPED_FAILOVER_PROFILES: [FailoverProfile; 3] = [
+    FailoverProfile::CONSERVATIVE,
+    FailoverProfile::BALANCED,
+    FailoverProfile::AGGRESSIVE,
+];
+
+/// Named failover timing posture.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FailoverProfileName {
+    Conservative,
+    Balanced,
+    Aggressive,
+    Custom,
+}
+
+impl FailoverProfileName {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Conservative => "conservative",
+            Self::Balanced => "balanced",
+            Self::Aggressive => "aggressive",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+/// Tuned failover constants over the existing lease, health, and grace
+/// mechanisms.
+///
+/// Shipped profiles document the intended trade-off:
+/// - `conservative`: long lease and high health threshold; favors avoiding
+///   false promotion over fast recovery.
+/// - `balanced`: default posture; keeps a moderate lease and health threshold
+///   for ordinary multi-node deployments.
+/// - `aggressive`: short lease and lower health threshold; favors fast recovery
+///   when the operator accepts a narrower timing margin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FailoverProfile {
+    pub name: FailoverProfileName,
+    pub lease_window_ms: u64,
+    pub member_health_score_threshold: u8,
+    pub promotion_grace_ms: u64,
+    pub max_clock_drift_ms: u64,
+}
+
+impl FailoverProfile {
+    pub const CONSERVATIVE: Self = Self {
+        name: FailoverProfileName::Conservative,
+        lease_window_ms: 60_000,
+        member_health_score_threshold: 90,
+        promotion_grace_ms: 30_000,
+        max_clock_drift_ms: 5_000,
+    };
+
+    pub const BALANCED: Self = Self {
+        name: FailoverProfileName::Balanced,
+        lease_window_ms: 30_000,
+        member_health_score_threshold: 75,
+        promotion_grace_ms: 10_000,
+        max_clock_drift_ms: 5_000,
+    };
+
+    pub const AGGRESSIVE: Self = Self {
+        name: FailoverProfileName::Aggressive,
+        lease_window_ms: 15_000,
+        member_health_score_threshold: 60,
+        promotion_grace_ms: 5_000,
+        max_clock_drift_ms: 2_000,
+    };
+
+    pub const fn shipped() -> &'static [Self] {
+        &SHIPPED_FAILOVER_PROFILES
+    }
+
+    pub const fn name_str(self) -> &'static str {
+        self.name.as_str()
+    }
+
+    pub fn validate(self) -> Result<Self, String> {
+        if self.lease_window_ms == 0 {
+            return Err("failover profile lease_window_ms must be positive".to_string());
+        }
+        if self.member_health_score_threshold > 100 {
+            return Err(
+                "failover profile member_health_score_threshold must be <= 100".to_string(),
+            );
+        }
+        if self.promotion_grace_ms >= self.lease_window_ms {
+            return Err(
+                "failover profile promotion_grace_ms must be smaller than lease_window_ms"
+                    .to_string(),
+            );
+        }
+        let safety_margin_ms = self.lease_window_ms - self.promotion_grace_ms;
+        if safety_margin_ms < self.max_clock_drift_ms {
+            return Err(format!(
+                "failover profile lease safety margin {safety_margin_ms}ms is below configured max clock drift {}ms",
+                self.max_clock_drift_ms
+            ));
+        }
+        Ok(self)
+    }
+
+    pub const fn lease_safety_margin_ms(self) -> u64 {
+        self.lease_window_ms - self.promotion_grace_ms
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shipped_failover_profiles_satisfy_lease_safety_validation() {
+        for profile in FailoverProfile::shipped() {
+            profile.validate().expect(profile.name_str());
+            assert!(
+                profile.lease_safety_margin_ms() >= profile.max_clock_drift_ms,
+                "{} profile violates lease clock-discipline margin",
+                profile.name_str()
+            );
+        }
+    }
+
+    #[test]
+    fn failover_profile_rejects_margin_below_configured_clock_drift() {
+        let invalid = FailoverProfile {
+            name: FailoverProfileName::Custom,
+            lease_window_ms: 1_000,
+            member_health_score_threshold: 80,
+            promotion_grace_ms: 900,
+            max_clock_drift_ms: 200,
+        };
+
+        let err = invalid.validate().expect_err("profile must be rejected");
+
+        assert!(err.contains("lease safety margin"), "{err}");
+        assert!(err.contains("max clock drift"), "{err}");
+    }
+
+    #[test]
+    fn runtime_open_rejects_invalid_failover_profile() {
+        let invalid = FailoverProfile {
+            name: FailoverProfileName::Custom,
+            lease_window_ms: 1_000,
+            member_health_score_threshold: 80,
+            promotion_grace_ms: 900,
+            max_clock_drift_ms: 200,
+        };
+        let options = crate::RedDBOptions::in_memory()
+            .with_replication(ReplicationConfig::primary().with_failover_profile(invalid));
+
+        let err = match crate::RedDBRuntime::with_options(options) {
+            Ok(_) => panic!("boot must reject config"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("invalid config"), "{err}");
+        assert!(err.to_string().contains("lease safety margin"), "{err}");
+    }
+
+    #[test]
+    fn changing_failover_profile_updates_active_profile() {
+        let mut config = ReplicationConfig::primary();
+
+        config
+            .change_failover_profile(FailoverProfile::AGGRESSIVE, "test")
+            .expect("valid profile applies");
+
+        assert_eq!(
+            config.failover_profile.name,
+            FailoverProfileName::Aggressive
+        );
+    }
+}
 
 /// Role of this RedDB instance in a replication cluster.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -135,6 +310,9 @@ pub struct ReplicationConfig {
     /// only for an async read-replica; a voting member refuses it and streams
     /// directly from the primary. See [`ReplicationConfig::resolved_upstream`].
     pub cascade_from: Option<CascadeUpstream>,
+    /// Active named failover profile. The profile is a bundle of tuned
+    /// lease/health/grace constants; it does not add new failover machinery.
+    pub failover_profile: FailoverProfile,
 }
 
 impl ReplicationConfig {
@@ -150,6 +328,7 @@ impl ReplicationConfig {
             slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
             replica_class: ReplicaClass::Voting,
             cascade_from: None,
+            failover_profile: FailoverProfile::BALANCED,
         }
     }
 
@@ -165,6 +344,7 @@ impl ReplicationConfig {
             slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
             replica_class: ReplicaClass::Voting,
             cascade_from: None,
+            failover_profile: FailoverProfile::BALANCED,
         }
     }
 
@@ -182,6 +362,7 @@ impl ReplicationConfig {
             slot_idle_timeout_ms: DEFAULT_SLOT_IDLE_TIMEOUT_MS,
             replica_class: ReplicaClass::Voting,
             cascade_from: None,
+            failover_profile: FailoverProfile::BALANCED,
         }
     }
 
@@ -211,6 +392,32 @@ impl ReplicationConfig {
     pub fn with_slot_idle_timeout_ms(mut self, timeout_ms: u64) -> Self {
         self.slot_idle_timeout_ms = timeout_ms;
         self
+    }
+
+    pub fn with_failover_profile(mut self, profile: FailoverProfile) -> Self {
+        self.failover_profile = profile;
+        self
+    }
+
+    pub fn validate_failover_profile(&self) -> Result<(), String> {
+        self.failover_profile.validate().map(|_| ())
+    }
+
+    pub fn change_failover_profile(
+        &mut self,
+        profile: FailoverProfile,
+        changed_by: impl Into<String>,
+    ) -> Result<(), String> {
+        let profile = profile.validate()?;
+        let old_profile = self.failover_profile.name_str().to_string();
+        self.failover_profile = profile;
+        crate::telemetry::operator_event::OperatorEvent::FailoverProfileChanged {
+            old_profile,
+            new_profile: profile.name_str().to_string(),
+            changed_by: changed_by.into(),
+        }
+        .emit_global();
+        Ok(())
     }
 
     /// Set the streaming class explicitly (issue #838).

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -181,6 +181,10 @@ impl RedDBRuntime {
         options: RedDBOptions,
         pool_config: ConnectionPoolConfig,
     ) -> RedDBResult<Self> {
+        options
+            .replication
+            .validate_failover_profile()
+            .map_err(RedDBError::InvalidConfig)?;
         // PLAN.md Phase 9.1 — capture wall-clock before storage
         // open so the cold-start phase markers can be backfilled
         // once Lifecycle is constructed below. Storage open

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -14,6 +14,36 @@ impl RedDBServer {
             "current_term".to_string(),
             JsonValue::Number(db.options().replication.term as f64),
         );
+        let profile = db.options().replication.failover_profile;
+        let mut profile_json = Map::new();
+        profile_json.insert(
+            "name".to_string(),
+            JsonValue::String(profile.name_str().to_string()),
+        );
+        profile_json.insert(
+            "lease_window_ms".to_string(),
+            JsonValue::Number(profile.lease_window_ms as f64),
+        );
+        profile_json.insert(
+            "member_health_score_threshold".to_string(),
+            JsonValue::Number(profile.member_health_score_threshold as f64),
+        );
+        profile_json.insert(
+            "promotion_grace_ms".to_string(),
+            JsonValue::Number(profile.promotion_grace_ms as f64),
+        );
+        profile_json.insert(
+            "max_clock_drift_ms".to_string(),
+            JsonValue::Number(profile.max_clock_drift_ms as f64),
+        );
+        profile_json.insert(
+            "lease_safety_margin_ms".to_string(),
+            JsonValue::Number(profile.lease_safety_margin_ms() as f64),
+        );
+        object.insert(
+            "failover_profile".to_string(),
+            JsonValue::Object(profile_json),
+        );
         match &db.options().replication.role {
             crate::replication::ReplicationRole::Standalone => {
                 object.insert(
@@ -468,6 +498,33 @@ mod tests {
         assert!(body.contains(r#""commit_watermark":"#), "{body}");
         assert!(body.contains(r#""full_resync_count":0"#), "{body}");
         assert!(body.contains(r#""partial_resync_count":0"#), "{body}");
+    }
+
+    #[test]
+    fn replication_status_surfaces_active_failover_profile() {
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory().with_replication(
+                ReplicationConfig::primary()
+                    .with_failover_profile(crate::replication::FailoverProfile::CONSERVATIVE),
+            ),
+        )
+        .expect("runtime");
+
+        let server = RedDBServer::new(runtime);
+        let response = server.handle_replication_status();
+        let body = String::from_utf8(response.body).expect("status body is utf8");
+
+        assert_eq!(response.status, 200);
+        assert!(body.contains(r#""failover_profile":{"#), "{body}");
+        assert!(body.contains(r#""name":"conservative""#), "{body}");
+        assert!(body.contains(r#""lease_window_ms":60000"#), "{body}");
+        assert!(
+            body.contains(r#""member_health_score_threshold":90"#),
+            "{body}"
+        );
+        assert!(body.contains(r#""promotion_grace_ms":30000"#), "{body}");
+        assert!(body.contains(r#""max_clock_drift_ms":5000"#), "{body}");
+        assert!(body.contains(r#""lease_safety_margin_ms":30000"#), "{body}");
     }
 
     #[test]

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -105,6 +105,12 @@ pub enum OperatorEvent {
         new_value: String,
         changed_by: String,
     },
+    /// The operator selected a different named failover profile.
+    FailoverProfileChanged {
+        old_profile: String,
+        new_profile: String,
+        changed_by: String,
+    },
     /// The server process failed to start cleanly.
     StartupFailed { phase: String, error: String },
     /// The server process was forced to shut down (e.g. OOM killer,
@@ -219,6 +225,7 @@ impl OperatorEvent {
             "AdminCapabilityGranted",
             "SecretRotationFailed",
             "ConfigChanged",
+            "FailoverProfileChanged",
             "StartupFailed",
             "ShutdownForced",
             "SchemaCorruption",
@@ -245,6 +252,7 @@ impl OperatorEvent {
             Self::AdminCapabilityGranted { .. } => "AdminCapabilityGranted",
             Self::SecretRotationFailed { .. } => "SecretRotationFailed",
             Self::ConfigChanged { .. } => "ConfigChanged",
+            Self::FailoverProfileChanged { .. } => "FailoverProfileChanged",
             Self::StartupFailed { .. } => "StartupFailed",
             Self::ShutdownForced { .. } => "ShutdownForced",
             Self::SchemaCorruption { .. } => "SchemaCorruption",
@@ -414,6 +422,21 @@ impl OperatorEvent {
                     AuditFieldEscaper::field("changed_by", changed_by),
                 ];
                 ("operator/config_changed", fields, summary)
+            }
+            Self::FailoverProfileChanged {
+                old_profile,
+                new_profile,
+                changed_by,
+            } => {
+                let summary = format!(
+                    "failover profile changed: old={old_profile} new={new_profile} by={changed_by}"
+                );
+                let fields = vec![
+                    AuditFieldEscaper::field("old_profile", old_profile),
+                    AuditFieldEscaper::field("new_profile", new_profile),
+                    AuditFieldEscaper::field("changed_by", changed_by),
+                ];
+                ("operator/failover_profile_changed", fields, summary)
             }
             Self::StartupFailed { phase, error } => {
                 let summary = format!("startup failed: phase={phase} error={error}");
@@ -820,6 +843,28 @@ mod tests {
             .and_then(|d| d.get("new_value"))
             .and_then(|x| x.as_str());
         assert_eq!(nv, Some("200"));
+    }
+
+    #[test]
+    fn failover_profile_changed_emits() {
+        let (logger, path) = make_logger();
+        OperatorEvent::FailoverProfileChanged {
+            old_profile: "balanced".into(),
+            new_profile: "aggressive".into(),
+            changed_by: "operator".into(),
+        }
+        .emit(&logger);
+        drain(&logger);
+        let v = read_last_line(&path);
+        assert_eq!(
+            v.get("action").and_then(|x| x.as_str()),
+            Some("operator/failover_profile_changed")
+        );
+        let new_profile = v
+            .get("detail")
+            .and_then(|d| d.get("new_profile"))
+            .and_then(|x| x.as_str());
+        assert_eq!(new_profile, Some("aggressive"));
     }
 
     #[test]

--- a/crates/reddb-server/src/telemetry/operator_event_router.rs
+++ b/crates/reddb-server/src/telemetry/operator_event_router.rs
@@ -666,6 +666,11 @@ mod tests {
                 new_value: "n".into(),
                 changed_by: "b".into(),
             },
+            OperatorEvent::FailoverProfileChanged {
+                old_profile: "balanced".into(),
+                new_profile: "aggressive".into(),
+                changed_by: "b".into(),
+            },
             OperatorEvent::StartupFailed {
                 phase: "p".into(),
                 error: "e".into(),
@@ -781,6 +786,15 @@ mod tests {
                 key: key.clone(),
                 old_value: old_value.clone(),
                 new_value: new_value.clone(),
+                changed_by: changed_by.clone(),
+            },
+            OperatorEvent::FailoverProfileChanged {
+                old_profile,
+                new_profile,
+                changed_by,
+            } => OperatorEvent::FailoverProfileChanged {
+                old_profile: old_profile.clone(),
+                new_profile: new_profile.clone(),
                 changed_by: changed_by.clone(),
             },
             OperatorEvent::StartupFailed { phase, error } => OperatorEvent::StartupFailed {


### PR DESCRIPTION
Automated AFK landing for #1845. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1845

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768993&installation_id=129708444&pr_number=2038&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2038&signature=a76eb2bfbc077699089f3f9f5c9ff6480ba273f0d24002541b3b69b8f2edb0d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->