### PR TITLE
fix(memory): govern UPDATE and native PATCH growth before publication

### DIFF
--- a/crates/reddb-server/src/application/ports_impls_entity.rs
+++ b/crates/reddb-server/src/application/ports_impls_entity.rs
@@ -1607,6 +1607,7 @@ impl RedDBRuntime {
     ) -> RedDBResult<CreateEntityOutput> {
         let applied =
             self.apply_loaded_patch_entity_core(collection, entity, payload, operations)?;
+        let _reservation = self.admit_entity_mutation(&applied)?;
         self.persist_applied_entity_mutations(std::slice::from_ref(&applied))?;
         #[cfg(test)]
         self.index_store_ref().mutation_test_hook(

--- a/crates/reddb-server/src/runtime.rs
+++ b/crates/reddb-server/src/runtime.rs
@@ -1556,6 +1556,8 @@ pub(crate) mod metric_descriptor_catalog;
 pub(crate) mod mutation;
 #[cfg(test)]
 mod mutation_index_topology_tests;
+#[cfg(test)]
+mod mutation_memory_tests;
 pub(crate) mod mvcc_lifecycle;
 pub(crate) mod node_load_telemetry;
 pub(crate) mod occupancy_sampler;

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -2204,7 +2204,7 @@ impl RedDBRuntime {
         // autocommit chunks visible. Prepared payload is bounded by admission.
         let topology_guard = topology_lock.read();
         let mut prepared = Vec::new();
-        let mut reservations = Vec::new();
+        let mut reservations = super::memory_admission::MutationMemoryReservations::new(self);
         for chunk in ids_to_update.chunks(UPDATE_APPLY_CHUNK_SIZE) {
             for entity in manager.get_many(chunk).into_iter().flatten() {
                 let assignments =
@@ -2215,7 +2215,7 @@ impl RedDBRuntime {
                     &compiled_plan,
                     assignments,
                 )?;
-                reservations.push(self.admit_entity_mutation(&applied)?);
+                reservations.admit(&applied)?;
                 touched_ids.push(applied.id);
                 prepared.push(applied);
             }
@@ -2345,7 +2345,7 @@ impl RedDBRuntime {
         let _rmw_guards: Vec<_> = lock_entries.iter().map(|entry| entry.2.lock()).collect();
 
         let mut applied_chunk = Vec::new();
-        let mut reservations = Vec::new();
+        let mut reservations = super::memory_admission::MutationMemoryReservations::new(self);
         for (_, logical_id, _) in &lock_entries {
             let Some(entity) = resolve_update_entity_by_logical_id(self, &query.table, *logical_id)
             else {
@@ -2371,7 +2371,7 @@ impl RedDBRuntime {
                 compiled_plan,
                 assignments,
             )?;
-            reservations.push(self.admit_entity_mutation(&applied)?);
+            reservations.admit(&applied)?;
             touched_ids.push(applied.id);
             applied_chunk.push(applied);
         }

--- a/crates/reddb-server/src/runtime/impl_dml.rs
+++ b/crates/reddb-server/src/runtime/impl_dml.rs
@@ -2199,10 +2199,13 @@ impl RedDBRuntime {
             return Ok(result);
         }
 
-        let mut affected: u64 = 0;
+        // Keep topology fixed while reserving every post-image. No chunk is
+        // published until all targets fit; a later denial cannot leave earlier
+        // autocommit chunks visible. Prepared payload is bounded by admission.
+        let topology_guard = topology_lock.read();
+        let mut prepared = Vec::new();
+        let mut reservations = Vec::new();
         for chunk in ids_to_update.chunks(UPDATE_APPLY_CHUNK_SIZE) {
-            let topology_guard = topology_lock.read();
-            let mut applied_chunk = Vec::with_capacity(chunk.len());
             for entity in manager.get_many(chunk).into_iter().flatten() {
                 let assignments =
                     self.materialize_update_assignments_for_entity(query, &entity, &compiled_plan)?;
@@ -2212,16 +2215,45 @@ impl RedDBRuntime {
                     &compiled_plan,
                     assignments,
                 )?;
+                reservations.push(self.admit_entity_mutation(&applied)?);
                 touched_ids.push(applied.id);
-                applied_chunk.push(applied);
-            }
-            self.persist_update_chunk(&applied_chunk)?;
-            affected += applied_chunk.len() as u64;
-            let lsns = self.flush_update_chunk(&applied_chunk, topology_guard)?;
-            if !query.suppress_events {
-                self.emit_update_events_for_collection(&query.table, &applied_chunk, &lsns)?;
+                prepared.push(applied);
             }
         }
+        let affected = prepared.len() as u64;
+        let mut published = 0;
+        let persistence = (|| -> RedDBResult<()> {
+            for chunk in prepared.chunks(UPDATE_APPLY_CHUNK_SIZE) {
+                if compiled_plan.row_touches_unique_columns
+                    || compiled_plan
+                        .row_contract_plan
+                        .as_ref()
+                        .is_some_and(|plan| plan.has_expressions)
+                {
+                    let db = self.db();
+                    let contract = crate::application::collection_contract_enforcer::CollectionContractWriteEnforcer::new(self, &db, &query.table);
+                    for item in chunk {
+                        let fields =
+                            crate::application::ports::entity_row_fields_snapshot(&item.entity);
+                        let previous_id =
+                            item.replaced_entity.as_ref().map_or(item.id, |old| old.id);
+                        contract.enforce_row_uniqueness(&fields, Some(previous_id))?;
+                    }
+                }
+                self.persist_update_chunk(chunk)?;
+                published += chunk.len();
+            }
+            Ok(())
+        })();
+        // A later storage/constraint error must still finish index and CDC
+        // maintenance for earlier published chunks, as the chunked path did.
+        let published_mutations = &prepared[..published];
+        let lsns = self.flush_update_chunk(published_mutations, topology_guard)?;
+        if !query.suppress_events {
+            self.emit_update_events_for_collection(&query.table, published_mutations, &lsns)?;
+        }
+        persistence?;
+        drop(reservations);
 
         if affected > 0 {
             self.note_table_write(&query.table);
@@ -2313,6 +2345,7 @@ impl RedDBRuntime {
         let _rmw_guards: Vec<_> = lock_entries.iter().map(|entry| entry.2.lock()).collect();
 
         let mut applied_chunk = Vec::new();
+        let mut reservations = Vec::new();
         for (_, logical_id, _) in &lock_entries {
             let Some(entity) = resolve_update_entity_by_logical_id(self, &query.table, *logical_id)
             else {
@@ -2338,6 +2371,7 @@ impl RedDBRuntime {
                 compiled_plan,
                 assignments,
             )?;
+            reservations.push(self.admit_entity_mutation(&applied)?);
             touched_ids.push(applied.id);
             applied_chunk.push(applied);
         }

--- a/crates/reddb-server/src/runtime/index_store.rs
+++ b/crates/reddb-server/src/runtime/index_store.rs
@@ -1392,6 +1392,42 @@ impl IndexStore {
         growth
     }
 
+    /// Reserve a new physical version's entries, or changed in-place keys.
+    /// Replaced keys are not credited before publication: other writers must
+    /// not spend space whose removal has not completed yet.
+    pub(crate) fn estimate_update_growth(
+        &self,
+        collection: &str,
+        before: &[(String, Value)],
+        entity: &crate::storage::UnifiedEntity,
+        versioned: bool,
+    ) -> u64 {
+        let registry = self.registry.read();
+        let mut indexes = registry
+            .values()
+            .filter(|index| index.collection == collection)
+            .peekable();
+        if indexes.peek().is_none() {
+            return 0;
+        }
+        let crate::storage::EntityData::Row(row) = &entity.data else {
+            return 0;
+        };
+        let after: Vec<_> = row
+            .iter_fields()
+            .map(|(name, value)| (name.to_string(), value.clone()))
+            .collect();
+        indexes
+            .filter(|index| {
+                versioned
+                    || index.columns.iter().any(|column| {
+                        index_field_value(before, column) != index_field_value(&after, column)
+                    })
+            })
+            .map(|index| estimate_registered_index_growth(index, &after))
+            .fold(0, u64::saturating_add)
+    }
+
     /// Build physical backing. Runtime callers hold exclusive collection topology
     /// from before collecting entities until after registering metadata.
     pub fn create_index(

--- a/crates/reddb-server/src/runtime/memory_accounting.rs
+++ b/crates/reddb-server/src/runtime/memory_accounting.rs
@@ -40,6 +40,10 @@ impl RedDBRuntime {
         &self,
         reservations: &mut super::memory_admission::MemoryReservations,
     ) {
+        #[cfg(test)]
+        {
+            reservations.samples += 1;
+        }
         let accounting = self.memory_accounting();
         let store = self.db().store();
 

--- a/crates/reddb-server/src/runtime/memory_admission.rs
+++ b/crates/reddb-server/src/runtime/memory_admission.rs
@@ -11,6 +11,8 @@ use reddb_types::Value;
 pub(super) struct MemoryReservations {
     pub(super) reserved_bytes: u64,
     pub(super) completed_bytes: u64,
+    #[cfg(test)]
+    pub(super) samples: usize,
 }
 
 /// Keep this guard through all storage/index writes, including failure cleanup.
@@ -34,6 +36,52 @@ impl Drop for MemoryReservation<'_> {
     }
 }
 
+/// Amortize pool sampling across small post-images while keeping every byte
+/// reserved before publication. At most one quantum of unused slack is held.
+pub(super) struct MutationMemoryReservations<'runtime> {
+    runtime: &'runtime crate::RedDBRuntime,
+    guards: Vec<MemoryReservation<'runtime>>,
+    available_bytes: u64,
+}
+
+impl<'runtime> MutationMemoryReservations<'runtime> {
+    pub(super) fn new(runtime: &'runtime crate::RedDBRuntime) -> Self {
+        Self {
+            runtime,
+            guards: Vec::new(),
+            available_bytes: 0,
+        }
+    }
+
+    pub(super) fn admit(
+        &mut self,
+        applied: &crate::application::entity::AppliedEntityMutation,
+    ) -> RedDBResult<()> {
+        const RESERVATION_QUANTUM_BYTES: u64 = 64 * 1024;
+        let growth = self.runtime.estimate_entity_mutation_growth(applied);
+        if growth > self.available_bytes {
+            let needed = growth - self.available_bytes;
+            // Extra slack is optional. If it does not fit, apply the ordinary
+            // reclamation/denial path only to the bytes this mutation needs.
+            let guard = match self
+                .runtime
+                .try_reserve_memory_growth(needed.max(RESERVATION_QUANTUM_BYTES))
+            {
+                Some(guard) => guard,
+                None => self.runtime.admit_non_evictable_growth(
+                    MemoryPool::SegmentArena,
+                    "update",
+                    needed,
+                )?,
+            };
+            self.available_bytes += guard.bytes;
+            self.guards.push(guard);
+        }
+        self.available_bytes -= growth;
+        Ok(())
+    }
+}
+
 const MAX_PRESSURE_TICKS: usize = 64;
 const FIELD_BASE_BYTES: u64 = 64;
 const INDEX_ENTRY_BYTES: u64 = 96;
@@ -43,6 +91,17 @@ impl crate::RedDBRuntime {
         &self,
         applied: &crate::application::entity::AppliedEntityMutation,
     ) -> RedDBResult<MemoryReservation<'_>> {
+        self.admit_non_evictable_growth(
+            MemoryPool::SegmentArena,
+            "update",
+            self.estimate_entity_mutation_growth(applied),
+        )
+    }
+
+    fn estimate_entity_mutation_growth(
+        &self,
+        applied: &crate::application::entity::AppliedEntityMutation,
+    ) -> u64 {
         let entity_bytes = crate::storage::unified::memory_size::entity_bytes(&applied.entity)
             .saturating_add(
                 crate::storage::unified::memory_size::entity_zone_growth_bytes(&applied.entity),
@@ -56,11 +115,7 @@ impl crate::RedDBRuntime {
             &applied.entity,
             applied.replaced_entity.is_some(),
         );
-        self.admit_non_evictable_growth(
-            MemoryPool::SegmentArena,
-            "update",
-            (entity_bytes as u64).saturating_add(index_growth),
-        )
+        (entity_bytes as u64).saturating_add(index_growth)
     }
 
     pub(crate) fn admit_non_evictable_growth(

--- a/crates/reddb-server/src/runtime/memory_admission.rs
+++ b/crates/reddb-server/src/runtime/memory_admission.rs
@@ -39,6 +39,30 @@ const FIELD_BASE_BYTES: u64 = 64;
 const INDEX_ENTRY_BYTES: u64 = 96;
 
 impl crate::RedDBRuntime {
+    pub(crate) fn admit_entity_mutation(
+        &self,
+        applied: &crate::application::entity::AppliedEntityMutation,
+    ) -> RedDBResult<MemoryReservation<'_>> {
+        let entity_bytes = crate::storage::unified::memory_size::entity_bytes(&applied.entity)
+            .saturating_add(
+                crate::storage::unified::memory_size::entity_zone_growth_bytes(&applied.entity),
+            );
+        // Reserve the full replacement, including in-place PATCH: the old
+        // payload remains resident until publication and another writer may
+        // replace it before we do. A stale pre-image must never grant credit.
+        let index_growth = self.index_store_ref().estimate_update_growth(
+            &applied.collection,
+            &applied.pre_mutation_fields,
+            &applied.entity,
+            applied.replaced_entity.is_some(),
+        );
+        self.admit_non_evictable_growth(
+            MemoryPool::SegmentArena,
+            "update",
+            (entity_bytes as u64).saturating_add(index_growth),
+        )
+    }
+
     pub(crate) fn admit_non_evictable_growth(
         &self,
         pool: MemoryPool,
@@ -129,7 +153,16 @@ impl crate::RedDBRuntime {
 }
 
 pub(crate) fn estimate_row_growth(fields: &[(String, Value)]) -> u64 {
-    entity_base_bytes().saturating_add(estimate_value_fields_bytes(fields))
+    entity_base_bytes()
+        .saturating_add(estimate_value_fields_bytes(fields))
+        .saturating_add(
+            fields
+                .iter()
+                .map(|(_, value)| {
+                    crate::storage::unified::memory_size::zone_growth_bytes(value) as u64
+                })
+                .fold(0, u64::saturating_add),
+        )
 }
 
 pub(crate) fn estimate_timeseries_point_growth(
@@ -171,18 +204,7 @@ pub(crate) fn estimate_index_growth(rows: &[Vec<(String, Value)>], columns: &[St
 }
 
 fn estimate_value_bytes(value: &Value) -> u64 {
-    match value {
-        Value::Text(text) => text.len() as u64,
-        Value::Blob(bytes) | Value::Json(bytes) => bytes.len() as u64,
-        Value::Vector(values) => values.len() as u64 * 4,
-        Value::NodeRef(value)
-        | Value::EdgeRef(value)
-        | Value::Email(value)
-        | Value::Url(value)
-        | Value::RowRef(value, _)
-        | Value::VectorRef(value, _) => value.len() as u64,
-        _ => 16,
-    }
+    (crate::storage::unified::memory_size::value_heap_bytes(value) as u64).max(16)
 }
 
 fn entity_base_bytes() -> u64 {

--- a/crates/reddb-server/src/runtime/mutation_memory_tests.rs
+++ b/crates/reddb-server/src/runtime/mutation_memory_tests.rs
@@ -460,3 +460,80 @@ fn mutation_memory_late_constraint_error_finishes_published_indexes() {
         .records
         .is_empty());
 }
+
+#[test]
+fn mutation_memory_native_vector_content_and_graph_type_are_governed() {
+    use crate::application::entity::{CreateNodeInput, CreateVectorInput};
+    for graph in [false, true] {
+        let runtime = RedDBRuntime::with_options(
+            RedDBOptions::in_memory().with_memory_budget(4 * 1024 * 1024),
+        )
+        .expect("runtime");
+        let (id, path) = if graph {
+            runtime.execute_query("CREATE GRAPH growth").expect("graph");
+            let id = runtime
+                .create_node(CreateNodeInput {
+                    collection: "growth".to_string(),
+                    label: "seed".to_string(),
+                    node_type: Some("small".to_string()),
+                    properties: Vec::new(),
+                    metadata: Vec::new(),
+                    embeddings: Vec::new(),
+                    table_links: Vec::new(),
+                    node_links: Vec::new(),
+                })
+                .expect("node")
+                .id;
+            (id, vec!["node_type".to_string()])
+        } else {
+            let id = runtime
+                .create_vector(CreateVectorInput {
+                    collection: "growth".to_string(),
+                    dense: vec![1.0, 0.0, 0.0],
+                    content: Some("small".to_string()),
+                    metadata: Vec::new(),
+                    link_row: None,
+                    link_node: None,
+                })
+                .expect("vector")
+                .id;
+            (id, vec!["fields".to_string(), "content".to_string()])
+        };
+        let manager = runtime
+            .db()
+            .store()
+            .get_collection("growth")
+            .expect("collection");
+        let snapshot = manager.get(id).expect("before");
+        let patch = |payload: String| {
+            runtime.patch_entity(PatchEntityInput {
+                collection: "growth".to_string(),
+                id,
+                payload: crate::json::Value::Null,
+                operations: vec![PatchEntityOperation {
+                    op: PatchEntityOperationType::Set,
+                    path: path.clone(),
+                    value: Some(crate::json::json!(payload)),
+                }],
+            })
+        };
+        let error =
+            patch("x".repeat(8 * 1024 * 1024)).expect_err("variable payload exceeds budget");
+        assert!(
+            error.to_string().contains("over budget"),
+            "graph={graph}: {error}"
+        );
+        let unchanged = manager.get(id).expect("unchanged");
+        assert_eq!(unchanged.kind, snapshot.kind);
+        assert_eq!(
+            format!("{:?}", unchanged.data),
+            format!("{:?}", snapshot.data)
+        );
+        let before = manager.resident_bytes();
+        patch("x".repeat(64 * 1024)).expect("admitted payload");
+        assert!(
+            manager.resident_bytes() >= before + 64 * 1024 - 5,
+            "graph={graph}: charge the admitted payload"
+        );
+    }
+}

--- a/crates/reddb-server/src/runtime/mutation_memory_tests.rs
+++ b/crates/reddb-server/src/runtime/mutation_memory_tests.rs
@@ -1,0 +1,458 @@
+use crate::application::entity::{
+    PatchEntityInput, PatchEntityOperation, PatchEntityOperationType,
+};
+use crate::application::ports::RuntimeEntityPort;
+use crate::{RedDBOptions, RedDBRuntime};
+
+fn varied_payload(bytes: usize) -> String {
+    const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-";
+    let mut state = 0x9e37_79b9u32;
+    (0..bytes)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            ALPHABET[(state & 63) as usize] as char
+        })
+        .collect()
+}
+
+fn seeded_runtime(budget: u64, document: bool) -> RedDBRuntime {
+    let runtime = RedDBRuntime::with_options(RedDBOptions::in_memory().with_memory_budget(budget))
+        .expect("runtime");
+    if document {
+        runtime
+            .execute_query("CREATE DOCUMENT growth")
+            .expect("collection");
+        runtime
+            .execute_query("INSERT INTO growth DOCUMENT VALUES ({\"payload\":\"small\"})")
+            .expect("seed");
+    } else {
+        runtime
+            .execute_query("CREATE TABLE growth (payload TEXT)")
+            .expect("table");
+        runtime
+            .execute_query("INSERT INTO growth (payload) VALUES ('small')")
+            .expect("seed");
+    }
+    runtime
+}
+
+#[test]
+fn mutation_memory_oversized_update_preserves_table_and_document() {
+    for document in [false, true] {
+        let runtime = seeded_runtime(128 * 1024, document);
+        let before = runtime
+            .execute_query("SELECT * FROM growth")
+            .expect("before")
+            .result
+            .records;
+        let result = runtime.execute_query(&format!(
+            "UPDATE growth SET payload = '{}'",
+            varied_payload(512 * 1024)
+        ));
+        assert!(
+            result.is_err(),
+            "growth must be denied: document={document}"
+        );
+        assert!(result
+            .expect_err("denied")
+            .to_string()
+            .contains("over budget"));
+        let after = runtime
+            .execute_query("SELECT * FROM growth")
+            .expect("after")
+            .result
+            .records;
+        assert_eq!(
+            format!("{before:?}"),
+            format!("{after:?}"),
+            "denial cannot publish an update"
+        );
+    }
+}
+
+#[test]
+fn mutation_memory_successful_update_accounts_for_payload_and_old_version() {
+    for document in [false, true] {
+        let runtime = seeded_runtime(4 * 1024 * 1024, document);
+        runtime.refresh_memory_accounting();
+        let before = runtime.memory_accounting().total_used_bytes();
+        let bytes = 64 * 1024;
+        let payload = varied_payload(bytes);
+        runtime
+            .execute_query(&format!("UPDATE growth SET payload = '{}'", payload))
+            .expect("within budget");
+        runtime.refresh_memory_accounting();
+        let after = runtime.memory_accounting().total_used_bytes();
+        let expected_minimum = if document { bytes / 2 } else { bytes } as u64;
+        assert_eq!(
+            runtime
+                .execute_query("SELECT payload FROM growth")
+                .expect("readback")
+                .result
+                .records[0]
+                .get("payload"),
+            Some(&reddb_types::Value::text(payload))
+        );
+        assert!(
+            after >= before + expected_minimum,
+            "new payload must be charged: before={before}, after={after}, document={document}"
+        );
+    }
+}
+
+#[test]
+fn mutation_memory_native_patch_rejects_before_publication() {
+    let runtime = seeded_runtime(128 * 1024, true);
+    let manager = runtime
+        .db()
+        .store()
+        .get_collection("growth")
+        .expect("collection");
+    let before = manager.query_all(|_| true).remove(0);
+    let result = runtime.patch_entity(PatchEntityInput {
+        collection: "growth".to_string(),
+        id: before.id,
+        payload: crate::json::Value::Null,
+        operations: vec![PatchEntityOperation {
+            op: PatchEntityOperationType::Set,
+            path: vec!["body".to_string(), "payload".to_string()],
+            value: Some(crate::json::json!(varied_payload(512 * 1024))),
+        }],
+    });
+    assert!(result
+        .expect_err("native PATCH must enforce the same budget")
+        .to_string()
+        .contains("over budget"));
+    assert_eq!(
+        format!("{:?}", before.data),
+        format!("{:?}", manager.get(before.id).expect("unchanged").data)
+    );
+}
+
+fn patch_payload(
+    runtime: &RedDBRuntime,
+    id: crate::storage::EntityId,
+    payload: &str,
+) -> crate::RedDBResult<()> {
+    runtime
+        .patch_entity(PatchEntityInput {
+            collection: "growth".to_string(),
+            id,
+            payload: crate::json::Value::Null,
+            operations: vec![PatchEntityOperation {
+                op: PatchEntityOperationType::Set,
+                path: vec!["fields".to_string(), "payload".to_string()],
+                value: Some(crate::json::json!(payload)),
+            }],
+        })
+        .map(|_| ())
+}
+
+#[test]
+fn mutation_memory_native_patch_updates_growing_and_sealed_counters() {
+    for sealed in [false, true] {
+        let runtime = seeded_runtime(4 * 1024 * 1024, false);
+        let manager = runtime
+            .db()
+            .store()
+            .get_collection("growth")
+            .expect("collection");
+        let id = manager.query_all(|_| true)[0].id;
+        if sealed {
+            manager.force_seal().expect("seal");
+        }
+        let before = manager.resident_bytes();
+        patch_payload(&runtime, id, &"x".repeat(64 * 1024)).expect("grow");
+        let grown = manager.resident_bytes();
+        assert!(
+            grown >= before + 64 * 1024,
+            "sealed={sealed}: {before} -> {grown}"
+        );
+        patch_payload(&runtime, id, "small").expect("shrink");
+        assert!(
+            manager.resident_bytes() < grown,
+            "in-place payload was released"
+        );
+        assert!(
+            manager.resident_bytes() > before,
+            "zone bounds still retain the larger payload"
+        );
+    }
+}
+
+#[test]
+fn mutation_memory_late_budget_denial_does_not_publish_earlier_chunks() {
+    let runtime =
+        RedDBRuntime::with_options(RedDBOptions::in_memory().with_memory_budget(128 * 1024 * 1024))
+            .expect("runtime");
+    runtime
+        .execute_query("CREATE TABLE growth (id INT, payload TEXT)")
+        .expect("table");
+    for start in (0..3000).step_by(500) {
+        let rows = (start..start + 500)
+            .map(|id| format!("({id}, 'small')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        runtime
+            .execute_query(&format!("INSERT INTO growth (id,payload) VALUES {rows}"))
+            .expect("seed");
+    }
+    runtime.refresh_memory_accounting();
+    let fields = vec![
+        ("id".to_string(), reddb_types::Value::Integer(0)),
+        (
+            "payload".to_string(),
+            reddb_types::Value::text("x".repeat(3000)),
+        ),
+    ];
+    let per_row = super::memory_admission::estimate_row_growth(&fields)
+        + runtime.index_store_ref().estimate_insert_growth(
+            "growth",
+            std::iter::once(fields.as_slice()),
+            false,
+        );
+    let headroom =
+        runtime.memory_budget().resolved_bytes - runtime.memory_accounting().total_used_bytes();
+    let _held = runtime
+        .admit_non_evictable_growth(
+            crate::storage::memory_pools::MemoryPool::SegmentArena,
+            "other work",
+            headroom - per_row * 2100,
+        )
+        .expect("leave space beyond one chunk, but not all rows");
+    let result = runtime.execute_query(&format!(
+        "UPDATE growth SET payload = '{}'",
+        "x".repeat(3000)
+    ));
+    assert!(
+        result.is_err(),
+        "all replacement versions exceed the budget"
+    );
+    assert_eq!(
+        runtime
+            .execute_query("SELECT id FROM growth WHERE payload = 'small'")
+            .expect("readback")
+            .result
+            .records
+            .len(),
+        3000,
+        "no earlier chunk can survive a later admission denial"
+    );
+}
+
+#[test]
+fn mutation_memory_index_growth_is_reserved_before_data_changes() {
+    use crate::storage::memory_pools::MemoryPool;
+    let runtime = seeded_runtime(256 * 1024, false);
+    runtime
+        .execute_query("CREATE INDEX payload_index ON growth (payload) USING BTREE")
+        .expect("index");
+    runtime.refresh_memory_accounting();
+    let headroom =
+        runtime.memory_budget().resolved_bytes - runtime.memory_accounting().total_used_bytes();
+    // Enough for the row, not both sorted and equality keys of the BTree.
+    let held = runtime
+        .admit_non_evictable_growth(
+            MemoryPool::SegmentArena,
+            "competing writer",
+            headroom - 90 * 1024,
+        )
+        .expect("reserve");
+    let sql = format!("UPDATE growth SET payload = '{}'", "x".repeat(16 * 1024));
+    assert!(
+        runtime.execute_query(&sql).is_err(),
+        "index bytes must participate in admission"
+    );
+    assert_eq!(
+        runtime
+            .execute_query("SELECT payload FROM growth WHERE payload = 'small'")
+            .expect("old index read")
+            .result
+            .records
+            .len(),
+        1
+    );
+    drop(held);
+    runtime
+        .execute_query(&sql)
+        .expect("retry after reservation returns");
+    assert_eq!(
+        runtime
+            .execute_query("SELECT payload FROM growth WHERE payload = 'small'")
+            .expect("old index entry removed")
+            .result
+            .records
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn mutation_memory_reservation_survives_publication_until_indexes_finish() {
+    use super::index_store::MutationTestPhase;
+    use crate::storage::memory_pools::MemoryPool;
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+    let runtime = seeded_runtime(256 * 1024, false);
+    let (published_send, published_receive) = mpsc::channel();
+    let (resume_send, resume_receive) = mpsc::channel();
+    let resume_receive = parking_lot::Mutex::new(resume_receive);
+    *runtime.index_store_ref().mutation_hook.lock() = Some(Arc::new(move |collection, phase| {
+        if collection == "growth" && phase == MutationTestPhase::StoragePublished {
+            published_send.send(()).expect("notify publication");
+            resume_receive
+                .lock()
+                .recv_timeout(Duration::from_secs(15))
+                .expect("resume writer");
+        }
+    }));
+    std::thread::scope(|scope| {
+        let writer = scope.spawn(|| {
+            runtime.execute_query(&format!(
+                "UPDATE growth SET payload = '{}'",
+                "x".repeat(32 * 1024)
+            ))
+        });
+        published_receive
+            .recv_timeout(Duration::from_secs(15))
+            .expect("storage publication");
+        runtime.refresh_memory_accounting();
+        let reserved = runtime.inner.memory_reservations.lock().reserved_bytes;
+        let headroom =
+            runtime.memory_budget().resolved_bytes - runtime.memory_accounting().total_used_bytes();
+        let rejected = runtime
+            .admit_non_evictable_growth(
+                MemoryPool::IndexMemory,
+                "concurrent index writer",
+                headroom,
+            )
+            .is_err();
+        resume_send.send(()).expect("resume writer");
+        writer
+            .join()
+            .expect("writer thread")
+            .expect("writer succeeds");
+        assert!(
+            reserved >= 32 * 1024,
+            "reservation must outlive storage publication"
+        );
+        assert!(
+            rejected,
+            "concurrent writer cannot spend in-flight index headroom"
+        );
+    });
+    *runtime.index_store_ref().mutation_hook.lock() = None;
+    runtime.refresh_memory_accounting();
+    assert_eq!(runtime.inner.memory_reservations.lock().reserved_bytes, 0);
+}
+
+#[test]
+fn mutation_memory_wal_child() {
+    let Some(path) = std::env::var_os("REDDB_MUTATION_MEMORY_WAL_TEST_PATH") else {
+        return;
+    };
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::persistent(path)
+            .with_memory_budget(4 * 1024 * 1024)
+            .with_auto_checkpoint(0),
+    )
+    .expect("persistent runtime");
+    runtime
+        .execute_query("CREATE TABLE growth (payload TEXT)")
+        .expect("table");
+    runtime
+        .execute_query("INSERT INTO growth (payload) VALUES ('small')")
+        .expect("seed");
+    runtime
+        .execute_query("UPDATE growth SET payload = 'committed'")
+        .expect("durable update");
+    assert!(runtime
+        .execute_query(&format!(
+            "UPDATE growth SET payload = '{}'",
+            "x".repeat(8 * 1024 * 1024)
+        ))
+        .is_err());
+    // Simulate process loss without running runtime/storage destructors.
+    std::process::exit(0);
+}
+
+#[test]
+fn mutation_memory_wal_recovery_preserves_success_and_excludes_denied_update() {
+    let directory = tempfile::tempdir().expect("directory");
+    let path = directory.path().join("growth.rdb");
+    let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--exact",
+            "runtime::mutation_memory_tests::mutation_memory_wal_child",
+            "--nocapture",
+        ])
+        .env("REDDB_MUTATION_MEMORY_WAL_TEST_PATH", &path)
+        .output()
+        .expect("child");
+    assert!(
+        output.status.success(),
+        "child failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::persistent(&path).with_memory_budget(4 * 1024 * 1024),
+    )
+    .expect("reopen");
+    assert_eq!(
+        runtime
+            .execute_query("SELECT payload FROM growth WHERE payload = 'committed'")
+            .expect("recovered")
+            .result
+            .records
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn mutation_memory_late_constraint_error_finishes_published_indexes() {
+    let runtime =
+        RedDBRuntime::with_options(RedDBOptions::in_memory().with_memory_budget(128 * 1024 * 1024))
+            .expect("runtime");
+    runtime
+        .execute_query("CREATE TABLE growth (id INT, record_key INT UNIQUE)")
+        .expect("table");
+    runtime
+        .execute_query("CREATE INDEX growth_lookup ON growth (record_key) USING BTREE")
+        .expect("index");
+    for start in (0..3000).step_by(500) {
+        let rows = (start..start + 500)
+            .map(|id| format!("({id}, {id})"))
+            .collect::<Vec<_>>()
+            .join(",");
+        runtime
+            .execute_query(&format!("INSERT INTO growth (id,record_key) VALUES {rows}"))
+            .expect("seed");
+    }
+    // The first chunk has distinct new keys; the last target collides with
+    // its first published key. Preparing everything must preserve this check.
+    let error = runtime
+        .execute_query(
+            "UPDATE growth SET record_key = CASE WHEN id = 2999 THEN 10000 ELSE id + 10000 END",
+        )
+        .expect_err("cross-chunk collision");
+    assert!(
+        error.to_string().to_lowercase().contains("unique"),
+        "{error}"
+    );
+    let rows = runtime
+        .execute_query("SELECT id FROM growth WHERE record_key = 10000")
+        .expect("published index remains readable")
+        .result
+        .records;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("id"), Some(&reddb_types::Value::Integer(0)));
+    assert!(runtime
+        .execute_query("SELECT id FROM growth WHERE record_key = 0")
+        .expect("old version hidden")
+        .result
+        .records
+        .is_empty());
+}

--- a/crates/reddb-server/src/runtime/mutation_memory_tests.rs
+++ b/crates/reddb-server/src/runtime/mutation_memory_tests.rs
@@ -226,10 +226,10 @@ fn mutation_memory_late_budget_denial_does_not_publish_earlier_chunks() {
         "UPDATE growth SET payload = '{}'",
         "x".repeat(3000)
     ));
-    assert!(
-        result.is_err(),
-        "all replacement versions exceed the budget"
-    );
+    assert!(result
+        .expect_err("all replacement versions exceed the budget")
+        .to_string()
+        .contains("over budget"));
     assert_eq!(
         runtime
             .execute_query("SELECT id FROM growth WHERE payload = 'small'")
@@ -261,10 +261,11 @@ fn mutation_memory_index_growth_is_reserved_before_data_changes() {
         )
         .expect("reserve");
     let sql = format!("UPDATE growth SET payload = '{}'", "x".repeat(16 * 1024));
-    assert!(
-        runtime.execute_query(&sql).is_err(),
-        "index bytes must participate in admission"
-    );
+    assert!(runtime
+        .execute_query(&sql)
+        .expect_err("index bytes must participate in admission")
+        .to_string()
+        .contains("over budget"));
     assert_eq!(
         runtime
             .execute_query("SELECT payload FROM growth WHERE payload = 'small'")
@@ -368,12 +369,15 @@ fn mutation_memory_wal_child() {
     runtime
         .execute_query("UPDATE growth SET payload = 'committed'")
         .expect("durable update");
-    assert!(runtime
+    // Stay below the parser's 1 MiB input cap. The row plus retained
+    // zone bounds exceed this runtime's 4 MiB memory budget.
+    let denied = runtime
         .execute_query(&format!(
             "UPDATE growth SET payload = '{}'",
-            "x".repeat(8 * 1024 * 1024)
+            "x".repeat(900 * 1024)
         ))
-        .is_err());
+        .expect_err("memory admission must reject the replacement");
+    assert!(denied.to_string().contains("over budget"), "{denied}");
     // Simulate process loss without running runtime/storage destructors.
     std::process::exit(0);
 }

--- a/crates/reddb-server/src/runtime/mutation_memory_tests.rs
+++ b/crates/reddb-server/src/runtime/mutation_memory_tests.rs
@@ -537,3 +537,58 @@ fn mutation_memory_native_vector_content_and_graph_type_are_governed() {
         );
     }
 }
+
+#[test]
+fn mutation_memory_batch_amortizes_pool_sampling() {
+    let runtime = seeded_runtime(4 * 1024 * 1024, false);
+    for _ in 1..100 {
+        runtime
+            .execute_query("INSERT INTO growth (payload) VALUES ('small')")
+            .expect("seed");
+    }
+    let before = runtime.inner.memory_reservations.lock().samples;
+    runtime
+        .execute_query("UPDATE growth SET payload = 'updated'")
+        .expect("batch update");
+    let samples = runtime.inner.memory_reservations.lock().samples - before;
+    assert!(
+        samples < 10,
+        "100 small mutations must not sample every pool per row: {samples}"
+    );
+    assert_eq!(
+        runtime
+            .execute_query("SELECT payload FROM growth WHERE payload = 'updated'")
+            .expect("readback")
+            .result
+            .records
+            .len(),
+        100
+    );
+}
+
+#[test]
+fn mutation_memory_batch_optional_slack_cannot_deny_a_fitting_update() {
+    let runtime = seeded_runtime(128 * 1024, false);
+    runtime.refresh_memory_accounting();
+    let headroom =
+        runtime.memory_budget().resolved_bytes - runtime.memory_accounting().total_used_bytes();
+    let _held = runtime
+        .admit_non_evictable_growth(
+            crate::storage::memory_pools::MemoryPool::IndexMemory,
+            "competing writer",
+            headroom - 8 * 1024,
+        )
+        .expect("leave less than a reservation quantum");
+    runtime
+        .execute_query("UPDATE growth SET payload = 'updated'")
+        .expect("the replacement fits without speculative slack");
+    assert_eq!(
+        runtime
+            .execute_query("SELECT payload FROM growth WHERE payload = 'updated'")
+            .expect("readback")
+            .result
+            .records
+            .len(),
+        1
+    );
+}

--- a/crates/reddb-server/src/storage/unified/memory_size.rs
+++ b/crates/reddb-server/src/storage/unified/memory_size.rs
@@ -119,13 +119,19 @@ pub(crate) fn entity_bytes(entity: &UnifiedEntity) -> usize {
             });
             columns.saturating_add(row.named.as_ref().map_or(0, named_fields_bytes))
         }
-        EntityData::Node(node) => named_fields_bytes(&node.properties),
+        EntityData::Node(node) => {
+            named_fields_bytes(&node.properties).saturating_add(match &entity.kind {
+                super::entity::EntityKind::GraphNode(kind) => kind.node_type.len(),
+                _ => 0,
+            })
+        }
         EntityData::Edge(edge) => named_fields_bytes(&edge.properties),
         EntityData::Vector(vector) => std::mem::size_of_val(vector.dense.as_slice())
             .saturating_add(vector.sparse.as_ref().map_or(0, |sparse| {
                 std::mem::size_of_val(sparse.indices.as_slice())
                     .saturating_add(std::mem::size_of_val(sparse.values.as_slice()))
-            })),
+            }))
+            .saturating_add(vector.content.as_ref().map_or(0, String::len)),
         EntityData::TimeSeries(point) => 64usize
             .saturating_add(point.metric.len())
             .saturating_add(named_fields_bytes(&point.fields))

--- a/crates/reddb-server/src/storage/unified/memory_size.rs
+++ b/crates/reddb-server/src/storage/unified/memory_size.rs
@@ -1,0 +1,180 @@
+//! Payload estimates shared by segment accounting and mutation admission.
+//! Shared values are charged per resident owner: an Arc count changing must
+//! not change the amount released when a segment is reclaimed.
+
+use super::entity::{EntityData, UnifiedEntity};
+use reddb_types::Value;
+
+pub(crate) fn canonical_heap_bytes(key: &reddb_types::CanonicalKey) -> usize {
+    use reddb_types::CanonicalKey;
+    match key {
+        CanonicalKey::Text(_, value) => value.len(),
+        CanonicalKey::Bytes(_, value) => value.len(),
+        CanonicalKey::PairTextU64(_, value, _) => value.len(),
+        CanonicalKey::PairTextText(_, first, second) => first.len().saturating_add(second.len()),
+        _ => 0,
+    }
+}
+
+/// Two bounds and their canonical keys may retain the replacement payload.
+pub(crate) fn zone_growth_bytes(value: &Value) -> usize {
+    value_heap_bytes(value).saturating_mul(4)
+}
+
+pub(crate) fn entity_zone_growth_bytes(entity: &UnifiedEntity) -> usize {
+    let EntityData::Row(row) = &entity.data else {
+        return 0;
+    };
+    if let Some(named) = &row.named {
+        named
+            .values()
+            .map(zone_growth_bytes)
+            .fold(0, usize::saturating_add)
+    } else {
+        row.columns
+            .iter()
+            .map(zone_growth_bytes)
+            .fold(0, usize::saturating_add)
+    }
+}
+
+pub(crate) fn value_heap_bytes(value: &Value) -> usize {
+    if !matches!(value, Value::Array(_)) {
+        return scalar_heap_bytes(value);
+    }
+    array_heap_bytes(value)
+}
+
+#[inline(never)]
+fn array_heap_bytes(value: &Value) -> usize {
+    // One iterator per permitted parser level, never recursion or heap scratch.
+    const LEVELS: usize = reddb_rql::limits::JSON_LITERAL_MAX_DEPTH as usize + 1;
+    let mut stack: [std::slice::Iter<'_, Value>; LEVELS] = std::array::from_fn(|_| [].iter());
+    let mut depth = 0;
+    let mut current = Some(value);
+    let mut bytes = 0usize;
+    loop {
+        if let Some(value) = current.take() {
+            if let Value::Array(values) = value {
+                if depth == LEVELS {
+                    // Values supplied directly by an API can exceed parser
+                    // limits. An unrepresentable estimate cannot be admitted.
+                    return usize::MAX;
+                }
+                bytes = bytes.saturating_add(std::mem::size_of_val(values.as_slice()));
+                stack[depth] = values.iter();
+                depth += 1;
+            } else {
+                bytes = bytes.saturating_add(scalar_heap_bytes(value));
+            }
+        }
+        if depth == 0 {
+            return bytes;
+        }
+        current = stack[depth - 1].next();
+        if current.is_none() {
+            depth -= 1;
+        }
+    }
+}
+
+fn scalar_heap_bytes(value: &Value) -> usize {
+    match value {
+        Value::Text(value) => value.len(),
+        Value::Blob(value) | Value::Json(value) | Value::Secret(value) => value.len(),
+        Value::Vector(value) => std::mem::size_of_val(value.as_slice()),
+        Value::NodeRef(value)
+        | Value::EdgeRef(value)
+        | Value::VectorRef(value, _)
+        | Value::RowRef(value, _)
+        | Value::DocRef(value, _)
+        | Value::TableRef(value)
+        | Value::Email(value)
+        | Value::Url(value)
+        | Value::Password(value)
+        | Value::DecimalText(value)
+        | Value::AssetCode(value) => value.len(),
+        Value::KeyRef(collection, key) => collection.len().saturating_add(key.len()),
+        Value::Money { asset_code, .. } => asset_code.len(),
+        _ => 0,
+    }
+}
+
+fn named_fields_bytes(fields: &std::collections::HashMap<String, Value>) -> usize {
+    fields.iter().fold(0usize, |bytes, (name, value)| {
+        bytes
+            .saturating_add(64)
+            .saturating_add(name.len())
+            .saturating_add(value_heap_bytes(value))
+    })
+}
+
+pub(crate) fn entity_bytes(entity: &UnifiedEntity) -> usize {
+    let data = match &entity.data {
+        EntityData::Row(row) => {
+            let columns = row.columns.iter().fold(0usize, |bytes, value| {
+                bytes
+                    .saturating_add(64)
+                    .saturating_add(value_heap_bytes(value))
+            });
+            columns.saturating_add(row.named.as_ref().map_or(0, named_fields_bytes))
+        }
+        EntityData::Node(node) => named_fields_bytes(&node.properties),
+        EntityData::Edge(edge) => named_fields_bytes(&edge.properties),
+        EntityData::Vector(vector) => std::mem::size_of_val(vector.dense.as_slice())
+            .saturating_add(vector.sparse.as_ref().map_or(0, |sparse| {
+                std::mem::size_of_val(sparse.indices.as_slice())
+                    .saturating_add(std::mem::size_of_val(sparse.values.as_slice()))
+            })),
+        EntityData::TimeSeries(point) => 64usize
+            .saturating_add(point.metric.len())
+            .saturating_add(named_fields_bytes(&point.fields))
+            .saturating_add(point.tags.iter().fold(0usize, |bytes, (name, value)| {
+                bytes
+                    .saturating_add(64)
+                    .saturating_add(name.len())
+                    .saturating_add(value.len())
+            })),
+        EntityData::QueueMessage(message) => {
+            128usize.saturating_add(value_heap_bytes(&message.payload))
+        }
+    };
+    entity.embeddings().iter().fold(
+        std::mem::size_of::<UnifiedEntity>()
+            .saturating_add(data)
+            .saturating_add(std::mem::size_of_val(entity.cross_refs())),
+        |bytes, embedding| {
+            bytes
+                .saturating_add(std::mem::size_of_val(embedding.vector.as_slice()))
+                .saturating_add(embedding.name.len())
+                .saturating_add(embedding.model.len())
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nested_arrays_charge_slots_and_variable_payloads_per_owner() {
+        let shared = Value::text("shared payload");
+        let value = Value::Array(vec![shared.clone(), Value::Array(vec![shared].into())].into());
+        assert_eq!(
+            value_heap_bytes(&value),
+            3 * std::mem::size_of::<Value>() + 2 * "shared payload".len()
+        );
+        let another_owner = value.clone();
+        assert_eq!(value_heap_bytes(&value), value_heap_bytes(&another_owner));
+    }
+
+    #[test]
+    fn excessively_nested_api_values_fail_closed() {
+        let mut value = Value::Null;
+        for _ in 0..reddb_rql::limits::JSON_LITERAL_MAX_DEPTH + 2 {
+            value = Value::Array(vec![value].into());
+        }
+        assert_eq!(value_heap_bytes(&value), usize::MAX);
+        assert_eq!(zone_growth_bytes(&value), usize::MAX);
+    }
+}

--- a/crates/reddb-server/src/storage/unified/mod.rs
+++ b/crates/reddb-server/src/storage/unified/mod.rs
@@ -46,6 +46,7 @@ pub mod entity_cache;
 pub mod hash_index;
 pub mod index;
 pub mod manager;
+pub(crate) mod memory_size;
 pub mod metadata;
 pub mod segment;
 pub mod segment_codec;

--- a/crates/reddb-server/src/storage/unified/segment.rs
+++ b/crates/reddb-server/src/storage/unified/segment.rs
@@ -304,6 +304,21 @@ pub struct ColZone {
 }
 
 impl ColZone {
+    fn payload_bytes(&self) -> usize {
+        super::memory_size::value_heap_bytes(&self.min)
+            .saturating_add(super::memory_size::value_heap_bytes(&self.max))
+            .saturating_add(
+                self.min_key
+                    .as_ref()
+                    .map_or(0, super::memory_size::canonical_heap_bytes),
+            )
+            .saturating_add(
+                self.max_key
+                    .as_ref()
+                    .map_or(0, super::memory_size::canonical_heap_bytes),
+            )
+    }
+
     fn new(v: Value) -> Self {
         Self {
             min_key: value_to_canonical_key(&v),
@@ -524,6 +539,7 @@ pub struct GrowingSegment {
 
     /// Per-column zone maps: col_name → (min, max) for segment pruning
     col_zones: HashMap<String, ColZone>,
+    zone_payload_bytes: usize,
     /// Sealed-only minmax-multi summaries built from canonical ordering.
     sealed_col_zones: HashMap<String, MultiColZone>,
 
@@ -695,6 +711,7 @@ impl GrowingSegment {
             cross_ref_forward: HashMap::new(),
             cross_ref_reverse: HashMap::new(),
             col_zones: HashMap::new(),
+            zone_payload_bytes: 0,
             sealed_col_zones: HashMap::new(),
             sequence: AtomicU64::new(0),
             memory_bytes: AtomicU64::new(0),
@@ -762,7 +779,9 @@ impl GrowingSegment {
                     .filter(|slot| slot.id == entity.id)
                 {
                     let snapshot = UpdateIndexSnapshot::from_entity(slot);
+                    let old_bytes = Self::estimate_entity_size(slot);
                     slot.clone_from(entity);
+                    self.replace_entity_memory(old_bytes, Self::estimate_entity_size(entity));
                     return Ok(snapshot);
                 }
             }
@@ -770,14 +789,18 @@ impl GrowingSegment {
                 return Err(SegmentError::NotFound(entity.id));
             };
             let snapshot = UpdateIndexSnapshot::from_entity(slot);
+            let old_bytes = Self::estimate_entity_size(slot);
             slot.clone_from(entity);
+            self.replace_entity_memory(old_bytes, Self::estimate_entity_size(entity));
             Ok(snapshot)
         } else {
             let Some(slot) = self.entities.get_mut(&entity.id) else {
                 return Err(SegmentError::NotFound(entity.id));
             };
             let snapshot = UpdateIndexSnapshot::from_entity(slot);
+            let old_bytes = Self::estimate_entity_size(slot);
             slot.clone_from(entity);
+            self.replace_entity_memory(old_bytes, Self::estimate_entity_size(entity));
             Ok(snapshot)
         }
     }
@@ -937,12 +960,21 @@ impl GrowingSegment {
         self.memory_bytes.fetch_add(bytes as u64, Ordering::Relaxed);
     }
 
+    fn replace_entity_memory(&self, previous: usize, current: usize) {
+        if current >= previous {
+            self.add_memory(current - previous);
+        } else {
+            self.release_memory(previous - current);
+        }
+    }
+
     /// This segment's approximate resident bytes. One relaxed load — the
     /// arena's contribution to the shared accounting pool (ADR 0073 §2).
     /// Unlike `stats()` this never walks the entity map, so a stats reader
     /// does not pay `O(entities)` to observe memory.
     pub fn memory_bytes(&self) -> u64 {
         self.memory_bytes.load(Ordering::Relaxed)
+            + self.zone_payload_bytes as u64
             + self.unique_key_lookup_bytes.load(Ordering::Relaxed)
             + self.graph_read_index_bytes.load(Ordering::Relaxed)
             + (self.hash_scan_ids.capacity() * std::mem::size_of::<EntityId>()) as u64
@@ -1061,29 +1093,7 @@ impl GrowingSegment {
 
     /// Estimate memory for an entity
     fn estimate_entity_size(entity: &UnifiedEntity) -> usize {
-        let mut size = std::mem::size_of::<UnifiedEntity>();
-
-        // Add data size
-        size += match &entity.data {
-            EntityData::Row(row) => row.columns.len() * 64, // Rough estimate
-            EntityData::Node(node) => node.properties.len() * 128,
-            EntityData::Edge(edge) => edge.properties.len() * 128,
-            EntityData::Vector(vec) => {
-                vec.dense.len() * 4 + vec.sparse.as_ref().map_or(0, |s| s.indices.len() * 8)
-            }
-            EntityData::TimeSeries(_) => 64,
-            EntityData::QueueMessage(_) => 128,
-        };
-
-        // Add embeddings
-        for emb in entity.embeddings() {
-            size += emb.vector.len() * 4 + emb.name.len() + emb.model.len();
-        }
-
-        // Add cross-refs
-        size += std::mem::size_of_val(entity.cross_refs());
-
-        size
+        super::memory_size::entity_bytes(entity)
     }
 
     /// Update per-column zone maps from a newly inserted entity's fields.
@@ -1093,30 +1103,37 @@ impl GrowingSegment {
     /// - **Positional** (`row.columns` + `row.schema`): bulk-inserted entities stored as `Vec<Value>`
     ///   keyed by the shared schema. Previously this path was silently skipped, meaning zone maps
     ///   were always empty for bulk-loaded tables and segment pruning never fired.
+    fn update_column_zone(&mut self, column: &str, value: &Value) {
+        if matches!(value, Value::Null) {
+            return;
+        }
+        match self.col_zones.entry(column.to_string()) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                let before = entry.get().payload_bytes();
+                entry.get_mut().update(value);
+                self.zone_payload_bytes = self
+                    .zone_payload_bytes
+                    .saturating_sub(before)
+                    .saturating_add(entry.get().payload_bytes());
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                let zone = ColZone::new(value.clone());
+                self.zone_payload_bytes =
+                    self.zone_payload_bytes.saturating_add(zone.payload_bytes());
+                entry.insert(zone);
+            }
+        }
+    }
+
     fn update_col_zones_from_entity(&mut self, entity: &UnifiedEntity) {
         if let EntityData::Row(row) = &entity.data {
             if let Some(named) = &row.named {
-                // Individual insert path — HashMap fields
-                for (col, val) in named {
-                    if matches!(val, Value::Null) {
-                        continue;
-                    }
-                    self.col_zones
-                        .entry(col.clone())
-                        .and_modify(|z| z.update(val))
-                        .or_insert_with(|| ColZone::new(val.clone()));
+                for (column, value) in named {
+                    self.update_column_zone(column, value);
                 }
             } else if let Some(schema) = &row.schema {
-                // Bulk-insert (columnar) path — positional Vec<Value> + shared schema.
-                // Previously skipped: zone maps were always empty for bulk-loaded tables.
-                for (col, val) in schema.iter().zip(row.columns.iter()) {
-                    if matches!(val, Value::Null) {
-                        continue;
-                    }
-                    self.col_zones
-                        .entry(col.clone())
-                        .and_modify(|z| z.update(val))
-                        .or_insert_with(|| ColZone::new(val.clone()));
+                for (column, value) in schema.iter().zip(&row.columns) {
+                    self.update_column_zone(column, value);
                 }
             }
         }
@@ -1190,6 +1207,21 @@ impl GrowingSegment {
             }
         }
 
+        let previous = self
+            .sealed_col_zones
+            .values()
+            .flat_map(|zones| &zones.intervals)
+            .map(ColZone::payload_bytes)
+            .fold(0, usize::saturating_add);
+        let current = sealed_col_zones
+            .values()
+            .flat_map(|zones| &zones.intervals)
+            .map(ColZone::payload_bytes)
+            .fold(0, usize::saturating_add);
+        self.zone_payload_bytes = self
+            .zone_payload_bytes
+            .saturating_sub(previous)
+            .saturating_add(current);
         self.sealed_col_zones = sealed_col_zones;
     }
 
@@ -1747,6 +1779,10 @@ impl GrowingSegment {
                 // instead of the old ncols×nrows.
                 let mut iter = values.into_iter();
                 if let Some(first) = iter.next() {
+                    let previous = self
+                        .col_zones
+                        .get(col_name)
+                        .map_or(0, ColZone::payload_bytes);
                     let zone = self
                         .col_zones
                         .entry(col_name.clone())
@@ -1755,14 +1791,15 @@ impl GrowingSegment {
                     for v in iter {
                         zone.update(&v);
                     }
+                    self.zone_payload_bytes = self
+                        .zone_payload_bytes
+                        .saturating_sub(previous)
+                        .saturating_add(zone.payload_bytes());
                 }
             }
         }
         for (col, val) in named_zone_updates {
-            self.col_zones
-                .entry(col)
-                .and_modify(|z| z.update(&val))
-                .or_insert_with(|| ColZone::new(val));
+            self.update_column_zone(&col, &val);
         }
 
         self.add_memory(batch_bytes);

--- a/scripts/mutation-memory-bench.mjs
+++ b/scripts/mutation-memory-bench.mjs
@@ -1,0 +1,49 @@
+// Diagnostic before/after SDK timings, not a cross-database benchmark.
+// Build both binaries with the same profile. Run with no concurrent builds:
+// REDDB_MEMORY_BUDGET=67108864 node scripts/mutation-memory-bench.mjs BEFORE AFTER
+import { connect } from '../drivers/js/src/index.js';
+import { performance } from 'node:perf_hooks';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+
+const [before, after] = process.argv.slice(2);
+if (!before || !after) throw new Error('Usage: node scripts/mutation-memory-bench.mjs BEFORE AFTER');
+const binaries = { before, after };
+const samples = { single: { before: [], after: [] }, bulk: { before: [], after: [] } };
+for (const mode of ['single', 'bulk']) {
+  for (let run = 0; run < 7; run++) {
+    for (const label of run % 2 ? ['after', 'before'] : ['before', 'after']) {
+      const db = await connect('memory://', { binary: binaries[label] });
+      try {
+        await db.query('CREATE TABLE perf_growth (id INT, payload TEXT)');
+        const rows = mode === 'single' ? 1 : 2500;
+        for (let offset = 0; offset < rows; offset += 500) {
+          const values = Array.from({ length: Math.min(500, rows - offset) }, (_, i) => `(${offset + i},'seed')`).join(',');
+          await db.query(`INSERT INTO perf_growth (id,payload) VALUES ${values}`);
+        }
+        const query = 'UPDATE perf_growth SET payload = $1' + (mode === 'single' ? ' WHERE id = 0' : '');
+        for (let i = 0; i < (mode === 'single' ? 30 : 1); i++) await db.query(query, ['warmup']);
+        const iterations = mode === 'single' ? 300 : 8;
+        const start = performance.now();
+        for (let i = 0; i < iterations; i++) await db.query(query, [`value-${i}`]);
+        const elapsed = (performance.now() - start) / iterations;
+        const readback = await db.query('SELECT id FROM perf_growth WHERE payload = $1', [`value-${iterations - 1}`]);
+        if (readback.rows.length !== rows) throw new Error(`${mode}/${label}: readback mismatch`);
+        samples[mode][label].push(elapsed);
+      } finally {
+        await db.close();
+      }
+    }
+  }
+}
+const result = {
+  node: process.version,
+  budget: process.env.REDDB_MEMORY_BUDGET ?? 'host-detected',
+  binary_sha256: Object.fromEntries(Object.entries(binaries).map(([label, path]) => [label, createHash('sha256').update(readFileSync(path)).digest('hex')])),
+  samples_ms: samples,
+  summary: Object.fromEntries(Object.entries(samples).map(([mode, values]) => {
+    const median = label => [...values[label]].sort((a, b) => a - b)[3];
+    return [mode, { before_ms: median('before'), after_ms: median('after'), change_percent: (median('after') / median('before') - 1) * 100 }];
+  })),
+};
+console.log(JSON.stringify(result, null, 2));

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -1960,13 +1960,15 @@ fn red_stats_echoes_an_explicitly_configured_memory_budget() {
 #[test]
 fn small_budget_denies_live_entity_growth_didactically_and_keeps_serving() {
     cleanup_scope();
-    let budget = 32 * 1024;
+    // Include the boot catalog payloads while leaving room for live inserts.
+    let budget = 64 * 1024;
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory().with_memory_budget(budget))
         .expect("runtime with a tiny explicit budget");
 
     exec(&rt, "CREATE TABLE budget_gate (id INT, body TEXT)");
 
     let mut denied = None;
+    let mut inserted = 0;
     for id in 0..1_000 {
         let sql = format!(
             "INSERT INTO budget_gate (id, body) VALUES ({id}, '{}')",
@@ -1976,10 +1978,15 @@ fn small_budget_denies_live_entity_growth_didactically_and_keeps_serving() {
             denied = Some(err.to_string());
             break;
         }
+        inserted += 1;
     }
+    assert!(
+        inserted > 0,
+        "the fixture must admit writes before reaching pressure"
+    );
     let err = denied.expect("small budget eventually denies live growth");
     assert!(
-        err.contains("operation needs ~") && err.contains("bytes over budget 32768"),
+        err.contains("operation needs ~") && err.contains(&format!("bytes over budget {budget}")),
         "{err}"
     );
     assert!(err.contains("largest consumers:"), "{err}");
@@ -2011,7 +2018,8 @@ fn small_budget_denies_live_entity_growth_didactically_and_keeps_serving() {
 #[test]
 fn pressure_reclamation_runs_consolidation_before_refusing_growth() {
     cleanup_scope();
-    let budget = 112 * 1024;
+    // Named row payloads and retained zone bounds participate in accounting.
+    let budget = 160 * 1024;
     let rt = RedDBRuntime::with_options(RedDBOptions::in_memory().with_memory_budget(budget))
         .expect("runtime with a small explicit budget");
 
@@ -2044,7 +2052,7 @@ fn pressure_reclamation_runs_consolidation_before_refusing_growth() {
 
     let before_reclamations = budget_unsigned(&rt, "pressure_reclamations_triggered");
     // Rows plus their index must fit after reclamation, not just current usage.
-    let pressure_rows = (10_000..10_032)
+    let pressure_rows = (10_000..10_064)
         .map(|id| format!("({id}, 'pressure')"))
         .collect::<Vec<_>>()
         .join(", ");

--- a/tests/grouped/schema_query_core/e2e_red_schema.rs
+++ b/tests/grouped/schema_query_core/e2e_red_schema.rs
@@ -2052,7 +2052,7 @@ fn pressure_reclamation_runs_consolidation_before_refusing_growth() {
 
     let before_reclamations = budget_unsigned(&rt, "pressure_reclamations_triggered");
     // Rows plus their index must fit after reclamation, not just current usage.
-    let pressure_rows = (10_000..10_064)
+    let pressure_rows = (10_000..10_048)
         .map(|id| format!("({id}, 'pressure')"))
         .collect::<Vec<_>>()
         .join(", ");


### PR DESCRIPTION
UPDATE and native PATCH could accept a growing payload beyond the configured memory budget, and in-place replacements left resident counters unchanged. With a 128 KiB budget, the parent binary accepted a 512 KiB low-compressibility payload in both tables and documents. The corrected binary returns `over budget` and preserves the original value.

Reserve each post-image, possible retained zone bounds, and secondary-index growth before storage publication. Keep reservations through index maintenance. Small UPDATE post-images share 64 KiB reservation quanta to amortize pool sampling; optional slack falls back to the exact requirement when it does not fit. Admit every UPDATE target before publishing the first 2,048-row chunk, preventing a later budget denial from leaving an earlier chunk visible. If a later non-budget failure occurs, finish index/CDC maintenance for already completed chunks.

The shared estimates cover variable Value payloads, arrays with bounded iterative traversal, graph properties/type, vector content/components, and retained physical versions. In-place grow/shrink updates reconcile segment counters without refunding payloads still retained by zone bounds.

Validation:
- 42 focused tests pass: table/document/native PATCH denial, vector and graph payloads, grow/shrink on growing and sealed segments, late batch denial, BTree keys, concurrent reservations, cross-chunk uniqueness, process-exit WAL recovery, amortized pool sampling and exact admission under tight headroom. Denial tests require the memory-budget error, including the WAL test below the parser input cap.
- 41 local red-schema/memory-pressure integration tests pass; 179 selected UPDATE/PATCH, uniqueness, rollback/savepoint and authorization tests also passed during implementation. The complete standard CI passes on the final commit, including all four test shards and PG-Wire client conformance.
- `cargo fmt --all -- --check`, `cargo check --locked --all`, and `rustup run 1.95.0 cargo clippy --locked --all -- -D warnings` pass.
- SDK readback reproduces the parent failure and verifies rejection with unchanged data after the fix.

Performance diagnostics (debug profile, Rust 1.97.1, Node 24.15.0, i7-1065G7, 64 MiB budget): seven fresh-process runs per binary, alternating order, 30/1 warmups and 300/8 measured UPDATE statements for single/bulk cases. The table is the median of **run-average** milliseconds per statement, not per-operation p95/p99.

| Scenario | Parent | This change | Observed change |
| --- | ---: | ---: | ---: |
| One-row UPDATE | 2.985 | 3.151 | +5.6% |
| 2,500-row UPDATE | 5325.069 | 6258.265 | +17.5% |

**Performance remains inconclusive and potentially regressed.** An unrelated Rust build and Vitest workload were observed during the final run; parent bulk samples rose to 12.59 s and 10.84 s. Earlier unbatched diagnostics showed +23.9% bulk latency. Reservation quanta reduce pool sampling (enforced by a test), but these shared-host measurements do not establish recovered end-to-end latency. Bulk performance is tracked in #2319; it is not counted as a win or as release acceptance evidence.

Reproduce on an uncontended host, using equally built parent/current binaries:

```sh
REDDB_MEMORY_BUDGET=67108864 node scripts/mutation-memory-bench.mjs BEFORE_BIN AFTER_BIN
```

Parent source: `d07b677c1a85f15ffa6ae38aaa3bdf74c7383e1d` (same tree as the saved baseline build). Current source: `6d7d529db13cf620a841e66e482748b768bbcc9f`. Full raw samples, including the unfavorable/outlier runs:

<details><summary>Raw performance samples and binary hashes</summary>

```json
{
  "node": "v24.15.0",
  "budget": "67108864",
  "binary_sha256": {
    "before": "1caacade17921616869c146c1527ae83260142b6d2408166ac65ee0171941a84",
    "after": "d2137d8a3730c266a68538f9cab68bce8cf92b4403c3f688a96ff27bb94a61e9"
  },
  "samples_ms": {
    "single": {
      "before": [
        2.985067706666667,
        2.5805554500000003,
        2.6203927466666666,
        2.951382716666667,
        3.0952943633333296,
        3.168037096666667,
        3.546330680000004
      ],
      "after": [
        3.1508865333333325,
        2.8948983766666667,
        2.5753786066666664,
        2.9461297466666654,
        3.8601693266666675,
        3.8399368166666683,
        3.83192707333333
      ]
    },
    "bulk": {
      "before": [
        5283.9695835,
        4616.952797500002,
        5174.586391749999,
        5344.377306999995,
        5325.068624750005,
        12590.798686374997,
        10838.358055375007
      ],
      "after": [
        6431.557797874999,
        5480.71715325,
        5942.365179624998,
        6320.0542228750055,
        5863.977453625004,
        6258.264853624991,
        6992.084361250003
      ]
    }
  },
  "summary": {
    "single": {
      "before_ms": 2.985067706666667,
      "after_ms": 3.1508865333333325,
      "change_percent": 5.554943571173809
    },
    "bulk": {
      "before_ms": 5325.068624750005,
      "after_ms": 6258.264853624991,
      "change_percent": 17.524585965665306
    }
  }
}
```
</details>

Memory estimates remain conservative: shared payloads are charged per resident owner, compressed document bodies use their stored size, and mutation admission reserves the full replacement without stale pre-image credit. This governs entity payloads and secondary-index growth, not total process RSS or separate metadata/cache accounting. No storage/wire format changes; arbitrary I/O-error statement atomicity is unchanged.

Cost sketch: N targets retain N prepared mutations and enough reservation quanta for their estimated bytes before publishing in existing 2,048-row chunks; payload estimation visits nested value slots without recursion or heap scratch. These measurements compare this patch with its parent, not SQLite, PostgreSQL, Cassandra or SurrealDB.

Refs #2270. Standard CI: https://github.com/reddb-io/reddb/actions/runs/34406789369
