### PR TITLE
fix(cli): expose reversible pager-zone migration

### DIFF
--- a/.changeset/safe-pager-zone-upgrade.md
+++ b/.changeset/safe-pager-zone-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@reddb-io/cli": patch
+---
+
+Expose the reversible legacy sidecar-to-zoned store conversion as `red migrate-pager-zone --path <FILE>` so applications can safely upgrade pre-1.23 databases before opening them.

--- a/crates/reddb-server/src/cli/commands.rs
+++ b/crates/reddb-server/src/cli/commands.rs
@@ -123,6 +123,12 @@ pub fn all_commands() -> Vec<CommandDef> {
       flags: migrate_from_redis_flags(),
     },
     CommandDef {
+      name: "migrate-pager-zone",
+      summary: "Convert a closed legacy sidecar-backed store to the zoned .rdb format",
+      usage: "red migrate-pager-zone --path ./data/reddb.rdb [--json]",
+      flags: migrate_pager_zone_flags(),
+    },
+    CommandDef {
       name: "salvage",
       summary: "Extract verified data from a damaged embedded store into a fresh .rdb",
       usage: "red salvage --source damaged.rdb --destination recovered.rdb [--json]",
@@ -735,6 +741,12 @@ fn migrate_from_redis_flags() -> Vec<FlagSchema> {
     ]
 }
 
+fn migrate_pager_zone_flags() -> Vec<FlagSchema> {
+    vec![FlagSchema::new("path")
+        .with_short('d')
+        .with_description("Closed legacy sidecar-backed .rdb file to convert")]
+}
+
 fn salvage_flags() -> Vec<FlagSchema> {
     vec![
         FlagSchema::new("source").with_description("Damaged source .rdb file to read"),
@@ -949,6 +961,14 @@ mod tests {
         assert!(help.contains("--dry-run"));
         assert!(help.contains("--redis-url"));
         assert!(help.contains("application-owned helper"));
+    }
+
+    #[test]
+    fn test_migrate_pager_zone_command_help() {
+        let help = command_help_text("migrate-pager-zone").unwrap();
+        assert!(help.contains("red migrate-pager-zone"));
+        assert!(help.contains("--path"));
+        assert!(help.contains("legacy sidecar-backed"));
     }
 
     #[test]

--- a/src/bin/red.rs
+++ b/src/bin/red.rs
@@ -1829,6 +1829,10 @@ fn main() {
             std::process::exit(run_migrate_from_redis_command(&result.flags));
         }
 
+        "migrate-pager-zone" => {
+            std::process::exit(run_migrate_pager_zone_command(&result.flags));
+        }
+
         "salvage" => {
             std::process::exit(run_salvage_command(&result.flags));
         }
@@ -3176,6 +3180,51 @@ fn run_salvage_command(flags: &HashMap<String, FlagValue>) -> i32 {
     }
 }
 
+fn run_migrate_pager_zone_command(flags: &HashMap<String, FlagValue>) -> i32 {
+    let json_mode = wants_json(flags);
+    let Some(path) = flag_string(flags, "path").filter(|value| !value.is_empty()) else {
+        let msg = "--path is required for migrate-pager-zone";
+        if json_mode {
+            json_error("migrate-pager-zone", msg);
+        }
+        eprintln!("migrate-pager-zone: {msg}");
+        return 2;
+    };
+
+    match reddb::pager_zone_migration::migrate_to_zoned(std::path::Path::new(&path)) {
+        Ok(report) => {
+            if json_mode {
+                let data_path = json_escape(&report.data_path.to_string_lossy());
+                let backup_path = json_escape(&report.backup_path.to_string_lossy());
+                json_ok(
+                    "migrate-pager-zone",
+                    &format!(
+                        "{{\"data_path\":\"{data_path}\",\"backup_path\":\"{backup_path}\",\"removed_sidecars\":{},\"header_recovered_from_shadow\":{},\"manifest_recovered_from_shadow\":{}}}",
+                        report.removed_sidecars.len(),
+                        report.header_recovered_from_shadow,
+                        report.manifest_recovered_from_shadow,
+                    ),
+                );
+            } else {
+                println!(
+                    "migrated {} to the zoned .rdb format; rollback copy retained at {}",
+                    report.data_path.display(),
+                    report.backup_path.display()
+                );
+            }
+            0
+        }
+        Err(err) => {
+            let msg = err.to_string();
+            if json_mode {
+                json_error("migrate-pager-zone", &msg);
+            }
+            eprintln!("migrate-pager-zone: {msg}");
+            1
+        }
+    }
+}
+
 fn validate_redis_tcp_connectivity(redis_url: &str) -> Result<(), String> {
     let addr = redis_socket_addr(redis_url)?;
     let mut addrs = addr
@@ -4142,6 +4191,13 @@ fn build_flags_for_command(command: Option<&str>) -> Vec<cli::types::FlagSchema>
                     .with_default("redis-migration"),
             ]);
         }
+        Some("migrate-pager-zone") => {
+            flags.push(
+                cli::types::FlagSchema::new("path")
+                    .with_short('d')
+                    .with_description("Closed legacy sidecar-backed .rdb file to convert"),
+            );
+        }
         Some("salvage") => {
             flags.extend(vec![
                 cli::types::FlagSchema::new("source")
@@ -4244,6 +4300,7 @@ fn build_completion_tree() -> Vec<(String, Vec<(String, Vec<String>)>)> {
         ("delete".to_string(), vec![]),
         ("tick".to_string(), vec![]),
         ("migrate-from-redis".to_string(), vec![]),
+        ("migrate-pager-zone".to_string(), vec![]),
         ("salvage".to_string(), vec![]),
         ("health".to_string(), vec![]),
         (
@@ -6693,6 +6750,35 @@ reddb_replica_lag_records{replica_id=\"b\"} 250\n";
 
     fn str_flag(value: &str) -> FlagValue {
         FlagValue::Str(value.to_string())
+    }
+
+    #[test]
+    fn migrate_pager_zone_converts_a_closed_legacy_store() {
+        let dir = std::env::temp_dir().join(format!(
+            "reddb-migrate-pager-zone-cli-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("app.rdb");
+
+        let pager = reddb::storage::engine::pager::Pager::open_default(&path).unwrap();
+        pager.sync().unwrap();
+        drop(pager);
+        reddb::pager_zone_migration::revert_to_sidecars(&path).unwrap();
+
+        let flags = HashMap::from([(
+            "path".to_string(),
+            str_flag(path.to_string_lossy().as_ref()),
+        )]);
+        assert_eq!(run_migrate_pager_zone_command(&flags), 0);
+        assert!(path.with_extension("rdb.pre-migration").exists());
+        assert!(!PathBuf::from(format!("{}-hdr", path.display())).exists());
+        assert!(!PathBuf::from(format!("{}-meta", path.display())).exists());
+
+        let reopened = reddb::storage::engine::pager::Pager::open_default(&path).unwrap();
+        drop(reopened);
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     fn env_lock() -> &'static Mutex<()> {


### PR DESCRIPTION
## What\n\n- expose the existing offline legacy sidecar-to-zoned conversion as `red migrate-pager-zone --path <FILE>`\n- retain the migration module's `.pre-migration` rollback point\n- support human and JSON output for application integration\n- add CLI routing/help and real closed-store conversion regression coverage\n\n## Why\n\nRedDB 1.23 rejects pre-zoned stores created by 1.19 and tells callers to invoke `pager_zone_migration::migrate_to_zoned`, but the released binary had no command that applications such as Red Request could call. This made a compatible, reversible format transition look like database corruption.\n\n## Verification\n\n- `cargo test --bin red migrate_pager_zone_converts_a_closed_legacy_store`\n- `cargo test -p reddb-io-server test_migrate_pager_zone_command_help`\n- `cargo test -p reddb-io-server --test phase1_zoned_rdb`\n- `cargo check --bin red`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787176118&installation_model_id=20659&pr_number=2069&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2069&signature=d94a1924779bf393fb01d9b8e9c77dc9b71ec426dc09a8408f024ac2c22680e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->