### PR TITLE
chore(afk): pin codex worker tiers to gpt-5.6/high

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -25,14 +25,28 @@ plugins:
         allowlist: "app/github-actions filipeforattini"
 
       # ----------------------------------------------------------------
-      # Worker model tiers. Pin every Claude tier to opus-4-8/high so a
-      # worker never falls through to the cheaper per-tier defaults
-      # (validate defaults to low). Flattening every tier onto one slug
-      # is the ADR 0049 posture; this is the durable form of the
-      # RED_AFK_MODEL/RED_AFK_EFFORT env override, so no launch needs it.
+      # Worker model tiers. Pin every Codex tier to gpt-5.6/high and every
+      # Claude tier to opus-4-8/high so a worker never falls through to the
+      # cheaper per-tier defaults (validate defaults to low). Flattening
+      # every tier onto one slug is the ADR 0049 posture; this is the
+      # durable form of the RED_AFK_MODEL/RED_AFK_EFFORT env override, so
+      # no launch needs it.
       # Precedence: --model flag > RED_AFK_MODEL env > this block > defaults.
       # ----------------------------------------------------------------
       models:
+        codex:
+          validate:
+            model: gpt-5.6
+            effort: high
+          simple:
+            model: gpt-5.6
+            effort: high
+          complex:
+            model: gpt-5.6
+            effort: high
+          think:
+            model: gpt-5.6
+            effort: high
         claude:
           validate:
             model: claude-opus-4-8


### PR DESCRIPTION
Requested by the maintainer: use `gpt-5.6` at `high` effort as the base model for the codex runner. Mirrors the existing `plugins.dev.afk.models.claude` pinning across all four tiers (`validate`/`simple`/`complex`/`think`) per the ADR 0049 flatten-the-tiers posture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788524368&installation_model_id=20659&pr_number=2104&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2104&signature=498d66420c3df2662019d6cd4db9256fc53affd781c7b4b49c0f99996470b8ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->