### PR TITLE
fix(wire-tls): fail closed + track readiness for explicit --wire-tls-bind (#2052)

### DIFF
--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -1779,23 +1779,54 @@ async fn spawn_wire_listeners(
         }
     }
 
-    // RedWire over TLS
+    // RedWire over TLS. A `--wire-tls-bind` is always an explicit request,
+    // so it fails closed: a TLS config/resolve error (including the gated
+    // auto-gen refusal) or a bind failure is fatal to boot — never a silent
+    // degrade to serving the other transports. Mirrors the TLS-only path
+    // (`run_wire_tls_only_server`) and the plaintext branch's explicit
+    // handling above.
     if let Some(wire_tls_addr) = config.wire_tls_bind_addr.clone() {
-        let tls_config = resolve_wire_tls_config(config);
-        match tls_config {
-            Ok(tls_cfg) => {
-                let wire_rt = Arc::new(runtime.clone());
-                tokio::spawn(async move {
-                    if let Err(e) =
-                        crate::wire::start_redwire_tls_listener(&wire_tls_addr, wire_rt, &tls_cfg)
-                            .await
-                    {
-                        tracing::error!(err = %e, "redwire+tls listener error");
-                    }
-                });
+        let tls_cfg = match resolve_wire_tls_config(config) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                tracing::error!(
+                    transport = "wire-tls",
+                    bind = %wire_tls_addr,
+                    error = %e,
+                    "fatal explicit redwire TLS config error"
+                );
+                return Err(format!("explicit redwire TLS config error: {e}"));
             }
-            Err(e) => tracing::error!(err = %e, "redwire TLS config error"),
-        }
+        };
+        // Bind up front so a contested/unbindable port fails the explicit
+        // request here instead of dying inside a fire-and-forget task.
+        let listener = match tokio::net::TcpListener::bind(&wire_tls_addr).await {
+            Ok(listener) => listener,
+            Err(err) => {
+                let reason = format!("wire-tls listener bind {wire_tls_addr}: {err}");
+                readiness.failed("wire-tls", &wire_tls_addr, true, reason.clone());
+                tracing::error!(
+                    transport = "wire-tls",
+                    bind = %wire_tls_addr,
+                    error = %err,
+                    "fatal explicit bind failure"
+                );
+                return Err(format!("explicit {reason}"));
+            }
+        };
+        readiness.active("wire-tls", &wire_tls_addr, true);
+        // The bind-first `_on` variant does not log online itself, so emit
+        // the transport-online line here (parity with the plaintext wire
+        // branch and the internally-binding `start_redwire_tls_listener`).
+        tracing::info!(transport = "redwire+tls", bind = %wire_tls_addr, "listener online");
+        let wire_rt = Arc::new(runtime.clone());
+        tokio::spawn(async move {
+            if let Err(e) =
+                crate::wire::start_redwire_tls_listener_on(listener, wire_rt, &tls_cfg).await
+            {
+                tracing::error!(err = %e, "redwire+tls listener error");
+            }
+        });
     }
     Ok(())
 }

--- a/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
+++ b/tests/grouped/cli_transport/e2e_issue_1588_wire_tls_bind.rs
@@ -58,13 +58,23 @@ impl Drop for ServerChild {
 }
 
 fn spawn_server(args: &[&str], stderr_path: &Path) -> ServerChild {
+    spawn_server_with_dev_flag(args, stderr_path, true)
+}
+
+/// Spawn `red server`, choosing whether to opt into self-signed wire-TLS
+/// auto-generation (`RED_WIRE_TLS_DEV`, mirroring `RED_HTTP_TLS_DEV`). With
+/// `dev_flag = false` the flag is explicitly cleared so a `--wire-tls-bind`
+/// without cert/key exercises the prod-refusal (fail-closed) path.
+fn spawn_server_with_dev_flag(args: &[&str], stderr_path: &Path, dev_flag: bool) -> ServerChild {
     let stderr_file = File::create(stderr_path).expect("create stderr file");
-    let child = Command::new(red_binary())
-        .args(args)
-        // Opt into self-signed wire-TLS auto-generation (gated by
-        // RED_WIRE_TLS_DEV, mirroring RED_HTTP_TLS_DEV). Inert unless
-        // `--wire-tls-bind` is used without an explicit cert/key.
-        .env("RED_WIRE_TLS_DEV", "1")
+    let mut cmd = Command::new(red_binary());
+    cmd.args(args);
+    if dev_flag {
+        cmd.env("RED_WIRE_TLS_DEV", "1");
+    } else {
+        cmd.env_remove("RED_WIRE_TLS_DEV");
+    }
+    let child = cmd
         .env_remove("REDDB_USERNAME")
         .env_remove("REDDB_PASSWORD")
         .env_remove("REDDB_VAULT")
@@ -141,6 +151,104 @@ fn wire_tls_only_serves_without_router_collision() {
     assert!(
         !stderr.contains("at least one server bind address must be configured"),
         "wire-tls-bind alone must be a valid server configuration.\nstderr:\n{stderr}"
+    );
+}
+
+/// Wait until the spawned server process exits. Returns `true` if it
+/// exited within the timeout, `false` if it was still running.
+fn wait_for_exit(server: &mut ServerChild, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Ok(Some(_status)) = server.child.try_wait() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+    false
+}
+
+/// In the combined multi-listener path (here: `--grpc-bind` +
+/// `--wire-tls-bind`), an explicit `--wire-tls-bind` with the dev opt-in
+/// brings the RedWire-over-TLS listener online alongside the other
+/// transport — the TLS listener is tracked, not fire-and-forget.
+#[test]
+fn wire_tls_bind_serves_alongside_grpc_with_dev_flag() {
+    let dir = support::temp_data_dir("issue-1588-wire-tls-grpc-up");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let grpc_addr = format!("127.0.0.1:{}", free_port());
+    let tls_addr = format!("127.0.0.1:{}", free_port());
+    let stderr_path = dir.join("server.stderr");
+
+    let mut server = spawn_server(
+        &[
+            "server",
+            "--path",
+            &db_path_str,
+            "--grpc-bind",
+            &grpc_addr,
+            "--wire-tls-bind",
+            &tls_addr,
+            "--no-auth",
+        ],
+        &stderr_path,
+    );
+
+    let serving = wait_until_serving(&mut server, &tls_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "wire-tls listener never came up on {tls_addr} in the combined path.\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("redwire+tls"),
+        "wire-tls listener must log itself online (redwire+tls).\nstderr:\n{stderr}"
+    );
+}
+
+/// The fail-closed guarantee: in the combined multi-listener path an
+/// explicit `--wire-tls-bind` with no cert/key and NO dev opt-in must be
+/// fatal to boot — never a silent degrade to serving the other transport
+/// only. Before the fix the TLS branch swallowed the config error and the
+/// server kept serving gRPC.
+#[test]
+fn wire_tls_bind_fails_closed_alongside_grpc_without_dev_flag() {
+    let dir = support::temp_data_dir("issue-1588-wire-tls-grpc-failclosed");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let grpc_addr = format!("127.0.0.1:{}", free_port());
+    let tls_addr = format!("127.0.0.1:{}", free_port());
+    let stderr_path = dir.join("server.stderr");
+
+    let mut server = spawn_server_with_dev_flag(
+        &[
+            "server",
+            "--path",
+            &db_path_str,
+            "--grpc-bind",
+            &grpc_addr,
+            "--wire-tls-bind",
+            &tls_addr,
+            "--no-auth",
+        ],
+        &stderr_path,
+        false,
+    );
+
+    let exited = wait_for_exit(&mut server, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        exited,
+        "server must fail closed (exit) when an explicit --wire-tls-bind cannot \
+         resolve TLS material; it kept running.\nstderr:\n{stderr}"
+    );
+    assert!(
+        TcpStream::connect(&grpc_addr).is_err(),
+        "server must not serve gRPC after the explicit wire-TLS bind failed closed.\nstderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("RED_WIRE_TLS_DEV") || stderr.contains("redwire TLS config"),
+        "fatal error must name the wire-TLS config failure.\nstderr:\n{stderr}"
     );
 }
 


### PR DESCRIPTION
Closes #2052 · slice of PRD #2050 (depends on #2051, merged).

## What
Make the combined multi-listener path (`spawn_wire_listeners`) fail closed for an explicit `--wire-tls-bind`, matching the TLS-only path.

Before: the wire-TLS branch spawned the listener fire-and-forget — a config/resolve error was logged and swallowed, a bind failure died inside the task — so the server kept serving other transports while the operator's explicit TLS bind silently never came up.

After (a `--wire-tls-bind` is always explicit):
- Resolve TLS material up front — fatal on error (including the gated auto-gen refusal from #2051).
- Bind synchronously — fatal on bind failure.
- Record `readiness.active`/`failed` and log the transport online.
- Spawn only the accept loop via `start_redwire_tls_listener_on`.

Boot never degrades to serving the other transports when explicit TLS can't come up. HTTP-TLS path untouched.

## Tests (extend the existing `e2e_issue_1588_wire_tls_bind` seam)
- `wire_tls_bind_serves_alongside_grpc_with_dev_flag` — combined path (`--grpc-bind` + `--wire-tls-bind`) with the opt-in brings the TLS listener online + logs it.
- `wire_tls_bind_fails_closed_alongside_grpc_without_dev_flag` — same without the opt-in exits fatally (fail-closed), never serves gRPC; error names the wire-TLS failure.

## Local gate (AFK backpressure)
- `cargo fmt --all -- --check` OK
- `scripts/lint-no-untyped-serialization.sh` OK (1257 files)
- `cargo clippy -p reddb-io-server --locked -- -D warnings` OK
- `cargo test -p reddb-io --test grouped_cli_transport wire_tls` OK (4 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786948528&installation_id=129708444&pr_number=2054&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2054&signature=b0e7c36d696ec7d3dc3d8b1a14f5d9ba431902bd6c61de8c9de0b9f8c1d71500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->