### PR TITLE
chore: #1782 Cross-model numeric equivalence: comparison, ordering, indexing

### DIFF
--- a/crates/reddb-rql/tests/reddb_corpus/cross_model_numeric_equivalence.slt
+++ b/crates/reddb-rql/tests/reddb_corpus/cross_model_numeric_equivalence.slt
@@ -1,0 +1,83 @@
+# RedDB-only conformance — cross-model numeric equivalence (issue #1782).
+#
+# Truth is hand-authored from the RedDB numeric contract: the same numeric
+# value written through row, KV, and document surfaces compares equal and orders
+# identically through SQL, including when indexes exist on the compared fields.
+
+statement ok
+CREATE TABLE issue1782_rows (name TEXT, n INT)
+
+statement ok
+CREATE INDEX idx_issue1782_rows_n ON issue1782_rows (n)
+
+statement ok
+INSERT INTO issue1782_rows (name, n) VALUES ('low', 9), ('same', 10), ('high', 11)
+
+statement ok
+CREATE KV issue1782_kv
+
+statement ok
+CREATE INDEX idx_issue1782_kv_value ON issue1782_kv (value)
+
+statement ok
+INSERT INTO issue1782_kv KV (key, value) VALUES ('low', 9)
+
+statement ok
+INSERT INTO issue1782_kv KV (key, value) VALUES ('same', 10)
+
+statement ok
+INSERT INTO issue1782_kv KV (key, value) VALUES ('high', 11)
+
+statement ok
+CREATE DOCUMENT issue1782_docs
+
+statement ok
+CREATE INDEX idx_issue1782_docs_n ON issue1782_docs (body.n)
+
+statement ok
+INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"low","n":9})
+
+statement ok
+INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"same","n":10})
+
+statement ok
+INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"high","n":11})
+
+query T nosort
+SELECT name FROM issue1782_rows WHERE n = 10.0
+----
+same
+
+query T nosort
+SELECT key FROM issue1782_kv WHERE value = 10.0
+----
+same
+
+query T nosort
+SELECT name FROM issue1782_docs WHERE body.n = 10.0
+----
+same
+
+query T nosort
+SELECT name FROM issue1782_rows WHERE n BETWEEN 9.5 AND 11 ORDER BY n
+----
+same
+high
+
+query T nosort
+SELECT key FROM issue1782_kv WHERE value BETWEEN 9.5 AND 11 ORDER BY value
+----
+same
+high
+
+query T nosort
+SELECT key FROM issue1782_kv WHERE value BETWEEN 10 AND 11 ORDER BY value DESC
+----
+high
+same
+
+query T nosort
+SELECT name FROM issue1782_docs WHERE body.n BETWEEN 9.5 AND 11 ORDER BY body.n
+----
+same
+high

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -55,6 +55,94 @@ pub(crate) struct RuntimeTableExecutionContext<'a> {
     pub(crate) table_alias: &'a str,
 }
 
+fn append_order_by_columns(cols: &mut Vec<String>, query: &TableQuery) -> bool {
+    if cols.is_empty() {
+        return false;
+    }
+    let mut appended = false;
+    for clause in &query.order_by {
+        if clause.expr.is_some() {
+            continue;
+        }
+        let FieldRef::TableColumn { column, .. } = &clause.field else {
+            continue;
+        };
+        if !cols.iter().any(|existing| existing == column) {
+            cols.push(column.clone());
+            appended = true;
+        }
+    }
+    appended
+}
+
+fn project_added_order_by_columns(
+    db: &RedDB,
+    records: Vec<UnifiedRecord>,
+    effective_projections: &[Projection],
+    table_name: &str,
+    table_alias: &str,
+    has_added_order_by_columns: bool,
+) -> RedDBResult<Vec<UnifiedRecord>> {
+    if !has_added_order_by_columns {
+        return Ok(records);
+    }
+    records
+        .iter()
+        .map(|record| {
+            project_runtime_record_with_db(
+                Some(db),
+                record,
+                effective_projections,
+                Some(table_name),
+                Some(table_alias),
+                false,
+                false,
+            )
+        })
+        .collect()
+}
+
+fn finish_ordered_index_records(
+    db: &RedDB,
+    query: &TableQuery,
+    effective_projections: &[Projection],
+    mut records: Vec<UnifiedRecord>,
+    table_name: &str,
+    table_alias: &str,
+    has_added_order_by_columns: bool,
+) -> RedDBResult<Vec<UnifiedRecord>> {
+    if !query.order_by.is_empty() {
+        crate::runtime::materialization_limit::guard(db, "sort", records.len())?;
+        super::super::join_filter::sort_records_by_order_by_with_db(
+            Some(db),
+            &mut records,
+            &query.order_by,
+            Some(table_name),
+            Some(table_alias),
+        );
+    }
+
+    if let Some(offset) = query.offset {
+        let offset = offset as usize;
+        if offset < records.len() {
+            records = records.into_iter().skip(offset).collect();
+        } else {
+            records.clear();
+        }
+    }
+    if let Some(limit) = query.limit {
+        records.truncate(limit as usize);
+    }
+    project_added_order_by_columns(
+        db,
+        records,
+        effective_projections,
+        table_name,
+        table_alias,
+        has_added_order_by_columns,
+    )
+}
+
 fn resolve_table_row_by_logical_id(
     db: &RedDB,
     table: &str,
@@ -591,12 +679,13 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         uses_document_projection,
     ) {
         let trace = std::env::var("REDDB_INDEX_TRACE").ok().as_deref() == Some("1");
-        let sorted_res = try_sorted_index_lookup(
-            filter,
-            &query.table,
-            idx_store,
-            query.limit.map(|l| l as usize),
-        );
+        let sorted_lookup_limit = if query.order_by.is_empty() && query.offset.is_none() {
+            query.limit.map(|l| l as usize)
+        } else {
+            None
+        };
+        let sorted_res =
+            try_sorted_index_lookup(filter, &query.table, idx_store, sorted_lookup_limit);
         if trace {
             eprintln!(
                 "sorted_index_lookup table={} filter={:?} result={:?}",
@@ -608,7 +697,8 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         if let Some(entity_ids) = sorted_res {
             // Even covered projections must fetch the candidate row so MVCC
             // can reject stale or tombstoned index IDs before materialization.
-            let explicit_cols = extract_select_column_names(&effective_projections);
+            let mut explicit_cols = extract_select_column_names(&effective_projections);
+            let has_added_order_by_columns = append_order_by_columns(&mut explicit_cols, query);
 
             // Re-apply the full filter — when the filter is a compound AND, the
             // sorted lookup used only the range predicate to narrow candidates.
@@ -657,7 +747,11 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             // path below so user-specified system fields (e.g. SELECT rid,
             // age FROM t) are not silently dropped.
             let lean = explicit_cols.is_empty(); // SELECT * → lean path
-            let limit = query.limit.map(|l| l as usize).unwrap_or(usize::MAX);
+            let limit = if query.order_by.is_empty() && query.offset.is_none() {
+                query.limit.map(|l| l as usize).unwrap_or(usize::MAX)
+            } else {
+                usize::MAX
+            };
 
             // Lean/SELECT-* path uses the borrow-based
             // `SegmentManager::for_each_id` → `runtime_table_record_lean_ref`
@@ -700,7 +794,15 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         records.push(record);
                     }
                 });
-                return Ok(records);
+                return finish_ordered_index_records(
+                    db,
+                    query,
+                    &effective_projections,
+                    records,
+                    table_name,
+                    table_alias,
+                    has_added_order_by_columns,
+                );
             }
 
             // Projection path (explicit columns): keep owned-entity flow.
@@ -731,7 +833,15 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     records.push(record);
                 }
             }
-            return Ok(records);
+            return finish_ordered_index_records(
+                db,
+                query,
+                &effective_projections,
+                records,
+                table_name,
+                table_alias,
+                has_added_order_by_columns,
+            );
         }
     }
 
@@ -1310,7 +1420,8 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             .collect();
 
         // Extract explicit column names for projection pushdown
-        let select_cols = extract_select_column_names(&effective_projections);
+        let mut select_cols = extract_select_column_names(&effective_projections);
+        let has_added_order_by_columns = append_order_by_columns(&mut select_cols, query);
 
         // Compile the filter ONCE before iterating. When the collection
         // schema is available, use compile_with_schema to pre-resolve
@@ -1590,7 +1701,14 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             records.truncate(limit as usize);
         }
 
-        return Ok(records);
+        return project_added_order_by_columns(
+            db,
+            records,
+            &effective_projections,
+            table_name,
+            table_alias,
+            has_added_order_by_columns,
+        );
     }
 
     // ── FAST PATH: Unfiltered scan — bypass planner for simple SELECT * ──

--- a/tests/grouped/docs_kv_queue/e2e_issue_1768_lossless_json_integers.rs
+++ b/tests/grouped/docs_kv_queue/e2e_issue_1768_lossless_json_integers.rs
@@ -19,6 +19,33 @@ fn select_one(rt: &RedDBRuntime, sql: &str, alias: &str) -> Value {
         .clone()
 }
 
+fn select_texts(rt: &RedDBRuntime, sql: &str, alias: &str) -> Vec<String> {
+    rt.execute_query(sql)
+        .unwrap_or_else(|err| panic!("{sql}: {err:?}"))
+        .result
+        .records
+        .iter()
+        .map(|record| match record.get(alias) {
+            Some(Value::Text(value)) => value.to_string(),
+            other => panic!("expected text field `{alias}`, got {other:?} in {record:?}"),
+        })
+        .collect()
+}
+
+fn explain_ops(rt: &RedDBRuntime, sql: &str) -> String {
+    rt.execute_query(&format!("EXPLAIN {sql}"))
+        .unwrap_or_else(|err| panic!("EXPLAIN {sql}: {err:?}"))
+        .result
+        .records
+        .iter()
+        .filter_map(|record| match record.get("op") {
+            Some(Value::Text(value)) => Some(value.to_string()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 #[test]
 fn large_integer_round_trips_exactly_through_document_body() {
     let rt = runtime();
@@ -74,6 +101,111 @@ fn genuine_float_keeps_float_behaviour() {
         ),
         Value::Float(0.5)
     );
+}
+
+#[test]
+fn cross_model_numeric_comparison_and_index_order_are_equivalent() {
+    let rt = runtime();
+    rt.execute_query("CREATE TABLE issue1782_rows (name TEXT, n INT)")
+        .expect("CREATE TABLE");
+    rt.execute_query("CREATE INDEX idx_issue1782_rows_n ON issue1782_rows (n)")
+        .expect("CREATE row index");
+    rt.execute_query(
+        "INSERT INTO issue1782_rows (name, n) VALUES ('low', 9), ('same', 10), ('high', 11)",
+    )
+    .expect("INSERT rows");
+
+    rt.execute_query("CREATE KV issue1782_kv")
+        .expect("CREATE KV");
+    rt.execute_query("CREATE INDEX idx_issue1782_kv_value ON issue1782_kv (value)")
+        .expect("CREATE kv index");
+    rt.execute_query("INSERT INTO issue1782_kv KV (key, value) VALUES ('low', 9)")
+        .expect("INSERT low kv");
+    rt.execute_query("INSERT INTO issue1782_kv KV (key, value) VALUES ('same', 10)")
+        .expect("INSERT same kv");
+    rt.execute_query("INSERT INTO issue1782_kv KV (key, value) VALUES ('high', 11)")
+        .expect("INSERT high kv");
+
+    rt.execute_query("CREATE DOCUMENT issue1782_docs")
+        .expect("CREATE DOCUMENT");
+    rt.execute_query("CREATE INDEX idx_issue1782_docs_n ON issue1782_docs (body.n)")
+        .expect("CREATE document index");
+    rt.execute_query(r#"INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"low","n":9})"#)
+        .expect("INSERT low doc");
+    rt.execute_query(r#"INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"same","n":10})"#)
+        .expect("INSERT same doc");
+    rt.execute_query(r#"INSERT INTO issue1782_docs DOCUMENT VALUES ({"name":"high","n":11})"#)
+        .expect("INSERT high doc");
+
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT name FROM issue1782_rows WHERE n = 10.0",
+            "name",
+        ),
+        vec!["same"],
+    );
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT key FROM issue1782_kv WHERE value = 10.0",
+            "key",
+        ),
+        vec!["same"],
+    );
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT body.name AS name FROM issue1782_docs WHERE body.n = 10.0",
+            "name",
+        ),
+        vec!["same"],
+    );
+
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT name FROM issue1782_rows WHERE n BETWEEN 9.5 AND 11 ORDER BY n",
+            "name",
+        ),
+        vec!["same", "high"],
+    );
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT key FROM issue1782_kv WHERE value BETWEEN 9.5 AND 11 ORDER BY value",
+            "key",
+        ),
+        vec!["same", "high"],
+    );
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT key FROM issue1782_kv WHERE value BETWEEN 10 AND 11 ORDER BY value DESC",
+            "key",
+        ),
+        vec!["high", "same"],
+    );
+    assert_eq!(
+        select_texts(
+            &rt,
+            "SELECT body.name AS name FROM issue1782_docs WHERE body.n BETWEEN 9.5 AND 11 ORDER BY body.n",
+            "name",
+        ),
+        vec!["same", "high"],
+    );
+
+    for sql in [
+        "SELECT name FROM issue1782_rows WHERE n = 10.0",
+        "SELECT key FROM issue1782_kv WHERE value = 10.0",
+        "SELECT body.name AS name FROM issue1782_docs WHERE body.n = 10.0",
+    ] {
+        let ops = explain_ops(&rt, sql);
+        assert!(
+            ops.contains("index_seek"),
+            "numeric equality should plan through an index for `{sql}`; ops={ops}"
+        );
+    }
 }
 
 proptest! {

--- a/tests/grouped/surface_contracts/rql_reddb_conformance.rs
+++ b/tests/grouped/surface_contracts/rql_reddb_conformance.rs
@@ -49,6 +49,7 @@ use sqllogictest::{DBOutput, DefaultColumnType, Runner, DB};
 /// accepted-but-unprojected and pinned with `statement ok` (characterization).
 const KEEP: &[&str] = &[
     "op",
+    "key",
     "label",
     "name",
     "content",


### PR DESCRIPTION
Automated AFK landing for #1782. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1782

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786779113&installation_id=129708444&pr_number=2043&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2043&signature=3f4261aabaddfaf0cf0f74be5185a05f07779ea7cded120d856358d6c6fa165d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->