### PR TITLE
fix(afk): align the clippy gate with CI and unbreak hook loading

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -81,7 +81,14 @@ plugins:
         # 3. Clippy at warn-as-error (mirrors CI's Quality gate).
         #    Pulled in here so a red local clippy fails the merge
         #    before the CI round-trip.
-        - cargo clippy --workspace --locked --all-targets -- -D warnings
+        #    Must stay byte-identical in scope to `.github/workflows/ci.yml`
+        #    (`cargo clippy --locked --all -- -D warnings`). It carried
+        #    `--all-targets` until 2026-07-19, which CI does not: that pulled in
+        #    ~79 pre-existing test-target lints and failed the gate on every
+        #    branch, parking innocent workers at `blocked:validation`. A gate
+        #    stricter than CI blocks work CI would accept, which defeats the
+        #    stated purpose above. Widen only by widening CI first.
+        - cargo clippy --locked --all -- -D warnings
 
       # ----------------------------------------------------------------
       # Hooks — intercept the AFK loop at named lifecycle points.
@@ -94,6 +101,15 @@ plugins:
       #     (use this for notifiers — broken notifiers MUST NOT
       #     starve the AFK, per ADR 0059 lesson).
       # Unknown hook names are a HARD ERROR at boot — typo protection.
+      #
+      # Every hook below MUST be a scalar (a single string, `|` block for
+      # multiple commands) — NOT a YAML list. As of bundle 2.74.4/2.74.6 the
+      # loader flattens a list into indexed keys and then validates the
+      # flattened key against the hook allowlist, so `pre_pick: [x]` is
+      # rejected at boot as `unknown hook name 'pre_pick.0'` even though
+      # `pre_pick` is allowlisted. These were lists until 2026-07-19 and
+      # crashed every `/afk` and `/go` boot. Do not convert them back
+      # without re-testing `red-skills-dev run --boot-only`.
       # ----------------------------------------------------------------
       hooks:
 
@@ -106,16 +122,14 @@ plugins:
         # Reorder by `priority:*` ascending (P0 first). Defensive:
         # a broken pre_pick must NOT starve the AFK, so the script
         # returns the original queue on parse/gh failure.
-        pre_pick:
-          - scripts/afk-pre-pick.sh
+        pre_pick: scripts/afk-pre-pick.sh
 
         # --- pre_attempt: inject house-style + boundary reminder -------
         # Cheaper than `--request -r` on every /afk invocation. Runs
         # before EACH attempt (so the reminder survives iteration).
         # `--request -r "..."` is still appended after this, so users
         # retain per-run overrides.
-        pre_attempt:
-          - scripts/afk-pre-attempt.sh
+        pre_attempt: scripts/afk-pre-attempt.sh
 
         # --- pre_merge: drift-guard (HARD GATE) ------------------------
         # Reject the merge BEFORE CI burns a round on it. Checks:
@@ -128,8 +142,7 @@ plugins:
         #   5. New Cargo dep without `# track: issue-XXXX` comment.
         # Thresholds are conservative on purpose — see ADR 0062 for
         # the rationale and the tuning policy.
-        pre_merge:
-          - scripts/afk-pre-merge.sh
+        pre_merge: scripts/afk-pre-merge.sh
 
         # --- post_merge: notifier --------------------------------------
         # Optional Slack-style hook. Disabled by default (no URL set);
@@ -142,15 +155,14 @@ plugins:
         # Prune worktrees that no longer have a branch attached, and
         # delete orphan afk/* branches. Defaults (cargo/gradle) handle
         # build-dir cleanup; this is git-state cleanup.
-        on_idle:
-          - git worktree prune
-          - |
-            git branch --list 'afk/*' | while read -r br; do
-              [ -z "$br" ] && continue
-              git worktree list --porcelain \
-                | grep -qF "  $br" \
-                || git branch -D "$br"
-            done
+        on_idle: |
+          git worktree prune
+          git branch --list 'afk/*' | while read -r br; do
+            [ -z "$br" ] && continue
+            git worktree list --porcelain \
+              | grep -qF "  $br" \
+              || git branch -D "$br"
+          done
 
         # --- defaults ---------------------------------------------------
         # Built-in defaults the harness ships with. Each can be turned


### PR DESCRIPTION
Two independent failures that together made the AFK harness unusable on this repo. Neither is caused by any code change — both were found while investigating why `/go` and `/afk` would not run.

## 1. The clippy gate was stricter than CI

`afk.backpressure` said it "mirrors CI's Quality gate". It did not:

| | Command |
|---|---|
| CI (`.github/workflows/ci.yml:249`) | `cargo clippy --locked --all -- -D warnings` |
| Gate (before) | `cargo clippy --workspace --locked --all-targets -- -D warnings` |

`--all-targets` pulls in test targets that CI deliberately does not check. That produced **79 errors — verified identical on a clean `main` checkout**, concentrated in `e2e_isolation_levels.rs` (60) and `e2e_vcs.rs` (59).

So the gate failed on **every branch**, regardless of the work, parking innocent workers at `blocked:validation`. A gate stricter than CI blocks work that CI would accept, which defeats its own stated purpose of failing before the CI round-trip. Now byte-identical in scope to CI.

Widening this is still a legitimate option — but it has to start with widening CI, and with the 79 lints fixed first. Worth a follow-up rather than smuggling it in here.

## 2. Hook loading was broken by bundle drift

Every hook was a YAML list. Bundle 2.74.4 and 2.74.6 cannot load that: the loader flattens a list into indexed keys and *then* validates the flattened key against the hook allowlist, so `pre_pick: [x]` is rejected at boot as:

```
UnknownHookError: unknown hook name 'pre_pick.0'
```

— even though `pre_pick` **is** in the allowlist (confirmed by extracting it from the bundle: `["pre_session","pre_pick","post_pick",...]`). This crashed every `/afk` and `/go` boot.

`.red/config.yaml` had not changed since 2026-07-12, when the last `/go` booted clean, so this is bundle-side drift rather than config rot. Hooks are now scalars, `on_idle`'s two commands folded into one `|` block, and the constraint is documented in-file so they do not get converted back.

## Verification

`red-skills-dev run --boot-only` — the hook error is gone and boot proceeds past hook loading to the operational probe. (It then reports the local trunk being behind `origin/main`, which is a separate pre-existing condition and not addressed here.)

## Correction: the queue filter is fine

An earlier revision of this description claimed no `size:*` label existed in this repo, which would make `scripts/afk-pre-pick.sh:71` (`select($has_size and $has_prio)`) discard the entire queue. **That claim was wrong.** It came from `gh label list --limit 200` silently truncating a 355-label repo — a conclusion of absence drawn from a truncated listing. All four of `size:xs`, `size:s`, `size:m`, `size:l` exist, as does `priority:high`.

The filter behaves as designed. The queue is empty for the ordinary reason: no open issue currently carries `ready-for-agent` together with a `size:*` and a `priority:*`. That is triage state, not a defect, and nothing in this PR depends on it.
