### PR TITLE
merge: #2137 Migrate MVCC visibility batch 2: DML, queue, search, events paths

### DIFF
--- a/crates/reddb-server/src/runtime/ask_pipeline.rs
+++ b/crates/reddb-server/src/runtime/ask_pipeline.rs
@@ -1093,15 +1093,8 @@ pub fn filter_values(
             .map(|v| v.as_slice())
             .unwrap_or(&[]);
 
-        for entity in manager.query_all(|_| true) {
-            if !ask_entity_allowed(
-                runtime,
-                scope,
-                collection,
-                &entity,
-                snap_ctx.as_ref(),
-                &mut rls_cache,
-            ) {
+        for entity in manager.scan(snap_ctx.as_ref(), |_| true) {
+            if !ask_entity_allowed(runtime, scope, collection, &entity, &mut rls_cache) {
                 continue;
             }
             if let Some(hit) = literal_match_in_entity(&entity, &tokens.literals, hint_columns) {
@@ -1125,7 +1118,6 @@ fn ask_entity_allowed(
     scope: &EffectiveScope,
     collection: &str,
     entity: &UnifiedEntity,
-    snap_ctx: Option<&crate::runtime::impl_core::SnapshotContext>,
     rls_cache: &mut HashMap<String, Option<crate::storage::query::ast::Filter>>,
 ) -> bool {
     if scope
@@ -1134,7 +1126,7 @@ fn ask_entity_allowed(
     {
         return false;
     }
-    runtime.search_entity_allowed(collection, entity, snap_ctx, rls_cache)
+    runtime.search_entity_rls_allowed(collection, entity, rls_cache)
 }
 
 struct AskScopeGuard {

--- a/crates/reddb-server/src/runtime/ask_pipeline.rs
+++ b/crates/reddb-server/src/runtime/ask_pipeline.rs
@@ -1094,7 +1094,7 @@ pub fn filter_values(
             .unwrap_or(&[]);
 
         for entity in manager.scan(snap_ctx.as_ref(), |_| true) {
-            if !ask_entity_allowed(runtime, scope, collection, &entity, &mut rls_cache) {
+            if !ask_scanned_entity_allowed(runtime, scope, collection, &entity, &mut rls_cache) {
                 continue;
             }
             if let Some(hit) = literal_match_in_entity(&entity, &tokens.literals, hint_columns) {
@@ -1114,6 +1114,23 @@ pub fn filter_values(
 }
 
 fn ask_entity_allowed(
+    runtime: &RedDBRuntime,
+    scope: &EffectiveScope,
+    collection: &str,
+    entity: &UnifiedEntity,
+    snap_ctx: Option<&crate::runtime::impl_core::SnapshotContext>,
+    rls_cache: &mut HashMap<String, Option<crate::storage::query::ast::Filter>>,
+) -> bool {
+    if scope
+        .visible_collections()
+        .is_some_and(|visible| !visible.contains(collection))
+    {
+        return false;
+    }
+    runtime.search_entity_allowed(collection, entity, snap_ctx, rls_cache)
+}
+
+fn ask_scanned_entity_allowed(
     runtime: &RedDBRuntime,
     scope: &EffectiveScope,
     collection: &str,

--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -5,9 +5,9 @@
 //! DELETE path into a small testable module. The same Interface will
 //! be reused by UPDATE in a follow-up; this commit covers DELETE only.
 //!
-//! Candidate discovery stays with each scan path. Table-row visibility
-//! is centralized through `TableRowMvccReadResolver` before any
-//! candidate id is returned to UPDATE or DELETE.
+//! Candidate discovery stays with each scan path. Segment scans apply
+//! visibility through the snapshot API; point/index candidates use the
+//! table-row resolver before reaching UPDATE or DELETE.
 
 use std::collections::HashMap;
 
@@ -147,6 +147,11 @@ impl<'a> DmlTargetScan<'a> {
             }
         }
 
+        let snapshot = if self.live_table_rows {
+            None
+        } else {
+            crate::runtime::impl_core::capture_current_snapshot()
+        };
         let mut ids = Vec::new();
         if let Some(filter) = self.filter {
             let mut owned_zone_preds = Vec::new();
@@ -179,10 +184,7 @@ impl<'a> DmlTargetScan<'a> {
                 })
                 .collect();
 
-            manager.for_each_entity_zoned(&zone_preds, |entity| {
-                if !self.visible_candidate(entity) {
-                    return true;
-                }
+            manager.scan_for_each_zoned_with_stats(snapshot.as_ref(), &zone_preds, |entity| {
                 if self.matches_update_target(entity)
                     && self.matches_filter(entity, compiled_filter.as_ref())
                 {
@@ -194,8 +196,8 @@ impl<'a> DmlTargetScan<'a> {
                 true
             });
         } else {
-            manager.for_each_entity(|entity| {
-                if self.visible_candidate(entity) && self.matches_update_target(entity) {
+            manager.scan_for_each(snapshot.as_ref(), |entity| {
+                if self.matches_update_target(entity) {
                     ids.push(entity.id);
                     if self.limit.map(|limit| ids.len() >= limit).unwrap_or(false) {
                         return false;

--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -147,11 +147,7 @@ impl<'a> DmlTargetScan<'a> {
             }
         }
 
-        let snapshot = if self.live_table_rows {
-            None
-        } else {
-            crate::runtime::impl_core::capture_current_snapshot()
-        };
+        let snapshot = crate::runtime::impl_core::capture_current_snapshot();
         let mut ids = Vec::new();
         if let Some(filter) = self.filter {
             let mut owned_zone_preds = Vec::new();
@@ -184,8 +180,9 @@ impl<'a> DmlTargetScan<'a> {
                 })
                 .collect();
 
-            manager.scan_for_each_zoned_with_stats(snapshot.as_ref(), &zone_preds, |entity| {
-                if self.matches_update_target(entity)
+            manager.for_each_entity_zoned_with_stats(&zone_preds, |entity| {
+                if self.candidate_visible(snapshot.as_ref(), entity)
+                    && self.matches_update_target(entity)
                     && self.matches_filter(entity, compiled_filter.as_ref())
                 {
                     ids.push(entity.id);
@@ -196,8 +193,10 @@ impl<'a> DmlTargetScan<'a> {
                 true
             });
         } else {
-            manager.scan_for_each(snapshot.as_ref(), |entity| {
-                if self.matches_update_target(entity) {
+            manager.for_each_entity(|entity| {
+                if self.candidate_visible(snapshot.as_ref(), entity)
+                    && self.matches_update_target(entity)
+                {
                     ids.push(entity.id);
                     if self.limit.map(|limit| ids.len() >= limit).unwrap_or(false) {
                         return false;
@@ -316,6 +315,30 @@ impl<'a> DmlTargetScan<'a> {
             return self.table_row_resolver.resolve_candidate(entity).is_some();
         }
         crate::runtime::impl_core::entity_visible_under_current_snapshot(entity)
+    }
+
+    /// DML-target visibility is kind-conditional, which the uniform
+    /// `scan_*` API cannot express (issue #2137 review): under
+    /// `live_table_rows` (the RMW UPDATE path) table rows are targeted at
+    /// their tip version (`xmax == 0`, including rows whose inserting
+    /// transaction has not committed — the lock wants the latest physical
+    /// version), while every other entity kind keeps the full snapshot
+    /// check. The moderation gate applies to all kinds (#1274).
+    fn candidate_visible(
+        &self,
+        snapshot: Option<&crate::runtime::impl_core::SnapshotContext>,
+        entity: &crate::storage::UnifiedEntity,
+    ) -> bool {
+        if crate::runtime::ai::moderation::entity_moderation_hidden(entity) {
+            return false;
+        }
+        if self.live_table_rows && matches!(entity.kind, EntityKind::TableRow { .. }) {
+            return entity.xmax == 0;
+        }
+        match snapshot {
+            Some(ctx) => crate::runtime::mvcc::entity_visible_with_context(Some(ctx), entity),
+            None => entity.xmax == 0,
+        }
     }
 
     fn matches_update_target(&self, entity: &crate::storage::UnifiedEntity) -> bool {

--- a/crates/reddb-server/src/runtime/graph_dsl.rs
+++ b/crates/reddb-server/src/runtime/graph_dsl.rs
@@ -9,14 +9,9 @@ pub(super) fn materialize_graph_with_projection(
     projection: Option<&RuntimeGraphProjection>,
 ) -> RedDBResult<GraphStore> {
     let graph = GraphStore::new();
-    // Phase 1.2 MVCC universal: capture the current connection's
-    // snapshot before `query_all` spawns parallel scan threads — the
-    // thread-local CURRENT_SNAPSHOT does not propagate into spawned
-    // workers, so we hand the context to the filter closure by move.
+    // Capture before the store fans the scan out across collection workers.
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
-    let entities = store.query_all(move |e| {
-        crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), e)
-    });
+    let entities = store.scan(snap_ctx.as_ref(), |_| true);
     let node_label_filters = projection
         .and_then(|projection| normalize_token_filter_list(projection.node_labels.clone()));
     let node_type_filters = projection

--- a/crates/reddb-server/src/runtime/graph_tvf.rs
+++ b/crates/reddb-server/src/runtime/graph_tvf.rs
@@ -18,9 +18,7 @@
 //! bumped to `pub(crate)` and re-exported from `impl_core` for the call sites
 //! that still live there.
 use super::authz::policy_columns::parse_positive_iterations;
-use super::execution_context::{
-    capture_current_snapshot, current_auth_identity, entity_visible_with_context,
-};
+use super::execution_context::{capture_current_snapshot, current_auth_identity};
 use super::rls_injection::{edge_passes_rls, node_passes_rls};
 use super::*;
 
@@ -770,11 +768,8 @@ impl RedDBRuntime {
             let Some(manager) = store.get_collection(collection) else {
                 continue;
             };
-            let entities = manager.query_all(|_| true);
+            let entities = manager.scan(snap_ctx.as_ref(), |_| true);
             for entity in entities {
-                if !entity_visible_with_context(snap_ctx.as_ref(), &entity) {
-                    continue;
-                }
                 let EntityKind::GraphNode(ref node) = entity.kind else {
                     continue;
                 };
@@ -803,11 +798,8 @@ impl RedDBRuntime {
             let Some(manager) = store.get_collection(collection) else {
                 continue;
             };
-            let entities = manager.query_all(|_| true);
+            let entities = manager.scan(snap_ctx.as_ref(), |_| true);
             for entity in entities {
-                if !entity_visible_with_context(snap_ctx.as_ref(), &entity) {
-                    continue;
-                }
                 let EntityKind::GraphEdge(ref edge) = entity.kind else {
                     continue;
                 };

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -989,7 +989,8 @@ impl RedDBRuntime {
             let manager = store
                 .get_collection(&query.table)
                 .ok_or_else(|| RedDBError::NotFound(query.table.clone()))?;
-            let entities = manager.query_all(|_| true);
+            let snapshot = crate::runtime::impl_core::capture_current_snapshot();
+            let entities = manager.scan(snapshot.as_ref(), |_| true);
             let recent: Vec<_> = entities
                 .into_iter()
                 .rev()

--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -68,7 +68,8 @@ impl RedDBRuntime {
         entities.sort_by_key(|entity| entity.id.raw());
 
         let effective_queue = crate::runtime::mutation::effective_queue_name(&subscription);
-        let mut existing_event_ids = queue_event_ids(store.as_ref(), &effective_queue)?;
+        let mut existing_event_ids =
+            queue_event_ids(store.as_ref(), &effective_queue, &snap_ctx)?;
         let subscription_id = subscription_identity(&subscription);
         let mut matched = 0u64;
         let mut enqueued = 0u64;
@@ -189,12 +190,18 @@ fn subscription_identity(subscription: &crate::catalog::SubscriptionDescriptor) 
     }
 }
 
-fn queue_event_ids(store: &UnifiedStore, queue: &str) -> RedDBResult<HashSet<String>> {
+fn queue_event_ids(
+    store: &UnifiedStore,
+    queue: &str,
+    snapshot: &crate::runtime::impl_core::SnapshotContext,
+) -> RedDBResult<HashSet<String>> {
     let Some(manager) = store.get_collection(queue) else {
         return Ok(HashSet::new());
     };
     let mut ids = HashSet::new();
-    for entity in manager.query_all(|entity| matches!(entity.kind, EntityKind::QueueMessage { .. }))
+    for entity in manager.scan(Some(snapshot), |entity| {
+        matches!(entity.kind, EntityKind::QueueMessage { .. })
+    })
     {
         let EntityData::QueueMessage(message) = entity.data else {
             continue;

--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -68,8 +68,7 @@ impl RedDBRuntime {
         entities.sort_by_key(|entity| entity.id.raw());
 
         let effective_queue = crate::runtime::mutation::effective_queue_name(&subscription);
-        let mut existing_event_ids =
-            queue_event_ids(store.as_ref(), &effective_queue, &snap_ctx)?;
+        let mut existing_event_ids = queue_event_ids(store.as_ref(), &effective_queue, &snap_ctx)?;
         let subscription_id = subscription_identity(&subscription);
         let mut matched = 0u64;
         let mut enqueued = 0u64;
@@ -201,8 +200,7 @@ fn queue_event_ids(
     let mut ids = HashSet::new();
     for entity in manager.scan(Some(snapshot), |entity| {
         matches!(entity.kind, EntityKind::QueueMessage { .. })
-    })
-    {
+    }) {
         let EntityData::QueueMessage(message) = entity.data else {
             continue;
         };

--- a/crates/reddb-server/src/runtime/impl_events.rs
+++ b/crates/reddb-server/src/runtime/impl_events.rs
@@ -68,7 +68,7 @@ impl RedDBRuntime {
         entities.sort_by_key(|entity| entity.id.raw());
 
         let effective_queue = crate::runtime::mutation::effective_queue_name(&subscription);
-        let mut existing_event_ids = queue_event_ids(store.as_ref(), &effective_queue, &snap_ctx)?;
+        let mut existing_event_ids = queue_event_ids(store.as_ref(), &effective_queue)?;
         let subscription_id = subscription_identity(&subscription);
         let mut matched = 0u64;
         let mut enqueued = 0u64;
@@ -189,18 +189,17 @@ fn subscription_identity(subscription: &crate::catalog::SubscriptionDescriptor) 
     }
 }
 
-fn queue_event_ids(
-    store: &UnifiedStore,
-    queue: &str,
-    snapshot: &crate::runtime::impl_core::SnapshotContext,
-) -> RedDBResult<HashSet<String>> {
+fn queue_event_ids(store: &UnifiedStore, queue: &str) -> RedDBResult<HashSet<String>> {
     let Some(manager) = store.get_collection(queue) else {
         return Ok(HashSet::new());
     };
     let mut ids = HashSet::new();
-    for entity in manager.scan(Some(snapshot), |entity| {
-        matches!(entity.kind, EntityKind::QueueMessage { .. })
-    }) {
+    // Deliberately visibility-free: the backfill dedup set must include
+    // consumed/ACKed messages (committed xmax, pre-vacuum). Filtering by
+    // snapshot would drop them from the set and re-enqueue events that
+    // were already delivered (issue #2137 review).
+    for entity in manager.query_all(|entity| matches!(entity.kind, EntityKind::QueueMessage { .. }))
+    {
         let EntityData::QueueMessage(message) = entity.data else {
             continue;
         };

--- a/crates/reddb-server/src/runtime/impl_graph_commands.rs
+++ b/crates/reddb-server/src/runtime/impl_graph_commands.rs
@@ -1406,20 +1406,15 @@ fn scan_collection_with_candidates(
     collection: &str,
     candidates: &Option<std::collections::HashSet<u64>>,
 ) -> Vec<UnifiedEntity> {
-    let resolver =
-        crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     match candidates {
         Some(ids) => store
             .get_collection(collection)
-            .map(|m| {
-                m.query_all(|e| {
-                    ids.contains(&e.id.raw()) && resolver.resolve_read_candidate(e).is_some()
-                })
-            })
+            .map(|manager| manager.scan(snapshot.as_ref(), |e| ids.contains(&e.id.raw())))
             .unwrap_or_default(),
         None => store
             .get_collection(collection)
-            .map(|m| m.query_all(|e| resolver.resolve_read_candidate(e).is_some()))
+            .map(|manager| manager.scan(snapshot.as_ref(), |_| true))
             .unwrap_or_default(),
     }
 }

--- a/crates/reddb-server/src/runtime/impl_kv.rs
+++ b/crates/reddb-server/src/runtime/impl_kv.rs
@@ -777,16 +777,9 @@ impl<'a> KvAtomicOps<'a> {
         // version with the greatest xmin — mirroring the table-row
         // resolver's per-logical-id rule, keyed on the KV `key` field.
         if self.is_versioned_collection(model, collection) {
-            let resolver =
-                crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement();
+            let snapshot = crate::runtime::impl_core::capture_current_snapshot();
             let mut best: Option<crate::storage::UnifiedEntity> = None;
-            for entity in manager.query_all(|_| true) {
-                if !kv_entity_has_key(&entity, key) {
-                    continue;
-                }
-                if resolver.resolve_read_candidate(&entity).is_none() {
-                    continue;
-                }
+            for entity in manager.scan(snapshot.as_ref(), |entity| kv_entity_has_key(entity, key)) {
                 let better = match &best {
                     Some(current) => entity.xmin >= current.xmin,
                     None => true,
@@ -823,13 +816,16 @@ impl<'a> KvAtomicOps<'a> {
         // the per-key version-selection used by `get_entity`.
         let versioned =
             self.is_versioned_collection(crate::catalog::CollectionModel::Kv, collection);
-        let resolver = versioned.then(|| {
-            crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver::current_statement()
-        });
+        let snapshot = crate::runtime::impl_core::capture_current_snapshot();
+        let entities = if versioned {
+            manager.scan(snapshot.as_ref(), |_| true)
+        } else {
+            manager.query_all(|_| true)
+        };
 
         let mut entries: std::collections::BTreeMap<String, crate::storage::UnifiedEntity> =
             std::collections::BTreeMap::new();
-        for entity in manager.query_all(|_| true) {
+        for entity in entities {
             let key = match &entity.data {
                 crate::storage::EntityData::Row(row) => row
                     .named
@@ -846,13 +842,6 @@ impl<'a> KvAtomicOps<'a> {
             };
             if prefix.is_some_and(|prefix| !key.starts_with(prefix)) {
                 continue;
-            }
-            if let Some(resolver) = resolver.as_ref() {
-                // Skip versions not visible to the current snapshot
-                // (tombstoned by a visible deleter, or not yet created).
-                if resolver.resolve_read_candidate(&entity).is_none() {
-                    continue;
-                }
             }
             let should_replace = match entries.get(&key) {
                 Some(existing) if versioned => entity.xmin >= existing.xmin,

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -2447,11 +2447,8 @@ pub(super) fn load_queue_message_views_with_runtime(
     let filter_arc = rls_filter.map(std::sync::Arc::new);
     let rt_arc = runtime;
     Ok(manager
-        .query_all(move |entity| {
+        .scan(snap_ctx.as_ref(), move |entity| {
             if !matches!(entity.kind, EntityKind::QueueMessage { .. }) {
-                return false;
-            }
-            if !crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity) {
                 return false;
             }
             if let (Some(filter), Some(rt)) = (filter_arc.as_ref(), rt_arc) {
@@ -3064,10 +3061,7 @@ pub(super) fn find_queue_dedup(
     let dedup_key = dedup_key.to_string();
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     manager
-        .query_all(|entity| {
-            if !crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity) {
-                return false;
-            }
+        .scan(snap_ctx.as_ref(), |entity| {
             entity.data.as_row().is_some_and(|row| {
                 row_text(row, "kind").as_deref() == Some(KIND_QUEUE_PUSH_DEDUP)
                     && row_text(row, "queue").as_deref() == Some(&queue)

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -355,9 +355,10 @@ impl RedDBRuntime {
         let manager = store
             .get_collection(collection)
             .ok_or_else(|| RedDBError::NotFound(collection.to_string()))?;
+        let snapshot = crate::runtime::impl_core::capture_current_snapshot();
 
         let vectors: Vec<(u64, Vec<f32>)> = manager
-            .query_all(|_| true)
+            .scan(snapshot.as_ref(), |_| true)
             .into_iter()
             .filter_map(|entity| match &entity.data {
                 EntityData::Vector(data) if !data.dense.is_empty() => {
@@ -697,13 +698,14 @@ impl RedDBRuntime {
 
         // Fallback: global scan if ContextIndex returned nothing
         if scored.is_empty() {
+            let snapshot = crate::runtime::impl_core::capture_current_snapshot();
             let query_tokens = tokenize_query(&query);
             if let Some(collections) = collection_scope {
                 for collection in collections {
                     let Some(manager) = store.get_collection(&collection) else {
                         continue;
                     };
-                    for entity in manager.query_all(|_| true) {
+                    for entity in manager.scan(snapshot.as_ref(), |_| true) {
                         let entity_tokens = entity_tokens_for_search(&entity);
                         let overlap = query_tokens
                             .iter()
@@ -906,18 +908,25 @@ impl RedDBRuntime {
         snap_ctx: Option<&crate::runtime::impl_core::SnapshotContext>,
         rls_cache: &mut HashMap<String, Option<crate::storage::query::ast::Filter>>,
     ) -> bool {
-        use crate::runtime::impl_core::{
-            entity_visible_with_context, rls_policy_filter, rls_policy_filter_for_kind,
-        };
-        use crate::storage::query::ast::{PolicyAction, PolicyTargetKind};
-        use crate::storage::unified::entity::EntityKind;
+        use crate::runtime::impl_core::entity_visible_with_context;
 
-        // 1. MVCC visibility (Phase 1).
         if !entity_visible_with_context(snap_ctx, entity) {
             return false;
         }
+        self.search_entity_rls_allowed(collection, entity, rls_cache)
+    }
 
-        // 2. RLS gate — only evaluate when the table has it enabled.
+    pub(crate) fn search_entity_rls_allowed(
+        &self,
+        collection: &str,
+        entity: &UnifiedEntity,
+        rls_cache: &mut HashMap<String, Option<crate::storage::query::ast::Filter>>,
+    ) -> bool {
+        use crate::runtime::impl_core::{rls_policy_filter, rls_policy_filter_for_kind};
+        use crate::storage::query::ast::{PolicyAction, PolicyTargetKind};
+        use crate::storage::unified::entity::EntityKind;
+
+        // RLS gate — only evaluate when the table has it enabled.
         if !self.is_rls_enabled(collection) {
             return true;
         }
@@ -1083,16 +1092,12 @@ impl RedDBRuntime {
                     let Some(manager) = store.get_collection(collection_name) else {
                         continue;
                     };
-                    for entity in manager.query_all(|_| true) {
+                    for entity in manager.scan(snap_ctx.as_ref(), |_| true) {
                         if scored.contains_key(&entity.id.raw()) {
                             continue;
                         }
-                        if !self.search_entity_allowed(
-                            collection_name,
-                            &entity,
-                            snap_ctx.as_ref(),
-                            &mut rls_cache,
-                        ) {
+                        if !self.search_entity_rls_allowed(collection_name, &entity, &mut rls_cache)
+                        {
                             continue;
                         }
                         let entity_tokens = entity_tokens_for_search(&entity);

--- a/crates/reddb-server/src/runtime/primary_queue_store.rs
+++ b/crates/reddb-server/src/runtime/primary_queue_store.rs
@@ -415,13 +415,9 @@ impl PrimaryQueueStore {
         // the message on subsequent reads.
         let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
         let mut out: Vec<QueueMessageOrdered> = manager
-            .query_all(move |entity| {
-                if !matches!(entity.kind, EntityKind::QueueMessage { .. })
-                    || !matches!(entity.data, EntityData::QueueMessage(_))
-                {
-                    return false;
-                }
-                crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity)
+            .scan(snap_ctx.as_ref(), |entity| {
+                matches!(entity.kind, EntityKind::QueueMessage { .. })
+                    && matches!(entity.data, EntityData::QueueMessage(_))
             })
             .into_iter()
             .filter_map(|entity| {

--- a/crates/reddb-server/src/runtime/query_exec/aggregate_pushdown_dispatch.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate_pushdown_dispatch.rs
@@ -24,7 +24,6 @@ use super::aggregate_planner::{
 };
 use super::filter_compiled::{classify_field, resolve_kind, CompiledEntityFilter, EntityFieldKind};
 use crate::api::{RedDBError, RedDBResult};
-use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 use crate::storage::query::ast::{Expr, FieldRef, Projection};
 use crate::storage::query::sql_lowering::{
     effective_table_filter, effective_table_group_by_exprs, effective_table_having_filter,
@@ -137,11 +136,8 @@ pub(super) fn try_execute_pushdown_aggregate(
         .map(|f| CompiledEntityFilter::compile(f, table_name, table_alias));
 
     let mut rows: Vec<ScanRow> = Vec::new();
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
-    manager.for_each_entity(|entity| {
-        if table_row_resolver.resolve_read_candidate(entity).is_none() {
-            return true;
-        }
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
         if let Some(f) = compiled_filter.as_ref() {
             if !f.evaluate(entity) {
                 return true;

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -222,20 +222,7 @@ pub(crate) fn runtime_vector_matches(
         query.k.max(1)
     };
 
-    for entity in manager.query_all(|entity| {
-        // `query_all` may fan out across worker threads that do not
-        // inherit the dispatch thread's snapshot thread-local, so we
-        // pass the captured snapshot context explicitly. In autocommit
-        // there is no captured context (`None`); the table-scan paths
-        // would treat that as "always visible", but a deleted/superseded
-        // vector carries `xmax != 0` and must be hidden — mirror the
-        // autocommit rule of `entity_visible_under_current_snapshot`.
-        if snap_ctx.is_none() {
-            return entity.xmax == 0
-                && !crate::runtime::ai::moderation::entity_moderation_hidden(entity);
-        }
-        crate::runtime::impl_core::entity_visible_with_context(snap_ctx.as_ref(), entity)
-    }) {
+    for entity in manager.scan(snap_ctx.as_ref(), |_| true) {
         if let Some(filter) = filter.as_ref() {
             if !runtime_vector_entity_matches_filter(db, &query.collection, entity.id, filter) {
                 continue;

--- a/crates/reddb-server/src/runtime/record_search.rs
+++ b/crates/reddb-server/src/runtime/record_search.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 use crate::storage::query::sql_lowering::effective_table_projections;
 use crate::storage::query::unified::{
     sys_key_collection, sys_key_created_at, sys_key_kind, sys_key_red_capabilities,
@@ -151,6 +150,7 @@ pub(super) fn scan_runtime_table_source_records_limited(
         .store()
         .get_collection(table)
         .ok_or_else(|| RedDBError::NotFound(table.to_string()))?;
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
 
     // A5 — parallel scan: for large unfiltered tables, collect entities once
     // then convert to records in parallel using the thread-pool coordinator.
@@ -165,13 +165,10 @@ pub(super) fn scan_runtime_table_source_records_limited(
         let schema = manager.column_schema();
         let table_name = table.to_string();
         let hydrate_store = db.store();
-        let table_row_resolver = TableRowMvccReadResolver::current_statement();
         let mut entities: Vec<crate::storage::unified::entity::UnifiedEntity> =
             Vec::with_capacity(entity_count);
-        manager.for_each_entity(|e| {
-            if table_row_resolver.resolve_read_candidate(e).is_some()
-                && db.replica_allows_entity_at_read(table, e)
-            {
+        manager.scan_for_each(snapshot.as_ref(), |e| {
+            if db.replica_allows_entity_at_read(table, e) {
                 entities.push(e.clone());
             }
             true
@@ -224,11 +221,7 @@ pub(super) fn scan_runtime_table_source_records_limited(
         Some(n) => Vec::with_capacity(n),
         None => Vec::new(),
     };
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
-    manager.for_each_entity(|entity| {
-        if table_row_resolver.resolve_read_candidate(entity).is_none() {
-            return true;
-        }
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
         if !db.replica_allows_entity_at_read(table, entity) {
             return true;
         }
@@ -257,12 +250,11 @@ pub(super) fn scan_runtime_universal_source_records_limited(
     limit: Option<usize>,
 ) -> RedDBResult<Vec<UnifiedRecord>> {
     use crate::runtime::impl_core::capture_current_snapshot;
-    use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
 
     // Cross-collection scans may run inside std::thread::scope — capture
     // the snapshot so worker threads see the same MVCC view instead of
     // defaulting to "no snapshot" (every row visible).
-    let table_row_resolver = TableRowMvccReadResolver::captured(capture_current_snapshot());
+    let snapshot = capture_current_snapshot();
     if let Some(collections) = candidate_collections {
         let store = db.store();
         let mut records = match limit {
@@ -273,12 +265,9 @@ pub(super) fn scan_runtime_universal_source_records_limited(
             let Some(manager) = store.get_collection(collection) else {
                 continue;
             };
-            manager.for_each_entity(|entity| {
+            manager.scan_for_each(snapshot.as_ref(), |entity| {
                 if records.len() >= limit.unwrap_or(usize::MAX) {
                     return false;
-                }
-                if table_row_resolver.resolve_read_candidate(entity).is_none() {
-                    return true;
                 }
                 if !db.replica_allows_entity_at_read(collection, entity) {
                     return true;
@@ -299,7 +288,7 @@ pub(super) fn scan_runtime_universal_source_records_limited(
 
     let records: Vec<UnifiedRecord> = db
         .store()
-        .query_all(move |e| table_row_resolver.resolve_read_candidate(e).is_some())
+        .scan(snapshot.as_ref(), |_| true)
         .into_iter()
         .filter_map(|(collection, entity)| {
             if !db.replica_allows_entity_at_read(&collection, &entity) {
@@ -338,8 +327,6 @@ pub(crate) fn stream_runtime_table_source_scan(
     table: &str,
     high_water_mark: usize,
 ) -> RedDBResult<super::query_exec::RowStream> {
-    use crate::runtime::table_row_mvcc_resolver::TableRowMvccReadResolver;
-
     let manager = db
         .store()
         .get_collection(table)
@@ -347,12 +334,10 @@ pub(crate) fn stream_runtime_table_source_scan(
     let schema = manager.column_schema();
     let table_name = table.to_string();
 
-    let table_row_resolver = TableRowMvccReadResolver::current_statement();
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     let mut entities: Vec<crate::storage::unified::entity::UnifiedEntity> = Vec::new();
-    manager.for_each_entity(|entity| {
-        if table_row_resolver.resolve_read_candidate(entity).is_some()
-            && db.replica_allows_entity_at_read(table, entity)
-        {
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
+        if db.replica_allows_entity_at_read(table, entity) {
             entities.push(entity.clone());
         }
         true

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -2367,9 +2367,24 @@ mod tests {
         assert!(!aggregate_pushdown.contains(".for_each_entity("));
         assert!(!ask.contains("for entity in manager.query_all(|_| true)"));
         assert!(!dml.contains("let entities = manager.query_all(|_| true);"));
-        assert!(!dml_targets.contains(".for_each_entity_zoned("));
-        assert!(!dml_targets.contains("manager.for_each_entity(|entity|"));
-        assert!(!events.contains("manager.query_all("));
+        // The DML target scan keeps raw iteration on purpose: its
+        // visibility is kind-conditional (live table rows at the tip
+        // version, everything else under the snapshot), which the uniform
+        // scan API cannot express. `candidate_visible` is the single gate.
+        assert_eq!(
+            dml_targets
+                .matches("self.candidate_visible(snapshot.as_ref(), entity)")
+                .count(),
+            2,
+            "both raw DML iterations must route through candidate_visible"
+        );
+        // The event-backfill dedup set is deliberately visibility-free:
+        // it must include consumed messages or backfill re-enqueues them.
+        assert_eq!(
+            events.matches("manager.query_all(").count(),
+            1,
+            "only the visibility-free backfill dedup may use query_all"
+        );
         assert!(!graph_commands.contains("TableRowMvccReadResolver"));
         assert!(!graph_dsl.contains("entity_visible_with_context(snap_ctx.as_ref(), e)"));
         assert!(!graph_tvf.contains("entity_visible_with_context(snap_ctx.as_ref(), &entity)"));

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -2346,6 +2346,42 @@ mod tests {
     }
 
     #[test]
+    fn remaining_visibility_scan_callers_use_snapshot_api() {
+        let aggregate_pushdown =
+            include_str!("../../runtime/query_exec/aggregate_pushdown_dispatch.rs");
+        let ask = include_str!("../../runtime/ask_pipeline.rs");
+        let dml = include_str!("../../runtime/impl_dml.rs");
+        let dml_targets = include_str!("../../runtime/dml_target_scan.rs");
+        let events = include_str!("../../runtime/impl_events.rs");
+        let graph_commands = include_str!("../../runtime/impl_graph_commands.rs");
+        let graph_dsl = include_str!("../../runtime/graph_dsl.rs");
+        let graph_tvf = include_str!("../../runtime/graph_tvf.rs");
+        let kv = include_str!("../../runtime/impl_kv.rs");
+        let queue = include_str!("../../runtime/impl_queue.rs");
+        let primary_queue = include_str!("../../runtime/primary_queue_store.rs");
+        let record_search = include_str!("../../runtime/record_search.rs");
+        let search = include_str!("../../runtime/impl_search.rs");
+        let vector = include_str!("../../runtime/query_exec/vector.rs");
+
+        assert!(!aggregate_pushdown.contains("TableRowMvccReadResolver"));
+        assert!(!aggregate_pushdown.contains(".for_each_entity("));
+        assert!(!ask.contains("for entity in manager.query_all(|_| true)"));
+        assert!(!dml.contains("let entities = manager.query_all(|_| true);"));
+        assert!(!dml_targets.contains(".for_each_entity_zoned("));
+        assert!(!dml_targets.contains("manager.for_each_entity(|entity|"));
+        assert!(!events.contains("manager.query_all("));
+        assert!(!graph_commands.contains("TableRowMvccReadResolver"));
+        assert!(!graph_dsl.contains("entity_visible_with_context(snap_ctx.as_ref(), e)"));
+        assert!(!graph_tvf.contains("entity_visible_with_context(snap_ctx.as_ref(), &entity)"));
+        assert!(!kv.contains("TableRowMvccReadResolver"));
+        assert!(!queue.contains("entity_visible_with_context(snap_ctx.as_ref(), entity)"));
+        assert!(!primary_queue.contains("entity_visible_with_context(snap_ctx.as_ref(), entity)"));
+        assert!(!record_search.contains("TableRowMvccReadResolver"));
+        assert!(!search.contains("for entity in manager.query_all(|_| true)"));
+        assert!(!vector.contains("manager.query_all("));
+    }
+
+    #[test]
     fn bloom_may_contain_key_probes_inserted_rid_bytes() {
         let manager = SegmentManager::new("test_collection");
 

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -1584,6 +1584,59 @@ impl UnifiedStore {
         collection_results.into_iter().flatten().collect()
     }
 
+    /// Scan every collection under an explicit MVCC snapshot.
+    pub fn scan<F>(
+        &self,
+        snapshot: Option<&crate::runtime::impl_core::SnapshotContext>,
+        filter: F,
+    ) -> Vec<(String, UnifiedEntity)>
+    where
+        F: Fn(&UnifiedEntity) -> bool + Clone + Send + Sync,
+    {
+        let pairs: Vec<(String, Arc<SegmentManager>)> = {
+            let collections = self.collections.read();
+            collections
+                .iter()
+                .map(|(name, manager)| (name.clone(), Arc::clone(manager)))
+                .collect()
+        };
+
+        let use_parallel = pairs.len() > 1 && crate::runtime::SystemInfo::should_parallelize();
+        if !use_parallel {
+            return pairs
+                .into_iter()
+                .flat_map(|(name, manager)| {
+                    manager
+                        .scan(snapshot, filter.clone())
+                        .into_iter()
+                        .map(move |entity| (name.clone(), entity))
+                })
+                .collect();
+        }
+
+        let filter_ref = &filter;
+        let collection_results: Vec<Vec<(String, UnifiedEntity)>> = std::thread::scope(|scope| {
+            pairs
+                .iter()
+                .map(|(name, manager)| {
+                    let name = name.clone();
+                    scope.spawn(move || {
+                        manager
+                            .scan(snapshot, |entity| filter_ref(entity))
+                            .into_iter()
+                            .map(|entity| (name.clone(), entity))
+                            .collect::<Vec<_>>()
+                    })
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .map(|handle| handle.join().unwrap_or_default())
+                .collect()
+        });
+
+        collection_results.into_iter().flatten().collect()
+    }
+
     /// Filter by metadata across all collections
     pub fn filter_metadata_all(
         &self,


### PR DESCRIPTION
Automated AFK landing for #2137. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2137

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788568357&installation_model_id=20659&pr_number=2197&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2197&signature=6d9dc48a9edb5215958ad43ba55307bb75631c6b1370e93fe0b733b2992e0962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->