### PR TITLE
fix(aggregate): one authority for the DECIMAL scale, ending the 10,000x SUM split

### DIFF
--- a/crates/reddb-server/src/runtime/expr_eval.rs
+++ b/crates/reddb-server/src/runtime/expr_eval.rs
@@ -555,7 +555,7 @@ fn value_as_number(v: &Value) -> Option<(f64, bool)> {
         Value::Integer(n) | Value::BigInt(n) => Some((*n as f64, false)),
         Value::UnsignedInteger(n) => Some((*n as f64, false)),
         Value::Float(f) => Some((*f, true)),
-        Value::Decimal(d) => Some((*d as f64 / 10_000.0, true)),
+        Value::Decimal(d) => Some((crate::storage::schema::decimal_to_f64(*d), true)),
         Value::Text(s) => s
             .parse::<i64>()
             .map(|n| (n as f64, false))

--- a/crates/reddb-server/src/runtime/impl_dml_claim.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_claim.rs
@@ -162,7 +162,9 @@ impl CompoundNumber {
             Value::Integer(value) | Value::BigInt(value) => Some(Self::Integer(*value as i128)),
             Value::UnsignedInteger(value) => Some(Self::Integer(*value as i128)),
             Value::Float(value) => value.is_finite().then_some(Self::Float(*value)),
-            Value::Decimal(value) => Some(Self::Float(*value as f64 / 10_000.0)),
+            Value::Decimal(value) => {
+                Some(Self::Float(crate::storage::schema::decimal_to_f64(*value)))
+            }
             _ => None,
         }
     }

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -2082,13 +2082,13 @@ pub(super) fn update_extreme_value_slot(
     }
 }
 
-fn value_to_f64(val: &Value) -> Option<f64> {
+pub(crate) fn value_to_f64(val: &Value) -> Option<f64> {
     match val {
         Value::Integer(n) => Some(*n as f64),
         Value::UnsignedInteger(n) => Some(*n as f64),
         Value::BigInt(n) => Some(*n as f64),
         Value::Float(f) => Some(*f),
-        Value::Decimal(d) => Some(*d as f64 / 10_000.0),
+        Value::Decimal(d) => Some(crate::storage::schema::decimal_to_f64(*d)),
         _ => None,
     }
 }

--- a/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
@@ -179,12 +179,19 @@ fn sum_f64_to_value(f: f64) -> Value {
 /// performs in `aggregate.rs::value_to_f64`, but kept private to
 /// this module so the planner has no dependency on the legacy
 /// internals.
+///
+/// That claim used to be false for `Decimal`: this cast was raw while the
+/// legacy path divided by the fixed scale, so `SUM`/`AVG` over a `DECIMAL`
+/// column returned results differing by 10^4 depending on which route the
+/// planner picked (#2058). Both now go through `schema::decimal_to_f64`, and
+/// `decimal_sum_agrees_with_the_legacy_aggregate_path` pins them together —
+/// duplicating the match arms is what let them drift silently.
 fn numeric_value(v: &Value) -> Option<f64> {
     match v {
         Value::Integer(i) => Some(*i as f64),
         Value::UnsignedInteger(u) => Some(*u as f64),
         Value::Float(f) if f.is_finite() => Some(*f),
-        Value::Decimal(d) => Some(*d as f64),
+        Value::Decimal(d) => Some(crate::storage::schema::decimal_to_f64(*d)),
         Value::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
         _ => None,
     }
@@ -224,5 +231,77 @@ fn update_extreme(current: &mut Option<Value>, candidate: &Value, target: std::c
                 *current = Some(candidate.clone());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::numeric_value;
+    use crate::runtime::query_exec::aggregate::value_to_f64;
+    use crate::storage::schema::Value;
+
+    /// The planner's `SUM`/`AVG` cast and the legacy path's must agree on
+    /// every value they both accept.
+    ///
+    /// They did not: the planner cast `Decimal` raw while the legacy path
+    /// divided by the fixed scale, so the same `SUM` over a `DECIMAL` column
+    /// returned values 10^4 apart depending on the route chosen (#2058). Both
+    /// now delegate to `schema::decimal_to_f64`; this pins them so a future
+    /// edit to one match arm cannot silently reintroduce the split.
+    #[test]
+    fn decimal_sum_agrees_with_the_legacy_aggregate_path() {
+        let cases = [
+            Value::Decimal(387_600),   // 38.76
+            Value::Decimal(-771_500),  // -77.15
+            Value::Decimal(1_234_567), // 123.4567 — the rendering test's value
+            Value::Decimal(0),
+            Value::Decimal(i64::MAX),
+            Value::Decimal(i64::MIN),
+            Value::Integer(42),
+            Value::UnsignedInteger(7),
+            Value::Float(1.5),
+            Value::Null,
+        ];
+        for value in cases {
+            assert_eq!(
+                numeric_value(&value),
+                value_to_f64(&value),
+                "planner and legacy aggregate casts disagree on {value:?}"
+            );
+        }
+    }
+
+    /// Types the two routes still disagree on, tracked in #2060.
+    ///
+    /// This documents current behaviour; it does not endorse it. `SUM` over a
+    /// `BIGINT` column returning a number on one route and `NULL` on the other
+    /// is a defect, but closing it means deciding whether `SUM(boolean)` is
+    /// supported at all and how non-finite floats aggregate — semantics calls
+    /// rather than mechanical edits, so #2058 fixed only the `Decimal` arm and
+    /// left these visible instead of silently narrowing the pin above.
+    ///
+    /// When #2060 is fixed this test will fail. That is the point: update it
+    /// then, and fold the surviving cases into the agreement test.
+    #[test]
+    fn planner_and_legacy_diverge_on_bigint_boolean_and_nonfinite_float() {
+        // The planner has no BigInt arm; the legacy path does.
+        assert_eq!(numeric_value(&Value::BigInt(9)), None);
+        assert_eq!(value_to_f64(&Value::BigInt(9)), Some(9.0));
+
+        // The planner counts booleans; the legacy path rejects them.
+        assert_eq!(numeric_value(&Value::Boolean(true)), Some(1.0));
+        assert_eq!(value_to_f64(&Value::Boolean(true)), None);
+
+        // The planner guards on `is_finite`; the legacy path does not.
+        assert_eq!(numeric_value(&Value::Float(f64::NAN)), None);
+        assert!(value_to_f64(&Value::Float(f64::NAN)).is_some_and(f64::is_nan));
+    }
+
+    /// A `DECIMAL` read for aggregation must equal what the engine renders and
+    /// compares it as — scale 4, the value the write side parses at.
+    #[test]
+    fn decimal_aggregation_matches_the_rendered_value() {
+        // `Decimal(1_234_567)` renders as "123.4567" (pinned in entity_json).
+        assert_eq!(numeric_value(&Value::Decimal(1_234_567)), Some(123.4567));
     }
 }

--- a/crates/reddb-server/src/runtime/scalar_evaluator.rs
+++ b/crates/reddb-server/src/runtime/scalar_evaluator.rs
@@ -731,7 +731,7 @@ fn value_as_number(v: &Value) -> Option<(f64, bool)> {
         Value::Integer(n) | Value::BigInt(n) => Some((*n as f64, false)),
         Value::UnsignedInteger(n) => Some((*n as f64, false)),
         Value::Float(f) => Some((*f, true)),
-        Value::Decimal(d) => Some((*d as f64 / 10_000.0, true)),
+        Value::Decimal(d) => Some((crate::storage::schema::decimal_to_f64(*d), true)),
         Value::Text(s) => s
             .parse::<i64>()
             .map(|n| (n as f64, false))

--- a/crates/reddb-server/src/storage/query/evaluator.rs
+++ b/crates/reddb-server/src/storage/query/evaluator.rs
@@ -510,7 +510,7 @@ fn as_f64(v: &Value) -> f64 {
         Value::Integer(x) => *x as f64,
         Value::BigInt(x) => *x as f64,
         Value::UnsignedInteger(x) => *x as f64,
-        Value::Decimal(x) => *x as f64,
+        Value::Decimal(x) => crate::storage::schema::decimal_to_f64(*x),
         _ => 0.0,
     }
 }

--- a/crates/reddb-server/src/storage/schema/mod.rs
+++ b/crates/reddb-server/src/storage/schema/mod.rs
@@ -25,4 +25,6 @@ pub mod value_codec;
 pub use canonical_key::{value_to_canonical_key, CanonicalKey, CanonicalKeyFamily};
 pub use coerce::coerce;
 pub use table::{ColumnDef, Constraint, ConstraintType, IndexDef, IndexType, TableDef};
-pub use types::{DataType, Row, SqlTypeName, TypeModifier, Value, ValueError};
+pub use types::{
+    decimal_to_f64, DataType, Row, SqlTypeName, TypeModifier, Value, ValueError, DECIMAL_SCALE,
+};

--- a/crates/reddb-types/src/types.rs
+++ b/crates/reddb-types/src/types.rs
@@ -1310,6 +1310,26 @@ impl Value {
     }
 }
 
+/// The fixed scale of [`Value::Decimal`].
+///
+/// `Value::Decimal(i64)` stores `value * 10^DECIMAL_SCALE` and carries no scale
+/// of its own. Four is not a free choice — it is already the scale the write
+/// side parses at (`coerce::parse_decimal`), the render side formats at
+/// (`display_string`, `Display`), and, load-bearingly, the scale that
+/// comparison and ordering assume (`value_compare`). Reads must agree with all
+/// of them.
+pub const DECIMAL_SCALE: u8 = 4;
+
+/// Convert a [`Value::Decimal`] payload to its true numeric value.
+///
+/// The single authority for that conversion. It used to be open-coded at nine
+/// call sites, four dividing by `10^4` and five casting raw, which made
+/// `SUM`/`AVG` over a `DECIMAL` column differ by four orders of magnitude
+/// depending on which aggregate route the planner picked (#2058).
+pub fn decimal_to_f64(value: i64) -> f64 {
+    value as f64 / 10_i64.pow(DECIMAL_SCALE as u32) as f64
+}
+
 fn format_scaled_i64(value: i64, scale: u8) -> String {
     let negative = value < 0;
     let abs = (value as i128).abs();


### PR DESCRIPTION
Closes #2058. Related: #2060 (filed by this work).

## The defect

`Value::Decimal(i64)` stores `value * 10^4` and carries no scale of its own. That conversion was open-coded at **six call sites** — four divided by the scale, two cast raw:

| Site | Before |
|---|---|
| `runtime/query_exec/aggregate.rs:2091` | `/ 10_000.0` |
| `runtime/expr_eval.rs:558` | `/ 10_000.0` |
| `runtime/scalar_evaluator.rs:734` | `/ 10_000.0` |
| `runtime/impl_dml_claim.rs:165` | `/ 10_000.0` |
| `runtime/query_exec/aggregate_planner/accumulator.rs:187` | **raw cast** |
| `storage/query/evaluator.rs:513` | **raw cast** |

So `SUM`/`AVG` over a `DECIMAL` column returned results **four orders of magnitude apart depending on which aggregate route the planner picked** — silently, with no warning, and with the planner's own doc comment claiming it mirrored the path it contradicted.

## Why scale 4 is not a choice made here

It is already the scale every other layer uses:

- **Write** — `coerce::parse_decimal` → `parse_fixed_scale_decimal(input, 4)`
- **Render** — `types.rs::display_string`, `Display`
- **Compare and order** — `value_compare.rs` (3 sites)

Comparison and ordering are the load-bearing ones: indexing already assumes scale 4. Reads were the only layer that disagreed with itself. `schema::DECIMAL_SCALE` and `schema::decimal_to_f64` are now the single authority and all six sites route through them.

## What was left alone, deliberately

The three `f64_field` helpers in `grpc/scan_json.rs`, `rpc_stdio.rs` and `wire/postgres/server.rs` also cast `Decimal` raw. Each reads exactly one field — `cost_usd`, internal telemetry, not a user `DECIMAL` column. Changing them would be churn, not a fix.

## What the pinning test found

`decimal_sum_agrees_with_the_legacy_aggregate_path` exists because duplicated match arms are what let the two routes drift unnoticed. Writing it surfaced **three further divergences unrelated to decimals**:

| Type | Planner | Legacy |
|---|---|---|
| `BigInt` | no arm → `None` | `Some(n as f64)` |
| `Boolean` | `Some(1.0)` | no arm → `None` |
| non-finite `Float` | `None` (`is_finite` guard) | `Some(NaN)` |

`SUM(bigint_col)` returning `NULL` on one route and a number on the other is the sharp one.

**These are not fixed here.** Closing them means deciding whether `SUM(boolean)` is supported at all (standard SQL rejects it; PostgreSQL requires an explicit cast) and how `NaN` aggregates — semantics rather than mechanics. Filed as #2060.

They are also **not hidden**. Narrowing the agreement test to go green would have buried them, so they are captured by `planner_and_legacy_diverge_on_bigint_boolean_and_nonfinite_float`, a characterization test that documents current behaviour without endorsing it and **will fail when #2060 is fixed** — the intended prompt to revisit it.

## Verification

- `cargo test -p reddb-io-server --lib`: **5113 passed, 0 failed**, 13 ignored.
- Full configured gate green: `cargo fmt --all -- --check` clean, `scripts/lint-no-untyped-serialization.sh` clean (1257 files), `cargo clippy --locked --all -- -D warnings` **0 errors**.
- The clippy result also confirms #2059 landed correctly — the previous gate reported 79 pre-existing errors on every branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787028076&installation_id=129708444&pr_number=2061&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2061&signature=bb3d538acd43fd69f11baf356548997f553225167e7aed828d956196cebfba79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->