### PR TITLE
merge: #2167 Operational manifest onto the Vfs with owned ordering verbs

### DIFF
--- a/crates/reddb-file/src/lib.rs
+++ b/crates/reddb-file/src/lib.rs
@@ -267,6 +267,7 @@ pub use native_store::{
 };
 pub use operational_manifest::{
     AppendOnlySegmentState, ForkHydrationState, ForkInfo, ForkOrigin, OperationalManifest,
+    PreparedCollectionCreate, PreparedCollectionDrop,
 };
 pub use physical_metadata::{
     copy_physical_export_data_file, copy_physical_metadata_binary_to_journal,
@@ -329,7 +330,7 @@ pub use vector_ivf_index::{
     decode_ivf_index_frame, encode_ivf_index_frame, IvfIndexFrame, IvfIndexFrameError,
     IvfListFrame, IVF_INDEX_HEADER_LEN, IVF_INDEX_MAGIC,
 };
-pub use vfs::{OpenMode, StdVfs, Vfs, VfsFile};
+pub use vfs::{OpenMode, StdVfs, Vfs, VfsDirEntry, VfsFile};
 
 pub use primary_replica::{
     cleanup_rebootstrap_artifacts, decode_rebootstrap_ready_marker_json,

--- a/crates/reddb-file/src/operational_manifest/fork.rs
+++ b/crates/reddb-file/src/operational_manifest/fork.rs
@@ -10,14 +10,14 @@
 //! authority's per-file line budget. Behavior is identical to the pre-split code.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
 use super::{
-    copy_file_durable, invalid_data, sanitize_component, sync_dir, CollectionEntry,
-    CollectionState, Manifest, OperationalManifest, FORKS_DIR,
+    invalid_data, sanitize_component, CollectionEntry, CollectionState, Manifest,
+    OperationalManifest, FORKS_DIR,
 };
+use crate::Vfs;
 
 /// Where a store fork came from: the parent store's identity and the durable LSN
 /// the fork is pinned at. Recorded in the fork's own operational manifest so a
@@ -47,10 +47,10 @@ pub struct ForkInfo {
 }
 
 #[derive(Debug, Clone)]
-pub struct PromoteForkOutcome {
+pub struct PromoteForkOutcome<V = crate::StdVfs> {
     pub name: String,
     pub fork_lsn: u64,
-    pub archived_parent: OperationalManifest,
+    pub archived_parent: OperationalManifest<V>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,12 +91,13 @@ impl Default for ForkHydrationProgress {
     }
 }
 
-impl OperationalManifest {
+impl<V: Vfs> OperationalManifest<V> {
     /// A fork's own operational manifest, rooted under this store's `forks/` dir.
     /// The fork is a full operational store root in its own right.
     pub fn fork_handle(&self, name: &str) -> Self {
         Self {
             root: self.forks_dir().join(sanitize_component(name)),
+            vfs: self.vfs.clone(),
         }
     }
 
@@ -149,7 +150,7 @@ impl OperationalManifest {
             }),
         };
         fork.publish(&manifest)?;
-        sync_dir(&self.forks_dir())
+        self.vfs.sync_dir(&self.forks_dir())
     }
 
     /// Hydrate a fork collection's private copy (copy-on-write): called on the
@@ -169,7 +170,7 @@ impl OperationalManifest {
         };
         self.ensure_dirs()?;
         let dest = self.collections_dir().join(&entry.path);
-        copy_file_durable(Path::new(&source), &dest)?;
+        self.copy_file_durable(Path::new(&source), &dest)?;
         entry.source = None;
         manifest.generation += 1;
         self.publish(&manifest)
@@ -201,7 +202,7 @@ impl OperationalManifest {
             }
             fork.ensure_dirs()?;
             let dest = fork.collections_dir().join(&fork_entry.path);
-            copy_file_durable(&source, &dest)?;
+            self.copy_file_durable(&source, &dest)?;
             fork_entry.source = None;
             manifest.generation += 1;
             fork.publish(&manifest)?;
@@ -212,17 +213,19 @@ impl OperationalManifest {
     /// List every store fork of this store: name, parent identity, and fork LSN.
     pub fn list_forks(&self) -> io::Result<Vec<ForkInfo>> {
         let mut out = Vec::new();
-        let entries = match fs::read_dir(self.forks_dir()) {
+        let entries = match self.vfs.read_dir(&self.forks_dir()) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
             Err(err) => return Err(err),
         };
         for entry in entries {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
+            if !entry.is_dir {
                 continue;
             }
-            let fork = Self { root: entry.path() };
+            let fork = Self {
+                root: entry.path,
+                vfs: self.vfs.clone(),
+            };
             if let Some(manifest) = fork.load_current()? {
                 let Some(origin) = manifest.fork_origin.as_ref() else {
                     continue;
@@ -250,11 +253,11 @@ impl OperationalManifest {
     /// fork was actually removed.
     pub fn drop_fork(&self, name: &str) -> io::Result<bool> {
         let fork = self.fork_handle(name);
-        if !fork.root.exists() {
+        if !self.vfs.exists(&fork.root) {
             return Ok(false);
         }
-        fs::remove_dir_all(&fork.root)?;
-        let _ = sync_dir(&self.forks_dir());
+        self.vfs.remove_dir_all(&fork.root)?;
+        let _ = self.vfs.sync_dir(&self.forks_dir());
         if let Some(manifest) = self.load_current()? {
             let protected_paths = self.protected_collection_paths(&manifest)?;
             self.quarantine_unreferenced_collection_files(&protected_paths)?;
@@ -278,8 +281,8 @@ impl OperationalManifest {
         let fork = self.fork_handle(name);
         let detached = self.detached_fork_handle(name);
 
-        if detached.root.exists() {
-            if fork.root.exists() {
+        if self.vfs.exists(&detached.root) {
+            if self.vfs.exists(&fork.root) {
                 return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
                     format!("detached store already exists for fork: {name}"),
@@ -290,18 +293,18 @@ impl OperationalManifest {
             return Ok(was_fork.then_some(detached));
         }
 
-        if !fork.root.exists() {
+        if !self.vfs.exists(&fork.root) {
             return Ok(None);
         }
 
         fork.hydrate_shared_collections()?;
         if let Some(parent) = detached.root.parent() {
-            fs::create_dir_all(parent)?;
+            self.vfs.create_dir_all(parent)?;
         }
-        fs::rename(&fork.root, &detached.root)?;
-        sync_dir(&self.forks_dir())?;
+        self.vfs.rename(&fork.root, &detached.root)?;
+        self.vfs.sync_dir(&self.forks_dir())?;
         if let Some(parent) = detached.root.parent() {
-            sync_dir(parent)?;
+            self.vfs.sync_dir(parent)?;
         }
         detached.clear_fork_origin()?;
         Ok(Some(detached))
@@ -313,9 +316,9 @@ impl OperationalManifest {
     /// used by restore/fork detach. The superseded primary is then moved to a
     /// deterministic retired root, so its disposition is explicit and cannot be
     /// mistaken for the active store.
-    pub fn promote_fork(&self, name: &str) -> io::Result<Option<PromoteForkOutcome>> {
+    pub fn promote_fork(&self, name: &str) -> io::Result<Option<PromoteForkOutcome<V>>> {
         let fork = self.fork_handle(name);
-        if !fork.root.exists() {
+        if !self.vfs.exists(&fork.root) {
             return Ok(None);
         }
         let origin = fork
@@ -330,14 +333,14 @@ impl OperationalManifest {
         }
 
         let staging = self.promoting_fork_handle(name);
-        if staging.root.exists() {
+        if self.vfs.exists(&staging.root) {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!("store fork promotion staging path already exists: {name}"),
             ));
         }
         let archived_parent = self.archived_parent_handle(name);
-        if archived_parent.root.exists() {
+        if self.vfs.exists(&archived_parent.root) {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!("retired parent store already exists for promoted fork: {name}"),
@@ -346,21 +349,21 @@ impl OperationalManifest {
 
         fork.hydrate_shared_collections()?;
         if let Some(parent) = staging.root.parent() {
-            fs::create_dir_all(parent)?;
+            self.vfs.create_dir_all(parent)?;
         }
-        fs::rename(&fork.root, &staging.root)?;
-        sync_dir(&self.forks_dir())?;
+        self.vfs.rename(&fork.root, &staging.root)?;
+        self.vfs.sync_dir(&self.forks_dir())?;
         if let Some(parent) = staging.root.parent() {
-            sync_dir(parent)?;
+            self.vfs.sync_dir(parent)?;
         }
 
-        fs::rename(&self.root, &archived_parent.root)?;
+        self.vfs.rename(&self.root, &archived_parent.root)?;
         if let Some(parent) = self.root.parent() {
-            sync_dir(parent)?;
+            self.vfs.sync_dir(parent)?;
         }
-        fs::rename(&staging.root, &self.root)?;
+        self.vfs.rename(&staging.root, &self.root)?;
         if let Some(parent) = self.root.parent() {
-            sync_dir(parent)?;
+            self.vfs.sync_dir(parent)?;
         }
         self.clear_fork_origin()?;
 
@@ -384,15 +387,17 @@ impl OperationalManifest {
 
     fn fork_handles(&self) -> io::Result<Vec<Self>> {
         let mut out = Vec::new();
-        let entries = match fs::read_dir(self.forks_dir()) {
+        let entries = match self.vfs.read_dir(&self.forks_dir()) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(out),
             Err(err) => return Err(err),
         };
         for entry in entries {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                out.push(Self { root: entry.path() });
+            if entry.is_dir {
+                out.push(Self {
+                    root: entry.path,
+                    vfs: self.vfs.clone(),
+                });
             }
         }
         Ok(out)
@@ -408,6 +413,7 @@ impl OperationalManifest {
             root: self
                 .root
                 .with_file_name(format!("{root_name}.detached-{}", sanitize_component(name))),
+            vfs: self.vfs.clone(),
         }
     }
 
@@ -422,6 +428,7 @@ impl OperationalManifest {
                 "{root_name}.retired-by-promote-{}",
                 sanitize_component(name)
             )),
+            vfs: self.vfs.clone(),
         }
     }
 
@@ -436,6 +443,7 @@ impl OperationalManifest {
                 "{root_name}.promoting-{}",
                 sanitize_component(name)
             )),
+            vfs: self.vfs.clone(),
         }
     }
 
@@ -451,7 +459,7 @@ impl OperationalManifest {
                 continue;
             };
             let dest = self.collections_dir().join(&entry.path);
-            copy_file_durable(Path::new(&source), &dest)?;
+            self.copy_file_durable(Path::new(&source), &dest)?;
             entry.source = None;
             changed = true;
         }
@@ -480,7 +488,7 @@ impl OperationalManifest {
         }
 
         let fork = self.fork_handle(&origin.name);
-        if fork.root.exists() {
+        if self.vfs.exists(&fork.root) {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!(
@@ -491,8 +499,8 @@ impl OperationalManifest {
         }
 
         let archived_parent = self.archived_parent_handle(&origin.name);
-        if archived_parent.root.exists() {
-            if self.root.exists() {
+        if self.vfs.exists(&archived_parent.root) {
+            if self.vfs.exists(&self.root) {
                 return Err(io::Error::new(
                     io::ErrorKind::AlreadyExists,
                     format!(
@@ -502,21 +510,21 @@ impl OperationalManifest {
                 ));
             }
         } else {
-            if !self.root.exists() {
+            if !self.vfs.exists(&self.root) {
                 return Err(invalid_data(format!(
                     "store fork promotion lost active parent before archive: {}",
                     origin.name
                 )));
             }
-            fs::rename(&self.root, &archived_parent.root)?;
+            self.vfs.rename(&self.root, &archived_parent.root)?;
             if let Some(parent) = self.root.parent() {
-                sync_dir(parent)?;
+                self.vfs.sync_dir(parent)?;
             }
         }
 
-        fs::rename(&staging.root, &self.root)?;
+        self.vfs.rename(&staging.root, &self.root)?;
         if let Some(parent) = self.root.parent() {
-            sync_dir(parent)?;
+            self.vfs.sync_dir(parent)?;
         }
         self.clear_fork_origin()
     }
@@ -539,7 +547,9 @@ impl OperationalManifest {
             return Ok(());
         };
         if origin.parent_store == self.store_identity()
-            && self.archived_parent_handle(&origin.name).root.exists()
+            && self
+                .vfs
+                .exists(&self.archived_parent_handle(&origin.name).root)
         {
             self.clear_fork_origin()?;
         }
@@ -554,25 +564,27 @@ impl OperationalManifest {
             return Ok(None);
         };
         let prefix = format!("{}.promoting-", root_name.to_string_lossy());
-        let entries = match fs::read_dir(parent) {
+        let entries = match self.vfs.read_dir(parent) {
             Ok(entries) => entries,
             Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err),
         };
         let mut staging = None;
         for entry in entries {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
+            if !entry.is_dir {
                 continue;
             }
-            let file_name = entry.file_name().to_string_lossy().into_owned();
+            let file_name = entry.file_name;
             if !file_name.starts_with(&prefix) {
                 continue;
             }
             if staging.is_some() {
                 return Err(invalid_data("multiple interrupted store fork promotions"));
             }
-            staging = Some(Self { root: entry.path() });
+            staging = Some(Self {
+                root: entry.path,
+                vfs: self.vfs.clone(),
+            });
         }
         Ok(staging)
     }
@@ -616,7 +628,7 @@ impl OperationalManifest {
                 progress.hydrated += 1;
                 continue;
             }
-            if self.collections_dir().join(&entry.path).exists() {
+            if self.vfs.exists(&self.collections_dir().join(&entry.path)) {
                 progress.hydrating += 1;
             } else {
                 progress.shared_by_reference += 1;

--- a/crates/reddb-file/src/operational_manifest/mod.rs
+++ b/crates/reddb-file/src/operational_manifest/mod.rs
@@ -5,11 +5,12 @@
 //! runtime crates do not define persistent manifest formats.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
-use std::io::{self, Write};
+use std::io::{self, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
+
+use crate::{OpenMode, StdVfs, Vfs, VfsFile};
 
 use crate::append_only_segment::{
     append_only_segment_chunk_checksums, decode_append_only_segment, AppendOnlySegmentBloom,
@@ -130,16 +131,51 @@ struct AppendOnlyRetiredState {
 }
 
 #[derive(Debug, Clone)]
-pub struct OperationalManifest {
+pub struct OperationalManifest<V = StdVfs> {
     root: PathBuf,
+    vfs: V,
 }
 
-impl OperationalManifest {
+/// Manifest-owned create operation. Construction durably prepares the physical
+/// collection file; [`publish`](Self::publish) is the only legal next phase.
+pub struct PreparedCollectionCreate<V: Vfs> {
+    manifest: OperationalManifest<V>,
+    name: String,
+}
+
+impl<V: Vfs> PreparedCollectionCreate<V> {
+    pub fn publish(self) -> io::Result<()> {
+        self.manifest.publish_collection_create(&self.name)
+    }
+}
+
+/// Manifest-owned drop operation. Construction durably publishes
+/// `pending_drop`; [`finish`](Self::finish) removes the physical file and then
+/// publishes the final manifest generation.
+pub struct PreparedCollectionDrop<V: Vfs> {
+    manifest: OperationalManifest<V>,
+    name: String,
+}
+
+impl<V: Vfs> PreparedCollectionDrop<V> {
+    pub fn finish(self) -> io::Result<()> {
+        self.manifest.finish_drop_collection(&self.name)
+    }
+}
+
+impl OperationalManifest<StdVfs> {
     pub fn for_db_path(path: &Path) -> Self {
+        Self::with_vfs(path, StdVfs)
+    }
+}
+
+impl<V: Vfs> OperationalManifest<V> {
+    pub fn with_vfs(path: &Path, vfs: V) -> Self {
         let mut root = path.as_os_str().to_os_string();
         root.push(".ops");
         Self {
             root: PathBuf::from(root),
+            vfs,
         }
     }
 
@@ -192,7 +228,7 @@ impl OperationalManifest {
             let fork_referenced_paths = self.fork_referenced_collection_paths()?;
             for (_, path) in &pending_drops {
                 if !fork_referenced_paths.contains(path) {
-                    let _ = fs::remove_file(self.collections_dir().join(path));
+                    let _ = self.vfs.remove_file(&self.collections_dir().join(path));
                 }
             }
             for (name, _) in pending_drops {
@@ -213,7 +249,9 @@ impl OperationalManifest {
             .collect::<Vec<_>>();
         if !pending_segments.is_empty() {
             for entry in &pending_segments {
-                let _ = fs::remove_file(self.append_only_segments_dir().join(&entry.path));
+                let _ = self
+                    .vfs
+                    .remove_file(&self.append_only_segments_dir().join(&entry.path));
                 record_retired_append_only_segment(&mut manifest, entry);
             }
             manifest
@@ -231,7 +269,31 @@ impl OperationalManifest {
     }
 
     pub fn create_collection(&self, name: &str) -> io::Result<()> {
+        self.prepare_collection_create(name)?.publish()
+    }
+
+    pub fn prepare_collection_create(&self, name: &str) -> io::Result<PreparedCollectionCreate<V>> {
         self.ensure_dirs()?;
+        let manifest = self.load_current()?.unwrap_or_else(empty_manifest);
+        if matches!(
+            manifest.collections.get(name).map(|entry| entry.state),
+            Some(CollectionState::Active)
+        ) {
+            return Ok(PreparedCollectionCreate {
+                manifest: self.clone(),
+                name: name.to_string(),
+            });
+        }
+
+        let path = self.collection_file_name(name);
+        self.prepare_collection_file_by_name(&path)?;
+        Ok(PreparedCollectionCreate {
+            manifest: self.clone(),
+            name: name.to_string(),
+        })
+    }
+
+    fn publish_collection_create(&self, name: &str) -> io::Result<()> {
         let mut manifest = self.load_current()?.unwrap_or_else(empty_manifest);
         if matches!(
             manifest.collections.get(name).map(|entry| entry.state),
@@ -239,9 +301,7 @@ impl OperationalManifest {
         ) {
             return Ok(());
         }
-
         let path = self.collection_file_name(name);
-        self.prepare_collection_file_by_name(&path)?;
         manifest.collections.insert(
             name.to_string(),
             CollectionEntry {
@@ -254,21 +314,29 @@ impl OperationalManifest {
         self.publish(&manifest)
     }
 
-    pub fn begin_drop_collection(&self, name: &str) -> io::Result<()> {
+    pub fn prepare_collection_drop(&self, name: &str) -> io::Result<PreparedCollectionDrop<V>> {
         self.ensure_dirs()?;
         let mut manifest = match self.load_current()? {
             Some(manifest) => manifest,
-            None => return Ok(()),
+            None => {
+                return Ok(PreparedCollectionDrop {
+                    manifest: self.clone(),
+                    name: name.to_string(),
+                })
+            }
         };
-        let Some(entry) = manifest.collections.get_mut(name) else {
-            return Ok(());
-        };
-        entry.state = CollectionState::PendingDrop;
-        manifest.generation += 1;
-        self.publish(&manifest)
+        if let Some(entry) = manifest.collections.get_mut(name) {
+            entry.state = CollectionState::PendingDrop;
+            manifest.generation += 1;
+            self.publish(&manifest)?;
+        }
+        Ok(PreparedCollectionDrop {
+            manifest: self.clone(),
+            name: name.to_string(),
+        })
     }
 
-    pub fn finish_drop_collection(&self, name: &str) -> io::Result<()> {
+    fn finish_drop_collection(&self, name: &str) -> io::Result<()> {
         self.ensure_dirs()?;
         let mut manifest = match self.load_current()? {
             Some(manifest) => manifest,
@@ -281,7 +349,9 @@ impl OperationalManifest {
             .fork_referenced_collection_paths()?
             .contains(&entry.path)
         {
-            let _ = fs::remove_file(self.collections_dir().join(entry.path));
+            let _ = self
+                .vfs
+                .remove_file(&self.collections_dir().join(entry.path));
         }
         manifest.generation += 1;
         self.publish(&manifest)
@@ -334,21 +404,18 @@ impl OperationalManifest {
 
         let path = self.append_only_segment_file_name(collection, segment_id);
         let segment_path = self.append_only_segments_dir().join(&path);
-        if segment_path.exists() {
+        if self.vfs.exists(&segment_path) {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!("closed append-only segment already exists: {path}"),
             ));
         }
         {
-            let mut file = OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(&segment_path)?;
+            let mut file = self.vfs.open(&segment_path, OpenMode::create_new())?;
             file.write_all(bytes)?;
             file.sync_all()?;
         }
-        sync_dir(&self.append_only_segments_dir())?;
+        self.vfs.sync_dir(&self.append_only_segments_dir())?;
 
         let entry = AppendOnlySegmentManifestEntry {
             collection: collection.to_string(),
@@ -436,7 +503,9 @@ impl OperationalManifest {
             return Ok(false);
         };
         let entry = manifest.append_only_segments.remove(index);
-        let _ = fs::remove_file(self.append_only_segments_dir().join(&entry.path));
+        let _ = self
+            .vfs
+            .remove_file(&self.append_only_segments_dir().join(&entry.path));
         record_retired_append_only_segment(&mut manifest, &entry);
         manifest.generation += 1;
         self.publish(&manifest)?;
@@ -522,20 +591,20 @@ impl OperationalManifest {
         );
         manifest.generation += 1;
         let bytes = manifest_to_bytes(&manifest)?;
-        fs::write(self.root.join(NEXT_MANIFEST_FILE), bytes)
+        self.write_file(&self.root.join(NEXT_MANIFEST_FILE), &bytes, false)
     }
 
     fn ensure_dirs(&self) -> io::Result<()> {
-        fs::create_dir_all(self.collections_dir())?;
-        fs::create_dir_all(self.append_only_segments_dir())?;
-        fs::create_dir_all(self.quarantine_dir())?;
-        sync_dir(&self.root)?;
+        self.vfs.create_dir_all(&self.collections_dir())?;
+        self.vfs.create_dir_all(&self.append_only_segments_dir())?;
+        self.vfs.create_dir_all(&self.quarantine_dir())?;
+        self.vfs.sync_dir(&self.root)?;
         Ok(())
     }
 
     fn load_current(&self) -> io::Result<Option<Manifest>> {
         let path = self.root.join(MANIFEST_FILE);
-        match fs::read(&path) {
+        match self.read_file(&path) {
             Ok(bytes) => manifest_from_bytes(&bytes).map(Some),
             Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err),
@@ -548,23 +617,19 @@ impl OperationalManifest {
         let next = self.root.join(NEXT_MANIFEST_FILE);
         let bytes = manifest_to_bytes(manifest)?;
         {
-            let mut file = File::create(&next)?;
+            let mut file = self.vfs.open(&next, OpenMode::create_truncate())?;
             file.write_all(&bytes)?;
             file.sync_all()?;
         }
-        fs::rename(&next, &current)?;
-        sync_dir(&self.root)
+        self.vfs.rename(&next, &current)?;
+        self.vfs.sync_dir(&self.root)
     }
 
     fn prepare_collection_file_by_name(&self, file_name: &str) -> io::Result<()> {
         let path = self.collections_dir().join(file_name);
-        let file = OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .write(true)
-            .open(&path)?;
+        let mut file = self.vfs.open(&path, OpenMode::create_keep_write())?;
         file.sync_all()?;
-        sync_dir(&self.collections_dir())
+        self.vfs.sync_dir(&self.collections_dir())
     }
 
     fn quarantine_unreferenced_collection_files(
@@ -588,25 +653,22 @@ impl OperationalManifest {
         dir: &Path,
         active_paths: &BTreeSet<String>,
     ) -> io::Result<()> {
-        if !dir.exists() {
+        if !self.vfs.exists(dir) {
             return Ok(());
         }
-        for entry in fs::read_dir(dir)? {
-            let entry = entry?;
-            let file_type = entry.file_type()?;
-            if !file_type.is_file() {
+        for entry in self.vfs.read_dir(dir)? {
+            if !entry.is_file {
                 continue;
             }
-            let file_name = entry.file_name().to_string_lossy().into_owned();
+            let file_name = entry.file_name;
             if active_paths.contains(&file_name) {
                 continue;
             }
-            let from = entry.path();
-            let to = unique_quarantine_path(&self.quarantine_dir(), &file_name);
-            fs::rename(from, to)?;
+            let to = self.unique_quarantine_path(&file_name);
+            self.vfs.rename(&entry.path, &to)?;
         }
-        sync_dir(dir)?;
-        sync_dir(&self.quarantine_dir())
+        self.vfs.sync_dir(dir)?;
+        self.vfs.sync_dir(&self.quarantine_dir())
     }
 
     fn validate_manifest_artifacts(&self, manifest: &Manifest) -> io::Result<()> {
@@ -615,7 +677,7 @@ impl OperationalManifest {
                 continue;
             }
             if let Some(source) = &entry.source {
-                if !Path::new(source).is_file() {
+                if !self.vfs.is_file(Path::new(source)) {
                     return Err(invalid_data(format!(
                         "missing collection artifact for shared fork source {name}: {source}"
                     )));
@@ -623,7 +685,7 @@ impl OperationalManifest {
                 continue;
             }
             let path = self.collections_dir().join(&entry.path);
-            if !path.is_file() {
+            if !self.vfs.is_file(&path) {
                 return Err(invalid_data(format!(
                     "missing collection artifact for {name}: {}",
                     path.display()
@@ -635,7 +697,7 @@ impl OperationalManifest {
                 continue;
             }
             let path = self.append_only_segments_dir().join(&entry.path);
-            if !path.is_file() {
+            if !self.vfs.is_file(&path) {
                 return Err(invalid_data(format!(
                     "missing append-only artifact for {}/{}: {}",
                     entry.collection,
@@ -645,6 +707,53 @@ impl OperationalManifest {
             }
         }
         Ok(())
+    }
+
+    fn read_file(&self, path: &Path) -> io::Result<Vec<u8>> {
+        let mut file = self.vfs.open(path, OpenMode::read_only())?;
+        file.seek(SeekFrom::Start(0))?;
+        let mut bytes = Vec::new();
+        let mut chunk = [0; 8 * 1024];
+        loop {
+            let read = file.read(&mut chunk)?;
+            if read == 0 {
+                break;
+            }
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+        Ok(bytes)
+    }
+
+    fn write_file(&self, path: &Path, bytes: &[u8], sync: bool) -> io::Result<()> {
+        let mut file = self.vfs.open(path, OpenMode::create_truncate())?;
+        file.write_all(bytes)?;
+        if sync {
+            file.sync_all()?;
+        }
+        Ok(())
+    }
+
+    fn copy_file_durable(&self, source: &Path, dest: &Path) -> io::Result<()> {
+        let bytes = self.read_file(source)?;
+        self.write_file(dest, &bytes, true)?;
+        if let Some(parent) = dest.parent() {
+            self.vfs.sync_dir(parent)?;
+        }
+        Ok(())
+    }
+
+    fn unique_quarantine_path(&self, file_name: &str) -> PathBuf {
+        let mut candidate = self.quarantine_dir().join(file_name);
+        if !self.vfs.exists(&candidate) {
+            return candidate;
+        }
+        for n in 1.. {
+            candidate = self.quarantine_dir().join(format!("{file_name}.{n}"));
+            if !self.vfs.exists(&candidate) {
+                return candidate;
+            }
+        }
+        unreachable!()
     }
 
     fn collections_dir(&self) -> PathBuf {
@@ -1210,20 +1319,6 @@ fn u8_from_u64(value: u64) -> io::Result<u8> {
     u8::try_from(value).map_err(|_| invalid_data(format!("value does not fit u8: {value}")))
 }
 
-fn unique_quarantine_path(dir: &Path, file_name: &str) -> PathBuf {
-    let mut candidate = dir.join(file_name);
-    if !candidate.exists() {
-        return candidate;
-    }
-    for n in 1.. {
-        candidate = dir.join(format!("{file_name}.{n}"));
-        if !candidate.exists() {
-            return candidate;
-        }
-    }
-    unreachable!()
-}
-
 /// Escape an arbitrary name into a single safe path component (no separators),
 /// mirroring the collection-file escaping so a fork name like `tenant/exp 1`
 /// becomes one directory.
@@ -1242,27 +1337,14 @@ fn sanitize_component(name: &str) -> String {
 
 /// Copy a file's bytes to `dest` durably (fsync file + parent dir). Used to
 /// hydrate a fork's private collection copy on copy-on-write.
-fn copy_file_durable(source: &Path, dest: &Path) -> io::Result<()> {
-    let bytes = fs::read(source)?;
-    let mut file = File::create(dest)?;
-    file.write_all(&bytes)?;
-    file.sync_all()?;
-    if let Some(parent) = dest.parent() {
-        sync_dir(parent)?;
-    }
-    Ok(())
-}
-
-fn sync_dir(path: &Path) -> io::Result<()> {
-    File::open(path)?.sync_all()
-}
-
 fn invalid_data(message: impl ToString) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message.to_string())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
 
     fn temp_db_path(name: &str) -> PathBuf {
@@ -1318,7 +1400,7 @@ mod tests {
             .recover_or_bootstrap(&["live".to_string(), "gone".to_string()])
             .unwrap();
         fs::write(manifest.collection_path_for_test("orphan"), b"orphan").unwrap();
-        manifest.begin_drop_collection("gone").unwrap();
+        let _drop = manifest.prepare_collection_drop("gone").unwrap();
 
         let completed = manifest.recover_or_bootstrap(&[]).unwrap();
 
@@ -1349,14 +1431,16 @@ mod tests {
             .to_string_lossy()
             .contains("%2F"));
 
-        manifest.begin_drop_collection("missing").unwrap();
+        let _drop = manifest.prepare_collection_drop("missing").unwrap();
         assert_eq!(
             manifest.read_generation_for_test().unwrap(),
             first_generation
         );
-        manifest.begin_drop_collection("tenant/a b").unwrap();
-        manifest.finish_drop_collection("missing").unwrap();
-        manifest.finish_drop_collection("tenant/a b").unwrap();
+        manifest
+            .prepare_collection_drop("tenant/a b")
+            .unwrap()
+            .finish()
+            .unwrap();
         assert!(!manifest.collection_path_for_test("tenant/a b").exists());
         assert!(manifest.read_generation_for_test().unwrap() > first_generation);
     }
@@ -1419,13 +1503,15 @@ mod tests {
 
     #[test]
     fn unique_quarantine_path_adds_suffix_when_needed() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::write(dir.path().join("orphan.rcol"), b"one").unwrap();
-        fs::write(dir.path().join("orphan.rcol.1"), b"two").unwrap();
+        let path = temp_db_path("unique_quarantine");
+        let manifest = OperationalManifest::for_db_path(&path);
+        manifest.ensure_dirs().unwrap();
+        fs::write(manifest.quarantine_dir().join("orphan.rcol"), b"one").unwrap();
+        fs::write(manifest.quarantine_dir().join("orphan.rcol.1"), b"two").unwrap();
 
         assert_eq!(
-            unique_quarantine_path(dir.path(), "orphan.rcol"),
-            dir.path().join("orphan.rcol.2")
+            manifest.unique_quarantine_path("orphan.rcol"),
+            manifest.quarantine_dir().join("orphan.rcol.2")
         );
     }
 
@@ -1570,7 +1656,7 @@ mod tests {
         write_collection(&parent, "users", b"as-of-fork");
         parent.create_fork("exp", 12).unwrap();
 
-        parent.begin_drop_collection("users").unwrap();
+        let _drop = parent.prepare_collection_drop("users").unwrap();
         let completed = parent.recover_or_bootstrap(&[]).unwrap();
 
         assert_eq!(completed, vec!["users".to_string()]);
@@ -1590,7 +1676,7 @@ mod tests {
         parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
         write_collection(&parent, "users", b"as-of-fork");
         parent.create_fork("exp", 12).unwrap();
-        parent.begin_drop_collection("users").unwrap();
+        let _drop = parent.prepare_collection_drop("users").unwrap();
         parent.recover_or_bootstrap(&[]).unwrap();
 
         assert!(parent.drop_fork("exp").unwrap());
@@ -1703,7 +1789,7 @@ mod tests {
         parent.recover_or_bootstrap(&["users".to_string()]).unwrap();
         write_collection(&parent, "users", b"as-of-fork");
         parent.create_fork("exp", 55).unwrap();
-        parent.begin_drop_collection("users").unwrap();
+        let _drop = parent.prepare_collection_drop("users").unwrap();
         parent.recover_or_bootstrap(&[]).unwrap();
         assert!(parent.collection_path_for_test("users").exists());
 

--- a/crates/reddb-file/src/vfs.rs
+++ b/crates/reddb-file/src/vfs.rs
@@ -6,7 +6,7 @@
 //! alternate implementations without introducing a product-to-test dependency.
 
 use std::io::{self, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// How a file is opened. Mirrors the subset of `OpenOptions` used by durable
 /// writers.
@@ -16,6 +16,7 @@ pub struct OpenMode {
     pub write: bool,
     pub create: bool,
     pub truncate: bool,
+    pub create_new: bool,
 }
 
 impl OpenMode {
@@ -26,6 +27,7 @@ impl OpenMode {
             write: true,
             create: true,
             truncate: true,
+            create_new: false,
         }
     }
 
@@ -37,8 +39,51 @@ impl OpenMode {
             write: true,
             create: true,
             truncate: false,
+            create_new: false,
         }
     }
+
+    /// Open an existing file for reading.
+    pub fn read_only() -> Self {
+        Self {
+            read: true,
+            write: false,
+            create: false,
+            truncate: false,
+            create_new: false,
+        }
+    }
+
+    /// Create a new file for writing, failing when it already exists.
+    pub fn create_new() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: false,
+            truncate: false,
+            create_new: true,
+        }
+    }
+
+    /// Create a file if absent and open it for writing without truncation.
+    pub fn create_keep_write() -> Self {
+        Self {
+            read: false,
+            write: true,
+            create: true,
+            truncate: false,
+            create_new: false,
+        }
+    }
+}
+
+/// One directory entry returned by [`Vfs::read_dir`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VfsDirEntry {
+    pub path: PathBuf,
+    pub file_name: String,
+    pub is_file: bool,
+    pub is_dir: bool,
 }
 
 /// A handle to one open file.
@@ -54,7 +99,7 @@ pub trait VfsFile {
 }
 
 /// A durable-I/O namespace for files and directory entries.
-pub trait Vfs {
+pub trait Vfs: Clone {
     /// The per-file handle this backend produces.
     type File: VfsFile;
 
@@ -64,6 +109,18 @@ pub trait Vfs {
     fn rename(&self, from: &Path, to: &Path) -> io::Result<()>;
     /// Force a directory's entries durable.
     fn sync_dir(&self, dir: &Path) -> io::Result<()>;
+    /// Create a directory and all missing parents.
+    fn create_dir_all(&self, dir: &Path) -> io::Result<()>;
+    /// List the immediate children of a directory.
+    fn read_dir(&self, dir: &Path) -> io::Result<Vec<VfsDirEntry>>;
+    /// Remove one file.
+    fn remove_file(&self, path: &Path) -> io::Result<()>;
+    /// Remove a directory tree.
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()>;
+    /// Return whether a path exists.
+    fn exists(&self, path: &Path) -> bool;
+    /// Return whether a path names a regular file.
+    fn is_file(&self, path: &Path) -> bool;
 }
 
 /// The production filesystem backend.
@@ -100,6 +157,7 @@ impl Vfs for StdVfs {
             .read(mode.read)
             .write(mode.write)
             .create(mode.create)
+            .create_new(mode.create_new)
             .truncate(mode.truncate)
             .open(path)
             .map(StdFile)
@@ -111,5 +169,40 @@ impl Vfs for StdVfs {
 
     fn sync_dir(&self, dir: &Path) -> io::Result<()> {
         std::fs::File::open(dir).and_then(|directory| directory.sync_all())
+    }
+
+    fn create_dir_all(&self, dir: &Path) -> io::Result<()> {
+        std::fs::create_dir_all(dir)
+    }
+
+    fn read_dir(&self, dir: &Path) -> io::Result<Vec<VfsDirEntry>> {
+        std::fs::read_dir(dir)?
+            .map(|entry| {
+                let entry = entry?;
+                let file_type = entry.file_type()?;
+                Ok(VfsDirEntry {
+                    path: entry.path(),
+                    file_name: entry.file_name().to_string_lossy().into_owned(),
+                    is_file: file_type.is_file(),
+                    is_dir: file_type.is_dir(),
+                })
+            })
+            .collect()
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        std::fs::remove_file(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        std::fs::remove_dir_all(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        path.is_file()
     }
 }

--- a/crates/reddb-file/tests/operational_manifest_vfs.rs
+++ b/crates/reddb-file/tests/operational_manifest_vfs.rs
@@ -1,0 +1,189 @@
+use std::io::{self, SeekFrom};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use reddb_file::{OpenMode, OperationalManifest, StdVfs, Vfs, VfsDirEntry, VfsFile};
+
+#[derive(Clone, Default)]
+struct RecordingVfs {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl RecordingVfs {
+    fn events(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+
+    fn record(&self, event: impl Into<String>) {
+        self.events.lock().unwrap().push(event.into());
+    }
+}
+
+struct RecordingFile {
+    file: <StdVfs as Vfs>::File,
+    path: String,
+    vfs: RecordingVfs,
+}
+
+impl VfsFile for RecordingFile {
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.vfs.record(format!("write:{}", self.path));
+        self.file.write_all(buf)
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.file.read(buf)
+    }
+
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.file.seek(pos)
+    }
+
+    fn sync_all(&mut self) -> io::Result<()> {
+        self.vfs.record(format!("sync_file:{}", self.path));
+        self.file.sync_all()
+    }
+}
+
+impl Vfs for RecordingVfs {
+    type File = RecordingFile;
+
+    fn open(&self, path: &Path, mode: OpenMode) -> io::Result<Self::File> {
+        self.record(format!("open:{}", path.display()));
+        StdVfs.open(path, mode).map(|file| RecordingFile {
+            file,
+            path: path.display().to_string(),
+            vfs: self.clone(),
+        })
+    }
+
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        self.record(format!("rename:{}->{}", from.display(), to.display()));
+        StdVfs.rename(from, to)
+    }
+
+    fn sync_dir(&self, dir: &Path) -> io::Result<()> {
+        self.record(format!("sync_dir:{}", dir.display()));
+        StdVfs.sync_dir(dir)
+    }
+
+    fn create_dir_all(&self, dir: &Path) -> io::Result<()> {
+        self.record(format!("create_dir_all:{}", dir.display()));
+        StdVfs.create_dir_all(dir)
+    }
+
+    fn read_dir(&self, dir: &Path) -> io::Result<Vec<VfsDirEntry>> {
+        StdVfs.read_dir(dir)
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        self.record(format!("remove_file:{}", path.display()));
+        StdVfs.remove_file(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        self.record(format!("remove_dir_all:{}", path.display()));
+        StdVfs.remove_dir_all(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        StdVfs.exists(path)
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        StdVfs.is_file(path)
+    }
+}
+
+#[test]
+fn collection_create_orders_physical_durability_before_manifest_publication() {
+    let directory = tempfile::tempdir().unwrap();
+    let db_path = directory.path().join("data.rdb");
+    let vfs = RecordingVfs::default();
+    let manifest = OperationalManifest::with_vfs(&db_path, vfs.clone());
+
+    manifest.create_collection("users").unwrap();
+
+    let events = vfs.events();
+    let physical_sync = events
+        .iter()
+        .position(|event| event.contains("sync_file:") && event.ends_with("users.rcol"))
+        .expect("collection file must be made durable");
+    let manifest_rename = events
+        .iter()
+        .position(|event| {
+            event.contains("manifest.json.next->") && event.ends_with("manifest.json")
+        })
+        .expect("manifest must be atomically published");
+    assert!(
+        physical_sync < manifest_rename,
+        "physical file must be durable before manifest publication: {events:?}"
+    );
+}
+
+#[test]
+fn collection_drop_publishes_pending_before_removing_the_physical_file() {
+    let directory = tempfile::tempdir().unwrap();
+    let db_path = directory.path().join("data.rdb");
+    let vfs = RecordingVfs::default();
+    let manifest = OperationalManifest::with_vfs(&db_path, vfs.clone());
+    manifest.create_collection("users").unwrap();
+    let events_before_drop = vfs.events().len();
+
+    let drop = manifest.prepare_collection_drop("users").unwrap();
+    drop.finish().unwrap();
+
+    let events = &vfs.events()[events_before_drop..];
+    let pending_publish = events
+        .iter()
+        .position(|event| event.contains("manifest.json.next->"))
+        .expect("pending-drop manifest must be published");
+    let physical_remove = events
+        .iter()
+        .position(|event| event.contains("remove_file:") && event.ends_with("users.rcol"))
+        .expect("collection file must be removed");
+    let final_publish = events
+        .iter()
+        .rposition(|event| event.contains("manifest.json.next->"))
+        .expect("final manifest must be published");
+    assert!(
+        pending_publish < physical_remove && physical_remove < final_publish,
+        "drop must publish pending, remove physical, then publish final: {events:?}"
+    );
+}
+
+#[test]
+fn manifest_write_path_has_one_file_owned_ordering_site() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    for relative in [
+        "src/operational_manifest/mod.rs",
+        "src/operational_manifest/fork.rs",
+    ] {
+        let source = std::fs::read_to_string(root.join(relative)).unwrap();
+        let production = source.split("#[cfg(test)]").next().unwrap();
+        for forbidden in ["std::fs", "fs::", "File::", "OpenOptions"] {
+            assert!(
+                !production.contains(forbidden),
+                "manifest writes must use Vfs; found {forbidden:?} in {relative}"
+            );
+        }
+    }
+
+    let server_root = root.join("../reddb-server/src");
+    for relative in [
+        "storage/unified/store/impl_entities.rs",
+        "storage/unified/store/impl_pages.rs",
+    ] {
+        let source = std::fs::read_to_string(server_root.join(relative)).unwrap();
+        for forbidden in [
+            "publish_operational_collection_create",
+            "publish_operational_collection_pending_drop",
+            "publish_operational_collection_drop_finished",
+        ] {
+            assert!(
+                !source.contains(forbidden),
+                "manifest phase reconstruction returned in {relative}: {forbidden}"
+            );
+        }
+    }
+}

--- a/crates/reddb-server/src/storage/operational_manifest.rs
+++ b/crates/reddb-server/src/storage/operational_manifest.rs
@@ -72,7 +72,7 @@ mod tests {
             store.create_collection("gone").unwrap();
         }
         let manifest = OperationalManifest::for_db_path(&path);
-        manifest.begin_drop_collection("gone").unwrap();
+        let _drop = manifest.prepare_collection_drop("gone").unwrap();
 
         let reopened = UnifiedStore::open(&path).unwrap();
         assert!(reopened.get_collection("gone").is_none());

--- a/crates/reddb-server/src/storage/unified/store/impl_entities.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_entities.rs
@@ -257,10 +257,20 @@ impl UnifiedStore {
         collections.insert(name.clone(), Arc::new(manager));
         drop(collections);
 
-        if let Err(err) = self.publish_operational_collection_create(&name) {
-            let mut collections = self.collections.write();
-            collections.remove(&name);
-            return Err(err);
+        let create = match self.prepare_operational_collection_create(&name) {
+            Ok(create) => create,
+            Err(err) => {
+                let mut collections = self.collections.write();
+                collections.remove(&name);
+                return Err(err);
+            }
+        };
+        if let Some(create) = create {
+            if let Err(err) = create.publish().map_err(StoreError::Io) {
+                let mut collections = self.collections.write();
+                collections.remove(&name);
+                return Err(err);
+            }
         }
 
         self.mark_paged_registry_dirty();
@@ -395,7 +405,7 @@ impl UnifiedStore {
 
     /// Drop a collection
     pub fn drop_collection(&self, name: &str) -> Result<(), StoreError> {
-        self.publish_operational_collection_pending_drop(name)?;
+        let drop = self.prepare_operational_collection_drop(name)?;
         let manager = {
             let mut collections = self.collections.write();
 
@@ -436,7 +446,9 @@ impl UnifiedStore {
         self.finish_paged_write([StoreWalAction::DropCollection {
             name: name.to_string(),
         }])?;
-        self.publish_operational_collection_drop_finished(name)?;
+        if let Some(drop) = drop {
+            drop.finish().map_err(StoreError::Io)?;
+        }
 
         Ok(())
     }

--- a/crates/reddb-server/src/storage/unified/store/impl_pages.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_pages.rs
@@ -523,39 +523,29 @@ impl UnifiedStore {
         Ok(())
     }
 
-    pub(crate) fn publish_operational_collection_create(
+    pub(crate) fn prepare_operational_collection_create(
         &self,
         name: &str,
-    ) -> Result<(), StoreError> {
+    ) -> Result<Option<reddb_file::PreparedCollectionCreate<reddb_file::StdVfs>>, StoreError> {
         let Some(path) = &self.db_path else {
-            return Ok(());
+            return Ok(None);
         };
         crate::storage::operational_manifest::OperationalManifest::for_db_path(path)
-            .create_collection(name)
+            .prepare_collection_create(name)
+            .map(Some)
             .map_err(StoreError::Io)
     }
 
-    pub(crate) fn publish_operational_collection_pending_drop(
+    pub(crate) fn prepare_operational_collection_drop(
         &self,
         name: &str,
-    ) -> Result<(), StoreError> {
+    ) -> Result<Option<reddb_file::PreparedCollectionDrop<reddb_file::StdVfs>>, StoreError> {
         let Some(path) = &self.db_path else {
-            return Ok(());
+            return Ok(None);
         };
         crate::storage::operational_manifest::OperationalManifest::for_db_path(path)
-            .begin_drop_collection(name)
-            .map_err(StoreError::Io)
-    }
-
-    pub(crate) fn publish_operational_collection_drop_finished(
-        &self,
-        name: &str,
-    ) -> Result<(), StoreError> {
-        let Some(path) = &self.db_path else {
-            return Ok(());
-        };
-        crate::storage::operational_manifest::OperationalManifest::for_db_path(path)
-            .finish_drop_collection(name)
+            .prepare_collection_drop(name)
+            .map(Some)
             .map_err(StoreError::Io)
     }
 

--- a/crates/unreliable-libc/src/vfs.rs
+++ b/crates/unreliable-libc/src/vfs.rs
@@ -48,7 +48,7 @@
 
 use crate::prng::SplitMix64;
 use reddb_file::dst::{self, FaultClass, FaultDecision, FaultRecord};
-use reddb_file::{OpenMode, Vfs, VfsFile};
+use reddb_file::{OpenMode, Vfs, VfsDirEntry, VfsFile};
 use std::collections::HashMap;
 use std::io::{self, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -580,7 +580,13 @@ impl Vfs for SimVfs {
             return Err(power_cut_error());
         }
         let exists = state.files.contains_key(path);
-        if !exists && !mode.create {
+        if mode.create_new && exists {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "file already exists",
+            ));
+        }
+        if !exists && !mode.create && !mode.create_new {
             return Err(io::Error::new(io::ErrorKind::NotFound, "no such file"));
         }
         let entry = state.files.entry(path.to_path_buf()).or_default();
@@ -644,6 +650,72 @@ impl Vfs for SimVfs {
             file.dirty.clear();
         }
         Ok(())
+    }
+
+    fn create_dir_all(&self, _dir: &Path) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn read_dir(&self, dir: &Path) -> io::Result<Vec<VfsDirEntry>> {
+        let state = self.lock();
+        let mut entries = Vec::new();
+        for path in state.files.keys() {
+            let Ok(relative) = path.strip_prefix(dir) else {
+                continue;
+            };
+            let Some(component) = relative.components().next() else {
+                continue;
+            };
+            let child = dir.join(component);
+            if entries
+                .iter()
+                .any(|entry: &VfsDirEntry| entry.path == child)
+            {
+                continue;
+            }
+            let is_file = path == &child;
+            entries.push(VfsDirEntry {
+                file_name: child
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+                path: child,
+                is_file,
+                is_dir: !is_file,
+            });
+        }
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        Ok(entries)
+    }
+
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        let mut state = self.lock();
+        state
+            .files
+            .remove(path)
+            .map(|_| ())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "file not found"))
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> io::Result<()> {
+        let mut state = self.lock();
+        state
+            .files
+            .retain(|candidate, _| !candidate.starts_with(path));
+        Ok(())
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        let state = self.lock();
+        state.files.contains_key(path)
+            || state
+                .files
+                .keys()
+                .any(|candidate| candidate.starts_with(path))
+    }
+
+    fn is_file(&self, path: &Path) -> bool {
+        self.lock().files.contains_key(path)
     }
 }
 


### PR DESCRIPTION
Automated AFK landing for #2167. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2167

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789094924&installation_model_id=20659&pr_number=2242&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2242&signature=e609df6ff903ebfd4fd5dbbadbbe59285357cf8e6ccd5ba52762b20420df1bb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->