### PR TITLE
feat(sql)!: support quoted identifiers and standard text quoting

### DIFF
--- a/crates/reddb-client/tests/conformance.rs
+++ b/crates/reddb-client/tests/conformance.rs
@@ -36,6 +36,29 @@ fn field<'a>(row: &'a [(String, ValueOut)], name: &str) -> &'a ValueOut {
 
 // ---------------------------------------------------------------- generic.*
 
+async fn case_generic_query_quoted_identifiers(db: &Reddb) {
+    db.query(r#"CREATE TABLE "select" ("key name" INT, "text value" TEXT)"#)
+        .await
+        .expect("quoted schema");
+    db.execute_with(
+        r#"INSERT INTO "select" ("key name", "text value") VALUES ($1,$2)"#,
+        (1i64, "hello"),
+    )
+    .await
+    .expect("bound values");
+    let result = db
+        .query_with(
+            r#"SELECT "text value" FROM "select" WHERE "key name"=$1"#,
+            (1i64,),
+        )
+        .await
+        .expect("quoted query");
+    assert_eq!(
+        field(&result.rows[0], "text value"),
+        &ValueOut::String("hello".into())
+    );
+}
+
 async fn case_generic_query_no_params(db: &Reddb) {
     db.query("CREATE TABLE generic_q (id INTEGER, name TEXT)")
         .await
@@ -591,6 +614,7 @@ macro_rules! embedded_case {
 mod embedded {
     use super::Reddb;
 
+    embedded_case!(case_generic_query_quoted_identifiers);
     embedded_case!(case_generic_query_no_params);
     embedded_case!(case_generic_query_with_params);
     embedded_case!(case_generic_insert_rid);
@@ -680,6 +704,7 @@ mod client_transport {
 
         // Same case bodies as the embedded suite — proves the helper surface
         // is transport-agnostic rather than asserting it by comment.
+        case_generic_query_quoted_identifiers(&db).await;
         case_generic_query_no_params(&db).await;
         case_generic_query_with_params(&db).await;
         case_generic_insert_rid(&db).await;

--- a/crates/reddb-rql/src/lexer.rs
+++ b/crates/reddb-rql/src/lexer.rs
@@ -246,6 +246,8 @@ pub enum Token {
 
     // Identifiers
     Ident(String),
+    /// SQL double-quoted identifier; kept distinct from contextual keywords.
+    QuotedIdent(String),
 
     // Operators
     Eq,      // =
@@ -477,6 +479,7 @@ impl fmt::Display for Token {
             Token::Float(n) => write!(f, "{}", n),
             Token::JsonLiteral(s) => write!(f, "{}", s),
             Token::Ident(s) => write!(f, "{}", s),
+            Token::QuotedIdent(s) => write!(f, "\"{}\"", s.replace('"', "\"\"")),
             Token::Eq => write!(f, "="),
             Token::Ne => write!(f, "<>"),
             Token::Lt => write!(f, "<"),
@@ -792,7 +795,13 @@ impl<'a> Lexer<'a> {
         // Dispatch based on first character
         let token = match ch {
             // String literals
-            '\'' | '"' => self.scan_string()?,
+            '\'' => self.scan_string()?,
+            '"' => {
+                let Token::String(name) = self.scan_string()? else {
+                    unreachable!("string scanner returns a string token");
+                };
+                Token::QuotedIdent(name)
+            }
 
             // Numbers
             '0'..='9' => self.scan_number()?,
@@ -1583,7 +1592,7 @@ mod tests {
             tokens,
             vec![
                 Token::String("hello".into()),
-                Token::String("world".into()),
+                Token::QuotedIdent("world".into()),
                 Token::String("it's".into()),
                 Token::Eof
             ]
@@ -2336,7 +2345,7 @@ mod tests {
                 Token::String("tab\tstop".into()),
                 Token::String("slash\\".into()),
                 Token::String("quote'".into()),
-                Token::String("dq\"".into()),
+                Token::QuotedIdent("dq\"".into()),
                 Token::String(r"raw\z".into()),
                 Token::Eof
             ]

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -937,6 +937,16 @@ impl<'a> Parser<'a> {
         result
     }
 
+    // Double quotes remain string delimiters inside JSON arrays and objects.
+    // At a SQL expression boundary the same token denotes a column identifier.
+    fn parse_nested_json_value(&mut self) -> Result<Value, ParseError> {
+        if let Token::QuotedIdent(value) = self.peek().clone() {
+            self.advance()?;
+            return Ok(Value::text(value));
+        }
+        self.parse_literal_value()
+    }
+
     fn parse_literal_value_inner(&mut self) -> Result<Value, ParseError> {
         // Recognize PASSWORD('plaintext') and SECRET('plaintext') as
         // typed literal constructors. The parser stores them as
@@ -1048,7 +1058,7 @@ impl<'a> Parser<'a> {
                 let mut items = Vec::new();
                 if !self.check(&Token::RBracket) {
                     loop {
-                        items.push(self.parse_literal_value()?);
+                        items.push(self.parse_nested_json_value()?);
                         if !self.consume(&Token::Comma)? {
                             break;
                         }
@@ -1074,7 +1084,7 @@ impl<'a> Parser<'a> {
                                 self.advance()?;
                                 s
                             }
-                            Token::Ident(s) => {
+                            Token::Ident(s) | Token::QuotedIdent(s) => {
                                 self.advance()?;
                                 s
                             }
@@ -1085,7 +1095,7 @@ impl<'a> Parser<'a> {
                             self.expect(Token::Eq)?;
                         }
                         // Value: recursive
-                        let val = self.parse_literal_value()?;
+                        let val = self.parse_nested_json_value()?;
                         map.insert(key, literal_value_to_json(&val));
                         if !self.consume(&Token::Comma)? {
                             break;

--- a/crates/reddb-rql/src/parser/dml.rs
+++ b/crates/reddb-rql/src/parser/dml.rs
@@ -1023,6 +1023,32 @@ impl<'a> Parser<'a> {
                 })?;
                 Ok(Value::Json(bytes))
             }
+            Token::Minus | Token::Dash | Token::Plus => {
+                let negative = !matches!(self.peek(), Token::Plus);
+                self.advance()?;
+                match self.peek().clone() {
+                    Token::Integer(n) => {
+                        self.advance()?;
+                        let value = if negative {
+                            n.checked_neg().ok_or_else(|| {
+                                ParseError::new("integer negation overflow", self.position())
+                            })?
+                        } else {
+                            n
+                        };
+                        Ok(Value::Integer(value))
+                    }
+                    Token::Float(n) => {
+                        self.advance()?;
+                        Ok(Value::Float(if negative { -n } else { n }))
+                    }
+                    ref other => Err(ParseError::expected(
+                        vec!["number after sign"],
+                        other,
+                        self.position(),
+                    )),
+                }
+            }
             Token::Integer(n) => {
                 self.advance()?;
                 Ok(Value::Integer(n))
@@ -1779,6 +1805,23 @@ mod tests {
             parser.parse_literal_value().expect("json object"),
             Value::Json(_)
         ));
+    }
+
+    #[test]
+    fn signed_array_literals_preserve_numeric_types() {
+        let mut parser = make_parser("[-9007199254740993, -0.25, +2, [-2.5e-3]]");
+        assert_eq!(
+            parser.parse_literal_value().expect("signed nested array"),
+            Value::Array(vec![
+                Value::Integer(-9007199254740993),
+                Value::Float(-0.25),
+                Value::Integer(2),
+                Value::Array(vec![Value::Float(-0.0025)]),
+            ])
+        );
+        for input in ["[-true]", "[-'text']", "[-[]]", "[+]", "[-]"] {
+            assert!(make_parser(input).parse_literal_value().is_err(), "{input}");
+        }
     }
 
     #[test]

--- a/crates/reddb-rql/src/parser/error.rs
+++ b/crates/reddb-rql/src/parser/error.rs
@@ -275,6 +275,7 @@ fn recognized_keyword_name(token: &Token) -> Option<String> {
         | Token::Float(_)
         | Token::JsonLiteral(_)
         | Token::Ident(_)
+        | Token::QuotedIdent(_)
         | Token::Eq
         | Token::Ne
         | Token::Lt
@@ -344,7 +345,7 @@ impl fmt::Display for SafeTokenDisplay<'_> {
             // User-controlled byte payloads. Render via `escape_debug`
             // so embedded CR / LF / NUL / quote bytes do not reach
             // downstream serialization sinks unescaped.
-            Token::Ident(s) => write_escaped(f, s),
+            Token::Ident(s) | Token::QuotedIdent(s) => write_escaped(f, s),
             Token::String(s) => {
                 f.write_str("'")?;
                 write_escaped(f, s)?;

--- a/crates/reddb-rql/src/parser/expr.rs
+++ b/crates/reddb-rql/src/parser/expr.rs
@@ -445,7 +445,8 @@ impl<'a> Parser<'a> {
         // two-token lookahead on the parser. If the next token is `(`
         // it's a function call; if `.` it's a qualified column ref;
         // otherwise it's a bare column ref.
-        if let Token::Ident(ref name) = *self.peek() {
+        if let Token::Ident(ref name) | Token::QuotedIdent(ref name) = *self.peek() {
+            let quoted = matches!(self.peek(), Token::QuotedIdent(_));
             let name_upper = name.to_uppercase();
 
             // CAST(expr AS type) — must test before consuming because
@@ -457,19 +458,21 @@ impl<'a> Parser<'a> {
             // uppercased name is CAST and the next token is `(`,
             // switch to the CAST form; otherwise the saved name
             // becomes the first segment of a column ref.
-            if name_upper == "CASE" {
+            if !quoted && name_upper == "CASE" {
                 return self.parse_case_expr(start);
             }
 
-            let saved_name = name.clone();
-            self.advance()?; // consume the identifier unconditionally
+            let saved_name = self.expect_ident()?;
 
             // Function call / CAST: IDENT (
             if matches!(self.peek(), Token::LParen) {
                 return self.parse_function_call_expr_with_name(start, saved_name);
             }
 
-            if let Some(function_name) = bare_zero_arg_function_name(&saved_name) {
+            if let Some(function_name) = (!quoted)
+                .then(|| bare_zero_arg_function_name(&saved_name))
+                .flatten()
+            {
                 let end = self.position();
                 return Ok(Expr::FunctionCall {
                     name: function_name.to_string(),

--- a/crates/reddb-rql/src/parser/filter.rs
+++ b/crates/reddb-rql/src/parser/filter.rs
@@ -539,11 +539,7 @@ impl<'a> Parser<'a> {
 
     fn parse_field_ref_segment(&mut self) -> Result<String, ParseError> {
         match &self.current.token {
-            Token::Ident(name) => {
-                let name = name.clone();
-                self.advance()?;
-                Ok(name)
-            }
+            Token::Ident(_) | Token::QuotedIdent(_) => self.expect_ident(),
             Token::Eof
             | Token::LParen
             | Token::RParen

--- a/crates/reddb-rql/src/parser/mod.rs
+++ b/crates/reddb-rql/src/parser/mod.rs
@@ -224,6 +224,12 @@ impl<'a> Parser<'a> {
                         self.position(),
                     ));
                 }
+                if matches!(self.peek(), Token::QuotedIdent(_)) && name.contains('.') {
+                    return Err(ParseError::new(
+                        "literal dots in quoted identifiers are not supported; quote each path segment separately".to_string(),
+                        self.position(),
+                    ));
+                }
                 let name = name.clone();
                 self.advance()?;
                 Ok(name)

--- a/crates/reddb-rql/src/parser/mod.rs
+++ b/crates/reddb-rql/src/parser/mod.rs
@@ -217,7 +217,13 @@ impl<'a> Parser<'a> {
     /// Consume an identifier and return its value
     pub fn expect_ident(&mut self) -> Result<String, ParseError> {
         match &self.current.token {
-            Token::Ident(name) => {
+            Token::Ident(name) | Token::QuotedIdent(name) => {
+                if name.is_empty() || name.contains('\0') {
+                    return Err(ParseError::new(
+                        "SQL identifiers must be nonempty and contain no NUL".to_string(),
+                        self.position(),
+                    ));
+                }
                 let name = name.clone();
                 self.advance()?;
                 Ok(name)
@@ -233,8 +239,11 @@ impl<'a> Parser<'a> {
     /// Consume an identifier or aggregate keyword when the grammar expects
     /// a user-defined column name.
     pub fn expect_column_ident(&mut self) -> Result<String, ParseError> {
+        if matches!(self.peek(), Token::Ident(_) | Token::QuotedIdent(_)) {
+            return self.expect_ident();
+        }
         let name = match &self.current.token {
-            Token::Ident(name) => name.clone(),
+            Token::Ident(name) | Token::QuotedIdent(name) => name.clone(),
             Token::Count => "count".to_string(),
             Token::Sum => "sum".to_string(),
             Token::Avg => "avg".to_string(),
@@ -255,9 +264,12 @@ impl<'a> Parser<'a> {
 
     /// Consume an identifier or keyword (for type names where keywords are valid)
     pub fn expect_ident_or_keyword(&mut self) -> Result<String, ParseError> {
+        if matches!(self.peek(), Token::Ident(_) | Token::QuotedIdent(_)) {
+            return self.expect_ident();
+        }
         // Get the string representation of the current token
         let name = match &self.current.token {
-            Token::Ident(name) => name.clone(),
+            Token::Ident(name) | Token::QuotedIdent(name) => name.clone(),
             Token::Count => "count".to_string(),
             Token::Sum => "sum".to_string(),
             Token::Avg => "avg".to_string(),
@@ -278,7 +290,7 @@ impl<'a> Parser<'a> {
         // Only advance for valid type-name-like tokens
         match &self.current.token {
             // Identifiers are always valid
-            Token::Ident(_) => {
+            Token::Ident(_) | Token::QuotedIdent(_) => {
                 self.advance()?;
                 Ok(name)
             }

--- a/crates/reddb-rql/src/parser/table.rs
+++ b/crates/reddb-rql/src/parser/table.rs
@@ -450,7 +450,8 @@ impl<'a> Parser<'a> {
             if !has_from || (self.check(&Token::As) && matches!(self.peek_next()?, Token::Of)) {
                 None
             } else if self.consume(&Token::As)?
-                || (self.check(&Token::Ident("".into())) && !self.is_clause_keyword())
+                || (matches!(self.peek(), Token::Ident(_) | Token::QuotedIdent(_))
+                    && !self.is_clause_keyword())
             {
                 Some(self.expect_ident()?)
             } else {

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -31,6 +31,26 @@ pub fn render(expr: &QueryExpr) -> String {
     }
 }
 
+/// Preserve ordinary names; quote keywords and names requiring delimiters.
+pub fn render_identifier(identifier: &str) -> String {
+    let mut lexer = crate::lexer::Lexer::new(identifier);
+    let contextual_keyword = matches!(
+        identifier.to_ascii_uppercase().as_str(),
+        "CASE" | "CONSTRAINT" | "CURRENT_TIMESTAMP" | "CURRENT_DATE" | "CURRENT_TIME"
+    );
+    let plain = !contextual_keyword
+        && matches!(lexer.next_token(), Ok(token) if token.token == crate::lexer::Token::Ident(identifier.to_string()))
+        && matches!(lexer.next_token(), Ok(token) if token.token == crate::lexer::Token::Eof);
+    if plain {
+        identifier.to_string()
+    } else {
+        format!(
+            "\"{}\"",
+            identifier.replace('\\', "\\\\").replace('"', "\"\"")
+        )
+    }
+}
+
 fn render_explain(inner: &QueryExpr) -> String {
     let rendered = render(inner);
     if rendered.is_empty() {
@@ -50,7 +70,7 @@ fn render_table(tq: &TableQuery) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     };
-    let mut sql = format!("SELECT {} FROM {}", cols, tq.table);
+    let mut sql = format!("SELECT {} FROM {}", cols, render_identifier(&tq.table));
     if let Some(filter) = &tq.filter {
         sql.push_str(" WHERE ");
         sql.push_str(&render_filter(filter));
@@ -59,7 +79,12 @@ fn render_table(tq: &TableQuery) -> String {
 }
 
 fn render_insert(iq: &InsertQuery) -> String {
-    let cols = iq.columns.join(", ");
+    let cols = iq
+        .columns
+        .iter()
+        .map(|name| render_identifier(name))
+        .collect::<Vec<_>>()
+        .join(", ");
     let rows: Vec<String> = iq
         .values
         .iter()
@@ -74,7 +99,7 @@ fn render_insert(iq: &InsertQuery) -> String {
         .collect();
     let mut sql = format!(
         "INSERT INTO {} ({}) VALUES {}",
-        iq.table,
+        render_identifier(&iq.table),
         cols,
         rows.join(", ")
     );
@@ -82,7 +107,13 @@ fn render_insert(iq: &InsertQuery) -> String {
         sql.push_str(" ON CONFLICT");
         if let Some(columns) = &clause.target {
             sql.push_str(" (");
-            sql.push_str(&columns.join(", "));
+            sql.push_str(
+                &columns
+                    .iter()
+                    .map(|column| render_identifier(column))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
             sql.push(')');
         }
         match &clause.action {
@@ -92,7 +123,9 @@ fn render_insert(iq: &InsertQuery) -> String {
                 sql.push_str(
                     &assignments
                         .iter()
-                        .map(|(column, expr)| format!("{column} = {}", render_expr_sql(expr)))
+                        .map(|(column, expr)| {
+                            format!("{} = {}", render_identifier(column), render_expr_sql(expr))
+                        })
                         .collect::<Vec<_>>()
                         .join(", "),
                 );
@@ -103,7 +136,7 @@ fn render_insert(iq: &InsertQuery) -> String {
 }
 
 fn render_update(uq: &UpdateQuery) -> String {
-    let mut sql = format!("UPDATE {}", uq.table);
+    let mut sql = format!("UPDATE {}", render_identifier(&uq.table));
     if let Some(target) = render_update_target(uq.target) {
         sql.push(' ');
         sql.push_str(target);
@@ -121,7 +154,12 @@ fn render_update(uq: &UpdateQuery) -> String {
                 .flatten()
                 .map(render_compound_assignment_op)
                 .unwrap_or("=");
-            format!("{} {} {}", column, op, render_expr_sql(expr))
+            format!(
+                "{} {} {}",
+                render_identifier(column),
+                op,
+                render_expr_sql(expr)
+            )
         })
         .collect::<Vec<_>>()
         .join(", ");
@@ -142,7 +180,7 @@ fn render_update(uq: &UpdateQuery) -> String {
 }
 
 fn render_delete(dq: &DeleteQuery) -> String {
-    let mut sql = format!("DELETE FROM {}", dq.table);
+    let mut sql = format!("DELETE FROM {}", render_identifier(&dq.table));
     if let Some(filter) = &dq.filter {
         sql.push_str(" WHERE ");
         sql.push_str(&render_filter(filter));
@@ -176,7 +214,11 @@ fn render_compound_assignment_op(op: BinOp) -> &'static str {
 fn render_queue_command(qc: &QueueCommand) -> String {
     match qc {
         QueueCommand::Push { queue, value, .. } => {
-            format!("QUEUE PUSH {} {}", queue, render_value_sql(value))
+            format!(
+                "QUEUE PUSH {} {}",
+                render_identifier(queue),
+                render_value_sql(value)
+            )
         }
         _ => String::new(),
     }
@@ -218,12 +260,14 @@ fn render_bin_op(op: BinOp) -> &'static str {
 fn render_projection(p: &Projection) -> String {
     match p {
         Projection::All => "*".to_string(),
-        Projection::Column(col) => col.clone(),
-        Projection::Alias(col, alias) => format!("{} AS {}", col, alias),
+        Projection::Column(col) => render_identifier(col),
+        Projection::Alias(col, alias) => {
+            format!("{} AS {}", render_identifier(col), render_identifier(alias))
+        }
         Projection::Field(field, alias) => {
             let col = render_field_ref(field);
             match alias {
-                Some(a) => format!("{} AS {}", col, a),
+                Some(a) => format!("{} AS {}", col, render_identifier(a)),
                 None => col,
             }
         }
@@ -233,8 +277,10 @@ fn render_projection(p: &Projection) -> String {
 
 pub(crate) fn render_field_ref(f: &FieldRef) -> String {
     match f {
-        FieldRef::TableColumn { table, column } if table.is_empty() => column.clone(),
-        FieldRef::TableColumn { table, column } => format!("{}.{}", table, column),
+        FieldRef::TableColumn { table, column } if table.is_empty() => render_identifier(column),
+        FieldRef::TableColumn { table, column } => {
+            format!("{}.{}", render_identifier(table), render_identifier(column))
+        }
         _ => "field".to_string(),
     }
 }

--- a/crates/reddb-rql/src/renderer.rs
+++ b/crates/reddb-rql/src/renderer.rs
@@ -51,6 +51,15 @@ pub fn render_identifier(identifier: &str) -> String {
     }
 }
 
+// Dotted AST names denote paths; literal dots in delimited names are rejected
+// by the parser because this AST does not retain segment quoting provenance.
+fn render_identifier_path(path: &str) -> String {
+    path.split('.')
+        .map(render_identifier)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
 fn render_explain(inner: &QueryExpr) -> String {
     let rendered = render(inner);
     if rendered.is_empty() {
@@ -70,7 +79,7 @@ fn render_table(tq: &TableQuery) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     };
-    let mut sql = format!("SELECT {} FROM {}", cols, render_identifier(&tq.table));
+    let mut sql = format!("SELECT {} FROM {}", cols, render_identifier_path(&tq.table));
     if let Some(filter) = &tq.filter {
         sql.push_str(" WHERE ");
         sql.push_str(&render_filter(filter));
@@ -99,7 +108,7 @@ fn render_insert(iq: &InsertQuery) -> String {
         .collect();
     let mut sql = format!(
         "INSERT INTO {} ({}) VALUES {}",
-        render_identifier(&iq.table),
+        render_identifier_path(&iq.table),
         cols,
         rows.join(", ")
     );
@@ -136,7 +145,7 @@ fn render_insert(iq: &InsertQuery) -> String {
 }
 
 fn render_update(uq: &UpdateQuery) -> String {
-    let mut sql = format!("UPDATE {}", render_identifier(&uq.table));
+    let mut sql = format!("UPDATE {}", render_identifier_path(&uq.table));
     if let Some(target) = render_update_target(uq.target) {
         sql.push(' ');
         sql.push_str(target);
@@ -156,7 +165,7 @@ fn render_update(uq: &UpdateQuery) -> String {
                 .unwrap_or("=");
             format!(
                 "{} {} {}",
-                render_identifier(column),
+                render_identifier_path(column),
                 op,
                 render_expr_sql(expr)
             )
@@ -180,7 +189,7 @@ fn render_update(uq: &UpdateQuery) -> String {
 }
 
 fn render_delete(dq: &DeleteQuery) -> String {
-    let mut sql = format!("DELETE FROM {}", render_identifier(&dq.table));
+    let mut sql = format!("DELETE FROM {}", render_identifier_path(&dq.table));
     if let Some(filter) = &dq.filter {
         sql.push_str(" WHERE ");
         sql.push_str(&render_filter(filter));
@@ -277,9 +286,15 @@ fn render_projection(p: &Projection) -> String {
 
 pub(crate) fn render_field_ref(f: &FieldRef) -> String {
     match f {
-        FieldRef::TableColumn { table, column } if table.is_empty() => render_identifier(column),
+        FieldRef::TableColumn { table, column } if table.is_empty() => {
+            render_identifier_path(column)
+        }
         FieldRef::TableColumn { table, column } => {
-            format!("{}.{}", render_identifier(table), render_identifier(column))
+            format!(
+                "{}.{}",
+                render_identifier_path(table),
+                render_identifier_path(column)
+            )
         }
         _ => "field".to_string(),
     }

--- a/crates/reddb-rql/tests/quoted_identifiers.rs
+++ b/crates/reddb-rql/tests/quoted_identifiers.rs
@@ -174,3 +174,14 @@ fn quoted_write_names_survive_rendering() {
         assert_eq!(rendered, sql);
     }
 }
+
+#[test]
+fn quoted_paths_keep_separators_outside_delimiters() {
+    let sql = r#"UPDATE docs SET "profile name".city = 'Lisbon' WHERE name = 'ada'"#;
+    let parsed = Parser::new(sql).expect("lexer").parse().expect("path");
+    assert_eq!(reddb_rql::renderer::render(&parsed), sql);
+    assert!(Parser::new(r#"SELECT "literal.dot" FROM docs"#)
+        .expect("lexer")
+        .parse()
+        .is_err());
+}

--- a/crates/reddb-rql/tests/quoted_identifiers.rs
+++ b/crates/reddb-rql/tests/quoted_identifiers.rs
@@ -1,0 +1,176 @@
+use reddb_rql::ast::{Expr, FieldRef, QueryExpr, SelectItem};
+use reddb_rql::lexer::{Lexer, Token};
+use reddb_rql::parser::Parser;
+use reddb_types::Value;
+
+fn literal(input: &str) -> Value {
+    let sql = format!("SELECT {input}");
+    let QueryExpr::Table(table) = Parser::new(&sql).expect("lexer").parse().expect("select") else {
+        panic!("table")
+    };
+    let SelectItem::Expr {
+        expr: Expr::Literal { value, .. },
+        ..
+    } = table.select_items[0].clone()
+    else {
+        panic!("literal")
+    };
+    value
+}
+
+#[test]
+fn quoted_identifiers_are_columns_not_literals_or_contextual_keywords() {
+    let mut parser =
+        Parser::new(r#"SELECT "CASE", "current_user", "a""b" AS "output name" FROM "select""#)
+            .expect("lex");
+    let QueryExpr::Table(table) = parser.parse().expect("quoted identifiers") else {
+        panic!("table query")
+    };
+    assert_eq!(table.table, "select");
+    for (item, expected) in table
+        .select_items
+        .iter()
+        .zip(["CASE", "current_user", "a\"b"])
+    {
+        let SelectItem::Expr {
+            expr:
+                Expr::Column {
+                    field: FieldRef::TableColumn { table, column },
+                    ..
+                },
+            ..
+        } = item
+        else {
+            panic!("column: {item:?}")
+        };
+        assert!(table.is_empty());
+        assert_eq!(column, expected);
+    }
+    let SelectItem::Expr { alias, .. } = &table.select_items[2] else {
+        panic!("alias")
+    };
+    assert_eq!(alias.as_deref(), Some("output name"));
+}
+
+#[test]
+fn json_quotes_remain_values_and_sql_single_quotes_remain_strings() {
+    for (sql, expected) in [
+        (r#"'text'"#, Value::text("text")),
+        (
+            r#"["a", "b\"c", 9007199254740993]"#,
+            Value::Array(vec![
+                Value::text("a"),
+                Value::text("b\"c"),
+                Value::Integer(9007199254740993),
+            ]),
+        ),
+    ] {
+        let value = literal(sql);
+        assert_eq!(value, expected);
+    }
+    for sql in [
+        r#"{"key":"text", "nested":["value"]}"#,
+        r#"{key:"text", nested:["value"]}"#,
+    ] {
+        let Value::Json(value) = literal(sql) else {
+            panic!("JSON value")
+        };
+        assert_eq!(
+            std::str::from_utf8(&value).expect("UTF-8"),
+            r#"{"key":"text","nested":["value"]}"#
+        );
+    }
+}
+
+#[test]
+fn quoted_constraint_keyword_is_a_column_name() {
+    let mut parser = Parser::new(
+        r#"CREATE TABLE "select" ("CONSTRAINT" TEXT, "value" INT, UNIQUE ("CONSTRAINT", "value"))"#,
+    )
+    .expect("lexer");
+    let QueryExpr::CreateTable(table) = parser.parse().expect("table") else {
+        panic!("table")
+    };
+    assert_eq!(table.columns[0].name, "CONSTRAINT");
+    assert_eq!(table.unique_constraints[0].columns, ["CONSTRAINT", "value"]);
+}
+
+#[test]
+fn lexer_distinguishes_identifier_and_string_quotes() {
+    let mut lexer = Lexer::new(r#""key" 'value' "a""b""#);
+    assert_eq!(
+        lexer.next_token().expect("identifier").token,
+        Token::QuotedIdent("key".into())
+    );
+    assert_eq!(
+        lexer.next_token().expect("string").token,
+        Token::String("value".into())
+    );
+    assert_eq!(
+        lexer.next_token().expect("escaped identifier").token,
+        Token::QuotedIdent("a\"b".into())
+    );
+}
+
+#[test]
+fn identifier_renderer_preserves_keywords_and_escaped_names() {
+    for name in [
+        "ordinary",
+        "select",
+        "CASE",
+        "CONSTRAINT",
+        "CURRENT_DATE",
+        "a\"b",
+        "white space",
+        "back\\slash",
+    ] {
+        let rendered = reddb_rql::renderer::render_identifier(name);
+        let sql = format!("SELECT {rendered} FROM example");
+        let QueryExpr::Table(table) = Parser::new(&sql)
+            .expect("lexer")
+            .parse()
+            .expect("rendered query")
+        else {
+            panic!("table")
+        };
+        let SelectItem::Expr {
+            expr:
+                Expr::Column {
+                    field: FieldRef::TableColumn { column, .. },
+                    ..
+                },
+            ..
+        } = &table.select_items[0]
+        else {
+            panic!("column")
+        };
+        assert_eq!(column, name);
+    }
+}
+
+#[test]
+fn empty_json_strings_remain_valid_but_empty_or_nul_identifiers_fail() {
+    assert_eq!(literal(r#"[""]"#), Value::Array(vec![Value::text("")]));
+    for sql in ["SELECT \"\"", "SELECT \"a\0b\""] {
+        assert!(Parser::new(sql).expect("lexer").parse().is_err());
+    }
+}
+
+#[test]
+fn quoted_write_names_survive_rendering() {
+    for sql in [
+        r#"INSERT INTO "select" ("key name", "a""b") VALUES (1, 'x') ON CONFLICT ("key name") DO UPDATE SET "a""b" = 'y'"#,
+        r#"UPDATE "select" SET "a""b" = 'value' WHERE "key name" = 1"#,
+        r#"DELETE FROM "select" WHERE "key name" = 1"#,
+        r#"QUEUE PUSH "queue name" 'value'"#,
+    ] {
+        let original = Parser::new(sql).expect("lexer").parse().expect("query");
+        let rendered = reddb_rql::renderer::render(&original);
+        let reparsed = Parser::new(&rendered)
+            .expect("rendered lexer")
+            .parse()
+            .expect("rendered query");
+        assert_eq!(reddb_rql::renderer::render(&reparsed), rendered);
+        assert_eq!(rendered, sql);
+    }
+}

--- a/crates/reddb-server/src/runtime/dml_target_scan.rs
+++ b/crates/reddb-server/src/runtime/dml_target_scan.rs
@@ -27,6 +27,7 @@ pub(super) struct DmlTargetScan<'a> {
     target: Option<UpdateTarget>,
     table_row_resolver: TableRowMvccReadResolver,
     live_table_rows: bool,
+    declared_table: bool,
 }
 
 impl<'a> DmlTargetScan<'a> {
@@ -44,6 +45,7 @@ impl<'a> DmlTargetScan<'a> {
             target: None,
             table_row_resolver: TableRowMvccReadResolver::current_statement(),
             live_table_rows: false,
+            declared_table: false,
         }
     }
 
@@ -62,6 +64,12 @@ impl<'a> DmlTargetScan<'a> {
             target: Some(target),
             table_row_resolver: TableRowMvccReadResolver::current_statement(),
             live_table_rows: false,
+            declared_table: runtime
+                .db()
+                .collection_contract_arc(table)
+                .is_some_and(|contract| {
+                    contract.declared_model == crate::catalog::CollectionModel::Table
+                }),
         }
     }
 
@@ -346,6 +354,11 @@ impl<'a> DmlTargetScan<'a> {
             return true;
         };
         match target {
+            // A declared SQL table may contain JSON/BLOB columns or columns
+            // named key/value. Their payload shape does not change its model.
+            UpdateTarget::Rows if self.declared_table => {
+                matches!(entity.kind, EntityKind::TableRow { .. })
+            }
             UpdateTarget::Rows => matches!(row_item_kind(entity), Some(RowItemKind::Row)),
             UpdateTarget::Documents => matches!(row_item_kind(entity), Some(RowItemKind::Document)),
             UpdateTarget::Kv => matches!(row_item_kind(entity), Some(RowItemKind::Kv)),

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1768,7 +1768,10 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         // Explicit column names and aliases must be projected on the fast
         // scan too. Returning raw records silently turns SELECT col AS alias
         // into SELECT *, including when the name is quoted.
-        if !matches!(effective_projections.as_slice(), [Projection::All]) {
+        // SESSIONIZE consumes its key/time inputs in the outer executor.
+        if query.sessionize.is_none()
+            && !matches!(effective_projections.as_slice(), [Projection::All])
+        {
             return records
                 .iter()
                 .map(|record| {

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1779,7 +1779,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             return records
                 .iter()
                 .map(|record| {
-                    project_runtime_record_with_db(
+                    let mut projected = project_runtime_record_with_db(
                         Some(db),
                         record,
                         &effective_projections,
@@ -1787,7 +1787,24 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
                         Some(table_alias),
                         false,
                         false,
-                    )
+                    )?;
+                    // Keep the system envelope for wire metadata and stream
+                    // resume; result.columns still describes only the SELECT.
+                    for key in [
+                        "rid",
+                        "collection",
+                        "kind",
+                        "tenant",
+                        "created_at",
+                        "updated_at",
+                    ] {
+                        if projected.get(key).is_none() {
+                            if let Some(value) = record.get(key) {
+                                projected.set(key, value.clone());
+                            }
+                        }
+                    }
+                    Ok(projected)
                 })
                 .collect();
         }

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -481,7 +481,7 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             || (effective_filter.is_some()
                 && effective_projections
                     .iter()
-                    .any(|p| matches!(p, Projection::Alias(_, _))));
+                    .any(|p| matches!(p, Projection::Alias(_, _) | Projection::Field(_, Some(_)))));
     let uses_document_projection =
         runtime_projections_use_document_path(&effective_projections, query);
 

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1765,6 +1765,25 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
             records.truncate(limit as usize);
         }
 
+        // Explicit column names and aliases must be projected on the fast
+        // scan too. Returning raw records silently turns SELECT col AS alias
+        // into SELECT *, including when the name is quoted.
+        if !matches!(effective_projections.as_slice(), [Projection::All]) {
+            return records
+                .iter()
+                .map(|record| {
+                    project_runtime_record_with_db(
+                        Some(db),
+                        record,
+                        &effective_projections,
+                        Some(table_name),
+                        Some(table_alias),
+                        false,
+                        false,
+                    )
+                })
+                .collect();
+        }
         return Ok(records);
     }
 

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1966,7 +1966,15 @@ pub(crate) fn execute_runtime_canonical_table_node(
                 let table_alias = context.table_alias;
                 let limit = context.query.limit.unwrap_or(10000) as usize;
 
-                let select_cols = extract_select_column_names(&effective_projections);
+                // The canonical parent still evaluates WHERE and ORDER BY
+                // before applying aliases. Keep its source fields available.
+                let select_cols = if effective_projections.iter().any(|p| {
+                    matches!(p, Projection::Alias(_, _) | Projection::Field(_, Some(_)))
+                }) {
+                    Vec::new()
+                } else {
+                    extract_select_column_names(&effective_projections)
+                };
                 let schema_arc = manager.column_schema();
                 let compiled = match schema_arc.as_ref() {
                     Some(schema) => {

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -474,8 +474,14 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
     let effective_filter = effective_table_filter(query);
     let effective_group_by = effective_table_group_by_exprs(query);
     let effective_having = effective_table_having_filter(query);
+    // Filtered/index-only shortcuts materialize source column names. An
+    // alias needs the canonical projection node to rename the result.
     let requires_runtime_projection =
-        projections_require_runtime_projection(&effective_projections);
+        projections_require_runtime_projection(&effective_projections)
+            || (effective_filter.is_some()
+                && effective_projections
+                    .iter()
+                    .any(|p| matches!(p, Projection::Alias(_, _))));
     let uses_document_projection =
         runtime_projections_use_document_path(&effective_projections, query);
 

--- a/crates/reddb-server/src/runtime/query_exec/table.rs
+++ b/crates/reddb-server/src/runtime/query_exec/table.rs
@@ -1772,6 +1772,10 @@ pub(crate) fn execute_runtime_canonical_table_query_indexed(
         if query.sessionize.is_none()
             && !matches!(effective_projections.as_slice(), [Projection::All])
         {
+            crate::runtime::retention_filter::apply(
+                &mut records,
+                db.collection_contract(query.table.as_str()).as_ref(),
+            );
             return records
                 .iter()
                 .map(|record| {

--- a/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
+++ b/crates/reddb-server/src/runtime/red_schema/catalog_views.rs
@@ -427,7 +427,7 @@ fn render_index_method_for_ddl(method: super::index_store::IndexMethodKind) -> &
 }
 
 fn render_sql_identifier(identifier: &str) -> String {
-    identifier.to_string()
+    reddb_rql::renderer::render_identifier(identifier)
 }
 
 pub(super) fn collections_snapshot(

--- a/crates/reddb-server/src/storage/query/planner/cache_key.rs
+++ b/crates/reddb-server/src/storage/query/planner/cache_key.rs
@@ -38,7 +38,7 @@
 //! by character and emits a canonical form:
 //!
 //! - Integers / floats: emit `?`
-//! - Quoted strings (single + double): emit `?`
+//! - Single-quoted strings: emit `?`; double-quoted identifiers stay verbatim.
 //! - `TRUE` / `FALSE` / `NULL` keywords (case-insensitive,
 //!   word-bounded): emit `?`
 //! - Everything else: copy verbatim.
@@ -105,13 +105,7 @@ pub fn normalize_cache_key(sql: &str) -> String {
         // case-sensitive so we emit them verbatim).
         if b == b'"' {
             let start = i;
-            i += 1;
-            while i < bytes.len() && bytes[i] != b'"' {
-                i += 1;
-            }
-            if i < bytes.len() {
-                i += 1;
-            }
+            i = quoted_identifier_end(bytes, i);
             out.push_str(&sql[start..i]);
             last_was_space = false;
             continue;
@@ -270,13 +264,7 @@ pub fn normalize_and_extract(sql: &str) -> (String, Vec<Value>) {
 
         if b == b'"' {
             let start = i;
-            i += 1;
-            while i < bytes.len() && bytes[i] != b'"' {
-                i += 1;
-            }
-            if i < bytes.len() {
-                i += 1;
-            }
+            i = quoted_identifier_end(bytes, i);
             out.push_str(&sql[start..i]);
             last_was_space = false;
             continue;
@@ -605,5 +593,44 @@ mod tests {
             extract_literal_bindings("SELECT * FROM t WHERE age = 18 AND active = true LIMIT 10")
                 .unwrap();
         assert_eq!(binds, vec![Value::Integer(18), Value::Boolean(true)]);
+    }
+}
+
+// Match lexer escapes without normalizing anything inside the identifier.
+fn quoted_identifier_end(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i = (i + 2).min(bytes.len());
+        } else if bytes[i] == b'"' {
+            if bytes.get(i + 1) == Some(&b'"') {
+                i += 2;
+            } else {
+                return i + 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    i
+}
+
+#[cfg(test)]
+mod quoted_identifier_tests {
+    use super::*;
+
+    #[test]
+    fn escaped_identifier_digits_are_not_literal_parameters() {
+        for name in [r#""a\"1""#, r#""a""1""#, r#""back\\slash 12""#] {
+            let query = format!("SELECT {name} FROM t WHERE v = 7");
+            let (key, binds) = normalize_and_extract(&query);
+            assert_eq!(key, format!("SELECT {name} FROM t WHERE v = ?"));
+            assert_eq!(key, normalize_cache_key(&query));
+            assert_eq!(binds, vec![Value::Integer(7)]);
+        }
+        assert_ne!(
+            normalize_and_extract(r#"SELECT "a\"1" FROM t WHERE v=7"#).0,
+            normalize_and_extract(r#"SELECT "a\"2" FROM t WHERE v=7"#).0,
+        );
     }
 }

--- a/crates/reddb-server/tests/sql_injection_audit.rs
+++ b/crates/reddb-server/tests/sql_injection_audit.rs
@@ -84,32 +84,20 @@ fn prepared_bound_string_is_treated_as_literal_not_sql() {
     );
 }
 
-/// V2 — a quoted string in identifier position fails at parse time. The
-/// lexer emits `Token::String` (not `Token::Ident`), so `expect_ident`
-/// in `parse_create_table_query` rejects the input before any engine
-/// sees it.
+/// V2 — quoted identifiers keep SQL metacharacters opaque. Single-quoted
+/// strings are still rejected in identifier positions.
 #[test]
-fn identifier_with_sql_metacharacters_is_rejected_at_parse() {
-    // Double-quoted form: lexer routes to scan_string → Token::String.
-    let result = parser::parse(r#"CREATE TABLE "users; DROP TABLE x" (id INT)"#);
-    let err = result.expect_err("must be a parse error");
-    let msg = err.to_string().to_lowercase();
-    assert!(
-        msg.contains("ident") || msg.contains("identifier") || msg.contains("expected"),
-        "error must point at the identifier rule, got: {}",
-        err
-    );
-
-    // Single-quoted form: same path.
-    let result = parser::parse("CREATE TABLE 'evil; DROP TABLE x' (id INT)");
-    assert!(
-        result.is_err(),
-        "single-quoted identifier must also be rejected"
-    );
-
-    // Sanity: a normal table name still parses.
-    let ok = parser::parse("CREATE TABLE legit_users (id INT)");
-    assert!(ok.is_ok(), "non-injection identifier must parse: {:?}", ok);
+fn quoted_identifier_with_sql_metacharacters_is_one_identifier() {
+    let parsed =
+        parse_multi(r#"CREATE TABLE "users; DROP TABLE x" (id INT)"#).expect("quoted identifier");
+    let QueryExpr::CreateTable(table) = parsed else {
+        panic!("expected exactly one CREATE TABLE");
+    };
+    assert_eq!(table.name, "users; DROP TABLE x");
+    assert_eq!(table.columns.len(), 1);
+    assert_eq!(table.columns[0].name, "id");
+    assert!(parser::parse("CREATE TABLE 'evil; DROP TABLE x' (id INT)").is_err());
+    assert!(parser::parse("CREATE TABLE legit_users (id INT)").is_ok());
 }
 
 /// V3 — a CREATE POLICY USING (...) body whose string-literal value

--- a/docs/query/select.md
+++ b/docs/query/select.md
@@ -262,3 +262,5 @@ counters such as `actual_rows` and `actual_ms`. RedDB never commits under
 > Row results include the public RedDB ID envelope fields `rid`, `collection`,
 > `kind`, `tenant`, `created_at`, and `updated_at`. For ordinary table rows,
 > `kind` is `row`.
+
+See [SQL quotation rules and migration](sql-quoting.md) for double-quoted identifiers, single-quoted text, and unchanged JSON quoting.

--- a/docs/query/sql-quoting.md
+++ b/docs/query/sql-quoting.md
@@ -10,7 +10,10 @@ SELECT "text value" FROM "select" WHERE "key name" = 1;
 
 An identifier may name a table, column, alias, or constraint. Double an embedded
 quote: `"a""b"` names the column `a"b`. Ordinary unquoted identifiers continue to
-work. Quoted keywords such as `"CASE"` and `"current_user"` are column names,
+work. Paths keep their dots outside the quotes, for example
+`"profile name"."city"`. Literal dots inside a single quoted identifier are
+currently rejected because the query AST cannot distinguish them from paths.
+Quoted keywords such as `"CASE"` and `"current_user"` are column names,
 not expressions with special behavior.
 
 For text, double an embedded single quote: `'it''s ready'`. Prefer query

--- a/docs/query/sql-quoting.md
+++ b/docs/query/sql-quoting.md
@@ -1,0 +1,50 @@
+# SQL quotation rules
+
+SQL uses double quotes for identifiers and single quotes for text values:
+
+```sql
+CREATE TABLE "select" ("key name" INT PRIMARY KEY, "text value" TEXT);
+INSERT INTO "select" ("key name", "text value") VALUES (1, 'hello');
+SELECT "text value" FROM "select" WHERE "key name" = 1;
+```
+
+An identifier may name a table, column, alias, or constraint. Double an embedded
+quote: `"a""b"` names the column `a"b`. Ordinary unquoted identifiers continue to
+work. Quoted keywords such as `"CASE"` and `"current_user"` are column names,
+not expressions with special behavior.
+
+For text, double an embedded single quote: `'it''s ready'`. Prefer query
+parameters for application values; parameter encoding is unchanged:
+
+```sql
+INSERT INTO "select" ("key name", "text value") VALUES ($1, $2);
+```
+
+Parameters represent values, not identifiers. Use a driver identifier helper
+when its supported name rules fit, or correctly delimit names in SQL passed to
+the driver's query method. Never interpolate unescaped application input.
+
+## Migration from double-quoted SQL strings
+
+This is a breaking grammar change with no legacy toggle. Replace SQL text
+literals such as `WHERE owner = "alice"` with `WHERE owner = 'alice'`, or bind
+`alice` as a parameter. `SELECT "title"` now reads the column named `title`;
+`SELECT 'title'` returns the text `title`.
+
+Update application SQL, fixtures, saved queries, views, and migration scripts
+before adopting this engine version. A wire/SDK upgrade alone cannot rewrite
+SQL strings stored in an application. Existing binary parameters and HTTP JSON
+request bodies keep their encodings.
+
+## JSON keeps double-quoted strings
+
+JSON objects and array values retain JSON quoting:
+
+```sql
+CREATE TABLE payloads (id INT, body JSON);
+INSERT INTO payloads (id, body)
+VALUES (1, {"title":"hello","tags":["one","two"]});
+```
+
+Do not replace double quotes inside JSON request bodies, stored JSON values, or
+inline JSON literals. They delimit JSON keys and text, not SQL identifiers.

--- a/docs/spec/sdk-helpers.md
+++ b/docs/spec/sdk-helpers.md
@@ -535,3 +535,12 @@ Driver minimum versions:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+### Quoted SQL identifiers
+
+The `generic.query.quoted_identifiers` conformance case creates
+`"select" ("key name" INT, "text value" TEXT)`, inserts `(1, 'hello')` using
+bound parameters, and selects `"text value"` with `"key name" = $1`. Every
+transport must return the field named `text value` containing `hello`.
+This exercises the query method; it does not broaden a helper's identifier
+validation rules. See [SQL quotation rules](../query/sql-quoting.md).

--- a/drivers/bun/README.md
+++ b/drivers/bun/README.md
@@ -54,3 +54,11 @@ REDDB_BINARY_PATH=/absolute/path/to/red bun run test
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/cpp/README.md
+++ b/drivers/cpp/README.md
@@ -206,3 +206,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/dart/README.md
+++ b/drivers/dart/README.md
@@ -275,3 +275,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/dotnet/README.md
+++ b/drivers/dotnet/README.md
@@ -258,3 +258,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/go/README.md
+++ b/drivers/go/README.md
@@ -303,3 +303,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/go/README.md
+++ b/drivers/go/README.md
@@ -311,3 +311,10 @@ SQL double quotes delimit identifiers; single quotes delimit text. For example,
 Bind application values as parameters. JSON object/array strings keep double
 quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
 before upgrading applications that used double-quoted SQL text literals.
+
+
+`Query` requests the full result envelope when the server advertises parameter
+support, including queries without parameters. Rich helpers read canonical
+`result.records` and legacy `rows` responses, preserve exact integers, and expose
+only projected columns when the envelope declares them. Older servers without
+parameter support retain the legacy summary response for unparameterized SQL.

--- a/drivers/go/conformance_test.go
+++ b/drivers/go/conformance_test.go
@@ -594,8 +594,9 @@ func TestConformance_tx_commit_persists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select: %v", err)
 	}
-	if !strings.Contains(string(body), "keep") {
-		t.Fatalf("commit did not persist: %s", body)
+	rows, err := allRows(body)
+	if err != nil || len(rows) != 1 || rows[0]["name"] != "keep" {
+		t.Fatalf("commit did not persist: %s (%v)", body, err)
 	}
 }
 
@@ -622,8 +623,9 @@ func TestConformance_tx_rollback_discards(t *testing.T) {
 	if err != nil {
 		t.Fatalf("select: %v", err)
 	}
-	if strings.Contains(string(body), "drop") {
-		t.Fatalf("rollback did not discard: %s", body)
+	rows, err := allRows(body)
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("rollback did not discard: %s (%v)", body, err)
 	}
 }
 

--- a/drivers/go/conformance_test.go
+++ b/drivers/go/conformance_test.go
@@ -166,6 +166,26 @@ func waitForConfConnect(ctx context.Context, uri string) (Conn, error) {
 
 // --- case ID: generic.* -----------------------------------------------
 
+// Case ID: generic.query.quoted_identifiers
+func TestConformance_generic_query_quoted_identifiers(t *testing.T) {
+	e := startConfEngine(t)
+	c, _ := e.dial(t)
+	ctx := context.Background()
+	if _, err := c.Exec(ctx, `CREATE TABLE "select" ("key name" INT, "text value" TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Exec(ctx, `INSERT INTO "select" ("key name", "text value") VALUES ($1,$2)`, int64(1), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := c.Query(ctx, `SELECT "text value" FROM "select" WHERE "key name"=$1`, int64(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"text value"`) || !strings.Contains(string(body), `"hello"`) {
+		t.Fatalf("quoted result: %s", body)
+	}
+}
+
 // Case ID: generic.query.no_params
 func TestConformance_generic_query_no_params(t *testing.T) {
 	e := startConfEngine(t)

--- a/drivers/go/conformance_test.go
+++ b/drivers/go/conformance_test.go
@@ -181,7 +181,11 @@ func TestConformance_generic_query_quoted_identifiers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(body), `"text value"`) || !strings.Contains(string(body), `"hello"`) {
+	rows, err := allRows(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || len(rows[0]) != 1 || rows[0]["text value"] != "hello" {
 		t.Fatalf("quoted result: %s", body)
 	}
 }

--- a/drivers/go/helpers.go
+++ b/drivers/go/helpers.go
@@ -893,20 +893,16 @@ func firstRow(body []byte) (map[string]any, uint64, error) {
 		return nil, 0, err
 	}
 	affected := affectedFromMap(obj)
-	rows, _ := obj["rows"].([]any)
-	if len(rows) == 0 {
+	if affected == 0 {
 		if nested, ok := obj["result"].(map[string]any); ok {
-			rows, _ = nested["rows"].([]any)
-			if affected == 0 {
-				affected = affectedFromMap(nested)
-			}
+			affected = affectedFromMap(nested)
 		}
 	}
+	rows := resultRows(obj)
 	if len(rows) == 0 {
 		return nil, affected, nil
 	}
-	row, _ := rows[0].(map[string]any)
-	return row, affected, nil
+	return rows[0], affected, nil
 }
 
 func allRows(body []byte) ([]map[string]any, error) {
@@ -914,19 +910,59 @@ func allRows(body []byte) ([]map[string]any, error) {
 	if err != nil || obj == nil {
 		return nil, err
 	}
-	raw, ok := obj["rows"].([]any)
-	if !ok {
+	return resultRows(obj), nil
+}
+
+// Canonical envelopes separate projected values from system metadata.
+// Legacy rows remain opaque: user fields named values/meta are not wrappers.
+func resultRows(obj map[string]any) []map[string]any {
+	raw, legacy := obj["rows"].([]any)
+	if !legacy {
 		if nested, ok := obj["result"].(map[string]any); ok {
-			raw, _ = nested["rows"].([]any)
+			obj = nested
+		}
+		raw, legacy = obj["rows"].([]any)
+		if !legacy {
+			raw, _ = obj["records"].([]any)
 		}
 	}
+	columns, _ := obj["columns"].([]any)
 	out := make([]map[string]any, 0, len(raw))
-	for _, r := range raw {
-		if m, ok := r.(map[string]any); ok {
-			out = append(out, m)
+	for _, item := range raw {
+		record, ok := item.(map[string]any)
+		if !ok {
+			continue
 		}
+		values, canonical := record["values"].(map[string]any)
+		if legacy || !canonical {
+			out = append(out, record)
+			continue
+		}
+		meta, _ := record["meta"].(map[string]any)
+		row := make(map[string]any)
+		if len(columns) > 0 {
+			for _, column := range columns {
+				name, ok := column.(string)
+				if !ok {
+					continue
+				}
+				if value, exists := values[name]; exists {
+					row[name] = value
+				} else if value, exists := meta[name]; exists {
+					row[name] = value
+				}
+			}
+		} else {
+			for key, value := range meta {
+				row[key] = value
+			}
+			for key, value := range values {
+				row[key] = value
+			}
+		}
+		out = append(out, row)
 	}
-	return out, nil
+	return out
 }
 
 func affectedFromBody(body []byte) (uint64, error) {

--- a/drivers/go/helpers_test.go
+++ b/drivers/go/helpers_test.go
@@ -458,3 +458,29 @@ func TestAffectedFromBody_HandlesNestedResult(t *testing.T) {
 		t.Fatalf("nested affected")
 	}
 }
+
+func TestCanonicalRecordRowsPreserveProjectionAndExactValues(t *testing.T) {
+	body := []byte(`{"result":{"columns":["text value","rid"],"records":[{"values":{"text value":"hello","unselected":"hidden"},"meta":{"rid":{"$uint":"18446744073709551615"},"tenant":"secret"}}]}}`)
+	rows, err := allRows(body)
+	if err != nil || len(rows) != 1 || len(rows[0]) != 2 {
+		t.Fatalf("canonical projection: %#v %v", rows, err)
+	}
+	if rows[0]["text value"] != "hello" || rows[0]["rid"] != uint64(18446744073709551615) {
+		t.Fatalf("canonical values: %#v", rows[0])
+	}
+	first, _, err := firstRow(body)
+	if err != nil || first["rid"] != rows[0]["rid"] {
+		t.Fatalf("canonical first row: %#v %v", first, err)
+	}
+}
+
+func TestLegacyRowsKeepValuesNamedPayload(t *testing.T) {
+	body := []byte(`{"rows":[{"values":{"nested":true},"meta":"user data"}]}`)
+	rows, err := allRows(body)
+	if err != nil || len(rows) != 1 || rows[0]["meta"] != "user data" {
+		t.Fatalf("legacy row: %#v %v", rows, err)
+	}
+	if _, ok := rows[0]["values"].(map[string]any); !ok {
+		t.Fatalf("values field must remain nested: %#v", rows[0])
+	}
+}

--- a/drivers/go/redwire/conn.go
+++ b/drivers/go/redwire/conn.go
@@ -520,10 +520,10 @@ func parseReason(payload []byte) string {
 
 // --- Operations ------------------------------------------------------
 
-// Query sends a SQL string and returns the raw Result.payload bytes. When
-// `params` is non-empty the call routes through the binary `QueryWithParams`
-// frame (0x28) and requires the server to have advertised FeatureParams; an
-// older server triggers ErrParamsUnsupported.
+// Query returns the full result envelope through QueryWithParams (0x28)
+// whenever FeatureParams is advertised, including zero-parameter queries.
+// Query (0x01) returns only a summary and is retained for older servers;
+// nonempty parameters on those servers trigger ErrParamsUnsupported.
 func (c *Conn) Query(ctx context.Context, sql string, params ...any) ([]byte, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -534,7 +534,7 @@ func (c *Conn) Query(ctx context.Context, sql string, params ...any) ([]byte, er
 	defer cleanup()
 
 	var frame *Frame
-	if len(params) == 0 {
+	if len(params) == 0 && !c.SupportsParams() {
 		frame = NewFrame(KindQuery, c.nextCorr(), []byte(sql))
 	} else {
 		if !c.SupportsParams() {

--- a/drivers/go/redwire/params_e2e_test.go
+++ b/drivers/go/redwire/params_e2e_test.go
@@ -106,9 +106,9 @@ func TestQuery_WithParams_UnsupportedServer(t *testing.T) {
 	}
 }
 
-// Empty params keeps emitting the legacy Query frame even when the server
-// supports parameterized queries — guards the byte-for-byte backwards path.
-func TestQuery_NoParams_EmitsLegacyQueryFrame(t *testing.T) {
+// The full-envelope frame returns records even with an empty parameter list.
+// TestQuery_RoundTrip separately covers servers without FeatureParams.
+func TestQuery_NoParams_RequestsFullEnvelope(t *testing.T) {
 	srv, cli := newFakeServerPair(t)
 	defer srv.close()
 
@@ -127,8 +127,12 @@ func TestQuery_NoParams_EmitsLegacyQueryFrame(t *testing.T) {
 		srv.writeFrame(NewFrame(KindAuthOk, 1, ok))
 
 		q := srv.readFrame()
-		if q.Kind != KindQuery {
-			t.Errorf("expected KindQuery (0x01), got 0x%02x", q.Kind)
+		if q.Kind != KindQueryWithParams {
+			t.Errorf("expected KindQueryWithParams (0x28), got 0x%02x", q.Kind)
+		}
+		expected, err := EncodeQueryWithParams("SELECT 1", nil)
+		if err != nil || string(q.Payload) != string(expected) {
+			t.Errorf("unexpected zero-parameter payload: %x", q.Payload)
 		}
 		srv.writeFrame(NewFrame(KindResult, q.CorrelationID, []byte("{}")))
 	}()

--- a/drivers/java/README.md
+++ b/drivers/java/README.md
@@ -263,3 +263,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/js-client/README.md
+++ b/drivers/js-client/README.md
@@ -225,3 +225,11 @@ MIT.
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/js/README.md
+++ b/drivers/js/README.md
@@ -608,3 +608,11 @@ remote URIs.
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/js/test/conformance.test.mjs
+++ b/drivers/js/test/conformance.test.mjs
@@ -82,6 +82,13 @@ await test('meta.spec_version', async (db) => {
 
 // --- generic.* --------------------------------------------------------
 
+await test('generic.query.quoted_identifiers', async (db) => {
+  await db.query('CREATE TABLE "select" ("key name" INT, "text value" TEXT)')
+  await db.query('INSERT INTO "select" ("key name", "text value") VALUES ($1,$2)', [1, 'hello'])
+  const result = await db.query('SELECT "text value" FROM "select" WHERE "key name"=$1', [1])
+  assertEqual(result.rows[0]['text value'], 'hello', 'quoted names and bound values')
+})
+
 await test('generic.query.no_params', async (db) => {
   await db.query('CREATE TABLE conf_q (id INTEGER, name TEXT)')
   await db.query("INSERT INTO conf_q (id, name) VALUES (1, 'a')")

--- a/drivers/kotlin/README.md
+++ b/drivers/kotlin/README.md
@@ -215,3 +215,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/php/README.md
+++ b/drivers/php/README.md
@@ -299,3 +299,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/python-asyncio/README.md
+++ b/drivers/python-asyncio/README.md
@@ -220,3 +220,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/python/README.md
+++ b/drivers/python/README.md
@@ -476,3 +476,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/drivers/python/tests/test_conformance.py
+++ b/drivers/python/tests/test_conformance.py
@@ -23,6 +23,14 @@ import reddb
 
 
 # ----------------------------------------------------------------- generic.*
+def test_generic_query_quoted_identifiers():
+    with reddb.connect("memory://") as db:
+        db.query('CREATE TABLE "select" ("key name" INT, "text value" TEXT)')
+        db.query('INSERT INTO "select" ("key name", "text value") VALUES ($1,$2)', 1, "hello")
+        result = db.query('SELECT "text value" FROM "select" WHERE "key name"=$1', 1)
+        assert result["rows"][0]["text value"] == "hello"
+
+
 def test_generic_query_no_params():
     with reddb.connect("memory://") as db:
         db.query("CREATE TABLE conf_q1 (name TEXT)")

--- a/drivers/zig/README.md
+++ b/drivers/zig/README.md
@@ -236,3 +236,11 @@ When you're ready to point this driver at a production RedDB cluster:
 
 _Status legend: ✅ supported · ⚠️ partial (known gaps) · ❌ unsupported._
 <!-- contract-matrix:end -->
+
+## SQL quotation compatibility
+
+SQL double quotes delimit identifiers; single quotes delimit text. For example,
+`SELECT "title" FROM articles WHERE author = 'alice'` reads the `title` column.
+Bind application values as parameters. JSON object/array strings keep double
+quotes. See the [SQL quotation migration guide](../../docs/query/sql-quoting.md)
+before upgrading applications that used double-quoted SQL text literals.

--- a/examples/sql_quoted_identifiers.sql
+++ b/examples/sql_quoted_identifiers.sql
@@ -1,0 +1,6 @@
+-- Double quotes identify names; single quotes delimit SQL text.
+CREATE TABLE "select" ("key name" INT PRIMARY KEY, "text value" TEXT, body JSON);
+INSERT INTO "select" ("key name", "text value", body)
+VALUES (1, 'it''s ready', {"title":"hello","tags":["one","two"]});
+SELECT "text value", body FROM "select" WHERE "key name" = 1;
+SHOW CREATE TABLE "select";

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -107,5 +107,55 @@ fn unfiltered_projection_keeps_retention_filtering() {
         result.result.records[0].get("visible id"),
         Some(&Value::Integer(1))
     );
-    assert_eq!(result.result.records[0].column_names(), ["visible id"]);
+    assert_eq!(result.result.columns, ["visible id"]);
+    assert!(result.result.records[0].get("rid").is_some());
+}
+
+#[test]
+fn signed_vector_insert_matches_parameter_and_exact_search() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE VECTOR signed_embeddings DIM 2 METRIC cosine")
+        .expect("vector");
+    rt.execute_query(
+        "INSERT INTO signed_embeddings VECTOR (dense,content) VALUES ([-0.25,0.5],'literal')",
+    )
+    .expect("signed literal");
+    rt.execute_query_with_params(
+        "INSERT INTO signed_embeddings VECTOR (dense,content) VALUES ($1,$2)",
+        &[Value::Vector(vec![-0.25, 0.5]), Value::text("parameter")],
+    )
+    .expect("signed parameter");
+    let result = rt
+        .execute_query("VECTOR SEARCH signed_embeddings SIMILAR TO [-0.25,0.5] LIMIT 2")
+        .expect("search");
+    assert_eq!(result.result.records.len(), 2);
+    let mut contents = Vec::new();
+    for row in &result.result.records {
+        let Some(Value::Float(score)) = row.get("score") else {
+            panic!("score")
+        };
+        assert!((score - 1.0).abs() < 1e-5);
+        let Some(Value::Text(content)) = row.get("content") else {
+            panic!("content")
+        };
+        contents.push(content.to_string());
+    }
+    contents.sort();
+    assert_eq!(contents, ["literal", "parameter"]);
+}
+
+#[test]
+fn quoted_identifier_metacharacters_do_not_execute_statements() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE TABLE protected_rows (id INT)")
+        .expect("protected table");
+    rt.execute_query("INSERT INTO protected_rows (id) VALUES (7)")
+        .expect("protected value");
+    rt.execute_query(r#"CREATE TABLE "users; DROP TABLE protected_rows" (id INT)"#)
+        .expect("opaque name");
+    let result = rt
+        .execute_query("SELECT id FROM protected_rows")
+        .expect("protected table survives");
+    assert_eq!(result.result.records.len(), 1);
+    assert_eq!(result.result.records[0].get("id"), Some(&Value::Integer(7)));
 }

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -64,7 +64,11 @@ fn sql_quoted_identifiers_persist_and_roundtrip_schema() {
         Some(&Value::text("replacement"))
     );
     let fresh = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("fresh");
-    fresh.execute_query(&ddl).expect("reconstruct schema");
+    // SHOW CREATE emits a script; execute_query accepts one statement.
+    // This fixture contains no semicolons inside its quoted identifiers.
+    for statement in ddl.split(';').map(str::trim).filter(|sql| !sql.is_empty()) {
+        fresh.execute_query(statement).expect("reconstruct schema");
+    }
 }
 
 #[test]

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -32,8 +32,20 @@ fn sql_quoted_identifiers_persist_and_roundtrip_schema() {
             result.result.records[0].get("CASE"),
             Some(&Value::Integer(7))
         );
-        rt.execute_query(r#"UPDATE "select" SET "a""b"='replacement' WHERE "key name"=1"#)
+        let updated = rt
+            .execute_query(r#"UPDATE "select" SET "a""b"='replacement' WHERE "key name"=1"#)
             .expect("update");
+        assert_eq!(
+            updated.affected_rows, 1,
+            "JSON column must not hide a table row"
+        );
+        let updated = rt
+            .execute_query(r#"SELECT "a""b" FROM "select" WHERE "key name"=1"#)
+            .expect("updated column before reopen");
+        assert_eq!(
+            updated.result.records[0].get("a\"b"),
+            Some(&Value::text("replacement"))
+        );
         let result = rt
             .execute_query(r#"SHOW CREATE TABLE "select""#)
             .expect("DDL");
@@ -162,4 +174,24 @@ fn quoted_identifier_metacharacters_do_not_execute_statements() {
         .expect("protected table survives");
     assert_eq!(result.result.records.len(), 1);
     assert_eq!(result.result.records[0].get("id"), Some(&Value::Integer(7)));
+}
+
+#[test]
+fn declared_table_key_value_columns_remain_updateable_rows() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query(r#"CREATE TABLE table_pairs ("key" INT, "value" TEXT)"#)
+        .expect("table");
+    rt.execute_query(r#"INSERT INTO table_pairs ("key","value") VALUES (1,'before')"#)
+        .expect("insert");
+    let result = rt
+        .execute_query(r#"UPDATE table_pairs SET "value"='after' WHERE "key"=1"#)
+        .expect("update table with KV-shaped columns");
+    assert_eq!(result.affected_rows, 1);
+    let result = rt
+        .execute_query(r#"SELECT "value" FROM table_pairs WHERE "key"=1"#)
+        .expect("read updated table");
+    assert_eq!(
+        result.result.records[0].get("value"),
+        Some(&Value::text("after"))
+    );
 }

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -1,0 +1,80 @@
+use reddb::{RedDBOptions, RedDBRuntime};
+use reddb_types::Value;
+
+#[test]
+fn sql_quoted_identifiers_persist_and_roundtrip_schema() {
+    let directory = tempfile::tempdir().expect("directory");
+    let options = RedDBOptions::persistent(directory.path().join("quotes.rdb"));
+    let ddl;
+    {
+        let rt = RedDBRuntime::with_options(options.clone()).expect("runtime");
+        rt.execute_query(r#"CREATE TABLE "select" ("key name" INT PRIMARY KEY, "a""b" TEXT, "CASE" INT, "body" JSON)"#).expect("quoted schema");
+        rt.execute_query_with_params(
+            r#"INSERT INTO "select" ("key name", "a""b", "CASE", "body") VALUES ($1,$2,$3,$4)"#,
+            &[
+                Value::Integer(1),
+                Value::text("a'\"b"),
+                Value::Integer(7),
+                Value::Json(br#"{"text":"unchanged","array":["one","two"]}"#.to_vec()),
+            ],
+        )
+        .expect("parameters");
+        let result = rt
+            .execute_query(
+                r#"SELECT "a""b" AS "output name", "CASE" FROM "select" WHERE "key name"=1"#,
+            )
+            .expect("columns");
+        assert_eq!(
+            result.result.records[0].get("output name"),
+            Some(&Value::text("a'\"b"))
+        );
+        assert_eq!(
+            result.result.records[0].get("CASE"),
+            Some(&Value::Integer(7))
+        );
+        rt.execute_query(r#"UPDATE "select" SET "a""b"='replacement' WHERE "key name"=1"#)
+            .expect("update");
+        let result = rt
+            .execute_query(r#"SHOW CREATE TABLE "select""#)
+            .expect("DDL");
+        let Some(Value::Text(value)) = result.result.records[0].get("ddl") else {
+            panic!("DDL")
+        };
+        ddl = value.to_string();
+        assert!(ddl.contains(r#""a""b""#), "{ddl}");
+    }
+    let rt = RedDBRuntime::with_options(options).expect("reopen");
+    let result = rt
+        .execute_query(r#"SELECT "a""b" FROM "select" WHERE "key name"=1"#)
+        .expect("reopened column");
+    assert_eq!(
+        result.result.records[0].get("a\"b"),
+        Some(&Value::text("replacement"))
+    );
+    let fresh = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("fresh");
+    fresh.execute_query(&ddl).expect("reconstruct schema");
+}
+
+#[test]
+fn sql_quoted_columns_do_not_share_cached_literal_plans() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    rt.execute_query("CREATE TABLE labels (first_label TEXT, second_label TEXT)")
+        .expect("table");
+    rt.execute_query("INSERT INTO labels (first_label,second_label) VALUES ('left','right')")
+        .expect("values");
+    for (sql, expected) in [
+        (r#"SELECT "first_label" AS value FROM labels"#, "left"),
+        (r#"SELECT "second_label" AS value FROM labels"#, "right"),
+        (
+            r#"SELECT 'first_label' AS value FROM labels"#,
+            "first_label",
+        ),
+        (r#"SELECT "first_label" AS value FROM labels"#, "left"),
+    ] {
+        let result = rt.execute_query(sql).expect("distinct cached query");
+        assert_eq!(
+            result.result.records[0].get("value"),
+            Some(&Value::text(expected))
+        );
+    }
+}

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -63,6 +63,7 @@ fn sql_quoted_columns_do_not_share_cached_literal_plans() {
     rt.execute_query("INSERT INTO labels (first_label,second_label) VALUES ('left','right')")
         .expect("values");
     for (sql, expected) in [
+        ("SELECT first_label AS value FROM labels", "left"),
         (r#"SELECT "first_label" AS value FROM labels"#, "left"),
         (r#"SELECT "second_label" AS value FROM labels"#, "right"),
         (
@@ -74,7 +75,9 @@ fn sql_quoted_columns_do_not_share_cached_literal_plans() {
         let result = rt.execute_query(sql).expect("distinct cached query");
         assert_eq!(
             result.result.records[0].get("value"),
-            Some(&Value::text(expected))
+            Some(&Value::text(expected)),
+            "{sql}: {:?}",
+            result.result.records
         );
     }
 }

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -81,3 +81,31 @@ fn sql_quoted_columns_do_not_share_cached_literal_plans() {
         );
     }
 }
+
+#[test]
+fn unfiltered_projection_keeps_retention_filtering() {
+    let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+    for sql in [
+        "CREATE TABLE retention_items (id INT, ts TIMESTAMP)",
+        "INSERT INTO retention_items (id,ts) VALUES (1,1)",
+        "ALTER COLLECTION retention_items SET RETENTION 1 s",
+    ] {
+        rt.execute_query(sql).expect(sql);
+    }
+    let query = r#"SELECT "id" AS "visible id" FROM retention_items"#;
+    assert!(rt
+        .execute_query(query)
+        .expect("retained projection")
+        .result
+        .records
+        .is_empty());
+    rt.execute_query("ALTER COLLECTION retention_items UNSET RETENTION")
+        .expect("unset retention");
+    let result = rt.execute_query(query).expect("projection");
+    assert_eq!(result.result.records.len(), 1);
+    assert_eq!(
+        result.result.records[0].get("visible id"),
+        Some(&Value::Integer(1))
+    );
+    assert_eq!(result.result.records[0].column_names(), ["visible id"]);
+}

--- a/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
+++ b/tests/grouped/schema_query_core/e2e_sql_quoted_identifiers.rs
@@ -71,6 +71,10 @@ fn sql_quoted_columns_do_not_share_cached_literal_plans() {
             "first_label",
         ),
         (r#"SELECT "first_label" AS value FROM labels"#, "left"),
+        (
+            r#"SELECT "first_label" AS value FROM labels WHERE first_label='left'"#,
+            "left",
+        ),
     ] {
         let result = rt.execute_query(sql).expect("distinct cached query");
         assert_eq!(

--- a/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
+++ b/tests/grouped/schema_query_core/e2e_table_unique_constraints.rs
@@ -18,18 +18,33 @@ fn duplicate(rt: &RedDBRuntime, query: &str) {
 fn table_unique_constraints_enforce_tuples_nulls_updates_and_savepoints() {
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
     execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, CONSTRAINT pair_key UNIQUE (left_key, right_key))");
-    execute(&rt, "INSERT INTO pairs VALUES (1,1,'a'),(2,1,'b'),(3,2,'a'),(4,NULL,'a'),(5,NULL,'a'),(6,1,NULL),(7,1,NULL)");
-    duplicate(&rt, "INSERT INTO pairs VALUES (8,1,'a')");
+    execute(&rt, "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a'),(2,1,'b'),(3,2,'a'),(4,NULL,'a'),(5,NULL,'a'),(6,1,NULL),(7,1,NULL)");
+    duplicate(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,1,'a')",
+    );
     duplicate(&rt, "UPDATE pairs SET right_key='a' WHERE id=2");
     execute(&rt, "BEGIN");
     execute(&rt, "SAVEPOINT probe");
-    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
-    duplicate(&rt, "INSERT INTO pairs VALUES (9,3,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,3,'a')",
+    );
+    duplicate(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (9,3,'a')",
+    );
     execute(&rt, "ROLLBACK TO SAVEPOINT probe");
-    execute(&rt, "INSERT INTO pairs VALUES (8,3,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (8,3,'a')",
+    );
     execute(&rt, "COMMIT");
     execute(&rt, "DELETE FROM pairs WHERE id=1");
-    execute(&rt, "INSERT INTO pairs VALUES (9,1,'a')");
+    execute(
+        &rt,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (9,1,'a')",
+    );
     let result = rt
         .execute_query("SELECT id FROM pairs WHERE left_key=1 AND right_key='b'")
         .expect("failed update is atomic");
@@ -65,7 +80,10 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
     {
         let rt = RedDBRuntime::with_options(options.clone()).expect("runtime");
         execute(&rt, "CREATE TABLE pairs (id INT PRIMARY KEY, left_key INT, right_key TEXT, UNIQUE (left_key, right_key), CONSTRAINT uniq_left_key_right_key UNIQUE (right_key, left_key))");
-        execute(&rt, "INSERT INTO pairs VALUES (1,1,'a')");
+        execute(
+            &rt,
+            "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a')",
+        );
         let result = rt.execute_query("SHOW CREATE TABLE pairs").expect("DDL");
         let Some(Value::Text(value)) = result.result.records[0].get("ddl") else {
             panic!("DDL text")
@@ -81,7 +99,10 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
         );
     }
     let reopened = RedDBRuntime::with_options(options).expect("reopen");
-    duplicate(&reopened, "INSERT INTO pairs VALUES (2,1,'a')");
+    duplicate(
+        &reopened,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (2,1,'a')",
+    );
     let fresh = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("fresh");
     for statement in ddl
         .split(';')
@@ -90,8 +111,14 @@ fn table_unique_constraints_survive_reopen_and_show_create_roundtrip() {
     {
         execute(&fresh, statement);
     }
-    execute(&fresh, "INSERT INTO pairs VALUES (1,1,'a')");
-    duplicate(&fresh, "INSERT INTO pairs VALUES (2,1,'a')");
+    execute(
+        &fresh,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (1,1,'a')",
+    );
+    duplicate(
+        &fresh,
+        "INSERT INTO pairs (id,left_key,right_key) VALUES (2,1,'a')",
+    );
 }
 
 #[test]

--- a/tests/grouped/sql_core.rs
+++ b/tests/grouped/sql_core.rs
@@ -122,3 +122,6 @@ mod e2e_unique_key_lookup;
 
 #[path = "schema_query_core/e2e_table_unique_constraints.rs"]
 mod e2e_table_unique_constraints;
+
+#[path = "schema_query_core/e2e_sql_quoted_identifiers.rs"]
+mod e2e_sql_quoted_identifiers;


### PR DESCRIPTION
Double quotes now identify SQL names and single quotes delimit text literals. Previously a quoted column could be parsed as a string. Escaped identifiers retain their spelling through parsing, canonical rendering, projection, UPDATE, persistence and SHOW CREATE reconstruction; inline JSON keeps its own quoting rules.

Filtered aliases retain their source fields until the parent filter and final projection execute. Unfiltered projections preserve retention filtering, SESSIONIZE inputs and stream resumption metadata. Declared SQL tables with JSON/BLOB or key/value columns remain table UPDATE targets instead of being reclassified from their payload shape. Signed numeric array literals preserve negative values, nested arrays and integer types.

The migration is breaking: applications using double-quoted SQL strings must use single quotes or parameters. Driver READMEs describe the migration, with conformance cases for Rust, JavaScript, Python and Go. A literal dot inside one quoted identifier is deliberately rejected because the current AST cannot distinguish it from a path; separately quoted path segments remain supported. This is not a claim of complete PostgreSQL compatibility or faster alias queries.

Go conformance also exposed two existing driver defects: zero-parameter queries requested summary-only frames, and helpers ignored canonical result.records. Go now requests full envelopes when supported and reads projected values/system metadata without losing exact integers or flattening legacy user fields named values/meta. The old-server fallback remains covered. Transaction tests inspect actual rows instead of echoed SQL.

Validation: the standard CI workflow 34181497535 passed at 0d4634cf2. Combined revision 15166aaf0638c6de5b539c9f1aed9790504f0511 passed standard CI 34181499340, cargo check, 171 focused regressions and a release build. Acceptance passed JavaScript 23, Go 19, Rust 26 (including embedded and RedWire) and Python 24 tests; Go unit tests also passed. All 118 multimodel/isolation checks, ten geographic/vector checks and the 120-query full SciFact retrieval control passed in #2291. Full RQL coverage previously passed (842 unit, 3 integration and 8 quotation tests; one ignored doctest), with no subsequent RQL code changes.

Part of #2270. Draft against the table-constraint branch; no main merge or release requested.
