### PR TITLE
feat(wire-tls): gate self-signed auto-generation behind RED_WIRE_TLS_DEV (#2051)

### DIFF
--- a/crates/reddb-server/src/wire/tls.rs
+++ b/crates/reddb-server/src/wire/tls.rs
@@ -85,7 +85,21 @@ pub(crate) fn generate_self_signed_dev_cert(
 
 /// Generate self-signed cert and write to files in the given directory.
 /// Returns the WireTlsConfig pointing to the written files.
+///
+/// Gated by `RED_WIRE_TLS_DEV=1`; refuses to auto-generate in any other
+/// context (refuses prod by default). This mirrors the HTTP edge's
+/// `RED_HTTP_TLS_DEV` opt-in ([`crate::server::tls::auto_generate_dev_cert`])
+/// — the two edges are independent, so enabling dev certs on one does not
+/// enable them on the other.
 pub fn auto_generate_cert(dir: &Path) -> Result<WireTlsConfig, Box<dyn std::error::Error>> {
+    let dev_flag = std::env::var("RED_WIRE_TLS_DEV").unwrap_or_default();
+    if !matches!(dev_flag.as_str(), "1" | "true" | "yes" | "on") {
+        return Err(
+            "refusing to auto-generate wire TLS cert: set RED_WIRE_TLS_DEV=1 to opt into self-signed dev certs"
+                .into(),
+        );
+    }
+
     let cert_path = dir.join("wire-tls-cert.pem");
     let key_path = dir.join("wire-tls-key.pem");
 
@@ -191,5 +205,55 @@ mod tests {
         let (cns, orgs) = subject_cn_and_orgs(&cert_pem);
         assert_eq!(cns, vec!["RedDB HTTP localhost".to_string()]);
         assert!(orgs.is_empty(), "HTTP cert must not carry an Organization");
+    }
+
+    /// Tests that mutate the process-global `RED_WIRE_TLS_DEV` env var must
+    /// serialize to avoid trampling each other under cargo's default
+    /// parallel test runner (mirrors the HTTP twin's `env_lock`).
+    fn env_lock() -> &'static std::sync::Mutex<()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+    }
+
+    #[test]
+    fn auto_generate_refuses_without_dev_flag() {
+        let _g = env_lock().lock();
+        let dir = std::env::temp_dir().join(format!(
+            "reddb-wire-tls-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        // Make sure flag is unset.
+        unsafe {
+            std::env::remove_var("RED_WIRE_TLS_DEV");
+        }
+        let err = auto_generate_cert(&dir).unwrap_err();
+        assert!(err.to_string().contains("RED_WIRE_TLS_DEV"));
+    }
+
+    #[test]
+    fn auto_generate_with_dev_flag_writes_cert() {
+        let _g = env_lock().lock();
+        let dir = std::env::temp_dir().join(format!(
+            "reddb-wire-tls-dev-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        unsafe {
+            std::env::set_var("RED_WIRE_TLS_DEV", "1");
+        }
+        let cfg = auto_generate_cert(&dir).expect("should generate");
+        assert!(cfg.cert_path.exists());
+        assert!(cfg.key_path.exists());
+        unsafe {
+            std::env::remove_var("RED_WIRE_TLS_DEV");
+        }
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
@@ -61,6 +61,10 @@ fn spawn_server(args: &[&str], stderr_path: &Path) -> ServerChild {
     let stderr_file = File::create(stderr_path).expect("create stderr file");
     let child = Command::new(red_binary())
         .args(args)
+        // Opt into self-signed wire-TLS auto-generation (gated by
+        // RED_WIRE_TLS_DEV, mirroring RED_HTTP_TLS_DEV). Inert unless
+        // `--wire-tls-bind` is used without an explicit cert/key.
+        .env("RED_WIRE_TLS_DEV", "1")
         .env_remove("REDDB_USERNAME")
         .env_remove("REDDB_PASSWORD")
         .env_remove("REDDB_VAULT")
@@ -100,7 +104,9 @@ fn wait_until_serving(server: &mut ServerChild, addr: &str, timeout: Duration) -
 /// `--wire-tls-bind` with no explicit `--wire-bind` brings the
 /// RedWire-over-TLS listener online — no router collision, no
 /// "at least one server bind address must be configured" abort.
-/// The TLS cert/key are auto-generated next to the data dir.
+/// The TLS cert/key are auto-generated next to the data dir (the
+/// listener opts into self-signed dev certs via `RED_WIRE_TLS_DEV=1`,
+/// set by `spawn_server`).
 #[test]
 fn wire_tls_only_serves_without_router_collision() {
     let dir = support::temp_data_dir("issue-1588-wire-tls-only");


### PR DESCRIPTION
Closes #2051 · slice of PRD #2050.

## What
Gate the wire (RedWire) TLS self-signed auto-generation behind a dedicated `RED_WIRE_TLS_DEV` opt-in, mirroring the HTTP-TLS edge's `RED_HTTP_TLS_DEV` prod-refusal.

- `wire::tls::auto_generate_cert` now refuses (error names the flag) unless `RED_WIRE_TLS_DEV` is `1|true|yes|on`; behaves as before when set (reuse existing material, else generate + write + `0600` key).
- Dedicated flag (not shared with HTTP) so the two edges stay independent.
- Explicit `--wire-tls-cert`/`--wire-tls-key` unaffected — the gate only guards the auto-gen fallback.
- HTTP-TLS path untouched.

Clean break (repo no-backcompat policy): ungated to gated flips this release, no deprecation window.

## Tests
- Unit tests mirroring the HTTP twin: `auto_generate_refuses_without_dev_flag`, `auto_generate_with_dev_flag_writes_cert` (both green locally).
- Existing `e2e_issue_1588_wire_tls_bind` opts in via `RED_WIRE_TLS_DEV=1` set in `spawn_server` (reflects the new contract).

## Local gate (AFK backpressure)
- `cargo fmt --all -- --check` OK
- `scripts/lint-no-untyped-serialization.sh` OK (1257 files)
- `cargo clippy -p reddb-io-server --locked -- -D warnings` OK
- `cargo test -p reddb-io-server --lib wire::tls` OK (4 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786947718&installation_id=129708444&pr_number=2053&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2053&signature=00e6b31260fab7c405a0fb27a3e757f2640358de2e17cfe61906ecda6bcf82d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->