### PR TITLE
merge: #2131 Vfs seam moves into the file crate (expand)

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -59,6 +59,7 @@ pub mod vector_btree_page_format;
 pub mod vector_hnsw_index;
 pub mod vector_ivf_index;
 pub mod vector_value_codec;
+pub mod vfs;
 pub mod wal_header;
 pub mod wal_record;
 pub mod zone_map;
@@ -328,6 +329,7 @@ pub use vector_ivf_index::{
     decode_ivf_index_frame, encode_ivf_index_frame, IvfIndexFrame, IvfIndexFrameError,
     IvfListFrame, IVF_INDEX_HEADER_LEN, IVF_INDEX_MAGIC,
 };
+pub use vfs::{OpenMode, StdVfs, Vfs, VfsFile};
 
 pub use primary_replica::{
     cleanup_rebootstrap_artifacts, decode_rebootstrap_ready_marker_json,

--- a/crates/reddb-file/src/vfs.rs
+++ b/crates/reddb-file/src/vfs.rs
@@ -1,0 +1,115 @@
+//! Durable filesystem abstraction.
+//!
+//! [`Vfs`] and [`VfsFile`] define the filesystem operations required by
+//! RedDB's durable write paths. [`StdVfs`] is the production implementation and
+//! preserves the behavior of direct `std::fs` calls. Test crates can provide
+//! alternate implementations without introducing a product-to-test dependency.
+
+use std::io::{self, Seek, SeekFrom, Write};
+use std::path::Path;
+
+/// How a file is opened. Mirrors the subset of `OpenOptions` used by durable
+/// writers.
+#[derive(Debug, Clone, Copy)]
+pub struct OpenMode {
+    pub read: bool,
+    pub write: bool,
+    pub create: bool,
+    pub truncate: bool,
+}
+
+impl OpenMode {
+    /// Create or truncate a file for writing.
+    pub fn create_truncate() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: true,
+            truncate: true,
+        }
+    }
+
+    /// Create a file if absent and open it for reading and writing without
+    /// truncating its contents.
+    pub fn create_keep() -> Self {
+        Self {
+            read: true,
+            write: true,
+            create: true,
+            truncate: false,
+        }
+    }
+}
+
+/// A handle to one open file.
+pub trait VfsFile {
+    /// Write the entire buffer, looping over short writes like `Write::write_all`.
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()>;
+    /// Read up to `buf.len()` bytes at the current position.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+    /// Reposition the cursor.
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
+    /// Force the file's contents durable.
+    fn sync_all(&mut self) -> io::Result<()>;
+}
+
+/// A durable-I/O namespace for files and directory entries.
+pub trait Vfs {
+    /// The per-file handle this backend produces.
+    type File: VfsFile;
+
+    /// Open or create a file at `path`.
+    fn open(&self, path: &Path, mode: OpenMode) -> io::Result<Self::File>;
+    /// Atomically rename `from` to `to`.
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()>;
+    /// Force a directory's entries durable.
+    fn sync_dir(&self, dir: &Path) -> io::Result<()>;
+}
+
+/// The production filesystem backend.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct StdVfs;
+
+/// A real `std::fs::File` implementing [`VfsFile`].
+#[derive(Debug)]
+pub struct StdFile(std::fs::File);
+
+impl VfsFile for StdFile {
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.0.write_all(buf)
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        io::Read::read(&mut self.0, buf)
+    }
+
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.0.seek(pos)
+    }
+
+    fn sync_all(&mut self) -> io::Result<()> {
+        self.0.sync_all()
+    }
+}
+
+impl Vfs for StdVfs {
+    type File = StdFile;
+
+    fn open(&self, path: &Path, mode: OpenMode) -> io::Result<StdFile> {
+        std::fs::OpenOptions::new()
+            .read(mode.read)
+            .write(mode.write)
+            .create(mode.create)
+            .truncate(mode.truncate)
+            .open(path)
+            .map(StdFile)
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        std::fs::rename(from, to)
+    }
+
+    fn sync_dir(&self, dir: &Path) -> io::Result<()> {
+        std::fs::File::open(dir).and_then(|directory| directory.sync_all())
+    }
+}

--- a/crates/reddb-file/tests/vfs.rs
+++ b/crates/reddb-file/tests/vfs.rs
@@ -1,0 +1,34 @@
+use reddb_file::{OpenMode, StdVfs, Vfs, VfsFile};
+use std::io::SeekFrom;
+
+#[test]
+fn std_vfs_preserves_file_and_directory_operations() {
+    let directory = tempfile::tempdir().expect("temporary directory should be created");
+    let source = directory.path().join("source");
+    let target = directory.path().join("target");
+    let vfs = StdVfs;
+
+    let mut file = vfs
+        .open(&source, OpenMode::create_truncate())
+        .expect("source should open for writing");
+    file.write_all(b"reddb")
+        .expect("source contents should be written");
+    file.sync_all().expect("source contents should be durable");
+    drop(file);
+
+    vfs.rename(&source, &target)
+        .expect("source should be renamed");
+    vfs.sync_dir(directory.path())
+        .expect("renamed directory entry should be durable");
+
+    let mut file = vfs
+        .open(&target, OpenMode::create_keep())
+        .expect("target should open without truncation");
+    file.seek(SeekFrom::Start(0))
+        .expect("target should seek to its start");
+    let mut bytes = [0; 5];
+    let count = file.read(&mut bytes).expect("target should be read");
+
+    assert_eq!(count, bytes.len());
+    assert_eq!(&bytes, b"reddb");
+}

--- a/crates/unreliable-libc/src/lib.rs
+++ b/crates/unreliable-libc/src/lib.rs
@@ -19,11 +19,11 @@
 //!   scenarios for FCW-before-WAL, WAL-append-before-finalize, savepoints, and
 //!   concurrent writers, layered on the same WAL oracle.
 //! * [`vfs`] — the in-process counterpart to the shim (DST Fatia, #1355): a
-//!   minimal `Vfs` / `VfsFile` durable-I/O trait pair with a production-default
-//!   [`StdVfs`](vfs::StdVfs) and a seed-driven, fault-injecting
-//!   [`SimVfs`](vfs::SimVfs) (torn writes, dropped / reordered `fsync`,
-//!   `ENOSPC`, partial rename). The workload routes every durable write through
-//!   it, so an in-process power-cut enumeration can reuse the same `oracle`.
+//!   seed-driven, fault-injecting [`SimVfs`](vfs::SimVfs) implementation of the
+//!   [`reddb_file::Vfs`] product seam (torn writes, dropped / reordered
+//!   `fsync`, `ENOSPC`, partial rename). The workload routes every durable write
+//!   through it, so an in-process power-cut enumeration can reuse the same
+//!   `oracle`.
 //!
 //! The shim makes the real libc durability path (`write`/`pwrite`/`fsync`/
 //! `fdatasync`/`rename`) fail with `EIO` and short writes, plus a seed-driven
@@ -53,7 +53,7 @@ pub use value_equivalence::{
     canonical_value_corpus, recover_committed_values, run_typed_workload, CommittedTx,
     EquivalenceError, RecoveredTx, TypedModel,
 };
-pub use vfs::{OpenMode, SimFaultConfig, SimVfs, StdVfs, Vfs, VfsFile};
+pub use vfs::{SimFaultConfig, SimVfs};
 pub use wal_workload::{
     decode_manifest, run_wal_workload, run_wal_workload_on, WorkloadOutcome, MANIFEST_FILE_NAME,
 };

--- a/crates/unreliable-libc/src/tm_commit_path.rs
+++ b/crates/unreliable-libc/src/tm_commit_path.rs
@@ -6,7 +6,6 @@
 //! and finally checks TM-specific commit semantics against the recovered prefix.
 
 use crate::prng::SplitMix64;
-use crate::vfs::{OpenMode, StdVfs, Vfs, VfsFile};
 use crate::wal_workload::WAL_FILE_NAME;
 use reddb_file::wal_header::{
     decode_wal_file_header, encode_wal_file_header, WAL_FILE_HEADER_BYTES,
@@ -14,6 +13,7 @@ use reddb_file::wal_header::{
 use reddb_file::wal_record::{
     decode_main_wal_record_frame, encode_main_wal_record_frame, MainWalRecordFrame,
 };
+use reddb_file::{OpenMode, StdVfs, Vfs, VfsFile};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, Cursor};
 use std::path::Path;

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -1,17 +1,9 @@
 //! A minimal durable-I/O abstraction (DST Fatia, #1355).
 //!
-//! [`Vfs`] / [`VfsFile`] are the in-process counterpart to the `LD_PRELOAD`
-//! shim: where the shim gives real-syscall fidelity, this trait pair lets the
-//! durable writers run against an in-memory, seed-driven, fault-injecting
-//! backend that is fast and OS-portable for exhaustive fault enumeration.
-//!
-//! The shape mirrors the existing `RemoteBackend` two-trait precedent in
-//! `reddb-server`: one trait for the namespace operations (`open` / `rename` /
-//! `sync_dir`) and one for the per-file operations (`read` / `write_all` /
-//! `seek` / `sync_all`). [`StdVfs`] is the production default — it is exactly
-//! today's `std::fs` behavior, so routing a durable writer through `&StdVfs`
-//! leaves the on-disk bytes unchanged. [`SimVfs`] is the fault-injecting
-//! backend used only by tests.
+//! [`SimVfs`] implements [`reddb_file::Vfs`] with an in-memory, seed-driven,
+//! fault-injecting backend that is fast and OS-portable for exhaustive fault
+//! enumeration. The durable-I/O contract and its production [`reddb_file::StdVfs`]
+//! implementation live with the product write paths in `reddb-file`.
 //!
 //! # Fault model ([`SimVfs`])
 //!
@@ -56,120 +48,14 @@
 
 use crate::prng::SplitMix64;
 use reddb_file::dst::{self, FaultClass, FaultDecision, FaultRecord};
+use reddb_file::{OpenMode, Vfs, VfsFile};
 use std::collections::HashMap;
-use std::io::{self, Seek, SeekFrom, Write};
+use std::io::{self, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 const TURBO_CRASH_INJECT_ENV: &str = "REDDB_TURBO_CRASH_AT";
 const PPM_DENOMINATOR: u64 = 1_000_000;
-
-/// How a file is opened. Mirrors the subset of `OpenOptions` the durable
-/// writers actually use.
-#[derive(Debug, Clone, Copy)]
-pub struct OpenMode {
-    pub read: bool,
-    pub write: bool,
-    pub create: bool,
-    pub truncate: bool,
-}
-
-impl OpenMode {
-    /// Create-or-truncate for writing (the WAL log's open mode).
-    pub fn create_truncate() -> Self {
-        Self {
-            read: false,
-            write: true,
-            create: true,
-            truncate: true,
-        }
-    }
-
-    /// Create-if-absent for writing without truncating (the dual-superblock
-    /// open mode: each checkpoint overwrites only its own slot).
-    pub fn create_keep() -> Self {
-        Self {
-            read: true,
-            write: true,
-            create: true,
-            truncate: false,
-        }
-    }
-}
-
-/// A handle to one open file. The durable writers only need to append, seek to a
-/// fixed offset, read back, and force durability.
-pub trait VfsFile {
-    /// Write the entire buffer, looping over short writes like `Write::write_all`.
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()>;
-    /// Read up to `buf.len()` bytes at the current position.
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
-    /// Reposition the cursor.
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
-    /// Force the file's contents durable (the moment a write can survive a crash).
-    fn sync_all(&mut self) -> io::Result<()>;
-}
-
-/// A durable-I/O namespace: open files, rename, and force directory durability.
-pub trait Vfs {
-    /// The per-file handle this backend produces.
-    type File: VfsFile;
-
-    /// Open (or create) a file at `path`.
-    fn open(&self, path: &Path, mode: OpenMode) -> io::Result<Self::File>;
-    /// Atomically rename `from` to `to` (subject to fault injection).
-    fn rename(&self, from: &Path, to: &Path) -> io::Result<()>;
-    /// Force a directory's entries durable (makes a prior `rename` survive a crash).
-    fn sync_dir(&self, dir: &Path) -> io::Result<()>;
-}
-
-// --------------------------------------------------------------------------
-// StdVfs — the production default (today's `std::fs` behavior, unchanged).
-// --------------------------------------------------------------------------
-
-/// The real filesystem backend. Routing a durable writer through `&StdVfs`
-/// produces byte-for-byte the same artifacts as direct `std::fs` calls.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct StdVfs;
-
-/// A real `std::fs::File`.
-#[derive(Debug)]
-pub struct StdFile(std::fs::File);
-
-impl VfsFile for StdFile {
-    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
-        self.0.write_all(buf)
-    }
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        io::Read::read(&mut self.0, buf)
-    }
-    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
-        self.0.seek(pos)
-    }
-    fn sync_all(&mut self) -> io::Result<()> {
-        self.0.sync_all()
-    }
-}
-
-impl Vfs for StdVfs {
-    type File = StdFile;
-
-    fn open(&self, path: &Path, mode: OpenMode) -> io::Result<StdFile> {
-        std::fs::OpenOptions::new()
-            .read(mode.read)
-            .write(mode.write)
-            .create(mode.create)
-            .truncate(mode.truncate)
-            .open(path)
-            .map(StdFile)
-    }
-    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
-        std::fs::rename(from, to)
-    }
-    fn sync_dir(&self, dir: &Path) -> io::Result<()> {
-        std::fs::File::open(dir).and_then(|d| d.sync_all())
-    }
-}
 
 // --------------------------------------------------------------------------
 // SimVfs — in-memory, seed-driven, fault-injecting backend (test only).
@@ -212,7 +98,7 @@ pub struct SimFaultConfig {
 }
 
 impl SimFaultConfig {
-    /// No faults: a faithful in-memory mirror of `StdVfs`.
+    /// No faults: a faithful in-memory mirror of [`reddb_file::StdVfs`].
     pub fn none() -> Self {
         Self {
             enospc_ppm: 0,
@@ -777,17 +663,6 @@ mod tests {
             out.extend_from_slice(&buf[..n]);
         }
         out
-    }
-
-    #[test]
-    fn std_vfs_roundtrips() {
-        let dir = tempfile::tempdir().unwrap();
-        let vfs = StdVfs;
-        let path = dir.path().join("a.bin");
-        let mut f = vfs.open(&path, OpenMode::create_truncate()).unwrap();
-        f.write_all(b"hello").unwrap();
-        f.sync_all().unwrap();
-        assert_eq!(read_back(&vfs, &path), b"hello");
     }
 
     #[test]

--- a/crates/unreliable-libc/src/wal_workload.rs
+++ b/crates/unreliable-libc/src/wal_workload.rs
@@ -18,9 +18,9 @@
 
 use crate::prng::SplitMix64;
 use crate::superblock::{self, Superblock};
-use crate::vfs::{OpenMode, StdVfs, Vfs, VfsFile};
 use reddb_file::wal_header::{encode_wal_file_header, WAL_FILE_VERSION};
 use reddb_file::wal_record::{encode_main_wal_record_frame, MainWalRecordFrame};
+use reddb_file::{OpenMode, StdVfs, Vfs, VfsFile};
 use std::io::{self, SeekFrom};
 use std::path::Path;
 


### PR DESCRIPTION
Automated AFK landing for #2131. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2131

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788563479&installation_model_id=20659&pr_number=2193&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2193&signature=bd8789dc853423b2bee0f9ea1345a50b55af17710eb6da1b5fa3401a6decec69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->