### PR TITLE
chore: #1852 Catalog-version and topology hints disseminated via the signal plane

### DIFF
--- a/crates/reddb-server/src/cluster/topology.rs
+++ b/crates/reddb-server/src/cluster/topology.rs
@@ -44,6 +44,7 @@ use super::ownership::{
 };
 use super::routing::RoutingHint;
 use super::slot::hash_shard_key_to_range_key;
+use crate::replication::{ReceivedSignal, SignalPlaneMessage};
 
 /// What authority a topology/serving-graph projection carries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -497,6 +498,29 @@ impl ClientTopology {
                 HintOutcome::UnknownRange
             }
         }
+    }
+
+    /// Consume signal-plane messages and refresh through the normal authoritative
+    /// topology path when a peer reports a newer ownership-catalog version.
+    ///
+    /// The signal is only a trigger: it does not mutate cached ownership itself.
+    /// Stale, duplicate, missing, or non-catalog signals are ignored, and the
+    /// snapshot returned by `refresh` is still applied through the same monotonic
+    /// [`apply_refresh`](Self::apply_refresh) guard as an ordinary poll.
+    pub fn refresh_on_newer_catalog_signal(
+        &mut self,
+        signals: impl IntoIterator<Item = ReceivedSignal>,
+        mut refresh: impl FnMut() -> TopologySnapshot,
+    ) -> Option<RefreshOutcome> {
+        for signal in signals {
+            let SignalPlaneMessage::CatalogVersionHint(hint) = signal.message else {
+                continue;
+            };
+            if hint.ownership_catalog_version > self.version.value() {
+                return Some(self.apply_refresh(refresh()));
+            }
+        }
+        None
     }
 }
 

--- a/tests/grouped/replication/e2e_issue_1836_ownership_admission.rs
+++ b/tests/grouped/replication/e2e_issue_1836_ownership_admission.rs
@@ -1,8 +1,18 @@
 //! Issue #1836 — durable writes pass through the ownership admission gate.
 //! Issue #1847 — planned cooperative handoff promotes a caught-up hot mirror.
+//! Issue #1852 — catalog-version hints accelerate topology refresh.
 
+use std::collections::BTreeMap;
 use std::time::{Duration, Instant};
 
+use reddb::cluster::{
+    ClientTopology, CollectionId, HintOutcome, NodeIdentity, PlacementMetadata, RangeId,
+    RangeOwnership, RefreshOutcome, RequestOperation, RouteDecision, RoutedRequest, RoutingPolicy,
+    ShardKeyMode, ShardOwnershipCatalog, TopologySnapshot,
+};
+use reddb::replication::{
+    CatalogVersionHint, SignalPlane, SignalPlaneMessage, SimulatedSignalPlane,
+};
 use reddb::storage::schema::Value;
 use reddb::{RedDBOptions, RedDBRuntime, ReplicationConfig};
 
@@ -139,4 +149,169 @@ fn cooperative_handoff_promotes_without_lease_expiry_and_fences_old_owner() {
         .collect::<Vec<_>>();
     ids.sort_unstable();
     assert_eq!(ids, vec![1, 2], "acked writes must survive once each");
+}
+
+#[test]
+fn signal_plane_catalog_hint_refreshes_routing_after_ownership_transition() {
+    let orders = collection("signal_hint_orders");
+    let mut catalog = catalog_with([full_range(&orders, 1, "CN=node-a", &["CN=node-b"])]);
+    let initial = catalog.topology_snapshot();
+
+    let member_names = ["node-a", "node-b", "node-c"];
+    let mut clients = member_names
+        .into_iter()
+        .map(|member| {
+            (
+                member_id(member),
+                ClientTopology::from_snapshot(initial.clone()),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut refreshes = member_names
+        .into_iter()
+        .map(|member| (member_id(member), 0usize))
+        .collect::<BTreeMap<_, _>>();
+
+    let range = catalog.range(&orders, RangeId::new(1)).unwrap().clone();
+    catalog
+        .apply_update(range.transfer_to(ident("CN=node-b"), [ident("CN=node-a")]))
+        .unwrap();
+    let fresh = catalog.topology_snapshot();
+    assert!(fresh.version() > initial.version());
+
+    for client in clients.values() {
+        assert_eq!(client.resolve(&orders, b"k").unwrap(), &ident("CN=node-a"));
+    }
+
+    let supervisor = member_id("supervisor");
+    let mut plane = SimulatedSignalPlane::new(vec![
+        supervisor.clone(),
+        member_id("node-a"),
+        member_id("node-b"),
+        member_id("node-c"),
+    ]);
+
+    plane.publish(
+        supervisor.clone(),
+        catalog_hint("supervisor", initial.version().value()),
+    );
+    for _ in 0..2 {
+        plane.advance_round();
+        drain_signal_refreshes(&mut clients, &mut refreshes, &mut plane, &fresh);
+    }
+    assert!(
+        refreshes.values().all(|count| *count == 0),
+        "stale catalog-version hints must not trigger refresh"
+    );
+
+    let mut stale_route_client = clients.get("node-a").unwrap().clone();
+    let request = RoutedRequest::new(orders.clone(), b"k".to_vec(), RequestOperation::Transaction);
+    let hint = match catalog.plan_route(&ident("CN=node-a"), &request, &RoutingPolicy::forwarding())
+    {
+        RouteDecision::Redirect { hint, .. } => hint,
+        other => panic!("expected stale-ownership redirect, got {other:?}"),
+    };
+    assert_eq!(stale_route_client.apply_hint(&hint), HintOutcome::Corrected);
+    assert_eq!(
+        stale_route_client.resolve(&orders, b"k").unwrap(),
+        &ident("CN=node-b")
+    );
+    assert!(stale_route_client.needs_refresh());
+
+    plane.publish(
+        supervisor,
+        catalog_hint("supervisor", fresh.version().value()),
+    );
+    for _ in 0..6 {
+        plane.advance_round();
+        drain_signal_refreshes(&mut clients, &mut refreshes, &mut plane, &fresh);
+        if clients
+            .values()
+            .all(|client| client.resolve(&orders, b"k") == Some(&ident("CN=node-b")))
+        {
+            break;
+        }
+    }
+
+    for (member, client) in &clients {
+        assert_eq!(
+            client.resolve(&orders, b"k").unwrap(),
+            &ident("CN=node-b"),
+            "{member} did not converge from signal-plane hint"
+        );
+        assert!(!client.needs_refresh(), "{member} should be authoritative");
+    }
+    assert_eq!(
+        refreshes.values().copied().collect::<Vec<_>>(),
+        vec![1, 1, 1],
+        "happy path refreshes once per member after the newer hint, not periodically"
+    );
+}
+
+fn collection(name: &str) -> CollectionId {
+    CollectionId::new(name).unwrap()
+}
+
+fn ident(cn: &str) -> NodeIdentity {
+    NodeIdentity::from_certificate_subject(cn).unwrap()
+}
+
+fn member_id(id: &str) -> String {
+    id.to_string()
+}
+
+fn full_range(
+    collection: &CollectionId,
+    id: u64,
+    owner: &str,
+    replicas: &[&str],
+) -> RangeOwnership {
+    RangeOwnership::establish(
+        collection.clone(),
+        RangeId::new(id),
+        ShardKeyMode::Hash,
+        reddb::cluster::RangeBounds::full(),
+        ident(owner),
+        replicas
+            .iter()
+            .map(|replica| ident(replica))
+            .collect::<Vec<_>>(),
+        PlacementMetadata::with_replication_factor(3),
+    )
+}
+
+fn catalog_with(ranges: impl IntoIterator<Item = RangeOwnership>) -> ShardOwnershipCatalog {
+    let mut catalog = ShardOwnershipCatalog::new();
+    for range in ranges {
+        catalog.apply_update(range).unwrap();
+    }
+    catalog
+}
+
+fn catalog_hint(member: &str, version: u64) -> SignalPlaneMessage {
+    SignalPlaneMessage::CatalogVersionHint(CatalogVersionHint {
+        member: member_id(member),
+        ownership_catalog_version: version,
+        topology_generation: version,
+        placement_generation: version,
+    })
+}
+
+fn drain_signal_refreshes(
+    clients: &mut BTreeMap<String, ClientTopology>,
+    refreshes: &mut BTreeMap<String, usize>,
+    plane: &mut SimulatedSignalPlane,
+    fresh: &TopologySnapshot,
+) {
+    for (member, client) in clients {
+        let signals = plane.drain_received(member);
+        let outcome = client.refresh_on_newer_catalog_signal(signals, || {
+            *refreshes.get_mut(member).unwrap() += 1;
+            fresh.clone()
+        });
+        assert!(
+            !matches!(outcome, Some(RefreshOutcome::Ignored)),
+            "newer signal should not fetch a stale topology snapshot"
+        );
+    }
 }


### PR DESCRIPTION
Automated AFK landing for #1852. Per-attempt history lives in the issue Envelopes, the local ledgers, and the `afk-attempts/*` snapshot branches.

Closes #1852

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786936053&installation_id=129708444&pr_number=2049&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2049&signature=34024f94443b5f2fb83b5aeddbd12d3fe8d0d3d10c118d4e6fe576395bb5ddee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->