### PR TITLE
merge: #2120 Command catalog: one operation vocabulary with declarative authorization (expand)

### DIFF
--- a/crates/reddb-server/src/application/mod.rs
+++ b/crates/reddb-server/src/application/mod.rs
@@ -39,7 +39,10 @@ pub use graph::{
     GraphUseCases,
 };
 pub use native::{InspectNativeArtifactInput, NativeUseCases, RuntimeReadiness};
-pub use operation_context::{OperationContext, WriteConsent, WriteConsentSeal, Xid};
+pub use operation_context::{
+    OperationContext, OperationContextFactory, OperationContextInput, WriteConsent,
+    WriteConsentSeal, Xid,
+};
 pub use ports::{
     RuntimeAdminPort, RuntimeCatalogPort, RuntimeEntityPort, RuntimeEntityPortCtx,
     RuntimeGraphPort, RuntimeNativePort, RuntimeNativePortCtx, RuntimeQueryPort,

--- a/crates/reddb-server/src/application/operation_context.rs
+++ b/crates/reddb-server/src/application/operation_context.rs
@@ -102,6 +102,43 @@ pub struct OperationContext {
     pub tenant: Option<String>,
 }
 
+/// Transport-neutral inputs collected at any request boundary.
+#[derive(Debug, Clone, Default)]
+pub struct OperationContextInput {
+    pub request_id: Option<String>,
+    pub principal: Option<String>,
+    pub tenant: Option<String>,
+    pub write_consent: Option<WriteConsent>,
+    pub connection_id: Option<u64>,
+    pub xid: Option<Xid>,
+}
+
+/// Canonical request-context factory shared by HTTP, gRPC, MCP, stdio, and
+/// wire adapters.
+pub struct OperationContextFactory;
+
+impl OperationContextFactory {
+    pub fn build(input: OperationContextInput) -> OperationContext {
+        let request_id = input
+            .request_id
+            .filter(|request_id| !request_id.is_empty())
+            .unwrap_or_else(mint_request_id);
+        let audit_principal = input
+            .principal
+            .filter(|principal| !principal.is_empty())
+            .unwrap_or_else(|| "anonymous".to_string());
+
+        OperationContext {
+            xid: input.xid,
+            connection_id: input.connection_id,
+            audit_principal,
+            request_id,
+            write_consent: input.write_consent,
+            tenant: input.tenant,
+        }
+    }
+}
+
 impl OperationContext {
     /// Anonymous, no-write-consent context. The default for any
     /// caller that hasn't been migrated to construct an explicit
@@ -233,5 +270,24 @@ mod tests {
         assert_eq!(ctx.connection_id, Some(42));
         assert_eq!(ctx.xid, Some(7));
         assert_eq!(ctx.tenant.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn factory_builds_the_same_context_for_every_transport() {
+        let ctx = OperationContextFactory::build(OperationContextInput {
+            request_id: Some("request-transport".to_string()),
+            principal: Some("acme/alice".to_string()),
+            tenant: Some("acme".to_string()),
+            write_consent: None,
+            connection_id: Some(42),
+            xid: Some(7),
+        });
+
+        assert_eq!(ctx.request_id, "request-transport");
+        assert_eq!(ctx.audit_principal, "acme/alice");
+        assert_eq!(ctx.tenant.as_deref(), Some("acme"));
+        assert_eq!(ctx.connection_id, Some(42));
+        assert_eq!(ctx.xid, Some(7));
+        assert!(ctx.write_consent.is_none());
     }
 }

--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -167,7 +167,7 @@ pub mod output_stream;
 mod patch_support;
 mod request_body;
 mod request_context;
-mod route_catalog;
+pub(crate) mod route_catalog;
 mod routes;
 mod routing;
 mod serverless_support;

--- a/crates/reddb-server/src/server/request_context.rs
+++ b/crates/reddb-server/src/server/request_context.rs
@@ -19,7 +19,7 @@
 //! `self.build_*_context(...)`; no public surface change.
 
 use crate::api::RedDBResult;
-use crate::application::OperationContext;
+use crate::application::{OperationContext, OperationContextFactory, OperationContextInput};
 use crate::runtime::write_gate::WriteKind;
 
 use super::RedDBServer;
@@ -32,14 +32,11 @@ impl RedDBServer {
         request_id: Option<&str>,
         principal: Option<&str>,
     ) -> OperationContext {
-        let ctx = match request_id {
-            Some(id) if !id.is_empty() => OperationContext::read_only(id),
-            _ => OperationContext::implicit(),
-        };
-        match principal {
-            Some(p) if !p.is_empty() => ctx.with_principal(p),
-            _ => ctx,
-        }
+        OperationContextFactory::build(OperationContextInput {
+            request_id: request_id.map(str::to_string),
+            principal: principal.map(str::to_string),
+            ..OperationContextInput::default()
+        })
     }
 
     /// Build a writing context. Calls `WriteGate::check_consent`,
@@ -57,20 +54,12 @@ impl RedDBServer {
         principal: Option<&str>,
     ) -> RedDBResult<OperationContext> {
         let consent = self.runtime.write_gate().check_consent(kind)?;
-        let request_id = request_id
-            .filter(|id| !id.is_empty())
-            .map(|id| id.to_string())
-            .unwrap_or_else(|| {
-                // Borrow OperationContext::implicit's minter by
-                // routing through it — keeps the id format
-                // consistent across read / write contexts.
-                OperationContext::implicit().request_id
-            });
-        let mut ctx = OperationContext::writing(consent, request_id);
-        if let Some(p) = principal.filter(|p| !p.is_empty()) {
-            ctx = ctx.with_principal(p);
-        }
-        Ok(ctx)
+        Ok(OperationContextFactory::build(OperationContextInput {
+            request_id: request_id.map(str::to_string),
+            principal: principal.map(str::to_string),
+            write_consent: Some(consent),
+            ..OperationContextInput::default()
+        }))
     }
 }
 

--- a/crates/reddb-server/src/server/route_catalog.rs
+++ b/crates/reddb-server/src/server/route_catalog.rs
@@ -495,10 +495,8 @@ impl<'a> IamCommandPolicyEngine<'a> {
 
 impl CommandPolicyEngine for IamCommandPolicyEngine<'_> {
     fn allows(&self, ctx: &OperationContext, command: &CommandSpec) -> bool {
-        let Some(action) = command_policy_action(command) else {
-            return true;
-        };
-        if ctx.audit_principal == "anonymous" {
+        let policy = command_policy(command);
+        if !policy.default_allow && ctx.audit_principal == "anonymous" {
             return false;
         }
 
@@ -511,32 +509,64 @@ impl CommandPolicyEngine for IamCommandPolicyEngine<'_> {
             principal_tenant: ctx.tenant.clone(),
             current_tenant: ctx.tenant.clone(),
             now_ms: crate::auth::now_ms(),
-            principal_is_platform_scoped: ctx.tenant.is_none(),
+            // OperationContext carries the request's tenant override, not the
+            // principal's scope; an absent override must never satisfy
+            // `platform_scoped` policy conditions meant for platform operators.
+            principal_is_platform_scoped: false,
             ..EvalContext::default()
         };
         let policies: Vec<&Policy> = self.policies.iter().map(Arc::as_ref).collect();
 
-        matches!(
-            policies::evaluate(&policies, action, &resource, &eval_context),
-            policies::Decision::Allow { .. } | policies::Decision::AdminBypass
-        )
+        match policies::evaluate(&policies, policy.action, &resource, &eval_context) {
+            policies::Decision::Deny { .. } => false,
+            policies::Decision::Allow { .. } => true,
+            // AdminBypass is documented dead ("treat admin as an ordinary
+            // principal") and must never become an automatic allow.
+            policies::Decision::DefaultDeny | policies::Decision::AdminBypass => {
+                policy.default_allow
+            }
+        }
     }
 }
 
-fn command_policy_action(command: &CommandSpec) -> Option<&'static str> {
+struct CommandPolicy {
+    action: &'static str,
+    /// Commands whose auth requirement is `Public`/`OptionalUser` need no
+    /// matching Allow policy — but explicit Deny guardrails still apply,
+    /// so the evaluator is always consulted.
+    default_allow: bool,
+}
+
+fn command_policy(command: &CommandSpec) -> CommandPolicy {
+    let method_action = match command.method {
+        RouteMethod::Get | RouteMethod::Options | RouteMethod::Head => "select",
+        RouteMethod::Post
+        | RouteMethod::Put
+        | RouteMethod::Patch
+        | RouteMethod::Delete
+        | RouteMethod::Any => "write",
+    };
     match command.auth {
-        RouteAuth::Public | RouteAuth::OptionalUser => None,
-        RouteAuth::UserRequired => match command.method {
-            RouteMethod::Get | RouteMethod::Options | RouteMethod::Head => Some("select"),
-            RouteMethod::Post
-            | RouteMethod::Put
-            | RouteMethod::Patch
-            | RouteMethod::Delete
-            | RouteMethod::Any => Some("write"),
+        RouteAuth::Public | RouteAuth::OptionalUser => CommandPolicy {
+            action: method_action,
+            default_allow: true,
         },
-        RouteAuth::AdminToken => Some("admin:*"),
-        RouteAuth::OpsCapability(action) => Some(action),
-        RouteAuth::StreamLease => Some("stream"),
+        RouteAuth::UserRequired => CommandPolicy {
+            action: method_action,
+            default_allow: false,
+        },
+        RouteAuth::AdminToken => CommandPolicy {
+            action: "admin:*",
+            default_allow: false,
+        },
+        RouteAuth::OpsCapability(action) => CommandPolicy {
+            action,
+            default_allow: false,
+        },
+        RouteAuth::StreamLease => CommandPolicy {
+            action: "stream",
+            default_allow: false,
+        },
     }
 }
 
@@ -1185,6 +1215,78 @@ mod tests {
         let deny_engine = IamCommandPolicyEngine::new(&deny_policies);
         assert!(matches!(
             CommandAuthorizer::new(&catalog, &deny_engine).authorize(&ctx, "test.command"),
+            Err(CommandAuthorizationError::Denied { .. })
+        ));
+    }
+
+    #[test]
+    fn iam_policy_engine_deny_guardrail_blocks_public_command() {
+        let deny = Arc::new(
+            Policy::from_json_str(
+                r#"{"id":"guardrail","version":1,"statements":[
+                    {"effect":"deny","actions":["select"],
+                     "resources":["command:client:health.get"]}
+                ]}"#,
+            )
+            .expect("deny policy"),
+        );
+        let catalog = CommandCatalog::build(vec![RouteSpec {
+            auth: RouteAuth::Public,
+            audience: RouteAudience::Client,
+            ..spec("health.get", RouteMethod::Get, "/health")
+        }])
+        .expect("command catalog");
+
+        // Without the guardrail a Public command is allowed by default,
+        // even anonymously.
+        let no_policies: Vec<Arc<Policy>> = vec![];
+        let open_engine = IamCommandPolicyEngine::new(&no_policies);
+        let anon = OperationContext::read_only("request-1");
+        assert!(CommandAuthorizer::new(&catalog, &open_engine)
+            .authorize(&anon, "health.get")
+            .is_ok());
+
+        // An explicit Deny wins for anonymous and authenticated callers alike.
+        let deny_policies = vec![deny];
+        let deny_engine = IamCommandPolicyEngine::new(&deny_policies);
+        assert!(matches!(
+            CommandAuthorizer::new(&catalog, &deny_engine).authorize(&anon, "health.get"),
+            Err(CommandAuthorizationError::Denied { .. })
+        ));
+        let user = OperationContext::read_only("request-2").with_principal("operator");
+        assert!(matches!(
+            CommandAuthorizer::new(&catalog, &deny_engine).authorize(&user, "health.get"),
+            Err(CommandAuthorizationError::Denied { .. })
+        ));
+    }
+
+    #[test]
+    fn iam_policy_engine_never_grants_platform_scoped_conditions() {
+        // The allow policy is restricted to platform-scoped principals.
+        // OperationContext carries no principal scope, so a request without
+        // a tenant override must NOT satisfy the condition.
+        let allow = Arc::new(
+            Policy::from_json_str(
+                r#"{"id":"platform-only","version":1,"statements":[
+                    {"effect":"allow","actions":["write"],
+                     "resources":["command:operator:test.command"],
+                     "condition":{"platform_scoped":true}}
+                ]}"#,
+            )
+            .expect("allow policy"),
+        );
+        let catalog = CommandCatalog::build(vec![RouteSpec {
+            audience: RouteAudience::Operator,
+            ..spec("test.command", RouteMethod::Post, "/test")
+        }])
+        .expect("command catalog");
+        let ctx = OperationContext::read_only("request-1").with_principal("tenant-user");
+        assert_eq!(ctx.tenant, None);
+
+        let policies = vec![allow];
+        let engine = IamCommandPolicyEngine::new(&policies);
+        assert!(matches!(
+            CommandAuthorizer::new(&catalog, &engine).authorize(&ctx, "test.command"),
             Err(CommandAuthorizationError::Denied { .. })
         ));
     }

--- a/crates/reddb-server/src/server/route_catalog.rs
+++ b/crates/reddb-server/src/server/route_catalog.rs
@@ -1,5 +1,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
+use std::sync::Arc;
+
+use crate::application::OperationContext;
+use crate::auth::policies::{self, EvalContext, Policy, ResourceRef};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) enum RouteMethod {
@@ -53,7 +57,7 @@ impl fmt::Display for RouteMethod {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RouteAudience {
+pub(crate) enum CommandAudience {
     Client,
     Operator,
     Infra,
@@ -61,8 +65,22 @@ pub(crate) enum RouteAudience {
     Internal,
 }
 
+impl CommandAudience {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "client",
+            Self::Operator => "operator",
+            Self::Infra => "infra",
+            Self::CompatibilityAdapter => "compatibility-adapter",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+pub(crate) type RouteAudience = CommandAudience;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RouteAuth {
+pub(crate) enum CommandAuthRequirement {
     Public,
     OptionalUser,
     UserRequired,
@@ -70,6 +88,8 @@ pub(crate) enum RouteAuth {
     OpsCapability(&'static str),
     StreamLease,
 }
+
+pub(crate) type RouteAuth = CommandAuthRequirement;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ListenerSurface {
@@ -79,11 +99,33 @@ pub(crate) enum ListenerSurface {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RouteStability {
+pub(crate) enum CommandStability {
     Stable,
     Compatibility,
     Deprecated,
     Internal,
+}
+
+pub(crate) type RouteStability = CommandStability;
+
+/// Transport-neutral payload shape carried by one command declaration.
+///
+/// Dispatchers may translate these shapes into HTTP bodies, protobuf
+/// messages, MCP values, or wire frames. `Unspecified` is accepted by the
+/// Rust type so catalog construction can report a useful error instead of
+/// forcing every declaration through a macro.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CommandShape {
+    Unspecified,
+    Empty,
+    Structured,
+    Stream,
+}
+
+impl CommandShape {
+    pub(crate) const fn is_declared(self) -> bool {
+        !matches!(self, Self::Unspecified)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -135,18 +177,22 @@ impl RouteAlias {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct RouteSpec {
+pub(crate) struct CommandSpec {
     pub(crate) id: &'static str,
+    pub(crate) input_shape: CommandShape,
+    pub(crate) output_shape: CommandShape,
     pub(crate) method: RouteMethod,
     pub(crate) pattern: &'static str,
     pub(crate) family: &'static str,
-    pub(crate) audience: RouteAudience,
-    pub(crate) auth: RouteAuth,
+    pub(crate) audience: CommandAudience,
+    pub(crate) auth: CommandAuthRequirement,
     pub(crate) surfaces: &'static [ListenerSurface],
-    pub(crate) stability: RouteStability,
+    pub(crate) stability: CommandStability,
     pub(crate) aliases: &'static [RouteAlias],
     pub(crate) middlewares: &'static [RouteMiddleware],
 }
+
+pub(crate) type RouteSpec = CommandSpec;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RouteGroupDefaults {
@@ -161,6 +207,8 @@ pub(crate) struct RouteGroupDefaults {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct RouteEntry {
     pub(crate) id: &'static str,
+    pub(crate) input_shape: CommandShape,
+    pub(crate) output_shape: CommandShape,
     pub(crate) method: RouteMethod,
     pub(crate) pattern: &'static str,
     pub(crate) aliases: &'static [RouteAlias],
@@ -170,6 +218,8 @@ impl RouteEntry {
     pub(crate) const fn new(id: &'static str, method: RouteMethod, pattern: &'static str) -> Self {
         Self {
             id,
+            input_shape: CommandShape::Structured,
+            output_shape: CommandShape::Structured,
             method,
             pattern,
             aliases: &[],
@@ -184,6 +234,8 @@ impl RouteEntry {
     ) -> Self {
         Self {
             id,
+            input_shape: CommandShape::Structured,
+            output_shape: CommandShape::Structured,
             method,
             pattern,
             aliases,
@@ -205,6 +257,8 @@ impl RouteRegistry {
         for entry in entries {
             self.route(RouteSpec {
                 id: entry.id,
+                input_shape: entry.input_shape,
+                output_shape: entry.output_shape,
                 method: entry.method,
                 pattern: entry.pattern,
                 family: defaults.family,
@@ -224,14 +278,15 @@ impl RouteRegistry {
 }
 
 #[derive(Debug)]
-pub(crate) struct RouteCatalog {
+pub(crate) struct CommandCatalog {
     routes: Vec<CompiledRoute>,
+    command_index: BTreeMap<&'static str, usize>,
     exact_index: BTreeMap<(RouteMethod, &'static str), usize>,
     dynamic_indices: Vec<usize>,
     aliases: Vec<CompiledAlias>,
 }
 
-impl RouteCatalog {
+impl CommandCatalog {
     pub(crate) fn build(specs: Vec<RouteSpec>) -> Result<Self, RouteCatalogError> {
         let mut seen_ids = BTreeSet::new();
         let mut routes = Vec::with_capacity(specs.len());
@@ -239,6 +294,9 @@ impl RouteCatalog {
         for spec in specs {
             if !seen_ids.insert(spec.id) {
                 return Err(RouteCatalogError::DuplicateRouteId { id: spec.id });
+            }
+            if !spec.input_shape.is_declared() || !spec.output_shape.is_declared() {
+                return Err(RouteCatalogError::UndeclaredCommandShape { id: spec.id });
             }
 
             let pattern = RoutePattern::parse(spec.pattern).map_err(|reason| {
@@ -300,9 +358,11 @@ impl RouteCatalog {
         }
 
         let mut exact_index = BTreeMap::new();
+        let mut command_index = BTreeMap::new();
         let mut dynamic_indices = Vec::new();
         let mut aliases = Vec::new();
         for (index, route) in routes.iter().enumerate() {
+            command_index.insert(route.spec.id, index);
             if route.pattern.is_exact() {
                 exact_index.insert((route.spec.method, route.pattern.raw), index);
             } else {
@@ -319,6 +379,7 @@ impl RouteCatalog {
 
         Ok(Self {
             routes,
+            command_index,
             exact_index,
             dynamic_indices,
             aliases,
@@ -327,6 +388,16 @@ impl RouteCatalog {
 
     pub(crate) fn routes(&self) -> impl Iterator<Item = &RouteSpec> {
         self.routes.iter().map(|route| &route.spec)
+    }
+
+    pub(crate) fn commands(&self) -> impl ExactSizeIterator<Item = &CommandSpec> {
+        self.routes.iter().map(|route| &route.spec)
+    }
+
+    pub(crate) fn command(&self, id: &str) -> Option<&CommandSpec> {
+        self.command_index
+            .get(id)
+            .map(|index| &self.routes[*index].spec)
     }
 
     pub(crate) fn find(&self, method: RouteMethod, path: &str) -> Option<RouteMatch<'_>> {
@@ -402,6 +473,122 @@ impl RouteCatalog {
     }
 }
 
+pub(crate) type RouteCatalog = CommandCatalog;
+
+/// Boundary to the ADR 0021 policy engine. Dispatchers supply a context and
+/// command id to [`CommandAuthorizer`]; this is the only seam that receives
+/// the command's authentication requirement and audience.
+pub(crate) trait CommandPolicyEngine {
+    fn allows(&self, ctx: &OperationContext, command: &CommandSpec) -> bool;
+}
+
+/// Adapter from command declarations to the ADR 0021 IAM evaluator.
+pub(crate) struct IamCommandPolicyEngine<'a> {
+    policies: &'a [Arc<Policy>],
+}
+
+impl<'a> IamCommandPolicyEngine<'a> {
+    pub(crate) fn new(policies: &'a [Arc<Policy>]) -> Self {
+        Self { policies }
+    }
+}
+
+impl CommandPolicyEngine for IamCommandPolicyEngine<'_> {
+    fn allows(&self, ctx: &OperationContext, command: &CommandSpec) -> bool {
+        let Some(action) = command_policy_action(command) else {
+            return true;
+        };
+        if ctx.audit_principal == "anonymous" {
+            return false;
+        }
+
+        let resource_name = format!("{}:{}", command.audience.as_str(), command.id);
+        let mut resource = ResourceRef::new("command", resource_name);
+        if let Some(tenant) = &ctx.tenant {
+            resource = resource.with_tenant(tenant);
+        }
+        let eval_context = EvalContext {
+            principal_tenant: ctx.tenant.clone(),
+            current_tenant: ctx.tenant.clone(),
+            now_ms: crate::auth::now_ms(),
+            principal_is_platform_scoped: ctx.tenant.is_none(),
+            ..EvalContext::default()
+        };
+        let policies: Vec<&Policy> = self.policies.iter().map(Arc::as_ref).collect();
+
+        matches!(
+            policies::evaluate(&policies, action, &resource, &eval_context),
+            policies::Decision::Allow { .. } | policies::Decision::AdminBypass
+        )
+    }
+}
+
+fn command_policy_action(command: &CommandSpec) -> Option<&'static str> {
+    match command.auth {
+        RouteAuth::Public | RouteAuth::OptionalUser => None,
+        RouteAuth::UserRequired => match command.method {
+            RouteMethod::Get | RouteMethod::Options | RouteMethod::Head => Some("select"),
+            RouteMethod::Post
+            | RouteMethod::Put
+            | RouteMethod::Patch
+            | RouteMethod::Delete
+            | RouteMethod::Any => Some("write"),
+        },
+        RouteAuth::AdminToken => Some("admin:*"),
+        RouteAuth::OpsCapability(action) => Some(action),
+        RouteAuth::StreamLease => Some("stream"),
+    }
+}
+
+pub(crate) struct CommandAuthorizer<'a, P: ?Sized> {
+    catalog: &'a CommandCatalog,
+    policy_engine: &'a P,
+}
+
+impl<'a, P: CommandPolicyEngine + ?Sized> CommandAuthorizer<'a, P> {
+    pub(crate) fn new(catalog: &'a CommandCatalog, policy_engine: &'a P) -> Self {
+        Self {
+            catalog,
+            policy_engine,
+        }
+    }
+
+    pub(crate) fn authorize(
+        &self,
+        ctx: &OperationContext,
+        command_id: &str,
+    ) -> Result<(), CommandAuthorizationError> {
+        let command = self
+            .catalog
+            .command(command_id)
+            .ok_or_else(|| CommandAuthorizationError::UnknownCommand(command_id.to_string()))?;
+        if self.policy_engine.allows(ctx, command) {
+            Ok(())
+        } else {
+            Err(CommandAuthorizationError::Denied {
+                command_id: command.id,
+            })
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CommandAuthorizationError {
+    UnknownCommand(String),
+    Denied { command_id: &'static str },
+}
+
+impl fmt::Display for CommandAuthorizationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnknownCommand(id) => write!(f, "unknown command {id}"),
+            Self::Denied { command_id } => write!(f, "command {command_id} denied by policy"),
+        }
+    }
+}
+
+impl std::error::Error for CommandAuthorizationError {}
+
 pub(crate) struct RouteMatch<'a> {
     pub(crate) spec: &'a RouteSpec,
     pub(crate) params: BTreeMap<String, String>,
@@ -409,6 +596,9 @@ pub(crate) struct RouteMatch<'a> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum RouteCatalogError {
+    UndeclaredCommandShape {
+        id: &'static str,
+    },
     InvalidPattern {
         route_id: &'static str,
         pattern: &'static str,
@@ -435,6 +625,9 @@ pub(crate) enum RouteCatalogError {
 impl fmt::Display for RouteCatalogError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::UndeclaredCommandShape { id } => {
+                write!(f, "command {id} has an undeclared input or output shape")
+            }
             Self::InvalidPattern {
                 route_id,
                 pattern,
@@ -664,6 +857,9 @@ fn split_request_path(path: &str) -> Option<Vec<&str>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::application::OperationContext;
+    use crate::auth::policies::Policy;
+    use std::sync::Arc;
 
     const NO_SURFACES: &[ListenerSurface] = &[ListenerSurface::Public];
     const NO_MIDDLEWARE: &[RouteMiddleware] = &[];
@@ -671,6 +867,8 @@ mod tests {
     fn spec(id: &'static str, method: RouteMethod, pattern: &'static str) -> RouteSpec {
         RouteSpec {
             id,
+            input_shape: CommandShape::Structured,
+            output_shape: CommandShape::Structured,
             method,
             pattern,
             family: "test",
@@ -860,5 +1058,134 @@ mod tests {
             catalog.resolve_alias(RouteMethod::Get, "/v1/ai/models/embedding-small"),
             Some("/ai/models/embedding-small".to_string())
         );
+    }
+
+    struct MatrixPolicyEngine {
+        allowed_auth: RouteAuth,
+        allowed_audience: RouteAudience,
+    }
+
+    impl CommandPolicyEngine for MatrixPolicyEngine {
+        fn allows(&self, _ctx: &OperationContext, command: &CommandSpec) -> bool {
+            command.auth == self.allowed_auth && command.audience == self.allowed_audience
+        }
+    }
+
+    #[test]
+    fn authorize_allows_and_denies_every_auth_requirement() {
+        for auth in [
+            RouteAuth::Public,
+            RouteAuth::OptionalUser,
+            RouteAuth::UserRequired,
+            RouteAuth::AdminToken,
+            RouteAuth::OpsCapability("ops:read:cluster"),
+            RouteAuth::StreamLease,
+        ] {
+            let catalog = CommandCatalog::build(vec![RouteSpec {
+                auth,
+                ..spec("test.command", RouteMethod::Post, "/test")
+            }])
+            .expect("command catalog");
+            let ctx = OperationContext::read_only("request-1");
+
+            let allow = MatrixPolicyEngine {
+                allowed_auth: auth,
+                allowed_audience: RouteAudience::Client,
+            };
+            assert!(CommandAuthorizer::new(&catalog, &allow)
+                .authorize(&ctx, "test.command")
+                .is_ok());
+
+            let deny = MatrixPolicyEngine {
+                allowed_auth: if auth == RouteAuth::Public {
+                    RouteAuth::UserRequired
+                } else {
+                    RouteAuth::Public
+                },
+                allowed_audience: RouteAudience::Client,
+            };
+            assert!(matches!(
+                CommandAuthorizer::new(&catalog, &deny).authorize(&ctx, "test.command"),
+                Err(CommandAuthorizationError::Denied { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn authorize_allows_and_denies_every_command_audience() {
+        for audience in [
+            RouteAudience::Client,
+            RouteAudience::Operator,
+            RouteAudience::Infra,
+            RouteAudience::CompatibilityAdapter,
+            RouteAudience::Internal,
+        ] {
+            let catalog = CommandCatalog::build(vec![RouteSpec {
+                audience,
+                ..spec("test.command", RouteMethod::Post, "/test")
+            }])
+            .expect("command catalog");
+            let ctx = OperationContext::read_only("request-1");
+
+            let allow = MatrixPolicyEngine {
+                allowed_auth: RouteAuth::UserRequired,
+                allowed_audience: audience,
+            };
+            assert!(CommandAuthorizer::new(&catalog, &allow)
+                .authorize(&ctx, "test.command")
+                .is_ok());
+
+            let deny = MatrixPolicyEngine {
+                allowed_auth: RouteAuth::UserRequired,
+                allowed_audience: RouteAudience::Internal,
+            };
+            if audience != RouteAudience::Internal {
+                assert!(matches!(
+                    CommandAuthorizer::new(&catalog, &deny).authorize(&ctx, "test.command"),
+                    Err(CommandAuthorizationError::Denied { .. })
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn iam_policy_engine_applies_explicit_deny_and_audience_resource() {
+        let allow = Arc::new(
+            Policy::from_json_str(
+                r#"{"id":"allow-operator","version":1,"statements":[
+                    {"effect":"allow","actions":["write"],
+                     "resources":["command:operator:test.command"]}
+                ]}"#,
+            )
+            .expect("allow policy"),
+        );
+        let deny = Arc::new(
+            Policy::from_json_str(
+                r#"{"id":"deny-command","version":1,"statements":[
+                    {"effect":"deny","actions":["write"],
+                     "resources":["command:operator:test.command"]}
+                ]}"#,
+            )
+            .expect("deny policy"),
+        );
+        let catalog = CommandCatalog::build(vec![RouteSpec {
+            audience: RouteAudience::Operator,
+            ..spec("test.command", RouteMethod::Post, "/test")
+        }])
+        .expect("command catalog");
+        let ctx = OperationContext::read_only("request-1").with_principal("operator");
+
+        let allow_policies = vec![allow.clone()];
+        let allow_engine = IamCommandPolicyEngine::new(&allow_policies);
+        assert!(CommandAuthorizer::new(&catalog, &allow_engine)
+            .authorize(&ctx, "test.command")
+            .is_ok());
+
+        let deny_policies = vec![allow, deny];
+        let deny_engine = IamCommandPolicyEngine::new(&deny_policies);
+        assert!(matches!(
+            CommandAuthorizer::new(&catalog, &deny_engine).authorize(&ctx, "test.command"),
+            Err(CommandAuthorizationError::Denied { .. })
+        ));
     }
 }

--- a/crates/reddb-server/src/server/routes/health/live.route.rs
+++ b/crates/reddb-server/src/server/routes/health/live.route.rs
@@ -1,11 +1,13 @@
 use crate::server::route_catalog::{
-    ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod, RouteRegistry,
-    RouteSpec, RouteStability,
+    CommandShape, ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod,
+    RouteRegistry, RouteSpec, RouteStability,
 };
 
 pub(crate) fn register(registry: &mut RouteRegistry) {
     registry.route(RouteSpec {
         id: "health.live",
+        input_shape: CommandShape::Empty,
+        output_shape: CommandShape::Structured,
         method: RouteMethod::Get,
         pattern: "/health/live",
         family: "health",

--- a/crates/reddb-server/src/server/routes/health/ready.route.rs
+++ b/crates/reddb-server/src/server/routes/health/ready.route.rs
@@ -1,11 +1,13 @@
 use crate::server::route_catalog::{
-    ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod, RouteRegistry,
-    RouteSpec, RouteStability,
+    CommandShape, ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod,
+    RouteRegistry, RouteSpec, RouteStability,
 };
 
 pub(crate) fn register(registry: &mut RouteRegistry) {
     registry.route(RouteSpec {
         id: "health.ready",
+        input_shape: CommandShape::Empty,
+        output_shape: CommandShape::Structured,
         method: RouteMethod::Get,
         pattern: "/health/ready",
         family: "health",

--- a/crates/reddb-server/src/server/routes/health/startup.route.rs
+++ b/crates/reddb-server/src/server/routes/health/startup.route.rs
@@ -1,11 +1,13 @@
 use crate::server::route_catalog::{
-    ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod, RouteRegistry,
-    RouteSpec, RouteStability,
+    CommandShape, ListenerSurface, RouteAudience, RouteAuth, RouteMiddleware, RouteMethod,
+    RouteRegistry, RouteSpec, RouteStability,
 };
 
 pub(crate) fn register(registry: &mut RouteRegistry) {
     registry.route(RouteSpec {
         id: "health.startup",
+        input_shape: CommandShape::Empty,
+        output_shape: CommandShape::Structured,
         method: RouteMethod::Get,
         pattern: "/health/startup",
         family: "health",

--- a/crates/reddb-server/src/server/routes/mod.rs
+++ b/crates/reddb-server/src/server/routes/mod.rs
@@ -51,6 +51,22 @@ mod tests {
     }
 
     #[test]
+    fn every_discovered_http_route_is_an_enumerable_command() {
+        let catalog = build_discovered_route_catalog().unwrap();
+        let route_ids: Vec<&str> = catalog.routes().map(|route| route.id).collect();
+        let commands: Vec<_> = catalog.commands().collect();
+        let command_ids: Vec<&str> = commands.iter().map(|command| command.id).collect();
+
+        assert_eq!(command_ids, route_ids);
+        assert!(commands
+            .iter()
+            .all(|command| command.input_shape.is_declared()));
+        assert!(commands
+            .iter()
+            .all(|command| command.output_shape.is_declared()));
+    }
+
+    #[test]
     fn discovered_routes_are_matchable() {
         let catalog = build_discovered_route_catalog().unwrap();
         let matched = catalog.find(RouteMethod::Get, "/health/live").unwrap();


### PR DESCRIPTION
Automated AFK landing for #2120. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2120

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788538632&installation_model_id=20659&pr_number=2175&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2175&signature=c9fcbd660d2a9c3691383091903f1131cbc1da839249266fbdebfaf8983c8bc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->