### PR TITLE
merge: #2055 Wire listeners never spawn in the HTTP-only dispatch path

### DIFF
--- a/crates/reddb-server/src/service_cli.rs
+++ b/crates/reddb-server/src/service_cli.rs
@@ -3251,21 +3251,64 @@ fn run_http_server(config: ServerCommandConfig, bind_addr: String) -> Result<(),
         ));
     };
     let db_options = config.to_db_options()?;
+    let rt_config = detect_runtime_config();
+    let worker_threads = config.workers.unwrap_or(rt_config.suggested_workers);
+
+    // Issue #2055 — the RedWire (and PG) accept loops are `tokio::spawn`ed
+    // and die with the runtime that hosted them, so — like `run_grpc_server`
+    // and `run_dual_server` — the HTTP-only path owns a multi-thread tokio
+    // runtime kept alive for the process lifetime. The synchronous axum HTTP
+    // server runs on its own OS thread (`serve_in_background_on`, which builds
+    // its own edge runtime), and this runtime's `block_on` stays parked on
+    // that thread's completion so the wire listeners spawned underneath keep
+    // running. Before this, binding HTTP without gRPC spawned no wire listener
+    // at all: `--wire-bind` / `--wire-tls-bind` and the env-derived plaintext
+    // default (`REDDB_WIRE_BIND_ADDR`) all silently vanished.
+    let tokio_runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(worker_threads)
+        .thread_stack_size(rt_config.stack_size)
+        .build()
+        .map_err(|err| format!("tokio runtime: {err}"))?;
+
+    // Guard lives on the outer stack so it outlives the tokio runtime.
     let (runtime, auth_store, _telemetry_guard) =
         build_runtime_and_auth_store(&config, db_options.clone())?;
     let _backup_tasks = spawn_backup_tasks_if_configured(&db_options, &runtime);
     spawn_admin_metrics_listeners(&runtime, &auth_store);
     spawn_http_tls_listener(&config, &runtime, &auth_store)?;
-    let server = build_http_server_with_transport_readiness(
-        runtime.clone(),
-        auth_store,
-        bind_addr.clone(),
-        transport_readiness,
-    );
-    let server = apply_http_limits(server, &config, &runtime);
-    let server = apply_ui_bundle(server, &config)?;
-    tracing::info!(transport = "http", bind = %bind_addr, "listener online");
-    server.serve_on(listener).map_err(|err| err.to_string())
+
+    let signal_runtime = runtime.clone();
+    tokio_runtime.block_on(async move {
+        spawn_lifecycle_signal_handler(signal_runtime).await;
+        // Bring up the RedWire listeners (plaintext + TLS) and the PG wire
+        // listener before the HTTP surface is built, so the readiness the
+        // HTTP `/health` snapshot captures enumerates every wire transport —
+        // parity with what `run_dual_server` records.
+        spawn_wire_listeners(&config, &runtime, &mut transport_readiness).await?;
+        spawn_pg_listener(&config, &runtime);
+
+        let server = build_http_server_with_transport_readiness(
+            runtime.clone(),
+            auth_store,
+            bind_addr.clone(),
+            transport_readiness,
+        );
+        let server = apply_http_limits(server, &config, &runtime);
+        let server = apply_ui_bundle(server, &config)?;
+        tracing::info!(transport = "http", bind = %bind_addr, "listener online");
+        let http_handle = server.serve_in_background_on(listener);
+
+        // Park on the HTTP thread. Keeping `block_on` here alive holds the
+        // runtime — and the wire accept loops spawned above — open for as
+        // long as the HTTP server runs; a return means the process is done.
+        match tokio::task::spawn_blocking(move || http_handle.join()).await {
+            Ok(Ok(Ok(()))) => Err("HTTP server exited unexpectedly".to_string()),
+            Ok(Ok(Err(err))) => Err(err.to_string()),
+            Ok(Err(_)) => Err("HTTP server thread panicked".to_string()),
+            Err(join_err) => Err(format!("HTTP server monitor task failed: {join_err}")),
+        }
+    })
 }
 
 /// PLAN.md HTTP TLS — when `http_tls_bind_addr` is set, spawn a

--- a/tests/cli_first_boot.rs
+++ b/tests/cli_first_boot.rs
@@ -610,15 +610,12 @@ fn first_boot_tolerates_cert_file_env_pointing_at_absent_bootstrap_cert_out() {
 /// non-fatally killed the TLS listener. The explicit TLS flag must own
 /// the port: the plaintext default is suppressed and the TLS listener
 /// comes up.
-// Currently unreachable: with `--http-bind` and no gRPC the dispatch in
-// `run_server` picks `run_http_server`, which never calls
-// `spawn_wire_listeners` — that call exists only in `run_grpc_server` and
-// `run_dual_server`. So no wire listener (TLS *or* plaintext) comes up in
-// the HTTP-only path, and `red.rs` still suppresses the env-derived
-// plaintext default, leaving the port orphaned. Wiring it up means
-// restructuring the HTTP-only path's tokio-runtime ownership, which is a
-// design decision beyond this fix.
-#[ignore = "wire listeners are not spawned in the HTTP-only dispatch path"]
+// Issue #2055: with `--http-bind` and no gRPC the dispatch in `run_server`
+// picks `run_http_server`, which now owns a tokio runtime and spawns the
+// wire listeners (plaintext + TLS) like `run_grpc_server` /
+// `run_dual_server`. Before the fix neither wire listener came up in the
+// HTTP-only path while `red.rs` still suppressed the env-derived plaintext
+// default, orphaning the port.
 #[test]
 fn wire_tls_flag_owns_port_over_env_plaintext_default() {
     let dir = support::temp_data_dir("wire-tls-owns-port");
@@ -718,4 +715,116 @@ fn explicit_wire_tls_bind_failure_is_fatal() {
         "the fatal error must name the failed wire-tls bind.\nstderr:\n{stderr}"
     );
     drop(blocker);
+}
+
+/// Issue #2055 — the DaaS provisioning shape: the release container image
+/// bakes `REDDB_WIRE_BIND_ADDR=0.0.0.0:5050`, and a run with `--http-bind`
+/// and no gRPC used to route to `run_http_server`, which never spawned any
+/// wire listener. The env-derived plaintext RedWire listener must come up in
+/// the HTTP-only path and accept a connection on its port.
+#[test]
+fn http_only_env_plaintext_wire_listener_accepts_connections() {
+    let dir = support::temp_data_dir("http-only-env-wire");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let head_pw = dir.join("head.pw");
+    let customer_pw = dir.join("customer.pw");
+    std::fs::write(&head_pw, "head-secret\n").unwrap();
+    std::fs::write(&customer_pw, "customer-secret\n").unwrap();
+    let head_pw_s = head_pw.to_str().unwrap();
+    let customer_pw_s = customer_pw.to_str().unwrap();
+    let http_port = free_port();
+    let http_addr = format!("127.0.0.1:{http_port}");
+    let wire_port = free_port();
+    let wire_addr = format!("127.0.0.1:{wire_port}");
+
+    // HTTP-only dispatch (no gRPC bind), plaintext wire taken from the
+    // baked-in container env var — exactly the shape that used to vanish.
+    let args = cloud_server_args(&db_path_str, &http_addr, head_pw_s, customer_pw_s);
+    let stderr_path = dir.join("server.stderr");
+    let mut server = spawn_server_with_envs(
+        &args,
+        &stderr_path,
+        &[("REDDB_WIRE_BIND_ADDR", wire_addr.as_str())],
+    );
+
+    let serving = wait_until_serving(&mut server, &http_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "HTTP-only boot with an env plaintext wire default must serve.\nstderr:\n{stderr}"
+    );
+    // The plaintext RedWire listener must accept a connection on its port.
+    let wire_up = wait_until_serving(&mut server, &wire_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        wire_up,
+        "the env-derived plaintext RedWire listener must accept a connection \
+         on {wire_addr} in the HTTP-only path.\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Address already in use"),
+        "no listener may lose the wire port to a collision.\nstderr:\n{stderr}"
+    );
+}
+
+/// Issue #2055 (acceptance) — the HTTP-only path must record the wire
+/// transport in `TransportReadiness`, the same `active("wire", …)` state
+/// `run_dual_server` records, so the HTTP `/health` snapshot enumerates it
+/// as ready rather than silently omitting a live listener.
+#[test]
+fn http_only_reports_wire_transport_ready_on_health() {
+    let dir = support::temp_data_dir("http-only-wire-ready");
+    let db_path = dir.join("data.rdb");
+    let db_path_str = db_path.display().to_string();
+    let head_pw = dir.join("head.pw");
+    let customer_pw = dir.join("customer.pw");
+    std::fs::write(&head_pw, "head-secret\n").unwrap();
+    std::fs::write(&customer_pw, "customer-secret\n").unwrap();
+    let head_pw_s = head_pw.to_str().unwrap();
+    let customer_pw_s = customer_pw.to_str().unwrap();
+    let http_port = free_port();
+    let http_addr = format!("127.0.0.1:{http_port}");
+    let wire_port = free_port();
+    let wire_addr = format!("127.0.0.1:{wire_port}");
+
+    // Explicit `--wire-bind` alongside `--http-bind`, no gRPC.
+    let mut args = cloud_server_args(&db_path_str, &http_addr, head_pw_s, customer_pw_s);
+    args.extend_from_slice(&["--wire-bind", &wire_addr]);
+    let stderr_path = dir.join("server.stderr");
+    let mut server = spawn_server_with_envs(&args, &stderr_path, &[]);
+
+    let serving = wait_until_serving(&mut server, &http_addr, Duration::from_secs(30));
+    let stderr = server.stderr();
+    assert!(
+        serving,
+        "HTTP-only boot with --wire-bind must serve.\nstderr:\n{stderr}"
+    );
+
+    // `/health` is public; its `transport_listeners.active` must list the
+    // wire transport as an explicit, ready listener.
+    let body = ureq::get(&format!("http://{http_addr}/health"))
+        .call()
+        .expect("GET /health")
+        .body_mut()
+        .read_to_string()
+        .expect("read /health body");
+    let health: serde_json::Value = serde_json::from_str(&body).expect("parse /health json");
+    let active = health["transport_listeners"]["active"]
+        .as_array()
+        .expect("transport_listeners.active array");
+    let wire = active
+        .iter()
+        .find(|entry| entry["transport"] == "wire")
+        .unwrap_or_else(|| {
+            panic!("HTTP-only /health must report the wire transport ready; got {body}")
+        });
+    assert_eq!(
+        wire["bind_addr"], wire_addr,
+        "the ready wire listener must report its bind address.\n/health: {body}"
+    );
+    assert_eq!(
+        wire["explicit"], true,
+        "an explicit --wire-bind must be recorded as explicit.\n/health: {body}"
+    );
 }


### PR DESCRIPTION
<!-- afk:reseed-trail v1 issue=2055 -->
🤖 **Re-seed trail** — #2055 on `afk/2055-wire-listeners-never-spawn-in-the-http-o`, lane `/afk`.

Rounds spent: 1/4. A Re-seed re-instructs the implementer in place —
same Worker, same Worktree, same branch — after a gate stage blocked the work.

| round | trigger | what it was asked to fix |
| --- | --- | --- |
| 1/4 | `gate-stage` (gate) | 🤖 /afk: feedback machine gate failed after DONE; correction retry 1/3. |

The Worker's branch and iteration log are the source of truth; this is a derived projection.

Closes #2055

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788285974&installation_model_id=20659&pr_number=2096&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2096&signature=ad4f3d817407ab706e0d9b9c0d6c100b4fe9f652d54e4e04b5805d2ac5b090a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->