### PR TITLE
merge: #2152 Fix the WHERE fallback that swallows evaluation errors

### DIFF
--- a/crates/reddb-server/src/runtime/evaluator_differential.rs
+++ b/crates/reddb-server/src/runtime/evaluator_differential.rs
@@ -8,7 +8,8 @@ use std::collections::HashMap;
 
 use super::expr_eval::evaluate_runtime_expr;
 use super::join_filter::{
-    evaluate_runtime_filter, resolve_runtime_field, runtime_partial_cmp, runtime_values_equal,
+    evaluate_runtime_filter_result_with_db, resolve_runtime_field, runtime_partial_cmp,
+    runtime_values_equal,
 };
 use crate::storage::query::ast::{BinOp, CompareOp, Expr, FieldRef, Filter as RuntimeFilter, Span};
 use crate::storage::query::engine::binding::Value as BindingValue;
@@ -389,7 +390,16 @@ fn eval_runtime_filter_adapter(case: &Case) -> String {
     let Some((filter, record)) = runtime_filter_fixture(case) else {
         return "unsupported".to_string();
     };
-    evaluate_runtime_filter(&record, &filter, None, None).to_string()
+    match evaluate_runtime_filter_result_with_db(None, &record, &filter, None, None) {
+        Ok(value) => value.to_string(),
+        Err(crate::RedDBError::Query(message)) if message.contains("arithmetic overflow") => {
+            "error:overflow".to_string()
+        }
+        Err(crate::RedDBError::Query(message)) if message.contains("division by zero") => {
+            "error:division-by-zero".to_string()
+        }
+        Err(error) => format!("error:{error}"),
+    }
 }
 
 fn eval_legacy_filter(case: &Case) -> String {
@@ -523,6 +533,18 @@ fn runtime_filter_fixture(case: &Case) -> Option<(RuntimeFilter, UnifiedRecord)>
                 RuntimeFilter::And(Box::new(left), Box::new(right))
             } else {
                 RuntimeFilter::Or(Box::new(left), Box::new(right))
+            }
+        }
+        CaseKind::Binary { op, .. }
+            if matches!(
+                op,
+                BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod
+            ) =>
+        {
+            RuntimeFilter::CompareExpr {
+                lhs: expression_for(case)?,
+                op: CompareOp::Eq,
+                rhs: Expr::lit(Value::Boolean(true)),
             }
         }
         CaseKind::Like { value, pattern } => {

--- a/crates/reddb-server/src/runtime/join_filter/filter.rs
+++ b/crates/reddb-server/src/runtime/join_filter/filter.rs
@@ -33,8 +33,19 @@ pub(in crate::runtime) fn evaluate_runtime_filter_with_db(
     table_name: Option<&str>,
     table_alias: Option<&str>,
 ) -> bool {
+    evaluate_runtime_filter_result_with_db(db, record, filter, table_name, table_alias)
+        .unwrap_or(false)
+}
+
+pub(in crate::runtime) fn evaluate_runtime_filter_result_with_db(
+    db: Option<&RedDB>,
+    record: &UnifiedRecord,
+    filter: &Filter,
+    table_name: Option<&str>,
+    table_alias: Option<&str>,
+) -> crate::RedDBResult<bool> {
     match filter {
-        Filter::Compare { field, op, value } => {
+        Filter::Compare { field, op, value } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .and_then(|candidate| evaluate_metadata_field_compare(field, candidate, *op, value))
@@ -44,61 +55,88 @@ pub(in crate::runtime) fn evaluate_runtime_filter_with_db(
                         .map(|candidate| compare_runtime_values(candidate, value, *op))
                 })
                 .unwrap_or(false)
-        }
+        }),
         Filter::CompareFields { left, op, right } => {
             let left_value = resolve_runtime_field(record, left, table_name, table_alias);
             let right_value = resolve_runtime_field(record, right, table_name, table_alias);
-            match (left_value, right_value) {
+            Ok(match (left_value, right_value) {
                 (Some(l), Some(r)) => compare_runtime_values(&l, &r, *op),
                 _ => false,
-            }
+            })
         }
         Filter::CompareExpr { lhs, op, rhs } => {
-            // Route through the typed evaluator (catalog-resolved
-            // operator / cast / function dispatch). Falls back to the
-            // untyped expr_eval walker for CONFIG / KV / ML_* and any
-            // other shape the evaluator does not cover yet.
+            // Route through the typed evaluator. Only unsupported runtime
+            // functions may use the db-aware walker; data and type errors
+            // are part of WHERE semantics and must reach the caller.
             let row = RecordRow {
                 record,
                 table_name,
                 table_alias,
             };
-            let eval_side = |expr| {
-                crate::storage::query::evaluator::evaluate(expr, &row)
-                    .ok()
-                    .or_else(|| {
-                        super::expr_eval::evaluate_runtime_expr_with_db(
-                            db,
-                            expr,
-                            record,
-                            table_name,
-                            table_alias,
-                        )
-                    })
+            let eval_side = |expr| -> crate::RedDBResult<Option<Value>> {
+                match crate::storage::query::evaluator::evaluate(expr, &row) {
+                    Ok(value) => Ok(Some(value)),
+                    Err(crate::storage::query::evaluator::EvalError::UnknownFunction {
+                        ..
+                    }) => Ok(super::expr_eval::evaluate_runtime_expr_with_db(
+                        db,
+                        expr,
+                        record,
+                        table_name,
+                        table_alias,
+                    )),
+                    Err(error) => Err(crate::RedDBError::Query(error.to_string())),
+                }
             };
-            match (eval_side(lhs), eval_side(rhs)) {
+            Ok(match (eval_side(lhs)?, eval_side(rhs)?) {
                 (Some(lv), Some(rv)) => compare_runtime_values(&lv, &rv, *op),
                 _ => false,
-            }
+            })
         }
         Filter::And(left, right) => {
-            evaluate_runtime_filter_with_db(db, record, left, table_name, table_alias)
-                && evaluate_runtime_filter_with_db(db, record, right, table_name, table_alias)
+            Ok(
+                evaluate_runtime_filter_result_with_db(db, record, left, table_name, table_alias)?
+                    && evaluate_runtime_filter_result_with_db(
+                        db,
+                        record,
+                        right,
+                        table_name,
+                        table_alias,
+                    )?,
+            )
         }
         Filter::Or(left, right) => {
-            evaluate_runtime_filter_with_db(db, record, left, table_name, table_alias)
-                || evaluate_runtime_filter_with_db(db, record, right, table_name, table_alias)
+            Ok(
+                evaluate_runtime_filter_result_with_db(db, record, left, table_name, table_alias)?
+                    || evaluate_runtime_filter_result_with_db(
+                        db,
+                        record,
+                        right,
+                        table_name,
+                        table_alias,
+                    )?,
+            )
         }
-        Filter::Not(inner) => {
-            !evaluate_runtime_filter_with_db(db, record, inner, table_name, table_alias)
+        Filter::Not(inner) => Ok(!evaluate_runtime_filter_result_with_db(
+            db,
+            record,
+            inner,
+            table_name,
+            table_alias,
+        )?),
+        Filter::IsNull(field) => Ok(
+            resolve_runtime_field(record, field, table_name, table_alias)
+                .map(|value| value == Value::Null)
+                .unwrap_or(true),
+        ),
+        Filter::IsNotNull(field) => {
+            Ok(
+                resolve_runtime_field(record, field, table_name, table_alias)
+                    .map(|value| value != Value::Null)
+                    .unwrap_or(false),
+            )
         }
-        Filter::IsNull(field) => resolve_runtime_field(record, field, table_name, table_alias)
-            .map(|value| value == Value::Null)
-            .unwrap_or(true),
-        Filter::IsNotNull(field) => resolve_runtime_field(record, field, table_name, table_alias)
-            .map(|value| value != Value::Null)
-            .unwrap_or(false),
-        Filter::In { field, values } => {
+        Filter::In { field, values } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .is_some_and(|candidate| {
@@ -108,38 +146,38 @@ pub(in crate::runtime) fn evaluate_runtime_filter_with_db(
                             .any(|value| compare_runtime_values(candidate, value, CompareOp::Eq))
                     })
                 })
-        }
-        Filter::Between { field, low, high } => {
+        }),
+        Filter::Between { field, low, high } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .is_some_and(|candidate| {
                     compare_runtime_values(candidate, low, CompareOp::Ge)
                         && compare_runtime_values(candidate, high, CompareOp::Le)
                 })
-        }
-        Filter::Like { field, pattern } => {
+        }),
+        Filter::Like { field, pattern } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .and_then(runtime_value_text)
                 .is_some_and(|value| like_matches(&value, pattern))
-        }
-        Filter::StartsWith { field, prefix } => {
+        }),
+        Filter::StartsWith { field, prefix } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .and_then(runtime_value_text)
                 .is_some_and(|value| value.starts_with(prefix))
-        }
-        Filter::EndsWith { field, suffix } => {
+        }),
+        Filter::EndsWith { field, suffix } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .and_then(runtime_value_text)
                 .is_some_and(|value| value.ends_with(suffix))
-        }
-        Filter::Contains { field, substring } => {
+        }),
+        Filter::Contains { field, substring } => Ok({
             resolve_runtime_field(record, field, table_name, table_alias)
                 .as_ref()
                 .is_some_and(|value| runtime_value_contains(value, substring))
-        }
+        }),
     }
 }
 

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -120,15 +120,16 @@ fn execute_runtime_table_query_materialized(
         && effective_having.is_none()
     {
         let source = UnifiedRecord::new();
-        let filter_matches = effective_filter.as_ref().is_none_or(|filter| {
-            super::join_filter::evaluate_runtime_filter_with_db(
+        let filter_matches = match effective_filter.as_ref() {
+            Some(filter) => super::join_filter::evaluate_runtime_filter_result_with_db(
                 Some(db),
                 &source,
                 filter,
                 None,
                 None,
-            )
-        });
+            )?,
+            None => true,
+        };
         let mut records = if filter_matches {
             vec![project_scalar_via_evaluator(
                 Some(db),

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -46,6 +46,31 @@ fn record_segment_scan_stats(stats: SegmentScanStats) {
     LAST_SEGMENT_SCAN_STATS.with(|slot| slot.set(stats));
 }
 
+fn filter_records_result(
+    records: Vec<UnifiedRecord>,
+    mut matches: impl FnMut(&UnifiedRecord) -> RedDBResult<bool>,
+) -> RedDBResult<Vec<UnifiedRecord>> {
+    let mut filtered = Vec::with_capacity(records.len());
+    for record in records {
+        if matches(&record)? {
+            filtered.push(record);
+        }
+    }
+    Ok(filtered)
+}
+
+fn runtime_filter_contains_compare_expr(filter: &Filter) -> bool {
+    match filter {
+        Filter::CompareExpr { .. } => true,
+        Filter::And(left, right) | Filter::Or(left, right) => {
+            runtime_filter_contains_compare_expr(left)
+                || runtime_filter_contains_compare_expr(right)
+        }
+        Filter::Not(inner) => runtime_filter_contains_compare_expr(inner),
+        _ => false,
+    }
+}
+
 fn compiled_entity_filter_matches(
     db: &RedDB,
     compiled: &super::filter_compiled::CompiledEntityFilter,
@@ -530,15 +555,15 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                 // back onto the inner projection keys.
                 let outer_alias = query.alias.as_deref();
                 if let Some(ref outer_filter) = effective_filter {
-                    records.retain(|record| {
-                        super::super::join_filter::evaluate_runtime_filter_with_db(
+                    records = filter_records_result(records, |record| {
+                        super::super::join_filter::evaluate_runtime_filter_result_with_db(
                             Some(db),
                             record,
                             outer_filter,
                             outer_alias,
                             outer_alias,
                         )
-                    });
+                    })?;
                 }
 
                 // Outer ORDER BY: sort the materialised records
@@ -1365,6 +1390,9 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     let tag_index_can_filter = tag_series_candidates_for_filter.is_some();
 
     if effective_filter.is_some()
+        && !effective_filter
+            .as_ref()
+            .is_some_and(runtime_filter_contains_compare_expr)
         && (!effective_filter
             .as_ref()
             .is_some_and(|filter| runtime_filter_uses_document_path(filter, query))
@@ -1893,6 +1921,9 @@ pub(crate) fn execute_runtime_canonical_table_node(
             // creating UnifiedRecord for entities that match the filter.
             // Skip for universal sources ("any") which need cross-collection scanning.
             if effective_filter.is_some()
+                && !effective_filter
+                    .as_ref()
+                    .is_some_and(runtime_filter_contains_compare_expr)
                 && !effective_filter.as_ref().is_some_and(|filter| {
                     runtime_filter_uses_document_path(filter, context.query)
                 })
@@ -2043,15 +2074,15 @@ pub(crate) fn execute_runtime_canonical_table_node(
 
             let mut records = execute_runtime_canonical_table_child(db, node, context)?;
             if let Some(filter) = effective_filter.as_ref() {
-                records.retain(|record| {
-                    super::super::join_filter::evaluate_runtime_filter_with_db(
+                records = filter_records_result(records, |record| {
+                    super::super::join_filter::evaluate_runtime_filter_result_with_db(
                         Some(db),
                         record,
                         filter,
                         Some(context.table_name),
                         Some(context.table_alias),
                     )
-                });
+                })?;
             }
             Ok(records)
         }
@@ -2069,21 +2100,24 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 // root column the document path traverses; the resolver
                 // already parses JSON-in-TEXT, and an unresolvable path
                 // is excluded by the predicate itself.
-                records.retain(|record| {
-                    (runtime_record_has_document_capability(record)
+                records = filter_records_result(records, |record| {
+                    if !(runtime_record_has_document_capability(record)
                         || runtime_record_carries_filter_document_roots(
                             record,
                             filter,
                             context.query,
                         ))
-                        && evaluate_runtime_filter_with_db(
-                            Some(db),
-                            record,
-                            filter,
-                            Some(context.table_name),
-                            Some(context.table_alias),
-                        )
-                });
+                    {
+                        return Ok(false);
+                    }
+                    evaluate_runtime_filter_result_with_db(
+                        Some(db),
+                        record,
+                        filter,
+                        Some(context.table_name),
+                        Some(context.table_alias),
+                    )
+                })?;
             }
             Ok(records)
         }
@@ -2701,6 +2735,29 @@ mod tests {
     fn exec(rt: &RedDBRuntime, sql: &str) {
         rt.execute_query(sql)
             .unwrap_or_else(|err| panic!("{sql}: {err:?}"));
+    }
+
+    #[test]
+    fn where_arithmetic_errors_do_not_switch_evaluators() {
+        let rt = rt();
+        exec(&rt, "CREATE TABLE where_errors (id INT)");
+        exec(&rt, "INSERT INTO where_errors (id) VALUES (1)");
+
+        let overflow = rt
+            .execute_query("SELECT id FROM where_errors WHERE 9223372036854775807 + 1 > 0")
+            .expect_err("WHERE integer overflow must propagate");
+        assert!(
+            overflow.to_string().contains("arithmetic overflow"),
+            "unexpected overflow error: {overflow}"
+        );
+
+        let division = rt
+            .execute_query("SELECT id FROM where_errors WHERE 1 / 0 > 0")
+            .expect_err("WHERE division by zero must propagate");
+        assert!(
+            division.to_string().contains("division by zero"),
+            "unexpected division error: {division}"
+        );
     }
 
     fn rid(rt: &RedDBRuntime, table: &str, id: i64) -> u64 {

--- a/crates/reddb-server/tests/fixtures/evaluator_divergence_matrix_v1.md
+++ b/crates/reddb-server/tests/fixtures/evaluator_divergence_matrix_v1.md
@@ -31,8 +31,8 @@ The table covers the known LIKE case/byte, NULL equality and 3VL, overflow, divi
 | integer boundaries / i64::MAX = same u64 | `true` | `true` | `true` | `false` | `false` | `true` | `true` | `unsupported` |
 | integer boundaries / i64::MIN < -1 | `true` | `true` | `true` | `true` | `true` | `true` | `true` | `true` |
 | integer boundaries / i64::MAX < u64::MAX | `error:implicit cast UnsignedInteger -> Integer failed: number too large to fit in target type` | `true` | `true` | `true` | `true` | `true` | `true` | `unsupported` |
-| arithmetic errors / i64::MAX + 1 | `error:overflow` | `i64:9223372036854775807` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` |
-| arithmetic errors / 1 / 0 | `error:division-by-zero` | `none` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` |
+| arithmetic errors / i64::MAX + 1 | `error:overflow` | `i64:9223372036854775807` | `error:overflow` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` |
+| arithmetic errors / 1 / 0 | `error:division-by-zero` | `none` | `error:division-by-zero` | `unsupported` | `unsupported` | `unsupported` | `unsupported` | `unsupported` |
 | numeric coercion / Integer(5) = Text(5) | `error:operator Eq not defined for (Integer, Text)` | `true` | `true` | `false` | `false` | `false` | `true` | `false` |
 | decimal / Decimal(1.0000) = DecimalText(1) | `error:operator Eq not defined for (Decimal, DecimalText)` | `false` | `false` | `false` | `false` | `true` | `false` | `unsupported` |
 | decimal / DecimalText(2) < DecimalText(10) | `error:operator Lt not defined for (DecimalText, DecimalText)` | `false` | `false` | `true` | `true` | `true` | `false` | `unsupported` |


### PR DESCRIPTION
Automated AFK landing for #2152. Per-attempt history lives in the issue Envelopes, the local ledgers, and pushed worker-branch commits.

Closes #2152

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789252962&installation_model_id=20659&pr_number=2252&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2252&signature=2691daf0a17f216a50de9f8b473542d36b2ceb61dbd3deb5ad65882cf98ff9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->