### PR TITLE
docs: add TOON output format term to data-model glossary

### DIFF
--- a/.red/context/data-model.md
+++ b/.red/context/data-model.md
@@ -30,6 +30,7 @@ Part of the [glossary map](../CONTEXT-MAP.md). How data is shaped and accessed, 
 - **Stream lease** — internal, unforwarded credential issued at `OpenStream`, bound to the snapshot pin. Outlives the bearer token so credential rotation does not terminate accepted streaming work; lease TTL is capped by snapshot TTL.
 - **Chunk page alignment** — output-stream production buffer reads in N × 16 KiB units (engine `PAGE_SIZE`). Server flushes when byte, row, or latency cap fires. Wire frames carry row-encoded data, not raw page bytes — drivers stay thin and storage layout stays free to evolve.
 - **Resumable annotation** — output-stream open returns `resumable: true|false` based on whether the query has a stable total order. Resume re-executes against the pinned snapshot with `resume_after_rid` filter; prefix hash detects substitution.
+- **TOON output format** — token-oriented object notation (RedDB's tooling at `reddb-io/toon`: Rust crate, `@reddb-io/toon`, `tq` CLI; TOONL is the append-only stream form) as a supported render target for query results, alongside table/CSV/JSON — decided 2026-08-05. A target encoding of the presentation renderer and a `RowFormat` variant in the client/CLI; agent/prompt-facing surfaces are its primary audience.
 
 ## Catalog & Discovery
 


### PR DESCRIPTION
Adds the **TOON output format** term to `.red/context/data-model.md`, recording the 2026-08-05 grill-session decision: TOON (reddb-io/toon tooling; TOONL for streams) becomes a supported render target for query results — a target encoding of the presentation renderer and a `RowFormat` variant in the client/CLI, with agent/prompt-facing surfaces as the primary audience.

Doc-only change landed through the standard docs-worktree lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788527680&installation_model_id=20659&pr_number=2106&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2106&signature=58b49f445df9bcbf24a16944d8b7c4257715171c833376bf90aa4c2e9629e20a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->