### PR TITLE
perf(storage): index secondary unique constraints

### DIFF
--- a/crates/reddb-server/src/application/collection_contract_enforcer.rs
+++ b/crates/reddb-server/src/application/collection_contract_enforcer.rs
@@ -665,10 +665,13 @@ fn find_row_uniqueness_conflict(
     let Some(manager) = db.store().get_collection(collection) else {
         return Ok(None);
     };
-    let mut rules = resolved_uniqueness_rules(&contract);
+    let rules = resolved_uniqueness_rules(&contract);
+    let columns: Vec<Vec<String>> = rules.iter().map(|rule| rule.columns.clone()).collect();
     if let Some(target) = target {
-        rules.retain(|rule| uniqueness_columns_match(&rule.columns, target));
-        if rules.is_empty() {
+        if !rules
+            .iter()
+            .any(|rule| uniqueness_columns_match(&rule.columns, target))
+        {
             return Err(crate::RedDBError::Query(format!(
                 "no unique or primary-key constraint on collection '{}' matches ON CONFLICT ({})",
                 collection,
@@ -685,8 +688,11 @@ fn find_row_uniqueness_conflict(
     let reserves_key = |entity: &crate::storage::UnifiedEntity| {
         snapshot_manager.row_reserves_unique_key(entity.xmin, entity.xmax, &own_xids)
     };
-    for rule in rules {
-        let mut expected = Vec::new();
+    for (key_index, rule) in rules.into_iter().enumerate() {
+        if target.is_some_and(|target| !uniqueness_columns_match(&rule.columns, target)) {
+            continue;
+        }
+        let mut signatures = Vec::new();
         let mut skip_rule = false;
         for column in &rule.columns {
             match input_fields.get(column.as_str()).copied() {
@@ -700,47 +706,19 @@ fn find_row_uniqueness_conflict(
                     skip_rule = true;
                     break;
                 }
-                Some(value) => expected.push((column, value, value_signature(value))),
+                Some(value) => signatures.push(value_signature(value)),
             }
         }
         if skip_rule {
             continue;
         }
-        if rule.primary_key {
-            let signatures: Vec<String> = expected
-                .into_iter()
-                .map(|(_, _, signature)| signature)
-                .collect();
-            if let Some(entity_id) = manager.find_primary_key_conflict(
-                &rule.columns,
-                &signatures,
-                exclude_id,
-                &reserves_key,
-            ) {
-                return Ok(Some(UniquenessConflict { rule, entity_id }));
-            }
-            continue;
-        }
-        let mut conflict_id = None;
-        // Borrow rows under the manager's existing read locks. Checking a key
-        // must not clone every entity and every unrelated payload in the table.
-        manager.for_each_entity(|entity| {
-            if exclude_id == Some(entity.id) {
-                return true;
-            }
-            let crate::storage::EntityData::Row(row) = &entity.data else {
-                return true;
-            };
-            let duplicate = expected.iter().all(|(column, expected, signature)| {
-                row.get_field(column)
-                    .is_some_and(|value| uniqueness_value_matches(value, expected, signature))
-            }) && reserves_key(entity);
-            if duplicate {
-                conflict_id = Some(entity.id);
-            }
-            !duplicate
-        });
-        if let Some(entity_id) = conflict_id {
+        if let Some(entity_id) = manager.find_unique_key_conflict(
+            &columns,
+            key_index,
+            &signatures,
+            exclude_id,
+            &reserves_key,
+        ) {
             return Ok(Some(UniquenessConflict { rule, entity_id }));
         }
     }
@@ -1162,19 +1140,6 @@ fn resolved_uniqueness_rules(
 
 fn value_signature(value: &Value) -> String {
     format!("{value:?}")
-}
-
-fn uniqueness_value_matches(value: &Value, expected: &Value, expected_signature: &str) -> bool {
-    // Compare common schema-normalized keys without formatting every stored
-    // row. Keep the existing signature semantics for other kinds, including
-    // floating-point NaNs and signed zero; Value equality differs there.
-    match (value, expected) {
-        (Value::Integer(left), Value::Integer(right)) => left == right,
-        (Value::UnsignedInteger(left), Value::UnsignedInteger(right)) => left == right,
-        (Value::Text(left), Value::Text(right)) => left == right,
-        (Value::Boolean(left), Value::Boolean(right)) => left == right,
-        _ => value_signature(value) == expected_signature,
-    }
 }
 
 fn normalize_contract_value(

--- a/crates/reddb-server/src/storage/unified/manager.rs
+++ b/crates/reddb-server/src/storage/unified/manager.rs
@@ -1213,19 +1213,21 @@ impl SegmentManager {
         self.visibility_map.mark_range_visible(start_page, end_page);
     }
 
-    /// Probe the primary-key lookup of each segment under the same entity
+    /// Probe a unique-key lookup in each segment under the same entity
     /// locks used by scans and writes. Lookup state is rebuilt lazily after
     /// recovery, consolidation, or a key-changing mutation.
-    pub(crate) fn find_primary_key_conflict(
+    pub(crate) fn find_unique_key_conflict(
         &self,
-        columns: &[String],
+        columns: &[Vec<String>],
+        key_index: usize,
         signatures: &[String],
         exclude_id: Option<EntityId>,
         reserves_key: &impl Fn(&UnifiedEntity) -> bool,
     ) -> Option<EntityId> {
         if let Some(growing) = self.growing.read().as_ref() {
-            if let Some(id) = growing.read().find_primary_key_conflict(
+            if let Some(id) = growing.read().find_unique_key_conflict(
                 columns,
+                key_index,
                 signatures,
                 exclude_id,
                 reserves_key,
@@ -1234,8 +1236,9 @@ impl SegmentManager {
             }
         }
         for segment in self.sealed.read().iter() {
-            if let Some(id) = segment.read().find_primary_key_conflict(
+            if let Some(id) = segment.read().find_unique_key_conflict(
                 columns,
+                key_index,
                 signatures,
                 exclude_id,
                 reserves_key,

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -49,7 +49,7 @@ pub mod manager;
 pub mod metadata;
 pub mod segment;
 pub mod segment_codec;
-mod segment_primary_key;
+mod segment_unique_key;
 pub mod store;
 pub mod tokenization;
 pub(super) mod visibility_map;

--- a/crates/reddb-server/src/storage/unified/segment.rs
+++ b/crates/reddb-server/src/storage/unified/segment.rs
@@ -34,7 +34,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::entity::{CrossRef, EntityData, EntityId, EntityKind, RefType, UnifiedEntity};
 use super::metadata::{Metadata, MetadataStorage};
-use super::segment_primary_key::SegmentPrimaryKey;
+use super::segment_unique_key::SegmentUniqueKey;
 use crate::storage::query::value_compare::partial_compare_values;
 use reddb_types::{value_to_canonical_key, CanonicalKey, Value};
 
@@ -455,10 +455,10 @@ pub struct GrowingSegment {
 
     /// Primary key index: (collection, pk_value) → EntityId
     pk_index: BTreeMap<(String, String), EntityId>,
-    /// Lazy schema-aware primary-key lookup, independent of the legacy
+    /// Lazy schema-aware unique-key lookups, independent of the legacy
     /// first-column index. Protected by the owning segment's entity lock.
-    primary_key_lookup: parking_lot::RwLock<Option<SegmentPrimaryKey>>,
-    primary_key_lookup_bytes: AtomicU64,
+    unique_key_lookup: parking_lot::RwLock<Vec<SegmentUniqueKey>>,
+    unique_key_lookup_bytes: AtomicU64,
     /// Type index: kind → EntityIds
     kind_index: HashMap<String, HashSet<EntityId>>,
     /// Cross-reference index: source → Vec<(target, ref_type)>
@@ -573,8 +573,8 @@ impl GrowingSegment {
             deleted: HashSet::new(),
             metadata: MetadataStorage::new(),
             pk_index: BTreeMap::new(),
-            primary_key_lookup: parking_lot::RwLock::new(None),
-            primary_key_lookup_bytes: AtomicU64::new(0),
+            unique_key_lookup: parking_lot::RwLock::new(Vec::new()),
+            unique_key_lookup_bytes: AtomicU64::new(0),
             kind_index: HashMap::new(),
             cross_ref_forward: HashMap::new(),
             cross_ref_reverse: HashMap::new(),
@@ -621,7 +621,7 @@ impl GrowingSegment {
         &mut self,
         entity: &UnifiedEntity,
     ) -> Result<UpdateIndexSnapshot, SegmentError> {
-        self.invalidate_primary_key_lookup();
+        self.invalidate_unique_key_lookup();
         if self.use_flat {
             let raw = entity.id.raw();
             if raw >= self.base_entity_id {
@@ -715,7 +715,7 @@ impl GrowingSegment {
     ///
     /// Returns `false` when the entity was already tombstoned.
     fn tombstone_flat_entity(&mut self, idx: usize, id: EntityId) -> bool {
-        self.invalidate_primary_key_lookup();
+        self.invalidate_unique_key_lookup();
         if !self.deleted.insert(id) {
             return false;
         }
@@ -731,7 +731,7 @@ impl GrowingSegment {
     ///
     /// Returns `false` when the entity is not present.
     fn remove_hashmap_entity(&mut self, id: EntityId) -> bool {
-        self.invalidate_primary_key_lookup();
+        self.invalidate_unique_key_lookup();
         let Some(entity) = self.entities.remove(&id) else {
             return false;
         };
@@ -796,7 +796,7 @@ impl GrowingSegment {
     /// does not pay `O(entities)` to observe memory.
     pub fn memory_bytes(&self) -> u64 {
         self.memory_bytes.load(Ordering::Relaxed)
-            + self.primary_key_lookup_bytes.load(Ordering::Relaxed)
+            + self.unique_key_lookup_bytes.load(Ordering::Relaxed)
     }
 
     /// Release a resident entity's payload from the memory estimate. Only for
@@ -895,7 +895,7 @@ impl GrowingSegment {
     /// segment, when the swap discovers a copied row was deleted from its
     /// source mid-consolidation. A tombstone here would defeat the whole point.
     pub(crate) fn evict_entity(&mut self, id: EntityId) -> bool {
-        self.invalidate_primary_key_lookup();
+        self.invalidate_unique_key_lookup();
         let Some(entity) = self.entities.remove(&id) else {
             return false;
         };
@@ -1069,11 +1069,17 @@ impl GrowingSegment {
 
     /// Index an entity
     fn index_entity(&mut self, entity: &UnifiedEntity) {
-        if let Some(index) = self.primary_key_lookup.get_mut().as_mut() {
+        let indexes = self.unique_key_lookup.get_mut();
+        for index in indexes.iter_mut() {
             index.insert(entity);
-            self.primary_key_lookup_bytes
-                .store(index.memory_bytes() as u64, Ordering::Relaxed);
         }
+        self.unique_key_lookup_bytes.store(
+            indexes
+                .iter()
+                .map(|index| index.memory_bytes() as u64)
+                .sum(),
+            Ordering::Relaxed,
+        );
         // Kind index
         let kind_key = entity.kind.storage_type().to_string();
         self.kind_index
@@ -1104,46 +1110,59 @@ impl GrowingSegment {
         }
     }
 
-    /// Find a physical row by the declared primary-key columns. The same
-    /// physical rows participate as in `for_each_fast`; MVCC conflict policy
-    /// belongs to the caller. Build once, then maintain on append. Mutations
-    /// that can replace or remove keys discard this derived structure.
-    pub(crate) fn find_primary_key_conflict(
+    /// Probe one declared UNIQUE/PRIMARY KEY against physical rows. Cache all
+    /// current definitions together so alternating constraints never rebuilds
+    /// the same segment. Schema changes replace the set; mutations invalidate it.
+    /// The caller owns MVCC conflict policy and null-key admission.
+    pub(crate) fn find_unique_key_conflict(
         &self,
-        columns: &[String],
+        columns: &[Vec<String>],
+        key_index: usize,
         signatures: &[String],
         exclude_id: Option<EntityId>,
         reserves_key: &impl Fn(&UnifiedEntity) -> bool,
     ) -> Option<EntityId> {
-        let cached = self.primary_key_lookup.read();
-        if let Some(index) = cached.as_ref().filter(|index| index.columns == columns) {
-            return self.find_primary_key_candidate(index, signatures, exclude_id, reserves_key);
+        assert!(
+            key_index < columns.len(),
+            "constraint index belongs to current schema"
+        );
+        let cached = self.unique_key_lookup.read();
+        if cached.iter().map(|index| &index.columns).eq(columns.iter()) {
+            return self.find_unique_key_candidate(
+                &cached[key_index],
+                signatures,
+                exclude_id,
+                reserves_key,
+            );
         }
         drop(cached);
-        let mut cached = self.primary_key_lookup.write();
-        if cached.as_ref().is_none_or(|index| index.columns != columns) {
-            let mut index = SegmentPrimaryKey::new(columns);
+        let mut cached = self.unique_key_lookup.write();
+        if !cached.iter().map(|index| &index.columns).eq(columns.iter()) {
+            let mut indexes: Vec<_> = columns
+                .iter()
+                .map(|columns| SegmentUniqueKey::new(columns))
+                .collect();
             self.for_each_fast(|entity| {
-                index.insert(entity);
+                for index in &mut indexes {
+                    index.insert(entity);
+                }
                 true
             });
-            self.primary_key_lookup_bytes
-                .store(index.memory_bytes() as u64, Ordering::Relaxed);
-            *cached = Some(index);
+            self.unique_key_lookup_bytes.store(
+                indexes
+                    .iter()
+                    .map(|index| index.memory_bytes() as u64)
+                    .sum(),
+                Ordering::Relaxed,
+            );
+            *cached = indexes;
         }
-        self.find_primary_key_candidate(
-            cached
-                .as_ref()
-                .expect("primary-key lookup initialized above"),
-            signatures,
-            exclude_id,
-            reserves_key,
-        )
+        self.find_unique_key_candidate(&cached[key_index], signatures, exclude_id, reserves_key)
     }
 
-    fn find_primary_key_candidate(
+    fn find_unique_key_candidate(
         &self,
-        index: &SegmentPrimaryKey,
+        index: &SegmentUniqueKey,
         signatures: &[String],
         exclude_id: Option<EntityId>,
         reserves_key: &impl Fn(&UnifiedEntity) -> bool,
@@ -1173,9 +1192,9 @@ impl GrowingSegment {
         })
     }
 
-    fn invalidate_primary_key_lookup(&mut self) {
-        *self.primary_key_lookup.get_mut() = None;
-        self.primary_key_lookup_bytes.store(0, Ordering::Relaxed);
+    fn invalidate_unique_key_lookup(&mut self) {
+        *self.unique_key_lookup.get_mut() = Vec::new();
+        self.unique_key_lookup_bytes.store(0, Ordering::Relaxed);
     }
 
     /// Check whether an early-exit probe key exists in this segment.
@@ -1336,13 +1355,19 @@ impl GrowingSegment {
             return Err(SegmentError::NotWritable);
         }
 
-        if let Some(index) = self.primary_key_lookup.get_mut().as_mut() {
+        let indexes = self.unique_key_lookup.get_mut();
+        for index in indexes.iter_mut() {
             for entity in &entities {
                 index.insert(entity);
             }
-            self.primary_key_lookup_bytes
-                .store(index.memory_bytes() as u64, Ordering::Relaxed);
         }
+        self.unique_key_lookup_bytes.store(
+            indexes
+                .iter()
+                .map(|index| index.memory_bytes() as u64)
+                .sum(),
+            Ordering::Relaxed,
+        );
 
         let n = entities.len();
 
@@ -1612,7 +1637,7 @@ impl UnifiedSegment for GrowingSegment {
     }
 
     fn get_mut(&mut self, id: EntityId) -> Option<&mut UnifiedEntity> {
-        self.invalidate_primary_key_lookup();
+        self.invalidate_unique_key_lookup();
         if self.deleted.contains(&id) || !self.state.is_writable() {
             return None;
         }
@@ -1959,8 +1984,9 @@ mod tests {
         key: Value,
         exclude: Option<EntityId>,
     ) -> Option<EntityId> {
-        segment.find_primary_key_conflict(
-            &["primary".into()],
+        segment.find_unique_key_conflict(
+            &[vec!["primary".into()]],
+            0,
             &[format!("{key:?}")],
             exclude,
             &|_| true,
@@ -1968,7 +1994,7 @@ mod tests {
     }
 
     #[test]
-    fn primary_key_lookup_follows_segment_mutations_and_sealing() {
+    fn unique_key_lookup_follows_segment_mutations_and_sealing() {
         let mut segment = GrowingSegment::new(1, "keys");
         segment
             .bulk_insert(vec![primary_key_row(1, Value::Integer(10))])
@@ -1996,7 +2022,7 @@ mod tests {
         segment
             .update_hot(primary_key_row(1, Value::Integer(11)), &["primary".into()])
             .expect("replace flat key");
-        assert_eq!(segment.primary_key_lookup_bytes.load(Ordering::Relaxed), 0);
+        assert_eq!(segment.unique_key_lookup_bytes.load(Ordering::Relaxed), 0);
         assert_eq!(primary_key_probe(&segment, Value::Integer(10), None), None);
         assert_eq!(
             primary_key_probe(&segment, Value::Integer(11), None),
@@ -2029,7 +2055,71 @@ mod tests {
     }
 
     #[test]
-    fn primary_key_lookup_preserves_signature_semantics_and_exclusion() {
+    fn unique_lookup_retains_all_current_definitions_and_rechecks_candidates() {
+        let mut segment = GrowingSegment::new(1, "keys");
+        segment
+            .bulk_insert(vec![
+                primary_key_row(1, Value::Integer(10)),
+                primary_key_row(2, Value::Integer(20)),
+            ])
+            .expect("initial rows");
+        let definitions = vec![
+            vec!["primary".into()],
+            vec!["payload".into()],
+            vec!["primary".into(), "payload".into()],
+        ];
+        let payload = format!("{:?}", Value::text("payload"));
+        assert_eq!(
+            segment.find_unique_key_conflict(
+                &definitions,
+                1,
+                &[payload.clone()],
+                None,
+                &|entity| entity.id != EntityId::new(1)
+            ),
+            Some(EntityId::new(2))
+        );
+        assert_eq!(segment.unique_key_lookup.read().len(), 3);
+        segment
+            .insert(primary_key_row(3, Value::Integer(30)))
+            .expect("append");
+        assert_eq!(
+            segment.find_unique_key_conflict(
+                &definitions,
+                2,
+                &[format!("{:?}", Value::Integer(30)), payload.clone()],
+                None,
+                &|_| true
+            ),
+            Some(EntityId::new(3))
+        );
+        let bytes = segment.unique_key_lookup_bytes.load(Ordering::Relaxed);
+        assert_eq!(
+            segment.find_unique_key_conflict(
+                &definitions,
+                0,
+                &[format!("{:?}", Value::Integer(20))],
+                None,
+                &|_| true
+            ),
+            Some(EntityId::new(2))
+        );
+        assert_eq!(segment.unique_key_lookup.read().len(), 3);
+        assert_eq!(
+            segment.unique_key_lookup_bytes.load(Ordering::Relaxed),
+            bytes
+        );
+        let reduced = vec![vec!["payload".into()]];
+        assert_eq!(
+            segment.find_unique_key_conflict(&reduced, 0, &[payload], None, &|_| true),
+            Some(EntityId::new(1))
+        );
+        assert_eq!(segment.unique_key_lookup.read().len(), 1);
+        assert!(segment.unique_key_lookup_bytes.load(Ordering::Relaxed) < bytes);
+    }
+
+    #[test]
+    fn unique_key_lookup_preserves_signature_semantics_and_exclusion() {
         let mut segment = GrowingSegment::new(1, "keys");
         let values = [
             Value::Float(f64::NAN),

--- a/crates/reddb-server/src/storage/unified/segment_unique_key.rs
+++ b/crates/reddb-server/src/storage/unified/segment_unique_key.rs
@@ -1,17 +1,17 @@
-//! Disposable primary-key lookup for a segment. Fingerprints only narrow the
+//! Disposable unique-key lookup for a segment. Fingerprints only narrow the
 //! candidate set; the caller checks the complete key before accepting a match.
 use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 
 use super::entity::{EntityData, EntityId, UnifiedEntity};
 
-pub(super) struct SegmentPrimaryKey {
+pub(super) struct SegmentUniqueKey {
     pub columns: Vec<String>,
     entries: HashMap<u64, Vec<EntityId>>,
     ids_bytes: usize,
 }
 
-impl SegmentPrimaryKey {
+impl SegmentUniqueKey {
     pub fn new(columns: &[String]) -> Self {
         Self {
             columns: columns.to_vec(),

--- a/tests/grouped/schema_query_core/e2e_unique_key_lookup.rs
+++ b/tests/grouped/schema_query_core/e2e_unique_key_lookup.rs
@@ -1,0 +1,120 @@
+fn set_unique_columns(runtime: &RedDBRuntime, name: &str, columns: &[&str]) {
+    let db = runtime.db();
+    let mut contract = db.collection_contract(name).expect("contract");
+    let table = contract.table_def.as_mut().expect("table definition");
+    table
+        .constraints
+        .retain(|constraint| constraint.name != "extra_unique");
+    if !columns.is_empty() {
+        table.constraints.push(
+            reddb_types::Constraint::new("extra_unique", reddb_types::ConstraintType::Unique)
+                .on_columns(columns.iter().map(|column| column.to_string()).collect()),
+        );
+    }
+    db.save_collection_contract(contract)
+        .expect("save catalog constraint");
+}
+
+use reddb::runtime::mvcc::{clear_current_connection_id, set_current_connection_id};
+use reddb::{RedDBOptions, RedDBRuntime};
+
+#[test]
+fn unique_lookup_tracks_multiple_constraints_nulls_and_schema_changes() {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    runtime
+        .execute_query(
+            "CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, org INT, code TEXT)",
+        )
+        .expect("schema");
+    set_unique_columns(&runtime, "accounts", &["org", "code"]);
+    runtime.execute_query("INSERT INTO accounts (id,email,org,code) VALUES (1,'one',1,'a'),(2,'two',2,'a'),(3,NULL,1,NULL),(4,NULL,1,NULL)").expect("distinct and nullable keys");
+    for sql in [
+        "INSERT INTO accounts (id,email,org,code) VALUES (5,'one',3,'a')",
+        "INSERT INTO accounts (id,email,org,code) VALUES (5,'five',1,'a')",
+        "INSERT INTO accounts (id,email,org,code) VALUES (1,'five',3,'a')",
+        "INSERT INTO accounts (id,email,org,code) VALUES (5,'five',3,'a'),(6,'six',3,'a')",
+    ] {
+        assert!(runtime.execute_query(sql).is_err(), "reject {sql}");
+    }
+    runtime
+        .execute_query("UPDATE accounts SET email='changed',org=3,code='b' WHERE id=1")
+        .expect("replace keys");
+    runtime
+        .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (5,'one',1,'a')")
+        .expect("reuse keys");
+    assert_eq!(runtime.execute_query("INSERT INTO accounts (id,email,org,code) VALUES (6,'six',1,'a') ON CONFLICT (org,code) DO NOTHING").expect("composite conflict").affected_rows, 0);
+    runtime
+        .execute_query("CREATE TABLE schema_keys (id INT PRIMARY KEY, code TEXT)")
+        .expect("schema");
+    runtime
+        .execute_query("INSERT INTO schema_keys (id,code) VALUES (1,'one')")
+        .expect("warm primary cache");
+    set_unique_columns(&runtime, "schema_keys", &["code"]);
+    assert!(runtime
+        .execute_query("INSERT INTO schema_keys (id,code) VALUES (2,'one')")
+        .is_err());
+    set_unique_columns(&runtime, "schema_keys", &[]);
+    runtime
+        .execute_query("INSERT INTO schema_keys (id,code) VALUES (2,'one')")
+        .expect("removed constraint no longer applies");
+}
+
+#[test]
+fn unique_composite_keys_preserve_savepoints_and_reopen() {
+    set_current_connection_id(227901);
+    let directory = tempfile::tempdir().expect("directory");
+    let path = directory.path().join("keys.rdb");
+    {
+        let runtime = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("runtime");
+        runtime
+            .execute_query(
+                "CREATE TABLE accounts (id INT PRIMARY KEY, email TEXT UNIQUE, org INT, code TEXT)",
+            )
+            .expect("schema");
+        set_unique_columns(&runtime, "accounts", &["org", "code"]);
+        runtime
+            .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (1,'one',1,'a')")
+            .expect("initial");
+        runtime.execute_query("BEGIN").expect("begin");
+        runtime.execute_query("SAVEPOINT child").expect("savepoint");
+        runtime
+            .execute_query("UPDATE accounts SET email='two',org=2 WHERE id=1")
+            .expect("replace composite");
+        runtime
+            .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (2,'one',1,'a')")
+            .expect("reuse own keys");
+        runtime
+            .execute_query("ROLLBACK TO SAVEPOINT child")
+            .expect("rollback child");
+        assert!(runtime
+            .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (2,'two',1,'a')")
+            .is_err());
+        runtime
+            .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (2,'two',2,'a')")
+            .expect("aborted replacement released");
+        runtime.execute_query("COMMIT").expect("commit");
+    }
+    let runtime = RedDBRuntime::with_options(RedDBOptions::persistent(&path)).expect("reopen");
+    assert!(runtime
+        .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (3,'three',1,'a')")
+        .is_err());
+    assert!(runtime
+        .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (3,'two',3,'a')")
+        .is_err());
+    runtime
+        .execute_query("DELETE FROM accounts WHERE id=2")
+        .expect("delete");
+    runtime
+        .execute_query("INSERT INTO accounts (id,email,org,code) VALUES (3,'two',2,'a')")
+        .expect("reuse deleted composite");
+    assert_eq!(
+        runtime
+            .execute_query("SELECT * FROM accounts")
+            .expect("readback")
+            .result
+            .records
+            .len(),
+        2
+    );
+    clear_current_connection_id();
+}

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -116,3 +116,6 @@ mod e2e_primary_key_lookup;
 
 #[path = "mvcc_transactions/e2e_mvcc_key_reuse.rs"]
 mod e2e_mvcc_key_reuse;
+
+#[path = "schema_query_core/e2e_unique_key_lookup.rs"]
+mod e2e_unique_key_lookup;


### PR DESCRIPTION
Secondary UNIQUE checks still scanned every physical row on each INSERT, despite the primary-key candidate index. Tables with several constraints repeatedly paid that growing cost.

Index every declared PRIMARY KEY/UNIQUE definition per segment and share one schema-bound cache across checks. Appends maintain every index; key mutations invalidate them; definition changes replace the cached set. Full key signature comparison, null handling, exclusion and the existing MVCC/admission gate remain in force. Memory accounting includes every cached constraint.

Stacked on #2278, continuing #2270. Two new end-to-end contracts cover multiple constraints, composite keys, nullable keys, catalog changes, savepoints and reopen; all 322 local SQL tests pass. A segment regression checks multiple cached definitions, candidate recheck and schema shrinkage. Check, formatting and CI run 34160675496 passed at this HEAD. Across 264 release runs on the current shared host, native insertion time at 4,000 rows fell 42.9% for UNIQUE and 61.6% for PK plus two secondary constraints; SDK UNIQUE at 1,000 rows fell 14.8% on tmpfs and 5.2% on disk. Primary-key controls were inconclusive within paired bootstrap uncertainty. Full evidence is archived in benchmark PR reddb-io/reddb-benchmark#3 (`unique-index-results.md`); this is a before/after comparison, not a new competitor result.

Composite constraints in these tests are declared through the existing catalog API because the SQL CREATE TABLE parser does not accept table-level UNIQUE syntax. No new SQL syntax, wire format or persistence format. More constrained columns consume more derived index memory. Draft; no merge.
