### PR TITLE
merge: #2126 Authority fences block concepts, not just names

### DIFF
--- a/crates/reddb-types/tests/fixtures/renamed_queue_side.rs
+++ b/crates/reddb-types/tests/fixtures/renamed_queue_side.rs
@@ -1,0 +1,4 @@
+pub enum RenamedQueueEnd {
+    Left,
+    Right,
+}

--- a/crates/reddb-types/tests/type_authority.rs
+++ b/crates/reddb-types/tests/type_authority.rs
@@ -14,6 +14,252 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+struct SeededConcept {
+    name: &'static str,
+    authority_path: &'static str,
+    grandfathered_server_paths: &'static [&'static str],
+    removal_slice: &'static str,
+}
+
+// These are the 32 architectural concepts that were declared on both sides of
+// an authority boundary when phase 2 began (#2113). Generic cross-domain names
+// (`Cursor`, `JsonValue`, `ParseError`, and `Value`) are deliberately absent:
+// their declarations represent unrelated concepts and cannot seed this fence.
+const SEEDED_CONCEPTS: &[SeededConcept] = &[
+    concept(
+        "ColumnStats",
+        "crates/reddb-rql/src/optimizer/stats.rs",
+        &["crates/reddb-server/src/storage/query/planner/cost.rs"],
+        "#2165",
+    ),
+    concept(
+        "CompareOp",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/query/executors/subquery.rs"],
+        "#2165",
+    ),
+    concept(
+        "DistanceMetric",
+        "crates/reddb-types/src/distance.rs",
+        &["crates/reddb-server/src/storage/vector/introspection.rs"],
+        "#2164",
+    ),
+    concept(
+        "EdgeDirection",
+        "crates/reddb-rql/src/core.rs",
+        &[
+            "crates/reddb-server/src/runtime.rs",
+            "crates/reddb-server/src/storage/query/rag/unified_adapter.rs",
+            "crates/reddb-server/src/storage/unified/index.rs",
+        ],
+        "#2165",
+    ),
+    concept(
+        "EmbeddedRdbArtifact",
+        "crates/reddb-file/src/embedded.rs",
+        &["crates/reddb-server/src/storage/embedded.rs"],
+        "#2113",
+    ),
+    concept(
+        "EntityType",
+        "crates/reddb-rql/src/modes/natural.rs",
+        &["crates/reddb-server/src/storage/query/rag/mod.rs"],
+        "#2165",
+    ),
+    concept(
+        "EscapeError",
+        "crates/reddb-wire/src/sanitizer.rs",
+        &["crates/reddb-server/src/server/header_escape_guard.rs"],
+        "#2113",
+    ),
+    concept(
+        "Filter",
+        "crates/reddb-rql/src/core.rs",
+        &[
+            "crates/reddb-server/src/storage/query/filter.rs",
+            "crates/reddb-server/src/storage/unified/dsl/filters.rs",
+        ],
+        "#2165",
+    ),
+    concept(
+        "FilterExpr",
+        "crates/reddb-rql/src/optimizer/filter_rank.rs",
+        &["crates/reddb-server/src/storage/query/engine/op.rs"],
+        "#2165",
+    ),
+    concept(
+        "FilterValue",
+        "crates/reddb-rql/src/optimizer/filter_rank.rs",
+        &["crates/reddb-server/src/storage/unified/dsl/filters.rs"],
+        "#2165",
+    ),
+    concept(
+        "Frame",
+        "crates/reddb-wire/src/redwire/frame.rs",
+        &["crates/reddb-server/src/runtime/ai/sse_frame_encoder.rs"],
+        "#2113",
+    ),
+    concept(
+        "GraphQueryBuilder",
+        "crates/reddb-rql/src/builders.rs",
+        &["crates/reddb-server/src/storage/unified/dsl/builders/graph.rs"],
+        "#2165",
+    ),
+    concept(
+        "IsolationLevel",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/transaction/mod.rs"],
+        "#2165",
+    ),
+    concept(
+        "JoinCondition",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/query/executors/join.rs"],
+        "#2165",
+    ),
+    concept(
+        "JoinType",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/query/executors/join.rs"],
+        "#2165",
+    ),
+    concept(
+        "MetadataFilter",
+        "crates/reddb-types/src/vector_metadata.rs",
+        &[
+            "crates/reddb-server/src/storage/unified/devx/query.rs",
+            "crates/reddb-server/src/storage/unified/metadata.rs",
+        ],
+        "#2127",
+    ),
+    concept(
+        "MetadataValue",
+        "crates/reddb-types/src/vector_metadata.rs",
+        &["crates/reddb-server/src/storage/unified/metadata.rs"],
+        "#2127",
+    ),
+    concept(
+        "NodePattern",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/query/rag/unified_adapter.rs"],
+        "#2165",
+    ),
+    concept(
+        "PageHeader",
+        "crates/reddb-file/src/vector_btree_page_format.rs",
+        &["crates/reddb-server/src/storage/engine/page.rs"],
+        "#2113",
+    ),
+    concept(
+        "PageType",
+        "crates/reddb-file/src/vector_btree_page_format.rs",
+        &["crates/reddb-server/src/storage/engine/page.rs"],
+        "#2113",
+    ),
+    concept(
+        "ParamValue",
+        "crates/reddb-wire/src/query_with_params.rs",
+        &["crates/reddb-server/src/runtime/query_request.rs"],
+        "#2113",
+    ),
+    concept(
+        "Position",
+        "crates/reddb-rql/src/lexer.rs",
+        &["crates/reddb-server/src/cluster/ownership.rs"],
+        "#2165",
+    ),
+    concept(
+        "PropertyFilter",
+        "crates/reddb-rql/src/modes/natural.rs",
+        &["crates/reddb-server/src/storage/unified/devx/query.rs"],
+        "#2165",
+    ),
+    concept(
+        "QueryIntent",
+        "crates/reddb-rql/src/modes/natural.rs",
+        &["crates/reddb-server/src/storage/query/rag/mod.rs"],
+        "#2165",
+    ),
+    concept(
+        "QueueSide",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/queue/deque.rs"],
+        "#2165",
+    ),
+    concept(
+        "SnapshotDescriptor",
+        "crates/reddb-file/src/physical_metadata/types.rs",
+        &["crates/reddb-server/src/storage/wal/recovery.rs"],
+        "#2113",
+    ),
+    concept(
+        "SystemClock",
+        "crates/reddb-file/src/clock.rs",
+        &[
+            "crates/reddb-server/src/runtime/queue_lifecycle.rs",
+            "crates/reddb-server/src/server/output_stream.rs",
+        ],
+        "#2113",
+    ),
+    concept(
+        "TableQueryBuilder",
+        "crates/reddb-rql/src/builders.rs",
+        &["crates/reddb-server/src/storage/unified/dsl/builders/table.rs"],
+        "#2165",
+    ),
+    concept(
+        "TableStats",
+        "crates/reddb-rql/src/optimizer/stats.rs",
+        &["crates/reddb-server/src/storage/query/planner/cost.rs"],
+        "#2165",
+    ),
+    concept(
+        "Token",
+        "crates/reddb-rql/src/lexer.rs",
+        &["crates/reddb-server/src/cli/token.rs"],
+        "#2165",
+    ),
+    concept(
+        "ValueFlag",
+        "crates/reddb-file/src/vector_value_codec.rs",
+        &["crates/reddb-server/src/storage/query/binary.rs"],
+        "#2113",
+    ),
+    concept(
+        "VectorSource",
+        "crates/reddb-rql/src/core.rs",
+        &["crates/reddb-server/src/storage/vector/introspection.rs"],
+        "#2165",
+    ),
+];
+
+const fn concept(
+    name: &'static str,
+    authority_path: &'static str,
+    grandfathered_server_paths: &'static [&'static str],
+    removal_slice: &'static str,
+) -> SeededConcept {
+    SeededConcept {
+        name,
+        authority_path,
+        grandfathered_server_paths,
+        removal_slice,
+    }
+}
+
+#[derive(Debug)]
+struct TypeDeclaration {
+    name: String,
+    shape: Vec<String>,
+    has_distinctive_shape: bool,
+}
+
+struct ConceptFingerprint<'a> {
+    concept: &'a SeededConcept,
+    shape: Vec<String>,
+    has_distinctive_shape: bool,
+}
+
 fn repo_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
@@ -67,6 +313,223 @@ fn declares_type(text: &str, name: &str) -> bool {
 /// redeclaration of a coercion entry point.
 fn declares_fn(text: &str, name: &str) -> bool {
     text.contains(&format!("fn {name}("))
+}
+
+/// Tokenize enough Rust to compare declaration shapes without depending on a
+/// parser implementation. Comments and whitespace disappear, quoted literals
+/// stay atomic, and identifiers remain available as semantic anchors.
+fn rust_tokens(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index].is_ascii_whitespace() {
+            index += 1;
+        } else if bytes[index..].starts_with(b"//") {
+            index += 2;
+            while index < bytes.len() && bytes[index] != b'\n' {
+                index += 1;
+            }
+        } else if bytes[index..].starts_with(b"/*") {
+            index += 2;
+            let mut depth = 1;
+            while index < bytes.len() && depth > 0 {
+                if bytes[index..].starts_with(b"/*") {
+                    depth += 1;
+                    index += 2;
+                } else if bytes[index..].starts_with(b"*/") {
+                    depth -= 1;
+                    index += 2;
+                } else {
+                    index += 1;
+                }
+            }
+        } else if bytes[index].is_ascii_alphabetic() || bytes[index] == b'_' {
+            let start = index;
+            index += 1;
+            while index < bytes.len()
+                && (bytes[index].is_ascii_alphanumeric() || bytes[index] == b'_')
+            {
+                index += 1;
+            }
+            tokens.push(text[start..index].to_string());
+        } else if bytes[index] == b'"' {
+            let start = index;
+            index += 1;
+            while index < bytes.len() {
+                if bytes[index] == b'\\' {
+                    index = (index + 2).min(bytes.len());
+                } else {
+                    let end = bytes[index] == b'"';
+                    index += 1;
+                    if end {
+                        break;
+                    }
+                }
+            }
+            tokens.push(text[start..index].to_string());
+        } else {
+            tokens.push((bytes[index] as char).to_string());
+            index += 1;
+        }
+    }
+
+    tokens
+}
+
+fn type_declarations(text: &str) -> Vec<TypeDeclaration> {
+    let tokens = rust_tokens(text);
+    let mut declarations = Vec::new();
+    let mut index = 0;
+
+    while index + 1 < tokens.len() {
+        if tokens[index] != "enum" && tokens[index] != "struct" {
+            index += 1;
+            continue;
+        }
+
+        let name = tokens[index + 1].clone();
+        if !name
+            .bytes()
+            .next()
+            .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+        {
+            index += 1;
+            continue;
+        }
+
+        let start = index;
+        let mut end = index + 2;
+        let mut brace_depth = 0usize;
+        let mut saw_body = false;
+        while end < tokens.len() {
+            match tokens[end].as_str() {
+                "{" => {
+                    saw_body = true;
+                    brace_depth += 1;
+                }
+                "}" if saw_body => {
+                    brace_depth -= 1;
+                    if brace_depth == 0 {
+                        end += 1;
+                        break;
+                    }
+                }
+                ";" if !saw_body => {
+                    end += 1;
+                    break;
+                }
+                _ => {}
+            }
+            end += 1;
+        }
+
+        let shape: Vec<String> = tokens[start..end]
+            .iter()
+            .map(|token| {
+                if token == &name {
+                    "$TYPE".to_string()
+                } else {
+                    token.clone()
+                }
+            })
+            .collect();
+        let semantic_anchors = shape
+            .iter()
+            .filter(|token| {
+                token
+                    .bytes()
+                    .next()
+                    .is_some_and(|byte| byte.is_ascii_alphabetic() || byte == b'_')
+                    && !matches!(token.as_str(), "enum" | "struct" | "pub" | "$TYPE")
+            })
+            .count();
+        declarations.push(TypeDeclaration {
+            name,
+            shape,
+            // A markerless/unit declaration is not concept-identifying. Its
+            // seeded name remains blocked, while renamed near-duplicates need
+            // the review rule documented in monorepo-structure.md.
+            has_distinctive_shape: semantic_anchors >= 2,
+        });
+        index = end;
+    }
+
+    declarations
+}
+
+fn concept_fingerprints(root: &Path) -> Vec<ConceptFingerprint<'_>> {
+    SEEDED_CONCEPTS
+        .iter()
+        .map(|concept| {
+            let authority_source = read(root.join(concept.authority_path));
+            let declaration = type_declarations(non_test_source(&authority_source))
+                .into_iter()
+                .find(|declaration| declaration.name == concept.name)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{} must declare seeded concept `{}`",
+                        concept.authority_path, concept.name
+                    )
+                });
+            ConceptFingerprint {
+                concept,
+                shape: declaration.shape,
+                has_distinctive_shape: declaration.has_distinctive_shape,
+            }
+        })
+        .collect()
+}
+
+fn relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn concept_violations_with_fingerprints(
+    root: &Path,
+    path: &Path,
+    text: &str,
+    fingerprints: &[ConceptFingerprint<'_>],
+) -> Vec<String> {
+    let rel = relative_path(root, path);
+    let declarations = type_declarations(non_test_source(text));
+    let mut violations = Vec::new();
+
+    for declaration in declarations {
+        for fingerprint in fingerprints {
+            let concept = fingerprint.concept;
+            let same_shape = fingerprint.has_distinctive_shape
+                && declaration.has_distinctive_shape
+                && declaration.shape == fingerprint.shape;
+            let grandfathered = concept.grandfathered_server_paths.contains(&rel.as_str())
+                && (declaration.name == concept.name || same_shape);
+            if grandfathered {
+                continue;
+            }
+
+            let blocked_name = declaration.name == concept.name;
+            let blocked_shape = same_shape;
+            if blocked_name || blocked_shape {
+                violations.push(format!(
+                    "{rel} declares `{}` as the seeded `{}` concept; use the authority declaration at {} (grandfather removal: {})",
+                    declaration.name, concept.name, concept.authority_path, concept.removal_slice
+                ));
+            }
+        }
+    }
+
+    violations
+}
+
+fn concept_violations_in_source(root: &Path, path: &Path, text: &str) -> Vec<String> {
+    let fingerprints = concept_fingerprints(root);
+    concept_violations_with_fingerprints(root, path, text, &fingerprints)
 }
 
 /// The types crate is the sole declaration site for the logical vocabulary.
@@ -183,6 +646,63 @@ fn server_must_not_redeclare_the_logical_type_system() {
     }
 }
 
+/// The concept fence blocks all 32 known cross-boundary concepts by both name
+/// and exact declaration shape. Existing declarations are temporary,
+/// path-specific exceptions; moving or renaming one does not preserve the
+/// exception.
+#[test]
+fn server_must_not_redeclare_seeded_authority_concepts() {
+    assert_eq!(
+        SEEDED_CONCEPTS.len(),
+        32,
+        "the phase-2 concept seed must stay explicit"
+    );
+
+    let root = repo_root();
+    let fingerprints = concept_fingerprints(&root);
+
+    for concept in SEEDED_CONCEPTS {
+        assert!(
+            concept.removal_slice.starts_with('#'),
+            "seeded concept `{}` needs a removal-slice pointer",
+            concept.name
+        );
+        for rel in concept.grandfathered_server_paths {
+            let source = read(root.join(rel));
+            let fingerprint = fingerprints
+                .iter()
+                .find(|fingerprint| fingerprint.concept.name == concept.name)
+                .expect("seeded concept fingerprint");
+            assert!(
+                type_declarations(non_test_source(&source))
+                    .iter()
+                    .any(|declaration| {
+                        declaration.name == concept.name
+                            || (fingerprint.has_distinctive_shape
+                                && declaration.has_distinctive_shape
+                                && declaration.shape == fingerprint.shape)
+                    }),
+                "stale grandfather for `{}` at {rel}; remove it from SEEDED_CONCEPTS",
+                concept.name
+            );
+        }
+    }
+
+    let server_src = root.join("crates/reddb-server/src");
+    let violations: Vec<String> = rust_files_under(&server_src)
+        .into_iter()
+        .flat_map(|path| {
+            concept_violations_with_fingerprints(&root, &path, &read(&path), &fingerprints)
+        })
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "server authority concept redeclarations:\n{}",
+        violations.join("\n")
+    );
+}
+
 /// The `storage::schema` shims must stay pure re-exports of the keystone crate.
 /// Guards the boundary from the positive side: if a shim is ever replaced by a
 /// real declaration, its `pub use reddb_types::` line disappears and this fails.
@@ -205,4 +725,18 @@ fn schema_shims_reexport_from_types_crate() {
             "storage/schema/{shim} must re-export from reddb_types, not declare types locally"
         );
     }
+}
+
+#[test]
+fn renamed_seeded_concept_fixture_fails_the_fence() {
+    let root = repo_root();
+    let fixture_path = root.join("crates/reddb-types/tests/fixtures/renamed_queue_side.rs");
+    let violations = concept_violations_in_source(&root, &fixture_path, &read(&fixture_path));
+
+    assert!(
+        violations.iter().any(|violation| {
+            violation.contains("RenamedQueueEnd") && violation.contains("QueueSide")
+        }),
+        "renaming QueueSide must not evade the concept fence: {violations:?}"
+    );
 }

--- a/docs/dev/monorepo-structure.md
+++ b/docs/dev/monorepo-structure.md
@@ -86,6 +86,23 @@ re-exports the envelope and adds the server-only `key_from_env`); per ADR 0046 a
 facade carries no second format. See ADR 0046 for the umbrella authority rule and
 ADRs 0052–0054 for the type, query, and crypto crates respectively.
 
+### Reviewing authority concepts
+
+The authority fence in `crates/reddb-types/tests/type_authority.rs` blocks the
+32 known cross-boundary concepts by name and by exact declaration shape. A
+rename therefore does not make a copied enum or struct server-owned. Existing
+server declarations are path-specific grandfather entries, each with an issue
+pointer for its removal; do not broaden those entries when moving code.
+
+The mechanical shape check is intentionally exact to avoid treating unrelated
+Rust types as the same concept. During review, also reject structural
+near-duplicates: a new server type with substantially the same fields, variants,
+responsibility, or conversion loop as an authority type must reuse or extend the
+authority declaration. If temporary duplication is unavoidable, it requires a
+named removal issue and a narrow, path-specific grandfather entry. Renaming,
+reordering fields, or adding a variant is not sufficient justification for a
+second declaration.
+
 ## Adapters
 
 Adapters sit at a seam and translate between a contract module and an external


### PR DESCRIPTION
Automated AFK landing for #2126. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2126

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788559742&installation_model_id=20659&pr_number=2188&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2188&signature=cbc25ebd02cbb2b2cd681c50c699a78b3fd4d45c0ba325ad1775aff858d64d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->