### PR TITLE
merge: #2219 Replica-loop race clobbers seeded state in handlers_replication tests

### DIFF
--- a/crates/reddb-server/src/api.rs
+++ b/crates/reddb-server/src/api.rs
@@ -213,6 +213,8 @@ pub struct RedDBOptions {
     pub remote_key: Option<String>,
     /// Replication configuration.
     pub replication: ReplicationConfig,
+    /// Whether replica runtimes start the background replication loop.
+    pub replica_loop_enabled: bool,
     /// Authentication & authorization configuration.
     pub auth: AuthConfig,
     /// Control Event Ledger configuration (issue #652). Read from
@@ -282,6 +284,7 @@ impl fmt::Debug for RedDBOptions {
             .field("remote_backend", &backend_name)
             .field("remote_key", &self.remote_key)
             .field("replication", &self.replication)
+            .field("replica_loop_enabled", &self.replica_loop_enabled)
             .field("auth", &self.auth)
             .field("control_events", &self.control_events)
             .field("query_audit", &self.query_audit)
@@ -317,6 +320,7 @@ impl Clone for RedDBOptions {
             remote_backend_atomic: self.remote_backend_atomic.clone(),
             remote_key: self.remote_key.clone(),
             replication: self.replication.clone(),
+            replica_loop_enabled: self.replica_loop_enabled,
             auth: self.auth.clone(),
             control_events: self.control_events,
             query_audit: self.query_audit.clone(),
@@ -361,6 +365,7 @@ impl Default for RedDBOptions {
             remote_backend_atomic: None,
             remote_key: None,
             replication: ReplicationConfig::standalone(),
+            replica_loop_enabled: true,
             auth: AuthConfig::default(),
             control_events: crate::runtime::control_events::ControlEventConfig::default(),
             query_audit: crate::runtime::query_audit::QueryAuditConfig::default(),
@@ -570,6 +575,11 @@ impl RedDBOptions {
 
     pub fn with_replication(mut self, config: ReplicationConfig) -> Self {
         self.replication = config;
+        self
+    }
+
+    pub fn with_replica_loop_enabled(mut self, enabled: bool) -> Self {
+        self.replica_loop_enabled = enabled;
         self
     }
 

--- a/crates/reddb-server/src/runtime/impl_lifecycle.rs
+++ b/crates/reddb-server/src/runtime/impl_lifecycle.rs
@@ -949,9 +949,10 @@ impl RedDBRuntime {
             }
         }
 
-        if let crate::replication::ReplicationRole::Replica { primary_addr } =
-            runtime.inner.db.options().replication.role.clone()
-        {
+        if let (true, crate::replication::ReplicationRole::Replica { primary_addr }) = (
+            runtime.inner.db.options().replica_loop_enabled,
+            runtime.inner.db.options().replication.role.clone(),
+        ) {
             let rt = runtime.clone();
             std::thread::Builder::new()
                 .name("reddb-replica".into())

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -397,7 +397,7 @@ mod tests {
     use crate::runtime::RedDBRuntime;
     use crate::RedDBOptions;
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn temp_data_path(name: &str) -> PathBuf {
         let suffix = SystemTime::now()
@@ -445,12 +445,27 @@ mod tests {
     fn replica_runtime_without_loop_preserves_seeded_rejoin_rewind_state() {
         let runtime = replica_waiting_for_rejoin_rewind();
 
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        std::thread::sleep(Duration::from_millis(300));
 
         assert_eq!(
             runtime.config_string("red.replication.state", ""),
             "rejoin_rewind_required"
         );
+    }
+
+    #[test]
+    fn replica_runtime_starts_replica_loop_by_default() {
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory()
+                .with_replication(ReplicationConfig::replica("http://127.0.0.1:1")),
+        )
+        .expect("runtime");
+        let deadline = Instant::now() + Duration::from_secs(5);
+
+        while runtime.config_string("red.replication.state", "") != "connecting" {
+            assert!(Instant::now() < deadline, "replica loop did not start");
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/crates/reddb-server/src/server/handlers_replication.rs
+++ b/crates/reddb-server/src/server/handlers_replication.rs
@@ -423,6 +423,7 @@ mod tests {
     fn replica_waiting_for_rejoin_rewind() -> RedDBRuntime {
         let runtime = RedDBRuntime::with_options(
             RedDBOptions::in_memory()
+                .with_replica_loop_enabled(false)
                 .with_replication(ReplicationConfig::replica("http://primary:5050")),
         )
         .expect("runtime");
@@ -438,6 +439,18 @@ mod tests {
             }),
         );
         runtime
+    }
+
+    #[test]
+    fn replica_runtime_without_loop_preserves_seeded_rejoin_rewind_state() {
+        let runtime = replica_waiting_for_rejoin_rewind();
+
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        assert_eq!(
+            runtime.config_string("red.replication.state", ""),
+            "rejoin_rewind_required"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Automated AFK landing for #2219. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2219

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789102177&installation_model_id=20659&pr_number=2245&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2245&signature=2e5c95f807080810c8a9aaaf9b2294ae7b3ad864fbf568b66753ce6bdf92d813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->