### PR TITLE
fix(release): strip container binary below size gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN cargo fetch --locked
 COPY src/ src/
 
 RUN cargo build --release --locked --bin red ${REDDB_CARGO_FEATURES:+--features ${REDDB_CARGO_FEATURES}} \
+    && strip /app/target/release/red \
     && mkdir -p /image/data /image/etc/reddb \
     && touch /image/data/.keep /image/etc/reddb/.keep
 


### PR DESCRIPTION
## Why

The stable v1.23.2 release measured the container at 67,555,410 bytes, above the strict 64 MiB gate, while the distributed static binary passed at 18,547,968 bytes. The container was the only release path copying an unstripped release binary.

## Change

Strip the release binary in the Docker builder stage before copying it into the distroless runtime image. The published executable paths already strip symbols; this makes the container consistent without relaxing the gate.

## Verification

- Confirmed GNU strip is present in rust:1.97-slim-bookworm.
- Full Docker image build and size measurement are running locally.
- The release workflow will rerun the authoritative Artifact Size Gate before v1.23.2 is published.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787178652&installation_model_id=20659&pr_number=2076&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2076&signature=52bd5f2538c0527a652000a2e9d8a8bc57a343002ab6692f7db6c8ad665de7cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->