### PR TITLE
perf(query): cache unbound parameterized SQL syntax

### DIFF
--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -426,7 +426,7 @@ impl RedDBRuntime {
         query: &str,
         params: &[Value],
     ) -> RedDBResult<RuntimeQueryResult> {
-        let parsed = parse_multi(query).map_err(|err| RedDBError::Query(err.to_string()))?;
+        let parsed = self.parameterized_query_ast(query)?;
         let bound = crate::storage::query::user_params::bind(&parsed, params).map_err(|err| {
             RedDBError::Validation {
                 message: err.to_string(),
@@ -437,6 +437,32 @@ impl RedDBRuntime {
             }
         })?;
         self.execute_bound_query_expr_in_frame(query, bound)
+    }
+
+    /// Cache only the unbound parser output. Binding, views, authorization,
+    /// configuration and snapshots are resolved anew for every execution.
+    fn parameterized_query_ast(&self, query: &str) -> RedDBResult<QueryExpr> {
+        use crate::storage::query::planner::{CachedPlan, QueryPlan};
+
+        // Keep exact parameterized statements separate from normalized plans.
+        let key = format!("\0parameters\0{query}");
+        if let Some(parsed) = self
+            .inner
+            .query_cache
+            .read()
+            .peek(&key)
+            .filter(|entry| entry.matches_exact_query(query))
+            .map(|entry| entry.plan.original.clone())
+        {
+            return Ok(parsed);
+        }
+        let parsed = parse_multi(query).map_err(|err| RedDBError::Query(err.to_string()))?;
+        let plan = QueryPlan::new(parsed.clone(), parsed.clone(), Default::default());
+        self.inner
+            .query_cache
+            .write()
+            .insert(key, CachedPlan::new(plan).with_exact_query(query));
+        Ok(parsed)
     }
 
     fn execute_bound_query_expr_in_frame(

--- a/tests/grouped/schema_query_core/e2e_parameter_ast_cache.rs
+++ b/tests/grouped/schema_query_core/e2e_parameter_ast_cache.rs
@@ -1,0 +1,136 @@
+use reddb::auth::Role;
+use reddb::runtime::mvcc::{clear_current_auth_identity, set_current_auth_identity};
+use reddb::{RedDBOptions, RedDBRuntime};
+use reddb_types::Value;
+
+#[test]
+fn parameter_cache_rebinds_types_and_preserves_arity_errors() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    let query = "SELECT $1 AS bound_value";
+    for value in [
+        Value::Integer(i64::MAX),
+        Value::text("a'\"b"),
+        Value::Null,
+        Value::Boolean(false),
+        Value::Vector(vec![0.8, 0.6]),
+        Value::Blob(vec![0, 1, 255]),
+    ] {
+        let result = rt
+            .execute_query_with_params(query, std::slice::from_ref(&value))
+            .expect("rebound value");
+        assert_eq!(result.result.records[0].get("bound_value"), Some(&value));
+    }
+    for params in [vec![], vec![Value::Integer(1), Value::Integer(2)]] {
+        assert!(rt.execute_query_with_params(query, &params).is_err());
+    }
+    let result = rt
+        .execute_query_with_params(query, &[Value::Integer(9)])
+        .expect("valid after invalid");
+    assert_eq!(
+        result.result.records[0].get("bound_value"),
+        Some(&Value::Integer(9))
+    );
+    let result = rt
+        .execute_query_with_params("SELECT 7 AS bound_value", &[])
+        .expect("exact SQL text");
+    assert_eq!(
+        result.result.records[0].get("bound_value"),
+        Some(&Value::Integer(7))
+    );
+}
+
+#[test]
+fn parameter_cache_preserves_transactions_and_recreated_schema() {
+    let directory = tempfile::tempdir().expect("fixture");
+    let rt = RedDBRuntime::with_options(RedDBOptions::persistent(
+        directory.path().join("params.rdb"),
+    ))
+    .expect("runtime");
+    rt.execute_query("CREATE TABLE items (id INT PRIMARY KEY, payload TEXT)")
+        .expect("table");
+    let insert = "INSERT INTO items (id,payload) VALUES ($1,$2)";
+    rt.execute_query("BEGIN").expect("begin");
+    rt.execute_query_with_params(insert, &[Value::Integer(1), Value::text("keep")])
+        .expect("first");
+    rt.execute_query("SAVEPOINT before_second")
+        .expect("savepoint");
+    rt.execute_query_with_params(insert, &[Value::Integer(2), Value::text("discard")])
+        .expect("second");
+    rt.execute_query("ROLLBACK TO SAVEPOINT before_second")
+        .expect("rollback");
+    rt.execute_query_with_params(insert, &[Value::Integer(2), Value::text("replacement")])
+        .expect("reuse");
+    rt.execute_query("COMMIT").expect("commit");
+    let query = "SELECT payload FROM items WHERE id=$1";
+    let result = rt
+        .execute_query_with_params(query, &[Value::Integer(2)])
+        .expect("read");
+    assert_eq!(
+        result.result.records[0].get("payload"),
+        Some(&Value::text("replacement"))
+    );
+    rt.execute_query("DROP TABLE items").expect("drop");
+    rt.execute_query("CREATE TABLE items (id INT PRIMARY KEY, payload INT)")
+        .expect("new schema");
+    rt.execute_query_with_params(insert, &[Value::Integer(2), Value::Integer(99)])
+        .expect("new column type");
+    let result = rt
+        .execute_query_with_params(query, &[Value::Integer(2)])
+        .expect("new read");
+    assert_eq!(
+        result.result.records[0].get("payload"),
+        Some(&Value::Integer(99))
+    );
+}
+
+#[test]
+fn parameter_cache_rechecks_identity_and_policy_changes() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    for query in [
+        "CREATE TABLE guarded (id INT, owner TEXT)",
+        "INSERT INTO guarded (id,owner) VALUES (1,'alice'),(2,'bob')",
+        "CREATE POLICY own_rows ON guarded USING (owner=CURRENT_USER())",
+        "ALTER TABLE guarded ENABLE ROW LEVEL SECURITY",
+    ] {
+        rt.execute_query(query).expect("fixture");
+    }
+    let query = "SELECT id FROM guarded WHERE id >= $1";
+    for (user, id) in [("alice", 1), ("bob", 2), ("alice", 1)] {
+        set_current_auth_identity(user.into(), Role::Read);
+        let result = rt.execute_query_with_params(query, &[Value::Integer(0)]);
+        clear_current_auth_identity();
+        let result = result.expect("scoped query");
+        assert_eq!(result.result.records.len(), 1);
+        assert_eq!(
+            result.result.records[0].get("id"),
+            Some(&Value::Integer(id))
+        );
+    }
+    rt.execute_query("DROP POLICY own_rows ON guarded")
+        .expect("revoke");
+    set_current_auth_identity("alice".into(), Role::Read);
+    let result = rt.execute_query_with_params(query, &[Value::Integer(0)]);
+    clear_current_auth_identity();
+    assert!(result.expect("default denial").result.records.is_empty());
+}
+
+#[test]
+fn parameter_cache_resolves_current_configuration() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE TABLE probes (id INT)")
+        .expect("table");
+    rt.execute_query("INSERT INTO probes (id) VALUES (1)")
+        .expect("row");
+    let query = "SELECT $config.mode AS cfg_mode FROM probes WHERE id=$1";
+    for mode in ["first", "second", "first"] {
+        rt.execute_query(&format!("SET CONFIG red.config.mode = '{mode}'"))
+            .expect("set config");
+        let result = rt
+            .execute_query_with_params(query, &[Value::Integer(1)])
+            .expect("live config");
+        assert_eq!(
+            result.result.records[0].get("cfg_mode"),
+            Some(&Value::text(mode))
+        );
+    }
+}

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -119,3 +119,6 @@ mod e2e_mvcc_key_reuse;
 
 #[path = "schema_query_core/e2e_unique_key_lookup.rs"]
 mod e2e_unique_key_lookup;
+
+#[path = "schema_query_core/e2e_parameter_ast_cache.rs"]
+mod e2e_parameter_ast_cache;


### PR DESCRIPTION
Repeated execute_query_with_params calls currently parse the same SQL text every time. Cache its unbound AST in the existing bounded query cache under a separate exact-text key, then bind and execute anew on each invocation.

No parameter values, schema resolution, identities, policy results, configuration values or snapshots are cached. Existing cache invalidation and eviction remain in effect. There is no wire or storage-format change.

Validation: all four new SQL integration tests pass, covering mixed parameter types and arity errors, savepoint rollback and recreated schema, identity/policy changes, and live configuration changes. Release measurements and CI are in progress; remains draft.

Part of #2270 and the approved competitiveness plan. Based on perf/competitive-integration; independent of the incremental index accounting optimization.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2285"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791420461&installation_model_id=20659&pr_number=2285&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2285&signature=608adbd7d279a2a5f5ce0ed245c3d9042f8c1978ee7ba44135475459eadf1c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->