### PR TITLE
chore: #1847 Cooperative lease handoff: planned owner-to-hot-mirror promotion with epoch bump

### DIFF
--- a/crates/reddb-server/src/runtime/write_gate.rs
+++ b/crates/reddb-server/src/runtime/write_gate.rs
@@ -595,6 +595,7 @@ impl OwnershipAdmissionGate {
             .chain(std::iter::once(mirror));
         self.catalog
             .apply_update(current.update_replicas(replicas))
+            .map(|_| ())
             .map_err(|err| RedDBError::Catalog(err.to_string()))
     }
 

--- a/crates/reddb-server/src/runtime/write_gate.rs
+++ b/crates/reddb-server/src/runtime/write_gate.rs
@@ -25,9 +25,10 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 
 use crate::api::{RedDBError, RedDBOptions, RedDBResult};
 use crate::cluster::{
-    admit_durable_write, CollectionId, DurableWriteReject, LeasedOwner, NodeIdentity,
-    OwnershipEpoch, OwnershipLease, PlacementMetadata, RangeBounds, RangeId, RangeOwnership,
-    ShardKeyMode, ShardOwnershipCatalog, SupervisorTerm,
+    admit_durable_write, CollectionId, DurableWriteReject, HotMirrorCandidate,
+    HotMirrorPromotionRefusal, LeasedOwner, NodeIdentity, OwnershipEpoch, OwnershipLease,
+    PlacementMetadata, RangeBounds, RangeId, RangeOwnership, ShardKeyMode, ShardOwnershipCatalog,
+    SupervisorTerm,
 };
 use crate::replication::cdc::RangeAuthority;
 use crate::replication::flow_control::{Admission, FlowController};
@@ -60,6 +61,17 @@ pub enum WriteKind {
     /// Serverless lifecycle endpoints that mutate state (attach / warmup
     /// / reclaim).
     Serverless,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CooperativeHandoffOutcome {
+    pub range_identity: String,
+    pub previous_owner: String,
+    pub new_owner: String,
+    pub previous_epoch: u64,
+    pub new_epoch: u64,
+    pub commit_watermark: u64,
+    pub target_lsn: u64,
 }
 
 impl WriteKind {
@@ -419,6 +431,50 @@ impl WriteGate {
         gate.promote_to(new_owner, new_term)
     }
 
+    pub fn register_primary_replica_hot_mirror(&self, mirror_subject: &str) -> RedDBResult<()> {
+        let mirror = node_identity(mirror_subject)?;
+        let mut guard = self.ownership.write();
+        let Some(gate) = guard.as_mut() else {
+            return Ok(());
+        };
+        gate.register_hot_mirror(mirror)
+    }
+
+    pub fn cooperative_handoff_primary_replica_owner(
+        &self,
+        new_owner_subject: &str,
+        new_term: u64,
+        target_lsn: u64,
+        commit_watermark: u64,
+    ) -> RedDBResult<CooperativeHandoffOutcome> {
+        let new_owner = node_identity(new_owner_subject)?;
+        let mut guard = self.ownership.write();
+        let Some(gate) = guard.as_mut() else {
+            return Ok(CooperativeHandoffOutcome {
+                range_identity: RESERVED_GLOBAL_SYSTEM_COLLECTION.to_string(),
+                previous_owner: String::new(),
+                new_owner: new_owner.to_string(),
+                previous_epoch: 0,
+                new_epoch: 0,
+                commit_watermark,
+                target_lsn,
+            });
+        };
+        let outcome =
+            gate.cooperative_handoff_to(new_owner, new_term, target_lsn, commit_watermark)?;
+        OperatorEvent::CooperativeLeaseHandoff {
+            range_identity: outcome.range_identity.clone(),
+            previous_owner: outcome.previous_owner.clone(),
+            new_owner: outcome.new_owner.clone(),
+            previous_epoch: outcome.previous_epoch,
+            new_epoch: outcome.new_epoch,
+            commit_watermark: outcome.commit_watermark,
+            target_lsn: outcome.target_lsn,
+        }
+        .emit_global();
+        Ok(outcome)
+    }
+
     pub fn primary_replica_range_authority(&self) -> Option<RangeAuthority> {
         self.ownership
             .read()
@@ -521,6 +577,75 @@ impl OwnershipAdmissionGate {
             .map_err(|err| RedDBError::Catalog(err.to_string()))?;
         self.current_term = SupervisorTerm::new(new_term);
         Ok(())
+    }
+
+    fn register_hot_mirror(&mut self, mirror: NodeIdentity) -> RedDBResult<()> {
+        let current = self
+            .catalog
+            .range(&self.collection, self.range_id)
+            .ok_or_else(|| RedDBError::Internal("reserved global system range missing".into()))?
+            .clone();
+        if current.replicas().contains(&mirror) {
+            return Ok(());
+        }
+        let replicas = current
+            .replicas()
+            .iter()
+            .cloned()
+            .chain(std::iter::once(mirror));
+        self.catalog
+            .apply_update(current.update_replicas(replicas))
+            .map_err(|err| RedDBError::Catalog(err.to_string()))
+    }
+
+    fn cooperative_handoff_to(
+        &mut self,
+        new_owner: NodeIdentity,
+        new_term: u64,
+        target_lsn: u64,
+        commit_watermark: u64,
+    ) -> RedDBResult<CooperativeHandoffOutcome> {
+        let current = self
+            .catalog
+            .range(&self.collection, self.range_id)
+            .ok_or_else(|| RedDBError::Internal("reserved global system range missing".into()))?
+            .clone();
+        let promotion = current
+            .promote_hot_mirror(
+                &HotMirrorCandidate::new(new_owner.clone(), target_lsn),
+                commit_watermark,
+            )
+            .map_err(|err| RedDBError::InvalidOperation(hot_mirror_refusal_message(&err)))?;
+        let outcome = CooperativeHandoffOutcome {
+            range_identity: format!("{}/{}", current.collection(), current.range_id()),
+            previous_owner: current.owner().to_string(),
+            new_owner: new_owner.to_string(),
+            previous_epoch: current.epoch().value(),
+            new_epoch: promotion.promoted().epoch().value(),
+            commit_watermark,
+            target_lsn,
+        };
+        self.catalog
+            .apply_update(promotion.promoted().clone())
+            .map_err(|err| RedDBError::Catalog(err.to_string()))?;
+        self.current_term = SupervisorTerm::new(new_term);
+        Ok(outcome)
+    }
+}
+
+fn hot_mirror_refusal_message(err: &HotMirrorPromotionRefusal) -> String {
+    match err {
+        HotMirrorPromotionRefusal::NotReplica { candidate, role } => {
+            format!("cooperative_handoff_refused reason=not_hot_mirror candidate={candidate} role={role:?}")
+        }
+        HotMirrorPromotionRefusal::WatermarkNotCovered {
+            candidate_lsn,
+            watermark,
+        } => {
+            format!(
+                "cooperative_handoff_refused reason=watermark_not_covered candidate_lsn={candidate_lsn} watermark={watermark}"
+            )
+        }
     }
 }
 

--- a/crates/reddb-server/src/telemetry/operator_event.rs
+++ b/crates/reddb-server/src/telemetry/operator_event.rs
@@ -201,6 +201,18 @@ pub enum OperatorEvent {
         ownership_epoch: u64,
         range_identity: String,
     },
+    /// A healthy owner cooperatively handed write authority to a caught-up
+    /// hot mirror before lease expiry/election. This is planned maintenance
+    /// evidence, distinct from failover.
+    CooperativeLeaseHandoff {
+        range_identity: String,
+        previous_owner: String,
+        new_owner: String,
+        previous_epoch: u64,
+        new_epoch: u64,
+        commit_watermark: u64,
+        target_lsn: u64,
+    },
     /// Replica apply rejected a stamped record because its range authority
     /// term/ownership epoch conflicts with the current ownership state.
     ReplicaAuthorityDivergence {
@@ -237,6 +249,7 @@ impl OperatorEvent {
             "QueueDlqPromoted",
             "DeposedPrimaryRollback",
             "OwnershipFenced",
+            "CooperativeLeaseHandoff",
             "ReplicaAuthorityDivergence",
         ]
     }
@@ -264,6 +277,7 @@ impl OperatorEvent {
             Self::QueueDlqPromoted { .. } => "QueueDlqPromoted",
             Self::DeposedPrimaryRollback { .. } => "DeposedPrimaryRollback",
             Self::OwnershipFenced { .. } => "OwnershipFenced",
+            Self::CooperativeLeaseHandoff { .. } => "CooperativeLeaseHandoff",
             Self::ReplicaAuthorityDivergence { .. } => "ReplicaAuthorityDivergence",
         }
     }
@@ -579,6 +593,31 @@ impl OperatorEvent {
                     AuditFieldEscaper::field("range_identity", range_identity),
                 ];
                 ("operator/ownership_fenced", fields, summary)
+            }
+            Self::CooperativeLeaseHandoff {
+                range_identity,
+                previous_owner,
+                new_owner,
+                previous_epoch,
+                new_epoch,
+                commit_watermark,
+                target_lsn,
+            } => {
+                let summary = format!(
+                    "cooperative lease handoff: range={range_identity} previous_owner={previous_owner} \
+                     new_owner={new_owner} epoch={previous_epoch}->{new_epoch} \
+                     commit_watermark={commit_watermark} target_lsn={target_lsn}"
+                );
+                let fields = vec![
+                    AuditFieldEscaper::field("range_identity", range_identity),
+                    AuditFieldEscaper::field("previous_owner", previous_owner),
+                    AuditFieldEscaper::field("new_owner", new_owner),
+                    AuditFieldEscaper::field("previous_epoch", previous_epoch),
+                    AuditFieldEscaper::field("new_epoch", new_epoch),
+                    AuditFieldEscaper::field("commit_watermark", commit_watermark),
+                    AuditFieldEscaper::field("target_lsn", target_lsn),
+                ];
+                ("operator/cooperative_lease_handoff", fields, summary)
             }
             Self::ReplicaAuthorityDivergence {
                 range_identity,
@@ -1009,6 +1048,50 @@ mod tests {
             detail.get("range_identity").and_then(|x| x.as_str()),
             Some("system.global/0")
         );
+    }
+
+    #[test]
+    fn cooperative_lease_handoff_emits_epoch_watermark_and_owners() {
+        let (logger, path) = make_logger();
+        OperatorEvent::CooperativeLeaseHandoff {
+            range_identity: "system.global/0".into(),
+            previous_owner: "CN=node-a,O=reddb".into(),
+            new_owner: "CN=node-b,O=reddb".into(),
+            previous_epoch: 1,
+            new_epoch: 2,
+            commit_watermark: 12,
+            target_lsn: 12,
+        }
+        .emit(&logger);
+        drain(&logger);
+        let v = read_last_line(&path);
+        assert_eq!(
+            v.get("action").and_then(|x| x.as_str()),
+            Some("operator/cooperative_lease_handoff")
+        );
+        let detail = v.get("detail").expect("event detail");
+        assert_eq!(
+            detail.get("range_identity").and_then(|x| x.as_str()),
+            Some("system.global/0")
+        );
+        assert_eq!(
+            detail.get("previous_owner").and_then(|x| x.as_str()),
+            Some("CN=node-a,O=reddb")
+        );
+        assert_eq!(
+            detail.get("new_owner").and_then(|x| x.as_str()),
+            Some("CN=node-b,O=reddb")
+        );
+        assert_eq!(
+            detail.get("previous_epoch").and_then(|x| x.as_i64()),
+            Some(1)
+        );
+        assert_eq!(detail.get("new_epoch").and_then(|x| x.as_i64()), Some(2));
+        assert_eq!(
+            detail.get("commit_watermark").and_then(|x| x.as_i64()),
+            Some(12)
+        );
+        assert_eq!(detail.get("target_lsn").and_then(|x| x.as_i64()), Some(12));
     }
 
     #[test]

--- a/crates/reddb-server/src/telemetry/operator_event_router.rs
+++ b/crates/reddb-server/src/telemetry/operator_event_router.rs
@@ -819,6 +819,23 @@ mod tests {
                     fields_changed: fields_changed.clone(),
                 }
             }
+            OperatorEvent::CooperativeLeaseHandoff {
+                range_identity,
+                previous_owner,
+                new_owner,
+                previous_epoch,
+                new_epoch,
+                commit_watermark,
+                target_lsn,
+            } => OperatorEvent::CooperativeLeaseHandoff {
+                range_identity: range_identity.clone(),
+                previous_owner: previous_owner.clone(),
+                new_owner: new_owner.clone(),
+                previous_epoch: *previous_epoch,
+                new_epoch: *new_epoch,
+                commit_watermark: *commit_watermark,
+                target_lsn: *target_lsn,
+            },
             OperatorEvent::DanglingAdminIntent { .. } => {
                 // Not cloneable without crypto type impls; skip.
                 OperatorEvent::ShutdownForced {

--- a/tests/grouped/replication/e2e_issue_1836_ownership_admission.rs
+++ b/tests/grouped/replication/e2e_issue_1836_ownership_admission.rs
@@ -1,5 +1,9 @@
 //! Issue #1836 — durable writes pass through the ownership admission gate.
+//! Issue #1847 — planned cooperative handoff promotes a caught-up hot mirror.
 
+use std::time::{Duration, Instant};
+
+use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime, ReplicationConfig};
 
 #[test]
@@ -42,4 +46,97 @@ fn standalone_single_node_write_is_not_range_gated() {
     runtime
         .execute_query("INSERT INTO standalone_items (id, name) VALUES (1, 'ok')")
         .expect("standalone DML still works");
+}
+
+#[test]
+fn cooperative_handoff_refuses_hot_mirror_below_commit_watermark() {
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary().with_term(7)),
+    )
+    .expect("primary runtime boots");
+
+    runtime
+        .execute_query("CREATE TABLE handoff_refusal_items (id INT, name TEXT)")
+        .expect("current owner may write");
+    runtime
+        .execute_query("INSERT INTO handoff_refusal_items (id, name) VALUES (1, 'before')")
+        .expect("current owner may write before handoff");
+    let watermark = runtime.cdc_current_lsn();
+    assert!(watermark > 0, "test needs an acknowledged write watermark");
+
+    runtime
+        .write_gate_arc()
+        .register_primary_replica_hot_mirror("CN=node-b,O=reddb")
+        .expect("target registered as hot mirror");
+    let err = runtime
+        .write_gate_arc()
+        .cooperative_handoff_primary_replica_owner("CN=node-b,O=reddb", 8, watermark - 1, watermark)
+        .expect_err("target behind the watermark must be refused");
+    let msg = err.to_string();
+    assert!(msg.contains("cooperative_handoff_refused"), "{msg}");
+    assert!(msg.contains("reason=watermark_not_covered"), "{msg}");
+}
+
+#[test]
+fn cooperative_handoff_promotes_without_lease_expiry_and_fences_old_owner() {
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::in_memory().with_replication(ReplicationConfig::primary().with_term(7)),
+    )
+    .expect("primary runtime boots");
+
+    runtime
+        .execute_query("CREATE TABLE handoff_items (id INT, name TEXT)")
+        .expect("current owner may write");
+    runtime
+        .execute_query("INSERT INTO handoff_items (id, name) VALUES (1, 'before')")
+        .expect("write before handoff is acknowledged");
+    runtime
+        .execute_query("INSERT INTO handoff_items (id, name) VALUES (2, 'during-drain')")
+        .expect("write during planned drain is acknowledged");
+
+    let watermark = runtime.cdc_current_lsn();
+    runtime
+        .write_gate_arc()
+        .register_primary_replica_hot_mirror("CN=node-b,O=reddb")
+        .expect("target registered as hot mirror");
+
+    let started = Instant::now();
+    let outcome = runtime
+        .write_gate_arc()
+        .cooperative_handoff_primary_replica_owner("CN=node-b,O=reddb", 8, watermark, watermark)
+        .expect("caught-up hot mirror promotes");
+    let write_gap = started.elapsed();
+
+    assert!(
+        write_gap < Duration::from_millis(50),
+        "planned handoff must not wait for lease expiry/election; gap={write_gap:?}"
+    );
+    assert_eq!(outcome.range_identity, "system.global/0");
+    assert_eq!(outcome.previous_epoch, 1);
+    assert_eq!(outcome.new_epoch, 2);
+    assert_eq!(outcome.commit_watermark, watermark);
+    assert_eq!(outcome.target_lsn, watermark);
+
+    let err = runtime
+        .execute_query("INSERT INTO handoff_items (id, name) VALUES (3, 'after')")
+        .expect_err("old owner must self-fence after handoff");
+    let msg = err.to_string();
+    assert!(msg.contains("ownership_fenced"), "{msg}");
+    assert!(msg.contains("reason=stale_ownership"), "{msg}");
+    assert!(msg.contains("current_epoch=2"), "{msg}");
+
+    let rows = runtime
+        .execute_query("SELECT id FROM handoff_items")
+        .expect("self-fenced owner may still read acknowledged rows");
+    let mut ids = rows
+        .result
+        .records
+        .iter()
+        .filter_map(|record| match record.get("id") {
+            Some(Value::Integer(id)) => Some(*id),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 2], "acked writes must survive once each");
 }


### PR DESCRIPTION
Automated AFK landing for #1847. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1847

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786772742&installation_id=129708444&pr_number=2041&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2041&signature=17a73cd708cb6fa2dbe09961826b173843a6f6bd7ca913cc411dd9ffa48a3edb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->