### PR TITLE
chore(afk): allowlist nightly-fuzz bot issues through the trust gate

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -14,6 +14,17 @@ plugins:
 
     afk:
       # ----------------------------------------------------------------
+      # Trust gate (fail-closed on public repos). The nightly parser-fuzz
+      # workflow files release-blockers as app/github-actions and the
+      # maintainer promotes them to ready-for-agent during triage, so both
+      # actors must be allowlisted or every bot-authored issue is held for
+      # summon forever. MUST be a single string (the loader `.split()`s it),
+      # not a YAML list.
+      # ----------------------------------------------------------------
+      trust-gate:
+        allowlist: "app/github-actions filipeforattini"
+
+      # ----------------------------------------------------------------
       # Worker model tiers. Pin every Claude tier to opus-4-8/high so a
       # worker never falls through to the cheaper per-tier defaults
       # (validate defaults to low). Flattening every tier onto one slug


### PR DESCRIPTION
The AFK trust gate runs fail-closed on this public repo. Issues authored by `app/github-actions` (the nightly parser-fuzz release-blockers) were held for summon on every drain — #2062 accumulated 11 claim/concede cycles across two days with zero progress.

The gate's own hint names `triage:summon` as a release path, but the pre-pick eligibility classifier only reads `afk.trust-gate.allowlist`; the label and `triage --summon` feed the triage belt, not eligibility. So the durable cure is the allowlist, carrying both actors the classifier checks: the issue author (`app/github-actions`) and the `ready-for-agent` promoter (`filipeforattini`).

The value is a single string, not a YAML list — the loader `.split()`s it (same class of constraint as the hooks-must-be-scalars note already in the file).

Verified live: with this config in the primary checkout, daemon-born worker `hT8S0` passed the gate and claimed #2062.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788438174&installation_model_id=20659&pr_number=2101&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2101&signature=fdd06df176af706fc412b775b75891b2bb63497721e23a462f3de2557c8330f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->