### PR TITLE
chore(afk): pin codex tiers to gpt-5.6-sol, claude tiers to opus-5

### DIFF
--- a/.red/config.yaml
+++ b/.red/config.yaml
@@ -25,40 +25,41 @@ plugins:
         allowlist: "app/github-actions filipeforattini"
 
       # ----------------------------------------------------------------
-      # Worker model tiers. Pin every Codex tier to gpt-5.6/high and every
-      # Claude tier to opus-4-8/high so a worker never falls through to the
-      # cheaper per-tier defaults (validate defaults to low). Flattening
-      # every tier onto one slug is the ADR 0049 posture; this is the
-      # durable form of the RED_AFK_MODEL/RED_AFK_EFFORT env override, so
-      # no launch needs it.
+      # Worker model tiers. Pin every Codex tier to gpt-5.6-sol/high (the
+      # flagship of the sol/terra/luna family, mirroring red-skills' coding
+      # tiers) and every Claude tier to opus-5/high, so a worker never
+      # falls through to the cheaper per-tier defaults (validate defaults
+      # to low). Flattening every tier onto one slug is the ADR 0049
+      # posture; this is the durable form of the RED_AFK_MODEL/
+      # RED_AFK_EFFORT env override, so no launch needs it.
       # Precedence: --model flag > RED_AFK_MODEL env > this block > defaults.
       # ----------------------------------------------------------------
       models:
         codex:
           validate:
-            model: gpt-5.6
+            model: gpt-5.6-sol
             effort: high
           simple:
-            model: gpt-5.6
+            model: gpt-5.6-sol
             effort: high
           complex:
-            model: gpt-5.6
+            model: gpt-5.6-sol
             effort: high
           think:
-            model: gpt-5.6
+            model: gpt-5.6-sol
             effort: high
         claude:
           validate:
-            model: claude-opus-4-8
+            model: claude-opus-5
             effort: high
           simple:
-            model: claude-opus-4-8
+            model: claude-opus-5
             effort: high
           complex:
-            model: claude-opus-4-8
+            model: claude-opus-5
             effort: high
           think:
-            model: claude-opus-4-8
+            model: claude-opus-5
             effort: high
 
       # ----------------------------------------------------------------


### PR DESCRIPTION
Applies the maintainer decision from the `/red-doctor --fix` session (2026-08-05): mirror red-skills' `gpt-5.6-sol` (sol/terra/luna flagship) on **all four** Codex tiers — including `validate`, deliberately diverging from red-skills' 5.5 hold there — and move all four Claude tiers to `claude-opus-5`, both at effort `high`.

Config-only change under `plugins.dev.afk.models`; precedence unchanged (`--model` flag > `RED_AFK_MODEL` env > this block > defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788530259&installation_model_id=20659&pr_number=2172&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2172&signature=13551f2c77194a060d3c0e68583c2e564c1b5ce183ec012bd939b7823c7c1288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->