### PR TITLE
merge: #2118 SnapshotScan: snapshot-carrying scan API on the Segment Manager (expand)

### DIFF
--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -62,10 +62,9 @@ impl RedDBRuntime {
         let manager = store
             .get_collection(&query.collection)
             .ok_or_else(|| RedDBError::NotFound(query.collection.clone()))?;
-        let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
-        let mut entities = manager.query_all(|entity| {
-            crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity)
-        });
+        let snap_ctx = crate::runtime::impl_core::capture_current_snapshot()
+            .expect("event backfill executes inside a statement snapshot");
+        let mut entities = manager.scan(&snap_ctx, |_| true);
         entities.sort_by_key(|entity| entity.id.raw());
 
         let effective_queue = crate::runtime::mutation::effective_queue_name(&subscription);

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -23,6 +23,7 @@ use super::segment::{
     GrowingSegment, SegmentConfig, SegmentError, SegmentId, SegmentState, SegmentStats,
     UnifiedSegment, ZoneColPred, ZoneColPredKind,
 };
+use crate::runtime::mvcc::{entity_visible_with_context, SnapshotContext};
 use crate::storage::btree::visibility_map::VisibilityMap;
 
 /// Fraction of a collection's sealed entities that must be tombstoned before
@@ -1476,6 +1477,21 @@ impl SegmentManager {
         (results, scan_stats)
     }
 
+    /// Scan every segment under an explicit MVCC snapshot.
+    ///
+    /// Visibility is evaluated while each segment iterator is active, before
+    /// the caller's filter. Unlike the raw iteration methods, this entry point
+    /// does not consult thread-local snapshot state, so it preserves the same
+    /// view when invoked from a different thread.
+    pub fn scan<F>(&self, snapshot: &SnapshotContext, filter: F) -> Vec<UnifiedEntity>
+    where
+        F: Fn(&UnifiedEntity) -> bool + Sync,
+    {
+        self.query_all(|entity| {
+            entity_visible_with_context(Some(snapshot), entity) && filter(entity)
+        })
+    }
+
     /// Query across all segments. Uses parallel scanning for sealed segments
     /// when more than one sealed segment exists.
     pub fn query_all<F>(&self, filter: F) -> Vec<UnifiedEntity>
@@ -2101,8 +2117,12 @@ impl UnifiedSegment for Arc<RwLock<GrowingSegment>> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+    use crate::runtime::mvcc::SnapshotContext;
     use crate::storage::schema::Value;
+    use crate::storage::transaction::snapshot::{Snapshot, SnapshotManager};
     use crate::storage::unified::entity::{EntityData, EntityKind, RowData};
 
     #[test]
@@ -2119,6 +2139,74 @@ mod tests {
         let id = manager.insert(entity).unwrap();
         assert!(manager.get(id).is_some());
         assert_eq!(manager.count(), 1);
+    }
+
+    #[test]
+    fn snapshot_scan_applies_table_driven_visibility_on_fresh_thread() {
+        let manager = Arc::new(SegmentManager::new("accounts"));
+        let cases = [
+            ("legacy row", 0, 0, true),
+            ("committed creator", 3, 0, true),
+            ("future creator", 11, 0, false),
+            ("in-progress creator", 4, 0, false),
+            ("committed deleter", 3, 7, false),
+            ("future deleter", 3, 11, true),
+            ("in-progress deleter", 3, 4, true),
+        ];
+
+        for (index, (_, xmin, xmax, _)) in cases.iter().enumerate() {
+            let row_id = index as u64 + 1;
+            let mut entity = UnifiedEntity::table_row(
+                EntityId::new(row_id),
+                "accounts",
+                row_id,
+                vec![Value::Integer(row_id as i64)],
+            );
+            entity.set_xmin(*xmin);
+            entity.set_xmax(*xmax);
+            manager.insert(entity).unwrap();
+        }
+
+        let snapshot = SnapshotContext {
+            snapshot: Snapshot {
+                xid: 10,
+                in_progress: HashSet::from([4]),
+            },
+            manager: Arc::new(SnapshotManager::new()),
+            own_xids: HashSet::new(),
+            requires_index_fallback: false,
+            serializable_reader: None,
+        };
+
+        let raw_visible_row_ids: HashSet<u64> = manager
+            .query_all(|entity| entity_visible_with_context(Some(&snapshot), entity))
+            .into_iter()
+            .filter_map(|entity| match entity.kind {
+                EntityKind::TableRow { row_id, .. } => Some(row_id),
+                _ => None,
+            })
+            .collect();
+
+        let scanned = std::thread::spawn(move || manager.scan(&snapshot, |_| true))
+            .join()
+            .unwrap();
+        let visible_row_ids: HashSet<u64> = scanned
+            .into_iter()
+            .filter_map(|entity| match entity.kind {
+                EntityKind::TableRow { row_id, .. } => Some(row_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(visible_row_ids, raw_visible_row_ids);
+
+        for (index, (name, _, _, expected_visible)) in cases.iter().enumerate() {
+            let row_id = index as u64 + 1;
+            assert_eq!(
+                visible_row_ids.contains(&row_id),
+                *expected_visible,
+                "{name} visibility mismatch"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #2118. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2118

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788535331&installation_model_id=20659&pr_number=2174&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2174&signature=79f3daf37fa27aaa6adfad8f6b75579b4ead6bc9fd5db99850c1d16d2e7412a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->