### PR TITLE
feat(vector): report measured work per executed operator

### DIFF
--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -398,6 +398,31 @@ pub(crate) fn unified_result_json_with_records(
     JsonValue::Object(object)
 }
 
+pub(crate) fn vector_operators_json(
+    operators: &[crate::storage::query::unified::VectorOperatorStats],
+) -> JsonValue {
+    JsonValue::Array(
+        operators
+            .iter()
+            .map(|operator| {
+                let mut fields = Map::new();
+                fields.insert(
+                    "operator".into(),
+                    JsonValue::String(operator.operator.clone()),
+                );
+                for (name, value) in [
+                    ("input_rows", operator.input_rows),
+                    ("output_rows", operator.output_rows),
+                    ("inclusive_time_us", operator.inclusive_time_us),
+                ] {
+                    fields.insert(name.into(), StorageValue::UnsignedInteger(value).to_json());
+                }
+                JsonValue::Object(fields)
+            })
+            .collect(),
+    )
+}
+
 pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
     let mut object = Map::new();
     object.insert(
@@ -430,6 +455,23 @@ pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
     );
     if let Some(vector) = &stats.vector {
         let mut metrics = Map::new();
+        metrics.insert("operators".into(), vector_operators_json(&vector.operators));
+        metrics.insert(
+            "mode_requested".into(),
+            JsonValue::String(vector.mode_requested.clone()),
+        );
+        metrics.insert(
+            "mode_executed".into(),
+            JsonValue::String(vector.mode_executed.clone()),
+        );
+        metrics.insert(
+            "fallback_reason".into(),
+            vector
+                .fallback_reason
+                .as_ref()
+                .map_or(JsonValue::Null, |reason| JsonValue::String(reason.clone())),
+        );
+
         metrics.insert("cache_hit".to_string(), JsonValue::Bool(vector.cache_hit));
         metrics.insert(
             "access_path".to_string(),
@@ -437,6 +479,11 @@ pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
         );
         metrics.insert("index_used".to_string(), JsonValue::Bool(vector.index_used));
         for (name, value) in [
+            (
+                "approximate_distance_evaluations",
+                vector.approximate_distance_evaluations,
+            ),
+            ("peak_topk_entries", vector.peak_topk_entries),
             ("candidates_examined", vector.candidates_examined),
             ("metadata_rejected", vector.metadata_rejected),
             ("rls_rejected", vector.rls_rejected),

--- a/crates/reddb-server/src/presentation/query_result_json.rs
+++ b/crates/reddb-server/src/presentation/query_result_json.rs
@@ -398,31 +398,6 @@ pub(crate) fn unified_result_json_with_records(
     JsonValue::Object(object)
 }
 
-pub(crate) fn vector_operators_json(
-    operators: &[crate::storage::query::unified::VectorOperatorStats],
-) -> JsonValue {
-    JsonValue::Array(
-        operators
-            .iter()
-            .map(|operator| {
-                let mut fields = Map::new();
-                fields.insert(
-                    "operator".into(),
-                    JsonValue::String(operator.operator.clone()),
-                );
-                for (name, value) in [
-                    ("input_rows", operator.input_rows),
-                    ("output_rows", operator.output_rows),
-                    ("inclusive_time_us", operator.inclusive_time_us),
-                ] {
-                    fields.insert(name.into(), StorageValue::UnsignedInteger(value).to_json());
-                }
-                JsonValue::Object(fields)
-            })
-            .collect(),
-    )
-}
-
 pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
     let mut object = Map::new();
     object.insert(
@@ -455,7 +430,7 @@ pub(crate) fn query_stats_json(stats: &QueryStats) -> JsonValue {
     );
     if let Some(vector) = &stats.vector {
         let mut metrics = Map::new();
-        metrics.insert("operators".into(), vector_operators_json(&vector.operators));
+        metrics.insert("operators".into(), vector.operators_json());
         metrics.insert(
             "mode_requested".into(),
             JsonValue::String(vector.mode_requested.clone()),

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3322,6 +3322,16 @@ impl RedDBRuntime {
                 Value::Float(stats.exec_time_us as f64 / 1000.0),
             ),
             ("metrics_scope", Value::text("vector_pipeline")),
+            (
+                "operators",
+                Value::Json(
+                    crate::presentation::query_result_json::vector_operators_json(
+                        &vector.operators,
+                    )
+                    .to_string()
+                    .into_bytes(),
+                ),
+            ),
         ];
         let columns = fields.iter().map(|(name, _)| name.to_string()).collect();
         let mut record = crate::storage::query::unified::UnifiedRecord::default();

--- a/crates/reddb-server/src/runtime/impl_core.rs
+++ b/crates/reddb-server/src/runtime/impl_core.rs
@@ -3324,13 +3324,7 @@ impl RedDBRuntime {
             ("metrics_scope", Value::text("vector_pipeline")),
             (
                 "operators",
-                Value::Json(
-                    crate::presentation::query_result_json::vector_operators_json(
-                        &vector.operators,
-                    )
-                    .to_string()
-                    .into_bytes(),
-                ),
+                Value::Json(vector.operators_json().to_string().into_bytes()),
             ),
         ];
         let columns = fields.iter().map(|(name, _)| name.to_string()).collect();

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -46,10 +46,14 @@ pub(crate) fn execute_runtime_canonical_vector_node(
     stats: &mut VectorQueryStats,
 ) -> RedDBResult<Vec<UnifiedRecord>> {
     let db = &runtime.inner.db;
-    match node.operator.as_str() {
+    let started = std::time::Instant::now();
+    let input_rows;
+    let records = match node.operator.as_str() {
         "vector_turbo_search" | "vector_exact_scan" => {
             let vector = resolve_runtime_vector_source(runtime, &query.query_vector)?;
+            let before = stats.candidates_examined;
             let matches = runtime_vector_matches(runtime, query, &vector, stats)?;
+            input_rows = stats.candidates_examined - before;
             Ok(matches
                 .into_iter()
                 .map(runtime_vector_record_from_match)
@@ -57,6 +61,7 @@ pub(crate) fn execute_runtime_canonical_vector_node(
         }
         "metadata_filter" => {
             let mut records = execute_runtime_canonical_vector_child(runtime, node, query, stats)?;
+            input_rows = records.len() as u64;
             if let Some(filter) = effective_vector_filter(query).as_ref() {
                 records.retain(|record| {
                     runtime_vector_record_matches_filter(db, &query.collection, record, filter)
@@ -66,6 +71,7 @@ pub(crate) fn execute_runtime_canonical_vector_node(
         }
         "similarity_threshold" => {
             let mut records = execute_runtime_canonical_vector_child(runtime, node, query, stats)?;
+            input_rows = records.len() as u64;
             if let Some(threshold) = query.threshold {
                 let metric = runtime_vector_metric(db, query);
                 records.retain(|record| {
@@ -76,14 +82,30 @@ pub(crate) fn execute_runtime_canonical_vector_node(
         }
         "topk" => {
             let mut records = execute_runtime_canonical_vector_child(runtime, node, query, stats)?;
+            input_rows = records.len() as u64;
             records.sort_by(compare_runtime_ranked_records);
             Ok(records.into_iter().take(query.k.max(1)).collect())
         }
-        "projection" => execute_runtime_canonical_vector_child(runtime, node, query, stats),
-        other => Err(RedDBError::Query(format!(
-            "unsupported canonical vector operator {other}"
-        ))),
-    }
+        "projection" => {
+            let records = execute_runtime_canonical_vector_child(runtime, node, query, stats)?;
+            input_rows = records.len() as u64;
+            Ok(records)
+        }
+        other => {
+            return Err(RedDBError::Query(format!(
+                "unsupported canonical vector operator {other}"
+            )))
+        }
+    }?;
+    stats
+        .operators
+        .push(crate::storage::query::unified::VectorOperatorStats {
+            operator: node.operator.clone(),
+            input_rows,
+            output_rows: records.len() as u64,
+            inclusive_time_us: u64::try_from(started.elapsed().as_micros()).unwrap_or(u64::MAX),
+        });
+    Ok(records)
 }
 
 pub(crate) fn execute_runtime_canonical_vector_child(

--- a/crates/reddb-server/src/runtime/query_exec/vector.rs
+++ b/crates/reddb-server/src/runtime/query_exec/vector.rs
@@ -48,7 +48,7 @@ pub(crate) fn execute_runtime_canonical_vector_node(
     let db = &runtime.inner.db;
     let started = std::time::Instant::now();
     let input_rows;
-    let records = match node.operator.as_str() {
+    let records: RedDBResult<Vec<UnifiedRecord>> = match node.operator.as_str() {
         "vector_turbo_search" | "vector_exact_scan" => {
             let vector = resolve_runtime_vector_source(runtime, &query.query_vector)?;
             let before = stats.candidates_examined;
@@ -96,7 +96,8 @@ pub(crate) fn execute_runtime_canonical_vector_node(
                 "unsupported canonical vector operator {other}"
             )))
         }
-    }?;
+    };
+    let records = records?;
     stats
         .operators
         .push(crate::storage::query::unified::VectorOperatorStats {

--- a/crates/reddb-server/src/storage/query/unified/types.rs
+++ b/crates/reddb-server/src/storage/query/unified/types.rs
@@ -652,9 +652,20 @@ pub struct QueryStats {
     pub vector: Option<VectorQueryStats>,
 }
 
+/// One executed canonical vector operator, recorded after its child completes.
+/// Inclusive time includes children and must not be summed across the tree.
+#[derive(Debug, Clone, Default)]
+pub struct VectorOperatorStats {
+    pub operator: String,
+    pub input_rows: u64,
+    pub output_rows: u64,
+    pub inclusive_time_us: u64,
+}
+
 /// Counters collected by execution, not inferred from the logical plan.
 #[derive(Debug, Clone, Default)]
 pub struct VectorQueryStats {
+    pub operators: Vec<VectorOperatorStats>,
     pub mode_requested: String,
     pub mode_executed: String,
     pub fallback_reason: Option<String>,

--- a/crates/reddb-server/src/storage/query/unified/types.rs
+++ b/crates/reddb-server/src/storage/query/unified/types.rs
@@ -683,6 +683,32 @@ pub struct VectorQueryStats {
     pub rows_returned: u64,
 }
 
+impl VectorQueryStats {
+    pub(crate) fn operators_json(&self) -> crate::json::Value {
+        use crate::json::{Map, Value as JsonValue};
+        JsonValue::Array(
+            self.operators
+                .iter()
+                .map(|operator| {
+                    let mut fields = Map::new();
+                    fields.insert(
+                        "operator".into(),
+                        JsonValue::String(operator.operator.clone()),
+                    );
+                    for (name, value) in [
+                        ("input_rows", operator.input_rows),
+                        ("output_rows", operator.output_rows),
+                        ("inclusive_time_us", operator.inclusive_time_us),
+                    ] {
+                        fields.insert(name.into(), Value::UnsignedInteger(value).to_json());
+                    }
+                    JsonValue::Object(fields)
+                })
+                .collect(),
+        )
+    }
+}
+
 #[cfg(test)]
 mod record_layout_tests {
     //! Property tests for the schema-shared `UnifiedRecord` layout

--- a/docs/guides/vector-search.md
+++ b/docs/guides/vector-search.md
@@ -173,3 +173,14 @@ caller transaction.
 - **Normalization**: Cosine similarity works best with normalized vectors
 - **Metadata filtering**: Use metadata to filter results by category, date, or author
 - **Hybrid search**: Combines the semantic understanding of vectors with the precision of keyword matching
+
+
+### Measured operator work
+
+Vector execution statistics and `EXPLAIN ANALYZE VECTOR SEARCH` include an
+`operators` array in child-before-parent order. Each entry reports the executed
+operator, input/output rows and `inclusive_time_us`. Time includes descendants;
+do not add entries to estimate total query time. The scan owns pushed-down
+visibility, RLS, metadata filtering and bounded top-k, so later logical filter
+nodes can legitimately reject zero rows. Cache hits retain the original
+measurements and set `cache_hit`; EXPLAIN ANALYZE performs a fresh execution.

--- a/tests/grouped/ai_local_vector/e2e_vector_execution_observability.rs
+++ b/tests/grouped/ai_local_vector/e2e_vector_execution_observability.rs
@@ -198,3 +198,29 @@ fn approximate_mode_reports_exact_fallback_without_a_turbo_route() {
     assert_eq!(stats.approximate_distance_evaluations, 0);
     assert!(!stats.index_used);
 }
+
+#[test]
+fn vector_operators_report_executed_counts_and_inclusive_times() {
+    let (_directory, rt) = fixture(false);
+    rt.execute_query("INSERT INTO embeddings VECTOR (dense) VALUES ([0.6,0.8]),([1.0,0.0])")
+        .expect("vectors");
+    let result = rt
+        .execute_query("EXPLAIN ANALYZE VECTOR SEARCH embeddings SIMILAR TO [1.0,0.0] LIMIT 1")
+        .expect("analysis");
+    let stats = result.result.stats.vector.as_ref().expect("vector stats");
+    let scan = stats
+        .operators
+        .iter()
+        .find(|op| op.operator == "vector_exact_scan")
+        .expect("measured scan");
+    assert_eq!(scan.input_rows, 3);
+    assert_eq!(scan.output_rows, 1);
+    let root = stats.operators.last().expect("root");
+    assert_eq!(root.output_rows, stats.rows_returned);
+    assert!(root.inclusive_time_us >= scan.inclusive_time_us);
+    assert!(result.result.stats.exec_time_us >= root.inclusive_time_us);
+    assert!(matches!(
+        result.result.records[0].get("operators"),
+        Some(Value::Json(_))
+    ));
+}


### PR DESCRIPTION
Vector diagnostics only exposed pipeline-wide counters. Record actual input/output row counts and inclusive execution time for each canonical vector operator, in child-before-parent order, and expose the array in EXPLAIN ANALYZE and result JSON. JSON now also includes requested/executed search mode, approximate distance count, top-k retention and fallback reason.

The physical scan owns pushed-down policy/filter/top-k work; logical wrapper nodes report only the work they execute. Inclusive times must not be added together. Cache-hit metrics retain their original-computation meaning; EXPLAIN ANALYZE bypasses result reuse.

Validation: added integration coverage for measured scan counts, root output and timing containment. Full CI is running. Stacked on perf/competitive-program; no merge or release requested.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/reddb-io/codesmith/reddb/pr/2288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791422483&installation_model_id=20659&pr_number=2288&repository=reddb-io%2Freddb&return_to=https%3A%2F%2Fgithub.com%2Freddb-io%2Freddb%2Fpull%2F2288&signature=02bdd94b1fb2555cda9f344e117523b61d47ac6b3ff0d68665a0c726d9428160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->