### PR TITLE
merge: #2094 parser-fuzz nightly files a new release-blocker every night instead of deduplicating

### DIFF
--- a/scripts/report-parser-fuzz-crashes.sh
+++ b/scripts/report-parser-fuzz-crashes.sh
@@ -15,11 +15,15 @@ gh label create "release-blocker" \
   --color "B60205" \
   --description "Blocks release until resolved" >/dev/null 2>&1 || true
 
-body="$(mktemp)"
+header="$(mktemp)"
 tmin_log="$(mktemp)"
 b64_file="$(mktemp)"
+create_body="$(mktemp)"
+comment_body="$(mktemp)"
+sections_dir="$(mktemp -d)"
 title_suffix="crash"
-trap 'rm -f "${body}" "${tmin_log}" "${b64_file}"' EXIT
+trap 'rm -rf "${header}" "${tmin_log}" "${b64_file}" "${create_body}" "${comment_body}" "${sections_dir}"' EXIT
+
 {
   echo "Nightly parser fuzz found a failure in \`${target}\`."
   echo
@@ -34,13 +38,20 @@ trap 'rm -f "${body}" "${tmin_log}" "${b64_file}"' EXIT
   echo
   echo "## Minimized input"
   echo
-} > "${body}"
+} > "${header}"
 
+# Build one Markdown section per artifact, keyed by the libFuzzer artifact
+# basename. The basename is a content hash, so it is a stable dedup key: an
+# identical reproducer found on a later night has the same basename and adds
+# nothing, while a genuinely new input carries a new basename.
+declare -a basenames=()
+idx=0
 while IFS= read -r artifact; do
-  minimized="${RUNNER_TEMP:-/tmp}/${target}-$(basename "${artifact}").min"
+  base="$(basename "${artifact}")"
+  minimized="${RUNNER_TEMP:-/tmp}/${target}-${base}.min"
   cp "${artifact}" "${minimized}"
   artifact_kind="crash"
-  if [[ "$(basename "${artifact}")" == oom-* ]]; then
+  if [[ "${base}" == oom-* ]]; then
     artifact_kind="out-of-memory"
     title_suffix="out-of-memory"
   fi
@@ -66,10 +77,64 @@ while IFS= read -r artifact; do
     echo
     echo '```'
     echo
-  } >> "${body}"
+  } > "${sections_dir}/${idx}"
+  basenames+=("${base}")
+  idx=$((idx + 1))
 done < <(find "${artifact_dir}" -type f | sort)
 
-gh issue create \
-  --title "release-blocker: parser fuzz ${title_suffix} in ${target}" \
-  --label "release-blocker" \
-  --body-file "${body}"
+title="release-blocker: parser fuzz ${title_suffix} in ${target}"
+
+# One open issue per (target, failure-kind): the title is fully determined by
+# ${title_suffix} and ${target}, so it doubles as the dedup key. Only OPEN
+# issues are dedup targets — a closed-but-recurring failure means the fix that
+# closed it regressed, and that occurrence deserves its own fresh history.
+issue_number="$(gh issue list --state open --label release-blocker \
+  --search "in:title \"parser fuzz ${title_suffix} in ${target}\"" \
+  --json number,title \
+  --jq "map(select(.title == \"${title}\")) | .[0].number // empty")"
+
+if [ -z "${issue_number}" ]; then
+  # No open match: file a fresh issue carrying every reproducer from this run.
+  cat "${header}" > "${create_body}"
+  for i in "${!basenames[@]}"; do
+    cat "${sections_dir}/${i}" >> "${create_body}"
+  done
+  gh issue create \
+    --title "${title}" \
+    --label "release-blocker" \
+    --body-file "${create_body}"
+  exit 0
+fi
+
+# Open match exists: comment only with reproducers whose basename is not already
+# recorded in the issue body or any of its comments. Re-found identical inputs
+# add nothing.
+existing_content="$(gh issue view "${issue_number}" --json body,comments \
+  --jq '.body, (.comments[]?.body)')"
+
+declare -a new_indices=()
+for i in "${!basenames[@]}"; do
+  if ! grep -qF -- "${basenames[$i]}" <<<"${existing_content}"; then
+    new_indices+=("${i}")
+  fi
+done
+
+if [ "${#new_indices[@]}" -eq 0 ]; then
+  # Known failure recurred with no new inputs: stay silent, just log.
+  echo "Known failure \"${title}\" recurred in ${GITHUB_RUN_URL:-unknown} with no new inputs (#${issue_number}); nothing to report."
+  exit 0
+fi
+
+{
+  echo "Nightly parser fuzz reproduced this failure again."
+  echo
+  echo "- Workflow run: ${GITHUB_RUN_URL:-unknown}"
+  echo
+  echo "## New reproducers"
+  echo
+} > "${comment_body}"
+for i in "${new_indices[@]}"; do
+  cat "${sections_dir}/${i}" >> "${comment_body}"
+done
+
+gh issue comment "${issue_number}" --body-file "${comment_body}"

--- a/scripts/test-report-parser-fuzz-crashes.sh
+++ b/scripts/test-report-parser-fuzz-crashes.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Tests for scripts/report-parser-fuzz-crashes.sh dedup behaviour.
+#
+# Every case stubs `gh` (and `cargo`, so no real fuzzer runs) via a temp bin
+# on PATH — the live tracker is never touched. Each stub appends one line per
+# invocation to ${CALL_LOG} and captures any --body-file it receives, so the
+# assertions can read exactly what the script tried to do.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="${SCRIPT_DIR}/report-parser-fuzz-crashes.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+BIN="${WORK}/bin"
+mkdir -p "${BIN}"
+
+# --- gh stub --------------------------------------------------------------
+# Behaviour is driven by env vars set per case:
+#   STUB_ISSUE_NUMBER  -> what `gh issue list ... --jq` returns (open match, or empty)
+#   STUB_ISSUE_BODY    -> what `gh issue view` returns (body + comments text)
+# It logs `list`, `view`, `create`, `comment <n>` lines to ${CALL_LOG} and
+# copies create/comment bodies to ${CREATE_BODY}/${COMMENT_BODY}.
+cat > "${BIN}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+sub="${1:-} ${2:-}"
+case "${sub}" in
+  "label create") exit 0 ;;
+  "issue list")
+    echo "list" >> "${CALL_LOG}"
+    printf '%s' "${STUB_ISSUE_NUMBER:-}"
+    ;;
+  "issue view")
+    echo "view ${3:-}" >> "${CALL_LOG}"
+    printf '%s' "${STUB_ISSUE_BODY:-}"
+    ;;
+  "issue create")
+    echo "create" >> "${CALL_LOG}"
+    body=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body-file" ]; then body="$2"; fi
+      shift
+    done
+    [ -n "${body}" ] && cp "${body}" "${CREATE_BODY}"
+    echo "https://github.com/reddb-io/reddb/issues/999"
+    ;;
+  "issue comment")
+    num="${3:-}"
+    echo "comment ${num}" >> "${CALL_LOG}"
+    body=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body-file" ]; then body="$2"; fi
+      shift
+    done
+    [ -n "${body}" ] && cp "${body}" "${COMMENT_BODY}"
+    ;;
+  *) echo "unexpected gh call: $*" >&2; exit 3 ;;
+esac
+STUB
+chmod +x "${BIN}/gh"
+
+# cargo stub: swallow `cargo +nightly fuzz tmin ...` so no real fuzzer runs.
+cat > "${BIN}/cargo" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "${BIN}/cargo"
+
+export PATH="${BIN}:${PATH}"
+export GITHUB_RUN_URL="https://github.com/reddb-io/reddb/actions/runs/12345"
+export RUNNER_TEMP="${WORK}/runner-temp"
+mkdir -p "${RUNNER_TEMP}"
+
+FAILURES=0
+fail() { echo "  FAIL: $*"; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok: $*"; }
+
+# Fresh isolated working tree + one oom artifact whose basename is a content hash.
+setup_case() {
+  local dir="$1" artifact_basename="$2"
+  rm -rf "${dir}"
+  mkdir -p "${dir}/fuzz/artifacts/migration_parser"
+  printf 'crashing-input-bytes' > "${dir}/fuzz/artifacts/migration_parser/${artifact_basename}"
+  export CALL_LOG="${dir}/calls.log"
+  export CREATE_BODY="${dir}/create-body.txt"
+  export COMMENT_BODY="${dir}/comment-body.txt"
+  : > "${CALL_LOG}"
+}
+
+count() { grep -c "^$1$" "${CALL_LOG}" 2>/dev/null || true; }
+
+ART="oom-deadbeefcafe"
+
+# --- Case 1: no matching open issue -> exactly one create -----------------
+echo "case 1: no open match -> gh issue create once"
+setup_case "${WORK}/c1" "${ART}"
+unset STUB_ISSUE_BODY
+STUB_ISSUE_NUMBER="" bash -c "cd '${WORK}/c1' && '${SCRIPT}' migration_parser" >/dev/null
+[ "$(count create)" = "1" ] && pass "create called once" || fail "create count = $(count create) (want 1)"
+[ "$(count 'comment .*')" = "0" ] || fail "comment should not be called"
+
+# --- Case 2: open match already contains the basename -> silence ----------
+echo "case 2: open match already records basename -> no create, no comment"
+setup_case "${WORK}/c2" "${ART}"
+export STUB_ISSUE_NUMBER="42"
+export STUB_ISSUE_BODY="Existing issue body mentioning artifact ${ART} already."
+bash -c "cd '${WORK}/c2' && '${SCRIPT}' migration_parser" >/dev/null
+[ "$(count create)" = "0" ] && pass "create not called" || fail "create called (want 0)"
+[ "$(grep -c '^comment ' "${CALL_LOG}" || true)" = "0" ] && pass "comment not called" || fail "comment called (want 0)"
+
+# --- Case 3: open match missing the basename -> one comment on that issue --
+echo "case 3: open match missing basename -> exactly one comment, no create"
+setup_case "${WORK}/c3" "${ART}"
+export STUB_ISSUE_NUMBER="42"
+export STUB_ISSUE_BODY="Existing issue body with an old artifact oom-oldhash only."
+bash -c "cd '${WORK}/c3' && '${SCRIPT}' migration_parser" >/dev/null
+[ "$(count create)" = "0" ] && pass "create not called" || fail "create called (want 0)"
+[ "$(count 'comment 42')" = "1" ] && pass "comment on #42 once" || fail "comment 42 count = $(count 'comment 42') (want 1)"
+if grep -qF "${GITHUB_RUN_URL}" "${COMMENT_BODY}"; then pass "comment carries run URL"; else fail "comment missing run URL"; fi
+EXPECTED_B64="$(printf 'crashing-input-bytes' | base64 --wrap=0)"
+if grep -qF "${EXPECTED_B64}" "${COMMENT_BODY}"; then pass "comment carries base64 reproducer"; else fail "comment missing base64 reproducer"; fi
+
+# --- Case 4: only a CLOSED same-title issue -> create (not a dedup target) -
+echo "case 4: closed-only issue -> gh issue create"
+setup_case "${WORK}/c4" "${ART}"
+unset STUB_ISSUE_BODY
+# `gh issue list --state open` finds nothing because the same-title issue is closed.
+STUB_ISSUE_NUMBER="" bash -c "cd '${WORK}/c4' && '${SCRIPT}' migration_parser" >/dev/null
+[ "$(count create)" = "1" ] && pass "create called once" || fail "create count = $(count create) (want 1)"
+[ "$(grep -c '^comment ' "${CALL_LOG}" || true)" = "0" ] && pass "comment not called" || fail "comment called (want 0)"
+
+echo
+if [ "${FAILURES}" -eq 0 ]; then
+  echo "All report-parser-fuzz-crashes dedup tests passed."
+else
+  echo "${FAILURES} assertion(s) failed."
+  exit 1
+fi


### PR DESCRIPTION
Automated AFK landing for #2094. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2094

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788287621&installation_model_id=20659&pr_number=2097&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2097&signature=14e9d4de2a368063acd3cf56cccb62cfdc77a433a1b35f0900881996e0a36000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->