### PR TITLE
merge: #2186 cas_wrong_bearer_returns_401_via_route flakes under parallel lib runs (RED_ADMIN_TOKEN race)

### DIFF
--- a/crates/reddb-server/src/server.rs
+++ b/crates/reddb-server/src/server.rs
@@ -49,6 +49,10 @@ fn analytics_job_json(job: &crate::PhysicalAnalyticsJob) -> JsonValue {
     crate::presentation::admin_json::analytics_job_json(job)
 }
 
+// Process-wide test guard for every RED_ADMIN_TOKEN mutation in server tests.
+#[cfg(test)]
+pub(crate) static RED_ADMIN_TOKEN_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/reddb-server/src/server/handlers_admin.rs
+++ b/crates/reddb-server/src/server/handlers_admin.rs
@@ -1651,9 +1651,9 @@ mod tests {
 
     #[test]
     fn cas_missing_bearer_returns_401_via_route() {
-        use std::sync::Mutex;
-        static GUARD: Mutex<()> = Mutex::new(());
-        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::server::RED_ADMIN_TOKEN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let prev = std::env::var("RED_ADMIN_TOKEN").ok();
         unsafe {
@@ -1681,9 +1681,9 @@ mod tests {
 
     #[test]
     fn cas_wrong_bearer_returns_401_via_route() {
-        use std::sync::Mutex;
-        static GUARD: Mutex<()> = Mutex::new(());
-        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::server::RED_ADMIN_TOKEN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let prev = std::env::var("RED_ADMIN_TOKEN").ok();
         unsafe {
@@ -1766,16 +1766,13 @@ mod tests {
 
     #[test]
     fn admin_blob_cache_routes_reject_unauth_when_admin_token_set() {
-        // Serialize on a per-process mutex because RED_ADMIN_TOKEN is a
-        // process-wide env var; running other admin-auth tests in
-        // parallel would race the unset/set sequence.
-        use std::sync::Mutex;
-        static GUARD: Mutex<()> = Mutex::new(());
-        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = crate::server::RED_ADMIN_TOKEN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
 
         let prev = std::env::var("RED_ADMIN_TOKEN").ok();
         // SAFETY: env mutation is unsafe in 2024; we serialize via
-        // GUARD above and restore the previous value at the end.
+        // RED_ADMIN_TOKEN_ENV_LOCK and restore the previous value at the end.
         unsafe {
             std::env::set_var("RED_ADMIN_TOKEN", "test-token-148");
         }

--- a/crates/reddb-server/src/server/routing.rs
+++ b/crates/reddb-server/src/server/routing.rs
@@ -1525,6 +1525,9 @@ mod tests {
 
     #[test]
     fn admin_users_requires_shared_secret_and_creates_regular_user() {
+        let _guard = crate::server::RED_ADMIN_TOKEN_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let previous = std::env::var_os("RED_ADMIN_TOKEN");
         std::env::set_var("RED_ADMIN_TOKEN", "admin-secret");
 


### PR DESCRIPTION
Automated AFK landing for #2186. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2186

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788584292&installation_model_id=20659&pr_number=2213&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2213&signature=2bd369a25f1037423c8bd8a7253a8c5f9bc3f0e3c9d698a041c61363f54503d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->