### PR TITLE
merge: #2171 Shard the Test Suite across free parallel runners with nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,12 +387,21 @@ jobs:
       - name: cargo check
         run: cargo check --locked ${{ matrix.features.args }}
 
-  tests:
-    name: Test Suite
+  test-shards:
+    # Issue #2171 — the integration lane is split deterministically across four
+    # free public runners. Shards 1-4 respectively absorb the non-integration,
+    # doctest, persistent, and size-budget lanes. Individual durations are
+    # visible in the matrix; a shard above 2x the median is the signal to
+    # revisit the assignment.
+    name: Test Suite shard (${{ matrix.shard }}/4)
     needs: gate
     if: needs.gate.outputs.run_heavy == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: sccache
@@ -422,13 +431,20 @@ jobs:
       - name: Build red_client (cross-binary smoke prereq)
         run: cargo build --locked --bin red_client -p reddb-io-client --no-default-features
       - name: red_client size budget
+        if: matrix.shard == 4
         run: ./scripts/check-red-client-size.sh
-      - name: Run default test layer (nextest — parallel across test binaries)
+      - name: Run non-integration test layer
+        if: matrix.shard == 1
+        env:
+          RUST_MIN_STACK: "8388608"
+        run: cargo nextest run --workspace --locked --profile ci -E 'not kind(test)'
+      - name: Run integration-test shard
         # cargo test runs the grouped integration binaries sequentially, so the
         # per-test sleeps (replication/timing tests) sum and blew past the 20m
         # cap. nextest runs every test in a global parallel process pool (sleeps
-        # overlap) and the `ci` profile enforces a hard per-test timeout
-        # (.config/nextest.toml) so a hung test is killed, not the whole run.
+        # overlap). The count partition assigns every integration test to one
+        # and only one runner, while the `ci` profile enforces a hard per-test
+        # timeout (.config/nextest.toml).
         #
         # RUST_MIN_STACK=8M: libtest spawns each #[test] fn in a new thread
         # with Rust's 2 MiB default stack.  Query-execution paths (view
@@ -437,10 +453,12 @@ jobs:
         # overflow without changing production behaviour.
         env:
           RUST_MIN_STACK: "8388608"
-        run: cargo nextest run --workspace --locked --profile ci
+        run: scripts/nextest-e2e-shard.sh "${{ matrix.shard }}" 4
       - name: Doctests (nextest does not execute doctests)
+        if: matrix.shard == 2
         run: cargo test --workspace --locked --doc
       - name: Run persistent multimodel layer
+        if: matrix.shard == 3
         env:
           CARGO_TARGET_DIR: target/persistent-tests
         run: >-
@@ -457,6 +475,19 @@ jobs:
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats
+
+  tests:
+    # Keep ADR 0059's single required context without changing branch
+    # protection. `always()` ensures a failed shard reaches this aggregate
+    # instead of turning it into a misleading skipped success.
+    name: Test Suite
+    needs: [gate, test-shards]
+    if: always() && needs.gate.outputs.run_heavy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Require every Test Suite shard
+        run: test "${{ needs.test-shards.result }}" = "success"
 
   driver-param-conformance:
     name: Driver Param Conformance

--- a/scripts/ci-docs-shim-contract.test.mjs
+++ b/scripts/ci-docs-shim-contract.test.mjs
@@ -139,3 +139,25 @@ test("docs-only merge groups skip every heavy job and code diffs keep them enabl
       `${jobId} is not guarded by the merge-group classifier`);
   }
 });
+
+test("Test Suite shards on free runners and reports one failure-propagating required context", () => {
+  const jobs = jobBlocks(read(CI));
+  const shards = jobs.get("test-shards");
+  const aggregate = jobs.get("tests");
+
+  assert.ok(shards, "ci.yml must define the test-shards matrix job");
+  assert.match(shards, /^ {4}name: Test Suite shard \(\$\{\{ matrix\.shard \}\}\/4\)$/m);
+  assert.match(shards, /^ {4}runs-on: ubuntu-24\.04$/m,
+    "test shards must use free GitHub-hosted public runners");
+  assert.match(shards, /shard: \[1, 2, 3, 4\]/);
+  assert.match(shards, /scripts\/nextest-e2e-shard\.sh "\$\{\{ matrix\.shard \}\}" 4/);
+
+  assert.ok(aggregate, "ci.yml must preserve a Test Suite aggregate job");
+  assert.match(aggregate, /^ {4}name: Test Suite$/m);
+  assert.match(aggregate, /^ {4}runs-on: ubuntu-latest$/m,
+    "the required-context aggregate must use a free GitHub-hosted public runner");
+  assert.match(aggregate, /needs: \[gate, test-shards\]/);
+  assert.match(aggregate, /always\(\).*needs\.gate\.outputs\.run_heavy == 'true'/);
+  assert.match(aggregate, /needs\.test-shards\.result.*success/,
+    "the required Test Suite context must fail when any shard fails");
+});


### PR DESCRIPTION
Automated AFK landing for #2171. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2171

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788582170&installation_model_id=20659&pr_number=2207&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2207&signature=534dc4a2b3881b93f43254a37fbe6ee2da4c8ec0c9cf23091538f449ba980250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->