### PR TITLE
perf(index): maintain incremental memory accounting

### DIFF
--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -73,6 +73,7 @@ fn btree_entry_bytes<'a>(
 pub struct SortedColumnIndex {
     /// Sorted entries: canonical key → entity IDs
     entries: BTreeMap<CanonicalKey, Vec<EntityId>>,
+    entry_memory_bytes: usize,
     /// Family seen in this index. Mixed families keep exact lookup safe but
     /// disable range pushdown.
     range_family: Option<CanonicalKeyFamily>,
@@ -84,6 +85,7 @@ impl SortedColumnIndex {
     pub fn new() -> Self {
         Self {
             entries: BTreeMap::new(),
+            entry_memory_bytes: 0,
             range_family: None,
             has_mixed_families: false,
             families: BTreeSet::new(),
@@ -97,7 +99,12 @@ impl SortedColumnIndex {
             None => self.range_family = Some(key.family()),
             _ => {}
         }
-        self.entries.entry(key).or_default().push(entity_id);
+        let entry = self.entries.entry(key);
+        if let std::collections::btree_map::Entry::Vacant(ref entry) = entry {
+            self.entry_memory_bytes += btree_entry_bytes(std::iter::once(entry.key()), 0);
+        }
+        self.entry_memory_bytes += std::mem::size_of::<EntityId>();
+        entry.or_default().push(entity_id);
     }
 
     fn range_enabled(&self, family: CanonicalKeyFamily) -> bool {
@@ -165,12 +172,7 @@ impl SortedColumnIndex {
     /// Approximate resident bytes (ADR 0073 §2). Same shape as the hash and
     /// bitmap estimators: keys plus posting lists plus a per-node constant.
     pub fn memory_bytes(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self
-                .entries
-                .iter()
-                .map(|(key, ids)| btree_entry_bytes(std::iter::once(key), ids.len()))
-                .sum::<usize>()
+        std::mem::size_of::<Self>() + self.entry_memory_bytes
     }
 
     /// Range scan with early stop at `limit` entity IDs.
@@ -420,17 +422,24 @@ impl SortedColumnIndex {
 /// + trailing-range queries.
 pub struct SortedCompositeIndex {
     entries: BTreeMap<Vec<CanonicalKey>, Vec<EntityId>>,
+    entry_memory_bytes: usize,
 }
 
 impl SortedCompositeIndex {
     pub fn new() -> Self {
         Self {
             entries: BTreeMap::new(),
+            entry_memory_bytes: 0,
         }
     }
 
     pub fn insert(&mut self, key: Vec<CanonicalKey>, entity_id: EntityId) {
-        self.entries.entry(key).or_default().push(entity_id);
+        let entry = self.entries.entry(key);
+        if let std::collections::btree_map::Entry::Vacant(ref entry) = entry {
+            self.entry_memory_bytes += btree_entry_bytes(entry.key().iter(), 0);
+        }
+        self.entry_memory_bytes += std::mem::size_of::<EntityId>();
+        entry.or_default().push(entity_id);
     }
 
     pub fn len(&self) -> usize {
@@ -440,12 +449,7 @@ impl SortedCompositeIndex {
     /// Approximate resident bytes (ADR 0073 §2). Every column of the composite
     /// key is charged, so a wide index costs what it weighs.
     pub fn memory_bytes(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self
-                .entries
-                .iter()
-                .map(|(key, ids)| btree_entry_bytes(key.iter(), ids.len()))
-                .sum::<usize>()
+        std::mem::size_of::<Self>() + self.entry_memory_bytes
     }
 
     /// Range scan with an exact prefix on the first `prefix.len()` columns
@@ -639,8 +643,11 @@ impl SortedIndexManager {
         };
         if let Some(old) = old_tuple {
             if let Some(ids) = idx.entries.get_mut(&old) {
+                let before = ids.len();
                 ids.retain(|id| *id != entity_id);
+                idx.entry_memory_bytes -= (before - ids.len()) * std::mem::size_of::<EntityId>();
                 if ids.is_empty() {
+                    idx.entry_memory_bytes -= btree_entry_bytes(old.iter(), 0);
                     idx.entries.remove(&old);
                 }
             }
@@ -1143,8 +1150,12 @@ impl SortedIndexManager {
                 return;
             };
             if let Some(bucket) = index.entries.get_mut(&key) {
+                let before = bucket.len();
                 bucket.retain(|id| *id != entity_id);
+                index.entry_memory_bytes -=
+                    (before - bucket.len()) * std::mem::size_of::<EntityId>();
                 if bucket.is_empty() {
+                    index.entry_memory_bytes -= btree_entry_bytes(std::iter::once(&key), 0);
                     index.entries.remove(&key);
                 }
             }
@@ -2148,6 +2159,76 @@ mod tests {
 
     fn ids(values: &[EntityId]) -> Vec<u64> {
         values.iter().map(|id| id.raw()).collect()
+    }
+
+    fn assert_memory_accounting(manager: &SortedIndexManager) {
+        let single = manager
+            .indices
+            .read()
+            .values()
+            .map(|index| {
+                std::mem::size_of::<SortedColumnIndex>()
+                    + index
+                        .entries
+                        .iter()
+                        .map(|(key, ids)| btree_entry_bytes(std::iter::once(key), ids.len()))
+                        .sum::<usize>()
+            })
+            .sum::<usize>();
+        let composite = manager
+            .composite
+            .read()
+            .values()
+            .map(|index| {
+                std::mem::size_of::<SortedCompositeIndex>()
+                    + index
+                        .entries
+                        .iter()
+                        .map(|(key, ids)| btree_entry_bytes(key.iter(), ids.len()))
+                        .sum::<usize>()
+            })
+            .sum::<usize>();
+        assert_eq!(manager.memory_bytes(), (single + composite) as u64);
+    }
+
+    #[test]
+    fn memory_accounting_tracks_sorted_updates_deletes_and_rebuilds() {
+        let manager = SortedIndexManager::new();
+        manager
+            .indices
+            .write()
+            .insert(("items".into(), "key".into()), SortedColumnIndex::new());
+        let columns = vec!["key".to_string(), "group".to_string()];
+        let mut entities = Vec::new();
+        for id in 0..128 {
+            let value = Value::text(format!("key-{}", id % 13));
+            manager.insert_one("items", "key", &value, EntityId::new(id));
+            manager.insert_one("items", "key", &value, EntityId::new(id));
+            entities.push((
+                EntityId::new(id),
+                vec![("key".into(), value), ("group".into(), Value::Integer(1))],
+            ));
+            assert_memory_accounting(&manager);
+        }
+        manager.build_composite("items", &columns, &entities);
+        assert_memory_accounting(&manager);
+        for (id, fields) in &entities {
+            manager.delete_one("items", "key", &fields[0].1, *id);
+            manager.delete_one("items", "key", &fields[0].1, *id);
+            let updated = vec![
+                ("key".into(), Value::text("updated")),
+                ("group".into(), Value::Integer(2)),
+            ];
+            manager.composite_entity_update("items", &columns, *id, fields, &updated);
+            assert_memory_accounting(&manager);
+            manager.composite_entity_update("items", &columns, *id, &updated, &[]);
+            assert_memory_accounting(&manager);
+        }
+        manager.build_composite("items", &columns, &entities);
+        assert_memory_accounting(&manager);
+        manager.composite.write().clear();
+        manager.indices.write().clear();
+        assert_eq!(manager.memory_bytes(), 0);
     }
 
     #[test]

--- a/crates/reddb-server/src/storage/unified/bitmap_index.rs
+++ b/crates/reddb-server/src/storage/unified/bitmap_index.rs
@@ -57,6 +57,8 @@ pub struct BitmapColumnIndex {
     pub column: String,
     /// Next available offset
     next_offset: u32,
+    /// Estimated keys, serialized bitmaps and map-entry bytes.
+    bitmap_memory_bytes: usize,
 }
 
 impl BitmapColumnIndex {
@@ -68,6 +70,7 @@ impl BitmapColumnIndex {
             offset_to_id: Vec::new(),
             column: column.into(),
             next_offset: 0,
+            bitmap_memory_bytes: 0,
         }
     }
 
@@ -79,20 +82,30 @@ impl BitmapColumnIndex {
             self.offset_to_id.push(entity_id);
             off
         });
-        self.bitmaps
-            .entry(value.to_vec())
-            .or_default()
-            .insert(offset);
+        let bitmap = self.bitmaps.entry(value.to_vec()).or_default();
+        let before = bitmap.serialized_size();
+        if bitmap.is_empty() {
+            self.bitmap_memory_bytes += value.len() + before + 48;
+        }
+        bitmap.insert(offset);
+        self.bitmap_memory_bytes = self.bitmap_memory_bytes - before + bitmap.serialized_size();
     }
 
     /// Remove an entity from the index (removes from all value bitmaps)
     pub fn remove(&mut self, entity_id: EntityId) {
         if let Some(offset) = self.id_to_offset.remove(&entity_id) {
-            for bitmap in self.bitmaps.values_mut() {
+            self.bitmaps.retain(|key, bitmap| {
+                let before = bitmap.serialized_size();
                 bitmap.remove(offset);
-            }
-            // Clean up empty bitmaps
-            self.bitmaps.retain(|_, bm| !bm.is_empty());
+                self.bitmap_memory_bytes -= before;
+                if bitmap.is_empty() {
+                    self.bitmap_memory_bytes -= key.len() + 48;
+                    false
+                } else {
+                    self.bitmap_memory_bytes += bitmap.serialized_size();
+                    true
+                }
+            });
         }
     }
 
@@ -138,13 +151,10 @@ impl BitmapColumnIndex {
 
     /// Approximate memory usage in bytes
     pub fn memory_bytes(&self) -> usize {
-        let mut size = std::mem::size_of::<Self>();
-        for (key, bm) in &self.bitmaps {
-            size += key.len() + bm.serialized_size() + 48;
-        }
-        size += self.id_to_offset.len() * 16; // HashMap overhead
-        size += self.offset_to_id.len() * 8; // Vec<EntityId>
-        size
+        std::mem::size_of::<Self>()
+            + self.bitmap_memory_bytes
+            + self.id_to_offset.len() * 16
+            + self.offset_to_id.len() * 8
     }
 }
 
@@ -350,6 +360,48 @@ pub struct BitmapIndexStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_memory_accounting(index: &BitmapColumnIndex) {
+        let recomputed = std::mem::size_of::<BitmapColumnIndex>()
+            + index
+                .bitmaps
+                .iter()
+                .map(|(key, bitmap)| key.len() + bitmap.serialized_size() + 48)
+                .sum::<usize>()
+            + index.id_to_offset.len() * 16
+            + index.offset_to_id.len() * 8;
+        assert_eq!(index.memory_bytes(), recomputed);
+    }
+
+    #[test]
+    fn memory_accounting_tracks_bitmap_transitions_and_reinsertion() {
+        let mut index = BitmapColumnIndex::new("state");
+        assert_memory_accounting(&index);
+        for id in 0..70_000 {
+            index.insert(EntityId::new(id), b"common");
+            if id % 4096 == 0 {
+                assert_memory_accounting(&index);
+            }
+        }
+        assert_memory_accounting(&index);
+        for id in 0..128 {
+            index.insert(EntityId::new(id), b"common");
+            index.insert(EntityId::new(id), &id.to_le_bytes());
+            assert_memory_accounting(&index);
+        }
+        for id in 0..70_000 {
+            index.remove(EntityId::new(id));
+            if id % 4096 == 0 {
+                assert_memory_accounting(&index);
+            }
+        }
+        assert_memory_accounting(&index);
+        assert_eq!(index.cardinality(), 0);
+        index.insert(EntityId::new(1), b"again");
+        assert_memory_accounting(&index);
+        index.remove(EntityId::new(1));
+        assert_memory_accounting(&index);
+    }
 
     #[test]
     fn test_bitmap_basic() {

--- a/crates/reddb-server/src/storage/unified/hash_index.rs
+++ b/crates/reddb-server/src/storage/unified/hash_index.rs
@@ -21,6 +21,8 @@ pub struct HashIndex {
     pub unique: bool,
     /// Number of keys
     key_count: usize,
+    /// Estimated key, posting-list and map-entry bytes.
+    entry_memory_bytes: usize,
 }
 
 impl HashIndex {
@@ -30,17 +32,23 @@ impl HashIndex {
             entries: HashMap::new(),
             unique,
             key_count: 0,
+            entry_memory_bytes: 0,
         }
     }
 
     /// Insert a key → entity mapping.
     /// Returns `Err` if the index is unique and the key already exists.
     pub fn insert(&mut self, key: Vec<u8>, entity_id: EntityId) -> Result<(), HashIndexError> {
+        let key_bytes = key.len();
         let entry = self.entries.entry(key).or_default();
         if self.unique && !entry.is_empty() {
             return Err(HashIndexError::DuplicateKey);
         }
         if !entry.contains(&entity_id) {
+            if entry.is_empty() {
+                self.entry_memory_bytes += key_bytes + 48;
+            }
+            self.entry_memory_bytes += std::mem::size_of::<EntityId>();
             entry.push(entity_id);
             self.key_count += 1;
         }
@@ -58,7 +66,9 @@ impl HashIndex {
             if let Some(pos) = ids.iter().position(|id| *id == entity_id) {
                 ids.swap_remove(pos);
                 self.key_count -= 1;
+                self.entry_memory_bytes -= std::mem::size_of::<EntityId>();
                 if ids.is_empty() {
+                    self.entry_memory_bytes -= key.len() + 48;
                     self.entries.remove(key);
                 }
                 return true;
@@ -69,10 +79,14 @@ impl HashIndex {
 
     /// Remove all entries for an entity ID (slower — scans all keys).
     pub fn remove_entity(&mut self, entity_id: EntityId) {
-        self.entries.retain(|_, ids| {
+        self.entries.retain(|key, ids| {
             if let Some(pos) = ids.iter().position(|id| *id == entity_id) {
                 ids.swap_remove(pos);
                 self.key_count -= 1;
+                self.entry_memory_bytes -= std::mem::size_of::<EntityId>();
+            }
+            if ids.is_empty() {
+                self.entry_memory_bytes -= key.len() + 48;
             }
             !ids.is_empty()
         });
@@ -105,16 +119,12 @@ impl HashIndex {
     pub fn clear(&mut self) {
         self.entries.clear();
         self.key_count = 0;
+        self.entry_memory_bytes = 0;
     }
 
     /// Approximate memory usage in bytes
     pub fn memory_bytes(&self) -> usize {
-        let mut size = std::mem::size_of::<Self>();
-        for (key, ids) in &self.entries {
-            size += key.len() + ids.len() * std::mem::size_of::<EntityId>() + 48;
-            // HashMap overhead
-        }
-        size
+        std::mem::size_of::<Self>() + self.entry_memory_bytes
     }
 }
 
@@ -298,6 +308,46 @@ pub struct HashIndexStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_memory_accounting(index: &HashIndex) {
+        let recomputed = std::mem::size_of::<HashIndex>()
+            + index
+                .entries
+                .iter()
+                .map(|(key, ids)| key.len() + ids.len() * std::mem::size_of::<EntityId>() + 48)
+                .sum::<usize>();
+        assert_eq!(index.memory_bytes(), recomputed);
+    }
+
+    #[test]
+    fn memory_accounting_tracks_duplicates_removal_and_clear() {
+        for unique in [false, true] {
+            let mut index = HashIndex::new(unique);
+            assert_memory_accounting(&index);
+            for id in 0..128 {
+                let key = vec![b'x'; usize::try_from(id % 13).expect("small key")];
+                let _ = index.insert(key.clone(), EntityId::new(id));
+                assert_memory_accounting(&index);
+                let _ = index.insert(key, EntityId::new(id));
+                assert_memory_accounting(&index);
+            }
+            for id in 0..128 {
+                if id % 2 == 0 {
+                    index.remove_entity(EntityId::new(id));
+                } else {
+                    let key = vec![b'x'; usize::try_from(id % 13).expect("small key")];
+                    index.remove(&key, EntityId::new(id));
+                }
+                assert_memory_accounting(&index);
+            }
+            assert!(index.is_empty());
+            index
+                .insert(b"again".to_vec(), EntityId::new(1))
+                .expect("empty index");
+            index.clear();
+            assert_memory_accounting(&index);
+        }
+    }
 
     #[test]
     fn test_hash_index_basic() {


### PR DESCRIPTION
Write admission recalculates index memory by traversing all hash, sorted and bitmap entries before each mutation. Maintain the existing estimate incrementally on insertion/removal so memory reporting reads counters instead of rescanning postings.

For N distinct indexed keys and N single-row writes, the accounting portion changes from O(N²) entry visits to O(N) counter updates (bitmap mutation still measures the touched bitmap). Admission limits, mutation locking, WAL and persistence ordering remain unchanged. The counters include their own struct footprint.

Validation at 03eb82388f04dcb195eb3d6c66502a0629d48a6d: standard CI 34174183375 and cargo check passed. All 36 index unit tests passed, including independent recomputation after duplicates, removals, bitmap container transitions and composite index rebuilds. The later integrated revision 15166aaf0638c6de5b539c9f1aed9790504f0511 additionally passed standard CI, 171 focused local regressions and release acceptance across four drivers and the multimodel corpus.

Completed all 432 accounting trials (one warmup and five measured before/after pairs per cell) and 18 synthetic snapshot trials, with full readback validation. Accounting timings compare only 1a365edb93790d5864da47d4e7a12e60fd495b36 against 03eb82388f04dcb195eb3d6c66502a0629d48a6d; they do not time the later integration. Snapshot timings characterize the baseline artifact API, with checksums and fsync preserved. Shared-host contention, including other projects' builds, prevents a general speed or competitor-lead claim. [Full measurements, paired ranges and provenance](https://github.com/reddb-io/reddb-benchmark/blob/09ff0aa92eb4575520a99ab75d825f18953880ba/src/runners/bun/competitive/program-results.md). Results are mixed: at 16k rows in memory, the median paired before/after ratio is 1.148 for UNIQUE and 0.865 for automatic hash. Ratios below 1 favor the earlier binary; a reserved-host repeat is needed before promoting a gain claim or dismissing a possible regression.

| Index mode, 16k rows in memory | Before/after median paired ratio | Observed paired range |
|---|---:|---:|
| bitmap | 0.999 | 0.913–1.198 |
| pk | 0.992 | 0.886–1.203 |
| plain | 0.865 | 0.622–1.199 |
| sorted | 1.088 | 0.638–1.797 |
| unindexed | 1.007 | 0.757–1.185 |
| unique | 1.148 | 1.018–2.480 |

Ratios above 1 favor the changed binary. The range is the minimum/maximum across five pairs, not a confidence interval. An isolated faster counter does not establish a faster application. Full results include unindexed controls, 1k/4k/16k memory, 1k/4k tmpfs and 1k disk cells.

Part of #2270; stacked on frozen perf/competitive-integration. This remains a draft. No main merge or release is requested.
