### PR TITLE
feat(vector): default to exact search with bounded top-k

### DIFF
--- a/crates/reddb-rql/src/core.rs
+++ b/crates/reddb-rql/src/core.rs
@@ -1658,6 +1658,14 @@ impl NodeSelector {
 // Vector Query
 // ============================================================================
 
+/// Accuracy contract for vector retrieval. Approximation requires explicit opt-in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum VectorSearchMode {
+    #[default]
+    Exact,
+    Approximate,
+}
+
 /// Vector similarity search query
 ///
 /// ```text
@@ -1668,6 +1676,8 @@ impl NodeSelector {
 /// ```
 #[derive(Debug, Clone)]
 pub struct VectorQuery {
+    /// Exact full-precision search by default.
+    pub mode: VectorSearchMode,
     /// Optional outer alias when used as a join source
     pub alias: Option<String>,
     /// Collection name to search
@@ -1692,6 +1702,7 @@ impl VectorQuery {
     /// Create a new vector query
     pub fn new(collection: &str, query: VectorSource) -> Self {
         Self {
+            mode: VectorSearchMode::Exact,
             alias: None,
             collection: collection.to_string(),
             query_vector: query,

--- a/crates/reddb-rql/src/parser/hybrid.rs
+++ b/crates/reddb-rql/src/parser/hybrid.rs
@@ -62,7 +62,13 @@ impl<'a> Parser<'a> {
             None
         };
 
+        let mode = if self.consume(&Token::Mode)? {
+            self.parse_vector_search_mode()?
+        } else {
+            Default::default()
+        };
         let vector = VectorQuery {
+            mode,
             alias: None,
             collection,
             query_vector,

--- a/crates/reddb-rql/src/parser/vector.rs
+++ b/crates/reddb-rql/src/parser/vector.rs
@@ -2,7 +2,7 @@
 
 use super::error::ParseError;
 use super::Parser;
-use crate::ast::{QueryExpr, VectorQuery, VectorSource};
+use crate::ast::{QueryExpr, VectorQuery, VectorSearchMode, VectorSource};
 use crate::lexer::Token;
 use reddb_types::distance::DistanceMetric;
 use reddb_types::vector_metadata::{MetadataFilter, MetadataValue};
@@ -15,6 +15,7 @@ impl<'a> Parser<'a> {
     /// VECTOR SEARCH collection
     /// SIMILAR TO [0.1, 0.2, ...] | 'text query' | (subquery)
     /// [WHERE metadata conditions]
+    /// [MODE EXACT|APPROXIMATE]
     /// [METRIC L2|COSINE|INNER_PRODUCT]
     /// [THRESHOLD 0.5]
     /// [INCLUDE VECTORS] [INCLUDE METADATA]
@@ -34,6 +35,7 @@ impl<'a> Parser<'a> {
         let query_vector = self.parse_vector_source()?;
 
         // Parse optional clauses
+        let mut mode = None;
         let mut filter: Option<MetadataFilter> = None;
         let mut metric: Option<DistanceMetric> = None;
         let mut threshold: Option<f32> = None;
@@ -45,6 +47,14 @@ impl<'a> Parser<'a> {
         loop {
             if self.consume(&Token::Where)? {
                 filter = Some(self.parse_metadata_filter()?);
+            } else if self.consume(&Token::Mode)? {
+                if mode.is_some() {
+                    return Err(ParseError::new(
+                        "duplicate vector MODE clause".to_string(),
+                        self.position(),
+                    ));
+                }
+                mode = Some(self.parse_vector_search_mode()?);
             } else if self.consume(&Token::Metric)? {
                 metric = Some(self.parse_distance_metric()?);
             } else if self.consume(&Token::Threshold)? {
@@ -73,6 +83,7 @@ impl<'a> Parser<'a> {
         }
 
         Ok(QueryExpr::Vector(VectorQuery {
+            mode: mode.unwrap_or_default(),
             alias: None,
             collection,
             query_vector,
@@ -83,6 +94,20 @@ impl<'a> Parser<'a> {
             include_metadata,
             threshold,
         }))
+    }
+
+    pub(super) fn parse_vector_search_mode(&mut self) -> Result<VectorSearchMode, ParseError> {
+        if self.consume_ident_ci("EXACT")? {
+            Ok(VectorSearchMode::Exact)
+        } else if self.consume_ident_ci("APPROXIMATE")? {
+            Ok(VectorSearchMode::Approximate)
+        } else {
+            Err(ParseError::expected(
+                vec!["EXACT", "APPROXIMATE"],
+                self.peek(),
+                self.position(),
+            ))
+        }
     }
 
     /// Parse vector source: literal array, text, reference, or subquery
@@ -580,6 +605,36 @@ mod tests {
             "VECTOR SEARCH docs SIMILAR TO (docs)",
         ] {
             assert!(parse_query(sql).is_err(), "{sql} should not parse");
+        }
+    }
+}
+
+#[cfg(test)]
+mod search_mode_tests {
+    use super::*;
+    #[test]
+    fn vector_modes_are_explicit_and_exact_by_default() {
+        for (clause, expected) in [
+            ("", VectorSearchMode::Exact),
+            ("MODE EXACT", VectorSearchMode::Exact),
+            ("MODE APPROXIMATE", VectorSearchMode::Approximate),
+        ] {
+            let sql = format!("VECTOR SEARCH embeddings SIMILAR TO [1,0] {clause} LIMIT 3");
+            let QueryExpr::Vector(query) = Parser::new(&sql)
+                .expect("lexer")
+                .parse_vector_query()
+                .expect("query")
+            else {
+                panic!("vector")
+            };
+            assert_eq!(query.mode, expected);
+        }
+        for clause in ["MODE QUICK", "MODE EXACT MODE APPROXIMATE"] {
+            let sql = format!("VECTOR SEARCH embeddings SIMILAR TO [1,0] {clause}");
+            assert!(Parser::new(&sql)
+                .expect("lexer")
+                .parse_vector_query()
+                .is_err());
         }
     }
 }

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3256,6 +3256,23 @@ impl RedDBRuntime {
             ("op", Value::text(vector.access_path.clone())),
             ("source", Value::text(source)),
             ("index_used", Value::Boolean(vector.index_used)),
+            ("mode_requested", Value::text(vector.mode_requested.clone())),
+            ("mode_executed", Value::text(vector.mode_executed.clone())),
+            (
+                "fallback_reason",
+                vector
+                    .fallback_reason
+                    .as_ref()
+                    .map_or(Value::Null, |reason| Value::text(reason.clone())),
+            ),
+            (
+                "approximate_distance_evaluations",
+                Value::UnsignedInteger(vector.approximate_distance_evaluations),
+            ),
+            (
+                "peak_topk_entries",
+                Value::UnsignedInteger(vector.peak_topk_entries),
+            ),
             (
                 "candidates_examined",
                 Value::UnsignedInteger(vector.candidates_examined),

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -1,6 +1,6 @@
 //! Vector similarity search executor.
 //!
-//! Handles `Vector` query expressions — ANN search over a collection's
+//! Handles `Vector` query expressions — exact or explicitly approximate search over a collection's
 //! registered vector index with optional metadata pre/post-filters.
 //! Split out of `query_exec.rs` to keep the main executor focused on
 //! table-scan paths.
@@ -8,9 +8,10 @@
 //! Uses `use super::*;` to inherit the parent executor's imports.
 
 use super::*;
-use crate::runtime::vector_index::{BruteForceVectorIndex, VectorIndexEntry};
+use crate::runtime::vector_index::VectorTopK;
 use crate::storage::engine::distance::DistanceMetric;
 use crate::storage::query::unified::{QueryStats, VectorQueryStats};
+use reddb_rql::ast::VectorSearchMode;
 use reddb_rql::sql_lowering::effective_vector_filter;
 
 pub(crate) fn execute_runtime_vector_query(
@@ -121,7 +122,16 @@ pub(crate) fn runtime_vector_matches(
     // `select_scorer()` (scalar / AVX2 / AVX-512BW / NEON, runtime
     // selected). Legacy `vector` collections continue on the
     // brute-force path below.
-    if let Some(state) = db.turbo_state(&query.collection) {
+    stats.mode_requested = match query.mode {
+        VectorSearchMode::Exact => "exact",
+        VectorSearchMode::Approximate => "approximate",
+    }
+    .to_string();
+    let turbo = (query.mode == VectorSearchMode::Approximate)
+        .then(|| db.turbo_state(&query.collection))
+        .flatten();
+    if let Some(state) = turbo {
+        stats.mode_executed = "approximate".to_string();
         stats.access_path = "vector_turbo_search".to_string();
         stats.index_used = true;
         // Issue #673 — wait briefly for the background rebuild to
@@ -152,8 +162,8 @@ pub(crate) fn runtime_vector_matches(
         // low-dimensional collections the quantisation collapses the scores
         // and the approximate order is wrong (#1372). Over-fetch a generous
         // candidate set from the index, then re-rank with full-precision
-        // exact distances so metric ordering is correct. The index still
-        // prunes the candidate set on large collections.
+        // exact distances. Packed scoring still visits the entire collection;
+        // only the full-precision reranking candidate set is reduced.
         const RERANK_OVERFETCH: usize = 32;
         let k = query.k.max(1);
         let collection_count = manager.count().max(1);
@@ -167,9 +177,10 @@ pub(crate) fn runtime_vector_matches(
         };
         let raw = {
             let index = state.index.lock();
+            stats.approximate_distance_evaluations = index.len() as u64;
             index.search(vector, search_k, metric)
         };
-        let mut results = Vec::with_capacity(raw.len());
+        let mut top = VectorTopK::new(k);
         let filter = effective_vector_filter(query);
         for hit in raw {
             stats.candidates_examined += 1;
@@ -230,63 +241,75 @@ pub(crate) fn runtime_vector_matches(
                     continue;
                 }
             }
-            results.push(SimilarResult {
-                entity_id: hit.entity_id,
-                score,
-                distance,
-                entity,
-            });
+            top.consider(&entity, score, distance);
         }
-        results.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.entity_id.raw().cmp(&b.entity_id.raw()))
-        });
-        results.truncate(k);
-        return Ok(results);
+        stats.peak_topk_entries = top.len() as u64;
+        return Ok(top.finish());
     }
 
     stats.access_path = "vector_exact_scan".to_string();
-    let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
-    let mut index = BruteForceVectorIndex::default();
+    stats.mode_executed = "exact".to_string();
+    if query.mode == VectorSearchMode::Approximate {
+        stats.fallback_reason = Some("no operational approximate index".to_string());
+    }
+    let snapshot = crate::runtime::impl_core::capture_current_snapshot();
     let filter = effective_vector_filter(query);
-    let search_k = if effective_vector_filter(query).is_some() {
-        manager.count().max(1)
-    } else {
-        query.k.max(1)
-    };
-
-    for entity in manager.scan(snap_ctx.as_ref(), |_| true) {
-        stats.candidates_examined += 1;
-        if rls_enabled
-            && !runtime.search_entity_rls_allowed(&query.collection, &entity, &mut rls_cache)
-        {
-            stats.rls_rejected += 1;
-            continue;
-        }
-        if let Some(filter) = filter.as_ref() {
-            if !runtime_vector_entity_matches_filter(db, &query.collection, entity.id, filter) {
+    let mut top = VectorTopK::new(query.k.max(1));
+    // Collect only ids while holding segment read locks. RLS expressions and
+    // metadata lookups may re-enter storage, so evaluate them after releasing
+    // those locks. Vector payloads are materialized one bounded batch at a time.
+    let mut ids = Vec::new();
+    manager.scan_for_each(snapshot.as_ref(), |entity| {
+        ids.push(entity.id);
+        true
+    });
+    for batch in ids.chunks(256) {
+        for entity in manager.get_many(batch).into_iter().flatten() {
+            stats.candidates_examined += 1;
+            if (snapshot.is_none() && entity.xmax != 0)
+                || !crate::runtime::impl_core::entity_visible_with_context(
+                    snapshot.as_ref(),
+                    &entity,
+                )
+            {
+                stats.visibility_rejected += 1;
+                continue;
+            }
+            if rls_enabled
+                && !runtime.search_entity_rls_allowed(&query.collection, &entity, &mut rls_cache)
+            {
+                stats.rls_rejected += 1;
+                continue;
+            }
+            if filter.as_ref().is_some_and(|filter| {
+                !runtime_vector_entity_matches_filter(db, &query.collection, entity.id, filter)
+            }) {
                 stats.metadata_rejected += 1;
                 continue;
             }
-        }
-        if let EntityData::Vector(data) = &entity.data {
-            index.upsert(VectorIndexEntry {
-                entity_id: entity.id,
-                vector: data.dense.clone(),
-                entity,
-            });
+            let EntityData::Vector(data) = &entity.data else {
+                continue;
+            };
+            if data.dense.len() != vector.len() {
+                continue;
+            }
+            stats.exact_distance_evaluations += 1;
+            let distance = crate::storage::engine::distance::distance(vector, &data.dense, metric);
+            let score = match metric {
+                DistanceMetric::Cosine => 1.0 - distance,
+                DistanceMetric::InnerProduct | DistanceMetric::L2 => -distance,
+            };
+            if query.threshold.is_some_and(|threshold| match metric {
+                DistanceMetric::L2 => distance > threshold,
+                DistanceMetric::Cosine | DistanceMetric::InnerProduct => score < threshold,
+            }) {
+                continue;
+            }
+            top.consider(&entity, score, distance);
         }
     }
-
-    Ok(index.search(
-        vector,
-        search_k,
-        metric,
-        query.threshold,
-        &mut stats.exact_distance_evaluations,
-    ))
+    stats.peak_topk_entries = top.len() as u64;
+    Ok(top.finish())
 }
 
 pub(crate) fn runtime_vector_record_matches_filter(

--- a/crates/reddb-server/src/runtime/vector_index.rs
+++ b/crates/reddb-server/src/runtime/vector_index.rs
@@ -1,95 +1,85 @@
 use std::cmp::Ordering;
+use std::collections::BinaryHeap;
 
-use crate::storage::engine::distance::{distance, DistanceMetric};
 use crate::storage::{EntityId, SimilarResult, UnifiedEntity};
 
-#[derive(Debug, Clone)]
-pub(crate) struct VectorIndexEntry {
-    pub entity_id: EntityId,
-    pub vector: Vec<f32>,
-    pub entity: UnifiedEntity,
+/// A bounded selection heap. The worst retained result is at the root.
+/// Ties prefer the smaller physical entity id, independent of scan order.
+pub(crate) struct VectorTopK {
+    limit: usize,
+    entries: BinaryHeap<RankedVector>,
 }
 
-#[derive(Debug, Default)]
-pub(crate) struct BruteForceVectorIndex {
-    entries: Vec<VectorIndexEntry>,
+struct RankedVector(SimilarResult);
+
+fn rank(left_score: f32, left_id: EntityId, right_score: f32, right_id: EntityId) -> Ordering {
+    if left_score == right_score {
+        left_id.raw().cmp(&right_id.raw())
+    } else {
+        right_score
+            .total_cmp(&left_score)
+            .then_with(|| left_id.raw().cmp(&right_id.raw()))
+    }
 }
 
-impl BruteForceVectorIndex {
-    pub(crate) fn upsert(&mut self, entry: VectorIndexEntry) {
-        if let Some(existing) = self
-            .entries
-            .iter_mut()
-            .find(|existing| existing.entity_id == entry.entity_id)
-        {
-            *existing = entry;
-        } else {
-            self.entries.push(entry);
+impl PartialEq for RankedVector {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for RankedVector {}
+impl PartialOrd for RankedVector {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for RankedVector {
+    fn cmp(&self, other: &Self) -> Ordering {
+        rank(
+            self.0.score,
+            self.0.entity_id,
+            other.0.score,
+            other.0.entity_id,
+        )
+    }
+}
+
+impl VectorTopK {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            entries: BinaryHeap::new(),
         }
     }
 
-    pub(crate) fn delete(&mut self, entity_id: EntityId) {
-        self.entries.retain(|entry| entry.entity_id != entity_id);
+    pub(crate) fn consider(&mut self, entity: &UnifiedEntity, score: f32, distance: f32) {
+        if self.limit == 0 {
+            return;
+        }
+        if self.entries.len() == self.limit {
+            let worst = self.entries.peek().expect("nonempty bounded heap");
+            if !rank(score, entity.id, worst.0.score, worst.0.entity_id).is_lt() {
+                return;
+            }
+            self.entries.pop();
+        }
+        self.entries.push(RankedVector(SimilarResult {
+            entity_id: entity.id,
+            score,
+            distance,
+            entity: entity.clone(),
+        }));
     }
 
-    pub(crate) fn search(
-        &self,
-        query: &[f32],
-        k: usize,
-        metric: DistanceMetric,
-        threshold: Option<f32>,
-        exact_distance_evaluations: &mut u64,
-    ) -> Vec<SimilarResult> {
-        let mut results: Vec<SimilarResult> = self
-            .entries
-            .iter()
-            .filter(|entry| entry.vector.len() == query.len())
-            .filter_map(|entry| {
-                *exact_distance_evaluations += 1;
-                let raw_distance = distance(query, &entry.vector, metric);
-                let score = vector_score(raw_distance, metric);
-                if !within_threshold(score, raw_distance, metric, threshold) {
-                    return None;
-                }
-                Some(SimilarResult {
-                    entity_id: entry.entity_id,
-                    score,
-                    distance: raw_distance,
-                    entity: entry.entity.clone(),
-                })
-            })
-            .collect();
-
-        results.sort_by(|left, right| {
-            right
-                .score
-                .partial_cmp(&left.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| left.entity_id.raw().cmp(&right.entity_id.raw()))
-        });
-        results.truncate(k);
-        results
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
     }
-}
 
-fn vector_score(distance: f32, metric: DistanceMetric) -> f32 {
-    match metric {
-        DistanceMetric::Cosine => 1.0 - distance,
-        DistanceMetric::InnerProduct | DistanceMetric::L2 => -distance,
-    }
-}
-
-fn within_threshold(
-    score: f32,
-    distance: f32,
-    metric: DistanceMetric,
-    threshold: Option<f32>,
-) -> bool {
-    let Some(threshold) = threshold else {
-        return true;
-    };
-    match metric {
-        DistanceMetric::L2 => distance <= threshold,
-        DistanceMetric::Cosine | DistanceMetric::InnerProduct => score >= threshold,
+    pub(crate) fn finish(self) -> Vec<SimilarResult> {
+        self.entries
+            .into_sorted_vec()
+            .into_iter()
+            .map(|entry| entry.0)
+            .collect()
     }
 }

--- a/crates/reddb-server/src/storage/query/executors/hybrid.rs
+++ b/crates/reddb-server/src/storage/query/executors/hybrid.rs
@@ -800,6 +800,7 @@ mod tests {
         executor.add_vector("hosts", 3, vec![0.99, 0.0], Some(3)); // Closest to query
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "hosts".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),
@@ -845,6 +846,7 @@ mod tests {
         executor.add_vector("hosts", 4, vec![0.9, 0.0], Some(4));
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "hosts".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),
@@ -888,6 +890,7 @@ mod tests {
         }
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "hosts".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),

--- a/crates/reddb-server/src/storage/query/executors/vector.rs
+++ b/crates/reddb-server/src/storage/query/executors/vector.rs
@@ -685,6 +685,7 @@ mod tests {
         executor.add_vector("test", 4, vec![0.9, 0.1, 0.0], None);
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "test".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0, 0.0]),
@@ -729,6 +730,7 @@ mod tests {
 
         // Search with filter: type = 'cve' AND severity >= 7
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "vulns".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),
@@ -758,6 +760,7 @@ mod tests {
         executor.add_vector("test", 2, vec![0.0, 1.0], None); // Far from query
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "test".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),
@@ -782,6 +785,7 @@ mod tests {
         executor.add_vector("test", 1, vec![1.0, 2.0, 3.0], None);
 
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "test".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 2.0, 3.0]),
@@ -810,6 +814,7 @@ mod tests {
 
         let executor = VectorExecutor::new(Arc::new(store));
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "refs".to_string(),
             query_vector: VectorSource::Reference {
@@ -838,6 +843,7 @@ mod tests {
 
         let executor = VectorExecutor::new(Arc::new(store));
         let inner = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "refs".to_string(),
             query_vector: VectorSource::Literal(vec![1.0, 0.0]),
@@ -849,6 +855,7 @@ mod tests {
             threshold: None,
         };
         let query = VectorQuery {
+            mode: Default::default(),
             alias: None,
             collection: "refs".to_string(),
             query_vector: VectorSource::Subquery(Box::new(QueryExpr::Vector(inner))),

--- a/crates/reddb-server/src/storage/query/planner/logical.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical.rs
@@ -431,7 +431,7 @@ pub(super) fn logical_plan_node_with_catalog(db: &RedDB, expr: &QueryExpr) -> Ca
         }
         QueryExpr::Vector(query) => {
             let mut details = BTreeMap::new();
-            let access = vector_access_path_hint(db, query.collection.as_str());
+            let access = vector_access_path_hint(db, query);
             let scan_estimate = base_collection_cardinality(db, query.collection.as_str());
             let effective_filter = effective_vector_filter(query);
             details.insert("access_path".to_string(), access.path.to_string());

--- a/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
+++ b/crates/reddb-server/src/storage/query/planner/logical_helpers.rs
@@ -558,7 +558,19 @@ pub(crate) fn hybrid_ranking_mode(fusion: &FusionStrategy) -> String {
     }
 }
 
-pub(crate) fn vector_access_path_hint(db: &RedDB, collection: &str) -> AccessPathDecision {
+pub(crate) fn vector_access_path_hint(
+    db: &RedDB,
+    query: &reddb_rql::ast::VectorQuery,
+) -> AccessPathDecision {
+    let collection = query.collection.as_str();
+    if query.mode == reddb_rql::ast::VectorSearchMode::Exact {
+        return AccessPathDecision {
+            path: "vector_exact_scan",
+            index_hint: None,
+            reason: "MODE EXACT evaluates eligible vectors at full precision".to_string(),
+            warning: None,
+        };
+    }
     let all_indexes = db.index_statuses();
     let indexes = all_indexes
         .clone()

--- a/crates/reddb-server/src/storage/query/planner/shape.rs
+++ b/crates/reddb-server/src/storage/query/planner/shape.rs
@@ -303,6 +303,7 @@ fn bind_query_expr_inner(expr: &QueryExpr, binds: &[Value]) -> Option<QueryExpr>
 
 fn parameterize_vector_query(query: &VectorQuery, next_index: &mut usize) -> Option<VectorQuery> {
     Some(VectorQuery {
+        mode: query.mode,
         alias: query.alias.clone(),
         collection: query.collection.clone(),
         query_vector: parameterize_vector_source(&query.query_vector, next_index)?,
@@ -322,6 +323,7 @@ fn parameterize_vector_query(query: &VectorQuery, next_index: &mut usize) -> Opt
 
 fn bind_vector_query(query: &VectorQuery, binds: &[Value]) -> Option<VectorQuery> {
     Some(VectorQuery {
+        mode: query.mode,
         alias: query.alias.clone(),
         collection: query.collection.clone(),
         query_vector: bind_vector_source(&query.query_vector, binds)?,

--- a/crates/reddb-server/src/storage/query/unified/types.rs
+++ b/crates/reddb-server/src/storage/query/unified/types.rs
@@ -655,6 +655,11 @@ pub struct QueryStats {
 /// Counters collected by execution, not inferred from the logical plan.
 #[derive(Debug, Clone, Default)]
 pub struct VectorQueryStats {
+    pub mode_requested: String,
+    pub mode_executed: String,
+    pub fallback_reason: Option<String>,
+    pub approximate_distance_evaluations: u64,
+    pub peak_topk_entries: u64,
     /// True when these measurements describe the cached computation.
     pub cache_hit: bool,
     pub access_path: String,

--- a/docs/guides/vector-search.md
+++ b/docs/guides/vector-search.md
@@ -120,28 +120,47 @@ SIMILAR TO [0.15,0.42,0.75,0.20,0.58,0.85,0.30,0.65]
 WHERE category = 'tutorial' LIMIT 5;
 ```
 
-`vector_turbo_search` means TurboQuant candidates followed by exact reranking.
-New collections created with `CREATE VECTOR` use this route. Legacy collections
-without the TurboQuant marker use `vector_exact_scan`. The plan's
-`access_path_reason` explains the choice, including registered HNSW/IVF indexes
-that this runtime route does not use. These names describe `VECTOR SEARCH`;
-other vector endpoints may have different execution paths.
+`VECTOR SEARCH` defaults to `MODE EXACT`, including collections created with
+`CREATE VECTOR`. Exact search evaluates every eligible vector at full precision,
+applying visibility, row policies, and metadata filters before selecting the best
+`k` results. Equal scores prefer the smaller entity id.
+
+Use `MODE APPROXIMATE` to opt into TurboQuant candidate selection followed by
+full-precision reranking:
+
+```sql
+VECTOR SEARCH articles SIMILAR TO [0.15,0.42,0.75,0.20,0.58,0.85,0.30,0.65]
+MODE APPROXIMATE LIMIT 5;
+```
+
+Approximate candidate selection can miss a true nearest neighbor. Its packed
+scorer still visits the entire index; a small reranking candidate count does not
+prove sublinear search. Without an operational TurboQuant route, execution falls
+back to exact search and reports why. Registered HNSW/IVF indexes do not change
+this runtime route.
+
+Exact selection retains at most `k` results. It gathers visible entity ids and
+fetches vector payloads in batches of 256 before evaluating policies, so the
+working set includes O(N) ids, one payload batch, and O(k) retained results.
 
 ANALYZE returns one measured row with `metrics_scope = vector_pipeline`:
 
 | Field | Meaning |
 | --- | --- |
+| `mode_requested`, `mode_executed` | Requested accuracy and actual execution mode |
+| `fallback_reason` | Why approximation fell back to exact, or NULL |
 | `index_used` | Whether the pipeline used the TurboQuant index |
-| `candidates_examined` | Visible scan entities or returned TurboQuant hits visited by the pipeline |
-| `metadata_rejected` | Candidates rejected by the effective predicate |
-| `visibility_rejected` | TurboQuant hits missing or invisible in the statement snapshot |
+| `candidates_examined` | Scan entities or returned TurboQuant hits visited by the pipeline |
+| `approximate_distance_evaluations` | Vectors scored by the packed index |
+| `metadata_rejected`, `rls_rejected` | Candidates rejected by predicates or row policies |
+| `visibility_rejected` | Candidates missing or invisible in the statement snapshot |
 | `exact_distance_evaluations` | Exact distance calls, including reranking |
+| `peak_topk_entries` | Maximum retained selection entries, bounded by k |
 | `actual_rows` | Rows returned after filtering and top-k |
-| `actual_ms` | Vector pipeline time, excluding the surrounding authorization/frame overhead |
+| `actual_ms` | Vector pipeline time, excluding surrounding authorization/frame overhead |
 
-These counters do not measure approximate scoring inside the index or each
-logical operator separately. A filtered TurboQuant query can still visit the
-whole collection. A small candidate count alone does not prove low index cost.
+These measurements describe the vector pipeline, not individual logical operator
+timings. Other vector endpoints may have different execution paths.
 
 Ordinary queries expose optional `stats.vector` measurements. `cache_hit=true`
 means those measurements describe the cached computation. ANALYZE always runs

--- a/tests/grouped/ai_local_vector/e2e_vector_execution_observability.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_execution_observability.rs
@@ -69,7 +69,7 @@ fn vector_analysis_executes_instead_of_reusing_cached_measurements() {
 #[test]
 fn turbo_plan_and_measurement_name_the_executed_path() {
     let (_directory, rt) = fixture(true);
-    let sql = "VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 1";
+    let sql = "VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] MODE APPROXIMATE LIMIT 1";
     let plan = rt.execute_query(&format!("EXPLAIN {sql}")).expect("plan");
     assert!(plan
         .result
@@ -82,6 +82,9 @@ fn turbo_plan_and_measurement_name_the_executed_path() {
     let metrics = analyzed.result.stats.vector.expect("metrics");
     assert_eq!(metrics.access_path, "vector_turbo_search");
     assert!(metrics.index_used);
+    assert_eq!(metrics.mode_requested, "approximate");
+    assert_eq!(metrics.mode_executed, "approximate");
+    assert_eq!(metrics.approximate_distance_evaluations, 1);
     assert_eq!(metrics.rows_returned, 1);
     assert_eq!(metrics.exact_distance_evaluations, 1);
 }
@@ -149,7 +152,9 @@ fn registered_hnsw_does_not_turn_an_exact_runtime_search_into_ann() {
         .expect("associated index");
     assert!(status.declared && status.operational && status.enabled);
     let plan = rt
-        .execute_query("EXPLAIN VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 1")
+        .execute_query(
+            "EXPLAIN VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] MODE APPROXIMATE LIMIT 1",
+        )
         .expect("plan");
     assert!(plan.result.records.iter().any(|row| {
         row.get("op") == Some(&Value::text("vector_exact_scan"))
@@ -173,4 +178,23 @@ fn vector_analysis_does_not_end_the_callers_transaction() {
         .execute_query("SELECT * FROM changes")
         .expect("read after rollback");
     assert!(rows.result.records.is_empty());
+}
+
+#[test]
+fn approximate_mode_reports_exact_fallback_without_a_turbo_route() {
+    let (_directory, rt) = fixture(false);
+    let result = rt
+        .execute_query(
+            "EXPLAIN ANALYZE VECTOR SEARCH embeddings SIMILAR TO [1,0] MODE APPROXIMATE LIMIT 1",
+        )
+        .expect("fallback");
+    let stats = result.result.stats.vector.expect("metrics");
+    assert_eq!(stats.mode_requested, "approximate");
+    assert_eq!(stats.mode_executed, "exact");
+    assert_eq!(
+        stats.fallback_reason.as_deref(),
+        Some("no operational approximate index")
+    );
+    assert_eq!(stats.approximate_distance_evaluations, 0);
+    assert!(!stats.index_used);
 }

--- a/tests/grouped/ai_local_vector/e2e_vector_row_isolation.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_row_isolation.rs
@@ -77,22 +77,25 @@ fn vector_rls_precedes_topk_on_turbo_and_legacy() {
         clear_current_auth_identity();
         let (_directory, runtime) = fixture(turbo);
         let collection = if turbo { "embeddings" } else { "legacy" };
-        set_current_auth_identity("alice".into(), Role::Read);
-        let sql = format!("VECTOR SEARCH {collection} SIMILAR TO [1.0,0.0] LIMIT 1");
-        assert_eq!(
-            contents(&runtime, &sql, "content"),
-            ["alice"],
-            "turbo={turbo}"
-        );
-        assert_eq!(contents(&runtime, &sql, "content"), ["alice"], "repeat");
-        set_current_auth_identity("nobody".into(), Role::Read);
-        assert!(contents(&runtime, &sql, "content").is_empty());
-        set_current_auth_identity("alice".into(), Role::Read);
-        assert_eq!(
-            contents(&runtime, &sql, "content"),
-            ["alice"],
-            "identity switch"
-        );
+        for mode in ["EXACT", "APPROXIMATE"] {
+            set_current_auth_identity("alice".into(), Role::Read);
+            let sql =
+                format!("VECTOR SEARCH {collection} SIMILAR TO [1.0,0.0] MODE {mode} LIMIT 1");
+            assert_eq!(
+                contents(&runtime, &sql, "content"),
+                ["alice"],
+                "turbo={turbo}"
+            );
+            assert_eq!(contents(&runtime, &sql, "content"), ["alice"], "repeat");
+            set_current_auth_identity("nobody".into(), Role::Read);
+            assert!(contents(&runtime, &sql, "content").is_empty());
+            set_current_auth_identity("alice".into(), Role::Read);
+            assert_eq!(
+                contents(&runtime, &sql, "content"),
+                ["alice"],
+                "identity switch"
+            );
+        }
     }
 }
 

--- a/tests/grouped/ai_local_vector/e2e_vector_search_modes.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_search_modes.rs
@@ -22,11 +22,7 @@ fn vector_exact_default_matches_full_precision_oracle_beyond_rerank_window() {
         ("inner_product", "METRIC INNER_PRODUCT"),
     ] {
         for filtered in [false, true] {
-            let filter = if filtered {
-                "WHERE metadata.eligible=true"
-            } else {
-                ""
-            };
+            let filter = if filtered { "WHERE eligible=true" } else { "" };
             let mut oracle = vectors
                 .iter()
                 .filter(|(_, _, eligible)| !filtered || *eligible)

--- a/tests/grouped/ai_local_vector/e2e_vector_search_modes.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_search_modes.rs
@@ -1,0 +1,100 @@
+use reddb::{RedDBOptions, RedDBRuntime};
+use reddb_types::Value;
+
+#[test]
+fn vector_exact_default_matches_full_precision_oracle_beyond_rerank_window() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE VECTOR embeddings DIM 2 METRIC cosine")
+        .expect("collection");
+    // More than the old k*32 candidates, with close directions and the best
+    // vector inserted last. Metadata selectivity changes the eligible winner.
+    let mut vectors = Vec::new();
+    for i in 0..160 {
+        let angle = (160 - i) as f32 * 0.0007;
+        let vector = [angle.cos(), angle.sin()];
+        let eligible = i % 3 == 0;
+        rt.execute_query(&format!("INSERT INTO embeddings VECTOR (dense,content) VALUES ([{},{}],'v{i}') WITH METADATA (eligible={eligible})", vector[0], vector[1])).expect("vector");
+        vectors.push((i, vector, eligible));
+    }
+    for (metric, clause) in [
+        ("cosine", ""),
+        ("l2", "METRIC L2"),
+        ("inner_product", "METRIC INNER_PRODUCT"),
+    ] {
+        for filtered in [false, true] {
+            let filter = if filtered {
+                "WHERE metadata.eligible=true"
+            } else {
+                ""
+            };
+            let mut oracle = vectors
+                .iter()
+                .filter(|(_, _, eligible)| !filtered || *eligible)
+                .map(|(i, v, _)| {
+                    let score = match metric {
+                        "l2" => -((1.0 - v[0]).powi(2) + v[1].powi(2)),
+                        "inner_product" => v[0],
+                        _ => v[0] / (v[0] * v[0] + v[1] * v[1]).sqrt(),
+                    };
+                    (*i, score)
+                })
+                .collect::<Vec<_>>();
+            oracle.sort_by(|a, b| b.1.total_cmp(&a.1).then(a.0.cmp(&b.0)));
+            let expected = oracle
+                .iter()
+                .take(3)
+                .map(|(i, _)| format!("v{i}"))
+                .collect::<Vec<_>>();
+            for mode in ["", "MODE EXACT"] {
+                let query = format!(
+                    "VECTOR SEARCH embeddings SIMILAR TO [1,0] {filter} {clause} {mode} LIMIT 3"
+                );
+                let result = rt.execute_query(&query).expect("exact query");
+                let contents = result
+                    .result
+                    .records
+                    .iter()
+                    .map(|record| match record.get("content") {
+                        Some(Value::Text(text)) => text.to_string(),
+                        other => panic!("content {other:?}"),
+                    })
+                    .collect::<Vec<_>>();
+                assert_eq!(contents, expected, "{query}");
+                let stats = result.result.stats.vector.expect("metrics");
+                assert_eq!(stats.mode_executed, "exact");
+                assert!(!stats.index_used);
+                assert_eq!(stats.approximate_distance_evaluations, 0);
+                assert_eq!(stats.exact_distance_evaluations, oracle.len() as u64);
+                assert_eq!(stats.peak_topk_entries, 3);
+            }
+        }
+    }
+}
+
+#[test]
+fn vector_exact_ties_and_threshold_are_stable() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE VECTOR ties DIM 2 METRIC cosine")
+        .expect("collection");
+    for content in ["first", "second", "third"] {
+        rt.execute_query(&format!(
+            "INSERT INTO ties VECTOR (dense,content) VALUES ([1,0],'{content}')"
+        ))
+        .expect("vector");
+    }
+    let result = rt
+        .execute_query("VECTOR SEARCH ties SIMILAR TO [1,0] THRESHOLD 1 LIMIT 2")
+        .expect("ties");
+    assert_eq!(
+        result.result.records[0].get("content"),
+        Some(&Value::text("first"))
+    );
+    assert_eq!(
+        result.result.records[1].get("content"),
+        Some(&Value::text("second"))
+    );
+    let result = rt
+        .execute_query("VECTOR SEARCH ties SIMILAR TO [0,1] THRESHOLD 0.5 LIMIT 2")
+        .expect("threshold");
+    assert!(result.result.records.is_empty());
+}

--- a/tests/grouped/ai_search.rs
+++ b/tests/grouped/ai_search.rs
@@ -77,3 +77,6 @@ mod e2e_vector_execution_observability;
 
 #[path = "ai_local_vector/e2e_vector_row_isolation.rs"]
 mod e2e_vector_row_isolation;
+
+#[path = "ai_local_vector/e2e_vector_search_modes.rs"]
+mod e2e_vector_search_modes;


### PR DESCRIPTION
VECTOR SEARCH currently uses TurboQuant candidates followed by exact reranking, which can omit the true nearest neighbors outside the candidate window. Make exact full-precision retrieval the default and require MODE APPROXIMATE to select the existing approximate route. Preserve the selected mode through hybrid parsing and cached-plan rebinding.

Exact search evaluates snapshot-visible, authorized, metadata-eligible vectors before top-k. Replace the temporary brute-force index (including repeated linear upserts and full result sorting) with a bounded heap; fetch payloads in batches after releasing segment locks so policy/metadata evaluation can re-enter storage safely. Working memory is O(N) entity ids plus one 256-vector batch and O(k) retained results; selection is O(N log k).

EXPLAIN names the selected path. ANALYZE reports requested/executed mode, fallback reason, approximate and exact distance work, and peak retained top-k entries. Approximate scoring still scans the packed index; this PR makes no sublinear ANN or recall claim. Disk layout is unchanged; the default result accuracy/execution path changes intentionally.

Adds parser coverage, an independent full-precision top-k oracle above the old rerank window, threshold/tie checks, fallback metrics and RLS coverage for both modes. Validation and CI are in progress; remains draft. Based on perf/competitive-integration for the approved competitiveness plan following #2270.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791420315&installation_model_id=20659&pr_number=2284&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2284&signature=1ab0ea80c563c224176f7797ecedede12b22413bc358e020f8e95f6190ad7b0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->