### PR TITLE
perf(runtime): batch UPDATE WAL publication and preserve recovery tails

### DIFF
--- a/crates/reddb-server/src/runtime/impl_dml_batch.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_batch.rs
@@ -241,11 +241,12 @@ impl RedDBRuntime {
         &self,
         applied: &[AppliedEntityMutation],
     ) -> RedDBResult<()> {
-        // Transactions and event-enabled statements already own their capture.
-        // Otherwise publish this bounded chunk with one durable WAL append,
+        // One item cannot amortize a WAL append. Transactions and event-enabled
+        // statements already own their capture. Otherwise publish this bounded
+        // chunk with one durable WAL append,
         // instead of synchronizing each old/new row-version pair separately.
         // The wrapper also appends completed writes if a later item fails.
-        if UnifiedStore::deferred_store_wal_capture_active() {
+        if applied.len() <= 1 || UnifiedStore::deferred_store_wal_capture_active() {
             self.persist_applied_entity_mutations(applied)?;
         } else {
             self.with_deferred_store_wal_for_dml(true, || {

--- a/crates/reddb-server/src/runtime/impl_dml_batch.rs
+++ b/crates/reddb-server/src/runtime/impl_dml_batch.rs
@@ -241,7 +241,17 @@ impl RedDBRuntime {
         &self,
         applied: &[AppliedEntityMutation],
     ) -> RedDBResult<()> {
-        self.persist_applied_entity_mutations(applied)?;
+        // Transactions and event-enabled statements already own their capture.
+        // Otherwise publish this bounded chunk with one durable WAL append,
+        // instead of synchronizing each old/new row-version pair separately.
+        // The wrapper also appends completed writes if a later item fails.
+        if UnifiedStore::deferred_store_wal_capture_active() {
+            self.persist_applied_entity_mutations(applied)?;
+        } else {
+            self.with_deferred_store_wal_for_dml(true, || {
+                self.persist_applied_entity_mutations(applied)
+            })?;
+        }
         #[cfg(test)]
         if let Some(first) = applied.first() {
             self.index_store_ref().mutation_test_hook(

--- a/crates/reddb-server/src/runtime/mutation_memory_tests.rs
+++ b/crates/reddb-server/src/runtime/mutation_memory_tests.rs
@@ -592,3 +592,92 @@ fn mutation_memory_batch_optional_slack_cannot_deny_a_fitting_update() {
         1
     );
 }
+
+#[test]
+fn bulk_update_wal_child() {
+    let Some(path) = std::env::var_os("REDDB_BULK_UPDATE_WAL_TEST_PATH") else {
+        return;
+    };
+    let runtime = RedDBRuntime::with_options(
+        RedDBOptions::persistent(&path)
+            .with_memory_budget(32 * 1024 * 1024)
+            .with_auto_checkpoint(0),
+    )
+    .expect("persistent runtime");
+    runtime
+        .execute_query("CREATE TABLE batch_growth (id INT, payload TEXT)")
+        .expect("table");
+    for start in (0..2050).step_by(500) {
+        let rows = (start..(start + 500).min(2050))
+            .map(|id| format!("({id}, 'seed')"))
+            .collect::<Vec<_>>()
+            .join(",");
+        runtime
+            .execute_query(&format!(
+                "INSERT INTO batch_growth (id,payload) VALUES {rows}"
+            ))
+            .expect("seed");
+    }
+    let generation_before = crate::storage::EmbeddedRdbArtifact::open(&path)
+        .expect("read initial durable boundary")
+        .selected_superblock
+        .generation;
+    runtime
+        .execute_query("UPDATE batch_growth SET payload = 'committed'")
+        .expect("durable bulk update");
+    let generation_after = crate::storage::EmbeddedRdbArtifact::open(&path)
+        .expect("read committed durable boundary")
+        .selected_superblock
+        .generation;
+    // Each embedded WAL append advances the durable superblock generation.
+    // Two chunks require two appends; either chunk may additionally grow the
+    // WAL region with a checkpoint. Per-row appends advanced it 2057 times.
+    let publications = generation_after - generation_before;
+    assert!(
+        (2..=4).contains(&publications),
+        "expected two chunk appends plus at most two growth checkpoints, got {publications}"
+    );
+    // Lose the process without a checkpoint or runtime/storage destructors.
+    std::process::exit(0);
+}
+
+#[test]
+fn bulk_update_wal_batches_and_recovers_every_key_after_process_exit() {
+    let directory = tempfile::tempdir().expect("directory");
+    let path = directory.path().join("batch-growth.rdb");
+    let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+        .args([
+            "--exact",
+            "runtime::mutation_memory_tests::bulk_update_wal_child",
+            "--nocapture",
+        ])
+        .env("REDDB_BULK_UPDATE_WAL_TEST_PATH", &path)
+        .output()
+        .expect("child");
+    assert!(
+        output.status.success(),
+        "child failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let runtime = RedDBRuntime::with_options(RedDBOptions::persistent(&path))
+        .expect("reopen after process loss");
+    let records = runtime
+        .execute_query("SELECT id,payload FROM batch_growth ORDER BY id")
+        .expect("recovered rows")
+        .result
+        .records;
+    assert_eq!(records.len(), 2050);
+    for (id, record) in records.iter().enumerate() {
+        assert_eq!(
+            record.get("id"),
+            Some(&reddb_types::Value::Integer(
+                i64::try_from(id).expect("small fixture")
+            ))
+        );
+        assert_eq!(
+            record.get("payload"),
+            Some(&reddb_types::Value::text("committed")),
+            "recovered payload for id={id}"
+        );
+    }
+}

--- a/crates/reddb-server/src/storage/unified/store/commit.rs
+++ b/crates/reddb-server/src/storage/unified/store/commit.rs
@@ -843,6 +843,10 @@ impl Drop for StoreCommitCoordinator {
 }
 
 impl UnifiedStore {
+    pub(crate) fn deferred_store_wal_capture_active() -> bool {
+        deferred_store_wal_capture_active()
+    }
+
     pub(crate) fn begin_deferred_store_wal_capture() {
         begin_deferred_store_wal_capture();
     }

--- a/crates/reddb-server/src/storage/unified/store/impl_file.rs
+++ b/crates/reddb-server/src/storage/unified/store/impl_file.rs
@@ -78,7 +78,10 @@ impl UnifiedStore {
         reddb_file::verify_native_store_crc32_footer(&mut buf, version)
             .map_err(|err| err.to_string())?;
 
-        let store = Self::with_config(config);
+        let mut store = Self::with_config(config);
+        // Reconstruct the snapshot without appending its old images to the
+        // live WAL. The caller replays that WAL after loading this snapshot.
+        let embedded_wal_path = store.config.embedded_wal_path.take();
         store.set_format_version(version);
 
         // Read collection count
@@ -156,6 +159,7 @@ impl UnifiedStore {
         if store.format_version() < STORE_VERSION_CURRENT {
             store.set_format_version(STORE_VERSION_CURRENT);
         }
+        store.config.embedded_wal_path = embedded_wal_path;
 
         Ok(store)
     }
@@ -1664,6 +1668,63 @@ impl UnifiedStore {
 mod aux_metadata_dump_tests {
     use super::*;
     use std::collections::HashMap;
+
+    #[test]
+    fn snapshot_load_preserves_existing_wal_and_restores_future_appends() {
+        let directory = tempfile::tempdir().expect("directory");
+        let path = directory.path().join("snapshot.rdb");
+        let store = UnifiedStore::with_config(UnifiedStoreConfig::default());
+        let old =
+            UnifiedEntity::table_row(EntityId::new(1), "rows", 1, vec![Value::text("snapshot")]);
+        store.insert_auto("rows", old).expect("snapshot row");
+        let snapshot = store.to_binary_dump_bytes();
+        crate::storage::EmbeddedRdbArtifact::create_with_snapshot(&path, &snapshot)
+            .expect("artifact");
+        let newer = UnifiedEntity::table_row(
+            EntityId::new(1),
+            "rows",
+            1,
+            vec![Value::text("durable WAL")],
+        );
+        let action = StoreWalAction::upsert_entity("rows", &newer, None, STORE_VERSION_CURRENT);
+        UnifiedStore::with_config(UnifiedStoreConfig::default().with_embedded_wal_path(&path))
+            .finish_paged_write([action])
+            .expect("durable update after snapshot");
+        let before = std::fs::read(&path).expect("original artifact bytes");
+        let loaded = UnifiedStore::load_from_bytes_with_config(
+            &snapshot,
+            UnifiedStoreConfig::default().with_embedded_wal_path(&path),
+        )
+        .expect("reconstruct snapshot");
+        assert_eq!(std::fs::read(&path).expect("artifact after load"), before);
+        assert_eq!(
+            loaded.config().embedded_wal_path.as_deref(),
+            Some(path.as_path())
+        );
+
+        let generation = crate::storage::EmbeddedRdbArtifact::open(&path)
+            .expect("boundary before future write")
+            .selected_superblock
+            .generation;
+        loaded
+            .insert_auto(
+                "rows",
+                UnifiedEntity::table_row(
+                    EntityId::new(2),
+                    "rows",
+                    2,
+                    vec![Value::text("future write")],
+                ),
+            )
+            .expect("future writes still append WAL");
+        assert_eq!(
+            crate::storage::EmbeddedRdbArtifact::open(&path)
+                .expect("boundary after future write")
+                .selected_superblock
+                .generation,
+            generation + 1
+        );
+    }
 
     #[test]
     fn aux_metadata_round_trips_through_binary_dump() {

--- a/docs/perf/bulk-update-wal-2026-09-09.md
+++ b/docs/perf/bulk-update-wal-2026-09-09.md
@@ -1,0 +1,96 @@
+# Bulk UPDATE WAL diagnosis (#2319)
+
+This is shared-host diagnostic evidence, not a competitive performance claim
+under ADR 0076. Other projects were compiling during the investigation.
+
+## Workload and storage
+
+The JavaScript SDK connects through the `red` subprocess using `memory://`.
+In this revision, that URI creates an **ephemeral persistent file**, including
+its embedded WAL. It does not select a RAM-only engine. The memory budget was
+64 MiB. The fixture seeds 2,500 `(id, payload)` rows in batches of 500, then
+updates every payload using a parameterized statement. Readback checks every
+expected key and value, including duplicate/missing/unexpected keys.
+
+The initial shortened diagnostic used four statements per process (the first
+is warmup), with Rust 1.97.1 debug binaries. Milliseconds, in execution order:
+
+| Source | Warmup | Statement 1 | Statement 2 | Statement 3 |
+| --- | ---: | ---: | ---: | ---: |
+| Before memory governance (`d07b677c1`) | 4447.123 | 4458.660 | 4945.785 | 5292.612 |
+| Merged memory governance (`f40d2244a`) | 4364.997 | 4571.041 | 5959.631 | 4923.904 |
+
+These runs confirm slow bulk UPDATEs, but do not attribute a regression to
+memory admission. They are not independent controlled comparisons.
+
+## Phase diagnosis
+
+Temporary timers on `f40d2244a` separated selection, preparation, admission,
+publication, secondary indexes and CDC. The four instrumented statements took
+4.550, 6.899, 7.076 and 7.300 seconds end to end. Publication accounted for
+4.438, 6.726, 6.883 and 7.089 seconds. Admission took only 11–19 milliseconds
+per statement (it is included in preparation, not added to it).
+
+A second probe split publication into old-version update, new-version insert,
+indexing, serialization and finalization. Most publication time was in
+`finish_paged_write`, called once per versioned row. The four end-to-end times
+were 13.898, 12.745, 17.151 and 14.614 seconds; finalization alone accounted for
+12.016, 10.863, 15.175 and 12.786 seconds. The much slower host during this run
+is another reason not to use these numbers as an accepted latency comparison.
+
+The embedded append writes WAL frames, synchronizes them, publishes the next
+superblock boundary, and synchronizes again. A sequential 2,500-row UPDATE
+therefore waits for 2,500 durable appends. The group commit coordinator cannot
+combine this embedded path's sequential per-row waits.
+
+Cost sketch: for N rows and chunk size C = 2,048, two synchronization calls per
+row cost approximately `2 * N * sync_latency`; batching the same WAL records
+per chunk reduces this component to `2 * ceil(N / C) * sync_latency`, plus
+any required WAL growth/checkpoint work. WAL payload bytes still have to be
+encoded and written. Acknowledged writes must remain durable.
+
+The full diagnostic script retains seven independent processes per binary,
+alternating order, the original warmups/iterations, per-statement samples and
+per-run p50/p95/p99. With only eight bulk statements, p95 and p99 are both the
+maximum observed statement; they are descriptive, not precise tail estimates.
+Do not treat correlated statements as independent runs for confidence bounds.
+
+## Change and correctness contract
+
+`persist_update_chunk` reuses the existing deferred-WAL wrapper for a chunk
+when no enclosing capture exists. An explicit transaction or event-enabled
+statement keeps ownership of its existing capture. An ordinary autocommit
+chunk appends its captured records durably before returning to index/CDC
+maintenance. The wrapper also appends completed writes if a later item fails,
+as the existing event-enabled autocommit path does.
+
+All-target memory admission and reservation lifetimes are unchanged. Normal
+UPDATE retains its 2,048-row publication chunks. This changes neither WAL
+encoding nor the configured durability policy. It does not add general
+statement rollback for I/O errors.
+
+The regression fixture updates 2,050 rows and reads the durable superblock
+generation. Before the change, it advanced 2,057 times (individual appends
+plus WAL-growth checkpoints). The required bound is two chunk appends and at
+most one growth checkpoint per chunk. The child then exits without running
+destructors; the parent reopens the database and checks all 2,050 IDs and
+payloads. No elapsed-time assertion is used for this structural regression.
+
+The first batching candidate passed the publication-count bound but failed
+recovery: the last two IDs retained `seed`. Inspection found that
+`load_from_bytes_with_config` reconstructed a snapshot using `insert_auto`
+while `embedded_wal_path` still targeted the live artifact. Loading old
+snapshot images could therefore append them after newer durable WAL images,
+including checkpointing the partially reconstructed store. Larger batches
+made the snapshot/WAL boundary in this fixture expose that existing hazard.
+
+Snapshot reconstruction now temporarily removes the embedded append path and
+restores it before returning the store. A separate regression starts with a
+snapshot plus a newer WAL action, checks that loading preserves the entire
+artifact byte for byte, and verifies that a subsequent normal insert still
+advances the durable boundary. The multi-chunk process-exit regression checks
+the complete snapshot-plus-WAL recovery path.
+
+Issue #2319 remains open for equivalent optimized builds and independent
+run-level latency evidence on an uncontended host. Neither this diagnosis nor
+a large reduction in sync count proves superiority to SQLite or SurrealDB.

--- a/scripts/mutation-memory-bench.mjs
+++ b/scripts/mutation-memory-bench.mjs
@@ -1,4 +1,5 @@
 // Diagnostic before/after SDK timings, not a cross-database benchmark.
+// memory:// uses an ephemeral persistent file, including the embedded WAL.
 // Build both binaries with the same profile. Run with no concurrent builds:
 // REDDB_MEMORY_BUDGET=67108864 node scripts/mutation-memory-bench.mjs BEFORE AFTER
 import { connect } from '../drivers/js/src/index.js';
@@ -45,6 +46,7 @@ for (const mode of ['single', 'bulk']) {
         if (ids.size !== rows) throw new Error(`${mode}/${label}: missing keys`);
         samples[mode][label].push(elapsed);
         statementSamples[mode][label].push(statements);
+        console.error(`${mode}/${label} run ${run + 1}/7: ${elapsed.toFixed(3)} ms/statement`);
       } finally {
         await db.close();
       }
@@ -54,6 +56,7 @@ for (const mode of ['single', 'bulk']) {
 const result = {
   node: process.version,
   classification: 'diagnostic; host exclusivity and build equivalence must be verified separately',
+  storage: 'memory:// (ephemeral file with embedded WAL, not a RAM-only backend)',
   workload: { runs: 7, single: { rows: 1, warmups: 30, iterations: 300 }, bulk: { rows: 2500, warmups: 1, iterations: 8 } },
   budget: process.env.REDDB_MEMORY_BUDGET ?? 'host-detected',
   binary_sha256: Object.fromEntries(Object.entries(binaries).map(([label, path]) => [label, createHash('sha256').update(readFileSync(path)).digest('hex')])),

--- a/scripts/mutation-memory-bench.mjs
+++ b/scripts/mutation-memory-bench.mjs
@@ -10,6 +10,7 @@ const [before, after] = process.argv.slice(2);
 if (!before || !after) throw new Error('Usage: node scripts/mutation-memory-bench.mjs BEFORE AFTER');
 const binaries = { before, after };
 const samples = { single: { before: [], after: [] }, bulk: { before: [], after: [] } };
+const statementSamples = { single: { before: [], after: [] }, bulk: { before: [], after: [] } };
 for (const mode of ['single', 'bulk']) {
   for (let run = 0; run < 7; run++) {
     for (const label of run % 2 ? ['after', 'before'] : ['before', 'after']) {
@@ -24,12 +25,26 @@ for (const mode of ['single', 'bulk']) {
         const query = 'UPDATE perf_growth SET payload = $1' + (mode === 'single' ? ' WHERE id = 0' : '');
         for (let i = 0; i < (mode === 'single' ? 30 : 1); i++) await db.query(query, ['warmup']);
         const iterations = mode === 'single' ? 300 : 8;
+        const statements = [];
         const start = performance.now();
-        for (let i = 0; i < iterations; i++) await db.query(query, [`value-${i}`]);
+        for (let i = 0; i < iterations; i++) {
+          const statementStart = performance.now();
+          await db.query(query, [`value-${i}`]);
+          statements.push(performance.now() - statementStart);
+        }
         const elapsed = (performance.now() - start) / iterations;
-        const readback = await db.query('SELECT id FROM perf_growth WHERE payload = $1', [`value-${iterations - 1}`]);
-        if (readback.rows.length !== rows) throw new Error(`${mode}/${label}: readback mismatch`);
+        const readback = await db.query('SELECT id,payload FROM perf_growth');
+        const ids = new Set();
+        for (const row of readback.rows) {
+          if (!Number.isInteger(row.id) || row.id < 0 || row.id >= rows || ids.has(row.id)
+              || row.payload !== `value-${iterations - 1}`) {
+            throw new Error(`${mode}/${label}: unexpected key, duplicate key or payload`);
+          }
+          ids.add(row.id);
+        }
+        if (ids.size !== rows) throw new Error(`${mode}/${label}: missing keys`);
         samples[mode][label].push(elapsed);
+        statementSamples[mode][label].push(statements);
       } finally {
         await db.close();
       }
@@ -38,9 +53,20 @@ for (const mode of ['single', 'bulk']) {
 }
 const result = {
   node: process.version,
+  classification: 'diagnostic; host exclusivity and build equivalence must be verified separately',
+  workload: { runs: 7, single: { rows: 1, warmups: 30, iterations: 300 }, bulk: { rows: 2500, warmups: 1, iterations: 8 } },
   budget: process.env.REDDB_MEMORY_BUDGET ?? 'host-detected',
   binary_sha256: Object.fromEntries(Object.entries(binaries).map(([label, path]) => [label, createHash('sha256').update(readFileSync(path)).digest('hex')])),
+  // Independent process runs remain the unit of comparison; statements within
+  // one run are correlated and must not be treated as independent repetitions.
   samples_ms: samples,
+  statement_samples_ms: statementSamples,
+  statement_percentiles_ms: Object.fromEntries(Object.entries(statementSamples).map(([mode, labels]) =>
+    [mode, Object.fromEntries(Object.entries(labels).map(([label, runs]) => [label, runs.map(values => {
+      const sorted = [...values].sort((a, b) => a - b);
+      const percentile = fraction => sorted[Math.ceil(fraction * sorted.length) - 1];
+      return { p50: percentile(0.5), p95: percentile(0.95), p99: percentile(0.99) };
+    })]))])),
   summary: Object.fromEntries(Object.entries(samples).map(([mode, values]) => {
     const median = label => [...values[label]].sort((a, b) => a - b)[3];
     return [mode, { before_ms: median('before'), after_ms: median('after'), change_percent: (median('after') / median('before') - 1) * 100 }];


### PR DESCRIPTION
Bulk UPDATE paid one durable embedded-WAL append per row. For multiple rows, this change collects the same records within each existing 2,048-row publication chunk and waits for durability before returning to index/CDC maintenance. Explicit transactions and event-enabled statements retain their enclosing WAL capture. Single-row updates retain the direct write path because there is no append to amortize. All-target memory admission, reservation lifetime, WAL encoding and configured durability remain unchanged.

The process-exit regression exposed a recovery hazard: reconstructing a snapshot with its live embedded append path enabled could write stale snapshot images after newer durable WAL images. Snapshot loading now disables that append path during reconstruction and restores it before returning. A separate test verifies byte-for-byte preservation of a snapshot plus newer WAL data, followed by a successful future append.

Evidence: a 2,050-row fixture previously advanced the durable superblock generation 2,057 times; it now fits two chunk appends plus bounded WAL-growth checkpoints and recovers every ID/payload after process exit without destructors. Temporary phase timers put most UPDATE time in per-row publication, with memory admission taking only 11–19 ms. `memory://` here uses an ephemeral persistent file, including WAL. The benchmark now verifies exact keys/values and records individual statement timings and per-run percentiles. See `docs/perf/bulk-update-wal-2026-09-09.md` for raw diagnostic observations and limits.

Cost sketch: synchronization work changes from approximately `2 * N * sync_latency` to `2 * ceil(N / 2048) * sync_latency`, plus WAL-growth/checkpoint work. Payload bytes still must be encoded and written. General I/O-error statement rollback is not added.

Validation:
- Focused local validation: 145 WAL tests, 15 mutation-memory tests and 7 index-topology tests passed. The full CI on the final commit reruns the complete unit/integration suite.
- Local `cargo fmt --all -- --check`, `cargo check --locked --all`, `cargo build --locked --bin red` and benchmark validation probes passed.
- Final PG-Wire client conformance passed: https://github.com/reddb-io/reddb/actions/runs/34432043649
- Final standard CI passed: https://github.com/reddb-io/reddb/actions/runs/34432043152 . A cache-service DNS failure before compilation was retried successfully; no checks were bypassed.

Final SDK diagnostic (Rust 1.97.1 debug builds, 64 MiB, seven fresh engine processes per binary, alternating order, exact readback):

| Workload | Before, ms/statement | After, ms/statement | Change |
| --- | ---: | ---: | ---: |
| Single row | 2.929 | 2.885 | -1.5% |
| 2,500 rows | 5192.250 | 325.251 | -93.7% |

These summaries are medians of independent run averages, not individual-statement p50. The host was shared with unrelated workloads. They are diagnostic and do not establish an accepted release/competitive performance claim.

<details><summary>Raw run averages and binary provenance</summary>

```json
{
  "node": "v24.15.0",
  "budget": "67108864",
  "binary_sha256": {
    "before": "d2137d8a3730c266a68538f9cab68bce8cf92b4403c3f688a96ff27bb94a61e9",
    "after": "fad3ab9dfd9f9b8e706d2488dbb8ed3cbafe6d263c0b80e28fb490168121f093"
  },
  "samples_ms": {
    "single": {
      "before": [
        3.5490317033333336,
        2.9162248433333327,
        2.929023076666666,
        2.90042229,
        3.003448759999998,
        2.9048017033333298,
        3.0116795333333295
      ],
      "after": [
        3.081531883333333,
        2.9057601433333335,
        2.874158823333334,
        2.885304463333335,
        2.907111663333332,
        2.8854428000000008,
        2.849521850000001
      ]
    },
    "bulk": {
      "before": [
        4579.372510125,
        4544.213527999998,
        5301.982953500001,
        5044.137619375,
        5221.009746,
        5320.753609375002,
        5192.249761375002
      ],
      "after": [
        320.2453716249993,
        321.87878462499975,
        325.2511386249971,
        318.87627350000184,
        508.40893850000066,
        603.5610299999971,
        363.17448850000073
      ]
    }
  },
  "statement_percentiles_ms": {
    "single": {
      "before": [
        {
          "p50": 3.483187999999984,
          "p95": 4.292318000000023,
          "p99": 4.62783300000001
        },
        {
          "p50": 2.8261520000005476,
          "p95": 3.762846999999965,
          "p99": 4.266652000000249
        },
        {
          "p50": 2.8549259999999776,
          "p95": 3.7307780000001003,
          "p99": 4.0715110000001005
        },
        {
          "p50": 2.8131929999999556,
          "p95": 3.7989049999996496,
          "p99": 4.10856000000058
        },
        {
          "p50": 2.9293220000017755,
          "p95": 3.695463000000018,
          "p99": 4.237881999999445
        },
        {
          "p50": 2.847326000000976,
          "p95": 3.607121000000916,
          "p99": 4.101033000000825
        },
        {
          "p50": 2.9503100000001723,
          "p95": 3.833982999998625,
          "p99": 4.300015999999232
        }
      ],
      "after": [
        {
          "p50": 3.002563999999893,
          "p95": 3.9698480000001837,
          "p99": 4.363600000000133
        },
        {
          "p50": 2.8267220000002453,
          "p95": 3.756666000000223,
          "p99": 4.062363999999889
        },
        {
          "p50": 2.8166400000000067,
          "p95": 3.5414780000000974,
          "p99": 4.191057000000001
        },
        {
          "p50": 2.8190309999999954,
          "p95": 3.732850999999755,
          "p99": 3.965335999999297
        },
        {
          "p50": 2.826716999999917,
          "p95": 3.7552940000005037,
          "p99": 4.218361000001096
        },
        {
          "p50": 2.7978229999989708,
          "p95": 3.679260000000795,
          "p99": 4.01630699999987
        },
        {
          "p50": 2.7928009999995993,
          "p95": 3.616823000000295,
          "p99": 4.087934000001042
        }
      ]
    },
    "bulk": {
      "before": [
        {
          "p50": 4476.718722999998,
          "p95": 5071.084907000004,
          "p99": 5071.084907000004
        },
        {
          "p50": 4530.313042999987,
          "p95": 5039.4684689999995,
          "p99": 5039.4684689999995
        },
        {
          "p50": 4468.790307999996,
          "p95": 7196.699890999997,
          "p99": 7196.699890999997
        },
        {
          "p50": 4615.798999999999,
          "p95": 7073.9849479999975,
          "p99": 7073.9849479999975
        },
        {
          "p50": 4819.570438000024,
          "p95": 6582.939179000008,
          "p99": 6582.939179000008
        },
        {
          "p50": 5138.623670000001,
          "p95": 6059.566678000032,
          "p99": 6059.566678000032
        },
        {
          "p50": 4541.905165000004,
          "p95": 7403.8680710000335,
          "p99": 7403.8680710000335
        }
      ],
      "after": [
        {
          "p50": 318.33472600000096,
          "p95": 391.6916360000032,
          "p99": 391.6916360000032
        },
        {
          "p50": 306.39022600000317,
          "p95": 410.7786930000002,
          "p99": 410.7786930000002
        },
        {
          "p50": 307.12930199998664,
          "p95": 411.2239460000128,
          "p99": 411.2239460000128
        },
        {
          "p50": 303.353283000004,
          "p95": 398.4016330000013,
          "p99": 398.4016330000013
        },
        {
          "p50": 487.08976500001154,
          "p95": 595.7453070000047,
          "p99": 595.7453070000047
        },
        {
          "p50": 492.38065800000913,
          "p95": 1001.3610779999872,
          "p99": 1001.3610779999872
        },
        {
          "p50": 360.44615999999223,
          "p95": 481.0865970000159,
          "p99": 481.0865970000159
        }
      ]
    }
  }
}
```

Before source: `f40d2244aed74de5d46b6d63dd4d7a44a6d204a7`. After source: `8fabe4021611411bca3eb0933d9d89e36821fc4e`. Single-row warmups/iterations: 30/300. Bulk: 2,500 rows seeded in batches of 500, warmups/iterations 1/8. With only eight bulk statements per run, p95/p99 are both that run's maximum.

An earlier candidate that also opened a batch for one row observed 4.452→5.791 ms (+30.1%) for single rows and 5688.746→327.930 ms (-94.2%) for bulk. That unfavorable observation is retained; the final candidate avoids unnecessary capture for one row. Host conditions changed, so the two rounds do not establish the cause or size of the single-row difference.

Full individual statement samples and earlier raw observations are retained in the task artifacts (`bulk-update-performance-final.json`, `bulk-update-performance-initial-batching.json`, `bulk-update-diagnosis-evidence.json`).
</details>

Refs #2319. Keep that issue open for equivalent optimized builds and independent run-level evidence on an uncontended host. Shared-host debug timings do not establish competitive leadership or attribute the earlier suspected memory-admission regression.
