### PR TITLE
chore: drop committed test scratch dirs and ignore crates/*/tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ perf.data.old
 **/wal/
 !crates/reddb-server/src/storage/wal/
 !crates/reddb-server/src/storage/wal/*.rs
+# Tests that build a repo-relative scratch dir land here; the crate has no
+# legitimate committed `tmp/`.
+crates/*/tmp/
 .red/brain/
 
 # RedSkills wiki — local-only, never committed

--- a/crates/reddb-server/tmp/reddb-backup-head-test-CbsKaM/manifests/head.json
+++ b/crates/reddb-server/tmp/reddb-backup-head-test-CbsKaM/manifests/head.json
@@ -1,1 +1,0 @@
-{"current_lsn":456,"last_archived_lsn":456,"snapshot_id":1,"snapshot_key":"snapshots/000000000001-123.snapshot","snapshot_time":123,"timeline_id":"main","wal_prefix":"wal/"}

--- a/crates/reddb-server/tmp/reddb-backup-head-test-MUe3OZ/manifests/head.json
+++ b/crates/reddb-server/tmp/reddb-backup-head-test-MUe3OZ/manifests/head.json
@@ -1,1 +1,0 @@
-{"current_lsn":456,"last_archived_lsn":456,"snapshot_id":1,"snapshot_key":"snapshots/000000000001-123.snapshot","snapshot_time":123,"timeline_id":"main","wal_prefix":"wal/"}

--- a/crates/reddb-server/tmp/reddb-snapshot-manifest-test-EgPBk8/snapshots/000000000001-123.snapshot.manifest.json
+++ b/crates/reddb-server/tmp/reddb-snapshot-manifest-test-EgPBk8/snapshots/000000000001-123.snapshot.manifest.json
@@ -1,1 +1,0 @@
-{"base_lsn":456,"format_version":2,"schema_version":2,"snapshot_id":1,"snapshot_key":"tmp/reddb-snapshot-manifest-test-EgPBk8/snapshots/000000000001-123.snapshot","snapshot_time":123,"timeline_id":"main"}

--- a/crates/reddb-server/tmp/reddb-snapshot-manifest-test-OAZ2Bi/snapshots/000000000001-123.snapshot.manifest.json
+++ b/crates/reddb-server/tmp/reddb-snapshot-manifest-test-OAZ2Bi/snapshots/000000000001-123.snapshot.manifest.json
@@ -1,1 +1,0 @@
-{"base_lsn":456,"format_version":2,"schema_version":2,"snapshot_id":1,"snapshot_key":"tmp/reddb-snapshot-manifest-test-OAZ2Bi/snapshots/000000000001-123.snapshot","snapshot_time":123,"timeline_id":"main"}


### PR DESCRIPTION
Four scratch directories were committed by tests that build a repo-relative temp path:

```
crates/reddb-server/tmp/reddb-backup-head-test-CbsKaM/manifests/head.json
crates/reddb-server/tmp/reddb-backup-head-test-MUe3OZ/manifests/head.json
crates/reddb-server/tmp/reddb-snapshot-manifest-test-EgPBk8/snapshots/000000000001-123.snapshot.manifest.json
crates/reddb-server/tmp/reddb-snapshot-manifest-test-OAZ2Bi/snapshots/000000000001-123.snapshot.manifest.json
```

They are inert, but they surface in every `git status` and in the merge output of unrelated branches — I hit them while merging `main` into a rework branch.

This deletes them and extends the existing test-artifact backstop block in `.gitignore` with `crates/*/tmp/`, so the next leak cannot be committed. No crate has a legitimate committed `tmp/`.

Not in scope: finding which tests create them. The backstop makes that a cleanliness question rather than a repo-contents one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788615008&installation_model_id=20659&pr_number=2220&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2220&signature=bd155d06265a16d45071e45dad650490f21486c00b7052d143b1b81ad478b576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->