### PR TITLE
merge: #2153 Fix the Kleene undecided-row leak at unchecked call sites

### DIFF
--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -376,7 +376,9 @@ impl<'a> DmlTargetScan<'a> {
         compiled_filter: Option<&query_exec::CompiledEntityFilter>,
     ) -> bool {
         match (self.filter, compiled_filter) {
-            (_, Some(compiled)) => compiled.evaluate(entity),
+            (_, Some(compiled)) => {
+                compiled.evaluate(entity) == query_exec::CompiledEntityFilterDecision::Match
+            }
             (Some(filter), None) => query_exec::evaluate_entity_filter_with_db(
                 Some(self.runtime.db().as_ref()),
                 entity,

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -26,7 +26,7 @@ mod vector;
 // `pub(crate)` is needed for the two helpers because wire/listener.rs
 // reaches them via `crate::runtime::query_exec::X` (cross-module path,
 // not just super-path).
-pub(crate) use filter_compiled::CompiledEntityFilter;
+pub(crate) use filter_compiled::{CompiledEntityFilter, CompiledEntityFilterDecision};
 pub(crate) use helpers::{
     evaluate_entity_filter, evaluate_entity_filter_with_db, extract_entity_id_from_filter,
     extract_select_column_names, extract_zone_predicates, try_hash_eq_lookup,

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -340,24 +340,22 @@ pub(crate) fn execute_aggregate_query(
         }
 
         if let Some(c) = compiled_filter.as_ref() {
-            if !c.evaluate(entity) {
-                return true;
-            }
-            if c.has_fallback() {
+            let matches = c.evaluate(entity).resolve_with_fallback(|| {
                 let Some(record) = get_or_make_record!() else {
-                    return true;
+                    return false;
                 };
-                if let Some(filter) = effective_filter.as_ref() {
-                    if !evaluate_runtime_filter_with_db(
+                effective_filter.as_ref().is_some_and(|filter| {
+                    evaluate_runtime_filter_with_db(
                         Some(db),
                         record,
                         filter,
                         Some(table_name),
                         Some(table_alias),
-                    ) {
-                        return true;
-                    }
-                }
+                    )
+                })
+            });
+            if !matches {
+                return true;
             }
         }
 

--- a/crates/reddb-server/src/runtime/query_exec/aggregate_pushdown_dispatch.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate_pushdown_dispatch.rs
@@ -22,7 +22,10 @@
 use super::aggregate_planner::{
     AggregateExpr, AggregateOp, AggregateQueryAst, AggregateQueryPlanner, ScanIterator, ScanRow,
 };
-use super::filter_compiled::{classify_field, resolve_kind, CompiledEntityFilter, EntityFieldKind};
+use super::filter_compiled::{
+    classify_field, resolve_kind, CompiledEntityFilter, CompiledEntityFilterDecision,
+    EntityFieldKind,
+};
 use crate::api::{RedDBError, RedDBResult};
 use crate::storage::query::ast::{Expr, FieldRef, Projection};
 use crate::storage::query::sql_lowering::{
@@ -134,12 +137,18 @@ pub(super) fn try_execute_pushdown_aggregate(
     let compiled_filter = effective_table_filter(query)
         .as_ref()
         .map(|f| CompiledEntityFilter::compile(f, table_name, table_alias));
+    if compiled_filter
+        .as_ref()
+        .is_some_and(CompiledEntityFilter::has_fallback)
+    {
+        return Ok(None);
+    }
 
     let mut rows: Vec<ScanRow> = Vec::new();
     let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     manager.scan_for_each(snapshot.as_ref(), |entity| {
         if let Some(f) = compiled_filter.as_ref() {
-            if !f.evaluate(entity) {
+            if f.evaluate(entity) != CompiledEntityFilterDecision::Match {
                 return true;
             }
         }

--- a/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
+++ b/crates/reddb-server/src/runtime/query_exec/filter_compiled.rs
@@ -505,6 +505,31 @@ pub struct CompiledEntityFilter {
     required_bloom: u64,
 }
 
+/// Result of evaluating one row with a [`CompiledEntityFilter`].
+///
+/// This deliberately is not a `bool`: fallback opcodes cannot be evaluated
+/// without runtime state, so every consumer must decide how to perform the
+/// full filter recheck before it can treat the row as a match.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "compiled filter decisions must handle NeedsFallback"]
+pub enum CompiledEntityFilterDecision {
+    Match,
+    Reject,
+    NeedsFallback,
+}
+
+impl CompiledEntityFilterDecision {
+    /// Convert the three-way decision to a match only after supplying the
+    /// runtime evaluation required by an undecided compiled predicate.
+    pub fn resolve_with_fallback(self, fallback: impl FnOnce() -> bool) -> bool {
+        match self {
+            Self::Match => true,
+            Self::Reject => false,
+            Self::NeedsFallback => fallback(),
+        }
+    }
+}
+
 impl CompiledEntityFilter {
     /// Walk the AST filter once and produce a flat opcode list.
     pub fn compile(filter: &Filter, table_name: &str, table_alias: &str) -> Self {
@@ -565,7 +590,7 @@ impl CompiledEntityFilter {
 
     /// Evaluate against an entity. Hot path — must stay allocation-free
     /// in the common case.
-    pub fn evaluate(&self, entity: &UnifiedEntity) -> bool {
+    pub fn evaluate(&self, entity: &UnifiedEntity) -> CompiledEntityFilterDecision {
         // Field-name bloom gate: if the entity is missing a required field,
         // it cannot satisfy any user-field predicate. Skip before any HashMap.
         // Only fires when entity.field_bloom is non-zero (named/document entities).
@@ -586,7 +611,7 @@ impl CompiledEntityFilter {
             && entity.field_bloom != 0
             && (entity.field_bloom & self.required_bloom) != self.required_bloom
         {
-            return false;
+            return CompiledEntityFilterDecision::Reject;
         }
 
         // Fixed-size three-valued stack — no heap allocation per row.
@@ -758,8 +783,11 @@ impl CompiledEntityFilter {
                 }
             }
         }
-        // Keep the row unless the prefilter proved it cannot match.
-        pop!(Some(true)) != Some(false)
+        match pop!(Some(true)) {
+            Some(true) => CompiledEntityFilterDecision::Match,
+            Some(false) => CompiledEntityFilterDecision::Reject,
+            None => CompiledEntityFilterDecision::NeedsFallback,
+        }
     }
 
     /// Evaluate the filter against a batch of entities. Appends the
@@ -773,25 +801,15 @@ impl CompiledEntityFilter {
     /// vectorizable `Compare` and `InSet` opcodes and widen `out` to
     /// a roaring bitmap. The signature here is forward-compatible.
     #[inline]
-    pub fn evaluate_batch(&self, entities: &[&UnifiedEntity], out: &mut Vec<bool>) {
+    pub fn evaluate_batch(
+        &self,
+        entities: &[&UnifiedEntity],
+        out: &mut Vec<CompiledEntityFilterDecision>,
+    ) {
         out.reserve(entities.len());
         for e in entities {
             out.push(self.evaluate(e));
         }
-    }
-
-    /// Convenience wrapper: run the batch evaluator and return only
-    /// the indices where the filter matched. Caller owns the
-    /// resulting vec. Reuses [`Self::evaluate_batch`] so future
-    /// vectorization benefits this path automatically.
-    #[inline]
-    pub fn matching_indices(&self, entities: &[&UnifiedEntity]) -> Vec<usize> {
-        let mut mask = Vec::with_capacity(entities.len());
-        self.evaluate_batch(entities, &mut mask);
-        mask.iter()
-            .enumerate()
-            .filter_map(|(i, &hit)| if hit { Some(i) } else { None })
-            .collect()
     }
 }
 
@@ -1255,7 +1273,10 @@ mod tests {
             }),
         );
 
-        assert!(compiled.evaluate(&entity));
+        assert_eq!(
+            compiled.evaluate(&entity),
+            CompiledEntityFilterDecision::Match
+        );
     }
 
     // Note: full evaluate() correctness is covered by the runtime
@@ -1300,10 +1321,34 @@ mod tests {
 
         let mut mask = Vec::new();
         compiled.evaluate_batch(&refs, &mut mask);
-        assert_eq!(mask, vec![false, true, true, false]);
+        assert_eq!(
+            mask,
+            vec![
+                CompiledEntityFilterDecision::Reject,
+                CompiledEntityFilterDecision::Match,
+                CompiledEntityFilterDecision::Match,
+                CompiledEntityFilterDecision::Reject,
+            ]
+        );
+    }
 
-        let indices = compiled.matching_indices(&refs);
-        assert_eq!(indices, vec![1, 2]);
+    #[test]
+    fn fallback_evaluation_requires_an_explicit_runtime_decision() {
+        let filter = Filter::Compare {
+            field: FieldRef::TableColumn {
+                table: String::new(),
+                column: "profile.role".to_string(),
+            },
+            op: CompareOp::Eq,
+            value: Value::text("admin"),
+        };
+        let compiled = CompiledEntityFilter::compile(&filter, "users", "u");
+        let entity = make_row_entity(1, vec![]);
+
+        assert_eq!(
+            compiled.evaluate(&entity),
+            CompiledEntityFilterDecision::NeedsFallback
+        );
     }
 
     #[test]
@@ -1321,6 +1366,5 @@ mod tests {
         let mut mask = Vec::new();
         compiled.evaluate_batch(&entities, &mut mask);
         assert!(mask.is_empty());
-        assert!(compiled.matching_indices(&entities).is_empty());
     }
 }

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -46,6 +46,19 @@ fn record_segment_scan_stats(stats: SegmentScanStats) {
     LAST_SEGMENT_SCAN_STATS.with(|slot| slot.set(stats));
 }
 
+fn compiled_entity_filter_matches(
+    db: &RedDB,
+    compiled: &super::filter_compiled::CompiledEntityFilter,
+    entity: &UnifiedEntity,
+    filter: &Filter,
+    table_name: &str,
+    table_alias: &str,
+) -> bool {
+    compiled.evaluate(entity).resolve_with_fallback(|| {
+        evaluate_entity_filter_with_db(Some(db), entity, filter, table_name, table_alias)
+    })
+}
+
 /// Build the JSON result from a set of entity IDs (from index lookup).
 /// Scan entities sequentially but only process those in the candidate set (from hash index).
 /// Faster than individual store.get() because HashMap iteration is sequential/cache-friendly.
@@ -778,7 +791,14 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         return;
                     }
                     if let Some(cf) = compiled_filter.as_ref() {
-                        if !cf.evaluate(entity) {
+                        if !compiled_entity_filter_matches(
+                            db,
+                            cf,
+                            entity,
+                            filter,
+                            table_name,
+                            table_alias,
+                        ) {
                             return;
                         }
                     }
@@ -817,7 +837,14 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     continue;
                 }
                 if let Some(cf) = compiled_filter.as_ref() {
-                    if !cf.evaluate(&entity_opt) {
+                    if !compiled_entity_filter_matches(
+                        db,
+                        cf,
+                        &entity_opt,
+                        filter,
+                        table_name,
+                        table_alias,
+                    ) {
                         continue;
                     }
                 }
@@ -919,10 +946,16 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                                 if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                                     continue;
                                 }
-                                if compiled_filter
-                                    .as_ref()
-                                    .is_none_or(|cf| cf.evaluate(&entity_opt))
-                                {
+                                if compiled_filter.as_ref().is_none_or(|cf| {
+                                    compiled_entity_filter_matches(
+                                        db,
+                                        cf,
+                                        &entity_opt,
+                                        filter,
+                                        table_name,
+                                        table_alias,
+                                    )
+                                }) {
                                     let record_opt = if lean {
                                         super::super::record_search::runtime_table_record_lean_in_collection(
                                             entity_opt,
@@ -1070,7 +1103,14 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                     continue;
                 }
-                if compiled_filter.evaluate(&entity_opt) {
+                if compiled_entity_filter_matches(
+                    db,
+                    &compiled_filter,
+                    &entity_opt,
+                    filter,
+                    table_name,
+                    table_alias,
+                ) {
                     let record_opt = if lean {
                         super::super::record_search::runtime_table_record_lean_in_collection(
                             entity_opt,
@@ -1188,10 +1228,18 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                             if !db.replica_allows_entity_at_read(&query.table, &entity_opt) {
                                 continue;
                             }
-                            if compiled_filter
-                                .as_ref()
-                                .is_none_or(|cf| cf.evaluate(&entity_opt))
-                            {
+                            if compiled_filter.as_ref().is_none_or(|cf| {
+                                effective_filter.as_ref().is_some_and(|filter| {
+                                    compiled_entity_filter_matches(
+                                        db,
+                                        cf,
+                                        &entity_opt,
+                                        filter,
+                                        table_name,
+                                        table_alias,
+                                    )
+                                })
+                            }) {
                                 let record_opt = if lean {
                                     super::super::record_search::runtime_table_record_lean_in_collection(
                                         entity_opt,
@@ -1437,10 +1485,6 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     table_alias,
                 ),
             });
-        let requires_filter_recheck = compiled
-            .as_ref()
-            .is_some_and(|filter| filter.has_fallback());
-
         // Pre-filter at entity level, only materialize records that pass.
         // Uses zone-map-aware iteration: sealed segments whose column zones
         // prove no row can match the predicate are skipped entirely.
@@ -1498,8 +1542,17 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         entity,
                     );
                     db.replica_allows_entity_at_read(&query.table, entity)
-                        && compiled.as_ref().is_none_or(|filter| {
-                            requires_filter_recheck || filter.evaluate(&hydrated)
+                        && compiled.as_ref().is_none_or(|compiled| {
+                            residual_filter.as_ref().is_some_and(|filter| {
+                                compiled_entity_filter_matches(
+                                    db,
+                                    compiled,
+                                    &hydrated,
+                                    filter,
+                                    table_name,
+                                    table_alias,
+                                )
+                            })
                         })
                 });
             record_segment_scan_stats(scan_stats);
@@ -1544,27 +1597,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                     runtime_table_record_from_entity(hydrated.clone())
                 };
                 if let Some(record) = record {
-                    if requires_filter_recheck {
-                        let Some(filter) = residual_filter.as_ref() else {
-                            continue;
-                        };
-                        let Some(filter_record) =
-                            runtime_table_record_from_entity(hydrated.clone())
-                        else {
-                            continue;
-                        };
-                        if super::super::join_filter::evaluate_runtime_filter_with_db(
-                            Some(db),
-                            &filter_record,
-                            filter,
-                            Some(table_name),
-                            Some(table_alias),
-                        ) {
-                            records.push(record);
-                        }
-                    } else {
-                        records.push(record);
-                    }
+                    records.push(record);
                 }
             }
         } else {
@@ -1591,7 +1624,18 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 );
                 if compiled
                     .as_ref()
-                    .is_none_or(|filter| requires_filter_recheck || filter.evaluate(&hydrated))
+                    .is_none_or(|compiled| {
+                        residual_filter.as_ref().is_some_and(|filter| {
+                            compiled_entity_filter_matches(
+                                db,
+                                compiled,
+                                &hydrated,
+                                filter,
+                                table_name,
+                                table_alias,
+                            )
+                        })
+                    })
                 {
                     let record = if !select_cols.is_empty() {
                         // Fast columnar path: use pre-computed schema indices when available.
@@ -1627,27 +1671,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                             runtime_table_record_from_entity(hydrated.clone())
                         };
                     if let Some(record) = record {
-                        if requires_filter_recheck {
-                            let Some(filter) = residual_filter.as_ref() else {
-                                return true;
-                            };
-                            let Some(filter_record) =
-                                runtime_table_record_from_entity(hydrated.clone())
-                            else {
-                                return true;
-                            };
-                            if super::super::join_filter::evaluate_runtime_filter_with_db(
-                                Some(db),
-                                &filter_record,
-                                filter,
-                                Some(table_name),
-                                Some(table_alias),
-                            ) {
-                                records.push(record);
-                            }
-                        } else {
-                            records.push(record);
-                        }
+                        records.push(record);
                     }
                 }
                 true // continue
@@ -1921,7 +1945,6 @@ pub(crate) fn execute_runtime_canonical_table_node(
                         table_alias,
                     ),
                 };
-                let requires_filter_recheck = compiled.has_fallback();
                 // Schema-index precomputation: same optimisation as the indexed scan path.
                 // Resolve projected column names → schema positions once before the loop.
                 let schema_col_indices: Option<Vec<(usize, usize)>> = if !select_cols.is_empty() {
@@ -1947,7 +1970,14 @@ pub(crate) fn execute_runtime_canonical_table_node(
                     if !db.replica_allows_entity_at_read(&context.query.table, entity) {
                         return true;
                     }
-                    if compiled.evaluate(entity) {
+                    if compiled_entity_filter_matches(
+                        db,
+                        &compiled,
+                        entity,
+                        filter,
+                        table_name,
+                        table_alias,
+                    ) {
                         let record = if !select_cols.is_empty() {
                             if let Some(ref idx_map) = schema_col_indices {
                                 super::super::record_search::runtime_table_record_with_col_indices(
@@ -1980,24 +2010,7 @@ pub(crate) fn execute_runtime_canonical_table_node(
                             runtime_table_record_from_entity(entity.clone())
                         };
                         if let Some(record) = record {
-                            if requires_filter_recheck {
-                                let Some(filter_record) =
-                                    runtime_table_record_from_entity(entity.clone())
-                                else {
-                                    return true;
-                                };
-                                if evaluate_runtime_filter_with_db(
-                                    Some(db),
-                                    &filter_record,
-                                    filter,
-                                    Some(table_name),
-                                    Some(table_alias),
-                                ) {
-                                    records.push(record);
-                                }
-                            } else {
-                                records.push(record);
-                            }
+                            records.push(record);
                         }
                     }
                     true

--- a/crates/reddb-server/src/wire/query_direct.rs
+++ b/crates/reddb-server/src/wire/query_direct.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 
 use crate::runtime::mvcc::entity_visible_under_current_snapshot;
 use crate::runtime::query_exec::{
-    extract_entity_id_from_filter, try_hash_eq_lookup, try_sorted_index_lookup,
-    CompiledEntityFilter,
+    evaluate_entity_filter_with_db, extract_entity_id_from_filter, try_hash_eq_lookup,
+    try_sorted_index_lookup, CompiledEntityFilter,
 };
 use crate::runtime::RedDBRuntime;
 use crate::storage::query::ast::{
@@ -239,7 +239,15 @@ pub(super) fn execute_direct_scan(runtime: &RedDBRuntime, tq: &TableQuery) -> Op
             if (row_count as usize) >= hard_limit {
                 return;
             }
-            if !compiled_filter.evaluate(entity) {
+            if !compiled_filter.evaluate(entity).resolve_with_fallback(|| {
+                evaluate_entity_filter_with_db(
+                    Some(db.as_ref()),
+                    entity,
+                    filter,
+                    table_name,
+                    table_alias,
+                )
+            }) {
                 return;
             }
             emit_one!(entity);
@@ -1909,6 +1917,79 @@ mod tests {
         assert_eq!(
             nrows, standard_rows,
             "fast path truncated rows early: got {nrows}, standard got {standard_rows}"
+        );
+    }
+
+    #[test]
+    fn fallback_predicate_is_applied_across_scan_strategies() {
+        let rt = mk_runtime();
+        rt.execute_query("CREATE TABLE fallback_rows (id INT, role TEXT, age INT)")
+            .unwrap();
+        rt.execute_query("CREATE INDEX idx_fallback_age ON fallback_rows (age) USING BTREE")
+            .unwrap();
+        rt.execute_query("CREATE INDEX idx_fallback_id ON fallback_rows (id) USING HASH")
+            .unwrap();
+        rt.execute_query(
+            "INSERT INTO fallback_rows (id, role, age) VALUES \
+             (1, 'admin', 20), (2, 'guest', 30), (3, 'admin', 40)",
+        )
+        .unwrap();
+
+        let predicate = "age BETWEEN 0 AND 100 AND role = CONFIG(app.missing.role, guest)";
+        let select_sql = format!("SELECT id FROM fallback_rows WHERE {predicate}");
+        let standard = rt
+            .execute_query(&select_sql)
+            .expect("standard scan succeeds");
+        assert_eq!(standard.result.records.len(), 1);
+        assert_eq!(
+            standard.result.records[0].get("id"),
+            Some(&Value::Integer(2))
+        );
+
+        let full_scan = rt
+            .execute_query(
+                "SELECT id FROM fallback_rows \
+                 WHERE role = CONFIG(app.missing.role, guest) ORDER BY id",
+            )
+            .expect("full scan succeeds");
+        assert_eq!(full_scan.result.records.len(), 1);
+        assert_eq!(
+            full_scan.result.records[0].get("id"),
+            Some(&Value::Integer(2))
+        );
+
+        let hash_scan = rt
+            .execute_query(
+                "SELECT id FROM fallback_rows \
+                 WHERE id = 1 AND role = CONFIG(app.missing.role, guest)",
+            )
+            .expect("hash-index scan succeeds");
+        assert!(
+            hash_scan.result.records.is_empty(),
+            "hash-index scan must reject a candidate that fails the fallback predicate"
+        );
+
+        let direct = try_handle_query_binary_direct(&rt, &select_sql)
+            .expect("direct indexed scan remains eligible");
+        let (_, direct_rows, _) = decode_wire_header(&direct);
+        assert_eq!(
+            direct_rows, 1,
+            "direct indexed scan must apply the runtime fallback predicate"
+        );
+
+        let aggregate = rt
+            .execute_query(&format!(
+                "SELECT role, COUNT(*) FROM fallback_rows WHERE {predicate} GROUP BY role"
+            ))
+            .expect("aggregate scan succeeds");
+        assert_eq!(
+            aggregate.result.records.len(),
+            1,
+            "aggregate pushdown must apply the same fallback predicate"
+        );
+        assert_eq!(
+            aggregate.result.records[0].get("role"),
+            Some(&Value::text("guest"))
         );
     }
 


### PR DESCRIPTION
Automated AFK landing for #2153. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555200&installation_model_id=20659&pr_number=2187&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2187&signature=ec97527341a1a79faa4441e1f546095d327cac42202e79304d76e9fb6a593ecc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->