### PR TITLE
chore: #1969 ADR 0038 Phase 3 — in-file double-write zone, torn-page protection, shm verdict

### DIFF
--- a/.red/adr/0038-embedded-single-file-zoned-rdb.md
+++ b/.red/adr/0038-embedded-single-file-zoned-rdb.md
@@ -74,6 +74,13 @@ the extension (clean break — no dual-read window beyond one minor release).
 | 3 | Double-write/recovery state in-file | `rdb-dwb` (+ shadow), `shm` review |
 | 4 | Server-profile disk-resident entity/segment zones (dataset > RAM) | — (new capability, not a retirement) |
 
+Phase 3 amendment: embedded keeps `shm` retired/absent. The `shm` file is
+coordination state, not durable state, and the embedded single-file contract
+does not need a sibling file to recover bytes. Profiles that require
+multi-process coordination may still provision `shm` through their explicit
+tier policy, but that is outside the embedded packaging contract and is asserted
+separately from the DWB sidecar census.
+
 Ordering within phases 1–3 may be re-sequenced by an ADR amendment with one
 line of rationale; silently skipping a phase is not allowed. Phase 4 is gated
 on ADR 0073 landing first (the cache hierarchy it pages through is

--- a/.red/adr/0038-embedded-single-file-zoned-rdb.md
+++ b/.red/adr/0038-embedded-single-file-zoned-rdb.md
@@ -81,6 +81,10 @@ multi-process coordination may still provision `shm` through their explicit
 tier policy, but that is outside the embedded packaging contract and is asserted
 separately from the DWB sidecar census.
 
+Phase 3 amendment: in-file DWB zone interpretation is gated by the paged-file
+version marker introduced with phase 3. Older stores route through the offline
+migration tool rather than treating pages 3-66 as a DWB zone.
+
 Ordering within phases 1–3 may be re-sequenced by an ADR amendment with one
 line of rationale; silently skipping a phase is not allowed. Phase 4 is gated
 on ADR 0073 landing first (the cache hierarchy it pages through is

--- a/crates/reddb-file/src/file_format.rs
+++ b/crates/reddb-file/src/file_format.rs
@@ -8,8 +8,11 @@ use std::fmt;
 /// Magic bytes for database file identification: `RDDB`.
 pub const PAGE_FILE_MAGIC: [u8; 4] = [0x52, 0x44, 0x44, 0x42];
 
-/// Database file version 1.0.0.
-pub const PAGE_FILE_VERSION: u32 = 0x0001_0000;
+/// Database file version 1.0.1.
+///
+/// 1.0.1 is the positive layout marker for ADR 0038 phase 3 stores whose
+/// double-write buffer lives in the reserved in-file zone.
+pub const PAGE_FILE_VERSION: u32 = 0x0001_0001;
 
 /// Paged database page size.
 pub const PAGED_PAGE_SIZE: usize = 16_384;

--- a/crates/reddb-file/src/layout.rs
+++ b/crates/reddb-file/src/layout.rs
@@ -560,8 +560,8 @@ pub fn pager_dwb_shadow_path(data_path: &Path) -> PathBuf {
     path_with_dash_suffix(data_path, PAGER_DWB_SHADOW_SUFFIX)
 }
 
-pub fn pager_shadow_sidecar_paths(data_path: &Path) -> [PathBuf; 1] {
-    [pager_dwb_shadow_path(data_path)]
+pub fn pager_shadow_sidecar_paths(_data_path: &Path) -> [PathBuf; 0] {
+    []
 }
 
 /// Filenames the live layout contract no longer recognises.
@@ -581,6 +581,8 @@ pub mod retired {
     pub const PAGER_HEADER_EXTENSION_V0: &str = "rdb-hdr";
     /// Retired: the pager metadata sidecar, now the in-file manifest zone.
     pub const PAGER_META_EXTENSION_V0: &str = "rdb-meta";
+    /// Retired: the pager double-write sidecar, now the in-file DWB zone.
+    pub const PAGER_DWB_EXTENSION_V0: &str = "rdb-dwb";
 
     pub fn pager_header_path_v0(data_path: &Path) -> PathBuf {
         data_path.with_extension(PAGER_HEADER_EXTENSION_V0)
@@ -590,12 +592,20 @@ pub mod retired {
         data_path.with_extension(PAGER_META_EXTENSION_V0)
     }
 
+    pub fn pager_dwb_path_v0(data_path: &Path) -> PathBuf {
+        data_path.with_extension(PAGER_DWB_EXTENSION_V0)
+    }
+
     pub fn pager_header_shadow_path_v0(data_path: &Path) -> PathBuf {
         path_with_dash_suffix(data_path, "hdr")
     }
 
     pub fn pager_meta_shadow_path_v0(data_path: &Path) -> PathBuf {
         path_with_dash_suffix(data_path, "meta")
+    }
+
+    pub fn pager_dwb_shadow_path_v0(data_path: &Path) -> PathBuf {
+        path_with_dash_suffix(data_path, "dwb")
     }
 
     /// Every retired phase-1 artifact path derived from `data_path`. For a
@@ -614,6 +624,20 @@ pub mod retired {
     /// any. Drives the didactic open-time refusal and the census assertion.
     pub fn first_present_phase1_sidecar(data_path: &Path) -> Option<PathBuf> {
         phase1_sidecar_paths(data_path)
+            .into_iter()
+            .find(|path| path.exists())
+    }
+
+    /// Every retired phase-3 DWB artifact path derived from `data_path`.
+    pub fn phase3_dwb_sidecar_paths(data_path: &Path) -> [PathBuf; 2] {
+        [
+            pager_dwb_path_v0(data_path),
+            pager_dwb_shadow_path_v0(data_path),
+        ]
+    }
+
+    pub fn first_present_phase3_dwb_sidecar(data_path: &Path) -> Option<PathBuf> {
+        phase3_dwb_sidecar_paths(data_path)
             .into_iter()
             .find(|path| path.exists())
     }
@@ -1030,17 +1054,14 @@ mod tests {
     }
 
     #[test]
-    fn the_live_pager_sidecar_set_is_the_dwb_alone() {
-        // Phase 1 retired `rdb-hdr`/`rdb-meta`; the DWB (phase 3) still ships.
+    fn the_live_pager_sidecar_set_is_empty_after_phase3() {
         let path = Path::new("/var/lib/reddb/main.rdb");
-        assert_eq!(
-            pager_shadow_sidecar_paths(path),
-            [PathBuf::from("/var/lib/reddb/main.rdb-dwb")]
-        );
+        let expected: [PathBuf; 0] = [];
+        assert_eq!(pager_shadow_sidecar_paths(path), expected);
     }
 
     #[test]
-    fn retired_phase1_names_stay_reachable_only_for_migration_and_refusal() {
+    fn retired_phase1_and_phase3_names_stay_reachable_only_for_migration_and_refusal() {
         let path = Path::new("/var/lib/reddb/main.rdb");
         // For a `.rdb` data file the extension and shadow forms coincide,
         // which is why a single glob catches both on a real store.
@@ -1051,6 +1072,13 @@ mod tests {
                 PathBuf::from("/var/lib/reddb/main.rdb-meta"),
                 PathBuf::from("/var/lib/reddb/main.rdb-hdr"),
                 PathBuf::from("/var/lib/reddb/main.rdb-meta"),
+            ]
+        );
+        assert_eq!(
+            retired::phase3_dwb_sidecar_paths(path),
+            [
+                PathBuf::from("/var/lib/reddb/main.rdb-dwb"),
+                PathBuf::from("/var/lib/reddb/main.rdb-dwb"),
             ]
         );
         // A non-`.rdb` data file (the blob-cache L2 store) shows the two forms

--- a/crates/reddb-file/tests/layout_authority/storage.rs
+++ b/crates/reddb-file/tests/layout_authority/storage.rs
@@ -464,6 +464,22 @@ fn server_source_does_not_embed_owned_file_suffixes() {
 }
 
 #[test]
+fn database_open_restores_dwb_zone_before_wal_replay() {
+    let root = repo_root();
+    let database = read(root.join("crates/reddb-server/src/storage/engine/database.rs"));
+    let pager_open = database
+        .find("Pager::open(&path, pager_config)")
+        .expect("database open should construct the pager");
+    let wal_replay = database
+        .find("Checkpointer::recover(&pager, &wal_path)")
+        .expect("database open should run WAL recovery");
+    assert!(
+        pager_open < wal_replay,
+        "Pager::open restores the in-file DWB zone and must happen before WAL replay reads pages"
+    );
+}
+
+#[test]
 fn tiered_layout_matrix_lives_in_reddb_file_tests() {
     let root = repo_root();
     let file_test = read(root.join("crates/reddb-file/tests/storage_layout.rs"));

--- a/crates/reddb-server/src/storage/engine/database.rs
+++ b/crates/reddb-server/src/storage/engine/database.rs
@@ -516,13 +516,15 @@ mod tests {
         {
             let db = Database::open(&path).unwrap();
             assert!(!db.is_read_only());
-            assert_eq!(db.page_count(), 3); // Header + reserved pages
+            // Header + reserved metadata/vault pages + ADR 0038 phase-3
+            // in-file double-write zone (FIRST_ALLOCATABLE_PAGE = 67).
+            assert_eq!(db.page_count(), 67);
         }
 
         // Should be able to reopen
         {
             let db = Database::open(&path).unwrap();
-            assert_eq!(db.page_count(), 3);
+            assert_eq!(db.page_count(), 67);
         }
 
         cleanup(&path);

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -89,6 +89,8 @@ pub enum PagerError {
     DwbZoneCorrupt(PathBuf),
     /// The store still carries a retired phase-1 pager sidecar (ADR 0038 §4).
     LegacySidecarStore { sidecar: PathBuf },
+    /// The store predates the phase-3 in-file DWB layout marker (ADR 0038 §4).
+    LegacyPagedStore { path: PathBuf },
 }
 
 /// A contiguous run of database pages reserved for vector-turbo payloads.
@@ -151,6 +153,14 @@ impl std::fmt::Display for PagerError {
                  first with the offline migration tool \
                  (`reddb_server::pager_zone_migration::migrate_to_zoned`); it is reversible.",
                 sidecar.display()
+            ),
+            Self::LegacyPagedStore { path } => write!(
+                f,
+                "refusing to open a pre-phase-3 paged store: {} does not carry the layout marker \
+                 for the in-file double-write zone. Convert the store first with the offline \
+                 migration tool (`reddb_server::pager_zone_migration::migrate_to_zoned`); it is \
+                 reversible.",
+                path.display()
             ),
         }
     }
@@ -663,7 +673,7 @@ mod tests {
     }
 
     #[test]
-    fn corrupt_in_file_dwb_zone_fails_didactically() {
+    fn interrupted_dwb_staging_write_is_discarded_on_open() {
         let path = temp_db_path();
         cleanup(&path);
 
@@ -683,11 +693,21 @@ mod tests {
             .expect("write corrupt DWB magic should succeed");
         file.sync_all().expect("sync_all() should succeed");
 
-        let err = match Pager::open_default(&path) {
-            Ok(_) => panic!("corrupt DWB zone must refuse open"),
-            Err(err) => err,
-        };
-        assert!(matches!(err, PagerError::DwbZoneCorrupt(_)));
+        {
+            let pager = Pager::open_default(&path).expect("torn staging frame should be discarded");
+            pager.sync().expect("sync() should succeed");
+        }
+
+        let mut cleared = [0u8; 4];
+        let mut file = OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .expect("open() should succeed");
+        file.seek(SeekFrom::Start(dwb_zone_offset_for_test()))
+            .expect("seek() should succeed");
+        file.read_exact(&mut cleared)
+            .expect("read_exact() should succeed");
+        assert_ne!(cleared, reddb_file::DWB_MAGIC);
 
         cleanup(&path);
     }

--- a/crates/reddb-server/src/storage/engine/pager.rs
+++ b/crates/reddb-server/src/storage/engine/pager.rs
@@ -48,6 +48,12 @@ pub use reddb_file::{DatabaseHeader, PhysicalFileHeader};
 
 /// Default cache size (pages)
 const DEFAULT_CACHE_SIZE: usize = 10_000;
+const DWB_ZONE_START_PAGE: u32 = 3;
+const DWB_ZONE_PAGES: u32 = 64;
+const DWB_ZONE_BYTES: usize = DWB_ZONE_PAGES as usize * PAGE_SIZE;
+const DWB_MAX_PAGES_PER_FRAME: usize =
+    (DWB_ZONE_BYTES - reddb_file::PAGED_DWB_HEADER_SIZE) / reddb_file::PAGED_DWB_ENTRY_SIZE;
+const FIRST_ALLOCATABLE_PAGE: u32 = DWB_ZONE_START_PAGE + DWB_ZONE_PAGES;
 
 #[cfg(test)]
 static COW_ATOMIC_WRITE_TEST_OVERRIDE: AtomicU8 = AtomicU8::new(0);
@@ -79,6 +85,8 @@ pub enum PagerError {
     SuperblockZoneUnrecoverable(PathBuf),
     /// The internal manifest zone failed its checksum (ADR 0074 §2).
     ManifestZoneCorrupt(PathBuf),
+    /// The in-file double-write zone failed validation (ADR 0074 §2).
+    DwbZoneCorrupt(PathBuf),
     /// The store still carries a retired phase-1 pager sidecar (ADR 0038 §4).
     LegacySidecarStore { sidecar: PathBuf },
 }
@@ -126,10 +134,19 @@ impl std::fmt::Display for PagerError {
                  and red salvage to extract what survives (ADR 0074 §2/§4).",
                 path.display()
             ),
+            Self::DwbZoneCorrupt(path) => write!(
+                f,
+                "double-write zone of {} failed validation: page recovery cannot prove \
+                 whether the protected in-place write completed. The store will not be opened \
+                 silently; run scrub to classify the fault and red salvage to extract trusted \
+                 rows (ADR 0074 §2/§4).",
+                path.display()
+            ),
             Self::LegacySidecarStore { sidecar } => write!(
                 f,
                 "refusing to open a legacy sidecar-backed store: found {}. The superblock \
-                 pair and the internal manifest now live inside the .rdb file (ADR 0038 §2), \
+                 pair, internal manifest, and double-write recovery state now live inside the \
+                 .rdb file (ADR 0038 §2/§4), \
                  and the engine never reads the retired sidecars silently. Convert the store \
                  first with the offline migration tool \
                  (`reddb_server::pager_zone_migration::migrate_to_zoned`); it is reversible.",
@@ -205,8 +222,8 @@ pub struct Pager {
     file: Mutex<File>,
     /// Exclusive file lock (held for lifetime, released on drop)
     _lock_file: Option<File>,
-    /// Double-write buffer file.
-    dwb_file: Option<Mutex<File>>,
+    /// Whether mutable pages are protected by the in-file DWB zone.
+    dwb_enabled: bool,
     /// Page cache
     cache: PageCache,
     /// Free page list
@@ -288,6 +305,10 @@ mod tests {
         reddb_file::layout::pager_dwb_shadow_path(path)
     }
 
+    fn dwb_zone_offset_for_test() -> u64 {
+        3 * PAGE_SIZE as u64
+    }
+
     static COW_ATOMIC_WRITE_OVERRIDE_GUARD: Mutex<()> = Mutex::new(());
 
     struct CowAtomicWriteOverrideGuard {
@@ -323,8 +344,13 @@ mod tests {
                 .map(|(page_id, page)| (*page_id, page.as_bytes())),
         );
 
-        let dwb_path = dwb_path_for(path);
-        let mut file = fs::File::create(&dwb_path).expect("create() should succeed");
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .expect("open() should succeed");
+        file.seek(SeekFrom::Start(dwb_zone_offset_for_test()))
+            .expect("seek() should succeed");
         file.write_all(&buf).expect("write_all() should succeed");
         file.sync_all().expect("sync_all() should succeed");
     }
@@ -362,8 +388,11 @@ mod tests {
 
         {
             let pager = Pager::open_default(&path).expect("open_default() should succeed");
-            assert_eq!(pager.page_count().expect("page_count() should succeed"), 3);
-            // Header + reserved pages
+            assert_eq!(
+                pager.page_count().expect("page_count() should succeed"),
+                FIRST_ALLOCATABLE_PAGE
+            );
+            // Header + reserved metadata pages + DWB zone
         }
 
         cleanup(&path);
@@ -382,7 +411,7 @@ mod tests {
             let page = pager
                 .allocate_page(PageType::BTreeLeaf)
                 .expect("allocate_page() should succeed");
-            assert_eq!(page.page_id(), 3);
+            assert_eq!(page.page_id(), FIRST_ALLOCATABLE_PAGE);
 
             pager.sync().expect("sync() should succeed");
         }
@@ -390,8 +419,11 @@ mod tests {
         // Reopen and verify
         {
             let pager = Pager::open_default(&path).expect("open_default() should succeed");
-            assert_eq!(pager.page_count().expect("page_count() should succeed"), 4);
-            // Header + reserved pages + 1 data page
+            assert_eq!(
+                pager.page_count().expect("page_count() should succeed"),
+                FIRST_ALLOCATABLE_PAGE + 1
+            );
+            // Header + reserved metadata pages + DWB zone + 1 data page
         }
 
         cleanup(&path);
@@ -579,14 +611,7 @@ mod tests {
             .expect("insert_cell() should succeed");
         write_dwb_fixture(&path, &[(page_id, recovered_page.clone())]);
 
-        let dwb_path = dwb_path_for(&path);
-        assert!(dwb_path.exists());
-        assert!(
-            fs::metadata(&dwb_path)
-                .expect("metadata() should succeed")
-                .len()
-                > 0
-        );
+        assert!(!dwb_path_for(&path).exists());
 
         {
             let pager = Pager::open(&path, config).expect("open() should succeed");
@@ -598,13 +623,7 @@ mod tests {
             assert_eq!(key, b"key");
             assert_eq!(value, b"value");
 
-            assert!(dwb_path.exists());
-            assert_eq!(
-                fs::metadata(&dwb_path)
-                    .expect("metadata() should succeed")
-                    .len(),
-                0
-            );
+            assert!(!dwb_path_for(&path).exists());
 
             let mut updated_page = recovered_page.clone();
             updated_page
@@ -615,14 +634,60 @@ mod tests {
                 .expect("write_page() should succeed");
             pager.flush().expect("flush() should succeed");
 
-            assert!(dwb_path.exists());
-            assert_eq!(
-                fs::metadata(&dwb_path)
-                    .expect("metadata() should succeed")
-                    .len(),
-                0
-            );
+            assert!(!dwb_path_for(&path).exists());
         }
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn retired_dwb_sidecar_routes_through_offline_migration() {
+        let path = temp_db_path();
+        cleanup(&path);
+
+        {
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            pager.sync().expect("sync() should succeed");
+        }
+
+        let dwb = dwb_path_for(&path);
+        fs::write(&dwb, b"legacy dwb sidecar").expect("write legacy sidecar");
+
+        let err = match Pager::open_default(&path) {
+            Ok(_) => panic!("retired DWB sidecar must refuse open"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, PagerError::LegacySidecarStore { .. }));
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn corrupt_in_file_dwb_zone_fails_didactically() {
+        let path = temp_db_path();
+        cleanup(&path);
+
+        {
+            let pager = Pager::open_default(&path).expect("open_default() should succeed");
+            pager.sync().expect("sync() should succeed");
+        }
+
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .expect("open() should succeed");
+        file.seek(SeekFrom::Start(dwb_zone_offset_for_test()))
+            .expect("seek() should succeed");
+        file.write_all(b"RDDW")
+            .expect("write corrupt DWB magic should succeed");
+        file.sync_all().expect("sync_all() should succeed");
+
+        let err = match Pager::open_default(&path) {
+            Ok(_) => panic!("corrupt DWB zone must refuse open"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, PagerError::DwbZoneCorrupt(_)));
 
         cleanup(&path);
     }
@@ -704,8 +769,8 @@ mod tests {
         }
 
         assert!(
-            dwb_path_for(&path).exists(),
-            "DWB must stay enabled when double_write=false is not proven safe"
+            !dwb_path_for(&path).exists(),
+            "DWB must stay enabled in-file when double_write=false is not proven safe"
         );
 
         cleanup(&path);
@@ -741,7 +806,7 @@ mod tests {
     }
 
     #[test]
-    fn double_write_false_on_cow_replays_then_removes_existing_dwb() {
+    fn double_write_false_on_cow_recovers_from_in_file_dwb_zone() {
         let _override = cow_atomic_write_override(true);
         let path = temp_db_path();
         cleanup(&path);
@@ -776,10 +841,7 @@ mod tests {
             assert_eq!(value, b"value");
         }
 
-        assert!(
-            !dwb_path_for(&path).exists(),
-            "CoW DWB-skip must replay any existing DWB before removing the sidecar"
-        );
+        assert!(!dwb_path_for(&path).exists());
 
         cleanup(&path);
     }
@@ -911,12 +973,7 @@ mod tests {
             assert_eq!(value, b"after");
         }
 
-        assert_eq!(
-            fs::metadata(dwb_path_for(&path))
-                .expect("metadata() should succeed")
-                .len(),
-            0
-        );
+        assert!(!dwb_path_for(&path).exists());
         cleanup(&path);
     }
 

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -227,18 +227,23 @@ impl Pager {
             }
         };
 
-        // Open double-write buffer file.
-        //
-        // gh-478: when `fold_dwb_into_wal` is enabled the DWB sidecar is
-        // suppressed — torn pages are healed by replaying FullPageImage WAL
-        // records during recovery. Any pre-existing `-dwb` is removed so a
-        // flipped flag cannot leave a stale sidecar on disk.
+        // ADR 0038 phase 3: the DWB sidecar is retired. When DWB is active,
+        // the recovery frame is written to a reserved zone inside the data
+        // file and fsynced before in-place page writes. A pre-existing sidecar
+        // marks a legacy store that must go through the offline migration tool.
         //
         // gh-895: an explicit `double_write = false` request is honored only
         // when the already-open data file is proven to live on a filesystem
         // with atomic CoW page writes. Unknown and non-CoW filesystems fail
-        // closed by keeping the DWB sidecar.
+        // closed by keeping the in-file DWB zone enabled.
         let fold_dwb = crate::physical::fold_dwb_into_wal_enabled();
+        if exists {
+            if let Some(sidecar) =
+                reddb_file::layout::retired::first_present_phase3_dwb_sidecar(&path)
+            {
+                return Err(PagerError::LegacySidecarStore { sidecar });
+            }
+        }
         if !config.double_write && !config.read_only && !fold_dwb {
             let skip_dwb_on_cow =
                 Self::cow_filesystem_has_atomic_page_writes(&path, &file).is_some();
@@ -246,27 +251,18 @@ impl Pager {
                 tracing::warn!(
                     path = %path.display(),
                     "double_write=false requested, but the data file is not proven to be on \
-                     ZFS or btrfs datacow; keeping the double-write buffer enabled"
+                     ZFS or btrfs datacow; keeping the in-file double-write buffer enabled"
                 );
                 config.double_write = true;
             }
         }
-
-        let dwb_file = if config.double_write && !config.read_only && !fold_dwb {
-            let f = Self::open_dwb_file(&path)?;
-            Some(Mutex::new(f))
-        } else {
-            if fold_dwb && !config.read_only {
-                let _ = std::fs::remove_file(Self::dwb_path(&path));
-            }
-            None
-        };
+        let dwb_enabled = config.double_write && !config.read_only && !fold_dwb;
 
         let mut pager = Self {
             path,
             file: Mutex::new(file),
             _lock_file: lock_file,
-            dwb_file,
+            dwb_enabled,
             cache: PageCache::new(config.cache_size),
             freelist: RwLock::new(FreeList::new()),
             header: RwLock::new(DatabaseHeader::default()),
@@ -277,11 +273,9 @@ impl Pager {
         };
 
         if exists {
-            // Recover from double-write buffer if needed
+            // Recover from the in-file double-write zone before loading the
+            // header or allowing WAL replay to read pages.
             pager.recover_from_dwb()?;
-            if !pager.config.double_write && !pager.config.read_only {
-                let _ = std::fs::remove_file(Self::dwb_path(&pager.path));
-            }
             // Load existing database (with header shadow fallback)
             pager.load_header()?;
             pager.bind_encryption_for_existing()?;
@@ -421,10 +415,10 @@ impl Pager {
             return Err(PagerError::ReadOnly);
         }
 
-        // Create header page. Page ids 1 and 2 are reserved so fixed
-        // metadata/vault pages cannot be handed out to normal B-tree
-        // allocation before those subsystems are initialized.
-        let initial_page_count = 3;
+        // Create header page. Page ids 1 and 2 are reserved for fixed
+        // metadata/vault pages. ADR 0038 phase 3 reserves the following DWB
+        // zone in-file so normal B-tree allocation starts after it.
+        let initial_page_count = FIRST_ALLOCATABLE_PAGE;
         let header_page = Page::new_header_page(initial_page_count);
         self.header_write()?.page_count = initial_page_count;
 
@@ -439,6 +433,7 @@ impl Pager {
         let mut vault_page = Page::new(PageType::Vault, 2);
         vault_page.update_checksum();
         self.write_page_raw(2, &vault_page)?;
+        self.clear_dwb_zone()?;
 
         // Publish both superblock copies so the ping-pong invariant — one
         // valid copy always survives a crash — holds from the very first
@@ -1113,25 +1108,55 @@ impl Pager {
         reddb_file::layout::pager_dwb_shadow_path(db_path)
     }
 
-    /// Open the double-write buffer file without truncating existing content.
-    ///
-    /// The file is intentionally preserved across restarts so recovery can
-    /// consume any crash-leftover pages before the next write cycle clears it.
-    fn open_dwb_file(db_path: &Path) -> Result<File, PagerError> {
-        Ok(OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(Self::dwb_path(db_path))?)
+    fn dwb_zone_offset() -> u64 {
+        DWB_ZONE_START_PAGE as u64 * PAGE_SIZE as u64
     }
 
-    /// Clear the DWB in place while preserving the file path and handle.
-    fn clear_dwb_file(file: &mut File) -> Result<(), PagerError> {
-        file.set_len(0)?;
-        file.seek(SeekFrom::Start(0))?;
+    fn write_dwb_zone_frame(&self, buf: &[u8]) -> Result<(), PagerError> {
+        if buf.len() > DWB_ZONE_BYTES {
+            return Err(PagerError::InvalidDatabase(
+                "DWB frame exceeds the reserved in-file zone".to_string(),
+            ));
+        }
+        let mut file = self.file_lock()?;
+        file.seek(SeekFrom::Start(Self::dwb_zone_offset()))?;
+        file.write_all(buf)?;
         file.sync_all()?;
         Ok(())
+    }
+
+    /// Clear the in-file DWB zone with valid reserved pages.
+    fn clear_dwb_zone(&self) -> Result<(), PagerError> {
+        let mut file = self.file_lock()?;
+        for page_id in DWB_ZONE_START_PAGE..FIRST_ALLOCATABLE_PAGE {
+            let mut page = Page::new(PageType::Header, page_id);
+            page.update_checksum();
+            file.seek(SeekFrom::Start(page_id as u64 * PAGE_SIZE as u64))?;
+            file.write_all(page.as_bytes())?;
+        }
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn dwb_zone_is_clear(buf: &[u8]) -> bool {
+        if buf.len() != DWB_ZONE_BYTES {
+            return false;
+        }
+        for (idx, chunk) in buf.chunks_exact(PAGE_SIZE).enumerate() {
+            let Ok(page) = Page::from_slice(chunk) else {
+                return false;
+            };
+            if page.verify_checksum().is_err() {
+                return false;
+            }
+            if page.page_id() != DWB_ZONE_START_PAGE + idx as u32 {
+                return false;
+            }
+            if page.page_type().ok() != Some(PageType::Header) {
+                return false;
+            }
+        }
+        true
     }
 
     /// Read the internal manifest page (page 1), the zone the superblock roots.
@@ -1145,33 +1170,34 @@ impl Pager {
 
     /// Write pages through the double-write buffer for torn page protection.
     ///
-    /// 1. Write all pages to the DWB file with a header (magic + count + checksum)
-    /// 2. fsync the DWB
+    /// 1. Write pages to the in-file DWB zone with a header (magic + count + checksum)
+    /// 2. fsync the DWB zone
     /// 3. Write all pages to their final locations in the .rdb file
-    /// 4. Truncate the DWB (marks as consumed)
+    /// 4. Clear the DWB zone (marks as consumed)
     fn write_pages_through_dwb(&self, pages: &[(u32, Page)]) -> Result<(), PagerError> {
-        if let Some(dwb_mutex) = &self.dwb_file {
-            let mut dwb = dwb_mutex.lock().map_err(|_| PagerError::LockPoisoned)?;
+        if self.dwb_enabled {
+            for chunk in pages.chunks(DWB_MAX_PAGES_PER_FRAME.max(1)) {
+                let buf = reddb_file::encode_paged_dwb_frame(
+                    chunk
+                        .iter()
+                        .map(|(page_id, page)| (*page_id, page.as_bytes())),
+                );
 
-            let buf = reddb_file::encode_paged_dwb_frame(
-                pages
-                    .iter()
-                    .map(|(page_id, page)| (*page_id, page.as_bytes())),
-            );
+                // Write DWB zone and fsync
+                self.write_dwb_zone_frame(&buf)?;
 
-            // Write DWB and fsync
-            dwb.seek(SeekFrom::Start(0))?;
-            dwb.write_all(&buf)?;
-            dwb.set_len(buf.len() as u64)?;
-            dwb.sync_all()?;
+                // Now write pages to their final locations
+                for (page_id, page) in chunk {
+                    self.write_page_raw(*page_id, page)?;
+                }
+                {
+                    let file = self.file_lock()?;
+                    file.sync_all()?;
+                }
 
-            // Now write pages to their final locations
-            for (page_id, page) in pages {
-                self.write_page_raw(*page_id, page)?;
+                // Reset the zone to its inactive page images.
+                self.clear_dwb_zone()?;
             }
-
-            // Truncate DWB to mark as consumed
-            Self::clear_dwb_file(&mut dwb)?;
 
             Ok(())
         } else {
@@ -1185,32 +1211,34 @@ impl Pager {
 
     /// Recover from double-write buffer after a crash.
     ///
-    /// If the DWB file contains valid pages, they were written before the crash
-    /// interrupted writing to the main file. Re-apply them.
+    /// If the DWB zone contains valid pages, they were written before the crash
+    /// interrupted writing to their home locations. Re-apply them.
     fn recover_from_dwb(&self) -> Result<(), PagerError> {
-        let dwb_path = Self::dwb_path(&self.path);
-        if !dwb_path.exists() {
+        let len = {
+            let file = self.file_lock()?;
+            file.metadata()?.len()
+        };
+        let zone_end = Self::dwb_zone_offset() + DWB_ZONE_BYTES as u64;
+        if len < zone_end {
             return Ok(());
         }
 
-        if let Some(dwb_mutex) = &self.dwb_file {
-            let mut file = dwb_mutex.lock().map_err(|_| PagerError::LockPoisoned)?;
-            return self.recover_from_dwb_file(&mut file);
+        let mut buf = vec![0u8; DWB_ZONE_BYTES];
+        {
+            let mut file = self.file_lock()?;
+            file.seek(SeekFrom::Start(Self::dwb_zone_offset()))?;
+            file.read_exact(&mut buf)?;
         }
-
-        let mut file = OpenOptions::new().read(true).write(true).open(&dwb_path)?;
-        self.recover_from_dwb_file(&mut file)
-    }
-
-    fn recover_from_dwb_file(&self, file: &mut File) -> Result<(), PagerError> {
-        file.seek(SeekFrom::Start(0))?;
-        let len = file.metadata()?.len();
-        let mut buf = vec![0u8; len as usize];
-        file.read_exact(&mut buf)?;
+        if buf.get(0..4) != Some(reddb_file::DWB_MAGIC.as_slice()) {
+            if Self::dwb_zone_is_clear(&buf) {
+                return Ok(());
+            }
+            return Err(PagerError::DwbZoneCorrupt(self.path.clone()));
+        }
 
         let entries = match reddb_file::decode_paged_dwb_frame(&buf) {
             Ok(entries) => entries,
-            Err(_) => return Self::clear_dwb_file(file),
+            Err(_) => return Err(PagerError::DwbZoneCorrupt(self.path.clone())),
         };
 
         // DWB is valid — re-apply pages to main file
@@ -1225,7 +1253,7 @@ impl Pager {
             file.sync_all()?;
         }
 
-        Self::clear_dwb_file(file)
+        self.clear_dwb_zone()
     }
 
     /// Write header and sync to disk (public for checkpointer).

--- a/crates/reddb-server/src/storage/engine/pager/impl.rs
+++ b/crates/reddb-server/src/storage/engine/pager/impl.rs
@@ -7,6 +7,7 @@ pub(super) const FS_NOCOW_FL: u64 = 0x0080_0000;
 /// The superblock zone occupies the head of page 0 (ADR 0038 §2 phase 1).
 pub(super) const SUPERBLOCK_SLOT_SIZE: usize = reddb_file::PAGED_SUPERBLOCK_SLOT_SIZE;
 pub(super) const SUPERBLOCK_ZONE_SIZE: usize = reddb_file::PAGED_SUPERBLOCK_ZONE_SIZE;
+pub(super) const PHASE3_DWB_ZONE_FILE_VERSION: u32 = reddb_file::PAGE_FILE_VERSION;
 
 /// The newest valid superblock copy together with its slot image.
 type NewestSuperblock = (
@@ -275,6 +276,7 @@ impl Pager {
         if exists {
             // Recover from the in-file double-write zone before loading the
             // header or allowing WAL replay to read pages.
+            pager.ensure_phase3_dwb_zone_layout()?;
             pager.recover_from_dwb()?;
             // Load existing database (with header shadow fallback)
             pager.load_header()?;
@@ -504,6 +506,18 @@ impl Pager {
         let mut image = [0u8; SUPERBLOCK_SLOT_SIZE];
         image.copy_from_slice(&zone[start..start + SUPERBLOCK_SLOT_SIZE]);
         Ok((selection, image))
+    }
+
+    fn ensure_phase3_dwb_zone_layout(&self) -> Result<(), PagerError> {
+        let (_, image) = self.newest_superblock()?;
+        let header = reddb_file::decode_database_header(&image)
+            .map_err(|err| PagerError::InvalidDatabase(err.to_string()))?;
+        if header.version < PHASE3_DWB_ZONE_FILE_VERSION {
+            return Err(PagerError::LegacyPagedStore {
+                path: self.path.clone(),
+            });
+        }
+        Ok(())
     }
 
     /// Seal `slot` for `copy_index`/`generation` and write exactly that slot,
@@ -1233,12 +1247,16 @@ impl Pager {
             if Self::dwb_zone_is_clear(&buf) {
                 return Ok(());
             }
-            return Err(PagerError::DwbZoneCorrupt(self.path.clone()));
+            self.clear_dwb_zone()?;
+            return Ok(());
         }
 
         let entries = match reddb_file::decode_paged_dwb_frame(&buf) {
             Ok(entries) => entries,
-            Err(_) => return Err(PagerError::DwbZoneCorrupt(self.path.clone())),
+            Err(_) => {
+                self.clear_dwb_zone()?;
+                return Ok(());
+            }
         };
 
         // DWB is valid — re-apply pages to main file
@@ -1328,6 +1346,23 @@ mod tests {
         .expect("operation should succeed");
         file.write_all(bytes).expect("write_all() should succeed");
         file.sync_all().expect("sync_all() should succeed");
+    }
+
+    fn stamp_pre_phase3_layout(path: &Path, page_count: u32) {
+        let zone = read_zone(path);
+        for copy_index in 0..reddb_file::PAGED_SUPERBLOCK_SLOT_COUNT {
+            let start = copy_index * SUPERBLOCK_SLOT_SIZE;
+            let mut slot = zone[start..start + SUPERBLOCK_SLOT_SIZE].to_vec();
+            let generation = reddb_file::paged_superblock_slot_generation(&slot, copy_index)
+                .expect("fresh store should publish both slots");
+            reddb_file::set_database_header_version(&mut slot, PHASE3_DWB_ZONE_FILE_VERSION - 1)
+                .expect("set_database_header_version() should succeed");
+            reddb_file::set_database_header_page_count(&mut slot, page_count)
+                .expect("set_database_header_page_count() should succeed");
+            reddb_file::seal_paged_superblock_slot(&mut slot, copy_index, generation)
+                .expect("seal_paged_superblock_slot() should succeed");
+            poke_slot(path, copy_index, &slot);
+        }
     }
 
     #[test]
@@ -1502,6 +1537,48 @@ mod tests {
         assert!(rendered.contains("migration tool"), "{rendered}");
 
         let _ = std::fs::remove_file(&sidecar);
+        cleanup(&path);
+    }
+
+    #[test]
+    fn pre_phase3_large_store_without_sidecar_routes_to_migration() {
+        let path = temp_db_path("pre-phase3-large");
+        {
+            let _ = Pager::open_default(&path).expect("open_default() should succeed");
+        }
+        stamp_pre_phase3_layout(&path, FIRST_ALLOCATABLE_PAGE);
+
+        let err = match Pager::open_default(&path) {
+            Ok(_) => panic!("pre-phase-3 stores need migration first"),
+            Err(err) => err,
+        };
+        let rendered = err.to_string();
+        assert!(matches!(err, PagerError::LegacyPagedStore { .. }));
+        assert!(rendered.contains("migration tool"), "{rendered}");
+
+        cleanup(&path);
+    }
+
+    #[test]
+    fn pre_phase3_small_store_without_sidecar_routes_to_migration() {
+        let path = temp_db_path("pre-phase3-small");
+        {
+            let _ = Pager::open_default(&path).expect("open_default() should succeed");
+        }
+        stamp_pre_phase3_layout(&path, 3);
+        OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("open() should succeed")
+            .set_len(3 * PAGE_SIZE as u64)
+            .expect("set_len() should succeed");
+
+        let err = match Pager::open_default(&path) {
+            Ok(_) => panic!("pre-phase-3 stores need migration first"),
+            Err(err) => err,
+        };
+        assert!(matches!(err, PagerError::LegacyPagedStore { .. }));
+
         cleanup(&path);
     }
 

--- a/tests/grouped/ai_search/support.rs
+++ b/tests/grouped/ai_search/support.rs
@@ -3,7 +3,7 @@ use std::sync::{Mutex, OnceLock};
 #[path = "../../support/mod.rs"]
 mod root_support;
 
-pub(crate) use root_support::{persistent_test_runtime, PersistentRuntime};
+pub(crate) use root_support::{persistent_test_runtime, temp_db_file, PersistentRuntime};
 
 pub(crate) fn env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();

--- a/tests/grouped/runtime_persistence/e2e_fold_dwb_into_wal_policy.rs
+++ b/tests/grouped/runtime_persistence/e2e_fold_dwb_into_wal_policy.rs
@@ -1,15 +1,12 @@
-//! Issue gh-478: fold DWB into WAL via FullPageImage (FPI) records.
+//! ADR 0038 phase 3: DWB state no longer uses a sidecar.
 //!
 //! Acceptance for this slice:
-//!  - flag `fold_dwb_into_wal` controls behaviour;
-//!  - OFF (default): legacy `-dwb` sidecar created next to the datafile;
-//!  - ON: `-dwb` sidecar is not opened, and any pre-existing `-dwb`
-//!    file is removed at open time;
+//!  - OFF (default): double-write protection writes its recovery frame inside
+//!    the `.rdb` file;
+//!  - ON: WAL FullPageImage records remain a valid higher-tier recovery path;
+//!  - neither path creates a `-dwb` sidecar on fresh stores;
 //!  - WAL `FullPageImage` records round-trip through encode/decode and
 //!    are recoverable via `WalReader::collect_full_page_images`.
-//!
-//! Tier auto-enable + checkpoint-cycle FPI emission are deferred (see
-//! issue notes).
 
 #[allow(dead_code)]
 #[path = "../../support/mod.rs"]
@@ -40,7 +37,7 @@ fn open_persistent(path: &Path) -> RedDBRuntime {
     for _ in 0..20 {
         let options = RedDBOptions::persistent(path)
             .with_storage_profile(StorageDeployPreset::PrimaryReplicaProductionHa.selection())
-            .expect("production HA profile should expose DWB sidecar behavior");
+            .expect("production HA profile should exercise DWB behavior");
         match RedDBRuntime::with_options(options) {
             Ok(rt) => return rt,
             Err(err) if err.to_string().contains("Database is locked") => {
@@ -54,7 +51,7 @@ fn open_persistent(path: &Path) -> RedDBRuntime {
 }
 
 #[test]
-fn fold_dwb_off_default_preserves_dwb_sidecar() {
+fn fold_dwb_off_default_uses_in_file_zone_without_sidecar() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
     set_fold_dwb_into_wal_enabled(false);
     std::env::remove_var("REDDB_FOLD_DWB_INTO_WAL");
@@ -74,32 +71,23 @@ fn fold_dwb_off_default_preserves_dwb_sidecar() {
 
     let dwb = dwb_path(path);
     assert!(
-        dwb.exists(),
-        "legacy -dwb sidecar must be present when fold is OFF: {dwb:?}",
+        !dwb.exists(),
+        "ADR 0038 phase 3 retires the -dwb sidecar even when DWB is active: {dwb:?}",
     );
 }
 
 #[test]
-fn fold_dwb_on_suppresses_and_removes_sidecar() {
+fn fold_dwb_on_keeps_fresh_store_sidecar_free() {
     let _g = POLICY_GUARD.lock().unwrap_or_else(|err| err.into_inner());
 
     let db = support::temp_db_file("fold_dwb_on");
     let path = db.path();
 
-    // First, create a database with the flag OFF so a -dwb sidecar lands
-    // on disk. Then flip ON and reopen: the sidecar must be cleaned up.
-    set_fold_dwb_into_wal_enabled(false);
+    set_fold_dwb_into_wal_enabled(true);
     {
         let rt = open_persistent(path);
         rt.execute_query("CREATE TABLE dwb_on_a (name TEXT)")
             .expect("ddl");
-        rt.checkpoint().expect("flush");
-    }
-    assert!(dwb_path(path).exists(), "fixture must produce -dwb");
-
-    set_fold_dwb_into_wal_enabled(true);
-    {
-        let rt = open_persistent(path);
         rt.execute_query("INSERT INTO dwb_on_a (name) VALUES ('alpha')")
             .expect("insert");
         rt.checkpoint().expect("flush");

--- a/tests/grouped/runtime_persistence/vault_capacity.rs
+++ b/tests/grouped/runtime_persistence/vault_capacity.rs
@@ -228,11 +228,12 @@ fn vault_single_user_fits_in_header_page() {
     vault.save(&pager, &state).unwrap();
 
     let pages_after = pager.page_count().unwrap();
-    // We had to bump page_count up to 3 to reserve the header slot;
-    // we don't allocate any data pages for a one-user payload, so
-    // page_count should sit at exactly 3.
+    // A fresh store reserves the metadata/vault pages plus the ADR 0038
+    // phase-3 in-file double-write zone (DWB_ZONE_START_PAGE=3 + 64 zone
+    // pages => FIRST_ALLOCATABLE_PAGE=67). A one-user payload allocates no
+    // data pages, so page_count sits at exactly that reserved boundary.
     assert_eq!(
-        pages_after, 3,
+        pages_after, 67,
         "one-user vault should not allocate any data pages; got page_count={pages_after}"
     );
 

--- a/tests/grouped/surface_contracts/smoke_embedded.rs
+++ b/tests/grouped/surface_contracts/smoke_embedded.rs
@@ -8,12 +8,22 @@ use reddb::application::{
 };
 use reddb::json::Value as JsonValue;
 use reddb::storage::schema::Value;
-use reddb::{ArtifactState, EntityUseCases, NativeUseCases, QueryUseCases};
+use reddb::{
+    shm_path_for, ArtifactState, EntityUseCases, NativeUseCases, QueryUseCases, RedDBOptions,
+    RedDBRuntime, StorageDeployPreset,
+};
+use std::fs;
 
 use super::support::PersistentRuntime;
 
 fn rt() -> PersistentRuntime {
     super::support::persistent_test_runtime("surface-smoke-embedded")
+}
+
+fn embedded_options(path: &std::path::Path) -> RedDBOptions {
+    RedDBOptions::persistent(path)
+        .with_storage_profile(StorageDeployPreset::Embedded.selection())
+        .expect("embedded profile should validate")
 }
 
 // ---------------------------------------------------------------------------
@@ -37,6 +47,59 @@ fn smoke_catalog_snapshot() {
     let rt = rt();
     let native = NativeUseCases::new(rt.runtime());
     let _report = native.health();
+}
+
+#[test]
+fn embedded_phase3_census_has_no_dwb_sidecars_and_no_shm() {
+    let db = super::support::temp_db_file("embedded-phase3-census");
+    let path = db.path();
+
+    {
+        let rt = RedDBRuntime::with_options(embedded_options(path)).expect("runtime opens");
+        rt.execute_query("CREATE TABLE phase3_rows (id INT, label TEXT)")
+            .expect("ddl");
+        for i in 0..96 {
+            rt.execute_query(&format!(
+                "INSERT INTO phase3_rows (id, label) VALUES ({i}, 'row-{i}')"
+            ))
+            .expect("page-heavy insert");
+        }
+        rt.checkpoint().expect("checkpoint");
+    }
+    {
+        let rt = RedDBRuntime::with_options(embedded_options(path)).expect("runtime reopens");
+        let rows = rt
+            .execute_query("SELECT id FROM phase3_rows")
+            .expect("select after reopen");
+        assert_eq!(rows.result.records.len(), 96);
+        rt.checkpoint().expect("second checkpoint");
+    }
+
+    let parent = path.parent().expect("db has parent");
+    let names: Vec<_> = fs::read_dir(parent)
+        .expect("read temp dir")
+        .map(|entry| {
+            entry
+                .expect("dir entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect();
+    assert!(
+        names
+            .iter()
+            .all(|name| !name.ends_with("-dwb") && !name.ends_with(".rdb-dwb")),
+        "fresh embedded lifecycle must not create retired DWB sidecars: {names:?}"
+    );
+    assert!(
+        !shm_path_for(path).exists(),
+        "ADR 0038 phase 3 verdict: embedded keeps shm retired/absent"
+    );
+    assert!(
+        names.iter().any(|name| name == "data.rdb"),
+        "data file should be present: {names:?}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1969.

ADR 0038 Phase 3: retires the `-dwb` sidecar for a reserved in-file double-write zone, fsynced before in-place page writes.

## Human review note (sensitive-path)
Reviewed the protected diff (`.red/adr/0038-*.md`, pager). Two data-safety fixes from prior review are confirmed sound:
- **Torn/undecodable DWB frame -> clear zone + `Ok(())`** (not corruption error): the frame is fsync'd before home writes, so a torn frame means either crash-before-durable (home intact) or crash-during-clear (home already durable).
- **Legacy pre-phase-3 stores routed to migration** via a positive version gate (`ensure_phase3_dwb_zone_layout`, `header.version < PHASE3_DWB_ZONE_FILE_VERSION`) plus the sidecar check.

Two new tests cover large + small pre-phase-3 stores routing to the migration tool.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786803449&installation_id=129708444&pr_number=2044&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2044&signature=805cdf83df0823e05bc1d5f75217988bd98a03889c2739a209d47aa9af96eadd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->