### PR TITLE
fix(geo): one recognition authority, exact-decimal coordinates, shared kRing sizing

### DIFF
--- a/crates/reddb-server/src/geo/h3.rs
+++ b/crates/reddb-server/src/geo/h3.rs
@@ -26,6 +26,22 @@ pub const MAX_RESOLUTION: i64 = 15;
 /// surfaces prune identically and stay result-identical.
 pub const MAX_POLYGON_COVER_CELLS: usize = 50_000;
 
+/// Cap on the kRing cover of a radius query. Past it the ring costs more to
+/// enumerate than a full scan, so every caller falls back to the exact scan.
+pub const MAX_COVER_RING: u32 = 128;
+
+/// The kRing radius that covers `radius_km` around a point at `res`.
+///
+/// `None` when the cover would exceed [`MAX_COVER_RING`] — the caller then
+/// takes the exact full scan. Shared by the executor and by `EXPLAIN` so the
+/// plan that `EXPLAIN` reports is the plan the executor runs; the two drifting
+/// apart would make `EXPLAIN` announce an index route that never happens.
+pub fn radius_cover_ring(radius_km: f64, res: u8) -> Option<u32> {
+    let edge_km = edge_length_km(res).max(f64::MIN_POSITIVE);
+    let k = (radius_km / edge_km).ceil() + 1.0;
+    (k.is_finite() && k <= f64::from(MAX_COVER_RING)).then_some(k as u32)
+}
+
 pub fn valid_resolution(res: i64) -> Option<u8> {
     if (MIN_RESOLUTION..=MAX_RESOLUTION).contains(&res) {
         Some(res as u8)
@@ -84,11 +100,19 @@ pub fn grid_disk(cell: u64, k: u32) -> Vec<u64> {
 
 /// Average hexagon edge length, in kilometres, for an H3 resolution.
 ///
-/// Sourced from h3o's per-resolution average-edge table. Used by the
-/// spatial query path to size the covering kRing for a radius search
-/// (`k ≈ radius_km / edge_km`): one grid step spans at least one edge
-/// length, so dividing the radius by the edge length over-estimates the
-/// ring count, which keeps the cover a safe superset (PRD #1574 slice 3).
+/// Sourced from h3o's per-resolution *average*-edge table, and used by
+/// [`radius_cover_ring`] to size the covering kRing for a radius search
+/// (`k ≈ radius_km / edge_km`).
+///
+/// Why an average is safe here: one grid step moves between hexagon centres
+/// by the short diagonal, `√3 · edge ≈ 1.73 · edge`, so a cell at grid
+/// distance `k` sits at least `k · √3 · edge` away and its nearest point at
+/// least `edge · (√3·k − 1)`. Dividing the radius by a plain `edge` therefore
+/// over-estimates `k` by roughly 1.73×, and that margin is what absorbs the
+/// gap between this average and the smallest real cell at the resolution —
+/// H3 cell size varies within a resolution, so the average alone would not
+/// justify the bound. The margin is what keeps the cover a safe superset
+/// (PRD #1574 slice 3).
 pub fn edge_length_km(res: u8) -> f64 {
     clamp_resolution(res).edge_length_km()
 }
@@ -211,6 +235,42 @@ mod tests {
         assert!(coarse > fine, "edge length must shrink as resolution grows");
         // Out-of-range bytes clamp to res 15 rather than panicking.
         assert!(edge_length_km(200) > 0.0);
+    }
+
+    #[test]
+    fn radius_cover_ring_grows_with_radius_and_caps() {
+        // A radius under one edge still needs a ring, and the ring grows with
+        // the radius at a fixed resolution.
+        let small = radius_cover_ring(0.1, 9).expect("small radius must cover");
+        let large = radius_cover_ring(5.0, 9).expect("larger radius must cover");
+        assert!(small >= 1, "the cover always includes the neighbour ring");
+        assert!(large > small, "a wider radius needs a wider ring");
+        // Past the cap the caller must fall back to the exact full scan.
+        assert_eq!(
+            radius_cover_ring(20_000.0, 15),
+            None,
+            "a cover beyond MAX_COVER_RING must decline, not truncate"
+        );
+        assert_eq!(radius_cover_ring(f64::NAN, 9), None);
+    }
+
+    #[test]
+    fn radius_cover_ring_stays_a_superset_of_the_radius() {
+        // The ring must reach at least as far as the radius it covers: `k`
+        // grid steps span at least `k * edge` km (the √3 short-diagonal
+        // margin is on top of that), so `k * edge >= radius` must hold.
+        for res in [5u8, 7, 9, 12] {
+            let edge = edge_length_km(res);
+            for radius_km in [0.05, 0.5, 2.0, 10.0] {
+                let Some(k) = radius_cover_ring(radius_km, res) else {
+                    continue;
+                };
+                assert!(
+                    f64::from(k) * edge >= radius_km,
+                    "ring {k} at res {res} must reach {radius_km} km (edge {edge})"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/geo/mod.rs
+++ b/crates/reddb-server/src/geo/mod.rs
@@ -52,16 +52,25 @@ pub fn recognize_geo_value(value: &Value) -> Option<(f64, f64)> {
     }
 }
 
+/// Field names accepted as latitude, in priority order.
+const LAT_ALIASES: [&str; 2] = ["lat", "latitude"];
+/// Field names accepted as longitude, in priority order.
+const LON_ALIASES: [&str; 3] = ["lon", "lng", "longitude"];
+
+/// Resolve a `{lat, lon}` object from any keyed source.
+///
+/// `lookup` maps an alias to an already-coerced degree value, so the storage
+/// and JSON sides share one alias list and differ only in how their own value
+/// representation becomes an `f64`.
+fn recognize_geo_aliases(lookup: impl Fn(&str) -> Option<f64>) -> Option<(f64, f64)> {
+    let lat = LAT_ALIASES.iter().find_map(|alias| lookup(alias))?;
+    let lon = LON_ALIASES.iter().find_map(|alias| lookup(alias))?;
+    recognize_geo_degrees(lat, lon)
+}
+
 /// Recognize an object-shaped value from row/node fields as `(lat, lon)` degrees.
 pub fn recognize_geo_fields<'a>(field: impl Fn(&str) -> Option<&'a Value>) -> Option<(f64, f64)> {
-    let lat = field("lat")
-        .or_else(|| field("latitude"))
-        .and_then(numeric_value_to_f64)?;
-    let lon = field("lon")
-        .or_else(|| field("lng"))
-        .or_else(|| field("longitude"))
-        .and_then(numeric_value_to_f64)?;
-    recognize_geo_degrees(lat, lon)
+    recognize_geo_aliases(|alias| field(alias).and_then(numeric_value_to_f64))
 }
 
 fn recognize_geo_degrees(lat: f64, lon: f64) -> Option<(f64, f64)> {
@@ -76,11 +85,22 @@ fn recognize_geo_degrees(lat: f64, lon: f64) -> Option<(f64, f64)> {
     }
 }
 
+/// Coerce a storage value to degrees.
+///
+/// Must stay coverage-equivalent with [`json_number_to_f64`]: a coordinate that
+/// one side recognizes and the other drops is a silent zero-result.
+///
+/// `Value::Decimal(i64)` is deliberately absent. It carries no scale of its own
+/// — `decimal_precision` is per-column metadata — so converting one here would
+/// have to assume a precision. The engine does not currently agree on that
+/// assumption, so a decimal coordinate must be stored as `DecimalText` (exact,
+/// self-describing) or a float.
 fn numeric_value_to_f64(value: &Value) -> Option<f64> {
     match value {
         Value::Float(value) => Some(*value),
         Value::Integer(value) => Some(*value as f64),
         Value::UnsignedInteger(value) => Some(*value as f64),
+        Value::DecimalText(text) => text.parse::<f64>().ok(),
         _ => None,
     }
 }
@@ -97,18 +117,12 @@ fn recognize_geo_json(bytes: &[u8]) -> Option<(f64, f64)> {
         let lat = &coordinates[1];
         return recognize_geo_degrees(json_number_to_f64(lat)?, json_number_to_f64(lon)?);
     }
-    let lat = object
-        .get("lat")
-        .or_else(|| object.get("latitude"))
-        .and_then(json_number_to_f64)?;
-    let lon = object
-        .get("lon")
-        .or_else(|| object.get("lng"))
-        .or_else(|| object.get("longitude"))
-        .and_then(json_number_to_f64)?;
-    recognize_geo_degrees(lat, lon)
+    recognize_geo_aliases(|alias| object.get(alias).and_then(json_number_to_f64))
 }
 
+/// Coerce a JSON value to degrees. Coverage-equivalent with
+/// [`numeric_value_to_f64`]; `as_f64` already spans integer, float, and exact
+/// decimal text.
 fn json_number_to_f64(value: &crate::json::Value) -> Option<f64> {
     value.as_f64()
 }
@@ -375,6 +389,40 @@ mod tests {
             .iter()
             .map(|(key, value)| ((*key).to_string(), value.clone()))
             .collect()
+    }
+
+    #[test]
+    fn exact_decimal_text_coordinates_are_recognized() {
+        // An exact decimal coordinate used to fall through to `None`, so a
+        // DECIMAL-typed lat/lon read as "no geo here" — a silent zero-result.
+        let decimal = fields(&[
+            ("lat", Value::DecimalText("38.76000000".to_string())),
+            ("lon", Value::DecimalText("-77.15000000".to_string())),
+        ]);
+        assert_eq!(
+            recognize_geo_fields(|key| decimal.get(key)),
+            Some((38.76, -77.15))
+        );
+    }
+
+    #[test]
+    fn both_halves_of_the_seam_cover_the_same_numeric_shapes() {
+        // The storage and JSON sides carry separate coercions by necessity —
+        // they read different representations — but a coordinate one accepts
+        // and the other drops is a silent zero-result. Exact decimals are
+        // where they last diverged.
+        for (text, expected) in [("38.76000000", 38.76), ("-77.15000000", -77.15)] {
+            assert_eq!(
+                numeric_value_to_f64(&Value::DecimalText(text.to_string())),
+                Some(expected),
+                "storage side must read exact decimal {text}"
+            );
+            assert_eq!(
+                json_number_to_f64(&crate::json::Value::Decimal(text.to_string())),
+                Some(expected),
+                "json side must read exact decimal {text}"
+            );
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -1437,15 +1437,12 @@ fn h3_cover_cells(lat: f64, lon: f64, radius_km: f64, resolution: u8) -> Vec<u64
     if cell == 0 {
         return Vec::new();
     }
-    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
-    // Cap the cover so a large radius over a fine resolution cannot blow up
-    // into hundreds of millions of cells; beyond it the full scan is cheaper.
-    const MAX_COVER_RING: u32 = 128;
-    let k_f = (radius_km / edge_km).ceil() + 1.0;
-    if !k_f.is_finite() || k_f > f64::from(MAX_COVER_RING) {
+    // The cover is capped so a large radius over a fine resolution cannot blow
+    // up into hundreds of millions of cells; beyond it the full scan is cheaper.
+    let Some(k) = crate::geo::h3::radius_cover_ring(radius_km, resolution) else {
         return Vec::new();
-    }
-    crate::geo::h3::grid_disk(cell, k_f as u32)
+    };
+    crate::geo::h3::grid_disk(cell, k)
 }
 
 impl RedDBRuntime {
@@ -1670,9 +1667,13 @@ impl RedDBRuntime {
             dists.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let d_k = dists[k - 1];
             // A point in any unscanned cell (grid distance > r) lies at least
-            // `r * edge_km` from the centre — a conservative lower bound. Once
-            // that already meets or exceeds the current K-th distance, the
-            // cover is a proven superset of the true nearest-K.
+            // `edge_km * (√3·r − 1)` from the centre, since one grid step spans
+            // the hexagon short diagonal `√3 · edge`. `r * edge_km` is well
+            // below that, so it is a conservative lower bound — and the ~1.73×
+            // slack is also what covers `edge_km` being the resolution's
+            // *average* edge rather than its smallest. Once the bound meets or
+            // exceeds the current K-th distance, the cover is a proven superset
+            // of the true nearest-K.
             if f64::from(r) * edge_km >= d_k {
                 return candidates;
             }

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -107,10 +107,7 @@ fn explain_h3_cover_is_enumerable(lat: f64, lon: f64, radius_km: f64, resolution
     if cell == 0 {
         return false;
     }
-    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
-    const MAX_COVER_RING: u32 = 128;
-    let k_f = (radius_km / edge_km).ceil() + 1.0;
-    k_f.is_finite() && k_f <= f64::from(MAX_COVER_RING)
+    crate::geo::h3::radius_cover_ring(radius_km, resolution).is_some()
 }
 
 impl RedDBRuntime {
@@ -5271,6 +5268,33 @@ mod render_prompt_tests {
             out.contains("Question: ignore previous instructions"),
             "fallback must still surface the question, got: {out}"
         );
+    }
+}
+
+#[cfg(test)]
+mod h3_cover_agreement_tests {
+    use super::explain_h3_cover_is_enumerable;
+    use crate::runtime::query_exec::table::h3_cover_cells_for_geo_predicate;
+
+    /// `EXPLAIN` must announce the H3 index route exactly when the executor
+    /// actually takes it. These two decided the cover independently until they
+    /// were folded onto `geo::h3::radius_cover_ring`; this pins them together
+    /// so a future edit to one cannot silently make `EXPLAIN` lie.
+    #[test]
+    fn explain_and_executor_agree_on_the_cover_decision() {
+        // Paris, spanning both sides of the MAX_COVER_RING cap.
+        let (lat, lon) = (48.8566, 2.3522);
+        for res in [0u8, 5, 7, 9, 12, 15] {
+            for radius_km in [0.0, 0.05, 1.0, 25.0, 500.0, 20_000.0, f64::NAN] {
+                let explained = explain_h3_cover_is_enumerable(lat, lon, radius_km, res);
+                let executed =
+                    !h3_cover_cells_for_geo_predicate(lat, lon, radius_km, res).is_empty();
+                assert_eq!(
+                    explained, executed,
+                    "EXPLAIN/executor disagree at res {res}, radius {radius_km} km"
+                );
+            }
+        }
     }
 }
 

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -16,7 +16,7 @@ mod indexed_scan;
 mod join;
 mod json_writers;
 mod row_stream;
-mod table;
+pub(crate) mod table;
 mod vector;
 
 // Re-export public helpers so call sites outside this module

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -446,7 +446,7 @@ fn h3_cell_candidate_ids(
     Some(ids.into_iter().map(|id| id.raw()).collect())
 }
 
-fn h3_cover_cells_for_geo_predicate(
+pub(crate) fn h3_cover_cells_for_geo_predicate(
     lat: f64,
     lon: f64,
     radius_km: f64,
@@ -456,13 +456,10 @@ fn h3_cover_cells_for_geo_predicate(
     if cell == 0 {
         return Vec::new();
     }
-    let edge_km = crate::geo::h3::edge_length_km(resolution).max(f64::MIN_POSITIVE);
-    const MAX_COVER_RING: u32 = 128;
-    let k_f = (radius_km / edge_km).ceil() + 1.0;
-    if !k_f.is_finite() || k_f > f64::from(MAX_COVER_RING) {
+    let Some(k) = crate::geo::h3::radius_cover_ring(radius_km, resolution) else {
         return Vec::new();
-    }
-    crate::geo::h3::grid_disk(cell, k_f as u32)
+    };
+    crate::geo::h3::grid_disk(cell, k)
 }
 
 pub(crate) fn execute_runtime_canonical_table_query_indexed(

--- a/tests/grouped/schema_query_core/e2e_h3_index.rs
+++ b/tests/grouped/schema_query_core/e2e_h3_index.rs
@@ -509,6 +509,40 @@ fn spatial_full_scan_reads_document_body_column() {
     );
 }
 
+/// The literal session from issue #1866, byte for byte — trailing zeros and
+/// all. The rest of the suite abbreviates these to `38.76`.
+///
+/// This is a characterization test, not a regression guard: the document body
+/// parses `38.76000000` to a float, so it passes with or without the exact
+/// decimal arm in `geo::numeric_value_to_f64` (which the unit tests there
+/// cover). What it pins is narrower and still worth pinning — that the exact
+/// bytes a real user typed keep resolving to a point, so a future change to
+/// the JSON number path cannot quietly break the reported repro.
+#[test]
+fn spatial_reads_document_body_with_the_reported_literals() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();
+    rt.execute_query("CREATE DOCUMENT events").unwrap();
+    rt.execute_query(
+        r#"INSERT INTO events DOCUMENT VALUES ({"gpsLocation":{"lat":38.76000000,"lon":-77.15000000}})"#,
+    )
+    .unwrap();
+
+    let radius = spatial_rows(
+        &rt,
+        "SEARCH SPATIAL RADIUS 38.76000000 -77.15000000 10.0 COLLECTION events COLUMN gpsLocation",
+    );
+    assert_eq!(
+        radius.len(),
+        1,
+        "the exact literals from #1866 must resolve to a point"
+    );
+    assert_eq!(
+        radius[0].1,
+        0.0_f64.to_bits(),
+        "exact centre hit must report zero distance"
+    );
+}
+
 #[test]
 fn h3_cell_projects_and_groups_row_geopoints() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).unwrap();


### PR DESCRIPTION
Follow-up review of the spatial surface shipped in v1.23.0 (PRD #1932 — the work that closed @markrileybot's report in #1866). The review found that the "one authority" principle that PRD declared was violated in three places by the same release, plus a silent zero-result one layer below the ones it fixed.

Closes #2056. Refs #1866.

## What changed

**Exact decimal coordinates were invisible to geo.** `numeric_value_to_f64` covered `Float`/`Integer`/`UnsignedInteger` only, so a `DecimalText` lat/lon fell through to `None` and read as "no geo here" — the same silent-zero failure class PRD #1932 set out to kill. The JSON half already handled it via `as_f64`, so the two halves of the seam disagreed.

**The alias lists were duplicated and had drifted.** `lat`/`latitude` and `lon`/`lng`/`longitude` existed in both `recognize_geo_fields` and `recognize_geo_json`, each with its own numeric coercion. They now resolve through one `recognize_geo_aliases` seam, so adding an alias is a single edit.

**The kRing sizing was copy-pasted verbatim in three places**, one of them the `EXPLAIN` path. Nothing pinned them equal, so a fix to one could leave `EXPLAIN` announcing an index route the executor never takes. Hoisted to `geo::h3::radius_cover_ring`, beside `MAX_POLYGON_COVER_CELLS` which already followed this pattern for the same stated reason. A new test asserts `EXPLAIN` and the executor agree across resolutions and radii.

**The superset justification did not hold as written.** The comments argued from `edge_length_km`, which is the resolution's *average* edge, while H3 cell size varies within a resolution. The bound is safe because one grid step spans the hexagon short diagonal `√3 · edge`, and that ~1.73x margin absorbs the average-vs-smallest gap. Comments only — no behavior change.

## What was deliberately left out

`Value::Decimal(i64)` is **not** added to the geo path. It carries no scale of its own (`decimal_precision` is per-column metadata), and the engine does not currently agree on an assumed precision:

- `aggregate.rs:2091`, `expr_eval.rs:558`, `scalar_evaluator.rs:734`, `impl_dml_claim.rs:165` divide by `10_000`
- `accumulator.rs:187`, `evaluator.rs:513`, `scan_json.rs:219`, `rpc_stdio.rs:1343`, `postgres/server.rs:1542` cast raw

`accumulator.rs:187` documents that it "mirrors the casts the legacy path performs in `aggregate.rs::value_to_f64`" — and does not. Picking a side inside the geo path would join that inconsistency rather than resolve it. The omission is documented at the call site and filed separately.

## Verification

- New tests fail without the fix — verified by temporarily reverting the `DecimalText` arm; both decimal unit tests break.
- `grouped_sql_core`: **303 passed, 0 failed**, including the pre-existing superset property tests unchanged.
- `geo::` unit tests: 28 passed.
- `cargo fmt --all -- --check`: clean. `scripts/lint-no-untyped-serialization.sh`: clean (1257 files).
- `cargo clippy --all-targets`: **79 pre-existing errors, identical on `main`** (concentrated in `e2e_isolation_levels.rs` and `e2e_vcs.rs` test targets). Not introduced here; none in the touched files.

## Note on the e2e test

`spatial_reads_document_body_with_the_reported_literals` uses the reporter's exact bytes (`38.76000000`) rather than the suite's abbreviated `38.76`. It is a **characterization test, not a regression guard** — the document body parses those literals to a float, so it passes with or without the decimal arm. That is stated in the test's doc comment so it is not mistaken for coverage it does not provide.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787023092&installation_id=129708444&pr_number=2057&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2057&signature=17a16e3ede22ca347ee56d61a82a94700b80aebfb7dbf92baaeb226e982dd284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->