### PR TITLE
chore: #2161 Client SCRAM adapter + cross-language conformance fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,6 +522,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.x'
       - uses: actions/setup-go@v7
         with:
           go-version: '1.25'
@@ -548,6 +551,9 @@ jobs:
         run: cargo test -p reddb-io-wire --test params_fixtures
       - name: Rust gRPC parameter fixtures
         run: cargo test -p reddb-io-client --features grpc --lib grpc_params_match_shared_fixtures
+      - name: Python RedWire SCRAM fixtures
+        working-directory: drivers/python
+        run: python tests/test_scram_conformance.py
       - name: Go RedWire/gRPC parameter fixtures
         working-directory: drivers/go
         run: go test ./redwire ./grpcx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2798,6 +2798,7 @@ version = "1.23.2"
 dependencies = [
  "async-trait",
  "csv",
+ "getrandom 0.4.2",
  "jsonwebtoken",
  "proptest",
  "prost",
@@ -2809,7 +2810,6 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "serde_json",
- "sha2 0.11.0",
  "tempfile",
  "tokio",
  "tokio-rustls",

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -27,7 +27,7 @@ embedded = ["dep:reddb-server"]
 grpc = []
 # RedWire native TCP client. No engine dep — speaks the wire
 # protocol directly. See ADR 0001.
-redwire = ["dep:getrandom", "dep:zstd"]
+redwire = ["dep:zstd"]
 # HTTP / HTTPS transport using reqwest. Parity with the JS
 # driver's HttpRpcClient — talks REST endpoints directly.
 http = ["dep:reqwest"]
@@ -77,7 +77,7 @@ zstd = { version = "0.13", default-features = false, optional = true }
 
 # The RedWire adapter supplies a CSPRNG nonce to reddb-wire's sans-I/O
 # SCRAM client driver.
-getrandom = { version = "0.4", optional = true }
+getrandom = "0.4"
 
 # TLS / mTLS for the RedWire client. Pulled in only by the
 # `redwire-tls` feature.

--- a/crates/reddb-client/Cargo.toml
+++ b/crates/reddb-client/Cargo.toml
@@ -27,7 +27,7 @@ embedded = ["dep:reddb-server"]
 grpc = []
 # RedWire native TCP client. No engine dep — speaks the wire
 # protocol directly. See ADR 0001.
-redwire = ["dep:zstd", "dep:sha2"]
+redwire = ["dep:getrandom", "dep:zstd"]
 # HTTP / HTTPS transport using reqwest. Parity with the JS
 # driver's HttpRpcClient — talks REST endpoints directly.
 http = ["dep:reqwest"]
@@ -75,9 +75,9 @@ reddb-server = { workspace = true, optional = true }
 # the `redwire` feature so embedded-only callers don't pay it.
 zstd = { version = "0.13", default-features = false, optional = true }
 
-# SHA-256 for SCRAM client primitives (Phase 3a/3c). Pulled in
-# only by the `redwire` feature.
-sha2 = { version = "0.11", optional = true }
+# The RedWire adapter supplies a CSPRNG nonce to reddb-wire's sans-I/O
+# SCRAM client driver.
+getrandom = { version = "0.4", optional = true }
 
 # TLS / mTLS for the RedWire client. Pulled in only by the
 # `redwire-tls` feature.

--- a/crates/reddb-client/src/redwire/handshake.rs
+++ b/crates/reddb-client/src/redwire/handshake.rs
@@ -4,9 +4,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::error::{ClientError, ErrorCode, Result};
 use reddb_wire::redwire::handshake::{
-    build_auth_response_anonymous_payload, build_auth_response_bearer_payload,
+    base64_std, build_auth_response_anonymous_payload, build_auth_response_bearer_payload,
     build_auth_response_frame, build_client_hello_frame, AuthFail, AuthOk, HelloAck,
 };
+use reddb_wire::redwire::scram::{ScramClientError, ScramClientHandshake, ScramClientOutput};
 
 use super::{io, Auth, ConnectOptions};
 use reddb_wire::redwire::{BuildError, MessageKind};
@@ -27,7 +28,7 @@ where
     // 1. Send Hello.
     let methods: Vec<&str> = match &opts.auth {
         Auth::Bearer(_) => vec!["bearer"],
-        Auth::Basic { .. } => vec!["basic"],
+        Auth::Basic { .. } => vec!["scram-sha-256"],
         Auth::ApiKey(_) => vec!["apikey"],
         Auth::Anonymous => vec!["anonymous", "bearer"],
     };
@@ -52,6 +53,16 @@ where
         }
     };
 
+    if chosen_auth == "scram-sha-256" {
+        return match &opts.auth {
+            Auth::Basic { user, pass } => run_scram(stream, user, pass).await,
+            _ => Err(ClientError::new(
+                ErrorCode::AuthRefused,
+                "server demanded SCRAM auth but no username/password was supplied",
+            )),
+        };
+    }
+
     // 3. Send AuthResponse for the chosen method.
     let resp_payload = match (chosen_auth.as_str(), &opts.auth) {
         ("anonymous", _) => build_auth_response_anonymous_payload(),
@@ -62,7 +73,7 @@ where
                 "server demanded bearer auth but no token was supplied",
             ));
         }
-        ("basic", Auth::Basic { .. }) | ("apikey", Auth::ApiKey(_)) => {
+        ("apikey", Auth::ApiKey(_)) => {
             return Err(ClientError::new(
                 ErrorCode::Protocol,
                 format!("client auth response codec is not implemented for {chosen_auth}"),
@@ -98,6 +109,74 @@ where
             format!("expected AuthOk/AuthFail, got {other:?}"),
         )),
     }
+}
+
+async fn run_scram<S>(stream: &mut S, username: &str, password: &str) -> Result<HandshakeOutcome>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send,
+{
+    let mut nonce_bytes = [0u8; 18];
+    getrandom::fill(&mut nonce_bytes).map_err(|error| {
+        ClientError::new(
+            ErrorCode::Protocol,
+            format!("generate SCRAM client nonce: {error}"),
+        )
+    })?;
+    let mut handshake = ScramClientHandshake::new(username, password, base64_std(&nonce_bytes))
+        .map_err(scram_error)?;
+
+    let client_first = expect_scram_response(handshake.start())?;
+    let first_frame = build_auth_response_frame(2, client_first).map_err(frame_build_err)?;
+    io::write_frame(stream, &first_frame).await?;
+
+    let server_first = io::read_frame(stream).await?;
+    let client_final = match handshake.step(server_first.kind, &server_first.payload) {
+        Ok(output) => expect_scram_output_response(output)?,
+        Err(ScramClientError::Refused(reason)) => return Ok(HandshakeOutcome::Refused(reason)),
+        Err(error) => return Err(scram_error(error)),
+    };
+    let final_frame = build_auth_response_frame(3, client_final).map_err(frame_build_err)?;
+    io::write_frame(stream, &final_frame).await?;
+
+    let server_final = io::read_frame(stream).await?;
+    match handshake.step(server_final.kind, &server_final.payload) {
+        Ok(ScramClientOutput::Authenticated(auth_ok)) => Ok(HandshakeOutcome::Authenticated {
+            session_id: auth_ok.session_id,
+            server_features: auth_ok.features,
+        }),
+        Ok(ScramClientOutput::Response(_)) => Err(ClientError::new(
+            ErrorCode::Protocol,
+            "SCRAM driver requested an extra response after server-final",
+        )),
+        Err(ScramClientError::Refused(reason)) => Ok(HandshakeOutcome::Refused(reason)),
+        Err(error) => Err(scram_error(error)),
+    }
+}
+
+fn expect_scram_response(
+    output: std::result::Result<ScramClientOutput, ScramClientError>,
+) -> Result<Vec<u8>> {
+    output
+        .map_err(scram_error)
+        .and_then(expect_scram_output_response)
+}
+
+fn expect_scram_output_response(output: ScramClientOutput) -> Result<Vec<u8>> {
+    match output {
+        ScramClientOutput::Response(payload) => Ok(payload),
+        ScramClientOutput::Authenticated(_) => Err(ClientError::new(
+            ErrorCode::Protocol,
+            "SCRAM driver authenticated before server-final",
+        )),
+    }
+}
+
+fn scram_error(error: ScramClientError) -> ClientError {
+    let code = match error {
+        ScramClientError::Refused(_) => ErrorCode::AuthRefused,
+        ScramClientError::Protocol(_) => ErrorCode::Protocol,
+    };
+    ClientError::new(code, error.to_string())
 }
 
 fn parse_hello_ack(payload: &[u8]) -> Result<HelloAck> {

--- a/crates/reddb-client/src/redwire/mod.rs
+++ b/crates/reddb-client/src/redwire/mod.rs
@@ -62,7 +62,7 @@ pub enum Auth {
     Anonymous,
     /// Bearer token (login-derived session token or API key).
     Bearer(String),
-    /// Username/password credentials. AuthResponse codec is follow-up work.
+    /// Username/password credentials negotiated through SCRAM-SHA-256.
     Basic { user: String, pass: String },
     /// API key credentials. AuthResponse codec is follow-up work.
     ApiKey(String),

--- a/crates/reddb-client/src/redwire/scram.rs
+++ b/crates/reddb-client/src/redwire/scram.rs
@@ -1,75 +1,12 @@
-//! SCRAM-SHA-256 client primitives. Mirrors `src/auth/scram.rs`
-//! in the engine — same byte layout, no engine dep so the driver
-//! stays standalone.
+//! Compatibility exports for SCRAM-SHA-256 client primitives.
 //!
-//! Server-side AuthStore migration is tracked in ADR 0002 Phase
-//! 3b; until that lands, the engine returns AuthFail for SCRAM
-//! attempts. This module is here so client code is ready to talk
-//! once the server flips on.
+//! The protocol authority and handshake drivers live in `reddb-wire`.
 
-use sha2::{Digest, Sha256};
-
-const HMAC_SHA256_BLOCK: usize = 64;
-
-/// HMAC-SHA256 implemented inline so the driver doesn't pull a
-/// new crate just for this. Bit-for-bit identical to the engine
-/// helper.
-pub fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
-    let mut padded = [0u8; HMAC_SHA256_BLOCK];
-    if key.len() > HMAC_SHA256_BLOCK {
-        let h = sha256(key);
-        padded[..32].copy_from_slice(&h);
-    } else {
-        padded[..key.len()].copy_from_slice(key);
-    }
-
-    let mut ipad = [0u8; HMAC_SHA256_BLOCK];
-    let mut opad = [0u8; HMAC_SHA256_BLOCK];
-    for i in 0..HMAC_SHA256_BLOCK {
-        ipad[i] = padded[i] ^ 0x36;
-        opad[i] = padded[i] ^ 0x5c;
-    }
-
-    let mut inner = Sha256::new();
-    inner.update(ipad);
-    inner.update(data);
-    let inner_hash = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(opad);
-    outer.update(inner_hash);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&outer.finalize());
-    out
-}
-
-pub fn sha256(data: &[u8]) -> [u8; 32] {
-    let mut h = Sha256::new();
-    h.update(data);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&h.finalize());
-    out
-}
+pub use reddb_wire::redwire::scram::{hmac_sha256, sha256, xor};
 
 /// PBKDF2-HMAC-SHA256 with a fixed 32-byte derived length.
 pub fn pbkdf2_sha256(password: &[u8], salt: &[u8], iter: u32) -> [u8; 32] {
-    let mut block = [0u8; 32];
-    let mut salted = Vec::with_capacity(salt.len() + 4);
-    salted.extend_from_slice(salt);
-    salted.extend_from_slice(&1u32.to_be_bytes());
-    let mut u = hmac_sha256(password, &salted);
-    block.copy_from_slice(&u);
-    for _ in 1..iter {
-        u = hmac_sha256(password, &u);
-        for i in 0..32 {
-            block[i] ^= u[i];
-        }
-    }
-    block
-}
-
-pub fn xor(a: &[u8], b: &[u8]) -> Vec<u8> {
-    a.iter().zip(b.iter()).map(|(x, y)| x ^ y).collect()
+    reddb_wire::redwire::scram::salted_password(password, salt, iter)
 }
 
 /// Compute the client proof for a SCRAM exchange.
@@ -77,8 +14,7 @@ pub fn client_proof(password: &[u8], salt: &[u8], iter: u32, auth_message: &[u8]
     let salted = pbkdf2_sha256(password, salt, iter);
     let client_key = hmac_sha256(&salted, b"Client Key");
     let stored_key = sha256(&client_key);
-    let signature = hmac_sha256(&stored_key, auth_message);
-    xor(&client_key, &signature)
+    reddb_wire::redwire::scram::client_proof(&stored_key, auth_message, &client_key)
 }
 
 /// Verify the server's signature on the way in (proves the server
@@ -95,19 +31,11 @@ pub fn verify_server_signature(
     }
     let salted = pbkdf2_sha256(password, salt, iter);
     let server_key = hmac_sha256(&salted, b"Server Key");
-    let expected = hmac_sha256(&server_key, auth_message);
-    constant_time_eq(&expected, presented_signature)
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for i in 0..a.len() {
-        diff |= a[i] ^ b[i];
-    }
-    diff == 0
+    reddb_wire::redwire::scram::verify_server_signature(
+        &server_key,
+        auth_message,
+        presented_signature,
+    )
 }
 
 #[cfg(test)]

--- a/crates/reddb-wire/src/redwire/scram.rs
+++ b/crates/reddb-wire/src/redwire/scram.rs
@@ -1,14 +1,14 @@
-//! SCRAM-SHA-256 primitives and sans-I/O server handshake driver.
+//! SCRAM-SHA-256 primitives and sans-I/O client/server handshake drivers.
 //!
-//! The driver owns SCRAM message sequencing and proof validation. Transport I/O,
+//! The drivers own SCRAM message sequencing and proof validation. Transport I/O,
 //! credential lookup, session creation, and authorization policy remain adapter concerns.
 
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::{Digest, Sha256};
 
 use super::handshake::{
-    build_scram_server_first, expect_auth_response_payload, parse_scram_client_final,
-    parse_scram_client_first,
+    base64_std, base64_std_decode, build_scram_server_first, expect_auth_response_payload,
+    parse_scram_client_final, parse_scram_client_first, AuthFail, AuthOk,
 };
 use super::MessageKind;
 
@@ -40,6 +40,268 @@ impl ScramVerifier {
             server_key,
         }
     }
+}
+
+/// One adapter action produced by a [`ScramClientHandshake`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScramClientOutput {
+    Response(Vec<u8>),
+    Authenticated(AuthOk),
+}
+
+/// Terminal client-side SCRAM failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScramClientError {
+    Refused(String),
+    Protocol(String),
+}
+
+impl std::fmt::Display for ScramClientError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Refused(reason) => write!(formatter, "SCRAM authentication refused: {reason}"),
+            Self::Protocol(reason) => formatter.write_str(reason),
+        }
+    }
+}
+
+impl std::error::Error for ScramClientError {}
+
+/// Transport-independent SCRAM-SHA-256 client exchange.
+pub struct ScramClientHandshake {
+    state: ScramClientState,
+}
+
+enum ScramClientState {
+    Ready {
+        username: String,
+        password: String,
+        client_nonce: String,
+    },
+    AwaitServerFirst {
+        password: String,
+        client_nonce: String,
+        client_first_bare: String,
+    },
+    AwaitServerFinal {
+        expected_server_signature: [u8; 32],
+    },
+    Complete,
+}
+
+impl ScramClientHandshake {
+    /// Create a client driver with adapter-supplied randomness.
+    pub fn new(
+        username: impl Into<String>,
+        password: impl Into<String>,
+        client_nonce: impl Into<String>,
+    ) -> Result<Self, ScramClientError> {
+        let username = username.into();
+        if username.is_empty() || username.contains([',', '=']) {
+            return Err(ScramClientError::Protocol(
+                "SCRAM username must be non-empty and contain neither ',' nor '='".to_string(),
+            ));
+        }
+        let client_nonce = client_nonce.into();
+        if client_nonce.is_empty() || client_nonce.contains(',') {
+            return Err(ScramClientError::Protocol(
+                "SCRAM client nonce must be non-empty and contain no ','".to_string(),
+            ));
+        }
+        Ok(Self {
+            state: ScramClientState::Ready {
+                username,
+                password: password.into(),
+                client_nonce,
+            },
+        })
+    }
+
+    /// Start the exchange by producing the client-first-message.
+    pub fn start(&mut self) -> Result<ScramClientOutput, ScramClientError> {
+        let state = std::mem::replace(&mut self.state, ScramClientState::Complete);
+        let ScramClientState::Ready {
+            username,
+            password,
+            client_nonce,
+        } = state
+        else {
+            return Err(unexpected_client_state());
+        };
+        let client_first_bare = format!("n={username},r={client_nonce}");
+        let response = format!("n,,{client_first_bare}").into_bytes();
+        self.state = ScramClientState::AwaitServerFirst {
+            password,
+            client_nonce,
+            client_first_bare,
+        };
+        Ok(ScramClientOutput::Response(response))
+    }
+
+    /// Consume one server frame and produce the next adapter action.
+    pub fn step(
+        &mut self,
+        kind: MessageKind,
+        payload: &[u8],
+    ) -> Result<ScramClientOutput, ScramClientError> {
+        let state = std::mem::replace(&mut self.state, ScramClientState::Complete);
+        match state {
+            ScramClientState::AwaitServerFirst {
+                password,
+                client_nonce,
+                client_first_bare,
+            } => {
+                self.receive_server_first(kind, payload, password, client_nonce, client_first_bare)
+            }
+            ScramClientState::AwaitServerFinal {
+                expected_server_signature,
+            } => Self::receive_server_final(kind, payload, &expected_server_signature),
+            ScramClientState::Ready { .. } | ScramClientState::Complete => {
+                Err(unexpected_client_state())
+            }
+        }
+    }
+
+    fn receive_server_first(
+        &mut self,
+        kind: MessageKind,
+        payload: &[u8],
+        password: String,
+        client_nonce: String,
+        client_first_bare: String,
+    ) -> Result<ScramClientOutput, ScramClientError> {
+        if kind == MessageKind::AuthFail {
+            return Err(auth_refused(payload));
+        }
+        if kind != MessageKind::AuthRequest {
+            return Err(ScramClientError::Protocol(format!(
+                "expected AuthRequest(server-first-message), got {kind:?}"
+            )));
+        }
+        let server_first = std::str::from_utf8(payload).map_err(|_| {
+            ScramClientError::Protocol("SCRAM server-first is not UTF-8".to_string())
+        })?;
+        let (combined_nonce, salt, iter) = parse_server_first(server_first, &client_nonce)?;
+        let client_final_no_proof = format!("c=biws,r={combined_nonce}");
+        let message = auth_message(&client_first_bare, server_first, &client_final_no_proof);
+        let salted = salted_password(password.as_bytes(), &salt, iter);
+        let client_key = hmac_sha256(&salted, b"Client Key");
+        let stored_key = sha256(&client_key);
+        let proof = client_proof(&stored_key, &message, &client_key);
+        let expected_server_signature =
+            server_signature(&hmac_sha256(&salted, b"Server Key"), &message);
+        let response = format!("{client_final_no_proof},p={}", base64_std(&proof)).into_bytes();
+        self.state = ScramClientState::AwaitServerFinal {
+            expected_server_signature,
+        };
+        Ok(ScramClientOutput::Response(response))
+    }
+
+    fn receive_server_final(
+        kind: MessageKind,
+        payload: &[u8],
+        expected_server_signature: &[u8; 32],
+    ) -> Result<ScramClientOutput, ScramClientError> {
+        if kind == MessageKind::AuthFail {
+            return Err(auth_refused(payload));
+        }
+        if kind != MessageKind::AuthOk {
+            return Err(ScramClientError::Protocol(format!(
+                "expected AuthOk/AuthFail, got {kind:?}"
+            )));
+        }
+        let auth_ok = AuthOk::from_payload(payload)
+            .map_err(|error| ScramClientError::Protocol(format!("decode SCRAM AuthOk: {error}")))?;
+        let encoded_signature = auth_ok.server_signature.as_deref().ok_or_else(|| {
+            ScramClientError::Protocol("SCRAM AuthOk omitted server signature".to_string())
+        })?;
+        let presented_signature = base64_std_decode(encoded_signature).ok_or_else(|| {
+            ScramClientError::Protocol(
+                "SCRAM AuthOk server signature is not valid base64".to_string(),
+            )
+        })?;
+        if !constant_time_eq(expected_server_signature, &presented_signature) {
+            return Err(ScramClientError::Protocol(
+                "SCRAM server signature did not verify".to_string(),
+            ));
+        }
+        Ok(ScramClientOutput::Authenticated(auth_ok))
+    }
+}
+
+fn parse_server_first(
+    server_first: &str,
+    client_nonce: &str,
+) -> Result<(String, Vec<u8>, u32), ScramClientError> {
+    let mut combined_nonce = None;
+    let mut encoded_salt = None;
+    let mut iterations = None;
+    for field in server_first.split(',') {
+        if let Some(value) = field.strip_prefix("r=") {
+            set_once(&mut combined_nonce, value, "r")?;
+        } else if let Some(value) = field.strip_prefix("s=") {
+            set_once(&mut encoded_salt, value, "s")?;
+        } else if let Some(value) = field.strip_prefix("i=") {
+            set_once(&mut iterations, value, "i")?;
+        }
+    }
+
+    let combined_nonce = combined_nonce.ok_or_else(|| {
+        ScramClientError::Protocol("SCRAM server-first omitted r=<nonce>".to_string())
+    })?;
+    if !combined_nonce.starts_with(client_nonce) || combined_nonce == client_nonce {
+        return Err(ScramClientError::Protocol(
+            "server nonce does not extend client nonce".to_string(),
+        ));
+    }
+    let encoded_salt = encoded_salt.ok_or_else(|| {
+        ScramClientError::Protocol("SCRAM server-first omitted s=<salt>".to_string())
+    })?;
+    let salt = base64_std_decode(encoded_salt)
+        .ok_or_else(|| ScramClientError::Protocol("server salt is not valid base64".to_string()))?;
+    if salt.is_empty() {
+        return Err(ScramClientError::Protocol(
+            "server salt is empty".to_string(),
+        ));
+    }
+    let iterations = iterations
+        .ok_or_else(|| {
+            ScramClientError::Protocol("SCRAM server-first omitted i=<iterations>".to_string())
+        })?
+        .parse::<u32>()
+        .map_err(|_| {
+            ScramClientError::Protocol("SCRAM iteration count is not an integer".to_string())
+        })?;
+    if iterations < MIN_ITER {
+        return Err(ScramClientError::Protocol(format!(
+            "SCRAM iteration count {iterations} is below minimum {MIN_ITER}"
+        )));
+    }
+    Ok((combined_nonce.to_string(), salt, iterations))
+}
+
+fn set_once<'a>(
+    destination: &mut Option<&'a str>,
+    value: &'a str,
+    name: &str,
+) -> Result<(), ScramClientError> {
+    if destination.replace(value).is_some() {
+        return Err(ScramClientError::Protocol(format!(
+            "SCRAM server-first repeated {name}= field"
+        )));
+    }
+    Ok(())
+}
+
+fn auth_refused(payload: &[u8]) -> ScramClientError {
+    match AuthFail::from_payload(payload) {
+        Ok(failure) => ScramClientError::Refused(failure.reason),
+        Err(error) => ScramClientError::Protocol(format!("decode SCRAM AuthFail: {error}")),
+    }
+}
+
+fn unexpected_client_state() -> ScramClientError {
+    ScramClientError::Protocol("unexpected SCRAM client message".to_string())
 }
 
 /// One external event consumed by [`ScramServerHandshake::step`].
@@ -351,6 +613,18 @@ pub fn verify_client_proof(
 
 pub fn server_signature(server_key: &[u8], auth_message: &[u8]) -> [u8; 32] {
     hmac_sha256(server_key, auth_message)
+}
+
+pub fn verify_server_signature(
+    server_key: &[u8],
+    auth_message: &[u8],
+    presented_signature: &[u8],
+) -> bool {
+    presented_signature.len() == 32
+        && constant_time_eq(
+            &server_signature(server_key, auth_message),
+            presented_signature,
+        )
 }
 
 fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {

--- a/crates/reddb-wire/tests/scram_handshake.rs
+++ b/crates/reddb-wire/tests/scram_handshake.rs
@@ -1,6 +1,7 @@
 use reddb_wire::redwire::handshake::base64_std;
 use reddb_wire::redwire::scram::{
-    ScramServerHandshake, ScramServerInput, ScramServerOutput, ScramVerifier,
+    ScramClientError, ScramClientHandshake, ScramClientOutput, ScramServerHandshake,
+    ScramServerInput, ScramServerOutput, ScramVerifier,
 };
 use reddb_wire::redwire::MessageKind;
 
@@ -116,6 +117,89 @@ fn malformed_exchange_is_rejected_without_io() {
             correlation_id: 22,
             reason: "scram client-final: missing p=<proof>".to_string(),
         }
+    );
+}
+
+#[test]
+fn rfc_7677_client_exchange_authenticates_without_io() {
+    let mut handshake = ScramClientHandshake::new("user", "pencil", CLIENT_NONCE)
+        .expect("RFC credentials are valid");
+
+    assert_eq!(
+        handshake.start().expect("client-first"),
+        ScramClientOutput::Response(format!("n,,n=user,r={CLIENT_NONCE}").into_bytes())
+    );
+    assert_eq!(
+        handshake
+            .step(MessageKind::AuthRequest, SERVER_FIRST.as_bytes())
+            .expect("client-final"),
+        ScramClientOutput::Response(
+            format!("c=biws,r={COMBINED_NONCE},p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ=")
+                .into_bytes()
+        )
+    );
+
+    let auth_ok = br#"{"session_id":"fixture","username":"user","role":"read","features":0,"v":"6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4="}"#;
+    let output = handshake
+        .step(MessageKind::AuthOk, auth_ok)
+        .expect("server signature is valid");
+    let ScramClientOutput::Authenticated(auth_ok) = output else {
+        panic!("RFC exchange should authenticate, got {output:?}");
+    };
+    assert_eq!(auth_ok.session_id, "fixture");
+    assert_eq!(auth_ok.username.as_deref(), Some("user"));
+}
+
+#[test]
+fn client_rejects_server_nonce_that_does_not_extend_its_nonce() {
+    let mut handshake = ScramClientHandshake::new("user", "pencil", CLIENT_NONCE)
+        .expect("RFC credentials are valid");
+    handshake.start().expect("client-first");
+
+    let error = handshake
+        .step(
+            MessageKind::AuthRequest,
+            b"r=attacker,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096",
+        )
+        .expect_err("unrelated nonce must be rejected");
+    assert_eq!(
+        error,
+        ScramClientError::Protocol("server nonce does not extend client nonce".to_string())
+    );
+}
+
+#[test]
+fn client_rejects_weak_iteration_count() {
+    let mut handshake = ScramClientHandshake::new("user", "pencil", CLIENT_NONCE)
+        .expect("RFC credentials are valid");
+    handshake.start().expect("client-first");
+
+    let weak = format!("r={COMBINED_NONCE},s=W22ZaJ0SNY7soEsUEjb6gQ==,i=1024");
+    let error = handshake
+        .step(MessageKind::AuthRequest, weak.as_bytes())
+        .expect_err("weak iteration count must be rejected");
+    assert_eq!(
+        error,
+        ScramClientError::Protocol("SCRAM iteration count 1024 is below minimum 4096".to_string())
+    );
+}
+
+#[test]
+fn client_rejects_forged_server_signature() {
+    let mut handshake = ScramClientHandshake::new("user", "pencil", CLIENT_NONCE)
+        .expect("RFC credentials are valid");
+    handshake.start().expect("client-first");
+    handshake
+        .step(MessageKind::AuthRequest, SERVER_FIRST.as_bytes())
+        .expect("client-final");
+
+    let forged = br#"{"session_id":"fixture","username":"user","role":"read","features":0,"v":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}"#;
+    let error = handshake
+        .step(MessageKind::AuthOk, forged)
+        .expect_err("forged signature must be rejected");
+    assert_eq!(
+        error,
+        ScramClientError::Protocol("SCRAM server signature did not verify".to_string())
     );
 }
 

--- a/drivers/python/Cargo.lock
+++ b/drivers/python/Cargo.lock
@@ -2312,6 +2312,7 @@ name = "reddb-io-client"
 version = "1.23.2"
 dependencies = [
  "async-trait",
+ "getrandom 0.4.3",
  "reddb-io-grpc-proto",
  "reddb-io-server",
  "reddb-io-types",

--- a/drivers/python/tests/test_scram_conformance.py
+++ b/drivers/python/tests/test_scram_conformance.py
@@ -1,0 +1,114 @@
+"""Replay the shared RedWire SCRAM-SHA-256 exchange fixtures."""
+
+import base64
+import hashlib
+import hmac
+import json
+from pathlib import Path
+
+
+FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "testdata"
+    / "conformance"
+    / "redwire"
+    / "scram"
+    / "exchanges.json"
+)
+MIN_ITERATIONS = 4096
+
+
+def _message(vector, direction, kind):
+    return next(
+        message
+        for message in vector["messages"]
+        if message["direction"] == direction and message["kind"] == kind
+    )
+
+
+def _parse_server_first(payload, client_nonce):
+    fields = {}
+    for item in payload.split(","):
+        key, separator, value = item.partition("=")
+        if not separator or key in fields:
+            raise ValueError("malformed SCRAM server-first message")
+        fields[key] = value
+
+    combined_nonce = fields.get("r", "")
+    if not combined_nonce.startswith(client_nonce) or combined_nonce == client_nonce:
+        raise ValueError("server nonce does not extend client nonce")
+
+    try:
+        salt = base64.b64decode(fields.get("s", ""), validate=True)
+    except ValueError as error:
+        raise ValueError("server salt is not valid base64") from error
+    if not salt:
+        raise ValueError("server salt is empty")
+
+    try:
+        iterations = int(fields.get("i", ""))
+    except ValueError as error:
+        raise ValueError("SCRAM iteration count is not an integer") from error
+    if iterations < MIN_ITERATIONS:
+        raise ValueError(
+            f"SCRAM iteration count {iterations} is below minimum {MIN_ITERATIONS}"
+        )
+    return combined_nonce, salt, iterations
+
+
+def _derive_exchange(vector, server_first):
+    username = vector["credentials"]["username"]
+    password = vector["credentials"]["password"]
+    client_nonce = vector["client_nonce"]
+    client_first_bare = f"n={username},r={client_nonce}"
+    assert _message(vector, "client_to_server", "AuthResponse(client-first)")[
+        "payload"
+    ] == f"n,,{client_first_bare}"
+
+    combined_nonce, salt, iterations = _parse_server_first(server_first, client_nonce)
+    client_final_without_proof = f"c=biws,r={combined_nonce}"
+    auth_message = (
+        f"{client_first_bare},{server_first},{client_final_without_proof}".encode()
+    )
+    salted_password = hashlib.pbkdf2_hmac(
+        "sha256", password.encode(), salt, iterations, dklen=32
+    )
+    client_key = hmac.new(salted_password, b"Client Key", hashlib.sha256).digest()
+    stored_key = hashlib.sha256(client_key).digest()
+    client_signature = hmac.new(stored_key, auth_message, hashlib.sha256).digest()
+    proof = bytes(left ^ right for left, right in zip(client_key, client_signature))
+    client_final = (
+        f"{client_final_without_proof},p={base64.b64encode(proof).decode()}"
+    )
+    assert _message(vector, "client_to_server", "AuthResponse(client-final)")[
+        "payload"
+    ] == client_final
+
+    server_key = hmac.new(salted_password, b"Server Key", hashlib.sha256).digest()
+    return hmac.new(server_key, auth_message, hashlib.sha256).digest()
+
+
+def test_shared_scram_exchange_vectors():
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    assert fixture["version"] == 1
+    assert fixture["layout"] == "redwire-scram-sha-256-exchanges-v1"
+
+    for vector in fixture["exchanges"]:
+        server_first = _message(vector, "server_to_client", "AuthRequest")["payload"]
+        expected = vector["expected"]
+        try:
+            server_signature = _derive_exchange(vector, server_first)
+            auth_ok = json.loads(
+                _message(vector, "server_to_client", "AuthOk")["payload"]
+            )
+            presented_signature = base64.b64decode(auth_ok["v"], validate=True)
+            if not hmac.compare_digest(server_signature, presented_signature):
+                raise ValueError("SCRAM server signature did not verify")
+        except ValueError as error:
+            assert expected == {"error": str(error)}, vector["name"]
+        else:
+            assert expected == {"authenticated": True}, vector["name"]
+
+
+if __name__ == "__main__":
+    test_shared_scram_exchange_vectors()

--- a/testdata/conformance/README.md
+++ b/testdata/conformance/README.md
@@ -17,6 +17,9 @@ Current shared fixtures:
   encoding fixtures. `reddb-wire` validates the canonical RedWire bytes,
   `reddb-grpc-proto` consumers validate the gRPC bytes, and language drivers
   validate their adapters against the same manifest.
+- `redwire/scram/exchanges.json` — recorded SCRAM-SHA-256 exchanges covering
+  successful authentication, nonce replay protection, iteration floors,
+  malformed salt, and server-signature verification.
 
 Rules:
 
@@ -37,6 +40,7 @@ Current authorities:
 | RedDB-only RQL corpus | `crates/reddb-rql/tests/reddb_corpus` |
 | RQL result rendering | `crates/reddb-rql/src/conformance.rs` |
 | RedWire param/value fixtures | `testdata/conformance/redwire/params/manifest.json` |
+| RedWire SCRAM fixtures | `testdata/conformance/redwire/scram/exchanges.json` |
 | RedWire protocol fence | `crates/reddb-wire/tests/protocol_authority.rs` |
 | File layout fence | `crates/reddb-file/tests/layout_authority.rs` |
 | File layout fence modules | `crates/reddb-file/tests/layout_authority` |

--- a/testdata/conformance/contract-authorities.json
+++ b/testdata/conformance/contract-authorities.json
@@ -45,6 +45,12 @@
       "owns": "RedWire parameter/value golden fixtures"
     },
     {
+      "id": "redwire-scram-fixtures",
+      "type": "file",
+      "path": "testdata/conformance/redwire/scram/exchanges.json",
+      "owns": "RedWire SCRAM-SHA-256 recorded exchanges and rejection vectors"
+    },
+    {
       "id": "redwire-protocol-authority",
       "type": "file",
       "path": "crates/reddb-wire/tests/protocol_authority.rs",

--- a/testdata/conformance/redwire/scram/exchanges.json
+++ b/testdata/conformance/redwire/scram/exchanges.json
@@ -1,0 +1,155 @@
+{
+  "version": 1,
+  "layout": "redwire-scram-sha-256-exchanges-v1",
+  "exchanges": [
+    {
+      "name": "rfc-7677-success",
+      "credentials": {
+        "username": "user",
+        "password": "pencil"
+      },
+      "client_nonce": "rOprNGfwEbeRWgbNEkqO",
+      "messages": [
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-first)",
+          "correlation_id": 2,
+          "payload": "n,,n=user,r=rOprNGfwEbeRWgbNEkqO"
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthRequest",
+          "correlation_id": 2,
+          "payload": "r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096"
+        },
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-final)",
+          "correlation_id": 3,
+          "payload": "c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ="
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthOk",
+          "correlation_id": 3,
+          "payload": "{\"session_id\":\"fixture\",\"username\":\"user\",\"role\":\"read\",\"features\":0,\"v\":\"6rriTRBi23WpRR/wtup+mMhUZUn/dB5nLTJRsjl95G4=\"}"
+        }
+      ],
+      "expected": {
+        "authenticated": true
+      }
+    },
+    {
+      "name": "server-nonce-does-not-extend-client",
+      "credentials": {
+        "username": "user",
+        "password": "pencil"
+      },
+      "client_nonce": "rOprNGfwEbeRWgbNEkqO",
+      "messages": [
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-first)",
+          "correlation_id": 2,
+          "payload": "n,,n=user,r=rOprNGfwEbeRWgbNEkqO"
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthRequest",
+          "correlation_id": 2,
+          "payload": "r=attacker,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096"
+        }
+      ],
+      "expected": {
+        "error": "server nonce does not extend client nonce"
+      }
+    },
+    {
+      "name": "iteration-count-below-minimum",
+      "credentials": {
+        "username": "user",
+        "password": "pencil"
+      },
+      "client_nonce": "rOprNGfwEbeRWgbNEkqO",
+      "messages": [
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-first)",
+          "correlation_id": 2,
+          "payload": "n,,n=user,r=rOprNGfwEbeRWgbNEkqO"
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthRequest",
+          "correlation_id": 2,
+          "payload": "r=rOprNGfwEbeRWgbNEkqOserver,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=1024"
+        }
+      ],
+      "expected": {
+        "error": "SCRAM iteration count 1024 is below minimum 4096"
+      }
+    },
+    {
+      "name": "salt-is-not-base64",
+      "credentials": {
+        "username": "user",
+        "password": "pencil"
+      },
+      "client_nonce": "rOprNGfwEbeRWgbNEkqO",
+      "messages": [
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-first)",
+          "correlation_id": 2,
+          "payload": "n,,n=user,r=rOprNGfwEbeRWgbNEkqO"
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthRequest",
+          "correlation_id": 2,
+          "payload": "r=rOprNGfwEbeRWgbNEkqOserver,s=***,i=4096"
+        }
+      ],
+      "expected": {
+        "error": "server salt is not valid base64"
+      }
+    },
+    {
+      "name": "forged-server-signature",
+      "credentials": {
+        "username": "user",
+        "password": "pencil"
+      },
+      "client_nonce": "rOprNGfwEbeRWgbNEkqO",
+      "messages": [
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-first)",
+          "correlation_id": 2,
+          "payload": "n,,n=user,r=rOprNGfwEbeRWgbNEkqO"
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthRequest",
+          "correlation_id": 2,
+          "payload": "r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,s=W22ZaJ0SNY7soEsUEjb6gQ==,i=4096"
+        },
+        {
+          "direction": "client_to_server",
+          "kind": "AuthResponse(client-final)",
+          "correlation_id": 3,
+          "payload": "c=biws,r=rOprNGfwEbeRWgbNEkqO%hvYDpWUa2RaTCAfuxFIlj)hNlF$k0,p=dHzbZapWIk4jUhN+Ute9ytag9zjfMHgsqmmiz7AndVQ="
+        },
+        {
+          "direction": "server_to_client",
+          "kind": "AuthOk",
+          "correlation_id": 3,
+          "payload": "{\"session_id\":\"fixture\",\"username\":\"user\",\"role\":\"read\",\"features\":0,\"v\":\"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"}"
+        }
+      ],
+      "expected": {
+        "error": "SCRAM server signature did not verify"
+      }
+    }
+  ]
+}

--- a/tests/grouped/redwire_protocol/redwire_smoke.rs
+++ b/tests/grouped/redwire_protocol/redwire_smoke.rs
@@ -16,7 +16,6 @@ use reddb_client::redwire::{
     Auth, BinaryValue, ConnectOptions, Flags, Frame, MessageKind, RedWireClient,
 };
 use reddb_client::{Value, ValueOut};
-use reddb_types::encoding::base64_encode;
 use tokio::net::TcpListener;
 
 async fn start_server() -> (SocketAddr, tokio::task::JoinHandle<()>) {
@@ -226,130 +225,18 @@ async fn scram_sha_256_end_to_end() {
     });
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-    // Drive the SCRAM exchange manually so we exercise every
-    // frame the server expects. Driver-side helper landing in
-    // the next Phase 3c bump.
-    use reddb_client::redwire::scram;
-    use std::io::Cursor;
-
-    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-    let mut socket = stream;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
-
-    // Magic + minor version.
-    socket
-        .write_all(&reddb_wire::redwire::supported_client_preface())
-        .await
-        .unwrap();
-
-    async fn send_frame(s: &mut tokio::net::TcpStream, frame: reddb_client::redwire::Frame) {
-        use reddb_wire::redwire::encode_frame;
-        let bytes = encode_frame(&frame);
-        s.write_all(&bytes).await.unwrap();
-    }
-    async fn read_frame(s: &mut tokio::net::TcpStream) -> reddb_client::redwire::Frame {
-        use reddb_wire::redwire::decode_frame;
-        let mut header = [0u8; 16];
-        s.read_exact(&mut header).await.unwrap();
-        let len = u32::from_le_bytes([header[0], header[1], header[2], header[3]]) as usize;
-        let mut buf = vec![0u8; len];
-        buf[..16].copy_from_slice(&header);
-        s.read_exact(&mut buf[16..]).await.unwrap();
-        decode_frame(&buf).unwrap().0
-    }
-
-    // Hello — offer SCRAM only so the picker chooses it.
-    let hello_body = br#"{"versions":[1],"auth_methods":["scram-sha-256"],"features":0}"#.to_vec();
-    send_frame(
-        &mut socket,
-        reddb_client::redwire::Frame::new(MessageKind::Hello, 1, hello_body),
+    let mut client = RedWireClient::connect(
+        ConnectOptions::new(addr.ip().to_string(), addr.port()).with_auth(Auth::Basic {
+            user: "alice".to_string(),
+            pass: "hunter2".to_string(),
+        }),
     )
-    .await;
-    let ack = read_frame(&mut socket).await;
-    assert_eq!(ack.kind, MessageKind::HelloAck);
-    let ack_obj: serde_json::Value = serde_json::from_slice(&ack.payload).unwrap();
-    assert_eq!(ack_obj["auth"], "scram-sha-256");
+    .await
+    .expect("Rust RedWire client should complete SCRAM");
 
-    // SCRAM client-first.
-    let client_nonce = "fyko+d2lbbFgONRv9qkxdawL";
-    let client_first_bare = format!("n=alice,r={client_nonce}");
-    let client_first = format!("n,,{client_first_bare}");
-    send_frame(
-        &mut socket,
-        reddb_client::redwire::Frame::new(MessageKind::AuthResponse, 2, client_first.into_bytes()),
-    )
-    .await;
-
-    // Server-first comes back via AuthRequest.
-    let server_first_frame = read_frame(&mut socket).await;
-    assert_eq!(server_first_frame.kind, MessageKind::AuthRequest);
-    let server_first = String::from_utf8(server_first_frame.payload).unwrap();
-
-    // Parse salt + iter + combined nonce.
-    let mut salt_b64 = String::new();
-    let mut iter: u32 = 0;
-    let mut combined_nonce = String::new();
-    for part in server_first.split(',') {
-        if let Some(v) = part.strip_prefix("r=") {
-            combined_nonce = v.to_string();
-        } else if let Some(v) = part.strip_prefix("s=") {
-            salt_b64 = v.to_string();
-        } else if let Some(v) = part.strip_prefix("i=") {
-            iter = v.parse().unwrap();
-        }
-    }
-    let salt = base64_decode(&salt_b64);
-
-    // Client-final.
-    let client_final_no_proof = format!("c=biws,r={combined_nonce}");
-    let auth_message = format!("{client_first_bare},{server_first},{client_final_no_proof}");
-    let proof = scram::client_proof(b"hunter2", &salt, iter, auth_message.as_bytes());
-    let proof_b64 = base64_encode(&proof);
-    let client_final = format!("{client_final_no_proof},p={proof_b64}");
-    send_frame(
-        &mut socket,
-        reddb_client::redwire::Frame::new(MessageKind::AuthResponse, 3, client_final.into_bytes()),
-    )
-    .await;
-
-    let ok = read_frame(&mut socket).await;
-    assert_eq!(ok.kind, MessageKind::AuthOk, "SCRAM should succeed");
-    let ok_obj: serde_json::Value = serde_json::from_slice(&ok.payload).unwrap();
-    assert_eq!(ok_obj["username"], "alice");
-    assert_eq!(ok_obj["role"], "write");
-    assert!(ok_obj["v"].is_string(), "AuthOk carries server signature");
-
-    // Bye + cleanup.
-    send_frame(
-        &mut socket,
-        reddb_client::redwire::Frame::new(MessageKind::Bye, 4, vec![]),
-    )
-    .await;
-
-    fn base64_decode(input: &str) -> Vec<u8> {
-        let trimmed = input.trim_end_matches('=');
-        let mut out = Vec::with_capacity(trimmed.len() * 3 / 4);
-        let mut buf = 0u32;
-        let mut bits = 0u8;
-        for ch in trimmed.bytes() {
-            let v: u32 = match ch {
-                b'A'..=b'Z' => (ch - b'A') as u32,
-                b'a'..=b'z' => (ch - b'a' + 26) as u32,
-                b'0'..=b'9' => (ch - b'0' + 52) as u32,
-                b'+' => 62,
-                b'/' => 63,
-                _ => continue,
-            };
-            buf = (buf << 6) | v;
-            bits += 6;
-            if bits >= 8 {
-                bits -= 8;
-                out.push(((buf >> bits) & 0xFF) as u8);
-            }
-        }
-        out
-    }
-    let _ = Cursor::new(0);
+    let result = client.query("SELECT 1").await.expect("authenticated query");
+    assert!(!result.statement.is_empty());
+    client.close().await.expect("close");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Automated AFK landing for #2161. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2161

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081979&installation_model_id=20659&pr_number=2238&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2238&signature=015146952038d597c6f338aca5f5bff9ee028876537d42a7c001846fecff69db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->