### PR TITLE
merge: #2136 Migrate MVCC visibility batch 1: table and aggregate scan paths

### DIFF
--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -64,7 +64,7 @@ impl RedDBRuntime {
             .ok_or_else(|| RedDBError::NotFound(query.collection.clone()))?;
         let snap_ctx = crate::runtime::impl_core::capture_current_snapshot()
             .expect("event backfill executes inside a statement snapshot");
-        let mut entities = manager.scan(&snap_ctx, |_| true);
+        let mut entities = manager.scan(Some(&snap_ctx), |_| true);
         entities.sort_by_key(|entity| entity.id.raw());
 
         let effective_queue = crate::runtime::mutation::effective_queue_name(&subscription);

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -18,7 +18,6 @@ use crate::runtime::join_filter::{
     projection_name, resolve_runtime_field, runtime_partial_cmp, sort_records_by_order_by_with_db,
 };
 use crate::runtime::runtime_table_record_from_entity_ref;
-use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 use crate::storage::query::ast::{
     BinOp, CompareOp, Expr, FieldRef, Filter, OrderByClause, Projection, Span, UnaryOp,
 };
@@ -323,12 +322,9 @@ pub(crate) fn execute_aggregate_query(
     >::new(spill_dir.path(), WORK_MEM_BYTES, ESTIMATED_ENTRY_BYTES);
     let mut spill_err: Option<String> = None;
 
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
-    manager.for_each_entity(|entity| {
-        if table_row_resolver.resolve_read_candidate(entity).is_none() {
-            return true;
-        }
-
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
+        .expect("aggregate scan executes inside a statement snapshot");
+    manager.scan_for_each(&snapshot, |entity| {
         // ── Lazy record materialisation ──────────────────────────────────
         // We defer `runtime_table_record_from_entity` until we actually
         // need it (complex filters, GROUP BY exprs or aggregate args that
@@ -3140,9 +3136,10 @@ fn try_execute_parallel_single_col_numeric_aggs(
         return Ok(None);
     };
 
-    let table_row_resolver =
-        TableRowMvccReadResolver::captured(crate::runtime::impl_core::capture_current_snapshot());
-    let acc = manager.fold_entities_parallel(
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
+        .expect("parallel aggregate scan executes inside a statement snapshot");
+    let acc = manager.scan_fold_parallel(
+        &snapshot,
         || FastNumericGroupAccumulator {
             groups: std::collections::HashMap::new(),
             unsupported_value: false,
@@ -3151,10 +3148,6 @@ fn try_execute_parallel_single_col_numeric_aggs(
             if local.unsupported_value {
                 return local;
             }
-            if table_row_resolver.resolve_read_candidate(entity).is_none() {
-                return local;
-            }
-
             let Some(value_cow) = group_accessor.get_value(entity) else {
                 local.unsupported_value = true;
                 return local;

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -322,9 +322,8 @@ pub(crate) fn execute_aggregate_query(
     >::new(spill_dir.path(), WORK_MEM_BYTES, ESTIMATED_ENTRY_BYTES);
     let mut spill_err: Option<String> = None;
 
-    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
-        .expect("aggregate scan executes inside a statement snapshot");
-    manager.scan_for_each(&snapshot, |entity| {
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
         // ── Lazy record materialisation ──────────────────────────────────
         // We defer `runtime_table_record_from_entity` until we actually
         // need it (complex filters, GROUP BY exprs or aggregate args that
@@ -3136,10 +3135,9 @@ fn try_execute_parallel_single_col_numeric_aggs(
         return Ok(None);
     };
 
-    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
-        .expect("parallel aggregate scan executes inside a statement snapshot");
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     let acc = manager.scan_fold_parallel(
-        &snapshot,
+        snapshot.as_ref(),
         || FastNumericGroupAccumulator {
             groups: std::collections::HashMap::new(),
             unsupported_value: false,

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1467,7 +1467,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         };
 
         // A5 — parallel scan: when there's no explicit LIMIT and the collection
-        // is large enough, use query_all_zoned which parallelises filter eval
+        // is large enough, use scan_zoned_with_stats which parallelises filter eval
         // across sealed segments using std::thread::scope. Sequential path kept
         // for LIMIT queries so the early-exit optimisation still works.
         let entity_count = manager.count();

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -190,14 +190,12 @@ fn execute_geo_candidate_scan(
         &crate::runtime::scalar_evaluator::PermissiveScope,
     );
 
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
+        .expect("geo table scan executes inside a statement snapshot");
     let hydrate_store = db.store();
     let mut records = Vec::new();
-    manager.for_each_entity(|entity| {
+    manager.scan_for_each(&snapshot, |entity| {
         if !candidate_ids.contains(&entity.id.raw()) {
-            return true;
-        }
-        if table_row_resolver.resolve_read_candidate(entity).is_none() {
             return true;
         }
         if !db.replica_allows_entity_at_read(&query.table, entity) {
@@ -1483,15 +1481,11 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
 
         let mut records: Vec<UnifiedRecord> = Vec::new();
         let hydrate_store = store;
+        let snapshot = crate::runtime::impl_core::capture_current_snapshot()
+            .expect("table scan executes inside a statement snapshot");
         if use_parallel {
-            // Parallel scan spawns worker threads that don't inherit the
-            // main thread's CURRENT_SNAPSHOT thread-local. Capture the
-            // context here so each closure invocation (on any thread) runs
-            // the same MVCC visibility gate.
-            let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
-            let table_row_resolver = TableRowMvccReadResolver::captured(snap_ctx);
             let (matching, scan_stats) =
-                manager.query_all_zoned_with_stats(&zone_preds, |entity| {
+                manager.scan_zoned_with_stats(&snapshot, &zone_preds, |entity| {
                     if let Some(candidates) = tag_series_candidates.as_ref() {
                         let EntityData::TimeSeries(point) = &entity.data else {
                             return false;
@@ -1505,8 +1499,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         hydrate_store.as_ref(),
                         entity,
                     );
-                    table_row_resolver.resolve_read_candidate(entity).is_some()
-                        && db.replica_allows_entity_at_read(&query.table, entity)
+                    db.replica_allows_entity_at_read(&query.table, entity)
                         && compiled.as_ref().is_none_or(|filter| {
                             requires_filter_recheck || filter.evaluate(&hydrated)
                         })
@@ -1577,13 +1570,10 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 }
             }
         } else {
-            let table_row_resolver = TableRowMvccReadResolver::current_statement();
-            let scan_stats = manager.for_each_entity_zoned_with_stats(&zone_preds, |entity| {
+            let scan_stats =
+                manager.scan_for_each_zoned_with_stats(&snapshot, &zone_preds, |entity| {
                 if records.len() >= limit {
                     return false; // stop iteration
-                }
-                if table_row_resolver.resolve_read_candidate(entity).is_none() {
-                    return true; // skip hidden tuple, keep scanning
                 }
                 if !db.replica_allows_entity_at_read(&query.table, entity) {
                     return true;
@@ -1951,13 +1941,11 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 };
 
                 let mut records: Vec<UnifiedRecord> = Vec::new();
-                let table_row_resolver = TableRowMvccReadResolver::current_statement();
-                manager.for_each_entity(|entity| {
+                let snapshot = crate::runtime::impl_core::capture_current_snapshot()
+                    .expect("filtered table scan executes inside a statement snapshot");
+                manager.scan_for_each(&snapshot, |entity| {
                     if records.len() >= limit {
                         return false;
-                    }
-                    if table_row_resolver.resolve_read_candidate(entity).is_none() {
-                        return true;
                     }
                     if !db.replica_allows_entity_at_read(&context.query.table, entity) {
                         return true;

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -190,11 +190,10 @@ fn execute_geo_candidate_scan(
         &crate::runtime::scalar_evaluator::PermissiveScope,
     );
 
-    let snapshot = crate::runtime::impl_core::capture_current_snapshot()
-        .expect("geo table scan executes inside a statement snapshot");
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     let hydrate_store = db.store();
     let mut records = Vec::new();
-    manager.scan_for_each(&snapshot, |entity| {
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
         if !candidate_ids.contains(&entity.id.raw()) {
             return true;
         }
@@ -1481,11 +1480,10 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
 
         let mut records: Vec<UnifiedRecord> = Vec::new();
         let hydrate_store = store;
-        let snapshot = crate::runtime::impl_core::capture_current_snapshot()
-            .expect("table scan executes inside a statement snapshot");
+        let snapshot = crate::runtime::impl_core::capture_current_snapshot();
         if use_parallel {
             let (matching, scan_stats) =
-                manager.scan_zoned_with_stats(&snapshot, &zone_preds, |entity| {
+                manager.scan_zoned_with_stats(snapshot.as_ref(), &zone_preds, |entity| {
                     if let Some(candidates) = tag_series_candidates.as_ref() {
                         let EntityData::TimeSeries(point) = &entity.data else {
                             return false;
@@ -1571,7 +1569,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             }
         } else {
             let scan_stats =
-                manager.scan_for_each_zoned_with_stats(&snapshot, &zone_preds, |entity| {
+                manager.scan_for_each_zoned_with_stats(snapshot.as_ref(), &zone_preds, |entity| {
                 if records.len() >= limit {
                     return false; // stop iteration
                 }
@@ -1941,9 +1939,8 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 };
 
                 let mut records: Vec<UnifiedRecord> = Vec::new();
-                let snapshot = crate::runtime::impl_core::capture_current_snapshot()
-                    .expect("filtered table scan executes inside a statement snapshot");
-                manager.scan_for_each(&snapshot, |entity| {
+                let snapshot = crate::runtime::impl_core::capture_current_snapshot();
+                manager.scan_for_each(snapshot.as_ref(), |entity| {
                     if records.len() >= limit {
                         return false;
                     }

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -2210,6 +2210,25 @@ mod tests {
     }
 
     #[test]
+    fn query_scan_callers_use_snapshot_api_for_visibility() {
+        let table = include_str!("../../runtime/query_exec/table.rs");
+        let aggregate = include_str!("../../runtime/query_exec/aggregate.rs");
+
+        assert_eq!(
+            table.matches(".for_each_entity(|entity|").count(),
+            1,
+            "only the visibility-independent schema inspection may use the raw table iterator"
+        );
+        assert!(!table.contains(".query_all_zoned_with_stats("));
+        assert!(!table.contains(".for_each_entity_zoned_with_stats("));
+        assert!(!table.contains("TableRowMvccReadResolver::captured"));
+
+        assert!(!aggregate.contains("TableRowMvccReadResolver"));
+        assert!(!aggregate.contains(".for_each_entity("));
+        assert!(!aggregate.contains(".fold_entities_parallel("));
+    }
+
+    #[test]
     fn bloom_may_contain_key_probes_inserted_rid_bytes() {
         let manager = SegmentManager::new("test_collection");
 

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -1477,38 +1477,52 @@ impl SegmentManager {
         (results, scan_stats)
     }
 
+    /// Visibility predicate for the `scan_*` family. `Some` delegates to the
+    /// canonical `entity_visible_with_context`; `None` is a frameless read
+    /// (autocommit or the prepared-statement fast path, which installs no
+    /// statement snapshot) and keeps the documented resolver fallback —
+    /// moderation gate plus hiding superseded physical versions — instead of
+    /// showing every version.
+    fn scan_entity_visible(snapshot: Option<&SnapshotContext>, entity: &UnifiedEntity) -> bool {
+        match snapshot {
+            Some(ctx) => entity_visible_with_context(Some(ctx), entity),
+            None => {
+                !crate::runtime::ai::moderation::entity_moderation_hidden(entity)
+                    && entity.xmax == 0
+            }
+        }
+    }
+
     /// Scan every segment under an explicit MVCC snapshot.
     ///
     /// Visibility is evaluated while each segment iterator is active, before
     /// the caller's filter. Unlike the raw iteration methods, this entry point
     /// does not consult thread-local snapshot state, so it preserves the same
     /// view when invoked from a different thread.
-    pub fn scan<F>(&self, snapshot: &SnapshotContext, filter: F) -> Vec<UnifiedEntity>
+    pub fn scan<F>(&self, snapshot: Option<&SnapshotContext>, filter: F) -> Vec<UnifiedEntity>
     where
         F: Fn(&UnifiedEntity) -> bool + Sync,
     {
-        self.query_all(|entity| {
-            entity_visible_with_context(Some(snapshot), entity) && filter(entity)
-        })
+        self.query_all(|entity| Self::scan_entity_visible(snapshot, entity) && filter(entity))
     }
 
     /// Visit every entity visible under an explicit MVCC snapshot.
     ///
     /// Returning `false` from `callback` stops the scan early. Hidden entities
     /// never reach the callback and therefore cannot stop the scan.
-    pub fn scan_for_each<F>(&self, snapshot: &SnapshotContext, mut callback: F)
+    pub fn scan_for_each<F>(&self, snapshot: Option<&SnapshotContext>, mut callback: F)
     where
         F: FnMut(&UnifiedEntity) -> bool,
     {
         self.for_each_entity(|entity| {
-            !entity_visible_with_context(Some(snapshot), entity) || callback(entity)
+            !Self::scan_entity_visible(snapshot, entity) || callback(entity)
         });
     }
 
     /// Fold entities visible under an explicit MVCC snapshot in parallel.
     pub fn scan_fold_parallel<T, FInit, FFold, FReduce>(
         &self,
-        snapshot: &SnapshotContext,
+        snapshot: Option<&SnapshotContext>,
         init: FInit,
         fold: FFold,
         reduce: FReduce,
@@ -1522,7 +1536,7 @@ impl SegmentManager {
         self.fold_entities_parallel(
             init,
             |acc, entity| {
-                if entity_visible_with_context(Some(snapshot), entity) {
+                if Self::scan_entity_visible(snapshot, entity) {
                     fold(acc, entity)
                 } else {
                     acc
@@ -1535,7 +1549,7 @@ impl SegmentManager {
     /// Visit zone-map candidates visible under an explicit MVCC snapshot.
     pub fn scan_for_each_zoned_with_stats<F>(
         &self,
-        snapshot: &SnapshotContext,
+        snapshot: Option<&SnapshotContext>,
         zone_preds: &[(&str, ZoneColPred<'_>)],
         mut callback: F,
     ) -> SegmentScanStats
@@ -1543,14 +1557,14 @@ impl SegmentManager {
         F: FnMut(&UnifiedEntity) -> bool,
     {
         self.for_each_entity_zoned_with_stats(zone_preds, |entity| {
-            !entity_visible_with_context(Some(snapshot), entity) || callback(entity)
+            !Self::scan_entity_visible(snapshot, entity) || callback(entity)
         })
     }
 
     /// Collect zone-map candidates visible under an explicit MVCC snapshot.
     pub fn scan_zoned_with_stats<F>(
         &self,
-        snapshot: &SnapshotContext,
+        snapshot: Option<&SnapshotContext>,
         zone_preds: &[(&str, ZoneColPred<'_>)],
         filter: F,
     ) -> (Vec<UnifiedEntity>, SegmentScanStats)
@@ -1558,7 +1572,7 @@ impl SegmentManager {
         F: Fn(&UnifiedEntity) -> bool + Sync,
     {
         self.query_all_zoned_with_stats(zone_preds, |entity| {
-            entity_visible_with_context(Some(snapshot), entity) && filter(entity)
+            Self::scan_entity_visible(snapshot, entity) && filter(entity)
         })
     }
 
@@ -2257,7 +2271,7 @@ mod tests {
             })
             .collect();
 
-        let scanned = std::thread::spawn(move || manager.scan(&snapshot, |_| true))
+        let scanned = std::thread::spawn(move || manager.scan(Some(&snapshot), |_| true))
             .join()
             .unwrap();
         let visible_row_ids: HashSet<u64> = scanned
@@ -2277,6 +2291,39 @@ mod tests {
                 "{name} visibility mismatch"
             );
         }
+    }
+
+    #[test]
+    fn frameless_scan_hides_superseded_versions_and_moderated_rows() {
+        // A `None` snapshot is the autocommit / prepared-fast-path read: it
+        // must keep the resolver fallback (xmax == 0), never show every
+        // version, and never panic (issue #2136 review).
+        let manager = SegmentManager::new("accounts");
+        let mut live =
+            UnifiedEntity::table_row(EntityId::new(1), "accounts", 1, vec![Value::Integer(1)]);
+        live.set_xmin(2);
+        live.set_xmax(0);
+        manager.insert(live).unwrap();
+
+        let mut superseded =
+            UnifiedEntity::table_row(EntityId::new(2), "accounts", 2, vec![Value::Integer(2)]);
+        superseded.set_xmin(2);
+        superseded.set_xmax(9);
+        manager.insert(superseded).unwrap();
+
+        let rows: Vec<u64> = manager
+            .scan(None, |_| true)
+            .into_iter()
+            .filter_map(|entity| match entity.kind {
+                EntityKind::TableRow { row_id, .. } => Some(row_id),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            rows,
+            vec![1],
+            "frameless scan must hide superseded versions"
+        );
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -1492,6 +1492,76 @@ impl SegmentManager {
         })
     }
 
+    /// Visit every entity visible under an explicit MVCC snapshot.
+    ///
+    /// Returning `false` from `callback` stops the scan early. Hidden entities
+    /// never reach the callback and therefore cannot stop the scan.
+    pub fn scan_for_each<F>(&self, snapshot: &SnapshotContext, mut callback: F)
+    where
+        F: FnMut(&UnifiedEntity) -> bool,
+    {
+        self.for_each_entity(|entity| {
+            !entity_visible_with_context(Some(snapshot), entity) || callback(entity)
+        });
+    }
+
+    /// Fold entities visible under an explicit MVCC snapshot in parallel.
+    pub fn scan_fold_parallel<T, FInit, FFold, FReduce>(
+        &self,
+        snapshot: &SnapshotContext,
+        init: FInit,
+        fold: FFold,
+        reduce: FReduce,
+    ) -> T
+    where
+        T: Send,
+        FInit: Fn() -> T + Send + Sync,
+        FFold: Fn(T, &UnifiedEntity) -> T + Send + Sync,
+        FReduce: Fn(T, T) -> T + Send + Sync,
+    {
+        self.fold_entities_parallel(
+            init,
+            |acc, entity| {
+                if entity_visible_with_context(Some(snapshot), entity) {
+                    fold(acc, entity)
+                } else {
+                    acc
+                }
+            },
+            reduce,
+        )
+    }
+
+    /// Visit zone-map candidates visible under an explicit MVCC snapshot.
+    pub fn scan_for_each_zoned_with_stats<F>(
+        &self,
+        snapshot: &SnapshotContext,
+        zone_preds: &[(&str, ZoneColPred<'_>)],
+        mut callback: F,
+    ) -> SegmentScanStats
+    where
+        F: FnMut(&UnifiedEntity) -> bool,
+    {
+        self.for_each_entity_zoned_with_stats(zone_preds, |entity| {
+            !entity_visible_with_context(Some(snapshot), entity) || callback(entity)
+        })
+    }
+
+    /// Collect zone-map candidates visible under an explicit MVCC snapshot.
+    pub fn scan_zoned_with_stats<F>(
+        &self,
+        snapshot: &SnapshotContext,
+        zone_preds: &[(&str, ZoneColPred<'_>)],
+        filter: F,
+    ) -> (Vec<UnifiedEntity>, SegmentScanStats)
+    where
+        F: Fn(&UnifiedEntity) -> bool + Sync,
+    {
+        self.query_all_zoned_with_stats(zone_preds, |entity| {
+            entity_visible_with_context(Some(snapshot), entity) && filter(entity)
+        })
+    }
+
     /// Query across all segments. Uses parallel scanning for sealed segments
     /// when more than one sealed segment exists.
     pub fn query_all<F>(&self, filter: F) -> Vec<UnifiedEntity>


### PR DESCRIPTION
Automated AFK landing for #2136. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788548190&installation_model_id=20659&pr_number=2182&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2182&signature=85e64f4208680dd5649426a367f109bfaff6524d641d786b86c38fb1c7bf7bd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->