### PR TITLE
fix(search): preserve authorization and historical snapshots

### DIFF
--- a/crates/reddb-server/src/replication/logical.rs
+++ b/crates/reddb-server/src/replication/logical.rs
@@ -614,9 +614,19 @@ impl LogicalChangeApplier {
                         "replication refresh record missing refresh_records payload".to_string(),
                     )
                 })?;
+                let mut replayed_xid = 0;
+                for bytes in &records {
+                    let (entity, _) =
+                        UnifiedStore::deserialize_entity_record(bytes, store.format_version())
+                            .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                    replayed_xid = replayed_xid.max(entity.xmin).max(entity.xmax);
+                }
                 store
                     .refresh_collection_from_records(&record.collection, records)
                     .map_err(|err| RedDBError::Internal(err.to_string()))?;
+                if let Some(manager) = store.snapshot_manager.get() {
+                    manager.observe_committed_xid(replayed_xid);
+                }
             }
             ChangeOperation::Insert | ChangeOperation::Update => {
                 let Some(bytes) = &record.entity_bytes else {
@@ -693,6 +703,12 @@ impl LogicalChangeApplier {
                 store
                     .context_index()
                     .index_entity(&record.collection, &entity);
+                // The runtime owns the read snapshot allocator. Logical
+                // replay preserves source xids, so publish their floor only
+                // after the entity and its metadata have been installed.
+                if let Some(manager) = store.snapshot_manager.get() {
+                    manager.observe_committed_xid(entity.xmin.max(entity.xmax));
+                }
             }
         }
         // Issue #1242 — only reached on successful apply (all early `return

--- a/crates/reddb-server/src/runtime/ai/ner.rs
+++ b/crates/reddb-server/src/runtime/ai/ner.rs
@@ -671,6 +671,7 @@ mod tests {
         use crate::storage::transaction::snapshot::Snapshot;
         use std::collections::HashSet;
         EffectiveScope {
+            captured_snapshot: None,
             tenant: None,
             identity: None,
             snapshot: Snapshot {

--- a/crates/reddb-server/src/runtime/ask_pipeline.rs
+++ b/crates/reddb-server/src/runtime/ask_pipeline.rs
@@ -1319,7 +1319,6 @@ mod tests {
     use crate::auth::Role;
     use crate::runtime::statement_frame::EffectiveScope;
     use crate::runtime::RedDBRuntime;
-    use crate::storage::transaction::snapshot::Snapshot;
     use crate::storage::unified::entity::{
         EntityData, EntityId, EntityKind, RowData, UnifiedEntity,
     };

--- a/crates/reddb-server/src/runtime/ask_pipeline.rs
+++ b/crates/reddb-server/src/runtime/ask_pipeline.rs
@@ -483,7 +483,7 @@ pub fn text_search_bm25_scoped(
         return Vec::new();
     }
 
-    let _scope_guard = AskScopeGuard::install(scope);
+    let _scope_guard = AskScopeGuard::install(runtime, scope);
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     let mut rls_cache: HashMap<String, Option<reddb_rql::ast::Filter>> = HashMap::new();
     let store = runtime.inner.db.store();
@@ -880,7 +880,7 @@ pub fn vector_search_scoped(
     };
     let per_collection = top_k.max(1);
     let mut hits: Vec<VectorHit> = Vec::new();
-    let _scope_guard = AskScopeGuard::install(scope);
+    let _scope_guard = AskScopeGuard::install(runtime, scope);
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     let mut rls_cache: HashMap<String, Option<reddb_rql::ast::Filter>> = HashMap::new();
     let store = runtime.inner.db.store();
@@ -956,7 +956,7 @@ pub fn graph_search_scoped(
     let depth = graph_depth
         .unwrap_or(crate::runtime::ai::mcp_ask_tool::DEPTH_DEFAULT as usize)
         .max(1);
-    let _scope_guard = AskScopeGuard::install(scope);
+    let _scope_guard = AskScopeGuard::install(runtime, scope);
     let input = SearchContextInput {
         query: question.to_string(),
         field: None,
@@ -1071,7 +1071,7 @@ pub fn filter_values(
     let visible = scope.visible_collections();
     let store = runtime.inner.db.store();
     let mut out: Vec<FilteredRow> = Vec::new();
-    let _scope_guard = AskScopeGuard::install(scope);
+    let _scope_guard = AskScopeGuard::install(runtime, scope);
     let snap_ctx = crate::runtime::impl_core::capture_current_snapshot();
     let mut rls_cache: HashMap<String, Option<reddb_rql::ast::Filter>> = HashMap::new();
 
@@ -1147,12 +1147,13 @@ fn ask_scanned_entity_allowed(
 }
 
 struct AskScopeGuard {
+    _snapshot: super::execution_context::CurrentSnapshotGuard,
     prev_tenant: Option<String>,
     prev_auth: Option<(String, crate::auth::Role)>,
 }
 
 impl AskScopeGuard {
-    fn install(scope: &EffectiveScope) -> Self {
+    fn install(runtime: &RedDBRuntime, scope: &EffectiveScope) -> Self {
         let prev_tenant = crate::runtime::impl_core::current_tenant();
         let prev_auth = crate::runtime::impl_core::current_auth_identity();
 
@@ -1168,6 +1169,9 @@ impl AskScopeGuard {
         }
 
         Self {
+            _snapshot: super::execution_context::CurrentSnapshotGuard::install(
+                scope.snapshot_context(runtime),
+            ),
             prev_tenant,
             prev_auth,
         }
@@ -1322,14 +1326,12 @@ mod tests {
     use reddb_types::Value;
     use std::sync::Arc;
 
-    fn make_scope(visible: HashSet<String>) -> EffectiveScope {
+    fn make_scope(rt: &RedDBRuntime, visible: HashSet<String>) -> EffectiveScope {
         EffectiveScope {
+            captured_snapshot: None,
             tenant: Some("acme".to_string()),
             identity: Some(("alice".to_string(), Role::Read)),
-            snapshot: Snapshot {
-                xid: 0,
-                in_progress: HashSet::new(),
-            },
+            snapshot: rt.current_snapshot(),
             visible_collections: Some(visible),
         }
     }
@@ -1481,7 +1483,7 @@ mod tests {
         )
         .expect("insert broad doc");
 
-        let scope = make_scope(["docs".to_string()].into_iter().collect());
+        let scope = make_scope(&rt, ["docs".to_string()].into_iter().collect());
         let candidates = CandidateCollections {
             collections: vec!["docs".to_string()],
             columns_by_collection: HashMap::new(),
@@ -1516,7 +1518,7 @@ mod tests {
             .expect("enable rls");
 
         let _tenant = TenantGuard::set("acme");
-        let scope = make_scope(["docs".to_string()].into_iter().collect());
+        let scope = make_scope(&rt, ["docs".to_string()].into_iter().collect());
         let candidates = CandidateCollections {
             collections: vec!["docs".to_string()],
             columns_by_collection: HashMap::new(),
@@ -1557,7 +1559,7 @@ mod tests {
             },
         );
 
-        let scope = make_scope(["docs".to_string()].into_iter().collect());
+        let scope = make_scope(&rt, ["docs".to_string()].into_iter().collect());
         let ctx = AskPipeline::execute_with_limit_and_min_score(
             &rt,
             &scope,
@@ -1598,7 +1600,7 @@ mod tests {
         )
         .expect("insert bob-carol edge");
 
-        let scope = make_scope(["tales".to_string()].into_iter().collect());
+        let scope = make_scope(&rt, ["tales".to_string()].into_iter().collect());
         let candidates = CandidateCollections {
             collections: vec!["tales".to_string()],
             columns_by_collection: HashMap::new(),
@@ -1635,7 +1637,7 @@ mod tests {
             .expect("enable rls");
 
         let _tenant = TenantGuard::set("acme");
-        let scope = make_scope(["docs".to_string()].into_iter().collect());
+        let scope = make_scope(&rt, ["docs".to_string()].into_iter().collect());
         let candidates = CandidateCollections {
             collections: vec!["docs".to_string()],
             columns_by_collection: HashMap::from([("docs".to_string(), vec!["body".to_string()])]),
@@ -1656,7 +1658,7 @@ mod tests {
     #[test]
     fn execute_refuses_empty_token_set() {
         let rt = fresh_runtime();
-        let scope = make_scope(HashSet::new());
+        let scope = make_scope(&rt, HashSet::new());
         let err = AskPipeline::execute(&rt, &scope, "??? ...")
             .expect_err("empty token set must short-circuit");
         let msg = format!("{err}");
@@ -1693,7 +1695,7 @@ mod tests {
             },
         );
         let visible: HashSet<String> = ["travel".to_string()].into_iter().collect();
-        let scope = make_scope(visible.clone());
+        let scope = make_scope(&rt, visible.clone());
         let tokens = TokenSet {
             keywords: vec!["passport".to_string()],
             literals: Vec::new(),
@@ -1755,7 +1757,7 @@ mod tests {
                 keywords: vec!["passport".to_string()],
                 literals,
             };
-            let scope = make_scope(visible.clone());
+            let scope = make_scope(&rt, visible.clone());
             let rows = filter_values(rt, &scope, &candidates, &tokens, DEFAULT_ROW_CAP);
             for row in &rows {
                 prop_assert!(
@@ -1803,7 +1805,7 @@ mod tests {
             .expect("seed secrets");
 
         let visible: HashSet<String> = ["travel".to_string()].into_iter().collect();
-        let scope = make_scope(visible);
+        let scope = make_scope(&rt, visible);
 
         let ctx = AskPipeline::execute(
             &rt,
@@ -1874,7 +1876,7 @@ mod tests {
     #[test]
     fn routed_default_backend_runs_heuristic() {
         let rt = fresh_runtime();
-        let scope = make_scope(HashSet::new());
+        let scope = make_scope(&rt, HashSet::new());
         let tokens = extract_tokens_routed(&rt, &scope, "passport FDD-12313")
             .expect("heuristic path is infallible");
         assert!(tokens.keywords.contains(&"passport".to_string()));
@@ -1888,7 +1890,7 @@ mod tests {
         let rt = fresh_runtime();
         write_config(&rt, "ai.ner.backend", "llm");
         write_config(&rt, "ai.ner.fallback", "use_heuristic");
-        let scope = make_scope(HashSet::new());
+        let scope = make_scope(&rt, HashSet::new());
         let tokens = tokio::task::spawn_blocking(move || {
             extract_tokens_routed(&rt, &scope, "passport FDD-12313")
         })
@@ -1906,7 +1908,7 @@ mod tests {
         let rt = fresh_runtime();
         write_config(&rt, "ai.ner.backend", "llm");
         write_config(&rt, "ai.ner.fallback", "empty_on_fail");
-        let scope = make_scope(HashSet::new());
+        let scope = make_scope(&rt, HashSet::new());
         let tokens = tokio::task::spawn_blocking(move || {
             extract_tokens_routed(&rt, &scope, "passport FDD-12313")
         })
@@ -1924,7 +1926,7 @@ mod tests {
         let rt = fresh_runtime();
         write_config(&rt, "ai.ner.backend", "llm");
         write_config(&rt, "ai.ner.fallback", "propagate");
-        let scope = make_scope(HashSet::new());
+        let scope = make_scope(&rt, HashSet::new());
         let err = tokio::task::spawn_blocking(move || {
             extract_tokens_routed(&rt, &scope, "passport FDD-12313")
         })
@@ -1955,7 +1957,7 @@ mod tests {
         )
         .expect("seed rows");
         let visible: HashSet<String> = ["travel".to_string()].into_iter().collect();
-        let scope = make_scope(visible);
+        let scope = make_scope(&rt, visible);
         let ctx = tokio::task::spawn_blocking(move || {
             AskPipeline::execute(&rt, &scope, "passport FDD-12313")
         })

--- a/crates/reddb-server/src/runtime/authorized_search.rs
+++ b/crates/reddb-server/src/runtime/authorized_search.rs
@@ -723,4 +723,37 @@ mod frame_regression_tests {
             },
         );
     }
+    #[test]
+    fn search_scope_preserves_own_savepoint_writes_and_aborts() {
+        use crate::runtime::statement_frame::{StatementExecutionFrame, StatementIdentity};
+        let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        for sql in [
+            "CREATE TABLE docs (id INT, body TEXT)",
+            "BEGIN",
+            "INSERT INTO docs (id,body) VALUES (1,'needle parent')",
+            "SAVEPOINT child",
+            "INSERT INTO docs (id,body) VALUES (2,'needle child')",
+        ] {
+            rt.execute_query(sql).expect(sql);
+        }
+        let scope = {
+            let frame = StatementExecutionFrame::build(
+                &rt,
+                StatementIdentity::Text("SEARCH TEXT 'needle' IN docs"),
+            )
+            .expect("frame");
+            let _installed = frame.install(&rt);
+            let mut scope = rt.ai_scope();
+            scope.visible_collections = Some(["docs".into()].into_iter().collect());
+            scope
+        };
+        let mut rows = text(&rt, &scope, 10);
+        rows.sort();
+        assert_eq!(rows, ["needle child", "needle parent"]);
+        rt.execute_query("ROLLBACK TO SAVEPOINT child")
+            .expect("rollback child");
+        assert_eq!(text(&rt, &scope, 10), ["needle parent"]);
+        rt.execute_query("ROLLBACK").expect("rollback parent");
+        assert!(text(&rt, &scope, 10).is_empty());
+    }
 }

--- a/crates/reddb-server/src/runtime/authorized_search.rs
+++ b/crates/reddb-server/src/runtime/authorized_search.rs
@@ -623,7 +623,7 @@ mod frame_regression_tests {
                 let EntityData::Row(row) = hit.entity.data else {
                     panic!("row")
                 };
-                let Some(Value::Text(value)) = row.get(1) else {
+                let Some(Value::Text(value)) = row.get_field("body") else {
                     panic!("text")
                 };
                 value.to_string()
@@ -692,13 +692,13 @@ mod frame_regression_tests {
     fn search_similar_filters_policy_before_topk_and_uses_frame_identity() {
         let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
         for sql in [
-            "CREATE VECTOR vectors DIM 2 METRIC cosine",
-            "INSERT INTO vectors VECTOR (dense,content) VALUES ([1.0,0.0],'denied') WITH METADATA (owner='bob')",
-            "INSERT INTO vectors VECTOR (dense,content) VALUES ([0.8,0.6],'visible') WITH METADATA (owner='alice')",
-            "CREATE POLICY own ON VECTORS OF vectors FOR SELECT TO read USING (metadata.owner=CURRENT_USER())",
-            "ALTER TABLE vectors ENABLE ROW LEVEL SECURITY",
+            "CREATE VECTOR embeddings DIM 2 METRIC cosine",
+            "INSERT INTO embeddings VECTOR (dense,content) VALUES ([1.0,0.0],'denied') WITH METADATA (owner='bob')",
+            "INSERT INTO embeddings VECTOR (dense,content) VALUES ([0.8,0.6],'visible') WITH METADATA (owner='alice')",
+            "CREATE POLICY own ON VECTORS OF embeddings FOR SELECT TO read USING (metadata.owner=CURRENT_USER())",
+            "ALTER TABLE embeddings ENABLE ROW LEVEL SECURITY",
         ] { rt.execute_query(sql).expect(sql); }
-        let mut frame = FakeReadFrame::with_visible(["vectors".into()].into_iter().collect());
+        let mut frame = FakeReadFrame::with_visible(["embeddings".into()].into_iter().collect());
         frame.snapshot = rt.current_snapshot();
         with_snapshot_bundle(
             &SnapshotBundle {
@@ -706,9 +706,15 @@ mod frame_regression_tests {
                 ..Default::default()
             },
             || {
-                let hits =
-                    AuthorizedSearch::execute_similar(&rt, &frame, "vectors", &[1.0, 0.0], 1, 0.0)
-                        .expect("similar");
+                let hits = AuthorizedSearch::execute_similar(
+                    &rt,
+                    &frame,
+                    "embeddings",
+                    &[1.0, 0.0],
+                    1,
+                    0.0,
+                )
+                .expect("similar");
                 assert_eq!(hits.len(), 1);
                 let EntityData::Vector(data) = &hits[0].entity.data else {
                     panic!("vector")

--- a/crates/reddb-server/src/runtime/authorized_search.rs
+++ b/crates/reddb-server/src/runtime/authorized_search.rs
@@ -66,7 +66,9 @@ impl AuthorizedSearch {
             )));
         }
         debug!(target: "authorized_search", "scope-checked, dispatching");
-        runtime.search_similar(collection, vector, k, min_score)
+        with_read_frame(runtime, scope, || {
+            runtime.search_similar(collection, vector, k, min_score)
+        })
     }
 
     /// Authorized SEARCH TEXT. The underlying executor accepts an
@@ -105,15 +107,17 @@ impl AuthorizedSearch {
                 ));
             }
         }
-        runtime.search_text(
-            query,
-            constrained,
-            entity_types,
-            capabilities,
-            fields,
-            limit,
-            fuzzy,
-        )
+        with_read_frame(runtime, scope, || {
+            runtime.search_text(
+                query,
+                constrained,
+                entity_types,
+                capabilities,
+                fields,
+                limit,
+                fuzzy,
+            )
+        })
     }
 
     /// Authorized SEARCH CONTEXT. Pre-filters the input collection list
@@ -154,10 +158,23 @@ impl AuthorizedSearch {
             input.collections = Some(bounded);
         }
 
-        let mut result = runtime.search_context(input)?;
+        let mut result = with_read_frame(runtime, scope, || runtime.search_context(input))?;
         post_filter_context_result(&mut result, visible);
         Ok(result)
     }
+}
+
+/// Bridge legacy search executors to the frame without re-resolving identity,
+/// tenant or transaction state. The existing guard restores all three on unwind.
+fn with_read_frame<R>(runtime: &RedDBRuntime, frame: &dyn ReadFrame, run: impl FnOnce() -> R) -> R {
+    let bundle = super::execution_context::SnapshotBundle {
+        snapshot: Some(frame.snapshot_context(runtime)),
+        auth: frame
+            .identity()
+            .map(|(name, role)| (name.to_string(), role)),
+        tenant: frame.effective_scope().map(str::to_string),
+    };
+    super::execution_context::with_snapshot_bundle(&bundle, run)
 }
 
 /// Defence-in-depth pass run after `search_context` returns. The
@@ -228,18 +245,17 @@ fn require_visible<'a>(
     }
 }
 
-/// Intersect a caller-supplied collection list with the visible set.
-/// `None` (no caller list) means "every collection" — we pass `None`
-/// through unchanged so the caller's existing default of "scan the
-/// whole DB" reads as "scan everything visible to the scope". The
-/// caller is expected to substitute the visible set explicitly when it
-/// needs a bounded global-scan corpus.
+/// Restrict both explicit and global requests to the frame's allow-list.
 fn constrain_collections(
     requested: Option<Vec<String>>,
     visible: &HashSet<String>,
 ) -> Option<Vec<String>> {
     match requested {
-        None => None,
+        None => {
+            let mut bounded: Vec<_> = visible.iter().cloned().collect();
+            bounded.sort();
+            Some(bounded)
+        }
         Some(list) => {
             let filtered: Vec<String> = list.into_iter().filter(|c| visible.contains(c)).collect();
             Some(filtered)
@@ -313,8 +329,10 @@ mod tests {
         let visible = set(&["a", "b"]);
         let got = constrain_collections(Some(vec!["a".into(), "c".into()]), &visible);
         assert_eq!(got, Some(vec!["a".into()]));
-        // None -> None passthrough.
-        assert!(constrain_collections(None, &visible).is_none());
+        assert_eq!(
+            constrain_collections(None, &visible),
+            Some(vec!["a".into(), "b".into()])
+        );
         // Touch `Role` so the import isn't dropped if test fixtures grow.
         let _ = Role::Read;
     }
@@ -569,6 +587,134 @@ mod tests {
         assert!(
             !bob.contains("orders"),
             "bob must not reuse alice's visible-collections cache entry"
+        );
+    }
+}
+
+#[cfg(test)]
+mod frame_regression_tests {
+    use super::*;
+    use crate::api::RedDBOptions;
+    use crate::auth::Role;
+    use crate::runtime::execution_context::{
+        snapshot_bundle, with_snapshot_bundle, SnapshotBundle,
+    };
+    use crate::runtime::statement_frame::test_support::FakeReadFrame;
+    use crate::storage::unified::entity::EntityData;
+    use reddb_types::Value;
+
+    fn text(runtime: &RedDBRuntime, frame: &dyn ReadFrame, limit: usize) -> Vec<String> {
+        let result = AuthorizedSearch::execute_text(
+            runtime,
+            frame,
+            "needle".into(),
+            None,
+            None,
+            None,
+            None,
+            Some(limit),
+            false,
+        )
+        .expect("text search");
+        result
+            .matches
+            .into_iter()
+            .map(|hit| {
+                let EntityData::Row(row) = hit.entity.data else {
+                    panic!("row")
+                };
+                let Some(Value::Text(value)) = row.get(1) else {
+                    panic!("text")
+                };
+                value.to_string()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn search_text_uses_frame_allowlist_and_identity_before_limit() {
+        let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        for sql in [
+            "CREATE TABLE docs (owner TEXT, body TEXT)",
+            "CREATE TABLE secrets (owner TEXT, body TEXT)",
+            "INSERT INTO docs (owner,body) VALUES ('bob','needle denied'),('alice','needle visible')",
+            "INSERT INTO secrets (owner,body) VALUES ('alice','needle secret')",
+            "CREATE POLICY own ON docs FOR SELECT TO read USING (owner=CURRENT_USER())",
+            "ALTER TABLE docs ENABLE ROW LEVEL SECURITY",
+        ] { rt.execute_query(sql).expect(sql); }
+        let mut frame = FakeReadFrame::with_visible(["docs".into()].into_iter().collect());
+        frame.snapshot = rt.current_snapshot();
+        let outer = SnapshotBundle {
+            auth: Some(("bob".into(), Role::Admin)),
+            tenant: Some("other".into()),
+            snapshot: None,
+        };
+        with_snapshot_bundle(&outer, || {
+            assert_eq!(text(&rt, &frame, 1), ["needle visible"]);
+            assert_eq!(text(&rt, &frame, 10), ["needle visible"]);
+            let restored = snapshot_bundle();
+            assert_eq!(restored.auth, outer.auth);
+            assert_eq!(restored.tenant, outer.tenant);
+            assert!(restored.snapshot.is_none());
+        });
+        frame.visible = Some(HashSet::new());
+        assert!(AuthorizedSearch::execute_text(
+            &rt,
+            &frame,
+            "needle".into(),
+            None,
+            None,
+            None,
+            None,
+            Some(10),
+            false
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn search_text_reads_frame_snapshot_even_after_committed_update() {
+        let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        rt.execute_query("CREATE TABLE docs (id INT PRIMARY KEY, body TEXT)")
+            .expect("table");
+        rt.execute_query("INSERT INTO docs (id,body) VALUES (1,'needle old')")
+            .expect("row");
+        let mut frame = FakeReadFrame::with_visible(["docs".into()].into_iter().collect());
+        frame.snapshot = rt.current_snapshot();
+        rt.execute_query("UPDATE docs SET body='needle new' WHERE id=1")
+            .expect("update");
+        assert_eq!(text(&rt, &frame, 10), ["needle old"]);
+        frame.snapshot = rt.current_snapshot();
+        assert_eq!(text(&rt, &frame, 10), ["needle new"]);
+    }
+
+    #[test]
+    fn search_similar_filters_policy_before_topk_and_uses_frame_identity() {
+        let rt = RedDBRuntime::with_options(RedDBOptions::in_memory()).expect("runtime");
+        for sql in [
+            "CREATE VECTOR vectors DIM 2 METRIC cosine",
+            "INSERT INTO vectors VECTOR (dense,content) VALUES ([1.0,0.0],'denied') WITH METADATA (owner='bob')",
+            "INSERT INTO vectors VECTOR (dense,content) VALUES ([0.8,0.6],'visible') WITH METADATA (owner='alice')",
+            "CREATE POLICY own ON VECTORS OF vectors FOR SELECT TO read USING (metadata.owner=CURRENT_USER())",
+            "ALTER TABLE vectors ENABLE ROW LEVEL SECURITY",
+        ] { rt.execute_query(sql).expect(sql); }
+        let mut frame = FakeReadFrame::with_visible(["vectors".into()].into_iter().collect());
+        frame.snapshot = rt.current_snapshot();
+        with_snapshot_bundle(
+            &SnapshotBundle {
+                auth: Some(("bob".into(), Role::Admin)),
+                ..Default::default()
+            },
+            || {
+                let hits =
+                    AuthorizedSearch::execute_similar(&rt, &frame, "vectors", &[1.0, 0.0], 1, 0.0)
+                        .expect("similar");
+                assert_eq!(hits.len(), 1);
+                let EntityData::Vector(data) = &hits[0].entity.data else {
+                    panic!("vector")
+                };
+                assert_eq!(data.content.as_deref(), Some("visible"));
+            },
         );
     }
 }

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -1539,18 +1539,16 @@ impl RedDBRuntime {
                 .enumerate()
                 .filter_map(|(i, entity)| {
                     if let EntityData::Row(ref row) = entity.data {
-                        if let Some(ref named) = row.named {
-                            let texts: Vec<String> = embed_config
-                                .fields
-                                .iter()
-                                .filter_map(|field| match named.get(field) {
-                                    Some(Value::Text(t)) if !t.is_empty() => Some(t.to_string()),
-                                    _ => None,
-                                })
-                                .collect();
-                            if !texts.is_empty() {
-                                return Some((i, texts.join(" ")));
-                            }
+                        let texts: Vec<String> = embed_config
+                            .fields
+                            .iter()
+                            .filter_map(|field| match row.get_field(field) {
+                                Some(Value::Text(t)) if !t.is_empty() => Some(t.to_string()),
+                                _ => None,
+                            })
+                            .collect();
+                        if !texts.is_empty() {
+                            return Some((i, texts.join(" ")));
                         }
                     }
                     None

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -590,6 +590,7 @@ impl RedDBRuntime {
             };
         let mut returning_result: Option<UnifiedResult> = None;
         let mut conflict_returning_records: Vec<UnifiedRecord> = Vec::new();
+        let mut auto_embed_ids = Vec::new();
 
         if matches!(query.entity_type, InsertEntityType::Row)
             && !matches!(
@@ -991,6 +992,9 @@ impl RedDBRuntime {
                 self.create_rows_batch(batch)?
             };
             inserted_count += outputs.len() as u64;
+            if query.auto_embed.is_some() {
+                auto_embed_ids.extend(outputs.iter().map(|output| output.id));
+            }
 
             // Chain mode: commit the new tip to the in-memory cache only after
             // the batch persisted successfully. If the batch threw mid-way the
@@ -1484,6 +1488,10 @@ impl RedDBRuntime {
                 }
             }
 
+            if query.auto_embed.is_some() {
+                auto_embed_ids.extend(entity_outputs.iter().map(|output| output.id));
+            }
+
             if let Some(items) = query.returning.as_ref() {
                 let mut result =
                     build_returning_result(items, &returning_field_snaps, Some(&entity_outputs));
@@ -1517,16 +1525,12 @@ impl RedDBRuntime {
                 embed_config.model.as_deref(),
             );
 
-            // Collect the just-inserted rows (most-recently appended, reversed back to insert order).
-            let manager = store
-                .get_collection(&query.table)
-                .ok_or_else(|| RedDBError::NotFound(query.table.clone()))?;
-            let snapshot = crate::runtime::impl_core::capture_current_snapshot();
-            let entities = manager.scan(snapshot.as_ref(), |_| true);
-            let recent: Vec<_> = entities
-                .into_iter()
-                .rev()
-                .take(effective_rows.len())
+            // Read only this INSERT's returned IDs. A pre-write statement
+            // snapshot correctly excludes newly committed rows; a fresh/global
+            // scan could instead pick another writer's rows or conflict skips.
+            let recent: Vec<_> = auto_embed_ids
+                .iter()
+                .filter_map(|id| store.get(&query.table, *id))
                 .collect();
 
             // Collector phase: (entity_index, combined_text) for rows that have non-empty fields.

--- a/crates/reddb-server/src/runtime/impl_queue.rs
+++ b/crates/reddb-server/src/runtime/impl_queue.rs
@@ -274,6 +274,15 @@ impl RedDBRuntime {
                     .rmw_locks
                     .lock_for(queue, "__queue_group_read__");
                 let _read_guard = read_lock.lock();
+                // WAIT is an autocommit live subscription: each retry must see
+                // commits since the previous probe. Keep identity/tenant fixed
+                // and restore the enclosing statement snapshot after the read.
+                let _snapshot_guard = wait_ms
+                    .and_then(|_| crate::runtime::impl_core::capture_current_snapshot())
+                    .map(|mut context| {
+                        context.snapshot = context.manager.fresh_read_snapshot();
+                        crate::runtime::execution_context::CurrentSnapshotGuard::install(context)
+                    });
                 let (lifecycle, _ps, txn) = runtime_lifecycle(runtime, queue);
                 lifecycle
                     .group_read(&txn, queue, group, consumer, count)

--- a/crates/reddb-server/src/runtime/impl_search.rs
+++ b/crates/reddb-server/src/runtime/impl_search.rs
@@ -331,36 +331,21 @@ impl RedDBRuntime {
             collection,
             crate::catalog::CollectionModel::Vector,
         )?;
-        let rls_enabled = self.is_rls_enabled(collection);
-        let candidate_count = if rls_enabled {
-            self.inner
-                .db
-                .store()
-                .get_collection(collection)
-                .map_or(k.max(1), |manager| manager.count().max(1))
-        } else {
-            k.max(1)
-        };
-        let mut results = self.inner.db.similar(collection, vector, candidate_count);
-        if results.is_empty() && self.inner.db.store().get_collection(collection).is_none() {
-            return Err(RedDBError::NotFound(collection.to_string()));
-        }
-        let mut rls_cache = HashMap::new();
-        results.retain(|result| {
-            result.score >= min_score
-                && super::impl_core::entity_visible_under_current_snapshot(&result.entity)
-                && (!rls_enabled
-                    || self.search_entity_rls_allowed(collection, &result.entity, &mut rls_cache))
-        });
-        results.sort_by(|left, right| {
-            right
-                .score
-                .partial_cmp(&left.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| left.entity_id.raw().cmp(&right.entity_id.raw()))
-        });
-        results.truncate(k.max(1));
-        Ok(results)
+        // SEARCH SIMILAR and ASK use the same exact, policy-before-top-k
+        // executor as VECTOR SEARCH. Preserve this API's cosine score contract.
+        let mut query = reddb_rql::ast::VectorQuery::new(
+            collection,
+            reddb_rql::ast::VectorSource::Literal(vector.to_vec()),
+        )
+        .limit(k);
+        query.metric = Some(reddb_rql::ast::DistanceMetric::Cosine);
+        query.threshold = Some(min_score);
+        super::query_exec::runtime_vector_matches(
+            self,
+            &query,
+            vector,
+            &mut crate::storage::query::unified::VectorQueryStats::default(),
+        )
     }
 
     pub fn search_ivf(
@@ -904,8 +889,17 @@ impl RedDBRuntime {
             builder = builder.fuzzy();
         }
 
+        let snapshot = super::execution_context::capture_current_snapshot();
+        let mut rls_cache = HashMap::new();
         let mut result = builder
-            .execute(&self.inner.db.store())
+            .execute_filtered(&self.inner.db.store(), snapshot.as_ref(), |entity| {
+                self.search_entity_allowed(
+                    entity.kind.collection(),
+                    entity,
+                    snapshot.as_ref(),
+                    &mut rls_cache,
+                )
+            })
             .map_err(|err| RedDBError::Query(err.to_string()))?;
         for item in &mut result.matches {
             item.components.text_relevance = Some(item.score);

--- a/crates/reddb-server/src/runtime/query_exec.rs
+++ b/crates/reddb-server/src/runtime/query_exec.rs
@@ -36,7 +36,7 @@ pub(crate) use indexed_scan::try_sorted_index_lookup;
 pub(super) use join::execute_runtime_join_query;
 pub(super) use json_writers::execute_runtime_serialize_single_entity;
 pub(crate) use json_writers::{decode_stored_tag_value, TIMESERIES_TAG_JSON_PREFIX};
-pub(super) use vector::execute_runtime_vector_query;
+pub(super) use vector::{execute_runtime_vector_query, runtime_vector_matches};
 
 // Private imports used by functions still in query_exec.rs.
 use aggregate::{execute_aggregate_query, has_aggregate_projections};

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -107,6 +107,17 @@ pub(crate) trait ReadFrame {
     /// historical xid.
     fn snapshot(&self) -> &Snapshot;
 
+    /// Complete visibility context, including the reader's savepoint writes.
+    fn snapshot_context(&self, runtime: &RedDBRuntime) -> SnapshotContext {
+        SnapshotContext {
+            snapshot: self.snapshot().clone(),
+            manager: runtime.inner.transaction_state.snapshot_manager(),
+            own_xids: HashSet::new(),
+            requires_index_fallback: true,
+            serializable_reader: None,
+        }
+    }
+
     /// AS OF xid floor when AS OF was applied for this statement,
     /// `None` for live reads. Useful for downstream callers that
     /// want to gate behaviour on historical-read mode without
@@ -811,6 +822,16 @@ impl StatementExecutionFrame {
 }
 
 impl ReadFrame for StatementExecutionFrame {
+    fn snapshot_context(&self, runtime: &RedDBRuntime) -> SnapshotContext {
+        SnapshotContext {
+            snapshot: self.snapshot.clone(),
+            manager: runtime.inner.transaction_state.snapshot_manager(),
+            own_xids: self.own_xids.clone(),
+            requires_index_fallback: self.requires_index_fallback,
+            serializable_reader: self.serializable_reader,
+        }
+    }
+
     fn effective_scope(&self) -> Option<&str> {
         self.effective_scope.as_deref()
     }
@@ -861,6 +882,7 @@ impl ReadFrame for StatementExecutionFrame {
 /// `StatementExecutionFrame::build` derives them) and resolves
 /// `visible_collections` via the `AuthStore` cache.
 pub struct EffectiveScope {
+    pub(crate) captured_snapshot: Option<SnapshotContext>,
     pub(crate) tenant: Option<String>,
     pub(crate) identity: Option<(String, Role)>,
     pub(crate) snapshot: Snapshot,
@@ -883,6 +905,18 @@ impl EffectiveScope {
 }
 
 impl ReadFrame for EffectiveScope {
+    fn snapshot_context(&self, runtime: &RedDBRuntime) -> SnapshotContext {
+        self.captured_snapshot
+            .clone()
+            .unwrap_or_else(|| SnapshotContext {
+                snapshot: self.snapshot.clone(),
+                manager: runtime.inner.transaction_state.snapshot_manager(),
+                own_xids: HashSet::new(),
+                requires_index_fallback: true,
+                serializable_reader: None,
+            })
+    }
+
     fn effective_scope(&self) -> Option<&str> {
         self.tenant.as_deref()
     }
@@ -937,7 +971,11 @@ impl RedDBRuntime {
     pub(crate) fn ai_scope(&self) -> EffectiveScope {
         let tenant = super::impl_core::current_tenant();
         let identity = super::impl_core::current_auth_identity();
-        let snapshot = self.current_snapshot();
+        let captured_snapshot = super::execution_context::capture_current_snapshot();
+        let snapshot = captured_snapshot.as_ref().map_or_else(
+            || self.current_snapshot(),
+            |context| context.snapshot.clone(),
+        );
         let visible_collections = match (self.inner.auth_store.read().clone(), identity.as_ref()) {
             (Some(store), Some((principal, role))) => {
                 let collections = self.inner.db.store().list_collections();
@@ -951,6 +989,7 @@ impl RedDBRuntime {
             _ => None,
         };
         EffectiveScope {
+            captured_snapshot,
             tenant,
             identity,
             snapshot,

--- a/crates/reddb-server/src/runtime/statement_frame.rs
+++ b/crates/reddb-server/src/runtime/statement_frame.rs
@@ -1205,14 +1205,12 @@ mod tests {
         let frame = StatementExecutionFrame::build(&rt, StatementIdentity::Text("SELECT 1"))
             .expect("frame builds for SELECT 1");
 
-        // Live reads: no AS OF floor, snapshot bounded by the
-        // manager's `peek_next_xid` so committed tuples are visible.
+        // The inclusive bound excludes the next unallocated writer xid.
+        // A pristine manager therefore has a valid empty snapshot at zero.
         let f: &dyn ReadFrame = &frame;
         assert!(f.as_of_floor().is_none(), "live read has no AS OF floor");
-        assert!(
-            f.snapshot().xid >= 1,
-            "autocommit snapshot xid is bounded by peek_next_xid"
-        );
+        assert_eq!(f.snapshot().xid, rt.snapshot_manager().peek_next_xid() - 1);
+        assert!(!f.snapshot().sees(rt.snapshot_manager().peek_next_xid(), 0));
     }
 
     #[test]

--- a/crates/reddb-server/src/runtime/transaction_state.rs
+++ b/crates/reddb-server/src/runtime/transaction_state.rs
@@ -168,13 +168,11 @@ impl TransactionState {
     pub(crate) fn current_snapshot(&self, connection_id: u64) -> Snapshot {
         if let Some(context) = self.context(connection_id) {
             if context.isolation == IsolationLevel::ReadCommitted {
-                let high_water = self.snapshot_manager.peek_next_xid();
-                return self.snapshot_manager.snapshot(high_water);
+                return self.snapshot_manager.fresh_read_snapshot();
             }
             return context.snapshot;
         }
-        let high_water = self.snapshot_manager.peek_next_xid();
-        self.snapshot_manager.snapshot(high_water)
+        self.snapshot_manager.fresh_read_snapshot()
     }
 
     pub(crate) fn writer_xid(&self, connection_id: u64) -> Option<Xid> {

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -35,7 +35,8 @@ use crate::storage::unified::entity::EntityId;
 /// many xids in a single `fetch_add` so back-to-back autocommit inserts
 /// share one atomic op instead of paying it per row. Sized small to
 /// keep a pristine `peek_next_xid()` close to the truth — VACUUM and
-/// diagnostics treat reserved-but-unused xids as already-committed.
+/// diagnostics observe the allocator high-water mark. Snapshots exclude
+/// reserved-but-unused slots from visibility until a later snapshot.
 pub(crate) const AUTOCOMMIT_POOL_BATCH: u64 = 16;
 
 /// A transaction identifier. Monotonic across the lifetime of the process.
@@ -55,7 +56,7 @@ pub struct Snapshot {
     /// The snapshot's xid — every row with `xmin <= xid` created before
     /// the snapshot is visible (assuming `xmax` hasn't passed).
     pub xid: Xid,
-    /// Transactions that were still active when the snapshot was taken.
+    /// Active transactions and reserved-but-unissued pool xids at capture.
     /// Their writes must be *hidden* even when `xmin <= xid`, because
     /// the writer hadn't committed yet from this snapshot's point of view.
     pub in_progress: HashSet<Xid>,
@@ -227,8 +228,14 @@ impl SnapshotManager {
     /// committed row version rather than a pinned statement snapshot.
     pub fn fresh_read_snapshot(&self) -> Snapshot {
         let state = self.state.read();
-        let xid = self.next_xid.load(Ordering::Relaxed);
-        let in_progress: HashSet<Xid> = state.active.iter().copied().collect();
+        let pool = self.autocommit_pool.lock();
+        // Visibility uses an inclusive bound. The allocator points at the
+        // next, not the last, xid; including it admits the next future writer.
+        let xid = self.next_xid.load(Ordering::Relaxed).saturating_sub(1);
+        let mut in_progress: HashSet<Xid> = state.active.iter().copied().collect();
+        // Reserved-but-unissued pool slots are future writers even though
+        // their numbers can be below this snapshot's high-water mark.
+        in_progress.extend(pool.next..pool.end);
         Snapshot { xid, in_progress }
     }
 
@@ -238,8 +245,10 @@ impl SnapshotManager {
     pub fn snapshot(&self, xid: Xid) -> Snapshot {
         let state = self.state.read();
         // Active xids other than our own appear as "in-progress" to us.
-        let in_progress: HashSet<Xid> =
+        let pool = self.autocommit_pool.lock();
+        let mut in_progress: HashSet<Xid> =
             state.active.iter().copied().filter(|&x| x != xid).collect();
+        in_progress.extend(pool.next..pool.end);
         Snapshot { xid, in_progress }
     }
 
@@ -710,5 +719,37 @@ mod tests {
         assert_eq!(m.oldest_active_xid(), Some(b));
         m.commit(b);
         assert_eq!(m.oldest_active_xid(), None);
+    }
+    #[test]
+    fn read_snapshot_excludes_first_future_writer_and_deleter() {
+        let manager = SnapshotManager::new();
+        let old = manager.begin();
+        manager.commit(old);
+        let snapshot = manager.fresh_read_snapshot();
+        let future = manager.begin();
+        manager.commit(future);
+        assert!(!snapshot.sees(future, XID_NONE));
+        assert!(snapshot.sees(old, future));
+        let fresh = manager.fresh_read_snapshot();
+        assert!(fresh.sees(future, XID_NONE));
+        assert!(!fresh.sees(old, future));
+    }
+
+    #[test]
+    fn snapshots_exclude_unissued_pool_slots_even_below_reader_xid() {
+        let manager = SnapshotManager::new();
+        let old = manager.allocate_committed_xid();
+        let reader = manager.begin();
+        let transaction_snapshot = manager.snapshot(reader);
+        let statement_snapshot = manager.fresh_read_snapshot();
+        let future = manager.allocate_committed_xid();
+        assert!(future < reader, "fixture must exercise the reserved range");
+        for snapshot in [transaction_snapshot, statement_snapshot] {
+            assert!(snapshot.sees(old, XID_NONE));
+            assert!(!snapshot.sees(future, XID_NONE));
+            assert!(snapshot.sees(old, future));
+        }
+        assert!(manager.fresh_read_snapshot().sees(future, XID_NONE));
+        manager.rollback(reader);
     }
 }

--- a/crates/reddb-server/src/storage/transaction/snapshot.rs
+++ b/crates/reddb-server/src/storage/transaction/snapshot.rs
@@ -449,7 +449,13 @@ impl SnapshotManager {
         if xid == XID_NONE {
             return;
         }
+        // Replay can import an xid from our still-unused reservation range.
+        // Retire those slots before publishing the floor: they must neither
+        // hide the recovered row in fresh snapshots nor be allocated again.
+        // Captured snapshots retain their original exclusions.
+        let mut pool = self.autocommit_pool.lock();
         let target = xid.saturating_add(1);
+        pool.next = pool.next.max(target.min(pool.end));
         let mut current = self.next_xid.load(Ordering::Relaxed);
         while current < target {
             match self.next_xid.compare_exchange(
@@ -751,5 +757,24 @@ mod tests {
         }
         assert!(manager.fresh_read_snapshot().sees(future, XID_NONE));
         manager.rollback(reader);
+    }
+
+    #[test]
+    fn replay_retires_reserved_xids_without_changing_captured_snapshots() {
+        let manager = SnapshotManager::new();
+        let first = manager.allocate_committed_xid();
+        let captured = manager.fresh_read_snapshot();
+        let replayed = first + 2;
+        manager.observe_committed_xid(replayed);
+        assert!(!captured.sees(replayed, XID_NONE));
+        assert!(manager.fresh_read_snapshot().sees(replayed, XID_NONE));
+        assert!(manager.allocate_committed_xid() > replayed);
+
+        let beyond_pool = manager.peek_next_xid() + 10;
+        let captured = manager.fresh_read_snapshot();
+        manager.observe_committed_xid(beyond_pool);
+        assert!(!captured.sees(beyond_pool, XID_NONE));
+        assert!(manager.fresh_read_snapshot().sees(beyond_pool, XID_NONE));
+        assert!(manager.allocate_committed_xid() > beyond_pool);
     }
 }

--- a/crates/reddb-server/src/storage/unified/dsl/builders/text.rs
+++ b/crates/reddb-server/src/storage/unified/dsl/builders/text.rs
@@ -61,4 +61,12 @@ impl TextSearchBuilder {
     pub fn execute(self, store: &Arc<UnifiedStore>) -> Result<QueryResult, ExecutionError> {
         execute_text_query(self, store)
     }
+    pub(crate) fn execute_filtered(
+        self,
+        store: &Arc<UnifiedStore>,
+        snapshot: Option<&crate::runtime::execution_context::SnapshotContext>,
+        allowed: impl FnMut(&super::super::super::entity::UnifiedEntity) -> bool,
+    ) -> Result<QueryResult, ExecutionError> {
+        super::super::execution::execute_text_query_filtered(self, store, snapshot, allowed)
+    }
 }

--- a/crates/reddb-server/src/storage/unified/dsl/execution.rs
+++ b/crates/reddb-server/src/storage/unified/dsl/execution.rs
@@ -423,6 +423,15 @@ pub fn execute_text_query(
     query: TextSearchBuilder,
     store: &Arc<UnifiedStore>,
 ) -> Result<QueryResult, ExecutionError> {
+    execute_text_query_filtered(query, store, None, |_| true)
+}
+
+pub(crate) fn execute_text_query_filtered(
+    query: TextSearchBuilder,
+    store: &Arc<UnifiedStore>,
+    snapshot: Option<&crate::runtime::execution_context::SnapshotContext>,
+    mut allowed: impl FnMut(&UnifiedEntity) -> bool,
+) -> Result<QueryResult, ExecutionError> {
     let start = Instant::now();
     let mut matches = Vec::new();
     let mut scanned = 0;
@@ -436,9 +445,14 @@ pub fn execute_text_query(
 
     for col_name in &collections {
         if let Some(manager) = store.get_collection(col_name) {
-            let entities = manager.query_all(|_| true);
+            let entities = manager.scan(snapshot, |_| true);
             for entity in entities {
                 scanned += 1;
+
+                // Evaluate policy outside segment locks and before scoring/limiting.
+                if !allowed(&entity) {
+                    continue;
+                }
 
                 // Extract searchable text from entity
                 let text = extract_searchable_text(&entity);

--- a/crates/reddb-server/src/telemetry/slow_query_logger.rs
+++ b/crates/reddb-server/src/telemetry/slow_query_logger.rs
@@ -310,6 +310,7 @@ mod tests {
 
     fn empty_scope() -> EffectiveScope {
         EffectiveScope {
+            captured_snapshot: None,
             tenant: None,
             identity: None,
             snapshot: Snapshot {

--- a/crates/reddb-server/tests/primary_replica_rebootstrap_runtime.rs
+++ b/crates/reddb-server/tests/primary_replica_rebootstrap_runtime.rs
@@ -108,6 +108,7 @@ fn runtime_promotes_ready_rebootstrap_pending_file_on_restart() {
     );
     let applier = LogicalChangeApplier::new(checkpoint_lsn);
     let promoted_db = promoted.db();
+    let before_replay = promoted.current_snapshot();
     let mut last_applied = checkpoint_lsn;
     for (lsn, data) in post_checkpoint_records {
         let record = ChangeRecord::decode(&data).expect("decode post-checkpoint logical WAL");
@@ -138,6 +139,18 @@ fn runtime_promotes_ready_rebootstrap_pending_file_on_restart() {
         1,
         "post-checkpoint WAL row should be visible after replay"
     );
+    let replayed = promoted_db
+        .store()
+        .get_collection("new_items")
+        .expect("replicated collection")
+        .query_all(|entity| entity.xmin > before_replay.xid);
+    assert!(!replayed.is_empty(), "fixture must replay a future xid");
+    let after_replay = promoted.current_snapshot();
+    for entity in replayed {
+        assert!(!before_replay.sees(entity.xmin, entity.xmax));
+        assert!(after_replay.sees(entity.xmin, entity.xmax));
+        assert!(promoted.snapshot_manager().peek_next_xid() > entity.xmin);
+    }
     let _ = fs::remove_file(reddb_file::layout::rebootstrap_previous_path(&data_path));
     primary_replica_file::cleanup(&data_path);
     primary_replica_file::cleanup(&source_path);

--- a/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
+++ b/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
@@ -443,8 +443,10 @@ fn auto_embed_uses_only_inserted_rows_and_skips_conflicts() {
     }));
     let rt = rt();
     register_installed_local_model(&rt, "mini", 2);
-    exec(&rt, "CREATE TABLE docs (id INT PRIMARY KEY, body TEXT)");
+    // Implicit collections admit both rows and attached vectors; an explicit
+    // CREATE TABLE correctly forbids vector writes under its model contract.
     exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'existing')");
+    exec(&rt, "CREATE UNIQUE INDEX docs_key ON docs (id) USING HASH");
     exec(&rt, "INSERT INTO docs (id,body) VALUES (2,'alpha'),(3,'beta') WITH AUTO EMBED (body) USING local MODEL 'mini'");
     exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'skipped') WITH AUTO EMBED (body) USING local MODEL 'mini' ON CONFLICT DO NOTHING");
     assert_eq!(

--- a/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
+++ b/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
@@ -446,9 +446,16 @@ fn auto_embed_uses_only_inserted_rows_and_skips_conflicts() {
     // Implicit collections admit both rows and attached vectors; an explicit
     // CREATE TABLE correctly forbids vector writes under its model contract.
     exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'existing')");
-    exec(&rt, "CREATE UNIQUE INDEX docs_key ON docs (id) USING HASH");
     exec(&rt, "INSERT INTO docs (id,body) VALUES (2,'alpha'),(3,'beta') WITH AUTO EMBED (body) USING local MODEL 'mini'");
-    exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'skipped') WITH AUTO EMBED (body) USING local MODEL 'mini' ON CONFLICT DO NOTHING");
+    exec(
+        &rt,
+        "CREATE TABLE skipped_docs (id INT PRIMARY KEY, body TEXT)",
+    );
+    exec(
+        &rt,
+        "INSERT INTO skipped_docs (id,body) VALUES (1,'existing')",
+    );
+    exec(&rt, "INSERT INTO skipped_docs (id,body) VALUES (1,'skipped') WITH AUTO EMBED (body) USING local MODEL 'mini' ON CONFLICT DO NOTHING");
     assert_eq!(
         *calls.lock().expect("calls"),
         vec![vec!["alpha".to_string(), "beta".to_string()]]

--- a/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
+++ b/tests/grouped/ai_local_vector/integration_auto_embed_local.rs
@@ -432,3 +432,26 @@ fn auto_embed_over_cdc_retries_then_dead_letters_then_redrives() {
 
     clear_local_embedding_backend_for_tests();
 }
+
+#[test]
+fn auto_embed_uses_only_inserted_rows_and_skips_conflicts() {
+    let _bg = backend_lock().lock().unwrap_or_else(|p| p.into_inner());
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    install_local_embedding_backend(Arc::new(FixedBackend {
+        vector: vec![1.0, 0.0],
+        calls: Arc::clone(&calls),
+    }));
+    let rt = rt();
+    register_installed_local_model(&rt, "mini", 2);
+    exec(&rt, "CREATE TABLE docs (id INT PRIMARY KEY, body TEXT)");
+    exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'existing')");
+    exec(&rt, "INSERT INTO docs (id,body) VALUES (2,'alpha'),(3,'beta') WITH AUTO EMBED (body) USING local MODEL 'mini'");
+    exec(&rt, "INSERT INTO docs (id,body) VALUES (1,'skipped') WITH AUTO EMBED (body) USING local MODEL 'mini' ON CONFLICT DO NOTHING");
+    assert_eq!(
+        *calls.lock().expect("calls"),
+        vec![vec!["alpha".to_string(), "beta".to_string()]]
+    );
+    let result = exec(&rt, "VECTOR SEARCH docs SIMILAR TO [1.0,0.0] LIMIT 5");
+    assert_eq!(result.result.records.len(), 2);
+    clear_local_embedding_backend_for_tests();
+}


### PR DESCRIPTION
SEARCH and ASK execute against the captured statement snapshot, tenant and authorization identity. Guards restore the enclosing frame on normal returns and unwinding. SEARCH TEXT constrains global reads to the captured allow-list and applies policies before ranking/limit; SEARCH SIMILAR uses the bounded exact cosine executor.

Fresh read snapshots use the inclusive allocated xid cutoff and exclude unused autocommit reservations. Subsequently allocated writer/deleter xids stay excluded from previously captured snapshots. Logical replay publishes imported xid floors to the runtime snapshot manager and retires overlapping unused reservations after installing entity data/metadata. The existing replica rebootstrap regression now sees post-checkpoint WAL rows while earlier snapshots remain unchanged.

AUTO EMBED reads this INSERT's returned IDs instead of scanning the last N collection rows; skipped conflicts create no embedding request. Autocommit QUEUE READ WAIT refreshes its snapshot on each retry while retaining identity and tenant.

Validation: the standard CI workflow 34179173235 passed at 438edc900. The original replica regression passed within its 845-test shard. The combined revision eff70cb82331151c524a2277c964adb195954733 also passed cargo check and 171 focused regressions covering search/ASK authorization, snapshots, replay, AUTO EMBED and commit notifications. Release multimodel/SciFact acceptance remains in progress in #2291.

Limits: this does not redesign the born-committed autocommit publication protocol or establish multi-primary xid coordination. Exact vector execution retains an O(N) visible-ID list with bounded payload batches and top-k state. No speed or general competitor-superiority claim is made.

Part of #2270. Draft against frozen perf/competitive-stage-one; no main merge or release requested.
