### PR TITLE
merge: #2214 Canonical query envelope emits bare NaN, which our own JSON parser cannot read back

### DIFF
--- a/crates/reddb-server/src/presentation/entity_json.rs
+++ b/crates/reddb-server/src/presentation/entity_json.rs
@@ -67,7 +67,20 @@ pub(crate) fn storage_value_to_json(value: &Value) -> JsonValue {
         Value::Null => JsonValue::Null,
         Value::Integer(value) => exact_i64_to_json(*value),
         Value::UnsignedInteger(value) => exact_u64_to_json(*value),
-        Value::Float(value) => JsonValue::Number(*value),
+        Value::Float(value) if value.is_finite() => JsonValue::Number(*value),
+        // Canonical query envelopes use the same lossless non-finite tags
+        // understood by RedDB drivers. Bare NaN/Infinity are not RFC 8259
+        // JSON and cannot be read back by `crate::json::from_slice`.
+        Value::Float(value) => {
+            let token = if value.is_nan() {
+                "NaN"
+            } else if value.is_sign_positive() {
+                "Infinity"
+            } else {
+                "-Infinity"
+            };
+            single_key_object("$float", JsonValue::String(token.to_string()))
+        }
         Value::Text(value) => JsonValue::String(value.to_string()),
         Value::Blob(value) => JsonValue::String(hex::encode(value)),
         Value::Boolean(value) => JsonValue::Bool(*value),

--- a/crates/reddb-server/src/presentation/query_result.rs
+++ b/crates/reddb-server/src/presentation/query_result.rs
@@ -810,13 +810,17 @@ mod tests {
         let rendered = envelope.to_string_compact();
         let parsed: JsonValue = crate::json::from_slice(rendered.as_bytes())
             .expect("canonical query envelope must parse after encoding");
-        assert_eq!(parsed, envelope);
+        assert_eq!(parsed.to_string_compact(), rendered);
+        let parsed_records = parsed["result"]["records"]
+            .as_array()
+            .expect("parsed canonical query envelope records must be an array");
+        assert_eq!(&parsed_records[0]["values"], values);
 
         let frame = envelope_frame(29, Ok(&result));
         assert_eq!(frame.payload, rendered.as_bytes());
         let parsed_frame: JsonValue = crate::json::from_slice(&frame.payload)
             .expect("RedWire canonical query envelope must parse after encoding");
-        assert_eq!(parsed_frame, envelope);
+        assert_eq!(parsed_frame, parsed);
     }
 
     /// gRPC has a distinct plain-JSON contract, which represents all

--- a/crates/reddb-server/src/presentation/query_result.rs
+++ b/crates/reddb-server/src/presentation/query_result.rs
@@ -702,6 +702,21 @@ mod tests {
         )
     }
 
+    fn non_finite_fixture() -> RuntimeQueryResult {
+        runtime_result(
+            "select",
+            0,
+            result_with(
+                &["nan", "positive_infinity", "negative_infinity"],
+                vec![
+                    Value::Float(f64::NAN),
+                    Value::Float(f64::INFINITY),
+                    Value::Float(f64::NEG_INFINITY),
+                ],
+            ),
+        )
+    }
+
     fn ask_fixture() -> RuntimeQueryResult {
         let result = result_with(
             &["answer", "provider", "model", "citations"],
@@ -771,6 +786,54 @@ mod tests {
             !rendered.contains(r#""rows""#),
             "ASK must not be row-wrapped, got {rendered}"
         );
+    }
+
+    /// HTTP and RedWire QueryWithParams share this canonical envelope.
+    /// Non-finite floats use the drivers' lossless tagged representation,
+    /// keeping the emitted bytes valid JSON and parseable by our own parser.
+    #[test]
+    fn canonical_envelope_non_finite_float_golden_round_trips() {
+        let result = non_finite_fixture();
+        let envelope = json(&result, &None, &None);
+        let records = envelope["result"]["records"]
+            .as_array()
+            .expect("canonical query envelope records must be an array");
+        let values = &records[0]["values"];
+        assert_eq!(
+            values.to_string_compact(),
+            concat!(
+                r#"{"nan":{"$float":"NaN"},"negative_infinity":{"$float":"-Infinity"},"#,
+                r#""positive_infinity":{"$float":"Infinity"}}"#
+            )
+        );
+
+        let rendered = envelope.to_string_compact();
+        let parsed: JsonValue = crate::json::from_slice(rendered.as_bytes())
+            .expect("canonical query envelope must parse after encoding");
+        assert_eq!(parsed, envelope);
+
+        let frame = envelope_frame(29, Ok(&result));
+        assert_eq!(frame.payload, rendered.as_bytes());
+        let parsed_frame: JsonValue = crate::json::from_slice(&frame.payload)
+            .expect("RedWire canonical query envelope must parse after encoding");
+        assert_eq!(parsed_frame, envelope);
+    }
+
+    /// gRPC has a distinct plain-JSON contract, which represents all
+    /// non-finite floats as null rather than adopting canonical tags.
+    #[test]
+    fn grpc_non_finite_float_golden_uses_null() {
+        let reply = proto_reply(non_finite_fixture(), &None, &None);
+        assert_eq!(
+            reply.result_json,
+            concat!(
+                r#"{"columns":["nan","positive_infinity","negative_infinity"],"#,
+                r#""record_count":1,"selection":{"scope":"any"},"records":[{"#,
+                r#""nan":null,"positive_infinity":null,"negative_infinity":null}]}"#
+            )
+        );
+        let _: JsonValue = crate::json::from_slice(reply.result_json.as_bytes())
+            .expect("gRPC result_json must remain parseable JSON");
     }
 
     /// Byte golden for the gRPC target: top-level key order stays


### PR DESCRIPTION
Automated AFK landing for #2214. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2214

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789100270&installation_model_id=20659&pr_number=2244&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2244&signature=b59c39a85484adad88310bb1c1bee59d46caa067d2c35789f2b0e3f50306b48e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->