### PR TITLE
merge: #2211 storage::ml::queue::backend_persists_submit_and_completion flakes under parallel CI load

### DIFF
--- a/crates/reddb-server/src/storage/ml/queue.rs
+++ b/crates/reddb-server/src/storage/ml/queue.rs
@@ -559,20 +559,8 @@ mod tests {
             backend.clone(),
         );
         let id = q.submit(MlJobKind::Train, "spam", "{}");
-        assert!(wait_until(
-            || q.get(id).map(|j| j.is_terminal()).unwrap_or(false),
-            Duration::from_secs(2),
-        ));
-        assert!(wait_until(
-            || backend
-                .get(super::ns::JOBS, &super::key::job(id))
-                .ok()
-                .flatten()
-                .and_then(|raw| MlJob::from_json(&raw))
-                .map(|job| job.status == MlJobStatus::Completed)
-                .unwrap_or(false),
-            Duration::from_secs(2),
-        ));
+        q.shutdown();
+
         // Raw record must exist and must reflect the completed status.
         let raw = backend
             .get(super::ns::JOBS, &super::key::job(id))
@@ -581,7 +569,6 @@ mod tests {
         let decoded = MlJob::from_json(&raw).unwrap();
         assert_eq!(decoded.status, MlJobStatus::Completed);
         assert_eq!(decoded.metrics_json.as_deref(), Some("{\"f1\":0.9}"));
-        q.shutdown();
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #2211. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2211

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788585934&installation_model_id=20659&pr_number=2215&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2215&signature=6e5aa45a79d12633bff82d209a85446ed325d5a9570cd9c573357963007df575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->