### PR TITLE
merge: #2060 SUM/AVG accept different types on the planner vs legacy aggregate route: BIGINT, BOOLEAN and non-finite FLOAT diverge

### DIFF
--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -45,6 +45,22 @@ use table::{
     take_last_segment_scan_stats, RuntimeTableExecutionContext,
 };
 
+/// Convert values accepted by `SUM` and `AVG` into their accumulator form.
+///
+/// Both aggregate execution routes use this function so their accepted types
+/// and IEEE 754 behavior cannot drift apart.
+fn aggregate_value_to_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Integer(value) => Some(*value as f64),
+        Value::UnsignedInteger(value) => Some(*value as f64),
+        Value::BigInt(value) => Some(*value as f64),
+        Value::Float(value) => Some(*value),
+        Value::Decimal(value) => Some(reddb_types::types::decimal_to_f64(*value)),
+        Value::Boolean(value) => Some(if *value { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
 pub(crate) use row_stream::{RowBufferArena, RowStream, DEFAULT_HIGH_WATER_MARK};
 
 /// Public table-query entry. Produces its result through the #806

--- a/crates/reddb-server/src/runtime/query_exec/aggregate.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate.rs
@@ -486,7 +486,7 @@ pub(crate) fn execute_aggregate_query(
                 }
             };
             let Some(val) = val else { continue };
-            let num = value_to_f64(&val);
+            let num = super::aggregate_value_to_f64(&val);
 
             match slot {
                 ProjSlot::CountStar => {}
@@ -1620,7 +1620,7 @@ fn render_aggregate_argument_key(arg: &Projection) -> String {
 fn resolve_static_projection_number(arg: Option<&Projection>) -> Option<f64> {
     let record = UnifiedRecord::new();
     let value = eval_projection_value_with_db(None, arg?, &record)?;
-    value_to_f64(&value)
+    super::aggregate_value_to_f64(&value)
 }
 
 fn resolve_static_projection_text(arg: Option<&Projection>) -> Option<String> {
@@ -2072,17 +2072,6 @@ pub(super) fn update_extreme_value_slot(
         None => {
             *slot = Some(candidate.clone());
         }
-    }
-}
-
-pub(crate) fn value_to_f64(val: &Value) -> Option<f64> {
-    match val {
-        Value::Integer(n) => Some(*n as f64),
-        Value::UnsignedInteger(n) => Some(*n as f64),
-        Value::BigInt(n) => Some(*n as f64),
-        Value::Float(f) => Some(*f),
-        Value::Decimal(d) => Some(reddb_types::types::decimal_to_f64(*d)),
-        _ => None,
     }
 }
 
@@ -3166,7 +3155,7 @@ fn try_execute_parallel_single_col_numeric_aggs(
                         let Some(value) = accessor.get_value(entity) else {
                             continue;
                         };
-                        let Some(num) = value_to_f64(value.as_ref()) else {
+                        let Some(num) = super::aggregate_value_to_f64(value.as_ref()) else {
                             continue;
                         };
                         if let Some(sum) = group.sums.get_mut(*slot) {
@@ -3627,6 +3616,141 @@ mod parallel_group_by_tests {
             "expected at least one group record"
         );
         assert!(total > 0, "expected some rows past filter");
+    }
+}
+
+#[cfg(test)]
+mod aggregate_numeric_route_parity_tests {
+    use crate::storage::unified::{EntityData, EntityId, EntityKind, RowData, UnifiedEntity};
+    use crate::{RedDBOptions, RedDBRuntime};
+    use reddb_types::Value;
+    use std::collections::HashMap;
+
+    const PLANNER_SUM_QUERY: &str = "SELECT bucket, SUM(value) FROM samples GROUP BY bucket";
+    const PLANNER_AVG_QUERY: &str = "SELECT bucket, AVG(value) FROM samples GROUP BY bucket";
+    // HAVING is deliberately outside the push-down and parallel fast-path
+    // envelopes, so these otherwise equivalent queries force the legacy route.
+    const LEGACY_SUM_QUERY: &str =
+        "SELECT bucket, SUM(value) FROM samples GROUP BY bucket HAVING COUNT(*) > 0";
+    const LEGACY_AVG_QUERY: &str =
+        "SELECT bucket, AVG(value) FROM samples GROUP BY bucket HAVING COUNT(*) > 0";
+
+    fn runtime_with_table(value_type: &str) -> RedDBRuntime {
+        let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory())
+            .expect("in-memory runtime should open");
+        runtime
+            .execute_query(&format!(
+                "CREATE TABLE samples (bucket TEXT, value {value_type})"
+            ))
+            .expect("table should be created");
+        runtime
+    }
+
+    fn insert(runtime: &RedDBRuntime, bucket: &str, value: Value) {
+        let named = HashMap::from([
+            ("bucket".to_string(), Value::text(bucket)),
+            ("value".to_string(), value),
+        ]);
+        let entity = UnifiedEntity::new(
+            EntityId::new(0),
+            EntityKind::TableRow {
+                table: "samples".into(),
+                row_id: 0,
+            },
+            EntityData::Row(RowData {
+                columns: Vec::new(),
+                named: Some(named),
+                schema: None,
+            }),
+        );
+        runtime
+            .db()
+            .store()
+            .insert("samples", entity)
+            .expect("typed aggregate input should be inserted");
+    }
+
+    fn aggregate_rows(runtime: &RedDBRuntime, query: &str) -> Vec<(String, f64)> {
+        let result = runtime
+            .execute_query(query)
+            .expect("aggregate query should run");
+        let aggregate_column = result
+            .result
+            .columns
+            .iter()
+            .find(|column| column.as_str() != "bucket")
+            .expect("aggregate column label")
+            .clone();
+        let mut rows = result
+            .result
+            .records
+            .iter()
+            .map(|record| {
+                let Value::Text(bucket) = record.get("bucket").expect("bucket output") else {
+                    panic!("bucket should be text")
+                };
+                (
+                    bucket.to_string(),
+                    number(record.get(&aggregate_column).expect("aggregate output")),
+                )
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        rows
+    }
+
+    fn number(value: &Value) -> f64 {
+        match value {
+            Value::Integer(value) => *value as f64,
+            Value::UnsignedInteger(value) => *value as f64,
+            Value::BigInt(value) => *value as f64,
+            Value::Float(value) => *value,
+            other => panic!("expected numeric aggregate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sum_and_avg_bigint_agree_on_planner_and_legacy_routes() {
+        let runtime = runtime_with_table("BIGINT");
+        insert(&runtime, "all", Value::BigInt(10));
+        insert(&runtime, "all", Value::BigInt(20));
+
+        let expected_sum = vec![("all".to_string(), 30.0)];
+        let expected_avg = vec![("all".to_string(), 15.0)];
+        assert_eq!(aggregate_rows(&runtime, PLANNER_SUM_QUERY), expected_sum);
+        assert_eq!(aggregate_rows(&runtime, LEGACY_SUM_QUERY), expected_sum);
+        assert_eq!(aggregate_rows(&runtime, PLANNER_AVG_QUERY), expected_avg);
+        assert_eq!(aggregate_rows(&runtime, LEGACY_AVG_QUERY), expected_avg);
+    }
+
+    #[test]
+    fn sum_boolean_counts_true_values_on_planner_and_legacy_routes() {
+        let runtime = runtime_with_table("BOOLEAN");
+        insert(&runtime, "all", Value::Boolean(true));
+        insert(&runtime, "all", Value::Boolean(false));
+        insert(&runtime, "all", Value::Boolean(true));
+
+        let planner = aggregate_rows(&runtime, PLANNER_SUM_QUERY);
+        let legacy = aggregate_rows(&runtime, LEGACY_SUM_QUERY);
+        assert_eq!(planner[0].1, 2.0);
+        assert_eq!(legacy[0].1, 2.0);
+    }
+
+    #[test]
+    fn nonfinite_float_propagates_on_planner_and_legacy_routes() {
+        let runtime = runtime_with_table("FLOAT");
+        insert(&runtime, "infinity", Value::Float(1.0));
+        insert(&runtime, "infinity", Value::Float(f64::INFINITY));
+        insert(&runtime, "nan", Value::Float(1.0));
+        insert(&runtime, "nan", Value::Float(f64::NAN));
+
+        for query in [PLANNER_SUM_QUERY, LEGACY_SUM_QUERY] {
+            let rows = aggregate_rows(&runtime, query);
+            assert_eq!(rows[0].0, "infinity");
+            assert_eq!(rows[0].1, f64::INFINITY);
+            assert_eq!(rows[1].0, "nan");
+            assert!(rows[1].1.is_nan());
+        }
     }
 }
 

--- a/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
+++ b/crates/reddb-server/src/runtime/query_exec/aggregate_planner/accumulator.rs
@@ -106,7 +106,7 @@ impl GroupAccumulator {
                 }
                 Slot::Sum { sum, seen_any } => {
                     if let Some(v) = inputs.get(expr.input_index) {
-                        if let Some(n) = numeric_value(v) {
+                        if let Some(n) = super::super::aggregate_value_to_f64(v) {
                             *sum += n;
                             *seen_any = true;
                         }
@@ -114,7 +114,7 @@ impl GroupAccumulator {
                 }
                 Slot::Avg { sum, count } => {
                     if let Some(v) = inputs.get(expr.input_index) {
-                        if let Some(n) = numeric_value(v) {
+                        if let Some(n) = super::super::aggregate_value_to_f64(v) {
                             *sum += n;
                             *count += 1;
                         }
@@ -173,30 +173,6 @@ fn sum_f64_to_value(f: f64) -> Value {
     }
 }
 
-/// Cast a `Value` into `f64` for SUM/AVG. NULL and non-numeric
-/// values yield `None`; the caller decides how to react (skip, or
-/// flip the all-NULL flag). Mirrors the casts the legacy path
-/// performs in `aggregate.rs::value_to_f64`, but kept private to
-/// this module so the planner has no dependency on the legacy
-/// internals.
-///
-/// That claim used to be false for `Decimal`: this cast was raw while the
-/// legacy path divided by the fixed scale, so `SUM`/`AVG` over a `DECIMAL`
-/// column returned results differing by 10^4 depending on which route the
-/// planner picked (#2058). Both now go through `schema::decimal_to_f64`, and
-/// `decimal_sum_agrees_with_the_legacy_aggregate_path` pins them together —
-/// duplicating the match arms is what let them drift silently.
-fn numeric_value(v: &Value) -> Option<f64> {
-    match v {
-        Value::Integer(i) => Some(*i as f64),
-        Value::UnsignedInteger(u) => Some(*u as f64),
-        Value::Float(f) if f.is_finite() => Some(*f),
-        Value::Decimal(d) => Some(reddb_types::types::decimal_to_f64(*d)),
-        Value::Boolean(b) => Some(if *b { 1.0 } else { 0.0 }),
-        _ => None,
-    }
-}
-
 /// Update `current` if `candidate` extends `target_ordering`.
 ///
 /// `Ordering::Less` → MIN behaviour (replace when candidate < current).
@@ -236,8 +212,7 @@ fn update_extreme(current: &mut Option<Value>, candidate: &Value, target: std::c
 
 #[cfg(test)]
 mod tests {
-    use super::numeric_value;
-    use crate::runtime::query_exec::aggregate::value_to_f64;
+    use super::super::super::aggregate_value_to_f64;
     use reddb_types::Value;
 
     /// The planner's `SUM`/`AVG` cast and the legacy path's must agree on
@@ -251,50 +226,70 @@ mod tests {
     #[test]
     fn decimal_sum_agrees_with_the_legacy_aggregate_path() {
         let cases = [
-            Value::Decimal(387_600),   // 38.76
-            Value::Decimal(-771_500),  // -77.15
-            Value::Decimal(1_234_567), // 123.4567 — the rendering test's value
-            Value::Decimal(0),
-            Value::Decimal(i64::MAX),
-            Value::Decimal(i64::MIN),
-            Value::Integer(42),
-            Value::UnsignedInteger(7),
-            Value::Float(1.5),
-            Value::Null,
+            (Value::Decimal(387_600), Some(38.76)),
+            (Value::Decimal(-771_500), Some(-77.15)),
+            (Value::Decimal(1_234_567), Some(123.4567)),
+            (Value::Decimal(0), Some(0.0)),
+            (
+                Value::Decimal(i64::MAX),
+                Some(reddb_types::types::decimal_to_f64(i64::MAX)),
+            ),
+            (
+                Value::Decimal(i64::MIN),
+                Some(reddb_types::types::decimal_to_f64(i64::MIN)),
+            ),
+            (Value::Integer(42), Some(42.0)),
+            (Value::UnsignedInteger(7), Some(7.0)),
+            (Value::Float(1.5), Some(1.5)),
+            (Value::Null, None),
         ];
-        for value in cases {
+        for (value, expected) in cases {
             assert_eq!(
-                numeric_value(&value),
-                value_to_f64(&value),
-                "planner and legacy aggregate casts disagree on {value:?}"
+                aggregate_value_to_f64(&value),
+                expected,
+                "shared aggregate cast changed for {value:?}"
             );
         }
     }
 
-    /// Types the two routes still disagree on, tracked in #2060.
-    ///
-    /// This documents current behaviour; it does not endorse it. `SUM` over a
-    /// `BIGINT` column returning a number on one route and `NULL` on the other
-    /// is a defect, but closing it means deciding whether `SUM(boolean)` is
-    /// supported at all and how non-finite floats aggregate — semantics calls
-    /// rather than mechanical edits, so #2058 fixed only the `Decimal` arm and
-    /// left these visible instead of silently narrowing the pin above.
-    ///
-    /// When #2060 is fixed this test will fail. That is the point: update it
-    /// then, and fold the surviving cases into the agreement test.
+    enum Expected {
+        Number(Option<f64>),
+        Nan,
+    }
+
+    /// The planner and legacy routes must accept the same complete value matrix.
     #[test]
-    fn planner_and_legacy_diverge_on_bigint_boolean_and_nonfinite_float() {
-        // The planner has no BigInt arm; the legacy path does.
-        assert_eq!(numeric_value(&Value::BigInt(9)), None);
-        assert_eq!(value_to_f64(&Value::BigInt(9)), Some(9.0));
+    fn planner_and_legacy_agree_on_the_complete_value_matrix() {
+        let cases = [
+            (Value::Integer(-3), Expected::Number(Some(-3.0))),
+            (Value::UnsignedInteger(4), Expected::Number(Some(4.0))),
+            (Value::BigInt(9), Expected::Number(Some(9.0))),
+            (Value::Float(1.5), Expected::Number(Some(1.5))),
+            (Value::Float(f64::NAN), Expected::Nan),
+            (
+                Value::Float(f64::INFINITY),
+                Expected::Number(Some(f64::INFINITY)),
+            ),
+            (
+                Value::Float(f64::NEG_INFINITY),
+                Expected::Number(Some(f64::NEG_INFINITY)),
+            ),
+            (Value::Decimal(1_234_567), Expected::Number(Some(123.4567))),
+            (Value::Boolean(true), Expected::Number(Some(1.0))),
+            (Value::Boolean(false), Expected::Number(Some(0.0))),
+            (Value::Text("not numeric".into()), Expected::Number(None)),
+            (Value::Null, Expected::Number(None)),
+        ];
 
-        // The planner counts booleans; the legacy path rejects them.
-        assert_eq!(numeric_value(&Value::Boolean(true)), Some(1.0));
-        assert_eq!(value_to_f64(&Value::Boolean(true)), None);
-
-        // The planner guards on `is_finite`; the legacy path does not.
-        assert_eq!(numeric_value(&Value::Float(f64::NAN)), None);
-        assert!(value_to_f64(&Value::Float(f64::NAN)).is_some_and(f64::is_nan));
+        for (value, expected) in cases {
+            let converted = aggregate_value_to_f64(&value);
+            match expected {
+                Expected::Number(expected) => {
+                    assert_eq!(converted, expected, "unexpected cast for {value:?}")
+                }
+                Expected::Nan => assert!(converted.is_some_and(f64::is_nan)),
+            }
+        }
     }
 
     /// A `DECIMAL` read for aggregation must equal what the engine renders and
@@ -302,6 +297,9 @@ mod tests {
     #[test]
     fn decimal_aggregation_matches_the_rendered_value() {
         // `Decimal(1_234_567)` renders as "123.4567" (pinned in entity_json).
-        assert_eq!(numeric_value(&Value::Decimal(1_234_567)), Some(123.4567));
+        assert_eq!(
+            aggregate_value_to_f64(&Value::Decimal(1_234_567)),
+            Some(123.4567)
+        );
     }
 }


### PR DESCRIPTION
Automated AFK landing for #2060. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2060

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789135127&installation_model_id=20659&pr_number=2247&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2247&signature=b09161ba04f6497a698a6fc572ad255611b8d32886f79e377835349eb8af1875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->