### PR TITLE
feat(sql): support table-level unique constraints

### DIFF
--- a/crates/reddb-rql/src/analyzer.rs
+++ b/crates/reddb-rql/src/analyzer.rs
@@ -7,6 +7,7 @@ use reddb_types::types::{DataType, SqlTypeName};
 pub enum AnalysisError {
     DuplicateColumn(String),
     UnsupportedType(String),
+    InvalidUniqueConstraint(String),
 }
 
 impl std::fmt::Display for AnalysisError {
@@ -14,6 +15,9 @@ impl std::fmt::Display for AnalysisError {
         match self {
             Self::DuplicateColumn(name) => write!(f, "duplicate column name: {name}"),
             Self::UnsupportedType(name) => write!(f, "unsupported SQL type: {name}"),
+            Self::InvalidUniqueConstraint(message) => {
+                write!(f, "invalid UNIQUE constraint: {message}")
+            }
         }
     }
 }
@@ -24,6 +28,7 @@ impl std::error::Error for AnalysisError {}
 pub struct AnalyzedCreateTableQuery {
     pub name: String,
     pub columns: Vec<AnalyzedColumnDef>,
+    pub unique_constraints: Vec<reddb_types::Constraint>,
     pub if_not_exists: bool,
     pub default_ttl_ms: Option<u64>,
     pub context_index_fields: Vec<String>,
@@ -66,11 +71,86 @@ pub fn analyze_create_table(
     Ok(AnalyzedCreateTableQuery {
         name: query.name.clone(),
         columns,
+        unique_constraints: analyze_unique_constraints(query)?,
         if_not_exists: query.if_not_exists,
         default_ttl_ms: query.default_ttl_ms,
         context_index_fields: query.context_index_fields.clone(),
         timestamps: query.timestamps,
     })
+}
+
+fn analyze_unique_constraints(
+    query: &CreateTableQuery,
+) -> Result<Vec<reddb_types::Constraint>, AnalysisError> {
+    let invalid = AnalysisError::InvalidUniqueConstraint;
+    let mut names = HashSet::new();
+    for column in &query.columns {
+        for (enabled, prefix) in [
+            (column.primary_key, "pk"),
+            (column.unique, "uniq"),
+            (column.not_null, "not_null"),
+        ] {
+            if enabled {
+                names.insert(format!("{prefix}_{}", column.name).to_ascii_lowercase());
+            }
+        }
+    }
+    if query.timestamps {
+        names.extend([
+            "not_null_created_at".to_string(),
+            "not_null_updated_at".to_string(),
+        ]);
+    }
+    // Reserve every explicit name before generating anonymous names, so declaration
+    // order cannot make an otherwise valid user-chosen name collide.
+    for constraint in &query.unique_constraints {
+        if let Some(name) = &constraint.name {
+            if name.is_empty() || !names.insert(name.to_ascii_lowercase()) {
+                return Err(invalid(format!(
+                    "duplicate or empty constraint name '{name}'"
+                )));
+            }
+        }
+    }
+    let mut resolved = Vec::with_capacity(query.unique_constraints.len());
+    for constraint in &query.unique_constraints {
+        if constraint.columns.is_empty() {
+            return Err(invalid("at least one column is required".to_string()));
+        }
+        let mut seen = HashSet::new();
+        let mut columns = Vec::with_capacity(constraint.columns.len());
+        for name in &constraint.columns {
+            let Some(column) = query
+                .columns
+                .iter()
+                .find(|column| column.name.eq_ignore_ascii_case(name))
+            else {
+                return Err(invalid(format!("unknown column '{name}'")));
+            };
+            if !seen.insert(column.name.to_ascii_lowercase()) {
+                return Err(invalid(format!("repeated column '{name}'")));
+            }
+            columns.push(column.name.clone());
+        }
+        let name = match &constraint.name {
+            Some(name) => name.clone(),
+            None => {
+                let base = format!("uniq_{}", columns.join("_"));
+                let mut name = base.clone();
+                let mut suffix = 2;
+                while !names.insert(name.to_ascii_lowercase()) {
+                    name = format!("{base}_{suffix}");
+                    suffix += 1;
+                }
+                name
+            }
+        };
+        resolved.push(
+            reddb_types::Constraint::new(name, reddb_types::ConstraintType::Unique)
+                .on_columns(columns),
+        );
+    }
+    Ok(resolved)
 }
 
 pub fn resolve_declared_data_type(declared: &str) -> Result<DataType, AnalysisError> {
@@ -109,6 +189,7 @@ mod tests {
             collection_model: CollectionModel::Table,
             name: "orders".to_string(),
             columns,
+            unique_constraints: Vec::new(),
             if_not_exists: true,
             default_ttl_ms: Some(60_000),
             metrics_rollup_policies: Vec::new(),
@@ -122,6 +203,42 @@ mod tests {
             analytics_config: Vec::new(),
             vault_own_master_key: false,
             ai_policy: None,
+        }
+    }
+
+    #[test]
+    fn table_unique_constraints_validate_references_and_generate_stable_names() {
+        use crate::ast::CreateUniqueConstraint;
+        let mut query = create_table(vec![column("LeftKey", "INT"), column("RightKey", "TEXT")]);
+        query.unique_constraints = vec![
+            CreateUniqueConstraint {
+                name: None,
+                columns: vec!["leftkey".into(), "RIGHTKEY".into()],
+            },
+            CreateUniqueConstraint {
+                name: Some("uniq_LeftKey_RightKey".into()),
+                columns: vec!["RightKey".into(), "LeftKey".into()],
+            },
+        ];
+        let analyzed = analyze_create_table(&query).expect("constraints");
+        assert_eq!(
+            analyzed.unique_constraints[0].name,
+            "uniq_LeftKey_RightKey_2"
+        );
+        assert_eq!(
+            analyzed.unique_constraints[0].columns,
+            ["LeftKey", "RightKey"]
+        );
+        for columns in [
+            vec![],
+            vec!["absent".into()],
+            vec!["LeftKey".into(), "leftkey".into()],
+        ] {
+            query.unique_constraints[0].columns = columns;
+            assert!(matches!(
+                analyze_create_table(&query),
+                Err(AnalysisError::InvalidUniqueConstraint(_))
+            ));
         }
     }
 

--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -2038,6 +2038,13 @@ pub struct DeleteQuery {
     pub suppress_events: bool,
 }
 
+/// A table-level UNIQUE declaration; unnamed constraints receive a stable catalog name.
+#[derive(Debug, Clone)]
+pub struct CreateUniqueConstraint {
+    pub name: Option<String>,
+    pub columns: Vec<String>,
+}
+
 /// CREATE TABLE name (columns) or CREATE {KV|CONFIG|VAULT} name
 #[derive(Debug, Clone)]
 pub struct CreateTableQuery {
@@ -2047,6 +2054,8 @@ pub struct CreateTableQuery {
     pub name: String,
     /// Column definitions
     pub columns: Vec<CreateColumnDef>,
+    /// Table-level UNIQUE constraints, including composite keys.
+    pub unique_constraints: Vec<CreateUniqueConstraint>,
     /// IF NOT EXISTS flag
     pub if_not_exists: bool,
     /// Optional default TTL applied to newly inserted items in this collection.

--- a/crates/reddb-rql/src/parser/ddl.rs
+++ b/crates/reddb-rql/src/parser/ddl.rs
@@ -4,9 +4,10 @@ use super::error::ParseError;
 use super::Parser;
 use crate::ast::{
     AlterOperation, AlterTableQuery, CreateCollectionQuery, CreateColumnDef, CreateTableQuery,
-    CreateVcsRefQuery, CreateVectorQuery, DropCollectionQuery, DropDocumentQuery, DropGraphQuery,
-    DropKvQuery, DropTableQuery, DropVcsRefQuery, DropVectorQuery, ExplainAlterQuery,
-    ExplainFormat, PartitionKind, PartitionSpec, QueryExpr, TruncateQuery, VcsRefKind,
+    CreateUniqueConstraint, CreateVcsRefQuery, CreateVectorQuery, DropCollectionQuery,
+    DropDocumentQuery, DropGraphQuery, DropKvQuery, DropTableQuery, DropVcsRefQuery,
+    DropVectorQuery, ExplainAlterQuery, ExplainFormat, PartitionKind, PartitionSpec, QueryExpr,
+    TruncateQuery, VcsRefKind,
 };
 use crate::lexer::Token;
 use reddb_types::catalog::{CollectionModel, SubscriptionDescriptor, SubscriptionOperation};
@@ -21,16 +22,7 @@ impl<'a> Parser<'a> {
         let if_not_exists = self.match_if_not_exists()?;
         let name = self.expect_ident()?;
 
-        self.expect(Token::LParen)?;
-        let mut columns = Vec::new();
-        loop {
-            let col = self.parse_column_def()?;
-            columns.push(col);
-            if !self.consume(&Token::Comma)? {
-                break;
-            }
-        }
-        self.expect(Token::RParen)?;
+        let (columns, unique_constraints) = self.parse_create_table_elements()?;
 
         let mut default_ttl_ms = None;
         let mut context_index_fields = Vec::new();
@@ -73,6 +65,7 @@ impl<'a> Parser<'a> {
             collection_model: CollectionModel::Table,
             name,
             columns,
+            unique_constraints,
             if_not_exists,
             default_ttl_ms,
             metrics_rollup_policies: Vec::new(),
@@ -87,6 +80,41 @@ impl<'a> Parser<'a> {
             vault_own_master_key: false,
             ai_policy: None,
         }))
+    }
+
+    fn parse_create_table_elements(
+        &mut self,
+    ) -> Result<(Vec<CreateColumnDef>, Vec<CreateUniqueConstraint>), ParseError> {
+        self.expect(Token::LParen)?;
+        let mut columns = Vec::new();
+        let mut unique_constraints = Vec::new();
+        loop {
+            let name = if self.consume_ident_ci("CONSTRAINT")? {
+                Some(self.expect_ident()?)
+            } else {
+                None
+            };
+            if name.is_some() || self.check(&Token::Unique) {
+                self.expect(Token::Unique)?;
+                self.expect(Token::LParen)?;
+                let mut keys = vec![self.expect_ident()?];
+                while self.consume(&Token::Comma)? {
+                    keys.push(self.expect_ident()?);
+                }
+                self.expect(Token::RParen)?;
+                unique_constraints.push(CreateUniqueConstraint {
+                    name,
+                    columns: keys,
+                });
+            } else {
+                columns.push(self.parse_column_def()?);
+            }
+            if !self.consume(&Token::Comma)? {
+                break;
+            }
+        }
+        self.expect(Token::RParen)?;
+        Ok((columns, unique_constraints))
     }
 
     /// Parse: DROP TABLE [IF EXISTS] name
@@ -138,16 +166,7 @@ impl<'a> Parser<'a> {
             return Err(ParseError::document_create_table(self.position()));
         }
 
-        self.expect(Token::LParen)?;
-        let mut columns = Vec::new();
-        loop {
-            let col = self.parse_column_def()?;
-            columns.push(col);
-            if !self.consume(&Token::Comma)? {
-                break;
-            }
-        }
-        self.expect(Token::RParen)?;
+        let (columns, unique_constraints) = self.parse_create_table_elements()?;
 
         let mut default_ttl_ms = None;
         let mut context_index_fields = Vec::new();
@@ -315,6 +334,7 @@ impl<'a> Parser<'a> {
             collection_model: CollectionModel::Table,
             name,
             columns,
+            unique_constraints,
             if_not_exists,
             default_ttl_ms,
             metrics_rollup_policies: Vec::new(),
@@ -457,6 +477,7 @@ impl<'a> Parser<'a> {
             collection_model: model,
             name,
             columns: Vec::new(),
+            unique_constraints: Vec::new(),
             if_not_exists,
             default_ttl_ms: None,
             metrics_rollup_policies: Vec::new(),
@@ -1755,6 +1776,37 @@ mod tests {
 
     fn parser(input: &str) -> Parser<'_> {
         Parser::new(input).unwrap_or_else(|err| panic!("failed to lex {input:?}: {err:?}"))
+    }
+
+    #[test]
+    fn table_unique_constraints_use_both_parser_entrypoints() {
+        let body = "pairs (left_key INT, UNIQUE (left_key, right_key), right_key TEXT, CONSTRAINT named_pair UNIQUE (right_key, left_key))";
+        for parsed in [
+            parser(body).parse_create_table_body(),
+            parser(&format!("CREATE TABLE {body}")).parse_create_table_query(),
+        ] {
+            let QueryExpr::CreateTable(table) = parsed.expect("table constraints") else {
+                panic!("expected table");
+            };
+            assert_eq!(table.columns.len(), 2);
+            assert_eq!(table.unique_constraints.len(), 2);
+            assert_eq!(table.unique_constraints[0].name, None);
+            assert_eq!(
+                table.unique_constraints[0].columns,
+                ["left_key", "right_key"]
+            );
+            assert_eq!(
+                table.unique_constraints[1].name.as_deref(),
+                Some("named_pair")
+            );
+        }
+        for body in [
+            "pairs (left_key INT, UNIQUE ())",
+            "pairs (left_key INT, CONSTRAINT named_pair (left_key))",
+            "pairs (left_key INT, UNIQUE (left_key,))",
+        ] {
+            assert!(parser(body).parse_create_table_body().is_err(), "{body}");
+        }
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/timeseries.rs
+++ b/crates/reddb-rql/src/parser/timeseries.rs
@@ -141,6 +141,7 @@ impl<'a> Parser<'a> {
             collection_model: CollectionModel::Metrics,
             name,
             columns: Vec::new(),
+            unique_constraints: Vec::new(),
             if_not_exists,
             default_ttl_ms: raw_retention_ms,
             metrics_rollup_policies: downsample_policies,

--- a/crates/reddb-server/src/application/ports_impls_schema.rs
+++ b/crates/reddb-server/src/application/ports_impls_schema.rs
@@ -62,6 +62,7 @@ impl RuntimeSchemaPort for RedDBRuntime {
             collection_model: crate::catalog::CollectionModel::Table,
             name,
             columns: columns.into_iter().map(to_create_column_def).collect(),
+            unique_constraints: Vec::new(),
             if_not_exists,
             default_ttl_ms,
             metrics_rollup_policies: Vec::new(),

--- a/crates/reddb-server/src/runtime/impl_ddl.rs
+++ b/crates/reddb-server/src/runtime/impl_ddl.rs
@@ -433,6 +433,7 @@ impl RedDBRuntime {
             collection_model: model,
             name: query.name.clone(),
             columns: Vec::new(),
+            unique_constraints: Vec::new(),
             if_not_exists: query.if_not_exists,
             default_ttl_ms: None,
             metrics_rollup_policies: Vec::new(),
@@ -1481,9 +1482,40 @@ impl RedDBRuntime {
         // Validate the target CREATE TABLE body so syntactically valid
         // but semantically broken targets (bad SQL types, duplicate
         // columns) are caught here rather than inside the diff engine.
-        analyze_create_table(&query.target).map_err(|err| RedDBError::Query(err.to_string()))?;
+        let analyzed = analyze_create_table(&query.target)
+            .map_err(|err| RedDBError::Query(err.to_string()))?;
 
         let current_contract = self.inner.db.collection_contract(&query.target.name);
+
+        // The column-diff planner cannot emit ADD/DROP CONSTRAINT. Do not
+        // silently report a complete migration when table-level UNIQUE changes.
+        let current_unique = current_contract
+            .as_ref()
+            .map(|contract| {
+                contract
+                    .table_def
+                    .iter()
+                    .flat_map(|table| &table.constraints)
+                    .filter(|constraint| {
+                        constraint.constraint_type == reddb_types::ConstraintType::Unique
+                            && !contract.declared_columns.iter().any(|column| {
+                                column.unique
+                                    && constraint.columns == [column.name.clone()]
+                                    && constraint.name == format!("uniq_{}", column.name)
+                            })
+                    })
+                    .map(|constraint| (constraint.name.clone(), constraint.columns.clone()))
+                    .collect::<BTreeSet<_>>()
+            })
+            .unwrap_or_default();
+        let target_unique = analyzed
+            .unique_constraints
+            .into_iter()
+            .map(|constraint| (constraint.name, constraint.columns))
+            .collect::<BTreeSet<_>>();
+        if current_unique != target_unique {
+            return Err(RedDBError::Query("NOT_YET_SUPPORTED: EXPLAIN ALTER cannot plan changes to table-level UNIQUE constraints".to_string()));
+        }
 
         let current_columns: Vec<crate::physical::DeclaredColumnContract> = current_contract
             .as_ref()
@@ -2821,6 +2853,11 @@ fn build_table_def_from_create_table(
         }
         table.columns.push(column_def_from_ddl(column)?);
     }
+    table.constraints.extend(
+        analyze_create_table(query)
+            .map_err(|err| RedDBError::Query(err.to_string()))?
+            .unique_constraints,
+    );
     // WITH timestamps = true: append the two runtime-managed columns
     // to the schema so resolved_contract_columns exposes them to the
     // normalize/validate path. Declared as UnsignedInteger (unix-ms),

--- a/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
@@ -303,12 +303,38 @@ fn render_show_create_table_ddl(
     contract: &crate::physical::CollectionContract,
     mut indices: Vec<super::index_store::RegisteredIndex>,
 ) -> String {
-    let columns = contract
+    let mut elements = contract
         .declared_columns
         .iter()
         .map(render_show_create_column)
-        .collect::<Vec<_>>()
-        .join(", ");
+        .collect::<Vec<_>>();
+    if let Some(table) = &contract.table_def {
+        for constraint in &table.constraints {
+            if constraint.constraint_type != reddb_types::ConstraintType::Unique {
+                continue;
+            }
+            let inline = constraint.columns.len() == 1
+                && contract.declared_columns.iter().any(|column| {
+                    column.unique
+                        && constraint.columns[0] == column.name
+                        && constraint.name == format!("uniq_{}", column.name)
+                });
+            if inline {
+                continue;
+            }
+            elements.push(format!(
+                "CONSTRAINT {} UNIQUE ({})",
+                render_sql_identifier(&constraint.name),
+                constraint
+                    .columns
+                    .iter()
+                    .map(|column| render_sql_identifier(column))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            ));
+        }
+    }
+    let columns = elements.join(", ");
     let mut statements = vec![format!(
         "CREATE TABLE {} ({columns})",
         render_sql_identifier(&contract.name)

--- a/docs/query/create-table.md
+++ b/docs/query/create-table.md
@@ -6,8 +6,9 @@ The `CREATE TABLE` statement defines a new collection with a typed schema.
 
 ```sql
 CREATE TABLE table_name (
-  column_name DataType [NOT NULL] [DEFAULT value],
+  column_name DataType [NOT NULL] [DEFAULT value] [UNIQUE],
   ...
+  [ [CONSTRAINT constraint_name] UNIQUE (column [, ...]) ]
 ) [WITH TTL duration]
   [WITH CONTEXT INDEX ON (column [, ...])]
 ```
@@ -26,6 +27,30 @@ CREATE TABLE hosts (
   last_seen Timestamp
 )
 ```
+
+## Uniqueness
+
+Use a table-level constraint when the combination of columns must be unique:
+
+```sql
+CREATE TABLE memberships (
+  id INT PRIMARY KEY,
+  organization TEXT NOT NULL,
+  username TEXT NOT NULL,
+  CONSTRAINT membership_key UNIQUE (organization, username)
+)
+```
+
+A username may occur in different organizations; the same pair cannot occur twice.
+`UNIQUE (organization, username)` also works without a constraint name. RedDB
+assigns a stable name and includes it in `SHOW CREATE TABLE`.
+
+Uniqueness is checked on inserts and updates and survives persistent reopen.
+A tuple containing `NULL` does not conflict with another tuple; use `NOT NULL`
+on every key column when that is undesirable. Missing or repeated key columns
+and duplicate constraint names are rejected before the table is created.
+`EXPLAIN ALTER` currently rejects changes to table-level UNIQUE constraints
+because its column migration planner cannot emit `ADD/DROP CONSTRAINT`.
 
 ## Supported Column Types
 

--- a/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
+++ b/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
@@ -18,18 +18,33 @@ fn duplicate(rt: &RedDBRuntime, query: &str) {
 fn table_unique_constraints_enforce_tuples_nulls_updates_and_savepoints() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
     execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, CONSTRAINT pair_key UNIQUE (left_key, right_key))");
-    execute(&rt, "INSERT INTO pairs VALUES (1,1,'a'),(2,1,'b'),(3,2,'a'),(4,NULL,'a'),(5,NULL,'a'),(6,1,NULL),(7,1,NULL)");
-    duplicate(&rt, "INSERT INTO pairs VALUES (8,1,'a')");
+    execute(&rt, "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a'),(2,1,'b'),(3,2,'a'),(4,NULL,'a'),(5,NULL,'a'),(6,1,NULL),(7,1,NULL)");
+    duplicate(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,1,'a')",
+    );
     duplicate(&rt, "UPDATE pairs SET right_key='a' WHERE id=2");
     execute(&rt, "BEGIN");
     execute(&rt, "SAVEPOINT probe");
-    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
-    duplicate(&rt, "INSERT INTO pairs VALUES (9,3,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,3,'a')",
+    );
+    duplicate(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (9,3,'a')",
+    );
     execute(&rt, "ROLLBACK TO SAVEPOINT probe");
-    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,3,'a')",
+    );
     execute(&rt, "COMMIT");
     execute(&rt, "DELETE FROM pairs WHERE id=1");
-    execute(&rt, "INSERT INTO pairs VALUES (9,1,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (9,1,'a')",
+    );
     let result = rt
         .execute_query("SELECT id FROM pairs WHERE left_key=1 AND right_key='b'")
         .expect("failed update is atomic");
@@ -65,7 +80,10 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
     {
         let rt = RedDBRuntime::with_options(options.clone()).expect("runtime");
         execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, UNIQUE (left_key, right_key), CONSTRAINT uniq_left_key_right_key UNIQUE (right_key, left_key))");
-        execute(&rt, "INSERT INTO pairs VALUES (1,1,'a')");
+        execute(
+            &rt,
+            "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a')",
+        );
         let result = rt.execute_query("SHOW CREATE TABLE pairs").expect("DDL");
         let Some(Value::Text(value)) = result.result.records[0].get("ddl") else {
             panic!("DDL text")
@@ -81,7 +99,10 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
         );
     }
     let reopened = RedDBRuntime::with_options(options).expect("reopen");
-    duplicate(&reopened, "INSERT INTO pairs VALUES (2,1,'a')");
+    duplicate(
+        &reopened,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (2,1,'a')",
+    );
     let fresh = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("fresh");
     for statement in ddl
         .split(';')
@@ -90,8 +111,14 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
     {
         execute(&fresh, statement);
     }
-    execute(&fresh, "INSERT INTO pairs VALUES (1,1,'a')");
-    duplicate(&fresh, "INSERT INTO pairs VALUES (2,1,'a')");
+    execute(
+        &fresh,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a')",
+    );
+    duplicate(
+        &fresh,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (2,1,'a')",
+    );
 }
 
 #[test]

--- a/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
+++ b/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
@@ -1,0 +1,112 @@
+use reddb::{RedDBOptions, RedDBRuntime};
+use reddb_types::Value;
+
+fn execute(rt: &RedDBRuntime, query: &str) {
+    rt.execute_query(query)
+        .unwrap_or_else(|err| panic!("{query}: {err}"));
+}
+
+fn duplicate(rt: &RedDBRuntime, query: &str) {
+    let error = rt
+        .execute_query(query)
+        .expect_err("duplicate must fail")
+        .to_string();
+    assert!(error.to_ascii_lowercase().contains("unique"), "{error}");
+}
+
+#[test]
+fn table_unique_constraints_enforce_tuples_nulls_updates_and_savepoints() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, CONSTRAINT pair_key UNIQUE (left_key, right_key))");
+    execute(&rt, "INSERT INTO pairs VALUES (1,1,'a'),(2,1,'b'),(3,2,'a'),(4,NULL,'a'),(5,NULL,'a'),(6,1,NULL),(7,1,NULL)");
+    duplicate(&rt, "INSERT INTO pairs VALUES (8,1,'a')");
+    duplicate(&rt, "UPDATE pairs SET right_key='a' WHERE id=2");
+    execute(&rt, "BEGIN");
+    execute(&rt, "SAVEPOINT probe");
+    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
+    duplicate(&rt, "INSERT INTO pairs VALUES (9,3,'a')");
+    execute(&rt, "ROLLBACK TO SAVEPOINT probe");
+    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
+    execute(&rt, "COMMIT");
+    execute(&rt, "DELETE FROM pairs WHERE id=1");
+    execute(&rt, "INSERT INTO pairs VALUES (9,1,'a')");
+    let result = rt
+        .execute_query("SELECT id FROM pairs WHERE left_key=1 AND right_key='b'")
+        .expect("failed update is atomic");
+    assert_eq!(result.result.records.len(), 1);
+    assert_eq!(result.result.records[0].get("id"), Some(&Value::Integer(2)));
+}
+
+#[test]
+fn table_unique_constraints_reject_invalid_definitions_before_creation() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    for clause in [
+        "UNIQUE (missing)",
+        "UNIQUE (left_key, LEFT_KEY)",
+        "CONSTRAINT same UNIQUE (left_key), CONSTRAINT SAME UNIQUE (right_key)",
+        "CONSTRAINT uniq_left_key UNIQUE (right_key)",
+    ] {
+        let error = rt
+            .execute_query(&format!(
+                "CREATE TABLE invalid_pair (left_key INT UNIQUE, right_key TEXT, {clause})"
+            ))
+            .expect_err("invalid definition");
+        assert!(error.to_string().contains("UNIQUE"), "{error}");
+        execute(&rt, "CREATE TABLE invalid_pair (id INT)");
+        execute(&rt, "DROP TABLE invalid_pair");
+    }
+}
+
+#[test]
+fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
+    let directory = tempfile::tempdir().expect("directory");
+    let options = RedDBOptions::persistent(directory.path().join("unique.rdb"));
+    let ddl;
+    {
+        let rt = RedDBRuntime::with_options(options.clone()).expect("runtime");
+        execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, UNIQUE (left_key, right_key), CONSTRAINT uniq_left_key_right_key UNIQUE (right_key, left_key))");
+        execute(&rt, "INSERT INTO pairs VALUES (1,1,'a')");
+        let result = rt.execute_query("SHOW CREATE TABLE pairs").expect("DDL");
+        let Some(Value::Text(value)) = result.result.records[0].get("ddl") else {
+            panic!("DDL text")
+        };
+        ddl = value.to_string();
+        assert!(
+            ddl.contains("CONSTRAINT uniq_left_key_right_key_2 UNIQUE (left_key, right_key)"),
+            "{ddl}"
+        );
+        assert!(
+            ddl.contains("CONSTRAINT uniq_left_key_right_key UNIQUE (right_key, left_key)"),
+            "{ddl}"
+        );
+    }
+    let reopened = RedDBRuntime::with_options(options).expect("reopen");
+    duplicate(&reopened, "INSERT INTO pairs VALUES (2,1,'a')");
+    let fresh = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("fresh");
+    for statement in ddl
+        .split(';')
+        .map(str::trim)
+        .filter(|statement| !statement.is_empty())
+    {
+        execute(&fresh, statement);
+    }
+    execute(&fresh, "INSERT INTO pairs VALUES (1,1,'a')");
+    duplicate(&fresh, "INSERT INTO pairs VALUES (2,1,'a')");
+}
+
+#[test]
+fn table_unique_constraints_explain_alter_never_omits_constraint_changes() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    execute(
+        &rt,
+        "CREATE TABLE pairs (left_key INT, right_key TEXT, UNIQUE (left_key, right_key))",
+    );
+    execute(&rt, "EXPLAIN ALTER FOR CREATE TABLE pairs (left_key INT, right_key TEXT, UNIQUE (left_key, right_key))");
+    for query in [
+        "EXPLAIN ALTER FOR CREATE TABLE pairs (left_key INT, right_key TEXT)",
+        "EXPLAIN ALTER FOR CREATE TABLE fresh (left_key INT, right_key TEXT, UNIQUE (left_key, right_key))",
+    ] {
+        let error = rt.execute_query(query).expect_err("unsupported constraint migration");
+        assert!(error.to_string().contains("table-level UNIQUE"), "{error}");
+    }
+}

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -119,3 +119,6 @@ mod e2e_mvcc_key_reuse;
 
 #[path = "schema_query_core/e2e_unique_key_lookup.rs"]
 mod e2e_unique_key_lookup;
+
+#[path = "schema_query_core/e2e_table_unique_constraints.rs"]
+mod e2e_table_unique_constraints;


### PR DESCRIPTION
`CREATE TABLE pairs (a INT, b TEXT, UNIQUE (a,b))` currently fails parsing although the catalog and write path can enforce composite uniqueness. Accept anonymous and named table-level UNIQUE declarations and carry them into the existing catalog constraints. Duplicate inserts/updates use the same enforcement path as other UNIQUE keys.

Validate missing/repeated columns and conflicting names before creating storage. Generate stable anonymous names, preserve constraints across SHOW CREATE roundtrips, and reject EXPLAIN ALTER changes that its column-only planner cannot express. Tuples containing NULL retain existing SQL uniqueness semantics; the durable catalog format is unchanged.

Adds parser/analyzer coverage and SQL tests for tuples, NULL, updates, savepoints, deletion, persistent reopen and DDL roundtrips. Local validation and CI are in progress; this PR stays draft.

Part of the approved SQLite/SurrealDB competitiveness plan following #2270. Based on `perf/competitive-integration`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791420157&installation_model_id=20659&pr_number=2283&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2283&signature=f83ad5cf56fc2929713e97d3622e3d4e658e43c069c4ed793faf3010194a07cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->