### PR TITLE
chore: #2148 stdio dispatch consumes the catalog: local/remote parity becomes explicit

### DIFF
--- a/crates/reddb-server/src/rpc_stdio.rs
+++ b/crates/reddb-server/src/rpc_stdio.rs
@@ -57,6 +57,127 @@ struct RemoteBackend<'a> {
 pub const PROTOCOL_VERSION: &str = "1.0";
 const STDIO_BULK_INSERT_CHUNK_ROWS: usize = 500;
 
+/// Remote behavior for one catalogued stdio method.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StdioRemoteDisposition {
+    Served,
+    Unsupported { error_code: &'static str },
+}
+
+/// One stdio JSON-RPC method mapped onto the canonical command vocabulary.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct StdioMethodCatalogEntry {
+    pub(crate) method: &'static str,
+    pub(crate) command_id: &'static str,
+    pub(crate) remote: StdioRemoteDisposition,
+}
+
+const fn stdio_method(
+    method: &'static str,
+    command_id: &'static str,
+    remote: StdioRemoteDisposition,
+) -> StdioMethodCatalogEntry {
+    StdioMethodCatalogEntry {
+        method,
+        command_id,
+        remote,
+    }
+}
+
+/// The complete non-auth stdio surface. Keeping the local command binding and
+/// remote disposition in one table makes a silent local-only method impossible:
+/// dispatch rejects any non-auth method absent from this catalog.
+const STDIO_METHOD_CATALOG: [StdioMethodCatalogEntry; 16] = [
+    stdio_method(
+        "tx.begin",
+        "query.execute",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::TX_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "tx.commit",
+        "query.execute",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::TX_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "query.open",
+        "streams.query.output",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::CURSOR_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "query.next",
+        "streams.query.output",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::CURSOR_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "query.close",
+        "streams.query.cancel",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::CURSOR_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "tx.rollback",
+        "query.execute",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::TX_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method("version", "health.live", StdioRemoteDisposition::Served),
+    stdio_method(
+        "health",
+        "ops.health.aggregate",
+        StdioRemoteDisposition::Served,
+    ),
+    stdio_method("query", "query.execute", StdioRemoteDisposition::Served),
+    stdio_method(
+        "prepare",
+        "query.execute",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::PREPARED_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "execute_prepared",
+        "query.execute",
+        StdioRemoteDisposition::Unsupported {
+            error_code: error_code::PREPARED_NOT_SUPPORTED_REMOTE,
+        },
+    ),
+    stdio_method(
+        "insert",
+        "collections.rows.create",
+        StdioRemoteDisposition::Served,
+    ),
+    stdio_method(
+        "bulk_insert",
+        "collections.bulk.rows",
+        StdioRemoteDisposition::Served,
+    ),
+    stdio_method(
+        "get",
+        "collections.entities.get",
+        StdioRemoteDisposition::Served,
+    ),
+    stdio_method(
+        "delete",
+        "collections.entities.delete",
+        StdioRemoteDisposition::Served,
+    ),
+    stdio_method("close", "health.live", StdioRemoteDisposition::Served),
+];
+
+pub(crate) fn stdio_method_catalog() -> &'static [StdioMethodCatalogEntry] {
+    &STDIO_METHOD_CATALOG
+}
+
 /// Stable error codes. Drivers map these to idiomatic exceptions.
 pub mod error_code {
     pub const PARSE_ERROR: &str = "PARSE_ERROR";
@@ -77,6 +198,10 @@ pub mod error_code {
     pub const TX_REPLAY_FAILED: &str = "TX_REPLAY_FAILED";
     /// Transactions over the remote gRPC proxy are not supported yet.
     pub const TX_NOT_SUPPORTED_REMOTE: &str = "TX_NOT_SUPPORTED_REMOTE";
+    /// Cursors over the remote gRPC proxy are not supported yet.
+    pub const CURSOR_NOT_SUPPORTED_REMOTE: &str = "CURSOR_NOT_SUPPORTED_REMOTE";
+    /// Prepared statements over the remote gRPC proxy are not supported yet.
+    pub const PREPARED_NOT_SUPPORTED_REMOTE: &str = "PREPARED_NOT_SUPPORTED_REMOTE";
     /// `query.next` / `query.close` referenced an unknown cursor id.
     /// Either the cursor was never opened, already closed, or was
     /// automatically dropped when its rows were exhausted.
@@ -403,29 +528,42 @@ fn handle_line(backend: &Backend<'_>, session: &mut Session, line: &str) -> Stri
 
     let params = parsed.get("params").cloned().unwrap_or(Value::Null);
 
-    let dispatch = std::panic::catch_unwind(AssertUnwindSafe(|| match backend {
-        Backend::Local(rt) => dispatch_method(rt, session, &method, &params),
-        Backend::Remote(remote) => {
-            // Transactions are session-local and the remote path forwards
-            // each call independently — there is no place to park a tx
-            // handle across gRPC hops yet. Surface a clear error so
-            // drivers can fall back to per-call auto-commit.
-            if matches!(
-                method.as_str(),
-                "tx.begin"
-                    | "tx.commit"
-                    | "tx.rollback"
-                    | "query.open"
-                    | "query.next"
-                    | "query.close"
-            ) {
-                Err((
-                    error_code::TX_NOT_SUPPORTED_REMOTE,
-                    format!("{method} is not supported over remote gRPC yet"),
-                ))
-            } else {
-                dispatch_method_remote(&remote.client, remote.tokio_rt, &method, &params)
+    let dispatch = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        let entry = stdio_method_catalog()
+            .iter()
+            .find(|entry| entry.method == method);
+        if !method.starts_with("auth.") && entry.is_none() {
+            return Err((
+                error_code::INVALID_REQUEST,
+                format!("unknown method: {method}"),
+            ));
+        }
+        if let Some(entry) = entry {
+            if crate::server::command_catalog()
+                .command(entry.command_id)
+                .is_none()
+            {
+                return Err((
+                    error_code::INTERNAL_ERROR,
+                    format!(
+                        "stdio method {method} names missing catalog command {}",
+                        entry.command_id
+                    ),
+                ));
             }
+        }
+
+        match backend {
+            Backend::Local(rt) => dispatch_method(rt, session, &method, &params),
+            Backend::Remote(remote) => match entry.map(|entry| entry.remote) {
+                Some(StdioRemoteDisposition::Unsupported { error_code }) => Err((
+                    error_code,
+                    format!("{method} is not supported over remote gRPC yet"),
+                )),
+                Some(StdioRemoteDisposition::Served) | None => {
+                    dispatch_method_remote(&remote.client, remote.tokio_rt, &method, &params)
+                }
+            },
         }
     }));
 

--- a/crates/reddb-server/src/server/route_catalog.rs
+++ b/crates/reddb-server/src/server/route_catalog.rs
@@ -559,7 +559,6 @@ impl CommandCatalog {
 pub(crate) fn render_command_coverage_matrix(catalog: &CommandCatalog) -> String {
     let grpc_ids = transport_surface::grpc_command_ids();
     let mcp_ids = transport_surface::mcp_command_ids();
-    let stdio_ids = transport_surface::stdio_command_ids();
     let redwire_ids = transport_surface::redwire_command_ids();
 
     let mut commands: Vec<_> = catalog.commands().collect();
@@ -581,7 +580,7 @@ pub(crate) fn render_command_coverage_matrix(catalog: &CommandCatalog) -> String
             command.auth.matrix_label(),
             coverage(&grpc_ids, command.id),
             coverage(&mcp_ids, command.id),
-            coverage(&stdio_ids, command.id),
+            stdio_coverage(command.id),
             coverage(&redwire_ids, command.id),
         ));
     }
@@ -596,29 +595,48 @@ fn coverage(served: &BTreeSet<&'static str>, id: &str) -> &'static str {
     }
 }
 
-/// The provenance note above the table. stdio gets a sentence of its own
-/// because it is the one transport with a real dispatch surface and no catalog
-/// binding at all: without the method counts its all-`undeclared` column would
-/// read as "stdio serves nothing".
+fn stdio_coverage(command_id: &str) -> String {
+    let dispositions: Vec<String> = crate::rpc_stdio::stdio_method_catalog()
+        .iter()
+        .filter(|entry| entry.command_id == command_id)
+        .map(|entry| match entry.remote {
+            crate::rpc_stdio::StdioRemoteDisposition::Served => {
+                format!("{}: local+remote", entry.method)
+            }
+            crate::rpc_stdio::StdioRemoteDisposition::Unsupported { error_code } => {
+                format!("{}: local; remote unsupported ({error_code})", entry.method)
+            }
+        })
+        .collect();
+    if dispositions.is_empty() {
+        "undeclared".to_string()
+    } else {
+        dispositions.join("<br>")
+    }
+}
+
+/// The provenance note above the table. stdio names both implemented and
+/// explicitly unsupported remote dispositions so neither reads as a gap.
 fn render_column_sources() -> String {
     let stdio_local = transport_surface::stdio_local_methods();
     let stdio_remote = transport_surface::stdio_remote_methods();
-    let stdio_gap = transport_surface::stdio_remote_gap();
+    let stdio_remote_served = transport_surface::stdio_remote_served_methods();
+    let stdio_remote_unsupported = transport_surface::stdio_remote_unsupported_methods();
 
     format!(
         "Each column is read from that transport's own source of truth:\n\n\
          - HTTP: the command catalog discovered from route declarations.\n\
          - gRPC: the rpc-to-command bindings in `crates/reddb-server/src/grpc/catalog_dispatch.rs`.\n\
          - MCP: the tool registry in `crates/reddb-server/src/mcp/tools.rs`.\n\
-         - stdio: `crates/reddb-server/src/rpc_stdio.rs` binds no command ids, so every stdio \
-         cell is a gap. Its dispatch tables serve {} local (embedded) and {} remote (gRPC proxy) \
-         JSON-RPC methods; {} locally served methods have no remote arm: {}.\n\
+         - stdio: the catalog-backed method table in \
+         `crates/reddb-server/src/rpc_stdio.rs` declares {} local methods and all {} remote \
+         dispositions: {} served and {} explicitly unsupported.\n\
          - RedWire: the `redwire_command_id` frame binding in \
          `crates/reddb-server/src/wire/redwire/session.rs`.\n",
         stdio_local.len(),
         stdio_remote.len(),
-        stdio_gap.len(),
-        stdio_gap.join(", "),
+        stdio_remote_served.len(),
+        stdio_remote_unsupported.len(),
     )
 }
 
@@ -1236,33 +1254,31 @@ mod tests {
         assert!(
             matrix.contains("| command | auth requirement | HTTP | gRPC | MCP | stdio | RedWire |")
         );
-        // `health.live` is an MCP tool and the RedWire Ping/Bye binding, but no
-        // gRPC rpc carries it.
+        // `health.live` is an MCP tool, two stdio methods and the RedWire
+        // Ping/Bye binding, but no gRPC rpc carries it.
         assert!(matrix.contains(
-            "| health.live | public | served | undeclared | served | undeclared | served |\n"
+            "| health.live | public | served | undeclared | served | version: local+remote<br>close: local+remote | served |\n"
         ));
-        // `ops.health.aggregate` is the `Health` rpc and nothing else.
+        // `ops.health.aggregate` is the gRPC and stdio health operation.
         assert!(matrix.contains(
-            "| ops.health.aggregate | public | served | served | undeclared | undeclared | undeclared |\n"
+            "| ops.health.aggregate | public | served | served | undeclared | health: local+remote | undeclared |\n"
         ));
     }
 
     #[test]
-    fn coverage_matrix_names_each_column_source_and_the_stdio_gap() {
+    fn coverage_matrix_names_each_column_source_and_stdio_dispositions() {
         let matrix = two_command_matrix();
-        let gap = transport_surface::stdio_remote_gap();
 
         assert!(matrix.contains("`crates/reddb-server/src/grpc/catalog_dispatch.rs`"));
         assert!(matrix.contains("`crates/reddb-server/src/mcp/tools.rs`"));
         assert!(matrix.contains("`crates/reddb-server/src/wire/redwire/session.rs`"));
-        assert_eq!(gap.len(), 8);
         assert!(matrix.contains(&format!(
-            "serve {} local (embedded) and {} remote (gRPC proxy) JSON-RPC methods; \
-             {} locally served methods have no remote arm: {}.",
+            "declares {} local methods and all {} remote dispositions: {} served and {} \
+             explicitly unsupported.",
             transport_surface::stdio_local_methods().len(),
             transport_surface::stdio_remote_methods().len(),
-            gap.len(),
-            gap.join(", ")
+            transport_surface::stdio_remote_served_methods().len(),
+            transport_surface::stdio_remote_unsupported_methods().len(),
         )));
     }
 

--- a/crates/reddb-server/src/server/transport_surface.rs
+++ b/crates/reddb-server/src/server/transport_surface.rs
@@ -11,9 +11,9 @@
 //! - RedWire: the real `handle_session` dispatch arms, mapped through
 //!   `redwire_command_id` in
 //!   `crates/reddb-server/src/wire/redwire/session.rs`.
-//! - stdio: `crates/reddb-server/src/rpc_stdio.rs` declares no command ids at
-//!   all, so its inventory is the empty set and the matrix reports its dispatch
-//!   tables as an unjoined surface. See [`stdio_command_ids`].
+//! - stdio: the catalog-backed method table in
+//!   [`crate::rpc_stdio::stdio_method_catalog`], including each remote
+//!   disposition.
 
 use std::collections::BTreeSet;
 
@@ -50,11 +50,6 @@ const REDWIRE_DISPATCH_KINDS: [MessageKind; 19] = [
 /// the call: embedded stdio has no auth backend, so `auth.*` is excluded from
 /// the local-versus-remote comparison.
 pub(crate) const STDIO_AUTH_PREFIX: &str = "auth.";
-
-/// Tokens that would appear in `rpc_stdio.rs` if the stdio dispatcher were
-/// bound to the command catalog. [`stdio_command_ids`] is empty only while none
-/// of them is present.
-const STDIO_CATALOG_MARKERS: [&str; 3] = ["command_id", "CommandAuthorizer", "command_catalog"];
 
 /// Catalog commands reachable over gRPC.
 pub(crate) fn grpc_command_ids() -> BTreeSet<&'static str> {
@@ -97,15 +92,12 @@ fn redwire_frame_kinds() -> Vec<&'static str> {
     .collect()
 }
 
-/// Catalog commands reachable over stdio: none.
-///
-/// `rpc_stdio.rs` dispatches on bare JSON-RPC method names and never names a
-/// catalog command, so there is nothing to join and every stdio cell is an
-/// honest coverage gap. `stdio_is_unbound_to_the_command_catalog` fails the
-/// moment that stops being true, which forces the real join to be written
-/// rather than letting this empty set quietly under-report the surface.
+/// Catalog commands with an explicit stdio disposition.
 pub(crate) fn stdio_command_ids() -> BTreeSet<&'static str> {
-    BTreeSet::new()
+    crate::rpc_stdio::stdio_method_catalog()
+        .iter()
+        .map(|entry| entry.command_id)
+        .collect()
 }
 
 /// Slice `source` between the first `start` anchor and the first `end`
@@ -166,9 +158,39 @@ pub(crate) fn stdio_local_methods() -> Vec<&'static str> {
     stdio_methods("fn dispatch_method(")
 }
 
-/// stdio JSON-RPC methods served by the remote (`grpc://` proxy) backend.
+/// stdio JSON-RPC methods with a remote (`grpc://` proxy) disposition.
 pub(crate) fn stdio_remote_methods() -> Vec<&'static str> {
-    stdio_methods("fn dispatch_method_remote(")
+    crate::rpc_stdio::stdio_method_catalog()
+        .iter()
+        .map(|entry| entry.method)
+        .collect()
+}
+
+/// stdio JSON-RPC methods implemented by the remote backend.
+pub(crate) fn stdio_remote_served_methods() -> Vec<&'static str> {
+    crate::rpc_stdio::stdio_method_catalog()
+        .iter()
+        .filter_map(|entry| {
+            matches!(
+                entry.remote,
+                crate::rpc_stdio::StdioRemoteDisposition::Served
+            )
+            .then_some(entry.method)
+        })
+        .collect()
+}
+
+/// stdio JSON-RPC methods explicitly rejected by the remote backend.
+pub(crate) fn stdio_remote_unsupported_methods() -> Vec<(&'static str, &'static str)> {
+    crate::rpc_stdio::stdio_method_catalog()
+        .iter()
+        .filter_map(|entry| match entry.remote {
+            crate::rpc_stdio::StdioRemoteDisposition::Served => None,
+            crate::rpc_stdio::StdioRemoteDisposition::Unsupported { error_code } => {
+                Some((entry.method, error_code))
+            }
+        })
+        .collect()
 }
 
 /// Locally served stdio methods that have no remote-mode arm. `auth.*` is
@@ -185,6 +207,7 @@ pub(crate) fn stdio_remote_gap() -> Vec<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::rpc_stdio::error_code;
 
     #[test]
     fn redwire_catalog_bindings_have_real_dispatch() {
@@ -238,40 +261,106 @@ mod tests {
         "auth.revoke_api_key",
     ];
 
-    /// The full stdio remote (gRPC proxy) table.
-    const STDIO_REMOTE_METHODS: [&str; 8] = [
-        "version",
-        "health",
-        "query",
-        "insert",
-        "bulk_insert",
-        "get",
-        "delete",
-        "close",
+    const STDIO_REMOTE_DISPOSITIONS: [(&str, &str, crate::rpc_stdio::StdioRemoteDisposition); 16] = [
+        (
+            "tx.begin",
+            "query.execute",
+            unsupported(error_code::TX_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "tx.commit",
+            "query.execute",
+            unsupported(error_code::TX_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "query.open",
+            "streams.query.output",
+            unsupported(error_code::CURSOR_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "query.next",
+            "streams.query.output",
+            unsupported(error_code::CURSOR_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "query.close",
+            "streams.query.cancel",
+            unsupported(error_code::CURSOR_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "tx.rollback",
+            "query.execute",
+            unsupported(error_code::TX_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "version",
+            "health.live",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "health",
+            "ops.health.aggregate",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "query",
+            "query.execute",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "prepare",
+            "query.execute",
+            unsupported(error_code::PREPARED_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "execute_prepared",
+            "query.execute",
+            unsupported(error_code::PREPARED_NOT_SUPPORTED_REMOTE),
+        ),
+        (
+            "insert",
+            "collections.rows.create",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "bulk_insert",
+            "collections.bulk.rows",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "get",
+            "collections.entities.get",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "delete",
+            "collections.entities.delete",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
+        (
+            "close",
+            "health.live",
+            crate::rpc_stdio::StdioRemoteDisposition::Served,
+        ),
     ];
 
-    /// The documented stdio remote gap: session-scoped transaction, cursor and
-    /// prepared-statement methods have no place to park state across a gRPC
-    /// hop, so 8 of the 16 non-auth local methods vanish in remote mode.
-    const STDIO_REMOTE_GAP: [&str; 8] = [
-        "tx.begin",
-        "tx.commit",
-        "query.open",
-        "query.next",
-        "query.close",
-        "tx.rollback",
-        "prepare",
-        "execute_prepared",
-    ];
+    const fn unsupported(error_code: &'static str) -> crate::rpc_stdio::StdioRemoteDisposition {
+        crate::rpc_stdio::StdioRemoteDisposition::Unsupported { error_code }
+    }
 
     #[test]
-    fn stdio_remote_mode_drops_exactly_the_documented_eight_methods() {
+    fn every_stdio_method_has_a_remote_disposition() {
         let local = stdio_local_methods();
         let remote = stdio_remote_methods();
+        let dispositions: Vec<_> = crate::rpc_stdio::stdio_method_catalog()
+            .iter()
+            .map(|entry| (entry.method, entry.command_id, entry.remote))
+            .collect();
 
         assert_eq!(local, STDIO_LOCAL_METHODS.to_vec());
-        assert_eq!(remote, STDIO_REMOTE_METHODS.to_vec());
-        assert_eq!(stdio_remote_gap(), STDIO_REMOTE_GAP.to_vec());
+        assert_eq!(dispositions, STDIO_REMOTE_DISPOSITIONS.to_vec());
+        assert_eq!(remote.len(), STDIO_REMOTE_DISPOSITIONS.len());
+        assert!(stdio_remote_gap().is_empty());
         assert!(
             remote.iter().all(|method| local.contains(method)),
             "remote mode serves a method the local table does not declare"
@@ -279,19 +368,8 @@ mod tests {
     }
 
     #[test]
-    fn stdio_is_unbound_to_the_command_catalog() {
-        let found: Vec<&str> = STDIO_CATALOG_MARKERS
-            .into_iter()
-            .filter(|marker| STDIO_SOURCE.contains(marker))
-            .collect();
-
-        assert_eq!(
-            found,
-            Vec::<&str>::new(),
-            "rpc_stdio.rs gained a command binding; stdio_command_ids must now \
-             report it instead of returning the empty set"
-        );
-        assert!(stdio_command_ids().is_empty());
+    fn stdio_is_bound_to_the_command_catalog() {
+        assert!(!stdio_command_ids().is_empty());
     }
 
     /// Every id an adapter claims to serve must exist in the catalog, or the
@@ -303,6 +381,7 @@ mod tests {
         let inventories = [
             ("gRPC", grpc_command_ids()),
             ("MCP", mcp_command_ids()),
+            ("stdio", stdio_command_ids()),
             ("RedWire", redwire_command_ids()),
         ];
 


### PR DESCRIPTION
Automated AFK landing for #2148. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2148

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789074824&installation_model_id=20659&pr_number=2237&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2237&signature=00d6cba2da9cb61b18d9aa0aaf48dca8488b2d0c29432746512383fc24ec032e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->