### PR TITLE
ci: cap recurring Blacksmith spend

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -34,5 +34,14 @@ final-status-level = "slow"
 slow-timeout = { period = "60s", terminate-after = 2 }
 retries = 1
 
+# Building a 200-table persistent catalog is intentionally CPU- and I/O-heavy.
+# Give this one overflow-chain regression exclusive access to the public runner
+# and a larger hard timeout; every other test keeps the 120-second ceiling.
+[[profile.ci.overrides]]
+filter = 'test(massive_catalog_forces_meta_overflow_chain)'
+threads-required = "num-cpus"
+slow-timeout = { period = "60s", terminate-after = 5 }
+retries = 0
+
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/blacksmith-testbox.yml
+++ b/.github/workflows/blacksmith-testbox.yml
@@ -1,0 +1,102 @@
+name: Blacksmith Testbox
+
+# Permanent reddb-only pilot. Warm with `--idle-timeout 10`, run the bounded
+# comparison command, then always call `blacksmith testbox stop --id <id>`.
+# Select exactly one job with `blacksmith testbox warmup blacksmith-testbox.yml
+# --job rust-{2,4,8}vcpu --idle-timeout 10`.
+on:
+  workflow_dispatch:
+    inputs:
+      testbox_id:
+        type: string
+        description: Testbox session ID
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  rust-2vcpu:
+    name: Rust 2 vCPU
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 90
+    steps:
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: testbox-rust-1.91.0-2vcpu
+          cache-on-failure: 'true'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Run Testbox
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
+        if: always()
+
+  rust-4vcpu:
+    name: Rust 4 vCPU
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 90
+    steps:
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: testbox-rust-1.91.0-4vcpu
+          cache-on-failure: 'true'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Run Testbox
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
+        if: always()
+
+  rust-8vcpu:
+    name: Rust 8 vCPU
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 90
+    steps:
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.91.0
+      - uses: ./.github/actions/install-protoc
+        with:
+          version: '28.3'
+      - uses: rui314/setup-mold@v1
+      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: testbox-rust-1.91.0-8vcpu
+          cache-on-failure: 'true'
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+      - name: Run Testbox
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
+        if: always()

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   changesets:
     name: Version Packages
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # Skip on the version-bump commit itself to avoid an infinite loop. The
     # commit landing the version bump is authored by github-actions[bot] —
     # that push doesn't need to re-trigger this workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,12 @@ on:
 # Cost guard: new pushes cancel older runs on the same ref. Release-grade
 # validation lives in release.yml; CI push runs should stay quick.
 #
-# Cost policy (July 2026, Blacksmith bill): expensive jobs (feature matrix,
-# cross-platform, driver conformance, containers, fuzz smoke, packaging) run
-# POST-MERGE on push to main/develop — never on an open PR. PRs keep the fast
-# correctness lane: gate, lints, contract gates, quality, tests, RQL
-# conformance. `workflow_dispatch` with full_ci=true still runs everything
-# on demand. rust-cache saves are restricted to non-PR runs (save-if) so PR
-# branches never persist multi-GB caches.
+# Cost policy (August 2026, Blacksmith bill): pushes and pull requests run only
+# the trunk correctness lane. Feature matrices, cross-platform builds, driver
+# conformance, containers, fuzz smoke, and packaging are release-adjacent and
+# run only through `workflow_dispatch` with full_ci=true. Stable release builds
+# remain authoritative in release.yml. rust-cache saves are restricted to
+# non-PR runs (save-if) so PR branches never persist multi-GB caches.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -55,7 +54,8 @@ jobs:
   # Dependabot (Dependabot PRs run the dedicated dependabot.yml workflow instead).
   gate:
     name: gate
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
     if: |
       github.actor != 'dependabot[bot]' &&
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
@@ -322,7 +322,7 @@ jobs:
     # operators may select for release artifacts.
     name: Feature Matrix (${{ matrix.features.label }})
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 20
     strategy:
@@ -427,7 +427,7 @@ jobs:
   driver-param-conformance:
     name: Driver Param Conformance
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -501,7 +501,7 @@ jobs:
     # statically links the engine, so `maturin develop` is self-contained.
     name: Driver Runnable Examples
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 35
     env:
@@ -550,7 +550,7 @@ jobs:
     # tarball, so this also exercises the include manifest end-to-end.
     name: Publish Dry-Run (crates.io)
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     env:
@@ -577,7 +577,7 @@ jobs:
   containers:
     name: Container Stack
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 25
     steps:
@@ -716,7 +716,7 @@ jobs:
     # (systemd install, mmap, Unix sockets) via cfg gates in the source.
     name: Windows (build + unit tests)
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-8vcpu-windows-2025
     timeout-minutes: 30
     steps:
@@ -741,7 +741,7 @@ jobs:
     # story complete. Same scope — library build + unit tests.
     name: macOS (build + unit tests)
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-6vcpu-macos-15
     timeout-minutes: 30
     steps:
@@ -760,11 +760,11 @@ jobs:
         run: cargo test --locked --lib
 
   fuzz-parsers:
-    # Post-merge bounded smoke window (cost policy above); the long
+    # On-demand bounded smoke window (cost policy above); the long
     # exploration window lives in parser-fuzz-nightly.yml.
     name: Fuzz Parsers
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     env:
@@ -819,7 +819,7 @@ jobs:
   package:
     name: cargo package dry-run
     needs: gate
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.full_ci)
+    if: github.event_name == 'workflow_dispatch' && inputs.full_ci
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,13 @@ on:
 # Cost guard: new pushes cancel older runs on the same ref. Release-grade
 # validation lives in release.yml; CI push runs should stay quick.
 #
-# Cost policy (August 2026, Blacksmith bill): pushes and pull requests run only
-# the trunk correctness lane. Feature matrices, cross-platform builds, driver
-# conformance, containers, fuzz smoke, and packaging are release-adjacent and
-# run only through `workflow_dispatch` with full_ci=true. Stable release builds
-# remain authoritative in release.yml. rust-cache saves are restricted to
-# non-PR runs (save-if) so PR branches never persist multi-GB caches.
+# Cost policy (August 2026, Blacksmith bill): pushes and pull requests run the
+# trunk correctness lane on free standard runners for this public repository.
+# Feature matrices, cross-platform builds, driver conformance, containers,
+# fuzz smoke, and packaging are release-adjacent and run on Blacksmith only
+# through `workflow_dispatch` with full_ci=true. Stable release builds remain
+# authoritative in release.yml. rust-cache saves are restricted to non-PR runs
+# (save-if) so PR branches never persist multi-GB caches.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -224,7 +225,7 @@ jobs:
   quality:
     name: Quality (fmt, check, clippy)
     needs: gate
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -260,7 +261,7 @@ jobs:
     # every later RQL-extraction slice must keep green.
     name: RQL Conformance (sqllogictest)
     needs: gate
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -292,7 +293,7 @@ jobs:
     # that motivated this gate.
     name: Drivers / Python (cargo check)
     needs: gate
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -357,7 +358,7 @@ jobs:
   tests:
     name: Test Suite
     needs: gate
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  merge_group:
+    types: [checks_requested]
   push:
     branches: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/crypto-coverage.yml
+++ b/.github/workflows/crypto-coverage.yml
@@ -25,7 +25,7 @@ jobs:
   crypto-coverage:
     name: Crypto Coverage Gate
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 15

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -27,7 +27,7 @@ jobs:
   check:
     name: Verify update compiles
     if: github.actor == 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -64,7 +64,7 @@ jobs:
     name: Auto-approve patch/minor bumps
     needs: check
     if: github.actor == 'dependabot[bot]'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to GitHub Pages
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/drill-nightly.yml
+++ b/.github/workflows/drill-nightly.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   drill:
     name: Backup/Restore Drills
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/drill-nightly.yml
+++ b/.github/workflows/drill-nightly.yml
@@ -1,8 +1,8 @@
-name: Nightly DR Drill
+name: Weekly DR Drill
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * 2'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -1,8 +1,8 @@
-name: DST Nightly
+name: DST Weekly
 
 on:
   schedule:
-    - cron: "23 7 * * *"
+    - cron: "23 7 * * 4"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dst-nightly.yml
+++ b/.github/workflows/dst-nightly.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   dst-seed-sweep:
     name: DST seed sweep
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -32,7 +32,7 @@ jobs:
 
   storage-fault-recovery:
     name: Storage fault recovery
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 25
     permissions:
       contents: read

--- a/.github/workflows/file-coverage.yml
+++ b/.github/workflows/file-coverage.yml
@@ -25,7 +25,7 @@ jobs:
   file-coverage:
     name: File Coverage Gate
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 30

--- a/.github/workflows/kv-bench.yml
+++ b/.github/workflows/kv-bench.yml
@@ -1,14 +1,8 @@
 name: KV Benchmark Gate
 
 on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - '.github/workflows/kv-bench.yml'
-      - 'bench/kv/**'
-      - 'bench/results/kv-release-baseline.json'
-      - 'crates/reddb-server/**'
-      - 'src/bin/red.rs'
+  schedule:
+    - cron: '11 5 * * 0'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/kv-bench.yml
+++ b/.github/workflows/kv-bench.yml
@@ -19,7 +19,7 @@ jobs:
   kv-bench:
     name: KV p99 gate
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     services:
       redis:

--- a/.github/workflows/parser-coverage.yml
+++ b/.github/workflows/parser-coverage.yml
@@ -26,7 +26,7 @@ jobs:
   parser-coverage:
     name: Parser Coverage Report
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 75
     concurrency:
       group: parser-fuzz-weekly-${{ github.ref }}-${{ matrix.target }}

--- a/.github/workflows/parser-fuzz-nightly.yml
+++ b/.github/workflows/parser-fuzz-nightly.yml
@@ -1,9 +1,18 @@
-name: Parser Fuzz Nightly
+name: Parser Fuzz Weekly
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 3 * * 6"
   workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: Fuzzing time per target
+        type: choice
+        default: '45'
+        options:
+          - '15'
+          - '45'
+          - '60'
 
 permissions:
   contents: read
@@ -14,14 +23,15 @@ env:
   CARGO_INCREMENTAL: 0
   FUZZ_RSS_LIMIT_MB: 4096
   FUZZ_MALLOC_LIMIT_MB: 2048
+  FUZZ_DURATION_SECONDS: ${{ (github.event_name == 'workflow_dispatch' && inputs.duration_minutes) || '2700' }}
 
 jobs:
   fuzz:
     name: Fuzz ${{ matrix.target }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 90
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 75
     concurrency:
-      group: parser-fuzz-nightly-${{ github.ref }}-${{ matrix.target }}
+      group: parser-fuzz-weekly-${{ github.ref }}-${{ matrix.target }}
       cancel-in-progress: false
     strategy:
       fail-fast: false
@@ -65,7 +75,7 @@ jobs:
       - name: Run ${{ matrix.target }}
         run: >
           cargo +nightly fuzz run ${{ matrix.target }} --
-          -max_total_time=3600
+          -max_total_time="${FUZZ_DURATION_SECONDS}"
           -rss_limit_mb="${FUZZ_RSS_LIMIT_MB}"
           -malloc_limit_mb="${FUZZ_MALLOC_LIMIT_MB}"
 

--- a/.github/workflows/pgwire-clients.yml
+++ b/.github/workflows/pgwire-clients.yml
@@ -35,7 +35,7 @@ jobs:
   pgwire-clients:
     name: PG-Wire Clients (psycopg, pgx, pgjdbc)
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -1,13 +1,6 @@
 name: Release Candidate
 
 on:
-  push:
-    branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - 'CHANGELOG**'
-      - 'LICENSE**'
   workflow_dispatch:
 
 permissions:
@@ -17,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
 
-# New pushes to main cancel the in-flight RC — only the latest commit matters.
+# Only one manually requested RC for a ref should run at a time.
 concurrency:
   group: release-candidate-${{ github.ref }}
   cancel-in-progress: true
@@ -25,7 +18,7 @@ concurrency:
 jobs:
   plan:
     name: Plan
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     outputs:
       should_skip: ${{ steps.plan.outputs.should_skip }}
@@ -140,7 +133,7 @@ jobs:
   publish-github:
     name: GitHub Pre-release
     needs: [plan, build-linux]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
@@ -236,7 +229,7 @@ jobs:
   publish-npm:
     name: Publish npm packages @rc
     needs: [plan, publish-github]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -269,7 +262,7 @@ jobs:
   publish-cargo:
     name: Skip crates @rc
     needs: [plan, build-linux]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     # Cargo pre-release publishing is intentionally skipped. The Rust workspace has
     # internal path dependency cycles (notably wire <-> grpc-proto) that make exact
     # RC version rewriting unsafe; stable release publishing remains authoritative.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   plan:
     name: Plan release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     outputs:
       should_skip: ${{ steps.plan.outputs.should_skip }}
       release_channel: ${{ steps.plan.outputs.release_channel }}
@@ -360,7 +360,7 @@ jobs:
   publish-github:
     name: GitHub Release
     needs: [plan, build, artifact-sizes]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
@@ -612,7 +612,7 @@ jobs:
     # before any npm tarball ships.
     name: Verify release assets
     needs: [plan, publish-github]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -627,7 +627,7 @@ jobs:
   publish-npm:
     name: Publish CLI npm package
     needs: [plan, publish-github, verify-release-assets]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -726,7 +726,7 @@ jobs:
   publish-js-driver:
     name: Publish @reddb-io/sdk (npm)
     needs: [plan, publish-github, verify-release-assets]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -762,7 +762,7 @@ jobs:
   publish-js-client:
     name: Publish @reddb-io/client (npm)
     needs: [plan, publish-github, verify-release-assets]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -798,7 +798,7 @@ jobs:
   publish-bun-client:
     name: Publish @reddb-io/client-bun (npm)
     needs: [plan, publish-github, verify-release-assets]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -834,7 +834,7 @@ jobs:
   publish-mcp:
     name: Publish @reddb-io/mcp (npm)
     needs: [plan, publish-github, verify-release-assets]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     if: |
       needs.plan.outputs.should_skip != 'true' &&
       needs.plan.outputs.release_channel == 'stable'
@@ -1111,7 +1111,7 @@ jobs:
     name: Upload wheels to PyPI
     needs: [plan, publish-python-wheels]
     if: false  # TODO: enable after creating PYPI_API_TOKEN secret
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/rql-coverage.yml
+++ b/.github/workflows/rql-coverage.yml
@@ -24,7 +24,7 @@ jobs:
   rql-coverage:
     name: RQL Coverage Report
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/sql-reference.yml
+++ b/.github/workflows/sql-reference.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   check:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/types-coverage.yml
+++ b/.github/workflows/types-coverage.yml
@@ -25,7 +25,7 @@ jobs:
   types-coverage:
     name: Types Coverage Gate
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/wire-coverage.yml
+++ b/.github/workflows/wire-coverage.yml
@@ -24,7 +24,7 @@ jobs:
   wire-coverage:
     name: Wire Coverage Gate
     if: github.actor != 'dependabot[bot]'
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 25

--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -14,7 +14,7 @@ plugins:
 
     afk:
       # ----------------------------------------------------------------
-      # Trust gate (fail-closed on public repos). The nightly parser-fuzz
+      # Trust gate (fail-closed on public repos). The scheduled parser-fuzz
       # workflow files release-blockers as app/github-actions and the
       # maintainer promotes them to ready-for-agent during triage, so both
       # actors must be allowlisted or every bot-authored issue is held for

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -276,7 +276,7 @@ test("weekly parser fuzz keeps bounded coverage for every smoke target", () => {
 
   assert.match(workflow, /cron: "17 3 \* \* 6"/);
   assert.match(workflow, /duration_minutes:[\s\S]*- '15'[\s\S]*- '45'[\s\S]*- '60'/);
-  assert.match(fuzz, /runs-on: blacksmith-4vcpu-ubuntu-2404/);
+  assert.match(fuzz, /runs-on: ubuntu-24\.04/);
   assert.match(fuzz, /timeout-minutes: 75/);
   for (const target of ["sql_parser", "migration_parser", "conn_string_parser", "query_with_params"]) {
     assert.match(fuzz, new RegExp(`- ${target}`));

--- a/scripts/release_tooling_contract.test.mjs
+++ b/scripts/release_tooling_contract.test.mjs
@@ -249,13 +249,14 @@ test("DST storage fault issue creation deduplicates open release blockers", () =
   assert.ok(createCall > existingReturn, "issue creation must happen after existing issue guard");
 });
 
-test("per-PR parser fuzz runs as one bounded required smoke check", () => {
+test("on-demand parser fuzz runs as one bounded smoke check", () => {
   const workflow = read(".github/workflows/ci.yml");
   const fuzzParsers = workflowJob(workflow, "fuzz-parsers");
 
-  assert.equal(workflowJob(workflow, "fuzz-targets"), "", "per-PR fuzz must not fan out into separate runners");
+  assert.equal(workflowJob(workflow, "fuzz-targets"), "", "fuzz smoke must not fan out into separate runners");
   assert.match(fuzzParsers, /name: Fuzz Parsers/);
   assert.match(fuzzParsers, /needs: gate/);
+  assert.match(fuzzParsers, /if: github\.event_name == 'workflow_dispatch' && inputs\.full_ci/);
   assert.match(fuzzParsers, /timeout-minutes: 15/);
   assert.match(fuzzParsers, /FUZZ_PR_TIME_SECONDS: 30/);
   assert.match(fuzzParsers, /shared-key: ubuntu-fuzz-pr-smoke/);
@@ -269,13 +270,16 @@ test("per-PR parser fuzz runs as one bounded required smoke check", () => {
   );
 });
 
-test("nightly parser fuzz keeps the long-window coverage for every PR target", () => {
+test("weekly parser fuzz keeps bounded coverage for every smoke target", () => {
   const workflow = read(".github/workflows/parser-fuzz-nightly.yml");
   const fuzz = workflowJob(workflow, "fuzz");
 
-  assert.match(fuzz, /timeout-minutes: 90/);
+  assert.match(workflow, /cron: "17 3 \* \* 6"/);
+  assert.match(workflow, /duration_minutes:[\s\S]*- '15'[\s\S]*- '45'[\s\S]*- '60'/);
+  assert.match(fuzz, /runs-on: blacksmith-4vcpu-ubuntu-2404/);
+  assert.match(fuzz, /timeout-minutes: 75/);
   for (const target of ["sql_parser", "migration_parser", "conn_string_parser", "query_with_params"]) {
     assert.match(fuzz, new RegExp(`- ${target}`));
   }
-  assert.match(fuzz, /cargo \+nightly fuzz run \$\{\{ matrix\.target \}\} -- -max_total_time=3600/);
+  assert.match(fuzz, /cargo \+nightly fuzz run \$\{\{ matrix\.target \}\} --[\s\S]*-max_total_time="\$\{FUZZ_DURATION_SECONDS\}"/);
 });


### PR DESCRIPTION
## Why

Recurring Blacksmith matrices, nightly workloads, fuzzing, and trunk checks made runner spend unbounded relative to normal development activity. This repository is public, so standard GitHub-hosted runners are free.

## What changes

- run the required `Test Suite`, quality, RQL conformance, and Python driver checks on `ubuntu-24.04`
- run weekly DR, DST, parser-fuzz, and KV benchmark schedules on `ubuntu-24.04`
- gate feature matrices, driver conformance, containers, fuzz smoke, packaging, Windows, and macOS behind `workflow_dispatch` with `full_ci=true`
- make release candidates manual while preserving the stable-release Blacksmith build matrix
- move lightweight orchestration, coverage, docs, Dependabot, and publish jobs to GitHub-hosted runners
- add a manual Blacksmith Testbox workflow for explicit 2/4/8-vCPU measurements
- update workflow contracts

Blacksmith remains available for explicit full-CI, performance, Testbox, and stable-release workloads. The live parser-fuzz and release-candidate workflows remain manually disabled until this rollout lands.

## Validation

- actionlint across changed active workflows
- `node --test scripts/release_tooling_contract.test.mjs` — 15/15 passing
- `git diff --check`

No release or deployment was invoked.