### PR TITLE
merge: #2117 Extract the Transaction State module behind begin/commit/rollback/savepoint

### DIFF
--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -348,7 +348,7 @@ fn run_backend<W: Write>(backend: &Backend<'_>, stdin: Stdin, stdout: &mut W) ->
     let reader = BufReader::new(stdin.lock());
     let mut session = Session::new();
     // Bind the session to a stable connection id so the runtime's
-    // `tx_contexts` (keyed by conn_id) survives across `handle_line`
+    // Transaction State (keyed by conn_id) survives across `handle_line`
     // calls within the same session.
     let conn_id = next_stdio_conn_id();
     crate::runtime::impl_core::set_current_connection_id(conn_id);

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1148,22 +1148,9 @@ struct RuntimeInner {
     /// In-memory only; resets across restart.
     pub(crate) retention_sweeper:
         parking_lot::RwLock<crate::runtime::retention_sweeper::RetentionSweeperState>,
-    /// MVCC snapshot manager (Phase 2.3 PG parity).
-    ///
-    /// Allocates monotonic `xid`s on BEGIN and tracks the active/aborted
-    /// sets used by `Snapshot::sees` to filter tuples by visibility. Each
-    /// query evaluates `entity.is_visible(snapshot.xid)` — pre-MVCC rows
-    /// (`xmin == 0`) stay visible to every snapshot, preserving backward
-    /// compatibility with data written before the xid fields existed.
-    snapshot_manager: Arc<crate::storage::transaction::snapshot::SnapshotManager>,
-    /// Connection → active transaction context map (Phase 2.3 PG parity).
-    ///
-    /// Keyed by connection id from `RuntimeConnection`. Populated on BEGIN,
-    /// cleared on COMMIT/ROLLBACK. When a statement executes outside a
-    /// transaction (autocommit path) no entry exists and writes stamp
-    /// `xid=0` — identical to pre-MVCC behaviour.
-    tx_contexts:
-        parking_lot::RwLock<HashMap<u64, crate::storage::transaction::snapshot::TxnContext>>,
+    /// Per-connection transaction contexts, local tenant overrides, and the
+    /// shared MVCC snapshot manager behind the Transaction State interface.
+    transaction_state: crate::runtime::transaction_state::TransactionState,
     /// Intent-lock hierarchy (IS/IX/S/X) used to break the implicit
     /// global-write serialisation in write paths. Populated at boot
     /// with `concurrency.locking.deadlock_timeout_ms` from the matrix
@@ -1177,14 +1164,6 @@ struct RuntimeInner {
     /// can hot-fix a bad config by restarting with a different env
     /// var set. Keys are restricted to those declared in the matrix.
     env_config_overrides: HashMap<String, String>,
-    /// Transaction-local tenant override (`SET LOCAL TENANT '<id>'`).
-    /// Keyed by connection id, mirroring `tx_contexts`. Lives only while
-    /// a transaction is open — `COMMIT` / `ROLLBACK` evict the entry,
-    /// returning the connection to whichever session-level tenant
-    /// (`SET TENANT 'x'`) was active before the transaction began.
-    /// Wins over the session value but loses to a per-statement
-    /// `WITHIN TENANT '<id>' …` override on the same call.
-    tx_local_tenants: parking_lot::RwLock<HashMap<u64, Option<String>>>,
     /// Row-level security policies (Phase 2.5 PG parity).
     ///
     /// Keyed by `(table_name, policy_name)`; the set of tables with RLS
@@ -1598,6 +1577,7 @@ pub(crate) mod slo_descriptor_catalog;
 pub mod snapshot_reuse;
 mod statement_frame;
 mod table_row_mvcc_resolver;
+pub(crate) mod transaction_state;
 pub mod turbo_crash_inject;
 mod vcs_command;
 mod vector_index;

--- a/crates/reddb-server/src/runtime/execution_context.rs
+++ b/crates/reddb-server/src/runtime/execution_context.rs
@@ -100,7 +100,7 @@ pub struct SnapshotContext {
 }
 
 /// Install a connection id on the current thread for the duration of a
-/// statement. Transaction state (`RuntimeInner::tx_contexts`) is keyed
+/// statement. The Transaction State module is keyed
 /// by this id so different connections can hold independent BEGINs.
 ///
 /// Pub so transports (PG wire, gRPC, HTTP per-request spawners) and
@@ -187,7 +187,7 @@ pub fn current_tenant() -> Option<String> {
 }
 
 thread_local! {
-    /// Snapshot of the active connection's `tx_local_tenants` entry for
+    /// Snapshot of the active connection's transaction-local tenant for
     /// the current `execute_query` call. Outer `Some(_)` means "a
     /// transaction-local tenant override is active for this call";
     /// inner is the override's value (`Some(s)` overrides to `s`,

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -512,8 +512,8 @@ impl RedDBRuntime {
         // ── ULTRA-TURBO: autocommit `SELECT * FROM t WHERE _entity_id = N` ──
         //
         // Moved above every boot-cost the normal path pays (WITHIN
-        // strip, SET LOCAL parse, tx_local_tenants read, snapshot
-        // guard, tracing span, tx_contexts read) because the bench's
+        // strip, SET LOCAL parse, transaction-state reads, snapshot
+        // guard, and tracing span) because the bench's
         // `select_point` scenario was observed at 28× vs PostgreSQL —
         // the dominant cost wasn't the entity fetch but the ceremony
         // before it. Only fires when there's no ambient transaction
@@ -525,9 +525,8 @@ impl RedDBRuntime {
             && !self.inner.query_audit.has_rules()
             && !self
                 .inner
-                .tx_contexts
-                .read()
-                .contains_key(&current_connection_id())
+                .transaction_state
+                .in_transaction(current_connection_id())
         {
             if let Some(result) = self.try_fast_entity_lookup(query) {
                 return result;
@@ -576,15 +575,14 @@ impl RedDBRuntime {
         // within an active transaction).
         if let Some(value) = parse_set_local_tenant(query)? {
             let conn_id = current_connection_id();
-            if !self.inner.tx_contexts.read().contains_key(&conn_id) {
+            if !self.inner.transaction_state.in_transaction(conn_id) {
                 return Err(RedDBError::Query(
                     "SET LOCAL TENANT requires an active transaction".to_string(),
                 ));
             }
             self.inner
-                .tx_local_tenants
-                .write()
-                .insert(conn_id, value.clone());
+                .transaction_state
+                .set_local_tenant(conn_id, value.clone());
             return Ok(RuntimeQueryResult::ok_message(
                 query.to_string(),
                 &match &value {
@@ -1430,7 +1428,6 @@ impl RedDBRuntime {
             // as autocommit (xid=0 → visible to every snapshot).
             QueryExpr::TransactionControl(ref ctl) => {
                 use crate::storage::query::ast::TxnControl;
-                use crate::storage::transaction::snapshot::{TxnContext, Xid};
                 use crate::storage::transaction::IsolationLevel;
 
                 // Phase 2.3 keys transactions by a thread-local connection id.
@@ -1444,107 +1441,61 @@ impl RedDBRuntime {
                         let isolation = requested_isolation
                             .map(IsolationLevel::from)
                             .unwrap_or(IsolationLevel::SnapshotIsolation);
-                        let mgr = Arc::clone(&self.inner.snapshot_manager);
-                        let xid = mgr.begin();
-                        if isolation == IsolationLevel::Serializable {
-                            mgr.begin_serializable(xid);
-                        }
-                        let snapshot = mgr.snapshot(xid);
-                        let ctx = TxnContext {
-                            xid,
-                            isolation,
-                            snapshot,
-                            savepoints: Vec::new(),
-                            released_sub_xids: Vec::new(),
-                        };
-                        self.inner.tx_contexts.write().insert(conn_id, ctx);
+                        let xid = self.inner.transaction_state.begin(conn_id, isolation);
                         ("begin", format!("BEGIN — xid={xid} (snapshot isolation)"))
                     }
                     TxnControl::Commit => {
-                        // SET LOCAL TENANT ends with the transaction.
-                        self.inner.tx_local_tenants.write().remove(&conn_id);
-                        let ctx = self.inner.tx_contexts.write().remove(&conn_id);
-                        match ctx {
+                        let context = self.inner.transaction_state.commit(conn_id, |ctx| {
+                            let mut own_xids = std::collections::HashSet::new();
+                            own_xids.insert(ctx.xid);
+                            for (_, sub) in &ctx.savepoints {
+                                own_xids.insert(*sub);
+                            }
+                            for sub in &ctx.released_sub_xids {
+                                own_xids.insert(*sub);
+                            }
+                            if let Err(err) = self.check_table_row_write_conflicts(
+                                conn_id,
+                                &ctx.snapshot,
+                                &own_xids,
+                                ctx.isolation,
+                            ) {
+                                self.revive_pending_versioned_updates(conn_id);
+                                self.revive_pending_tombstones(conn_id);
+                                self.discard_pending_kv_watch_events(conn_id);
+                                self.discard_pending_queue_wakes(conn_id);
+                                self.discard_pending_store_wal_actions(conn_id);
+                                self.release_pending_claim_locks(conn_id);
+                                return Err(err);
+                            }
+                            if let Err(err) = self.check_queue_dedup_write_conflicts(
+                                conn_id,
+                                &ctx.snapshot,
+                                &own_xids,
+                            ) {
+                                self.revive_pending_versioned_updates(conn_id);
+                                self.revive_pending_tombstones(conn_id);
+                                self.discard_pending_queue_dedup(conn_id);
+                                self.discard_pending_kv_watch_events(conn_id);
+                                self.discard_pending_queue_wakes(conn_id);
+                                self.discard_pending_store_wal_actions(conn_id);
+                                self.release_pending_claim_locks(conn_id);
+                                return Err(err);
+                            }
+                            self.restore_pending_write_stamps(conn_id);
+                            if let Err(err) = self.flush_pending_store_wal_actions(conn_id) {
+                                self.revive_pending_versioned_updates(conn_id);
+                                self.revive_pending_tombstones(conn_id);
+                                self.discard_pending_queue_dedup(conn_id);
+                                self.discard_pending_kv_watch_events(conn_id);
+                                self.discard_pending_queue_wakes(conn_id);
+                                self.release_pending_claim_locks(conn_id);
+                                return Err(err);
+                            }
+                            Ok(())
+                        })?;
+                        match context {
                             Some(ctx) => {
-                                let mut own_xids = std::collections::HashSet::new();
-                                own_xids.insert(ctx.xid);
-                                for (_, sub) in &ctx.savepoints {
-                                    own_xids.insert(*sub);
-                                }
-                                for sub in &ctx.released_sub_xids {
-                                    own_xids.insert(*sub);
-                                }
-                                if let Err(err) = self.check_table_row_write_conflicts(
-                                    conn_id,
-                                    &ctx.snapshot,
-                                    &own_xids,
-                                    ctx.isolation,
-                                ) {
-                                    for (_, sub) in &ctx.savepoints {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    for sub in &ctx.released_sub_xids {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    self.inner.snapshot_manager.rollback(ctx.xid);
-                                    self.revive_pending_versioned_updates(conn_id);
-                                    self.revive_pending_tombstones(conn_id);
-                                    self.discard_pending_kv_watch_events(conn_id);
-                                    self.discard_pending_queue_wakes(conn_id);
-                                    self.discard_pending_store_wal_actions(conn_id);
-                                    self.release_pending_claim_locks(conn_id);
-                                    return Err(err);
-                                }
-                                if let Err(err) = self.check_queue_dedup_write_conflicts(
-                                    conn_id,
-                                    &ctx.snapshot,
-                                    &own_xids,
-                                ) {
-                                    for (_, sub) in &ctx.savepoints {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    for sub in &ctx.released_sub_xids {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    self.inner.snapshot_manager.rollback(ctx.xid);
-                                    self.revive_pending_versioned_updates(conn_id);
-                                    self.revive_pending_tombstones(conn_id);
-                                    self.discard_pending_queue_dedup(conn_id);
-                                    self.discard_pending_kv_watch_events(conn_id);
-                                    self.discard_pending_queue_wakes(conn_id);
-                                    self.discard_pending_store_wal_actions(conn_id);
-                                    self.release_pending_claim_locks(conn_id);
-                                    return Err(err);
-                                }
-                                self.restore_pending_write_stamps(conn_id);
-                                if let Err(err) = self.flush_pending_store_wal_actions(conn_id) {
-                                    for (_, sub) in &ctx.savepoints {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    for sub in &ctx.released_sub_xids {
-                                        self.inner.snapshot_manager.rollback(*sub);
-                                    }
-                                    self.inner.snapshot_manager.rollback(ctx.xid);
-                                    self.revive_pending_versioned_updates(conn_id);
-                                    self.revive_pending_tombstones(conn_id);
-                                    self.discard_pending_queue_dedup(conn_id);
-                                    self.discard_pending_kv_watch_events(conn_id);
-                                    self.discard_pending_queue_wakes(conn_id);
-                                    self.release_pending_claim_locks(conn_id);
-                                    return Err(err);
-                                }
-                                // Phase 2.3.2e: commit every open sub-xid
-                                // so they also become visible. Their
-                                // work is promoted to the parent txn's
-                                // result exactly like a RELEASE would
-                                // have done.
-                                for (_, sub) in &ctx.savepoints {
-                                    self.inner.snapshot_manager.commit(*sub);
-                                }
-                                for sub in &ctx.released_sub_xids {
-                                    self.inner.snapshot_manager.commit(*sub);
-                                }
-                                self.inner.snapshot_manager.commit(ctx.xid);
                                 self.finalize_pending_versioned_updates(conn_id);
                                 self.finalize_pending_tombstones(conn_id);
                                 self.finalize_pending_queue_dedup(conn_id);
@@ -1560,19 +1511,8 @@ impl RedDBRuntime {
                         }
                     }
                     TxnControl::Rollback => {
-                        self.inner.tx_local_tenants.write().remove(&conn_id);
-                        let ctx = self.inner.tx_contexts.write().remove(&conn_id);
-                        match ctx {
+                        match self.inner.transaction_state.rollback(conn_id) {
                             Some(ctx) => {
-                                // Phase 2.3.2e: abort every open sub-xid
-                                // too so their writes stay hidden.
-                                for (_, sub) in &ctx.savepoints {
-                                    self.inner.snapshot_manager.rollback(*sub);
-                                }
-                                for sub in &ctx.released_sub_xids {
-                                    self.inner.snapshot_manager.rollback(*sub);
-                                }
-                                self.inner.snapshot_manager.rollback(ctx.xid);
                                 // Phase 2.3.2b: tuples that the txn had
                                 // xmax-stamped become live again — wipe xmax
                                 // back to 0 so later snapshots see them.
@@ -1598,14 +1538,8 @@ impl RedDBRuntime {
                     // aborting; ROLLBACK TO aborts the sub-xid (and
                     // any nested ones) + revives their tombstones.
                     TxnControl::Savepoint(name) => {
-                        let mgr = Arc::clone(&self.inner.snapshot_manager);
-                        let mut guard = self.inner.tx_contexts.write();
-                        match guard.get_mut(&conn_id) {
-                            Some(ctx) => {
-                                let sub = mgr.begin();
-                                ctx.savepoints.push((name.clone(), sub));
-                                ("savepoint", format!("SAVEPOINT {name} — sub_xid={sub}"))
-                            }
+                        match self.inner.transaction_state.savepoint(conn_id, name) {
+                            Some(sub) => ("savepoint", format!("SAVEPOINT {name} — sub_xid={sub}")),
                             None => (
                                 "savepoint",
                                 "SAVEPOINT outside transaction — no-op".to_string(),
@@ -1613,38 +1547,15 @@ impl RedDBRuntime {
                         }
                     }
                     TxnControl::ReleaseSavepoint(name) => {
-                        let mut guard = self.inner.tx_contexts.write();
-                        match guard.get_mut(&conn_id) {
-                            Some(ctx) => {
-                                let pos = ctx
-                                    .savepoints
-                                    .iter()
-                                    .position(|(n, _)| n == name)
-                                    .ok_or_else(|| {
-                                        RedDBError::Internal(format!(
-                                            "savepoint {name} does not exist"
-                                        ))
-                                    })?;
-                                // RELEASE pops the named savepoint and
-                                // any nested ones. Their sub-xids move
-                                // to `released_sub_xids` so they commit
-                                // (or roll back) alongside the parent
-                                // xid — PG semantics: released
-                                // savepoints still contribute their
-                                // work, but their names are gone.
-                                let released = ctx.savepoints.len() - pos;
-                                let popped: Vec<Xid> = ctx
-                                    .savepoints
-                                    .split_off(pos)
-                                    .into_iter()
-                                    .map(|(_, x)| x)
-                                    .collect();
-                                ctx.released_sub_xids.extend(popped);
-                                (
-                                    "release_savepoint",
-                                    format!("RELEASE SAVEPOINT {name} — {released} level(s)"),
-                                )
-                            }
+                        match self
+                            .inner
+                            .transaction_state
+                            .release_savepoint(conn_id, name)?
+                        {
+                            Some(released) => (
+                                "release_savepoint",
+                                format!("RELEASE SAVEPOINT {name} — {released} level(s)"),
+                            ),
                             None => (
                                 "release_savepoint",
                                 "RELEASE outside transaction — no-op".to_string(),
@@ -1652,49 +1563,23 @@ impl RedDBRuntime {
                         }
                     }
                     TxnControl::RollbackToSavepoint(name) => {
-                        let mgr = Arc::clone(&self.inner.snapshot_manager);
-                        // Splice out the savepoint + nested ones under
-                        // a narrow lock, then run the snapshot-manager
-                        // + tombstone side-effects without the tx map
-                        // held so nothing re-enters.
-                        let drop_result: Option<(Xid, Vec<Xid>)> = {
-                            let mut guard = self.inner.tx_contexts.write();
-                            if let Some(ctx) = guard.get_mut(&conn_id) {
-                                let pos = ctx
-                                    .savepoints
-                                    .iter()
-                                    .position(|(n, _)| n == name)
-                                    .ok_or_else(|| {
-                                        RedDBError::Internal(format!(
-                                            "savepoint {name} does not exist"
-                                        ))
-                                    })?;
-                                let savepoint_xid = ctx.savepoints[pos].1;
-                                let aborted: Vec<Xid> = ctx
-                                    .savepoints
-                                    .split_off(pos)
-                                    .into_iter()
-                                    .map(|(_, x)| x)
-                                    .collect();
-                                Some((savepoint_xid, aborted))
-                            } else {
-                                None
-                            }
-                        };
-
-                        match drop_result {
-                            Some((savepoint_xid, aborted)) => {
-                                for x in &aborted {
-                                    mgr.rollback(*x);
-                                }
-                                let reverted_updates =
-                                    self.revive_versioned_updates_since(conn_id, savepoint_xid);
-                                let revived = self.revive_tombstones_since(conn_id, savepoint_xid);
+                        match self
+                            .inner
+                            .transaction_state
+                            .rollback_to_savepoint(conn_id, name)?
+                        {
+                            Some(rollback) => {
+                                let reverted_updates = self.revive_versioned_updates_since(
+                                    conn_id,
+                                    rollback.savepoint_xid,
+                                );
+                                let revived =
+                                    self.revive_tombstones_since(conn_id, rollback.savepoint_xid);
                                 (
                                     "rollback_to_savepoint",
                                     format!(
                                         "ROLLBACK TO SAVEPOINT {name} — aborted {} sub_xid(s), reverted {reverted_updates} update(s), revived {revived} tombstone(s)",
-                                        aborted.len(),
+                                        rollback.aborted_xids.len(),
                                     ),
                                 )
                             }
@@ -2337,7 +2222,10 @@ impl RedDBRuntime {
                             }
                             vacuum_stats.add(&stats);
                         }
-                        self.inner.snapshot_manager.prune_aborted(cutoff_xid);
+                        self.inner
+                            .transaction_state
+                            .snapshot_manager()
+                            .prune_aborted(cutoff_xid);
                         // Stats refresh covers every target (same as ANALYZE).
                         for t in &targets {
                             self.refresh_table_planner_stats(t);
@@ -3296,7 +3184,7 @@ impl RedDBRuntime {
 
         let explain = self.explain_query(inner_sql)?;
         let conn_id = current_connection_id();
-        if self.inner.tx_contexts.read().contains_key(&conn_id) {
+        if self.inner.transaction_state.in_transaction(conn_id) {
             return Err(RedDBError::Query(
                 "EXPLAIN ANALYZE requires no active transaction".to_string(),
             ));

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -312,11 +312,7 @@ impl RedDBRuntime {
                 retention_sweeper: parking_lot::RwLock::new(
                     crate::runtime::retention_sweeper::RetentionSweeperState::new(),
                 ),
-                snapshot_manager: Arc::new(
-                    crate::storage::transaction::snapshot::SnapshotManager::new(),
-                ),
-                tx_contexts: parking_lot::RwLock::new(HashMap::new()),
-                tx_local_tenants: parking_lot::RwLock::new(HashMap::new()),
+                transaction_state: crate::runtime::transaction_state::TransactionState::new(),
                 env_config_overrides: crate::runtime::config_overlay::collect_env_overrides(),
                 lock_manager: Arc::new({
                     // Sourced from the matrix: Tier B key
@@ -1033,12 +1029,9 @@ impl RedDBRuntime {
                 continue;
             };
             for entity in manager.query_all(|_| true) {
-                self.inner
-                    .snapshot_manager
-                    .observe_committed_xid(entity.xmin);
-                self.inner
-                    .snapshot_manager
-                    .observe_committed_xid(entity.xmax);
+                let snapshot_manager = self.inner.transaction_state.snapshot_manager();
+                snapshot_manager.observe_committed_xid(entity.xmin);
+                snapshot_manager.observe_committed_xid(entity.xmax);
             }
         }
     }

--- a/crates/reddb-server/src/runtime/impl_vcs.rs
+++ b/crates/reddb-server/src/runtime/impl_vcs.rs
@@ -669,8 +669,9 @@ impl RedDBRuntime {
         // Each commit therefore has a unique, monotonic root_xid — a
         // prerequisite for `AS OF BRANCH` to map to distinct
         // snapshots across divergent branches.
-        let root_xid = self.inner.snapshot_manager.begin();
-        self.inner.snapshot_manager.commit(root_xid);
+        let snapshot_manager = self.inner.transaction_state.snapshot_manager();
+        let root_xid = snapshot_manager.begin();
+        snapshot_manager.commit(root_xid);
         let timestamp_ms = now_ms();
         let committer = input.committer.unwrap_or_else(|| input.author.clone());
 
@@ -705,7 +706,7 @@ impl RedDBRuntime {
         // Pin the root xid so VACUUM cannot reclaim history while the
         // commit is reachable.
         if root_xid != XID_NONE {
-            self.inner.snapshot_manager.pin(root_xid);
+            snapshot_manager.pin(root_xid);
         }
 
         // Advance (or create) the branch ref.
@@ -850,7 +851,10 @@ impl RedDBRuntime {
             input.connection_id,
             &branch_ref,
             Some(&target_hash),
-            self.inner.snapshot_manager.peek_next_xid(),
+            self.inner
+                .transaction_state
+                .snapshot_manager()
+                .peek_next_xid(),
         )?;
 
         // Update per-connection HEAD pointer for status/introspection.
@@ -982,8 +986,9 @@ impl RedDBRuntime {
             .max()
             .unwrap_or(0);
         let height = parent_height + 1;
-        let root_xid = self.inner.snapshot_manager.begin();
-        self.inner.snapshot_manager.commit(root_xid);
+        let snapshot_manager = self.inner.transaction_state.snapshot_manager();
+        let root_xid = snapshot_manager.begin();
+        snapshot_manager.commit(root_xid);
 
         let hash = compute_commit_hash(root_xid, &parents, &author, &message, timestamp_ms);
 
@@ -1005,7 +1010,7 @@ impl RedDBRuntime {
         // merge_state_id so status() surfaces the in-progress state.
         save_commit(store, &merge_commit)?;
         if root_xid != XID_NONE {
-            self.inner.snapshot_manager.pin(root_xid);
+            snapshot_manager.pin(root_xid);
         }
         if !head_branch.is_empty() {
             save_ref(
@@ -1127,8 +1132,9 @@ impl RedDBRuntime {
             .map(|c| c.height)
             .unwrap_or(0);
         let height = parent_height + 1;
-        let root_xid = self.inner.snapshot_manager.begin();
-        self.inner.snapshot_manager.commit(root_xid);
+        let snapshot_manager = self.inner.transaction_state.snapshot_manager();
+        let root_xid = snapshot_manager.begin();
+        snapshot_manager.commit(root_xid);
         let timestamp_ms = now_ms();
 
         let hash = compute_commit_hash(root_xid, &parents, &author, &message, timestamp_ms);
@@ -1145,7 +1151,7 @@ impl RedDBRuntime {
         };
         save_commit(store, &pick_commit)?;
         if root_xid != XID_NONE {
-            self.inner.snapshot_manager.pin(root_xid);
+            snapshot_manager.pin(root_xid);
         }
         if !head_branch.is_empty() {
             save_ref(
@@ -1242,8 +1248,9 @@ impl RedDBRuntime {
             .map(|c| c.height)
             .unwrap_or(0);
         let height = parent_height + 1;
-        let root_xid = self.inner.snapshot_manager.begin();
-        self.inner.snapshot_manager.commit(root_xid);
+        let snapshot_manager = self.inner.transaction_state.snapshot_manager();
+        let root_xid = snapshot_manager.begin();
+        snapshot_manager.commit(root_xid);
         let timestamp_ms = now_ms();
 
         let hash = compute_commit_hash(root_xid, &parents, &author, &message, timestamp_ms);
@@ -1260,7 +1267,7 @@ impl RedDBRuntime {
         };
         save_commit(store, &rv_commit)?;
         if root_xid != XID_NONE {
-            self.inner.snapshot_manager.pin(root_xid);
+            snapshot_manager.pin(root_xid);
         }
         if !head_branch.is_empty() {
             save_ref(
@@ -1363,7 +1370,7 @@ impl RedDBRuntime {
         let from_xid = RedDBRuntime::vcs_resolve_as_of(self, AsOfSpec::Commit(from_hash.clone()))?;
         let to_xid = RedDBRuntime::vcs_resolve_as_of(self, AsOfSpec::Commit(to_hash.clone()))?;
 
-        let sm = &self.inner.snapshot_manager;
+        let sm = self.inner.transaction_state.snapshot_manager();
         let from_snap = sm.snapshot(from_xid);
         let to_snap = sm.snapshot(to_xid);
 
@@ -1708,7 +1715,7 @@ fn materialize_merge_conflicts(
     let ours_xid = rt.vcs_resolve_as_of(AsOfSpec::Commit(ours_hash.to_string()))?;
     let theirs_xid = rt.vcs_resolve_as_of(AsOfSpec::Commit(theirs_hash.to_string()))?;
 
-    let sm = &rt.inner.snapshot_manager;
+    let sm = rt.inner.transaction_state.snapshot_manager();
     let base_snap = sm.snapshot(base_xid);
     let ours_snap = sm.snapshot(ours_xid);
     let theirs_snap = sm.snapshot(theirs_xid);

--- a/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/mvcc_lifecycle.rs
@@ -86,7 +86,7 @@ impl RedDBRuntime {
         f: impl FnOnce() -> RedDBResult<T>,
     ) -> RedDBResult<T> {
         let conn_id = current_connection_id();
-        if !self.inner.tx_contexts.read().contains_key(&conn_id) {
+        if !self.inner.transaction_state.in_transaction(conn_id) {
             return f();
         }
 
@@ -108,7 +108,7 @@ impl RedDBRuntime {
         f: impl FnOnce() -> RedDBResult<T>,
     ) -> RedDBResult<T> {
         let conn_id = current_connection_id();
-        if self.inner.tx_contexts.read().contains_key(&conn_id) {
+        if self.inner.transaction_state.in_transaction(conn_id) {
             return self.with_deferred_store_wal_if_transaction(f);
         }
         if !capture_autocommit_events {
@@ -208,8 +208,16 @@ impl RedDBRuntime {
     ) -> bool {
         xid != 0
             && !own_xids.contains(&xid)
-            && !self.inner.snapshot_manager.is_aborted(xid)
-            && !self.inner.snapshot_manager.is_active(xid)
+            && !self
+                .inner
+                .transaction_state
+                .snapshot_manager()
+                .is_aborted(xid)
+            && !self
+                .inner
+                .transaction_state
+                .snapshot_manager()
+                .is_active(xid)
             && (xid > snapshot.xid || snapshot.in_progress.contains(&xid))
     }
 
@@ -322,7 +330,8 @@ impl RedDBRuntime {
         if isolation == crate::storage::transaction::IsolationLevel::Serializable
             && self
                 .inner
-                .snapshot_manager
+                .transaction_state
+                .snapshot_manager()
                 .serializable_commit_would_be_dangerous(
                     *own_xids.iter().min().unwrap_or(&0),
                     &serializable_write_set,
@@ -371,7 +380,11 @@ impl RedDBRuntime {
                 })
             }) {
                 if candidate.id == metadata_id
-                    || self.inner.snapshot_manager.is_aborted(candidate.xmin)
+                    || self
+                        .inner
+                        .transaction_state
+                        .snapshot_manager()
+                        .is_aborted(candidate.xmin)
                 {
                     continue;
                 }
@@ -664,21 +677,9 @@ impl RedDBRuntime {
     ///   implicit xid=0 — the read path treats pre-MVCC rows as always
     ///   visible so this degrades to "see everything committed".
     pub fn current_snapshot(&self) -> crate::storage::transaction::snapshot::Snapshot {
-        let conn_id = current_connection_id();
-        if let Some(ctx) = self.inner.tx_contexts.read().get(&conn_id).cloned() {
-            if ctx.isolation == crate::storage::transaction::IsolationLevel::ReadCommitted {
-                let high_water = self.inner.snapshot_manager.peek_next_xid();
-                return self.inner.snapshot_manager.snapshot(high_water);
-            }
-            return ctx.snapshot;
-        }
-        // Autocommit: take a fresh snapshot bounded by `peek_next_xid` so
-        // every already-committed xid (which is strictly less) passes the
-        // `xmin <= snap.xid` gate, while concurrently-active xids land in
-        // the `in_progress` set and stay hidden until they commit. Using
-        // xid=0 would incorrectly hide every MVCC-stamped tuple.
-        let high_water = self.inner.snapshot_manager.peek_next_xid();
-        self.inner.snapshot_manager.snapshot(high_water)
+        self.inner
+            .transaction_state
+            .current_snapshot(current_connection_id())
     }
 
     /// Xid of the current connection's active transaction, or `None` when
@@ -691,12 +692,9 @@ impl RedDBRuntime {
     /// (e.g. VACUUM min-active calculations) should read `ctx.xid`
     /// directly.
     pub fn current_xid(&self) -> Option<crate::storage::transaction::snapshot::Xid> {
-        let conn_id = current_connection_id();
         self.inner
-            .tx_contexts
-            .read()
-            .get(&conn_id)
-            .map(|ctx| ctx.writer_xid())
+            .transaction_state
+            .writer_xid(current_connection_id())
     }
 
     /// `true` when the given connection id has an open `BEGIN`. Issue
@@ -706,17 +704,17 @@ impl RedDBRuntime {
     /// connection-id plumbing run with id `0`, which never carries a
     /// transaction context, so this returns `false` on those paths.
     pub fn connection_in_transaction(&self, conn_id: u64) -> bool {
-        self.inner.tx_contexts.read().contains_key(&conn_id)
+        self.inner.transaction_state.in_transaction(conn_id)
     }
 
     /// Access the shared `SnapshotManager` — useful for VACUUM to compute
     /// the oldest-active xid when reclaiming dead tuples.
     pub fn snapshot_manager(&self) -> Arc<crate::storage::transaction::snapshot::SnapshotManager> {
-        Arc::clone(&self.inner.snapshot_manager)
+        self.inner.transaction_state.snapshot_manager()
     }
 
     pub(crate) fn mvcc_vacuum_cutoff_xid(&self) -> crate::storage::transaction::snapshot::Xid {
-        let manager = &self.inner.snapshot_manager;
+        let manager = self.inner.transaction_state.snapshot_manager();
         let next_xid = manager.peek_next_xid();
         let mut cutoff = next_xid;
         if let Some(oldest_active) = manager.oldest_active_xid() {
@@ -739,16 +737,8 @@ impl RedDBRuntime {
     pub fn current_txn_own_xids(
         &self,
     ) -> std::collections::HashSet<crate::storage::transaction::snapshot::Xid> {
-        let mut set = std::collections::HashSet::new();
-        if let Some(ctx) = self.inner.tx_contexts.read().get(&current_connection_id()) {
-            set.insert(ctx.xid);
-            for (_, sub) in &ctx.savepoints {
-                set.insert(*sub);
-            }
-            for sub in &ctx.released_sub_xids {
-                set.insert(*sub);
-            }
-        }
-        set
+        self.inner
+            .transaction_state
+            .own_xids(current_connection_id())
     }
 }

--- a/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/vcs_views.rs
@@ -120,9 +120,8 @@ pub(super) fn status_snapshot(runtime: &RedDBRuntime) -> RedDBResult<Vec<Unified
     let status = runtime.vcs_status(crate::application::vcs::StatusInput { connection_id })?;
     let isolation = runtime
         .inner
-        .tx_contexts
-        .read()
-        .get(&connection_id)
+        .transaction_state
+        .context(connection_id)
         .map(|ctx| ctx.isolation);
     Ok(vec![UnifiedRecord::with_schema(
         schema,

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -312,8 +312,8 @@ pub(super) struct PreparedStatement {
 impl StatementExecutionFrame {
     pub(super) fn build(runtime: &RedDBRuntime, query: &str) -> RedDBResult<Self> {
         let conn_id = current_connection_id();
-        let tx_local_tenant = runtime.inner.tx_local_tenants.read().get(&conn_id).cloned();
-        let tx_context = runtime.inner.tx_contexts.read().get(&conn_id).cloned();
+        let tx_local_tenant = runtime.inner.transaction_state.local_tenant(conn_id);
+        let tx_context = runtime.inner.transaction_state.context(conn_id);
         let own_xids = own_transaction_xids(tx_context.as_ref());
         let serializable_reader = tx_context
             .as_ref()
@@ -396,7 +396,7 @@ impl StatementExecutionFrame {
             _kv_store_guard: KvStoreGuard::install(runtime.inner.auth_store.read().clone()),
             _snapshot_guard: CurrentSnapshotGuard::install(SnapshotContext {
                 snapshot: self.snapshot.clone(),
-                manager: Arc::clone(&runtime.inner.snapshot_manager),
+                manager: runtime.inner.transaction_state.snapshot_manager(),
                 own_xids: self.own_xids.clone(),
                 requires_index_fallback: self.requires_index_fallback,
                 serializable_reader: self.serializable_reader,
@@ -978,8 +978,13 @@ impl RedDBRuntime {
     }
 
     fn result_cache_safe(&self, conn_id: u64) -> bool {
-        let has_active_xids = self.inner.snapshot_manager.oldest_active_xid().is_some();
-        let in_own_tx = self.inner.tx_contexts.read().contains_key(&conn_id);
+        let has_active_xids = self
+            .inner
+            .transaction_state
+            .snapshot_manager()
+            .oldest_active_xid()
+            .is_some();
+        let in_own_tx = self.inner.transaction_state.in_transaction(conn_id);
         !has_active_xids && !in_own_tx
     }
 }

--- a/crates/reddb-server/src/runtime/transaction_state.rs
+++ b/crates/reddb-server/src/runtime/transaction_state.rs
@@ -1,0 +1,324 @@
+//! Per-connection transaction state and lifecycle transitions.
+//!
+//! This module owns the connection-to-transaction and transaction-local
+//! tenant maps. Runtime dispatch supplies commit-time validation and pending
+//! write finalization, while transaction and savepoint state changes stay
+//! behind this interface.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::api::{RedDBError, RedDBResult};
+use crate::storage::transaction::snapshot::{Snapshot, SnapshotManager, TxnContext, Xid};
+use crate::storage::transaction::IsolationLevel;
+
+pub(crate) struct RollbackToSavepoint {
+    pub(crate) savepoint_xid: Xid,
+    pub(crate) aborted_xids: Vec<Xid>,
+}
+
+pub(crate) struct TransactionState {
+    snapshot_manager: Arc<SnapshotManager>,
+    contexts: RwLock<HashMap<u64, TxnContext>>,
+    local_tenants: RwLock<HashMap<u64, Option<String>>>,
+}
+
+impl TransactionState {
+    pub(crate) fn new() -> Self {
+        Self {
+            snapshot_manager: Arc::new(SnapshotManager::new()),
+            contexts: RwLock::new(HashMap::new()),
+            local_tenants: RwLock::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn begin(&self, connection_id: u64, isolation: IsolationLevel) -> Xid {
+        let xid = self.snapshot_manager.begin();
+        if isolation == IsolationLevel::Serializable {
+            self.snapshot_manager.begin_serializable(xid);
+        }
+        let context = TxnContext {
+            xid,
+            isolation,
+            snapshot: self.snapshot_manager.snapshot(xid),
+            savepoints: Vec::new(),
+            released_sub_xids: Vec::new(),
+        };
+        self.contexts.write().insert(connection_id, context);
+        xid
+    }
+
+    pub(crate) fn commit<E>(
+        &self,
+        connection_id: u64,
+        prepare: impl FnOnce(&TxnContext) -> Result<(), E>,
+    ) -> Result<Option<TxnContext>, E> {
+        self.local_tenants.write().remove(&connection_id);
+        let Some(context) = self.contexts.write().remove(&connection_id) else {
+            return Ok(None);
+        };
+
+        if let Err(error) = prepare(&context) {
+            self.rollback_context(&context);
+            return Err(error);
+        }
+
+        for (_, xid) in &context.savepoints {
+            self.snapshot_manager.commit(*xid);
+        }
+        for xid in &context.released_sub_xids {
+            self.snapshot_manager.commit(*xid);
+        }
+        self.snapshot_manager.commit(context.xid);
+        Ok(Some(context))
+    }
+
+    pub(crate) fn rollback(&self, connection_id: u64) -> Option<TxnContext> {
+        self.local_tenants.write().remove(&connection_id);
+        let context = self.contexts.write().remove(&connection_id)?;
+        self.rollback_context(&context);
+        Some(context)
+    }
+
+    fn rollback_context(&self, context: &TxnContext) {
+        for (_, xid) in &context.savepoints {
+            self.snapshot_manager.rollback(*xid);
+        }
+        for xid in &context.released_sub_xids {
+            self.snapshot_manager.rollback(*xid);
+        }
+        self.snapshot_manager.rollback(context.xid);
+    }
+
+    pub(crate) fn savepoint(&self, connection_id: u64, name: &str) -> Option<Xid> {
+        let mut contexts = self.contexts.write();
+        let context = contexts.get_mut(&connection_id)?;
+        let xid = self.snapshot_manager.begin();
+        context.savepoints.push((name.to_string(), xid));
+        Some(xid)
+    }
+
+    pub(crate) fn release_savepoint(
+        &self,
+        connection_id: u64,
+        name: &str,
+    ) -> RedDBResult<Option<usize>> {
+        let mut contexts = self.contexts.write();
+        let Some(context) = contexts.get_mut(&connection_id) else {
+            return Ok(None);
+        };
+        let position = context
+            .savepoints
+            .iter()
+            .position(|(savepoint_name, _)| savepoint_name == name)
+            .ok_or_else(|| RedDBError::Internal(format!("savepoint {name} does not exist")))?;
+        let released = context.savepoints.len() - position;
+        context.released_sub_xids.extend(
+            context
+                .savepoints
+                .split_off(position)
+                .into_iter()
+                .map(|(_, xid)| xid),
+        );
+        Ok(Some(released))
+    }
+
+    pub(crate) fn rollback_to_savepoint(
+        &self,
+        connection_id: u64,
+        name: &str,
+    ) -> RedDBResult<Option<RollbackToSavepoint>> {
+        let mut contexts = self.contexts.write();
+        let Some(context) = contexts.get_mut(&connection_id) else {
+            return Ok(None);
+        };
+        let position = context
+            .savepoints
+            .iter()
+            .position(|(savepoint_name, _)| savepoint_name == name)
+            .ok_or_else(|| RedDBError::Internal(format!("savepoint {name} does not exist")))?;
+        let savepoint_xid = context.savepoints[position].1;
+        let aborted_xids = context
+            .savepoints
+            .split_off(position)
+            .into_iter()
+            .map(|(_, xid)| xid)
+            .collect::<Vec<_>>();
+        drop(contexts);
+
+        for xid in &aborted_xids {
+            self.snapshot_manager.rollback(*xid);
+        }
+        Ok(Some(RollbackToSavepoint {
+            savepoint_xid,
+            aborted_xids,
+        }))
+    }
+
+    pub(crate) fn context(&self, connection_id: u64) -> Option<TxnContext> {
+        self.contexts.read().get(&connection_id).cloned()
+    }
+
+    pub(crate) fn in_transaction(&self, connection_id: u64) -> bool {
+        self.contexts.read().contains_key(&connection_id)
+    }
+
+    pub(crate) fn current_snapshot(&self, connection_id: u64) -> Snapshot {
+        if let Some(context) = self.context(connection_id) {
+            if context.isolation == IsolationLevel::ReadCommitted {
+                let high_water = self.snapshot_manager.peek_next_xid();
+                return self.snapshot_manager.snapshot(high_water);
+            }
+            return context.snapshot;
+        }
+        let high_water = self.snapshot_manager.peek_next_xid();
+        self.snapshot_manager.snapshot(high_water)
+    }
+
+    pub(crate) fn writer_xid(&self, connection_id: u64) -> Option<Xid> {
+        self.context(connection_id)
+            .map(|context| context.writer_xid())
+    }
+
+    pub(crate) fn own_xids(&self, connection_id: u64) -> HashSet<Xid> {
+        let mut xids = HashSet::new();
+        if let Some(context) = self.context(connection_id) {
+            xids.insert(context.xid);
+            xids.extend(context.savepoints.into_iter().map(|(_, xid)| xid));
+            xids.extend(context.released_sub_xids);
+        }
+        xids
+    }
+
+    pub(crate) fn set_local_tenant(&self, connection_id: u64, tenant: Option<String>) {
+        self.local_tenants.write().insert(connection_id, tenant);
+    }
+
+    pub(crate) fn local_tenant(&self, connection_id: u64) -> Option<Option<String>> {
+        self.local_tenants.read().get(&connection_id).cloned()
+    }
+
+    pub(crate) fn snapshot_manager(&self) -> Arc<SnapshotManager> {
+        Arc::clone(&self.snapshot_manager)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage::transaction::IsolationLevel;
+
+    use super::TransactionState;
+
+    #[test]
+    fn begin_commit_and_rollback_update_snapshot_state() {
+        let state = TransactionState::new();
+
+        let committed_xid = state.begin(11, IsolationLevel::SnapshotIsolation);
+        assert!(state.in_transaction(11));
+        assert_eq!(state.writer_xid(11), Some(committed_xid));
+        assert!(state.snapshot_manager().is_active(committed_xid));
+
+        let committed = state
+            .commit(11, |_| Ok::<_, ()>(()))
+            .expect("commit preparation should succeed")
+            .expect("connection should have an active transaction");
+        assert_eq!(committed.xid, committed_xid);
+        assert!(!state.in_transaction(11));
+        assert!(!state.snapshot_manager().is_active(committed_xid));
+        assert!(!state.snapshot_manager().is_aborted(committed_xid));
+
+        let aborted_xid = state.begin(11, IsolationLevel::ReadCommitted);
+        let aborted = state
+            .rollback(11)
+            .expect("connection should have an active transaction");
+        assert_eq!(aborted.xid, aborted_xid);
+        assert!(!state.in_transaction(11));
+        assert!(state.snapshot_manager().is_aborted(aborted_xid));
+    }
+
+    #[test]
+    fn savepoint_release_and_rollback_follow_nested_sequence() {
+        let state = TransactionState::new();
+        let parent_xid = state.begin(21, IsolationLevel::SnapshotIsolation);
+        let outer_xid = state
+            .savepoint(21, "outer")
+            .expect("transaction should accept a savepoint");
+        let released_xid = state
+            .savepoint(21, "released")
+            .expect("transaction should accept a nested savepoint");
+
+        assert_eq!(
+            state
+                .release_savepoint(21, "released")
+                .expect("savepoint should exist"),
+            Some(1)
+        );
+        assert_eq!(state.writer_xid(21), Some(outer_xid));
+
+        let nested_xid = state
+            .savepoint(21, "nested")
+            .expect("transaction should accept another nested savepoint");
+        let rolled_back = state
+            .rollback_to_savepoint(21, "outer")
+            .expect("savepoint should exist")
+            .expect("connection should have an active transaction");
+        assert_eq!(rolled_back.savepoint_xid, outer_xid);
+        assert_eq!(rolled_back.aborted_xids, vec![outer_xid, nested_xid]);
+        assert_eq!(state.writer_xid(21), Some(parent_xid));
+        assert!(state.snapshot_manager().is_aborted(outer_xid));
+        assert!(state.snapshot_manager().is_aborted(nested_xid));
+
+        state
+            .commit(21, |_| Ok::<_, ()>(()))
+            .expect("commit preparation should succeed")
+            .expect("connection should have an active transaction");
+        assert!(!state.snapshot_manager().is_active(parent_xid));
+        assert!(!state.snapshot_manager().is_active(released_xid));
+        assert!(!state.snapshot_manager().is_aborted(released_xid));
+    }
+
+    #[test]
+    fn connections_keep_transaction_and_local_tenant_state_isolated() {
+        let state = TransactionState::new();
+        let first_xid = state.begin(31, IsolationLevel::SnapshotIsolation);
+        let second_xid = state.begin(32, IsolationLevel::ReadCommitted);
+        let first_savepoint = state
+            .savepoint(31, "first_only")
+            .expect("first connection should have an active transaction");
+
+        assert_eq!(state.writer_xid(31), Some(first_savepoint));
+        assert_eq!(state.writer_xid(32), Some(second_xid));
+        assert_eq!(state.context(31).expect("first context").xid, first_xid);
+        assert_eq!(state.context(32).expect("second context").xid, second_xid);
+
+        state.set_local_tenant(31, Some("tenant-a".to_string()));
+        state.set_local_tenant(32, Some("tenant-b".to_string()));
+        assert_eq!(
+            state.local_tenant(31).flatten().as_deref(),
+            Some("tenant-a")
+        );
+        assert_eq!(
+            state.local_tenant(32).flatten().as_deref(),
+            Some("tenant-b")
+        );
+
+        state
+            .rollback(31)
+            .expect("first transaction should roll back");
+        assert!(!state.in_transaction(31));
+        assert!(state.in_transaction(32));
+        assert_eq!(state.local_tenant(31), None);
+        assert_eq!(
+            state.local_tenant(32).flatten().as_deref(),
+            Some("tenant-b")
+        );
+
+        state
+            .commit(32, |_| Ok::<_, ()>(()))
+            .expect("commit preparation should succeed")
+            .expect("connection should have an active transaction");
+        assert_eq!(state.local_tenant(32), None);
+    }
+}

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -3738,7 +3738,7 @@ mod tests {
         // with an active `BEGIN` is rejected with
         // `stream_in_transaction_unsupported`. We set a non-zero
         // connection id on this thread, execute `BEGIN` to populate
-        // the runtime's `tx_contexts` registry, then invoke the
+        // runtime's Transaction State registry, then invoke the
         // streaming dispatch and expect a structured 409 refusal.
         use crate::runtime::impl_core::{clear_current_connection_id, set_current_connection_id};
 

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -76,7 +76,7 @@ impl Snapshot {
 }
 
 /// Per-transaction state tracked on the runtime while BEGIN/COMMIT/ROLLBACK
-/// is active. Attached to a connection via `RuntimeInner::tx_contexts`.
+/// is active. Attached to a connection by the runtime Transaction State module.
 #[derive(Debug, Clone)]
 pub struct TxnContext {
     pub xid: Xid,


### PR DESCRIPTION
Automated AFK landing for #2117. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2117

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788534185&installation_model_id=20659&pr_number=2173&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2173&signature=ec00059cf056c3e45cace1f9c513deaaf28534fc98fa531887e5f8fcf3cbe608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->