### PR TITLE
fix(rls): resolve document policies and graph property paths

### DIFF
--- a/crates/reddb-rql/src/sql.rs
+++ b/crates/reddb-rql/src/sql.rs
@@ -3223,6 +3223,7 @@ impl<'a> Parser<'a> {
                 use crate::ast::PolicyTargetKind;
                 let kw = match self.peek() {
                     Token::Ident(s) => Some(s.to_ascii_uppercase()),
+                    Token::Vectors => Some("VECTORS".to_string()),
                     _ => None,
                 };
                 let kind = kw.as_deref().and_then(|k| match k {

--- a/crates/reddb-server/src/runtime/query_exec/helpers.rs
+++ b/crates/reddb-server/src/runtime/query_exec/helpers.rs
@@ -458,17 +458,20 @@ pub(crate) fn resolve_entity_document_path(
         }
     }
 
-    if let EntityData::Node(ref node) = entity.data {
-        if let Some(value) = node.properties.get(root) {
-            if tail.is_empty() {
-                return Some(value.clone());
-            }
-            return resolve_runtime_document_path_from_value(value, tail);
-        }
-    }
-
-    if let EntityData::Edge(ref edge) = entity.data {
-        if let Some(value) = edge.properties.get(root) {
+    let graph_properties = match &entity.data {
+        EntityData::Node(node) => Some(&node.properties),
+        EntityData::Edge(edge) => Some(&edge.properties),
+        _ => None,
+    };
+    if let Some(properties) = graph_properties {
+        // Graph records expose their property bag under `properties` as well
+        // as direct fields. Keep static comparisons consistent with expressions.
+        let (root, tail) = if root == "properties" {
+            tail.split_first()?
+        } else {
+            (root, tail)
+        };
+        if let Some(value) = properties.get(root) {
             if tail.is_empty() {
                 return Some(value.clone());
             }

--- a/crates/reddb-server/src/runtime/rls_injection.rs
+++ b/crates/reddb-server/src/runtime/rls_injection.rs
@@ -184,13 +184,12 @@ pub(crate) fn inject_rls_filters(
     frame: &dyn super::statement_frame::ReadFrame,
     mut table: reddb_rql::ast::TableQuery,
 ) -> Option<reddb_rql::ast::TableQuery> {
-    use reddb_rql::ast::{Filter, PolicyAction};
+    use reddb_rql::ast::Filter;
 
     // `None` role falls through to policies with no `TO role` clause.
     let role = frame.identity().map(|(_, role)| role);
     let role_str = role.map(|r| r.as_str().to_string());
-    let policies =
-        runtime.matching_rls_policies(&table.table, role_str.as_deref(), PolicyAction::Select);
+    let policies = runtime.matching_select_rls_policies(&table.table, role_str.as_deref());
 
     if policies.is_empty() {
         // RLS enabled + no policy match = deny everything. Signal the
@@ -282,7 +281,7 @@ fn collect_join_side_policy(
     expr: &reddb_rql::ast::QueryExpr,
     out: &mut Vec<reddb_rql::ast::Filter>,
 ) -> bool {
-    use reddb_rql::ast::{Filter, PolicyAction, QueryExpr};
+    use reddb_rql::ast::{Filter, QueryExpr};
     match expr {
         QueryExpr::Table(t) => {
             if !runtime.inner.rls_enabled_tables.read().contains(&t.table) {
@@ -290,8 +289,7 @@ fn collect_join_side_policy(
             }
             let role = frame.identity().map(|(_, role)| role);
             let role_str = role.map(|r| r.as_str().to_string());
-            let policies =
-                runtime.matching_rls_policies(&t.table, role_str.as_deref(), PolicyAction::Select);
+            let policies = runtime.matching_select_rls_policies(&t.table, role_str.as_deref());
             if policies.is_empty() {
                 return false;
             }
@@ -376,6 +374,28 @@ pub(crate) fn apply_foreign_table_filters(
 }
 
 impl RedDBRuntime {
+    /// SELECT and JOIN use the relational AST for both tables and documents.
+    /// Resolve the policy kind from the declared collection model.
+    fn matching_select_rls_policies(
+        &self,
+        table: &str,
+        role: Option<&str>,
+    ) -> Vec<reddb_rql::ast::Filter> {
+        use reddb_rql::ast::{PolicyAction, PolicyTargetKind};
+
+        let kind = if self
+            .db()
+            .collection_contract_arc(table)
+            .is_some_and(|contract| {
+                contract.declared_model == crate::catalog::CollectionModel::Document
+            }) {
+            PolicyTargetKind::Documents
+        } else {
+            PolicyTargetKind::Table
+        };
+        self.matching_rls_policies_for_kind(table, role, PolicyAction::Select, kind)
+    }
+
     /// Access the shared `ForeignTableRegistry` (Phase 3.2 PG parity).
     ///
     /// Callers use this to check whether a table name is a registered

--- a/tests/grouped/auth_iam_security.rs
+++ b/tests/grouped/auth_iam_security.rs
@@ -125,3 +125,6 @@ mod vault_capacity;
 
 #[path = "runtime_persistence/vault_chain_recovery.rs"]
 mod vault_chain_recovery;
+
+#[path = "auth_security/e2e_model_policy_resolution.rs"]
+mod e2e_model_policy_resolution;

--- a/tests/grouped/auth_security/e2e_model_policy_resolution.rs
+++ b/tests/grouped/auth_security/e2e_model_policy_resolution.rs
@@ -1,0 +1,392 @@
+//! Cross-model policy resolution and policy-change regressions.
+use reddb::auth::Role;
+use reddb::json::{Map, Value as Json};
+use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
+use reddb::{RedDBOptions, RedDBRuntime};
+use reddb_types::Value;
+
+fn capture(rt: &RedDBRuntime, name: &str, sql: &str, field: &str, expected: &[&str]) -> Json {
+    let mut row = Map::new();
+    row.insert("name".into(), Json::String(name.into()));
+    row.insert("sql".into(), Json::String(sql.into()));
+    row.insert(
+        "expected".into(),
+        Json::Array(expected.iter().map(|s| Json::String((*s).into())).collect()),
+    );
+    match rt.execute_query(sql) {
+        Ok(result) => {
+            let mut actual: Vec<String> = result
+                .result
+                .records
+                .iter()
+                .map(|record| match record.get(field) {
+                    Some(Value::Text(value)) => value.to_string(),
+                    other => format!("unexpected field: {other:?}"),
+                })
+                .collect();
+            actual.sort();
+            let mut wanted: Vec<String> = expected.iter().map(|s| (*s).to_string()).collect();
+            wanted.sort();
+            row.insert("valid".into(), Json::Bool(actual == wanted));
+            row.insert(
+                "actual".into(),
+                Json::Array(actual.into_iter().map(Json::String).collect()),
+            );
+        }
+        Err(error) => {
+            row.insert("valid".into(), Json::Bool(false));
+            row.insert("error".into(), Json::String(error.to_string()));
+        }
+    }
+    Json::Object(row)
+}
+
+fn node_rid(rt: &RedDBRuntime, name: &str) -> Result<u64, Box<dyn std::error::Error>> {
+    let result = rt.execute_query(&format!("SELECT rid FROM links WHERE label='{name}'"))?;
+    match result
+        .result
+        .records
+        .first()
+        .and_then(|record| record.get("rid"))
+    {
+        Some(Value::UnsignedInteger(value)) => Ok(*value),
+        Some(Value::Integer(value)) => Ok(u64::try_from(*value)?),
+        other => Err(format!("expected node RID for {name}, got {other:?}").into()),
+    }
+}
+
+#[test]
+fn document_graph_vector_policy_corpus() -> Result<(), Box<dyn std::error::Error>> {
+    let directory = tempfile::tempdir()?;
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(directory.path().join("db.rdb")))?;
+    for query in [
+        "CREATE VECTOR embeddings DIM 2 METRIC cosine",
+        "INSERT INTO embeddings VECTOR (dense,content) VALUES ([1.0,0.0],'bob') WITH METADATA (owner='bob')",
+        "INSERT INTO embeddings VECTOR (dense,content) VALUES ([0.8,0.6],'alice') WITH METADATA (owner='alice')",
+        "CREATE DOCUMENT papers",
+        "INSERT INTO papers DOCUMENT VALUES ({name:'alice',owner:'alice'})",
+        "INSERT INTO papers DOCUMENT VALUES ({name:'bob',owner:'bob'})",
+        "CREATE DOCUMENT public_papers",
+        "INSERT INTO public_papers DOCUMENT VALUES ({name:'alice'})",
+        "INSERT INTO public_papers DOCUMENT VALUES ({name:'bob'})",
+        "CREATE GRAPH links",
+        "INSERT INTO links NODE (label,node_type,owner) VALUES ('alice','Paper','alice')",
+        "INSERT INTO links NODE (label,node_type,owner) VALUES ('bob','Paper','bob')",
+        "CREATE POLICY own_docs ON DOCUMENTS OF papers USING (owner=CURRENT_USER())",
+        "CREATE POLICY own_nodes ON NODES OF links USING (properties.owner=CURRENT_USER())",
+        "CREATE POLICY visible_edges ON EDGES OF links USING (properties.visible=true)",
+    ] { rt.execute_query(query).map_err(|error| format!("{query}: {error}"))?; }
+    let alice_rid = node_rid(&rt, "alice")?;
+    let bob_rid = node_rid(&rt, "bob")?;
+    for (from, to) in [
+        (alice_rid, alice_rid),
+        (bob_rid, bob_rid),
+        (alice_rid, bob_rid),
+    ] {
+        rt.execute_query(&format!("INSERT INTO links EDGE (label,from,to,visible) VALUES ('provided_by',{from},{to},true)"))?;
+    }
+    let traversal = "MATCH (p:Paper)-[:provided_by]->(n:Paper) RETURN n.label";
+    let mut cases = vec![
+        capture(
+            &rt,
+            "document_fixture_without_rls",
+            "SELECT name FROM papers",
+            "name",
+            &["alice", "bob"],
+        ),
+        capture(
+            &rt,
+            "graph_fixture_without_rls",
+            "MATCH (n:Paper) RETURN n.label",
+            "n.label",
+            &["alice", "bob"],
+        ),
+        capture(
+            &rt,
+            "vector_fixture_without_rls",
+            "VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 10",
+            "content",
+            &["alice", "bob"],
+        ),
+        capture(
+            &rt,
+            "graph_traversal_without_rls",
+            traversal,
+            "n.label",
+            &["alice", "bob", "bob"],
+        ),
+    ];
+    rt.execute_query("ALTER TABLE papers ENABLE ROW LEVEL SECURITY")?;
+    rt.execute_query("ALTER TABLE links ENABLE ROW LEVEL SECURITY")?;
+    let syntax =
+        "CREATE POLICY own_vectors ON VECTORS OF embeddings USING (metadata.owner=CURRENT_USER())";
+    let result = rt.execute_query(syntax);
+    let mut record = Map::new();
+    record.insert(
+        "name".into(),
+        Json::String("vector_policy_documented_syntax".into()),
+    );
+    record.insert("sql".into(), Json::String(syntax.into()));
+    record.insert("valid".into(), Json::Bool(result.is_ok()));
+    if let Err(error) = result {
+        record.insert("error".into(), Json::String(error.to_string()));
+        // The documented legacy TABLE policy also applies to vector entities.
+        // Use it to test enforcement independently of the syntax failure.
+        rt.execute_query(
+            "CREATE POLICY own_vectors ON embeddings USING (metadata.owner=CURRENT_USER())",
+        )?;
+    }
+    rt.execute_query("ALTER TABLE embeddings ENABLE ROW LEVEL SECURITY")?;
+    cases.push(Json::Object(record));
+    let search = "VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 1";
+    for (iteration, user) in ["alice", "bob", "alice", "nobody"].into_iter().enumerate() {
+        set_current_auth_identity(user.to_string(), Role::Read);
+        let expected: &[&str] = if user == "nobody" {
+            &[]
+        } else {
+            std::slice::from_ref(&user)
+        };
+        cases.push(capture(
+            &rt,
+            &format!("identity_{user}_{iteration}"),
+            "SELECT CURRENT_USER() AS principal",
+            "principal",
+            &[user],
+        ));
+        cases.push(capture(
+            &rt,
+            &format!("vector_rls_{user}_{}", cases.len()),
+            search,
+            "content",
+            expected,
+        ));
+        cases.push(capture(
+            &rt,
+            &format!("document_rls_{user}_{iteration}"),
+            "SELECT name FROM papers",
+            "name",
+            expected,
+        ));
+        cases.push(capture(
+            &rt,
+            &format!("graph_rls_{user}_{iteration}"),
+            "MATCH (n:Paper) RETURN n.label",
+            "n.label",
+            expected,
+        ));
+        cases.push(capture(
+            &rt,
+            &format!("graph_traversal_rls_{user}_{iteration}"),
+            traversal,
+            "n.label",
+            expected,
+        ));
+        cases.push(capture(&rt, &format!("join_rls_{user}_{iteration}"),
+            "SELECT d.name FROM papers d JOIN VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 10 AS v ON d.name=v.content",
+            "d.name", expected));
+        cases.push(capture(&rt, &format!("vector_leaf_join_rls_{user}_{iteration}"),
+            "SELECT v.content FROM public_papers d JOIN VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 10 AS v ON d.name=v.content",
+            "v.content", expected));
+        clear_current_auth_identity();
+    }
+    rt.execute_query("DROP POLICY own_vectors ON embeddings")?;
+    set_current_auth_identity("alice".into(), Role::Read);
+    cases.push(capture(
+        &rt,
+        "vector_no_matching_policy",
+        search,
+        "content",
+        &[],
+    ));
+    clear_current_auth_identity();
+    rt.execute_query("DROP POLICY own_docs ON papers")?;
+    rt.execute_query("CREATE POLICY legacy_docs ON papers USING (owner=CURRENT_USER())")?;
+    set_current_auth_identity("alice".into(), Role::Read);
+    cases.push(capture(
+        &rt,
+        "document_legacy_policy_alice",
+        "SELECT name FROM papers",
+        "name",
+        &["alice"],
+    ));
+    clear_current_auth_identity();
+    rt.execute_query("DROP POLICY visible_edges ON links")?;
+    rt.execute_query("CREATE POLICY all_edges ON EDGES OF links USING (true)")?;
+    set_current_auth_identity("alice".into(), Role::Read);
+    cases.push(capture(
+        &rt,
+        "graph_traversal_unconditional_edge_policy_alice",
+        traversal,
+        "n.label",
+        &["alice"],
+    ));
+    clear_current_auth_identity();
+    let failures: Vec<_> = cases
+        .iter()
+        .filter(|case| case.get("valid") != Some(&Json::Bool(true)))
+        .collect();
+    assert!(failures.is_empty(), "policy corpus failures: {failures:?}");
+    Ok(())
+}
+
+#[test]
+fn graph_policy_changes_invalidate_cached_paths() {
+    let directory = tempfile::tempdir().expect("persistent fixture");
+    for options in [
+        RedDBOptions::in_memory(),
+        RedDBOptions::persistent(directory.path().join("policy.rdb")),
+    ] {
+        let rt = RedDBRuntime::with_options(options).expect("runtime");
+        for sql in [
+            "CREATE GRAPH links",
+            "INSERT INTO links NODE (label,node_type) VALUES ('alice','Paper')",
+        ] {
+            rt.execute_query(sql).expect("fixture");
+        }
+        let id = node_rid(&rt, "alice").expect("node rid");
+        rt.execute_query(&format!(
+            "INSERT INTO links EDGE (label,from,to,visible) VALUES ('provided_by',{id},{id},true)"
+        ))
+        .expect("edge");
+        for sql in [
+            "CREATE POLICY nodes ON NODES OF links USING (true)",
+            "CREATE POLICY edges ON EDGES OF links USING (true)",
+            "ALTER TABLE links ENABLE ROW LEVEL SECURITY",
+        ] {
+            rt.execute_query(sql).expect("policies");
+        }
+        let query = "MATCH (p:Paper)-[:provided_by]->(n:Paper) RETURN n.label";
+        for _ in 0..2 {
+            assert_eq!(
+                rt.execute_query(query)
+                    .expect("allowed and cached")
+                    .result
+                    .records
+                    .len(),
+                1
+            );
+        }
+        rt.execute_query("DROP POLICY edges ON links")
+            .expect("revoke");
+        let revoked = rt.execute_query(query).expect("no edge policy");
+        assert!(
+            revoked.result.records.is_empty(),
+            "revoked paths: {:?}, cache: {:?}",
+            revoked.result.records,
+            rt.result_cache_metrics()
+        );
+        rt.execute_query("CREATE POLICY edges ON EDGES OF links USING (false)")
+            .expect("explicit deny");
+        assert!(rt
+            .execute_query(query)
+            .expect("denied")
+            .result
+            .records
+            .is_empty());
+        rt.execute_query("DROP POLICY edges ON links")
+            .expect("drop deny");
+        rt.execute_query("CREATE POLICY edges ON EDGES OF links USING (true)")
+            .expect("restore");
+        assert_eq!(
+            rt.execute_query(query)
+                .expect("restored")
+                .result
+                .records
+                .len(),
+            1
+        );
+    }
+}
+
+#[test]
+fn typed_policy_targets_preserve_kind_and_role_boundaries() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    for target in [
+        "NODES",
+        "EDGES",
+        "VECTORS",
+        "MESSAGES",
+        "POINTS",
+        "DOCUMENTS",
+    ] {
+        rt.execute_query(&format!(
+            "CREATE POLICY typed ON {target} OF fixture FOR SELECT TO read USING (true)"
+        ))
+        .expect("documented typed policy syntax");
+        rt.execute_query("DROP POLICY typed ON fixture")
+            .expect("drop policy");
+    }
+    for sql in [
+        "CREATE TABLE private_rows (name TEXT)",
+        "INSERT INTO private_rows (name) VALUES ('private')",
+        "CREATE POLICY docs_only ON DOCUMENTS OF private_rows USING (true)",
+        "ALTER TABLE private_rows ENABLE ROW LEVEL SECURITY",
+        "CREATE DOCUMENT docs",
+        "INSERT INTO docs DOCUMENT VALUES ({name:'private'})",
+        "CREATE POLICY docs_admin ON DOCUMENTS OF docs FOR SELECT TO admin USING (true)",
+        "ALTER TABLE docs ENABLE ROW LEVEL SECURITY",
+    ] {
+        rt.execute_query(sql).expect("fixture");
+    }
+    set_current_auth_identity("alice".into(), Role::Read);
+    let table = rt.execute_query("SELECT name FROM private_rows");
+    let docs = rt.execute_query("SELECT name FROM docs");
+    clear_current_auth_identity();
+    assert!(table.expect("wrong model denied").result.records.is_empty());
+    assert!(docs.expect("wrong role denied").result.records.is_empty());
+}
+
+#[test]
+fn graph_property_namespace_matches_static_and_dynamic_predicates() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    for sql in [
+        "CREATE GRAPH links",
+        "INSERT INTO links NODE (label,node_type,owner,visible) VALUES ('alice','Paper','alice',true)",
+        "INSERT INTO links NODE (label,node_type,owner,visible) VALUES ('bob','Paper','bob',false)",
+        "CREATE POLICY nodes ON NODES OF links USING (properties.visible=true)",
+    ] {
+        rt.execute_query(sql).expect("fixture");
+    }
+    let id = node_rid(&rt, "alice").expect("visible endpoint");
+    rt.execute_query("ALTER TABLE links ENABLE ROW LEVEL SECURITY")
+        .expect("enable RLS");
+    for visible in [true, false] {
+        rt.execute_query(&format!(
+            "INSERT INTO links EDGE (label,from,to,visible) VALUES ('provided_by',{id},{id},{visible})"
+        )).expect("edge fixture");
+    }
+    rt.execute_query("CREATE POLICY edges ON EDGES OF links USING (properties.visible=true)")
+        .expect("edge policy");
+    let result = capture(
+        &rt,
+        "hidden edge",
+        "MATCH (p:Paper)-[:provided_by]->(n:Paper) RETURN n.label",
+        "n.label",
+        &["alice"],
+    );
+    assert_eq!(result.get("valid"), Some(&Json::Bool(true)), "{result:?}");
+    let result = capture(
+        &rt,
+        "static node namespace",
+        "MATCH (n:Paper) RETURN n.label",
+        "n.label",
+        &["alice"],
+    );
+    assert_eq!(result.get("valid"), Some(&Json::Bool(true)), "{result:?}");
+    rt.execute_query("DROP POLICY nodes ON links")
+        .expect("drop");
+    rt.execute_query(
+        "CREATE POLICY nodes ON NODES OF links USING (properties.owner=CURRENT_USER())",
+    )
+    .expect("dynamic policy");
+    set_current_auth_identity("bob".into(), Role::Read);
+    let result = capture(
+        &rt,
+        "dynamic node namespace",
+        "MATCH (n:Paper) RETURN n.label",
+        "n.label",
+        &["bob"],
+    );
+    clear_current_auth_identity();
+    assert_eq!(result.get("valid"), Some(&Json::Bool(true)), "{result:?}");
+}


### PR DESCRIPTION
SELECT and JOIN on declared document collections ignored `ON DOCUMENTS OF` policies, and static graph predicates such as `properties.visible=true` rejected permitted paths. `CREATE POLICY ... ON VECTORS OF` also failed because VECTORS is a reserved lexer token.

Resolve relational SELECT policies using the declared collection model, recognize the graph property namespace in direct entity filtering, and accept the reserved vector token in typed policy targets. Table-scoped policy compatibility, role matching and default denial are preserved. No persistence or wire-format change.

Stacked on #2275, continuing the #2270 competitive audit. The original native policy corpus reproduced ten failures on that base and passes after these fixes. Added integration coverage for all six documented target kinds, wrong-model/wrong-role denial, static/dynamic node predicates, hidden edges, and policy revocation/restoration with memory and file stores. The dependency's vector-isolation and literal-cache fixes remain in place; no additional cache changes were needed.

Validation at `58bd73004a8710b12dcf67804f1105336a29af76`: 136 document/queue tests and 66 graph tests pass. The auth suite had 233 passes and one ASK audit assertion failure; its output included an earlier Bob credential-resolution event alongside the correct Alice denial. The test passed alone and in CI; the original failure is retained. Cargo check (`--locked --tests -p reddb-io`), formatting and release build pass. CI 34162110928 is green on this exact HEAD, including all four new tests.

The full unchanged release corpus exits zero: RedDB 63/63, SurrealDB 55/55. Counts include different controls and are not a quality score or a performance/ANN comparison. Full expected/actual results, build/library hashes and validation logs are in reddb-io/reddb-benchmark#3 (`multimodel-results.md`, `evidence/2026-09-07/model-policy/`). Transport authentication and general HYBRID/SEARCH/ASK coverage are outside this audit. Draft for review; no merge.
