### PR TITLE
fix(afk): pre_merge hook writes its report to stderr, not stdout

### DIFF
--- a/scripts/afk-pre-merge.sh
+++ b/scripts/afk-pre-merge.sh
@@ -6,12 +6,19 @@
 # routes the issue to `ready-for-human` with `blocked:validation`
 # and the offending lines end up in the envelope.
 #
-# Contract (see ADR 0062):
+# Contract (see ADR 0062, and the hook table in the dev plugin's
+# `afk/docs/CONFIG.md` which is the authority on the stdio protocol):
 #   - Input:  RED_AFK_WORKTREE_PATH env + (optional) unified diff on
 #             stdin. The harness guarantees the worktree is on the
 #             worker branch with the attempt's commits applied.
-#   - Output: human-readable report on stdout. The AFK captures it
-#             for the envelope; we do NOT mutate context here.
+#   - Output: report goes to STDERR. Stdout is the engine's structured
+#             channel: "empty stdout -> context unchanged; JSON object
+#             -> AFK replaces the mutable slice; non-JSON stdout is a
+#             parse failure". We do NOT mutate context here, so stdout
+#             must stay empty. Printing the report to stdout aborted
+#             the merge and mislabelled it `merge-conflict` — it cost
+#             10 workers a full attempt each on 2026-08-13
+#             (red-skills#3862). Keep every report line `>&2`.
 #   - Exit:   0 = merge allowed; non-zero = merge BLOCKED.
 #             `pre_*` non-zero aborts the step, which is the gate.
 #
@@ -78,7 +85,7 @@ failed=0
 check() {
     local title="$1"
     local detail="$2"
-    printf '[FAIL] %s\n%s\n\n' "$title" "$detail"
+    printf '[FAIL] %s\n%s\n\n' "$title" "$detail" >&2
     failed=1
 }
 
@@ -191,5 +198,5 @@ if [ "$failed" -ne 0 ]; then
 fi
 
 printf 'pre_merge: OK (%s files, base=%s head=%s)\n' \
-    "$NUM_CHANGED" "$BASE" "$HEAD"
+    "$NUM_CHANGED" "$BASE" "$HEAD" >&2
 exit 0


### PR DESCRIPTION
## What broke

The dev plugin's hook protocol (`afk/docs/CONFIG.md`) makes a hook's **stdout** the structured channel:

> empty stdout → context unchanged; JSON object on stdout → AFK replaces the mutable slice; **non-JSON stdout is treated as a parse failure**.

`scripts/afk-pre-merge.sh` mutates no context, so its stdout must be empty — but it printed its human-readable report there, on both the success path and the `[FAIL]` path.

So the engine aborted **every** merge with `pre_merge-abort`, even though the hook exited `0` and approved the merge:

```
pre_merge: exit rc=0: scripts/afk-pre-merge.sh          <- approved
pre_merge: non-JSON stdout (parse failure)
worker.blocked {"outcome":"merge-conflict","reason":"pre_merge-abort"}
```

## Cost

**Ten workers on 2026-08-13**, each dying at the last step *after* completing and validating its work — one at `+189/-82` over 58 tool calls and ~59 minutes. Each left a pushed branch with no PR:

```
[afk] orphaned work: afk/2152-fix-the-where-fallback-... - 5 commits ahead of the base, no open pull request
```

And because `blocked:merge-conflict` is outside the machine-authority requeue set, every occurrence escalated to a human `/hitl` gate for a conflict that never existed.

## The fix

Two `printf`s get `>&2`. Stdout is now empty (verified: 0 bytes, `rc=0`), and the report still reaches the envelope — the engine captures stderr, as the `worker.stderr` lane entries show.

### On the header's contract text

The header claimed `Output: human-readable report on stdout` under a `see ADR 0062` attribution. **ADR 0062 says no such thing.** Its `pre_merge` section specifies only the five drift-guard checks and their thresholds; the ADR never mentions a stdio channel at all (`grep -E 'stdout|report|Output'` over the file returns nothing). That line was this script's own invention, misattributed.

So there is no conflicting ADR to repair — a claim an earlier revision of this PR description made, incorrectly. The header now cites `CONFIG.md` as the stdio authority and keeps ADR 0062 as the authority for the checks, which is what it actually governs, and records the incident so the line is not reintroduced.

The `printf` inside the awk program (new-dependency check) is deliberately untouched: it writes to awk's stdout, captured into a shell variable, not to the hook's stdout.

## Verification

```
$ out=$(bash scripts/afk-pre-merge.sh 2>/dev/null); echo "rc=$? bytes=$(printf '%s' "$out" | wc -c)"
rc=0 bytes=0
$ bash scripts/afk-pre-merge.sh 2>&1 >/dev/null
pre_merge: OK (0 files, base=origin/main head=HEAD)
```

The other two wired hooks were checked and are correct as-is: `afk-pre-attempt.sh` and `afk-pre-pick.sh` emit JSON on stdout **on purpose**, because they do mutate their context slices.

Refs reddb-io/red-skills#3862